### PR TITLE
First attempt at core automator implementation

### DIFF
--- a/.agents/skills/babysit-pr/SKILL.md
+++ b/.agents/skills/babysit-pr/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: babysit-pr
+description: >
+  Babysit a GitHub pull request after creation by continuously polling CI checks/workflow
+  runs, new review comments, and mergeability state until the PR is ready to merge (or
+  merged/closed). Diagnose failures, retry likely flaky failures up to 3 times, auto-fix
+  and push branch-related issues when appropriate, and stop only when user help is required
+  (e.g. CI infrastructure issues, exhausted flaky retries, or ambiguous/blocking review
+  feedback). Use when the user asks to monitor a PR, watch CI, handle review comments, or
+  keep an eye on failures and feedback on an open PR.
+allowed-tools: Bash(python3 */skills/babysit-pr/scripts/*), Bash(gh pr *), Bash(gh run *), Bash(gh api *), Bash(git push *), Bash(git commit *), Bash(git diff *), Bash(git log *), Bash(git status), Bash(git branch *), Bash(git worktree *), Bash(./gradlew check *), Read, Edit
+---
+
+# PR Babysitter
+
+Monitor a PR persistently until one of the terminal states is reached:
+- PR merged or closed
+- CI fully green, no unaddressed review comments, no merge conflicts
+- A situation requiring user intervention
+
+## Inputs
+
+- No PR argument — infer from current branch (`--pr auto`)
+- PR number — e.g. `123`
+- PR URL — e.g. `https://github.com/rock3r/spectre/pull/123`
+
+## Core workflow
+
+0. **Before running any script**, output a single line so the user knows which PR this conversation is tracking — e.g. `Babysitting PR [#1](https://github.com/rock3r/spectre/pull/1)`. Resolve the PR number/URL from the user's input or the current branch first if needed.
+1. Start with `--watch` for monitoring requests; `--once` for a single snapshot.
+2. Run the watcher to snapshot PR/CI/review state.
+3. Inspect the `actions` list in the JSON output.
+4. Diagnose CI failures — classify as branch-related (fix and push) vs. flaky (retry).
+5. Process actionable review comments from trusted humans, Bugbot, and Codex.
+6. Verify mergeability on each loop.
+7. After any push, relaunch `--watch` in the same turn.
+8. Continue until a terminal stop condition is reached.
+
+## Key commands
+
+```bash
+# Single snapshot of current state
+python3 .agents/skills/babysit-pr/scripts/gh_pr_watch.py --pr auto --once
+
+# Continuously poll until terminal
+python3 .agents/skills/babysit-pr/scripts/gh_pr_watch.py --pr auto --watch
+
+# Trigger a rerun of failed jobs for the current SHA
+python3 .agents/skills/babysit-pr/scripts/gh_pr_watch.py --pr auto --retry-failed-now
+
+# Explicit PR number or URL
+python3 .agents/skills/babysit-pr/scripts/gh_pr_watch.py --pr 42 --watch
+python3 .agents/skills/babysit-pr/scripts/gh_pr_watch.py --pr https://github.com/rock3r/spectre/pull/42 --once
+```
+
+## Stop conditions
+
+| `actions` value | Meaning |
+|---|---|
+| `stop_pr_closed` | PR was merged or closed — done |
+| `stop_ready_to_merge` | CI green, no blocking reviews, no conflicts |
+| `stop_exhausted_retries` | Flaky reruns hit the retry limit — user must investigate |
+| `stop_non_retryable_failure` | Terminal failure is not in retry-eligible workflows — diagnose/fix before continuing |
+| `stop_session_timeout` | `--max-session-minutes` elapsed (default 90 min) — stop and report |
+| `diagnose_hung_check` | A pending check has exceeded its hung threshold (Bugbot: 20 min, CI: 30 min) — stop and report |
+
+Keep polling when CI is running (`idle`), when new review items arrive (`process_review_comment`),
+or when CI is green but the PR is awaiting approval.
+
+## Post-merge cleanup (when `stop_pr_closed` and PR is merged)
+
+After a PR is merged, clean up the local environment automatically:
+
+1. **Delete the local branch**:
+   ```bash
+   git branch -D <head_branch>
+   ```
+
+2. **Remove the git worktree**, if the branch was checked out in one:
+   ```bash
+   git worktree list
+   git worktree remove /path/to/worktree
+   ```
+
+**Only delete the local branch and worktree** — never touch remote branches.
+
+Skip silently if the branch or worktree doesn't exist locally.
+
+## Push discipline — batch all fixes before pushing (cost control)
+
+Each push triggers new Bugbot + Codex runs. **Never push until all of the following are true:**
+
+1. `./gradlew check` passes locally (no CI failures to fix after the push).
+2. Every Bugbot and Codex comment thread from the current review round is **resolved on GitHub** — either the fix was pushed and the thread resolved, or a short reply was posted explaining why it does not apply and the thread was then resolved.
+3. Neither Bugbot nor Codex is still `IN_PROGRESS` — wait for both to finish so their comments can be collected and fixed in the same push.
+
+**Workflow when fixes are needed:**
+
+1. Collect all outstanding issues: failed CI logs + any Bugbot/Codex comments already posted.
+2. Fix everything locally in one pass.
+3. Run `./gradlew check` to confirm green.
+4. Only then push — one push per fix cycle.
+
+If either bot finishes while you are mid-fix and posts new comments, incorporate those fixes into the same commit before pushing.
+
+## Bugbot + Codex merge gate (mandatory)
+
+**Never merge until both Cursor Bugbot and Codex report clean.** For Bugbot, only `SUCCESS` is green.
+
+- If either bot is still `IN_PROGRESS` → keep polling, do not push.
+- If Bugbot conclusion is `NEUTRAL` or `SKIPPING` → it may have posted comments. Always check `gh api repos/{owner}/{repo}/pulls/{pr}/comments` for `cursor[bot]` and `chatgpt-codex-connector[bot]` comments.
+- If Bugbot conclusion is `SUCCESS` and Codex posted no new comments → proceed to merge.
+- Do **not** merge on NEUTRAL or SKIPPING, even if all other checks pass.
+
+## Review bots
+
+The watcher surfaces feedback from:
+- **cursor[bot]** — Cursor Bugbot
+- **chatgpt-codex-connector[bot]** — OpenAI Codex
+- Trusted humans: authors with `OWNER`, `MEMBER`, or `COLLABORATOR` association
+
+## Decision rules
+
+See `references/heuristics.md` for the full classification checklist:
+- **Branch-related failure**: edit the code, collect all other pending issues (Bugbot, Codex, human reviews), fix everything, run `./gradlew check`, then push once.
+- **Likely flaky/unrelated**: rerun via `--retry-failed-now`; retry budget defaults to 3 per SHA.
+- **Ambiguous or requires product decision**: stop and ask the user.
+
+## Output format
+
+All modes emit newline-delimited JSON. The `actions` array drives what to do next.
+`blocking_review_items` contains actionable inline review comments still attached to the current head SHA:
+
+```json
+{
+  "pr": { "number": 1, "head_sha": "abc123", "mergeable": "MERGEABLE", ... },
+  "checks": { "pending_count": 0, "failed_count": 1, "passed_count": 1, "all_terminal": true },
+  "failed_runs": [{ "run_id": 123, "workflow_name": "CI", "conclusion": "failure", "retry_eligible": false, ... }],
+  "hung_checks": [],
+  "new_review_items": [],
+  "blocking_review_items": [],
+  "actions": ["diagnose_ci_failure", "stop_non_retryable_failure"],
+  "retry_state": { "current_sha_retries_used": 0, "max_flaky_retries": 3 }
+}
+```

--- a/.agents/skills/babysit-pr/references/github-api-notes.md
+++ b/.agents/skills/babysit-pr/references/github-api-notes.md
@@ -1,0 +1,93 @@
+# GitHub CLI / API Notes For `babysit-pr`
+
+## Primary commands used
+
+### PR metadata
+
+```bash
+gh pr view --json number,url,state,mergedAt,closedAt,headRefName,headRefOid,headRepository,headRepositoryOwner,mergeable,mergeStateStatus,reviewDecision
+```
+
+Used to resolve PR number, URL, branch, head SHA, and closed/merged/mergeable state.
+
+### PR checks summary
+
+```bash
+gh pr checks --json name,state,bucket,link,workflow,event,startedAt,completedAt
+```
+
+Used to compute pending/failed/passed counts and whether the current CI round is terminal.
+`bucket` values: `pass`, `fail`, `pending`, `skipping`.
+
+### Workflow runs for head SHA
+
+```bash
+gh api repos/{owner}/{repo}/actions/runs -X GET -f head_sha=<sha> -f per_page=100
+```
+
+Used to discover failed workflow runs and rerunnable run IDs.
+
+### Failed log inspection
+
+```bash
+gh run view <run-id> --json jobs,name,workflowName,conclusion,status,url,headSha
+gh run view <run-id> --log-failed
+```
+
+Used to classify branch-related vs. flaky/unrelated failures.
+
+### Retry failed jobs only
+
+```bash
+gh run rerun <run-id> --failed
+```
+
+Reruns only failed jobs (and their dependencies) for a workflow run.
+
+## Review-related endpoints
+
+```bash
+# Issue comments on PR
+gh api repos/{owner}/{repo}/issues/<pr_number>/comments?per_page=100
+
+# Inline PR review comments
+gh api repos/{owner}/{repo}/pulls/<pr_number>/comments?per_page=100
+
+# Review submissions
+gh api repos/{owner}/{repo}/pulls/<pr_number>/reviews?per_page=100
+```
+
+## JSON fields consumed by the watcher
+
+### `gh pr view`
+
+| Field | Used for |
+|---|---|
+| `number` | Identifying the PR |
+| `url` | Extracting `owner/repo` |
+| `state` | Detecting closed PRs |
+| `mergedAt` / `closedAt` | Terminal state detection |
+| `headRefName` | Branch name |
+| `headRefOid` | Head SHA for workflow run lookup |
+| `mergeable` | Merge conflict detection |
+| `mergeStateStatus` | Blocking state detection (`BLOCKED`, `DIRTY`, `DRAFT`) |
+| `reviewDecision` | Approval gating (`REVIEW_REQUIRED`, `CHANGES_REQUESTED`) |
+
+### `gh pr checks`
+
+| Field | Used for |
+|---|---|
+| `bucket` | Pass/fail/pending classification |
+| `state` | Supplementary pending detection |
+| `name` / `workflow` | Human-readable failure reporting |
+| `link` | Deep-linking to failed runs |
+
+### Actions runs API (`workflow_runs[]`)
+
+| Field | Used for |
+|---|---|
+| `id` | Run ID for rerun commands |
+| `name` / `display_title` | Workflow name in failure report |
+| `status` / `conclusion` | Failure classification |
+| `html_url` | Link to run in CI report |
+| `head_sha` | Filtering runs to current commit |

--- a/.agents/skills/babysit-pr/references/heuristics.md
+++ b/.agents/skills/babysit-pr/references/heuristics.md
@@ -1,0 +1,67 @@
+# CI / Review Heuristics
+
+## CI classification checklist
+
+Treat as **branch-related** when logs clearly indicate a regression caused by the PR branch:
+
+- Compile/typecheck/lint failures in files or modules touched by the branch
+- Deterministic unit/integration test failures in changed areas
+- Snapshot output changes caused by UI/text changes in the branch
+- Static analysis violations (Detekt findings) introduced by the latest push
+- Build script/config changes in the PR causing a deterministic failure
+
+Treat as **likely flaky or unrelated** when evidence points to transient or external issues:
+
+- DNS/network/registry timeout errors while fetching Gradle/Maven dependencies
+- Runner image provisioning or startup failures
+- GitHub Actions infrastructure/service outages (e.g. API rate limits during JDK setup)
+- Non-deterministic failures in concurrency or timing-sensitive tests
+- Cloud/service rate limits or transient API outages
+
+If uncertain, inspect the failed logs once before choosing rerun.
+
+## Decision tree (fix vs rerun vs stop)
+
+1. If PR is merged/closed: stop.
+2. If there are failed checks:
+   - Diagnose first.
+   - If branch-related: fix locally, **but do not push yet** — continue to steps 3 and 4 first.
+   - If likely flaky/unrelated and all checks for the current SHA are terminal: rerun failed jobs.
+   - If checks are still pending: wait.
+3. If Bugbot or Codex is `IN_PROGRESS`: wait for them to finish before pushing anything. Collect their comments when they complete.
+4. Independently, process any new trusted human, Bugbot, or Codex review comments. Fix them locally.
+5. **Push once** only when: CI fixes are done AND all review bots are done AND `./gradlew check` is green.
+6. After the push (and before merging), **resolve every review bot comment thread on GitHub**: if the issue was fixed, resolve the thread; if it does not apply, post a short reply explaining why and then resolve the thread. The PR must have no open bot threads at merge time.
+7. If flaky reruns for the same SHA reach the configured limit (default 3): stop and report.
+
+> **Cost rule**: every push triggers Bugbot + Codex runs. Batch all local fixes — CI failures,
+> Bugbot comments, Codex comments, human review comments — into a single commit before pushing.
+> Never push speculatively mid-fix-cycle.
+
+## Review comment agreement criteria
+
+Address the comment when:
+
+- The comment is technically correct.
+- The change is actionable in the current branch.
+- The requested change does not conflict with the user's intent or recent guidance.
+- The change can be made safely without unrelated refactors.
+- After fixing, run `./gradlew check` to confirm no regressions.
+
+Do not auto-fix when:
+
+- The comment is ambiguous and needs clarification.
+- The request conflicts with explicit user instructions.
+- The proposed change requires product/design decisions the user has not made.
+- The codebase is in a dirty/unrelated state that makes safe editing uncertain.
+
+## Stop-and-ask conditions
+
+Stop and ask the user instead of continuing automatically when:
+
+- The local worktree has unrelated uncommitted changes.
+- `gh` auth/permissions fail.
+- The PR branch cannot be pushed.
+- CI failures persist after the flaky retry budget.
+- Reviewer feedback requires a product decision or cross-team coordination.
+- `./gradlew check` fails after an attempted fix and the cause is not obvious.

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -405,14 +405,14 @@ def failed_runs_from_workflow_runs(runs, head_sha):
             continue
         if str(run.get("head_sha") or "") != head_sha:
             continue
-        workflow_name = run.get("name") or run.get("display_title") or ""
+        workflow_id = run.get("workflow_id") or run.get("name") or run.get("display_title") or ""
         run_id = run.get("id") or 0
-        prev = latest_by_workflow.get(workflow_name)
+        prev = latest_by_workflow.get(workflow_id)
         if prev is None or run_id > (prev.get("id") or 0):
-            latest_by_workflow[workflow_name] = run
+            latest_by_workflow[workflow_id] = run
 
     failed_runs = []
-    for workflow_name, run in latest_by_workflow.items():
+    for _workflow_id, run in latest_by_workflow.items():
         conclusion = str(run.get("conclusion") or "")
         if conclusion not in FAILED_RUN_CONCLUSIONS:
             continue
@@ -1119,6 +1119,7 @@ def run_watch(args):
             or "stop_non_retryable_failure" in actions
             or "stop_ready_to_merge" in actions
             or "diagnose_hung_check" in actions
+            or "diagnose_skipping_checks" in actions
         ):
             print_event("stop", {"snapshot": snapshot, "state_file": str(state_path)})
             return 0

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -346,9 +346,9 @@ def summarize_checks(checks):
         bucket = str(check.get("bucket") or "").lower()
         if is_pending_check(check):
             pending_count += 1
-        if bucket == "fail":
+        elif bucket == "fail":
             failed_count += 1
-        if bucket == "pass":
+        elif bucket == "pass":
             passed_count += 1
     return {
         "pending_count": pending_count,

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -357,16 +357,29 @@ def summarize_checks(checks):
 
 def get_workflow_runs_for_sha(repo, head_sha):
     endpoint = f"repos/{repo}/actions/runs"
-    data = gh_json(
-        ["api", endpoint, "-X", "GET", "-f", f"head_sha={head_sha}", "-f", "per_page=100"],
-        repo=repo,
-    )
-    if not isinstance(data, dict):
-        raise GhCommandError("Unexpected payload from actions runs API")
-    runs = data.get("workflow_runs") or []
-    if not isinstance(runs, list):
-        raise GhCommandError("Expected `workflow_runs` to be a list")
-    return runs
+    page = 1
+    all_runs = []
+    while True:
+        data = gh_json(
+            [
+                "api", endpoint, "-X", "GET",
+                "-f", f"head_sha={head_sha}",
+                "-f", f"per_page=100",
+                "-f", f"page={page}",
+                "-f", "event=pull_request",
+            ],
+            repo=repo,
+        )
+        if not isinstance(data, dict):
+            raise GhCommandError("Unexpected payload from actions runs API")
+        runs = data.get("workflow_runs") or []
+        if not isinstance(runs, list):
+            raise GhCommandError("Expected `workflow_runs` to be a list")
+        all_runs.extend(runs)
+        if len(runs) < 100:
+            break
+        page += 1
+    return all_runs
 
 
 def is_retry_eligible_workflow_name(workflow_name):

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -397,16 +397,25 @@ def is_retry_eligible_failed_run(run):
 
 
 def failed_runs_from_workflow_runs(runs, head_sha):
-    failed_runs = []
+    # Keep only the latest run per workflow (highest run_id) to ignore
+    # superseded reruns that are no longer the active failure.
+    latest_by_workflow = {}
     for run in runs:
         if not isinstance(run, dict):
             continue
         if str(run.get("head_sha") or "") != head_sha:
             continue
+        workflow_name = run.get("name") or run.get("display_title") or ""
+        run_id = run.get("id") or 0
+        prev = latest_by_workflow.get(workflow_name)
+        if prev is None or run_id > (prev.get("id") or 0):
+            latest_by_workflow[workflow_name] = run
+
+    failed_runs = []
+    for workflow_name, run in latest_by_workflow.items():
         conclusion = str(run.get("conclusion") or "")
         if conclusion not in FAILED_RUN_CONCLUSIONS:
             continue
-        workflow_name = run.get("name") or run.get("display_title") or ""
         failed_runs.append(
             {
                 "run_id": run.get("id"),
@@ -835,6 +844,9 @@ def recommend_actions(
 
     if hung_checks:
         actions.append("diagnose_hung_check")
+
+    if checks_summary.get("skipping_count", 0) > 0 and checks_summary["all_terminal"]:
+        actions.append("diagnose_skipping_checks")
 
     has_failed_pr_checks = checks_summary["failed_count"] > 0
     if has_failed_pr_checks:

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -416,14 +416,15 @@ def failed_runs_from_workflow_runs(runs, head_sha):
         conclusion = str(run.get("conclusion") or "")
         if conclusion not in FAILED_RUN_CONCLUSIONS:
             continue
+        wf_name = run.get("name") or run.get("display_title") or ""
         failed_runs.append(
             {
                 "run_id": run.get("id"),
-                "workflow_name": workflow_name,
+                "workflow_name": wf_name,
                 "status": str(run.get("status") or ""),
                 "conclusion": conclusion,
                 "html_url": str(run.get("html_url") or ""),
-                "retry_eligible": is_retry_eligible_workflow_name(workflow_name),
+                "retry_eligible": is_retry_eligible_workflow_name(wf_name),
             }
         )
     failed_runs.sort(

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -60,13 +60,6 @@ GREEN_STATE_MAX_POLL_SECONDS = 2 * 60
 # the bot's findings are ever seen.
 CHECKS_TERMINAL_GRACE_PERIOD_SECONDS = 60
 
-# Actionable inline review comments on the current head SHA block merge
-# readiness for a bounded freshness window. This catches the race where review
-# feedback arrives shortly after checks complete, while avoiding a permanent
-# merge block for comments that were already handled/resolved without a new
-# commit.
-BLOCKING_REVIEW_ITEM_FRESH_SECONDS = 30 * 60
-
 # Per-check-name hung thresholds: if a check has been IN_PROGRESS longer than
 # this many seconds without completing, surface a diagnose_hung_check action.
 # Matched by substring of the lowercased check name; "default" is the fallback.
@@ -550,20 +543,10 @@ def is_blocking_review_item(item, head_sha, now_seconds=None):
     commit_id = str(item.get("commit_id") or "")
     if not commit_id or not head_sha or commit_id != head_sha:
         return False
-
-    created_at = str(item.get("created_at") or "")
-    if not created_at:
-        return True
-    try:
-        created_at_seconds = datetime.fromisoformat(
-            created_at.replace("Z", "+00:00")
-        ).timestamp()
-    except ValueError:
-        return True
-
-    now = float(now_seconds) if now_seconds is not None else time.time()
-    age_seconds = max(0, now - created_at_seconds)
-    return age_seconds <= BLOCKING_REVIEW_ITEM_FRESH_SECONDS
+    # Any inline bot/human comment on the current SHA blocks until explicitly
+    # resolved. Age-based expiry was removed because it allowed unresolved
+    # comments to silently fall out of the blocking list after 30 minutes.
+    return True
 
 
 def fetch_new_review_items(pr, state, authenticated_login=None):
@@ -629,11 +612,10 @@ def fetch_new_review_items(pr, state, authenticated_login=None):
             item.get("id") or "",
         )
     )
-    now_seconds = time.time()
     blocking_items = [
         item
         for item in actionable_items
-        if is_blocking_review_item(item, head_sha=head_sha, now_seconds=now_seconds)
+        if is_blocking_review_item(item, head_sha=head_sha)
     ]
     blocking_items.sort(
         key=lambda item: (

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -1096,7 +1096,7 @@ def run_watch(args):
             return 0
         try:
             snapshot, state_path = collect_snapshot(args)
-        except (GhCommandError, RuntimeError, ValueError) as err:
+        except (GhCommandError, RuntimeError) as err:
             sys.stderr.write(f"gh_pr_watch.py poll error (retrying): {err}\n")
             time.sleep(poll_seconds)
             continue

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -335,6 +335,7 @@ def summarize_checks(checks):
     pending_count = 0
     failed_count = 0
     passed_count = 0
+    skipping_count = 0
     for check in checks:
         bucket = str(check.get("bucket") or "").lower()
         if is_pending_check(check):
@@ -343,10 +344,13 @@ def summarize_checks(checks):
             failed_count += 1
         elif bucket == "pass":
             passed_count += 1
+        elif bucket in ("neutral", "skipping"):
+            skipping_count += 1
     return {
         "pending_count": pending_count,
         "failed_count": failed_count,
         "passed_count": passed_count,
+        "skipping_count": skipping_count,
         "all_terminal": pending_count == 0,
     }
 
@@ -718,7 +722,11 @@ def is_pr_ready_to_merge(
         return False
     if not checks_summary["all_terminal"]:
         return False
-    if checks_summary["failed_count"] > 0 or checks_summary["pending_count"] > 0:
+    if (
+        checks_summary["failed_count"] > 0
+        or checks_summary["pending_count"] > 0
+        or checks_summary.get("skipping_count", 0) > 0
+    ):
         return False
     if new_review_items:
         return False
@@ -1073,7 +1081,12 @@ def run_watch(args):
                 },
             )
             return 0
-        snapshot, state_path = collect_snapshot(args)
+        try:
+            snapshot, state_path = collect_snapshot(args)
+        except (GhCommandError, RuntimeError, ValueError) as err:
+            sys.stderr.write(f"gh_pr_watch.py poll error (retrying): {err}\n")
+            time.sleep(poll_seconds)
+            continue
         actions = set(snapshot.get("actions") or [])
         if (
             "stop_pr_closed" in actions

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -566,7 +566,7 @@ def is_blocking_review_item(item, head_sha, now_seconds=None):
     return age_seconds <= BLOCKING_REVIEW_ITEM_FRESH_SECONDS
 
 
-def fetch_new_review_items(pr, state, fresh_state, authenticated_login=None):
+def fetch_new_review_items(pr, state, authenticated_login=None):
     repo = pr["repo"]
     pr_number = pr["number"]
     head_sha = str(pr.get("head_sha") or "")
@@ -824,7 +824,6 @@ def collect_snapshot(args):
     new_review_items, blocking_review_items = fetch_new_review_items(
         pr,
         state,
-        fresh_state=fresh_state,
         authenticated_login=authenticated_login,
     )
 

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -1,0 +1,1103 @@
+#!/usr/bin/env python3
+"""Watch GitHub PR CI and review activity for PR babysitting workflows."""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from urllib.parse import urlparse
+
+FAILED_RUN_CONCLUSIONS = {
+    "failure",
+    "timed_out",
+    "cancelled",
+    "action_required",
+    "startup_failure",
+    "stale",
+}
+PENDING_CHECK_STATES = {
+    "QUEUED",
+    "IN_PROGRESS",
+    "PENDING",
+    "WAITING",
+    "REQUESTED",
+}
+# Login keyword fragments that identify actionable review bots.
+# A bot comment is surfaced when its login contains any of these keywords.
+# Cursor Bugbot posts as cursor[bot]; Codex posts as chatgpt-codex-connector[bot].
+REVIEW_BOT_LOGIN_KEYWORDS = {
+    "cursor",
+    "codex",
+}
+TRUSTED_AUTHOR_ASSOCIATIONS = {
+    "OWNER",
+    "MEMBER",
+    "COLLABORATOR",
+}
+MERGE_BLOCKING_REVIEW_DECISIONS = {
+    "REVIEW_REQUIRED",
+    "CHANGES_REQUESTED",
+}
+MERGE_CONFLICT_OR_BLOCKING_STATES = {
+    "BLOCKED",
+    "DIRTY",
+    "DRAFT",
+    "UNKNOWN",
+}
+GREEN_STATE_MAX_POLL_SECONDS = 2 * 60
+
+# Minimum seconds to wait after all checks go terminal before declaring the PR
+# ready to merge.  Review bots (e.g. Cursor Bugbot) complete their CI check run
+# first, then post inline review comments to the PR a few seconds later via a
+# separate API call.  Without this grace period the watcher can emit
+# stop_ready_to_merge in that narrow window, causing the agent to merge before
+# the bot's findings are ever seen.
+CHECKS_TERMINAL_GRACE_PERIOD_SECONDS = 60
+
+# Actionable inline review comments on the current head SHA block merge
+# readiness for a bounded freshness window. This catches the race where review
+# feedback arrives shortly after checks complete, while avoiding a permanent
+# merge block for comments that were already handled/resolved without a new
+# commit.
+BLOCKING_REVIEW_ITEM_FRESH_SECONDS = 30 * 60
+
+# Per-check-name hung thresholds: if a check has been IN_PROGRESS longer than
+# this many seconds without completing, surface a diagnose_hung_check action.
+# Matched by substring of the lowercased check name; "default" is the fallback.
+HUNG_CHECK_THRESHOLDS_SECONDS = {
+    "cursor": 20 * 60,   # Cursor Bugbot: avg ~8 min, max observed ~12 min
+    "default": 30 * 60,  # CI / E2E: normal 5-6 min, slow-but-legit up to ~20 min
+}
+
+# Retry budget should focus on historically flaky checks. Based on recent PR
+# failure analysis, CI workflow failures are usually deterministic
+# lint/static-analysis/code issues, while E2E failures are more likely to be
+# transient and worth one or more reruns.
+RETRY_ELIGIBLE_WORKFLOW_KEYWORDS = {
+    "e2e",
+}
+
+MAX_SESSION_MINUTES_DEFAULT = 90
+
+
+class GhCommandError(RuntimeError):
+    pass
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize PR/CI/review state for PR babysitting and optionally "
+            "trigger flaky reruns."
+        )
+    )
+    parser.add_argument("--pr", default="auto", help="auto, PR number, or PR URL")
+    parser.add_argument("--repo", help="Optional OWNER/REPO override")
+    parser.add_argument("--poll-seconds", type=int, default=30, help="Watch poll interval")
+    parser.add_argument(
+        "--max-flaky-retries",
+        type=int,
+        default=3,
+        help="Max rerun cycles per head SHA before stop recommendation",
+    )
+    parser.add_argument("--state-file", help="Path to state JSON file")
+    parser.add_argument("--once", action="store_true", help="Emit one snapshot and exit")
+    parser.add_argument("--watch", action="store_true", help="Continuously emit JSONL snapshots")
+    parser.add_argument(
+        "--retry-failed-now",
+        action="store_true",
+        help="Rerun failed jobs for current failed workflow runs when policy allows",
+    )
+    parser.add_argument(
+        "--max-session-minutes",
+        type=int,
+        default=MAX_SESSION_MINUTES_DEFAULT,
+        help=(
+            "In --watch mode, stop with stop_session_timeout after this many minutes "
+            f"(default: {MAX_SESSION_MINUTES_DEFAULT})"
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable output (default behavior for --once and --retry-failed-now)",
+    )
+    args = parser.parse_args()
+
+    if args.poll_seconds <= 0:
+        parser.error("--poll-seconds must be > 0")
+    if args.max_flaky_retries < 0:
+        parser.error("--max-flaky-retries must be >= 0")
+    if args.watch and args.retry_failed_now:
+        parser.error("--watch cannot be combined with --retry-failed-now")
+    if not args.once and not args.watch and not args.retry_failed_now:
+        args.once = True
+    return args
+
+
+def _format_gh_error(cmd, err):
+    stdout = (err.stdout or "").strip()
+    stderr = (err.stderr or "").strip()
+    parts = [f"GitHub CLI command failed: {' '.join(cmd)}"]
+    if stdout:
+        parts.append(f"stdout: {stdout}")
+    if stderr:
+        parts.append(f"stderr: {stderr}")
+    return "\n".join(parts)
+
+
+def gh_text(args, repo=None):
+    cmd = ["gh"]
+    # `gh api` does not accept `-R/--repo` on all gh versions. The watcher's
+    # API calls use explicit endpoints (e.g. repos/{owner}/{repo}/...), so the
+    # repo flag is unnecessary there.
+    if repo and (not args or args[0] != "api"):
+        cmd.extend(["-R", repo])
+    cmd.extend(args)
+    try:
+        proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError as err:
+        raise GhCommandError("`gh` command not found") from err
+    except subprocess.CalledProcessError as err:
+        raise GhCommandError(_format_gh_error(cmd, err)) from err
+    return proc.stdout
+
+
+def gh_json(args, repo=None):
+    raw = gh_text(args, repo=repo).strip()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as err:
+        raise GhCommandError(f"Failed to parse JSON from gh output for {' '.join(args)}") from err
+
+
+def parse_pr_spec(pr_spec):
+    if pr_spec == "auto":
+        return {"mode": "auto", "value": None}
+    if re.fullmatch(r"\d+", pr_spec):
+        return {"mode": "number", "value": pr_spec}
+    parsed = urlparse(pr_spec)
+    if parsed.scheme and parsed.netloc and "/pull/" in parsed.path:
+        return {"mode": "url", "value": pr_spec}
+    raise ValueError("--pr must be 'auto', a PR number, or a PR URL")
+
+
+def pr_view_fields():
+    return (
+        "number,url,state,mergedAt,closedAt,headRefName,headRefOid,"
+        "headRepository,headRepositoryOwner,mergeable,mergeStateStatus,reviewDecision"
+    )
+
+
+def checks_fields():
+    return "name,state,bucket,link,workflow,event,startedAt,completedAt"
+
+
+def resolve_pr(pr_spec, repo_override=None):
+    parsed = parse_pr_spec(pr_spec)
+    cmd = ["pr", "view"]
+    if parsed["value"] is not None:
+        cmd.append(parsed["value"])
+    cmd.extend(["--json", pr_view_fields()])
+    data = gh_json(cmd, repo=repo_override)
+    if not isinstance(data, dict):
+        raise GhCommandError("Unexpected PR payload from `gh pr view`")
+
+    pr_url = str(data.get("url") or "")
+    repo = (
+        repo_override
+        or extract_repo_from_pr_url(pr_url)
+        or extract_repo_from_pr_view(data)
+    )
+    if not repo:
+        raise GhCommandError("Unable to determine OWNER/REPO for the PR")
+
+    state = str(data.get("state") or "")
+    merged = bool(data.get("mergedAt"))
+    closed = bool(data.get("closedAt")) or state.upper() == "CLOSED"
+
+    return {
+        "number": int(data["number"]),
+        "url": pr_url,
+        "repo": repo,
+        "head_sha": str(data.get("headRefOid") or ""),
+        "head_branch": str(data.get("headRefName") or ""),
+        "state": state,
+        "merged": merged,
+        "closed": closed,
+        "mergeable": str(data.get("mergeable") or ""),
+        "merge_state_status": str(data.get("mergeStateStatus") or ""),
+        "review_decision": str(data.get("reviewDecision") or ""),
+    }
+
+
+def extract_repo_from_pr_view(data):
+    head_repo = data.get("headRepository")
+    head_owner = data.get("headRepositoryOwner")
+    owner = None
+    name = None
+    if isinstance(head_owner, dict):
+        owner = head_owner.get("login") or head_owner.get("name")
+    elif isinstance(head_owner, str):
+        owner = head_owner
+    if isinstance(head_repo, dict):
+        name = head_repo.get("name")
+        repo_owner = head_repo.get("owner")
+        if not owner and isinstance(repo_owner, dict):
+            owner = repo_owner.get("login") or repo_owner.get("name")
+    elif isinstance(head_repo, str):
+        name = head_repo
+    if owner and name:
+        return f"{owner}/{name}"
+    return None
+
+
+def extract_repo_from_pr_url(pr_url):
+    parsed = urlparse(pr_url)
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) >= 4 and parts[2] == "pull":
+        return f"{parts[0]}/{parts[1]}"
+    return None
+
+
+def load_state(path):
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as err:
+            raise RuntimeError(f"State file is not valid JSON: {path}") from err
+        if not isinstance(data, dict):
+            raise RuntimeError(f"State file must contain an object: {path}")
+        return data, False
+    return {
+        "pr": {},
+        "started_at": None,
+        "last_seen_head_sha": None,
+        "retries_by_sha": {},
+        "seen_issue_comment_ids": [],
+        "seen_review_comment_ids": [],
+        "seen_review_ids": [],
+        "last_snapshot_at": None,
+        # Timestamp (unix seconds) when checks first went all_terminal for the
+        # current head SHA.  Used to enforce a grace period before emitting
+        # stop_ready_to_merge so that review bots have time to post their
+        # inline review comments after completing their check run.
+        "checks_went_terminal_at": None,
+        # The head SHA for which checks_went_terminal_at was recorded.
+        "checks_terminal_sha": None,
+    }, True
+
+
+def save_state(path, state):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(state, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=f"{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            tmp_file.write(payload)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def default_state_file_for(pr):
+    repo_slug = pr["repo"].replace("/", "-")
+    return Path(f"/tmp/babysit-pr-{repo_slug}-pr{pr['number']}.json")
+
+
+def get_pr_checks(pr_spec, repo):
+    parsed = parse_pr_spec(pr_spec)
+    cmd = ["pr", "checks"]
+    if parsed["value"] is not None:
+        cmd.append(parsed["value"])
+    cmd.extend(["--json", checks_fields()])
+    data = gh_json(cmd, repo=repo)
+    if data is None:
+        return []
+    if not isinstance(data, list):
+        raise GhCommandError("Unexpected payload from `gh pr checks`")
+    return data
+
+
+def is_pending_check(check):
+    bucket = str(check.get("bucket") or "").lower()
+    state = str(check.get("state") or "").upper()
+    return bucket == "pending" or state in PENDING_CHECK_STATES
+
+
+def summarize_checks(checks):
+    pending_count = 0
+    failed_count = 0
+    passed_count = 0
+    for check in checks:
+        bucket = str(check.get("bucket") or "").lower()
+        if is_pending_check(check):
+            pending_count += 1
+        if bucket == "fail":
+            failed_count += 1
+        if bucket == "pass":
+            passed_count += 1
+    return {
+        "pending_count": pending_count,
+        "failed_count": failed_count,
+        "passed_count": passed_count,
+        "all_terminal": pending_count == 0,
+    }
+
+
+def get_workflow_runs_for_sha(repo, head_sha):
+    endpoint = f"repos/{repo}/actions/runs"
+    data = gh_json(
+        ["api", endpoint, "-X", "GET", "-f", f"head_sha={head_sha}", "-f", "per_page=100"],
+        repo=repo,
+    )
+    if not isinstance(data, dict):
+        raise GhCommandError("Unexpected payload from actions runs API")
+    runs = data.get("workflow_runs") or []
+    if not isinstance(runs, list):
+        raise GhCommandError("Expected `workflow_runs` to be a list")
+    return runs
+
+
+def is_retry_eligible_workflow_name(workflow_name):
+    lower = str(workflow_name or "").lower()
+    return any(keyword in lower for keyword in RETRY_ELIGIBLE_WORKFLOW_KEYWORDS)
+
+
+def is_retry_eligible_failed_run(run):
+    if not isinstance(run, dict):
+        return False
+    explicit = run.get("retry_eligible")
+    if isinstance(explicit, bool):
+        return explicit
+    return is_retry_eligible_workflow_name(run.get("workflow_name") or "")
+
+
+def failed_runs_from_workflow_runs(runs, head_sha):
+    failed_runs = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("head_sha") or "") != head_sha:
+            continue
+        conclusion = str(run.get("conclusion") or "")
+        if conclusion not in FAILED_RUN_CONCLUSIONS:
+            continue
+        workflow_name = run.get("name") or run.get("display_title") or ""
+        failed_runs.append(
+            {
+                "run_id": run.get("id"),
+                "workflow_name": workflow_name,
+                "status": str(run.get("status") or ""),
+                "conclusion": conclusion,
+                "html_url": str(run.get("html_url") or ""),
+                "retry_eligible": is_retry_eligible_workflow_name(workflow_name),
+            }
+        )
+    failed_runs.sort(
+        key=lambda item: (str(item.get("workflow_name") or ""), str(item.get("run_id") or ""))
+    )
+    return failed_runs
+
+
+def get_authenticated_login():
+    data = gh_json(["api", "user"])
+    if not isinstance(data, dict) or not data.get("login"):
+        raise GhCommandError("Unable to determine authenticated GitHub login from `gh api user`")
+    return str(data["login"])
+
+
+def comment_endpoints(repo, pr_number):
+    return {
+        "issue_comment": f"repos/{repo}/issues/{pr_number}/comments",
+        "review_comment": f"repos/{repo}/pulls/{pr_number}/comments",
+        "review": f"repos/{repo}/pulls/{pr_number}/reviews",
+    }
+
+
+def gh_api_list_paginated(endpoint, repo=None, per_page=100):
+    items = []
+    page = 1
+    while True:
+        sep = "&" if "?" in endpoint else "?"
+        page_endpoint = f"{endpoint}{sep}per_page={per_page}&page={page}"
+        payload = gh_json(["api", page_endpoint], repo=repo)
+        if payload is None:
+            break
+        if not isinstance(payload, list):
+            raise GhCommandError(f"Unexpected paginated payload from gh api {endpoint}")
+        items.extend(payload)
+        if len(payload) < per_page:
+            break
+        page += 1
+    return items
+
+
+def normalize_issue_comments(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        out.append(
+            {
+                "kind": "issue_comment",
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "author_association": str(item.get("author_association") or ""),
+                "created_at": str(item.get("created_at") or ""),
+                "body": str(item.get("body") or ""),
+                "path": None,
+                "line": None,
+                "commit_id": None,
+                "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def normalize_review_comments(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        line = item.get("line")
+        if line is None:
+            line = item.get("original_line")
+        out.append(
+            {
+                "kind": "review_comment",
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "author_association": str(item.get("author_association") or ""),
+                "created_at": str(item.get("created_at") or ""),
+                "body": str(item.get("body") or ""),
+                "path": item.get("path"),
+                "line": line,
+                "commit_id": str(item.get("commit_id") or ""),
+                "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def normalize_reviews(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        out.append(
+            {
+                "kind": "review",
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "author_association": str(item.get("author_association") or ""),
+                "created_at": str(item.get("submitted_at") or item.get("created_at") or ""),
+                "body": str(item.get("body") or ""),
+                "path": None,
+                "line": None,
+                "commit_id": None,
+                "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def extract_login(user_obj):
+    if isinstance(user_obj, dict):
+        return str(user_obj.get("login") or "")
+    return ""
+
+
+def is_bot_login(login):
+    return bool(login) and login.endswith("[bot]")
+
+
+def is_actionable_review_bot_login(login):
+    if not is_bot_login(login):
+        return False
+    lower_login = login.lower()
+    return any(keyword in lower_login for keyword in REVIEW_BOT_LOGIN_KEYWORDS)
+
+
+def is_trusted_human_review_author(item, authenticated_login):
+    author = str(item.get("author") or "")
+    if not author:
+        return False
+    if authenticated_login and author == authenticated_login:
+        return True
+    association = str(item.get("author_association") or "").upper()
+    return association in TRUSTED_AUTHOR_ASSOCIATIONS
+
+
+def is_blocking_review_item(item, head_sha, now_seconds=None):
+    if not isinstance(item, dict):
+        return False
+    if str(item.get("kind") or "") != "review_comment":
+        return False
+    commit_id = str(item.get("commit_id") or "")
+    if not commit_id or not head_sha or commit_id != head_sha:
+        return False
+
+    created_at = str(item.get("created_at") or "")
+    if not created_at:
+        return True
+    try:
+        created_at_seconds = datetime.fromisoformat(
+            created_at.replace("Z", "+00:00")
+        ).timestamp()
+    except ValueError:
+        return True
+
+    now = float(now_seconds) if now_seconds is not None else time.time()
+    age_seconds = max(0, now - created_at_seconds)
+    return age_seconds <= BLOCKING_REVIEW_ITEM_FRESH_SECONDS
+
+
+def fetch_new_review_items(pr, state, fresh_state, authenticated_login=None):
+    repo = pr["repo"]
+    pr_number = pr["number"]
+    head_sha = str(pr.get("head_sha") or "")
+    endpoints = comment_endpoints(repo, pr_number)
+
+    issue_payload = gh_api_list_paginated(endpoints["issue_comment"], repo=repo)
+    review_comment_payload = gh_api_list_paginated(endpoints["review_comment"], repo=repo)
+    review_payload = gh_api_list_paginated(endpoints["review"], repo=repo)
+
+    issue_items = normalize_issue_comments(issue_payload)
+    review_comment_items = normalize_review_comments(review_comment_payload)
+    review_items = normalize_reviews(review_payload)
+    all_items = issue_items + review_comment_items + review_items
+
+    seen_issue = {str(x) for x in state.get("seen_issue_comment_ids") or []}
+    seen_review_comment = {str(x) for x in state.get("seen_review_comment_ids") or []}
+    seen_review = {str(x) for x in state.get("seen_review_ids") or []}
+
+    # On a brand-new state file, surface existing review activity instead of
+    # silently treating it as seen. This avoids missing already-pending review
+    # feedback when monitoring starts after comments were posted.
+
+    actionable_items = []
+    new_items = []
+    for item in all_items:
+        item_id = item.get("id")
+        if not item_id:
+            continue
+        author = item.get("author") or ""
+        if not author:
+            continue
+        if is_bot_login(author):
+            if not is_actionable_review_bot_login(author):
+                continue
+        elif not is_trusted_human_review_author(item, authenticated_login):
+            continue
+
+        actionable_items.append(item)
+
+        kind = item["kind"]
+        if kind == "issue_comment" and item_id in seen_issue:
+            continue
+        if kind == "review_comment" and item_id in seen_review_comment:
+            continue
+        if kind == "review" and item_id in seen_review:
+            continue
+
+        new_items.append(item)
+        if kind == "issue_comment":
+            seen_issue.add(item_id)
+        elif kind == "review_comment":
+            seen_review_comment.add(item_id)
+        elif kind == "review":
+            seen_review.add(item_id)
+
+    new_items.sort(
+        key=lambda item: (
+            item.get("created_at") or "",
+            item.get("kind") or "",
+            item.get("id") or "",
+        )
+    )
+    now_seconds = time.time()
+    blocking_items = [
+        item
+        for item in actionable_items
+        if is_blocking_review_item(item, head_sha=head_sha, now_seconds=now_seconds)
+    ]
+    blocking_items.sort(
+        key=lambda item: (
+            item.get("created_at") or "",
+            item.get("kind") or "",
+            item.get("id") or "",
+        )
+    )
+
+    state["seen_issue_comment_ids"] = sorted(seen_issue)
+    state["seen_review_comment_ids"] = sorted(seen_review_comment)
+    state["seen_review_ids"] = sorted(seen_review)
+    return new_items, blocking_items
+
+
+def current_retry_count(state, head_sha):
+    retries = state.get("retries_by_sha") or {}
+    value = retries.get(head_sha, 0)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def set_retry_count(state, head_sha, count):
+    retries = state.get("retries_by_sha")
+    if not isinstance(retries, dict):
+        retries = {}
+    retries[head_sha] = int(count)
+    state["retries_by_sha"] = retries
+
+
+def unique_actions(actions):
+    out = []
+    seen = set()
+    for action in actions:
+        if action not in seen:
+            out.append(action)
+            seen.add(action)
+    return out
+
+
+def is_pr_ready_to_merge(
+    pr,
+    checks_summary,
+    new_review_items,
+    checks_terminal_elapsed=None,
+    blocking_review_items=None,
+):
+    if pr["closed"] or pr["merged"]:
+        return False
+    if not checks_summary["all_terminal"]:
+        return False
+    if checks_summary["failed_count"] > 0 or checks_summary["pending_count"] > 0:
+        return False
+    if new_review_items:
+        return False
+    if blocking_review_items:
+        return False
+    if str(pr.get("mergeable") or "") != "MERGEABLE":
+        return False
+    if str(pr.get("merge_state_status") or "") in MERGE_CONFLICT_OR_BLOCKING_STATES:
+        return False
+    if str(pr.get("review_decision") or "") in MERGE_BLOCKING_REVIEW_DECISIONS:
+        return False
+    # Enforce a grace period after checks go terminal.  Review bots complete
+    # their CI check run first and post inline PR review comments a few seconds
+    # later via a separate API call.  Declaring the PR ready before the grace
+    # period elapses risks missing those comments and merging prematurely.
+    if checks_terminal_elapsed is not None and checks_terminal_elapsed < CHECKS_TERMINAL_GRACE_PERIOD_SECONDS:
+        return False
+    return True
+
+
+def hung_threshold_for_check(check_name):
+    """Return the hung-detection threshold in seconds for a given check name."""
+    lower = (check_name or "").lower()
+    for keyword, threshold in HUNG_CHECK_THRESHOLDS_SECONDS.items():
+        if keyword == "default":
+            continue
+        if keyword in lower:
+            return threshold
+    return HUNG_CHECK_THRESHOLDS_SECONDS["default"]
+
+
+def hung_checks_from_checks(checks):
+    """Return checks that have been pending longer than their hung threshold."""
+    hung = []
+    now = time.time()
+    for check in checks:
+        if not is_pending_check(check):
+            continue
+        started_at_str = check.get("startedAt") or ""
+        if not started_at_str:
+            continue
+        try:
+            started_at = datetime.fromisoformat(
+                started_at_str.replace("Z", "+00:00")
+            ).timestamp()
+        except ValueError:
+            continue
+        elapsed = now - started_at
+        threshold = hung_threshold_for_check(check.get("name") or "")
+        if elapsed > threshold:
+            hung.append(
+                {
+                    "name": check.get("name") or "",
+                    "elapsed_seconds": int(elapsed),
+                    "threshold_seconds": threshold,
+                }
+            )
+    return hung
+
+
+def recommend_actions(
+    pr,
+    checks_summary,
+    failed_runs,
+    new_review_items,
+    hung_checks,
+    retries_used,
+    max_retries,
+    checks_terminal_elapsed=None,
+    blocking_review_items=None,
+):
+    actions = []
+    if pr["closed"] or pr["merged"]:
+        if new_review_items:
+            actions.append("process_review_comment")
+        actions.append("stop_pr_closed")
+        return unique_actions(actions)
+
+    if is_pr_ready_to_merge(
+        pr,
+        checks_summary,
+        new_review_items,
+        checks_terminal_elapsed=checks_terminal_elapsed,
+        blocking_review_items=blocking_review_items,
+    ):
+        actions.append("stop_ready_to_merge")
+        return unique_actions(actions)
+
+    if new_review_items:
+        actions.append("process_review_comment")
+    elif blocking_review_items:
+        actions.append("process_review_comment")
+
+    if hung_checks:
+        actions.append("diagnose_hung_check")
+
+    has_failed_pr_checks = checks_summary["failed_count"] > 0
+    if has_failed_pr_checks:
+        retry_eligible_failed_runs = [run for run in failed_runs if is_retry_eligible_failed_run(run)]
+        non_retry_eligible_failed_runs = [run for run in failed_runs if not is_retry_eligible_failed_run(run)]
+        actions.append("diagnose_ci_failure")
+        if checks_summary["all_terminal"]:
+            if non_retry_eligible_failed_runs:
+                actions.append("stop_non_retryable_failure")
+            elif retry_eligible_failed_runs:
+                if retries_used >= max_retries:
+                    actions.append("stop_exhausted_retries")
+                else:
+                    actions.append("retry_failed_checks")
+            else:
+                actions.append("stop_non_retryable_failure")
+
+    if not actions:
+        actions.append("idle")
+    return unique_actions(actions)
+
+
+def collect_snapshot(args):
+    pr = resolve_pr(args.pr, repo_override=args.repo)
+    state_path = Path(args.state_file) if args.state_file else default_state_file_for(pr)
+    state, fresh_state = load_state(state_path)
+
+    if not state.get("started_at"):
+        state["started_at"] = int(time.time())
+
+    # `gh pr checks -R <repo>` requires an explicit PR/branch/url argument.
+    # After resolving `--pr auto`, reuse the concrete PR number.
+    checks = get_pr_checks(str(pr["number"]), repo=pr["repo"])
+    checks_summary = summarize_checks(checks)
+    hung_checks = hung_checks_from_checks(checks)
+    workflow_runs = get_workflow_runs_for_sha(pr["repo"], pr["head_sha"])
+    failed_runs = failed_runs_from_workflow_runs(workflow_runs, pr["head_sha"])
+    authenticated_login = get_authenticated_login()
+    new_review_items, blocking_review_items = fetch_new_review_items(
+        pr,
+        state,
+        fresh_state=fresh_state,
+        authenticated_login=authenticated_login,
+    )
+
+    # Track when checks first went all_terminal for the current head SHA.
+    # This timestamp is used to enforce a grace period before emitting
+    # stop_ready_to_merge, preventing a race where the script declares the PR
+    # ready before review bots have finished posting their inline comments.
+    now = int(time.time())
+    head_sha = pr["head_sha"]
+    if checks_summary["all_terminal"]:
+        if state.get("checks_terminal_sha") != head_sha:
+            # First time we see all_terminal for this SHA — record the timestamp.
+            state["checks_terminal_sha"] = head_sha
+            state["checks_went_terminal_at"] = now
+        recorded_at = state.get("checks_went_terminal_at")
+        if recorded_at is None:
+            # SHA matched but timestamp is absent (e.g. manually edited state
+            # file). Initialize to now so the grace period starts from this poll.
+            state["checks_went_terminal_at"] = now
+            checks_terminal_elapsed = 0
+        else:
+            checks_terminal_elapsed = max(0, now - int(recorded_at))
+    else:
+        # Checks are still running — reset so the grace period starts fresh
+        # once they become terminal.
+        state["checks_terminal_sha"] = None
+        state["checks_went_terminal_at"] = None
+        checks_terminal_elapsed = None
+
+    retries_used = current_retry_count(state, pr["head_sha"])
+    actions = recommend_actions(
+        pr,
+        checks_summary,
+        failed_runs,
+        new_review_items,
+        hung_checks,
+        retries_used,
+        args.max_flaky_retries,
+        checks_terminal_elapsed=checks_terminal_elapsed,
+        blocking_review_items=blocking_review_items,
+    )
+
+    state["pr"] = {"repo": pr["repo"], "number": pr["number"]}
+    state["last_seen_head_sha"] = pr["head_sha"]
+    state["last_snapshot_at"] = now
+    save_state(state_path, state)
+
+    snapshot = {
+        "pr": pr,
+        "checks": checks_summary,
+        "failed_runs": failed_runs,
+        "hung_checks": hung_checks,
+        "new_review_items": new_review_items,
+        "blocking_review_items": blocking_review_items,
+        "actions": actions,
+        "retry_state": {
+            "current_sha_retries_used": retries_used,
+            "max_flaky_retries": args.max_flaky_retries,
+        },
+        "checks_terminal_elapsed_seconds": checks_terminal_elapsed,
+    }
+    return snapshot, state_path
+
+
+def retry_failed_now(args):
+    snapshot, state_path = collect_snapshot(args)
+    pr = snapshot["pr"]
+    checks_summary = snapshot["checks"]
+    failed_runs = snapshot["failed_runs"]
+    retries_used = snapshot["retry_state"]["current_sha_retries_used"]
+    max_retries = snapshot["retry_state"]["max_flaky_retries"]
+
+    result = {
+        "snapshot": snapshot,
+        "state_file": str(state_path),
+        "rerun_attempted": False,
+        "rerun_count": 0,
+        "rerun_run_ids": [],
+        "reason": None,
+    }
+
+    if pr["closed"] or pr["merged"]:
+        result["reason"] = "pr_closed"
+        return result
+    if checks_summary["failed_count"] <= 0:
+        result["reason"] = "no_failed_pr_checks"
+        return result
+    if not failed_runs:
+        result["reason"] = "no_failed_runs"
+        return result
+    if not checks_summary["all_terminal"]:
+        result["reason"] = "checks_still_pending"
+        return result
+
+    retry_eligible_failed_runs = [run for run in failed_runs if is_retry_eligible_failed_run(run)]
+    non_retry_eligible_failed_runs = [run for run in failed_runs if not is_retry_eligible_failed_run(run)]
+    if non_retry_eligible_failed_runs:
+        result["reason"] = "contains_non_retryable_failed_runs"
+        return result
+    if not retry_eligible_failed_runs:
+        result["reason"] = "no_retry_eligible_failed_runs"
+        return result
+    if retries_used >= max_retries:
+        result["reason"] = "retry_budget_exhausted"
+        return result
+
+    for run in retry_eligible_failed_runs:
+        run_id = run.get("run_id")
+        if run_id in (None, ""):
+            continue
+        gh_text(["run", "rerun", str(run_id), "--failed"], repo=pr["repo"])
+        result["rerun_run_ids"].append(run_id)
+
+    if result["rerun_run_ids"]:
+        state, _ = load_state(state_path)
+        new_count = current_retry_count(state, pr["head_sha"]) + 1
+        set_retry_count(state, pr["head_sha"], new_count)
+        state["last_snapshot_at"] = int(time.time())
+        save_state(state_path, state)
+        result["rerun_attempted"] = True
+        result["rerun_count"] = len(result["rerun_run_ids"])
+        result["reason"] = "rerun_triggered"
+    else:
+        result["reason"] = "failed_runs_missing_ids"
+
+    return result
+
+
+def print_json(obj):
+    sys.stdout.write(json.dumps(obj, sort_keys=True) + "\n")
+    sys.stdout.flush()
+
+
+def print_event(event, payload):
+    print_json({"event": event, "payload": payload})
+
+
+def is_ci_green(snapshot):
+    """Return True only when it is safe to start backing off the poll interval.
+
+    Requirements:
+    - All checks are terminal with no failures.
+    - The PR review decision is not actively blocking (REVIEW_REQUIRED /
+      CHANGES_REQUESTED): those states mean we are explicitly waiting for a
+      reviewer, so backing off would delay detecting their response.
+    - The checks-terminal grace period has fully elapsed.  During the grace
+      window we are explicitly waiting for review bots to post their inline
+      comments, so backing off would delay detecting them.
+    """
+    if _grace_period_active(snapshot):
+        return False
+    checks = snapshot.get("checks") or {}
+    pr = snapshot.get("pr") or {}
+    review_decision = str(pr.get("review_decision") or "")
+    return (
+        bool(checks.get("all_terminal"))
+        and int(checks.get("failed_count") or 0) == 0
+        and int(checks.get("pending_count") or 0) == 0
+        and review_decision not in MERGE_BLOCKING_REVIEW_DECISIONS
+    )
+
+
+def snapshot_change_key(snapshot):
+    pr = snapshot.get("pr") or {}
+    checks = snapshot.get("checks") or {}
+    review_items = snapshot.get("new_review_items") or []
+    blocking_review_items = snapshot.get("blocking_review_items") or []
+    return (
+        str(pr.get("head_sha") or ""),
+        str(pr.get("state") or ""),
+        str(pr.get("mergeable") or ""),
+        str(pr.get("merge_state_status") or ""),
+        str(pr.get("review_decision") or ""),
+        int(checks.get("passed_count") or 0),
+        int(checks.get("failed_count") or 0),
+        int(checks.get("pending_count") or 0),
+        tuple(
+            (str(item.get("kind") or ""), str(item.get("id") or ""))
+            for item in review_items
+            if isinstance(item, dict)
+        ),
+        tuple(
+            (str(item.get("kind") or ""), str(item.get("id") or ""))
+            for item in blocking_review_items
+            if isinstance(item, dict)
+        ),
+        tuple(snapshot.get("actions") or []),
+        # Include whether the checks-terminal grace period is still active.
+        # This flips exactly once (True → False) when the grace period expires,
+        # ensuring the change-key transitions at that moment and preventing the
+        # exponential backoff from starting until after the grace window closes.
+        _grace_period_active(snapshot),
+    )
+
+
+def _grace_period_active(snapshot):
+    elapsed = snapshot.get("checks_terminal_elapsed_seconds")
+    if elapsed is None:
+        return False
+    return elapsed < CHECKS_TERMINAL_GRACE_PERIOD_SECONDS
+
+
+def run_watch(args):
+    poll_seconds = args.poll_seconds
+    last_change_key = None
+    watch_started_at = time.time()
+    max_session_seconds = args.max_session_minutes * 60
+    while True:
+        elapsed = time.time() - watch_started_at
+        if elapsed > max_session_seconds:
+            print_event(
+                "stop",
+                {
+                    "actions": ["stop_session_timeout"],
+                    "elapsed_seconds": int(elapsed),
+                    "max_session_seconds": max_session_seconds,
+                },
+            )
+            return 0
+        snapshot, state_path = collect_snapshot(args)
+        print_event(
+            "snapshot",
+            {
+                "snapshot": snapshot,
+                "state_file": str(state_path),
+                "next_poll_seconds": poll_seconds,
+            },
+        )
+        actions = set(snapshot.get("actions") or [])
+        if (
+            "stop_pr_closed" in actions
+            or "stop_exhausted_retries" in actions
+            or "stop_non_retryable_failure" in actions
+            or "stop_ready_to_merge" in actions
+            or "diagnose_hung_check" in actions
+        ):
+            print_event("stop", {"actions": snapshot.get("actions"), "pr": snapshot.get("pr")})
+            return 0
+
+        current_change_key = snapshot_change_key(snapshot)
+        changed = current_change_key != last_change_key
+        green = is_ci_green(snapshot)
+
+        if not green:
+            poll_seconds = args.poll_seconds
+        elif changed or last_change_key is None:
+            poll_seconds = args.poll_seconds
+        else:
+            poll_seconds = min(poll_seconds * 2, GREEN_STATE_MAX_POLL_SECONDS)
+
+        last_change_key = current_change_key
+        time.sleep(poll_seconds)
+
+
+def main():
+    args = parse_args()
+    try:
+        if args.retry_failed_now:
+            print_json(retry_failed_now(args))
+            return 0
+        if args.watch:
+            return run_watch(args)
+        snapshot, state_path = collect_snapshot(args)
+        snapshot["state_file"] = str(state_path)
+        print_json(snapshot)
+        return 0
+    except (GhCommandError, RuntimeError, ValueError) as err:
+        sys.stderr.write(f"gh_pr_watch.py error: {err}\n")
+        return 1
+    except KeyboardInterrupt:
+        sys.stderr.write("gh_pr_watch.py interrupted\n")
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -535,17 +535,13 @@ def is_trusted_human_review_author(item, authenticated_login):
     return association in TRUSTED_AUTHOR_ASSOCIATIONS
 
 
-def is_blocking_review_item(item, head_sha, unresolved_comment_ids=None):
+def is_blocking_review_item(item, unresolved_comment_ids=None):
     if not isinstance(item, dict):
         return False
     if str(item.get("kind") or "") != "review_comment":
         return False
-    commit_id = str(item.get("commit_id") or "")
-    if not commit_id or not head_sha or commit_id != head_sha:
-        return False
-    # Only block on comments whose review thread is still unresolved. GitHub
-    # maps commit_id to the latest SHA for unchanged lines, so without this
-    # check resolved threads would continue to appear as blocking after fixes.
+    # Block on any inline comment whose thread is unresolved, regardless of which
+    # commit it was posted on. Unresolved threads always represent pending feedback.
     if unresolved_comment_ids is not None:
         item_id = str(item.get("id") or "")
         return item_id in unresolved_comment_ids
@@ -605,7 +601,6 @@ def fetch_unresolved_comment_ids(repo, pr_number):
 def fetch_new_review_items(pr, state, authenticated_login=None):
     repo = pr["repo"]
     pr_number = pr["number"]
-    head_sha = str(pr.get("head_sha") or "")
     endpoints = comment_endpoints(repo, pr_number)
 
     issue_payload = gh_api_list_paginated(endpoints["issue_comment"], repo=repo)
@@ -669,9 +664,7 @@ def fetch_new_review_items(pr, state, authenticated_login=None):
     blocking_items = [
         item
         for item in actionable_items
-        if is_blocking_review_item(
-            item, head_sha=head_sha, unresolved_comment_ids=unresolved_comment_ids
-        )
+        if is_blocking_review_item(item, unresolved_comment_ids=unresolved_comment_ids)
     ]
     blocking_items.sort(
         key=lambda item: (

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -535,7 +535,7 @@ def is_trusted_human_review_author(item, authenticated_login):
     return association in TRUSTED_AUTHOR_ASSOCIATIONS
 
 
-def is_blocking_review_item(item, head_sha, now_seconds=None):
+def is_blocking_review_item(item, head_sha, unresolved_comment_ids=None):
     if not isinstance(item, dict):
         return False
     if str(item.get("kind") or "") != "review_comment":
@@ -543,10 +543,52 @@ def is_blocking_review_item(item, head_sha, now_seconds=None):
     commit_id = str(item.get("commit_id") or "")
     if not commit_id or not head_sha or commit_id != head_sha:
         return False
-    # Any inline bot/human comment on the current SHA blocks until explicitly
-    # resolved. Age-based expiry was removed because it allowed unresolved
-    # comments to silently fall out of the blocking list after 30 minutes.
+    # Only block on comments whose review thread is still unresolved. GitHub
+    # maps commit_id to the latest SHA for unchanged lines, so without this
+    # check resolved threads would continue to appear as blocking after fixes.
+    if unresolved_comment_ids is not None:
+        item_id = str(item.get("id") or "")
+        return item_id in unresolved_comment_ids
     return True
+
+
+def fetch_unresolved_comment_ids(repo, pr_number):
+    """Returns a set of comment IDs (as strings) belonging to unresolved review threads."""
+    owner, name = repo.split("/", 1)
+    query = (
+        "{"
+        f'  repository(owner: "{owner}", name: "{name}") {{'
+        f"    pullRequest(number: {pr_number}) {{"
+        "      reviewThreads(first: 100) {"
+        "        nodes {"
+        "          isResolved"
+        "          comments(first: 100) {"
+        "            nodes { databaseId }"
+        "          }"
+        "        }"
+        "      }"
+        "    }"
+        "  }"
+        "}"
+    )
+    result = gh_json(["api", "graphql", "-f", f"query={query}"])
+    threads = (
+        (result or {})
+        .get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+        .get("nodes", [])
+    )
+    ids = set()
+    for thread in threads:
+        if thread.get("isResolved"):
+            continue
+        for comment in (thread.get("comments") or {}).get("nodes", []):
+            db_id = comment.get("databaseId")
+            if db_id is not None:
+                ids.add(str(db_id))
+    return ids
 
 
 def fetch_new_review_items(pr, state, authenticated_login=None):
@@ -612,10 +654,13 @@ def fetch_new_review_items(pr, state, authenticated_login=None):
             item.get("id") or "",
         )
     )
+    unresolved_comment_ids = fetch_unresolved_comment_ids(repo, pr_number)
     blocking_items = [
         item
         for item in actionable_items
-        if is_blocking_review_item(item, head_sha=head_sha)
+        if is_blocking_review_item(
+            item, head_sha=head_sha, unresolved_comment_ids=unresolved_comment_ids
+        )
     ]
     blocking_items.sort(
         key=lambda item: (
@@ -802,11 +847,10 @@ def collect_snapshot(args):
     hung_checks = hung_checks_from_checks(checks)
     workflow_runs = get_workflow_runs_for_sha(pr["repo"], pr["head_sha"])
     failed_runs = failed_runs_from_workflow_runs(workflow_runs, pr["head_sha"])
-    authenticated_login = get_authenticated_login()
     new_review_items, blocking_review_items = fetch_new_review_items(
         pr,
         state,
-        authenticated_login=authenticated_login,
+        authenticated_login=args.authenticated_login,
     )
 
     # Track when checks first went all_terminal for the current head SHA.
@@ -1026,14 +1070,6 @@ def run_watch(args):
             )
             return 0
         snapshot, state_path = collect_snapshot(args)
-        print_event(
-            "snapshot",
-            {
-                "snapshot": snapshot,
-                "state_file": str(state_path),
-                "next_poll_seconds": poll_seconds,
-            },
-        )
         actions = set(snapshot.get("actions") or [])
         if (
             "stop_pr_closed" in actions
@@ -1057,11 +1093,22 @@ def run_watch(args):
             poll_seconds = min(poll_seconds * 2, GREEN_STATE_MAX_POLL_SECONDS)
 
         last_change_key = current_change_key
+        # Emit snapshot after computing poll_seconds so next_poll_seconds is accurate.
+        print_event(
+            "snapshot",
+            {
+                "snapshot": snapshot,
+                "state_file": str(state_path),
+                "next_poll_seconds": poll_seconds,
+            },
+        )
         time.sleep(poll_seconds)
 
 
 def main():
     args = parse_args()
+    # Fetch once per session; collect_snapshot accesses it via args.authenticated_login.
+    args.authenticated_login = get_authenticated_login()
     try:
         if args.retry_failed_now:
             print_json(retry_failed_now(args))

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -553,41 +553,52 @@ def is_blocking_review_item(item, head_sha, unresolved_comment_ids=None):
 
 
 def fetch_unresolved_comment_ids(repo, pr_number):
-    """Returns a set of comment IDs (as strings) belonging to unresolved review threads."""
+    """Returns a set of comment IDs (as strings) belonging to unresolved review threads.
+
+    Paginates through all review threads and their comments to avoid missing any
+    unresolved feedback on large PRs.
+    """
     owner, name = repo.split("/", 1)
-    query = (
-        "{"
-        f'  repository(owner: "{owner}", name: "{name}") {{'
-        f"    pullRequest(number: {pr_number}) {{"
-        "      reviewThreads(first: 100) {"
-        "        nodes {"
-        "          isResolved"
-        "          comments(first: 100) {"
-        "            nodes { databaseId }"
-        "          }"
-        "        }"
-        "      }"
-        "    }"
-        "  }"
-        "}"
-    )
-    result = gh_json(["api", "graphql", "-f", f"query={query}"])
-    threads = (
-        (result or {})
-        .get("data", {})
-        .get("repository", {})
-        .get("pullRequest", {})
-        .get("reviewThreads", {})
-        .get("nodes", [])
-    )
     ids = set()
-    for thread in threads:
-        if thread.get("isResolved"):
-            continue
-        for comment in (thread.get("comments") or {}).get("nodes", []):
-            db_id = comment.get("databaseId")
-            if db_id is not None:
-                ids.add(str(db_id))
+    cursor = None
+    while True:
+        after = f', after: "{cursor}"' if cursor else ""
+        query = (
+            "{"
+            f'  repository(owner: "{owner}", name: "{name}") {{'
+            f"    pullRequest(number: {pr_number}) {{"
+            f"      reviewThreads(first: 100{after}) {{"
+            "        pageInfo { hasNextPage endCursor }"
+            "        nodes {"
+            "          isResolved"
+            "          comments(first: 100) {"
+            "            nodes { databaseId }"
+            "          }"
+            "        }"
+            "      }"
+            "    }"
+            "  }"
+            "}"
+        )
+        result = gh_json(["api", "graphql", "-f", f"query={query}"])
+        threads_data = (
+            (result or {})
+            .get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+        )
+        for thread in (threads_data or {}).get("nodes", []):
+            if thread.get("isResolved"):
+                continue
+            for comment in (thread.get("comments") or {}).get("nodes", []):
+                db_id = comment.get("databaseId")
+                if db_id is not None:
+                    ids.add(str(db_id))
+        page_info = (threads_data or {}).get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
     return ids
 
 
@@ -1078,7 +1089,7 @@ def run_watch(args):
             or "stop_ready_to_merge" in actions
             or "diagnose_hung_check" in actions
         ):
-            print_event("stop", {"actions": snapshot.get("actions"), "pr": snapshot.get("pr")})
+            print_event("stop", {"snapshot": snapshot, "state_file": str(state_path)})
             return 0
 
         current_change_key = snapshot_change_key(snapshot)
@@ -1107,9 +1118,10 @@ def run_watch(args):
 
 def main():
     args = parse_args()
-    # Fetch once per session; collect_snapshot accesses it via args.authenticated_login.
-    args.authenticated_login = get_authenticated_login()
     try:
+        # Fetch once per session inside the error-handling block so GhCommandError
+        # from missing/expired auth is caught and reported via the structured error path.
+        args.authenticated_login = get_authenticated_login()
         if args.retry_failed_now:
             print_json(retry_failed_now(args))
             return 0

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,34 @@
+# Gradle
 .gradle/
-.idea/
+build/
+out/
+
+# Kotlin
 .kotlin/
-.tmp/
-.plans/
-.worktrees/
-worktrees/
-**/build/
-**/out/
+
+# IntelliJ / Android Studio
+.idea/*
+!.idea/codeStyles/
+!.idea/detekt.xml
+!.idea/externalDependencies.xml
+!.idea/inspectionProfiles/
+!.idea/runConfigurations/
+!.idea/ktfmt.xml
+!.idea/vcs.xml
 *.iml
+
+# OS
 .DS_Store
+
+# Worktrees
+/.worktrees/
+/worktrees/
+/.claude/worktrees/
+
+# Plans / scratch
+.plans/
+/.agents/tasks/
+.agents/skills/*/tmp/
+
+# Temp
+.tmp/

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -11,5 +11,11 @@ dependencies {
     implementation(libs.compose.foundation)
     implementation(libs.compose.ui)
     implementation(libs.kotlinx.coroutines.core)
+    implementation(libs.kotlinx.coroutines.swing)
     detektPlugins(libs.compose.rules.detekt)
+
+    testImplementation(libs.kotlin.testJunit5)
+    testImplementation(libs.kotlinx.coroutines.test)
 }
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -19,7 +19,7 @@ data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) 
             val lastColon = key.lastIndexOf(':')
             require(lastColon > 0) { "Invalid NodeKey: $key" }
             val beforeLast = key.lastIndexOf(':', lastColon - 1)
-            require(beforeLast > 0) { "Invalid NodeKey: $key" }
+            require(beforeLast >= 0) { "Invalid NodeKey: $key" }
 
             val surfaceId = key.substring(0, beforeLast)
             val ownerIndex = key.substring(beforeLast + 1, lastColon).toInt()

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -1,0 +1,93 @@
+package dev.sebastiano.spectre.core
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+import java.awt.Point
+
+data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) {
+
+    override fun toString(): String = "$surfaceId:$ownerIndex:$nodeId"
+
+    companion object {
+
+        fun parse(key: String): NodeKey {
+            // Split from the right: last segment is nodeId, second-to-last is ownerIndex,
+            // everything before is surfaceId (which may contain colons).
+            val lastColon = key.lastIndexOf(':')
+            require(lastColon > 0) { "Invalid NodeKey: $key" }
+            val beforeLast = key.lastIndexOf(':', lastColon - 1)
+            require(beforeLast > 0) { "Invalid NodeKey: $key" }
+
+            val surfaceId = key.substring(0, beforeLast)
+            val ownerIndex = key.substring(beforeLast + 1, lastColon).toInt()
+            val nodeId = key.substring(lastColon + 1).toInt()
+            return NodeKey(surfaceId, ownerIndex, nodeId)
+        }
+    }
+}
+
+class AutomatorNode(
+    val key: NodeKey,
+    val semanticsNode: SemanticsNode,
+    val trackedWindow: TrackedWindow,
+) {
+
+    val testTag: String?
+        get() = semanticsNode.config.getOrNull(SemanticsProperties.TestTag)
+
+    val text: String?
+        get() = semanticsNode.config.getOrNull(SemanticsProperties.Text)?.firstOrNull()?.text
+
+    val editableText: String?
+        get() = semanticsNode.config.getOrNull(SemanticsProperties.EditableText)?.text
+
+    val contentDescription: String?
+        get() =
+            semanticsNode.config.getOrNull(SemanticsProperties.ContentDescription)?.firstOrNull()
+
+    val role: Role?
+        get() = semanticsNode.config.getOrNull(SemanticsProperties.Role)
+
+    val isDisabled: Boolean
+        get() = semanticsNode.config.getOrNull(SemanticsProperties.Disabled) != null
+
+    val isFocused: Boolean
+        get() = semanticsNode.config.getOrNull(SemanticsProperties.Focused) == true
+
+    val isSelected: Boolean
+        get() = semanticsNode.config.getOrNull(SemanticsProperties.Selected) == true
+
+    val boundsInWindow: Rect
+        get() = semanticsNode.boundsInWindow
+
+    val centerOnScreen: Point
+        get() {
+            val bounds = semanticsNode.boundsInWindow
+            val scale = trackedWindow.window.graphicsConfiguration.defaultTransform.scaleX.toFloat()
+            // boundsInWindow is relative to the Compose content area, which sits inside
+            // the window's content pane (below title bar and decorations).
+            // Use ComposePanel location if available, otherwise the content pane for JFrames,
+            // falling back to the window itself for undecorated windows.
+            val contentOrigin = trackedWindow.composeContentOrigin
+            return composeBoundsToAwtCenter(
+                left = bounds.left,
+                top = bounds.top,
+                right = bounds.right,
+                bottom = bounds.bottom,
+                scale = scale,
+                panelScreenX = contentOrigin.x,
+                panelScreenY = contentOrigin.y,
+            )
+        }
+
+    override fun toString(): String = buildString {
+        append("AutomatorNode(key=$key")
+        testTag?.let { append(", tag=$it") }
+        text?.let { append(", text=$it") }
+        role?.let { append(", role=$it") }
+        append(")")
+    }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -38,15 +38,20 @@ class AutomatorNode(
     val testTag: String?
         get() = semanticsNode.config.getOrNull(SemanticsProperties.TestTag)
 
+    val texts: List<String>
+        get() = semanticsNode.config.getOrNull(SemanticsProperties.Text)?.map { it.text }.orEmpty()
+
     val text: String?
-        get() = semanticsNode.config.getOrNull(SemanticsProperties.Text)?.firstOrNull()?.text
+        get() = texts.firstOrNull()
 
     val editableText: String?
         get() = semanticsNode.config.getOrNull(SemanticsProperties.EditableText)?.text
 
+    val contentDescriptions: List<String>
+        get() = semanticsNode.config.getOrNull(SemanticsProperties.ContentDescription).orEmpty()
+
     val contentDescription: String?
-        get() =
-            semanticsNode.config.getOrNull(SemanticsProperties.ContentDescription)?.firstOrNull()
+        get() = contentDescriptions.firstOrNull()
 
     val role: Role?
         get() = semanticsNode.config.getOrNull(SemanticsProperties.Role)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -35,38 +35,22 @@ class AutomatorNode(
     val trackedWindow: TrackedWindow,
 ) {
 
-    val testTag: String?
-        get() = semanticsNode.config.getOrNull(SemanticsProperties.TestTag)
-
-    val texts: List<String>
-        get() = semanticsNode.config.getOrNull(SemanticsProperties.Text)?.map { it.text }.orEmpty()
-
-    val text: String?
-        get() = texts.firstOrNull()
-
-    val editableText: String?
-        get() = semanticsNode.config.getOrNull(SemanticsProperties.EditableText)?.text
-
-    val contentDescriptions: List<String>
-        get() = semanticsNode.config.getOrNull(SemanticsProperties.ContentDescription).orEmpty()
-
-    val contentDescription: String?
-        get() = contentDescriptions.firstOrNull()
-
-    val role: Role?
-        get() = semanticsNode.config.getOrNull(SemanticsProperties.Role)
-
-    val isDisabled: Boolean
-        get() = semanticsNode.config.getOrNull(SemanticsProperties.Disabled) != null
-
-    val isFocused: Boolean
-        get() = semanticsNode.config.getOrNull(SemanticsProperties.Focused) == true
-
-    val isSelected: Boolean
-        get() = semanticsNode.config.getOrNull(SemanticsProperties.Selected) == true
-
-    val boundsInWindow: Rect
-        get() = semanticsNode.boundsInWindow
+    // Eagerly snapshot all semantics properties at construction time (which runs on
+    // the EDT inside readAllNodes) so callers can safely read them from any thread.
+    val testTag: String? = semanticsNode.config.getOrNull(SemanticsProperties.TestTag)
+    val texts: List<String> =
+        semanticsNode.config.getOrNull(SemanticsProperties.Text)?.map { it.text }.orEmpty()
+    val text: String? = texts.firstOrNull()
+    val editableText: String? =
+        semanticsNode.config.getOrNull(SemanticsProperties.EditableText)?.text
+    val contentDescriptions: List<String> =
+        semanticsNode.config.getOrNull(SemanticsProperties.ContentDescription).orEmpty()
+    val contentDescription: String? = contentDescriptions.firstOrNull()
+    val role: Role? = semanticsNode.config.getOrNull(SemanticsProperties.Role)
+    val isDisabled: Boolean = semanticsNode.config.getOrNull(SemanticsProperties.Disabled) != null
+    val isFocused: Boolean = semanticsNode.config.getOrNull(SemanticsProperties.Focused) == true
+    val isSelected: Boolean = semanticsNode.config.getOrNull(SemanticsProperties.Selected) == true
+    val boundsInWindow: Rect = semanticsNode.boundsInWindow
 
     val centerOnScreen: Point
         get() = readOnEdt {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -64,20 +64,17 @@ class AutomatorNode(
         get() = semanticsNode.boundsInWindow
 
     val centerOnScreen: Point
-        get() {
+        get() = readOnEdt {
             val bounds = semanticsNode.boundsInWindow
-            val scale = trackedWindow.window.graphicsConfiguration.defaultTransform.scaleX.toFloat()
-            // boundsInWindow is relative to the Compose content area, which sits inside
-            // the window's content pane (below title bar and decorations).
-            // Use ComposePanel location if available, otherwise the content pane for JFrames,
-            // falling back to the window itself for undecorated windows.
+            val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
             val contentOrigin = trackedWindow.composeContentOrigin
-            return composeBoundsToAwtCenter(
+            composeBoundsToAwtCenter(
                 left = bounds.left,
                 top = bounds.top,
                 right = bounds.right,
                 bottom = bounds.bottom,
-                scale = scale,
+                scaleX = transform.scaleX.toFloat(),
+                scaleY = transform.scaleY.toFloat(),
                 panelScreenX = contentOrigin.x,
                 panelScreenY = contentOrigin.y,
             )

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -76,15 +76,19 @@ private constructor(
         }
     }
 
-    fun printTree(): String = buildString {
+    fun printTree(): String {
         refreshWindows()
-        for ((windowIndex, trackedWindow) in windows.withIndex()) {
-            val kind = if (trackedWindow.isPopup) "popup" else "main"
-            appendLine("Window $windowIndex ($kind): ${trackedWindow.surfaceId}")
-            val allNodes = semanticsReader.readAllNodes(listOf(trackedWindow))
-            val roots = allNodes.filter { it.semanticsNode.parent == null }
-            for (root in roots) {
-                appendNodeTree(root, allNodes, depth = 1)
+        return readOnEdt {
+            buildString {
+                for ((windowIndex, trackedWindow) in windows.withIndex()) {
+                    val kind = if (trackedWindow.isPopup) "popup" else "main"
+                    appendLine("Window $windowIndex ($kind): ${trackedWindow.surfaceId}")
+                    val allNodes = semanticsReader.readAllNodes(listOf(trackedWindow))
+                    val roots = allNodes.filter { it.semanticsNode.parent == null }
+                    for (root in roots) {
+                        appendNodeTree(root, allNodes, depth = 1)
+                    }
+                }
             }
         }
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -64,32 +64,26 @@ private constructor(
         text: String? = null,
         timeout: Duration = 5.seconds,
         pollInterval: Duration = 100.milliseconds,
-    ): AutomatorNode =
-        waitUntil(timeout = timeout, pollInterval = pollInterval) {
+    ): AutomatorNode {
+        require(tag != null || text != null) { "Either tag or text must be specified" }
+        return waitUntil(timeout = timeout, pollInterval = pollInterval) {
             refreshWindows()
-            when {
-                tag != null -> findOneByTestTag(tag)
-                text != null -> findOneByText(text)
-                else -> error("Either tag or text must be specified")
+            val candidates = allNodes()
+            candidates.firstOrNull { node ->
+                (tag == null || node.testTag == tag) && (text == null || node.text == text)
             }
         }
+    }
 
     fun printTree(): String = buildString {
         refreshWindows()
         for ((windowIndex, trackedWindow) in windows.withIndex()) {
             val kind = if (trackedWindow.isPopup) "popup" else "main"
             appendLine("Window $windowIndex ($kind): ${trackedWindow.surfaceId}")
-            val nodes = semanticsReader.readAllNodes(listOf(trackedWindow))
-            for (node in nodes) {
-                val indent = "  "
-                append(indent)
-                append("[${node.key.nodeId}]")
-                node.testTag?.let { append(" testTag=\"$it\"") }
-                node.text?.let { append(" text=\"$it\"") }
-                node.role?.let { append(" role=$it") }
-                if (node.isFocused) append(" focused")
-                if (node.isDisabled) append(" disabled")
-                appendLine()
+            val allNodes = semanticsReader.readAllNodes(listOf(trackedWindow))
+            val roots = allNodes.filter { it.semanticsNode.parent == null }
+            for (root in roots) {
+                appendNodeTree(root, allNodes, depth = 1)
             }
         }
     }
@@ -101,5 +95,26 @@ private constructor(
             semanticsReader: SemanticsReader = SemanticsReader(),
             robotDriver: RobotDriver = RobotDriver(),
         ): ComposeAutomator = ComposeAutomator(windowTracker, semanticsReader, robotDriver)
+    }
+}
+
+private fun StringBuilder.appendNodeTree(
+    node: AutomatorNode,
+    allNodes: List<AutomatorNode>,
+    depth: Int,
+) {
+    append("  ".repeat(depth))
+    append("[${node.key.nodeId}]")
+    node.testTag?.let { append(" testTag=\"$it\"") }
+    node.text?.let { append(" text=\"$it\"") }
+    node.role?.let { append(" role=$it") }
+    if (node.isFocused) append(" focused")
+    if (node.isDisabled) append(" disabled")
+    appendLine()
+    for (child in node.semanticsNode.children) {
+        val childNode = allNodes.find { it.key.nodeId == child.id }
+        if (childNode != null) {
+            appendNodeTree(childNode, allNodes, depth + 1)
+        }
     }
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -69,8 +69,12 @@ private constructor(
         return waitUntil(timeout = timeout, pollInterval = pollInterval) {
             refreshWindows()
             val byTag = if (tag != null) findByTestTag(tag) else allNodes()
-            val byText = if (text != null) findByText(text) else allNodes()
-            byTag.firstOrNull { it in byText }
+            if (text == null) {
+                byTag.firstOrNull()
+            } else {
+                val textKeys = findByText(text).map { it.key }.toSet()
+                byTag.firstOrNull { it.key in textKeys }
+            }
         }
     }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -68,12 +68,10 @@ private constructor(
         require(tag != null || text != null) { "Either tag or text must be specified" }
         return waitUntil(timeout = timeout, pollInterval = pollInterval) {
             refreshWindows()
-            val byTag = if (tag != null) findByTestTag(tag) else allNodes()
-            if (text == null) {
-                byTag.firstOrNull()
-            } else {
-                val textKeys = findByText(text).map { it.key }.toSet()
-                byTag.firstOrNull { it.key in textKeys }
+            // Single readAllNodes snapshot, then filter locally for both criteria
+            allNodes().firstOrNull { node ->
+                (tag == null || node.testTag == tag) &&
+                    (text == null || node.texts.any { it == text } || node.editableText == text)
             }
         }
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -77,8 +77,8 @@ private constructor(
     }
 
     fun printTree(): String {
-        refreshWindows()
         return readOnEdt {
+            refreshWindows()
             buildString {
                 for ((windowIndex, trackedWindow) in windows.withIndex()) {
                     val kind = if (trackedWindow.isPopup) "popup" else "main"

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -67,11 +67,13 @@ private constructor(
     ): AutomatorNode {
         require(tag != null || text != null) { "Either tag or text must be specified" }
         return waitUntil(timeout = timeout, pollInterval = pollInterval) {
-            refreshWindows()
-            // Single readAllNodes snapshot, then filter locally for both criteria
-            allNodes().firstOrNull { node ->
-                (tag == null || node.testTag == tag) &&
-                    (text == null || node.texts.any { it == text } || node.editableText == text)
+            // Wrap snapshot + filter in readOnEdt so semantics property reads are thread-safe
+            readOnEdt {
+                refreshWindows()
+                allNodes().firstOrNull { node ->
+                    (tag == null || node.testTag == tag) &&
+                        (text == null || node.texts.any { it == text } || node.editableText == text)
+                }
             }
         }
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -68,10 +68,11 @@ private constructor(
         require(tag != null || text != null) { "Either tag or text must be specified" }
         return waitUntil(timeout = timeout, pollInterval = pollInterval) {
             refreshWindows()
-            val candidates = allNodes()
-            candidates.firstOrNull { node ->
-                (tag == null || node.testTag == tag) && (text == null || node.text == text)
-            }
+            // Use the same matching logic as findByText (all texts + editableText)
+            val byTag = if (tag != null) findByTestTag(tag) else allNodes()
+            val byText =
+                if (text != null) byTag.filter { node -> nodeMatchesText(node, text) } else byTag
+            byText.firstOrNull()
         }
     }
 
@@ -98,6 +99,9 @@ private constructor(
     }
 }
 
+private fun nodeMatchesText(node: AutomatorNode, text: String): Boolean =
+    node.texts.any { it == text } || node.editableText == text
+
 private fun StringBuilder.appendNodeTree(
     node: AutomatorNode,
     allNodes: List<AutomatorNode>,
@@ -111,8 +115,10 @@ private fun StringBuilder.appendNodeTree(
     if (node.isFocused) append(" focused")
     if (node.isDisabled) append(" disabled")
     appendLine()
+    // Match children by full NodeKey (ownerIndex + nodeId) to avoid cross-owner collisions
     for (child in node.semanticsNode.children) {
-        val childNode = allNodes.find { it.key.nodeId == child.id }
+        val childKey = NodeKey(node.key.surfaceId, node.key.ownerIndex, child.id)
+        val childNode = allNodes.find { it.key == childKey }
         if (childNode != null) {
             appendNodeTree(childNode, allNodes, depth + 1)
         }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -1,0 +1,105 @@
+package dev.sebastiano.spectre.core
+
+import androidx.compose.ui.semantics.Role
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+class ComposeAutomator
+private constructor(
+    private val windowTracker: WindowTracker,
+    private val semanticsReader: SemanticsReader,
+    private val robotDriver: RobotDriver,
+) {
+
+    val windows: List<TrackedWindow>
+        get() = windowTracker.trackedWindows
+
+    fun refreshWindows() {
+        windowTracker.refresh()
+    }
+
+    fun allNodes(): List<AutomatorNode> = semanticsReader.readAllNodes(windows)
+
+    fun findByTestTag(tag: String): List<AutomatorNode> =
+        semanticsReader.findByTestTag(tag, windows)
+
+    fun findOneByTestTag(tag: String): AutomatorNode? = findByTestTag(tag).firstOrNull()
+
+    fun findByText(text: String, exact: Boolean = true): List<AutomatorNode> =
+        semanticsReader.findByText(text, windows, exact)
+
+    fun findOneByText(text: String, exact: Boolean = true): AutomatorNode? =
+        findByText(text, exact).firstOrNull()
+
+    fun findByContentDescription(description: String): List<AutomatorNode> =
+        semanticsReader.findByContentDescription(description, windows)
+
+    fun findByRole(role: Role): List<AutomatorNode> = semanticsReader.findByRole(role, windows)
+
+    fun click(node: AutomatorNode) {
+        val center = node.centerOnScreen
+        robotDriver.click(center.x, center.y)
+    }
+
+    fun doubleClick(node: AutomatorNode) {
+        val center = node.centerOnScreen
+        robotDriver.doubleClick(center.x, center.y)
+    }
+
+    fun typeText(text: String) {
+        robotDriver.typeText(text)
+    }
+
+    fun pressKey(keyCode: Int, modifiers: Int = 0) {
+        robotDriver.pressKey(keyCode, modifiers)
+    }
+
+    fun screenshot(region: Rectangle? = null): BufferedImage = robotDriver.screenshot(region)
+
+    suspend fun waitForNode(
+        tag: String? = null,
+        text: String? = null,
+        timeout: Duration = 5.seconds,
+        pollInterval: Duration = 100.milliseconds,
+    ): AutomatorNode =
+        waitUntil(timeout = timeout, pollInterval = pollInterval) {
+            refreshWindows()
+            when {
+                tag != null -> findOneByTestTag(tag)
+                text != null -> findOneByText(text)
+                else -> error("Either tag or text must be specified")
+            }
+        }
+
+    fun printTree(): String = buildString {
+        refreshWindows()
+        for ((windowIndex, trackedWindow) in windows.withIndex()) {
+            val kind = if (trackedWindow.isPopup) "popup" else "main"
+            appendLine("Window $windowIndex ($kind): ${trackedWindow.surfaceId}")
+            val nodes = semanticsReader.readAllNodes(listOf(trackedWindow))
+            for (node in nodes) {
+                val indent = "  "
+                append(indent)
+                append("[${node.key.nodeId}]")
+                node.testTag?.let { append(" testTag=\"$it\"") }
+                node.text?.let { append(" text=\"$it\"") }
+                node.role?.let { append(" role=$it") }
+                if (node.isFocused) append(" focused")
+                if (node.isDisabled) append(" disabled")
+                appendLine()
+            }
+        }
+    }
+
+    companion object {
+
+        fun create(
+            windowTracker: WindowTracker = WindowTracker(),
+            semanticsReader: SemanticsReader = SemanticsReader(),
+            robotDriver: RobotDriver = RobotDriver(),
+        ): ComposeAutomator = ComposeAutomator(windowTracker, semanticsReader, robotDriver)
+    }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -68,11 +68,9 @@ private constructor(
         require(tag != null || text != null) { "Either tag or text must be specified" }
         return waitUntil(timeout = timeout, pollInterval = pollInterval) {
             refreshWindows()
-            // Use the same matching logic as findByText (all texts + editableText)
             val byTag = if (tag != null) findByTestTag(tag) else allNodes()
-            val byText =
-                if (text != null) byTag.filter { node -> nodeMatchesText(node, text) } else byTag
-            byText.firstOrNull()
+            val byText = if (text != null) findByText(text) else allNodes()
+            byTag.firstOrNull { it in byText }
         }
     }
 
@@ -98,9 +96,6 @@ private constructor(
         ): ComposeAutomator = ComposeAutomator(windowTracker, semanticsReader, robotDriver)
     }
 }
-
-private fun nodeMatchesText(node: AutomatorNode, text: String): Boolean =
-    node.texts.any { it == text } || node.editableText == text
 
 private fun StringBuilder.appendNodeTree(
     node: AutomatorNode,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/EdtUtils.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/EdtUtils.kt
@@ -1,0 +1,11 @@
+package dev.sebastiano.spectre.core
+
+import javax.swing.SwingUtilities
+
+internal fun <T> readOnEdt(block: () -> T): T {
+    if (SwingUtilities.isEventDispatchThread()) return block()
+
+    var result: Result<T>? = null
+    SwingUtilities.invokeAndWait { result = runCatching(block) }
+    return result!!.getOrThrow()
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
@@ -10,27 +10,25 @@ import java.awt.Point
  *
  * Formula from IntelliJ remote-driver's ComposeXpathDataModelExtension.
  */
-fun composeToAwtX(composeX: Float, scale: Float, panelScreenX: Int): Int =
-    (composeX / scale).toInt() + panelScreenX
+fun composeToAwtX(composeX: Float, scaleX: Float, panelScreenX: Int): Int =
+    (composeX / scaleX).toInt() + panelScreenX
 
-fun composeToAwtY(composeY: Float, scale: Float, panelScreenY: Int): Int =
-    (composeY / scale).toInt() + panelScreenY
-
-fun composeToAwtSize(composeWidth: Float, composeHeight: Float, scale: Float): Pair<Int, Int> =
-    Pair((composeWidth / scale).toInt(), (composeHeight / scale).toInt())
+fun composeToAwtY(composeY: Float, scaleY: Float, panelScreenY: Int): Int =
+    (composeY / scaleY).toInt() + panelScreenY
 
 fun composeBoundsToAwtCenter(
     left: Float,
     top: Float,
     right: Float,
     bottom: Float,
-    scale: Float,
+    scaleX: Float,
+    scaleY: Float,
     panelScreenX: Int,
     panelScreenY: Int,
 ): Point {
-    val awtLeft = composeToAwtX(left, scale, panelScreenX)
-    val awtTop = composeToAwtY(top, scale, panelScreenY)
-    val awtRight = composeToAwtX(right, scale, panelScreenX)
-    val awtBottom = composeToAwtY(bottom, scale, panelScreenY)
+    val awtLeft = composeToAwtX(left, scaleX, panelScreenX)
+    val awtTop = composeToAwtY(top, scaleY, panelScreenY)
+    val awtRight = composeToAwtX(right, scaleX, panelScreenX)
+    val awtBottom = composeToAwtY(bottom, scaleY, panelScreenY)
     return Point((awtLeft + awtRight) / 2, (awtTop + awtBottom) / 2)
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
@@ -1,0 +1,36 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.Point
+
+/**
+ * Converts a Compose X coordinate to an AWT screen X coordinate.
+ *
+ * Compose semantics geometry is in physical (Compose) pixels. AWT/Robot operates in scaled screen
+ * units. The conversion divides by scale, then adds the panel's screen offset.
+ *
+ * Formula from IntelliJ remote-driver's ComposeXpathDataModelExtension.
+ */
+fun composeToAwtX(composeX: Float, scale: Float, panelScreenX: Int): Int =
+    (composeX / scale).toInt() + panelScreenX
+
+fun composeToAwtY(composeY: Float, scale: Float, panelScreenY: Int): Int =
+    (composeY / scale).toInt() + panelScreenY
+
+fun composeToAwtSize(composeWidth: Float, composeHeight: Float, scale: Float): Pair<Int, Int> =
+    Pair((composeWidth / scale).toInt(), (composeHeight / scale).toInt())
+
+fun composeBoundsToAwtCenter(
+    left: Float,
+    top: Float,
+    right: Float,
+    bottom: Float,
+    scale: Float,
+    panelScreenX: Int,
+    panelScreenY: Int,
+): Point {
+    val awtLeft = composeToAwtX(left, scale, panelScreenX)
+    val awtTop = composeToAwtY(top, scale, panelScreenY)
+    val awtRight = composeToAwtX(right, scale, panelScreenX)
+    val awtBottom = composeToAwtY(bottom, scale, panelScreenY)
+    return Point((awtLeft + awtRight) / 2, (awtTop + awtBottom) / 2)
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -73,9 +73,11 @@ private fun runOffEdt(block: () -> Unit) {
         block()
         return
     }
-    val thread = Thread(block, "spectre-robot")
+    var result: Result<Unit>? = null
+    val thread = Thread({ result = runCatching(block) }, "spectre-robot")
     thread.start()
     thread.join()
+    result!!.getOrThrow()
 }
 
 fun pasteModifierKeyCode(isMacOs: Boolean): Int =

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -43,10 +43,11 @@ class RobotDriver(
     }
 
     fun pressKey(keyCode: Int, modifiers: Int = 0) = runOffEdt {
-        if (modifiers != 0) robot.keyPress(modifiers)
+        val modifierKeys = modifierMaskToKeyCodes(modifiers)
+        for (mod in modifierKeys) robot.keyPress(mod)
         robot.keyPress(keyCode)
         robot.keyRelease(keyCode)
-        if (modifiers != 0) robot.keyRelease(modifiers)
+        for (mod in modifierKeys.reversed()) robot.keyRelease(mod)
     }
 
     fun screenshot(region: Rectangle? = null): BufferedImage {
@@ -82,6 +83,17 @@ private fun runOffEdt(block: () -> Unit) {
 
 fun pasteModifierKeyCode(isMacOs: Boolean): Int =
     if (isMacOs) KeyEvent.VK_META else KeyEvent.VK_CONTROL
+
+/**
+ * Translates an AWT modifier bitmask (e.g. [InputEvent.CTRL_DOWN_MASK]) into individual key codes
+ * that Robot can press/release.
+ */
+fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
+    if (mask and InputEvent.CTRL_DOWN_MASK != 0) add(KeyEvent.VK_CONTROL)
+    if (mask and InputEvent.SHIFT_DOWN_MASK != 0) add(KeyEvent.VK_SHIFT)
+    if (mask and InputEvent.ALT_DOWN_MASK != 0) add(KeyEvent.VK_ALT)
+    if (mask and InputEvent.META_DOWN_MASK != 0) add(KeyEvent.VK_META)
+}
 
 fun detectMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -51,12 +51,7 @@ class RobotDriver(
     }
 
     fun screenshot(region: Rectangle? = null): BufferedImage {
-        val captureRegion =
-            region
-                ?: GraphicsEnvironment.getLocalGraphicsEnvironment()
-                    .defaultScreenDevice
-                    .defaultConfiguration
-                    .bounds
+        val captureRegion = region ?: virtualDesktopBounds()
         return robot.createScreenCapture(captureRegion)
     }
 }
@@ -96,5 +91,14 @@ fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
 }
 
 fun detectMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
+
+private fun virtualDesktopBounds(): Rectangle {
+    val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
+    var bounds = Rectangle()
+    for (device in ge.screenDevices) {
+        bounds = bounds.union(device.defaultConfiguration.bounds)
+    }
+    return bounds
+}
 
 private const val DEFAULT_AUTO_DELAY_MS = 10

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -32,23 +32,22 @@ class RobotDriver(
         }
     }
 
-    fun typeText(text: String) {
+    fun typeText(text: String) = runOffEdt {
         val clipboard = Toolkit.getDefaultToolkit().systemClipboard
         val previousContents = runCatching { clipboard.getContents(null) }.getOrNull()
-        clipboard.setContents(StringSelection(text), null)
-        runOffEdt {
+        try {
+            clipboard.setContents(StringSelection(text), null)
             val modifier = pasteModifierKeyCode(detectMacOs())
             robot.keyPress(modifier)
             robot.keyPress(KeyEvent.VK_V)
             robot.keyRelease(KeyEvent.VK_V)
             robot.keyRelease(modifier)
-        }
-        // Restore via invokeLater so the EDT processes any pending Robot-generated
-        // paste events before the clipboard is replaced. This is safe whether
-        // typeText is called from the EDT (runOffEdt unblocks first, paste events
-        // are queued ahead of invokeLater) or from a background thread.
-        if (previousContents != null) {
-            SwingUtilities.invokeLater {
+        } finally {
+            // Restore synchronously so the clipboard state is deterministic across
+            // back-to-back typeText calls. Note: this automation API is intended for
+            // use from background threads (coroutines), not from the EDT. Calling
+            // typeText from the EDT is unsupported and may race with paste processing.
+            if (previousContents != null) {
                 runCatching { clipboard.setContents(previousContents, null) }
             }
         }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -32,21 +32,26 @@ class RobotDriver(
         }
     }
 
-    fun typeText(text: String) = runOffEdt {
+    fun typeText(text: String) {
         val clipboard = Toolkit.getDefaultToolkit().systemClipboard
         val previousContents = runCatching { clipboard.getContents(null) }.getOrNull()
         try {
             clipboard.setContents(StringSelection(text), null)
-            val modifier = pasteModifierKeyCode(detectMacOs())
-            robot.keyPress(modifier)
-            robot.keyPress(KeyEvent.VK_V)
-            robot.keyRelease(KeyEvent.VK_V)
-            robot.keyRelease(modifier)
+            runOffEdt {
+                val modifier = pasteModifierKeyCode(detectMacOs())
+                robot.keyPress(modifier)
+                robot.keyPress(KeyEvent.VK_V)
+                robot.keyRelease(KeyEvent.VK_V)
+                robot.keyRelease(modifier)
+            }
+            // Wait for the EDT to finish processing the paste event before restoring
+            // the clipboard. waitForIdle() is safe only when NOT on the EDT; when
+            // called from the EDT, runOffEdt blocks the EDT so waitForIdle would
+            // deadlock. EDT callers are unsupported and accept the restore race.
+            if (!SwingUtilities.isEventDispatchThread()) {
+                robot.waitForIdle()
+            }
         } finally {
-            // Restore synchronously so the clipboard state is deterministic across
-            // back-to-back typeText calls. Note: this automation API is intended for
-            // use from background threads (coroutines), not from the EDT. Calling
-            // typeText from the EDT is unsupported and may race with paste processing.
             if (previousContents != null) {
                 runCatching { clipboard.setContents(previousContents, null) }
             }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -32,18 +32,23 @@ class RobotDriver(
         }
     }
 
-    fun typeText(text: String) = runOffEdt {
+    fun typeText(text: String) {
         val clipboard = Toolkit.getDefaultToolkit().systemClipboard
         val previousContents = runCatching { clipboard.getContents(null) }.getOrNull()
-        try {
-            clipboard.setContents(StringSelection(text), null)
+        clipboard.setContents(StringSelection(text), null)
+        runOffEdt {
             val modifier = pasteModifierKeyCode(detectMacOs())
             robot.keyPress(modifier)
             robot.keyPress(KeyEvent.VK_V)
             robot.keyRelease(KeyEvent.VK_V)
             robot.keyRelease(modifier)
-        } finally {
-            if (previousContents != null) {
+        }
+        // Restore via invokeLater so the EDT processes any pending Robot-generated
+        // paste events before the clipboard is replaced. This is safe whether
+        // typeText is called from the EDT (runOffEdt unblocks first, paste events
+        // are queued ahead of invokeLater) or from a background thread.
+        if (previousContents != null) {
+            SwingUtilities.invokeLater {
                 runCatching { clipboard.setContents(previousContents, null) }
             }
         }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -1,0 +1,86 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+import java.awt.Robot
+import java.awt.Toolkit
+import java.awt.datatransfer.StringSelection
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import java.awt.image.BufferedImage
+import javax.swing.SwingUtilities
+
+class RobotDriver(
+    private val robot: Robot =
+        Robot().apply {
+            autoDelay = DEFAULT_AUTO_DELAY_MS
+            isAutoWaitForIdle = false
+        }
+) {
+
+    fun click(screenX: Int, screenY: Int) = runOffEdt {
+        robot.mouseMove(screenX, screenY)
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+    }
+
+    fun doubleClick(screenX: Int, screenY: Int) = runOffEdt {
+        robot.mouseMove(screenX, screenY)
+        repeat(2) {
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+        }
+    }
+
+    fun typeText(text: String) = runOffEdt {
+        val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+        clipboard.setContents(StringSelection(text), null)
+        val modifier = pasteModifierKeyCode(detectMacOs())
+        robot.keyPress(modifier)
+        robot.keyPress(KeyEvent.VK_V)
+        robot.keyRelease(KeyEvent.VK_V)
+        robot.keyRelease(modifier)
+    }
+
+    fun pressKey(keyCode: Int, modifiers: Int = 0) = runOffEdt {
+        if (modifiers != 0) robot.keyPress(modifiers)
+        robot.keyPress(keyCode)
+        robot.keyRelease(keyCode)
+        if (modifiers != 0) robot.keyRelease(modifiers)
+    }
+
+    fun screenshot(region: Rectangle? = null): BufferedImage {
+        val captureRegion =
+            region
+                ?: GraphicsEnvironment.getLocalGraphicsEnvironment()
+                    .defaultScreenDevice
+                    .defaultConfiguration
+                    .bounds
+        return robot.createScreenCapture(captureRegion)
+    }
+}
+
+/**
+ * Robot actions must not run on the EDT because Robot.waitForIdle() would deadlock. When called
+ * from the EDT, this dispatches the block to a temporary thread and waits for it to complete.
+ *
+ * Note: isAutoWaitForIdle is disabled to avoid the Robot internally calling waitForIdle() (which
+ * would still deadlock if the spawned thread tried it). The autoDelay provides a small pause
+ * between events instead.
+ */
+private fun runOffEdt(block: () -> Unit) {
+    if (!SwingUtilities.isEventDispatchThread()) {
+        block()
+        return
+    }
+    val thread = Thread(block, "spectre-robot")
+    thread.start()
+    thread.join()
+}
+
+fun pasteModifierKeyCode(isMacOs: Boolean): Int =
+    if (isMacOs) KeyEvent.VK_META else KeyEvent.VK_CONTROL
+
+fun detectMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
+
+private const val DEFAULT_AUTO_DELAY_MS = 10

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -94,9 +94,12 @@ fun detectMacOs(): Boolean = System.getProperty("os.name").lowercase().contains(
 
 private fun virtualDesktopBounds(): Rectangle {
     val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
-    var bounds = Rectangle()
-    for (device in ge.screenDevices) {
-        bounds = bounds.union(device.defaultConfiguration.bounds)
+    val devices = ge.screenDevices
+    // Seed with the first device's bounds to avoid Rectangle() defaulting to (0,0)
+    // which would incorrectly include the origin in multi-monitor offset setups
+    var bounds = devices.first().defaultConfiguration.bounds
+    for (i in 1 until devices.size) {
+        bounds = bounds.union(devices[i].defaultConfiguration.bounds)
     }
     return bounds
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -34,12 +34,19 @@ class RobotDriver(
 
     fun typeText(text: String) = runOffEdt {
         val clipboard = Toolkit.getDefaultToolkit().systemClipboard
-        clipboard.setContents(StringSelection(text), null)
-        val modifier = pasteModifierKeyCode(detectMacOs())
-        robot.keyPress(modifier)
-        robot.keyPress(KeyEvent.VK_V)
-        robot.keyRelease(KeyEvent.VK_V)
-        robot.keyRelease(modifier)
+        val previousContents = runCatching { clipboard.getContents(null) }.getOrNull()
+        try {
+            clipboard.setContents(StringSelection(text), null)
+            val modifier = pasteModifierKeyCode(detectMacOs())
+            robot.keyPress(modifier)
+            robot.keyPress(KeyEvent.VK_V)
+            robot.keyRelease(KeyEvent.VK_V)
+            robot.keyRelease(modifier)
+        } finally {
+            if (previousContents != null) {
+                runCatching { clipboard.setContents(previousContents, null) }
+            }
+        }
     }
 
     fun pressKey(keyCode: Int, modifiers: Int = 0) = runOffEdt {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -5,7 +5,6 @@ import androidx.compose.ui.awt.ComposeWindow
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
-import javax.swing.SwingUtilities
 
 class SemanticsReader {
 
@@ -68,12 +67,4 @@ class SemanticsReader {
             traverseTree(child, trackedWindow, ownerIndex, result)
         }
     }
-}
-
-private fun <T> readOnEdt(block: () -> T): T {
-    if (SwingUtilities.isEventDispatchThread()) return block()
-
-    var result: Result<T>? = null
-    SwingUtilities.invokeAndWait { result = runCatching(block) }
-    return result!!.getOrThrow()
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -51,8 +51,10 @@ class SemanticsReader {
         val window = trackedWindow.window
         if (window is ComposeWindow) return window.semanticsOwners
 
-        // For non-ComposeWindow containers, find embedded ComposePanels
-        return findComposePanels(window).flatMap { it.semanticsOwners }
+        // Use the specific ComposePanel stored in TrackedWindow to keep
+        // owners aligned with the panel used for coordinate mapping.
+        val panel = trackedWindow.composePanel ?: return emptyList()
+        return panel.semanticsOwners
     }
 
     private fun traverseTree(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -21,8 +21,7 @@ class SemanticsReader {
         exact: Boolean = true,
     ): List<AutomatorNode> =
         readAllNodes(trackedWindows).filter { node ->
-            val nodeText = node.text ?: return@filter false
-            if (exact) nodeText == text else nodeText.contains(text, ignoreCase = true)
+            matchesText(node.text, text, exact) || matchesText(node.editableText, text, exact)
         }
 
     fun findByContentDescription(
@@ -69,4 +68,9 @@ class SemanticsReader {
             traverseTree(child, trackedWindow, ownerIndex, result)
         }
     }
+}
+
+private fun matchesText(nodeText: String?, query: String, exact: Boolean): Boolean {
+    if (nodeText == null) return false
+    return if (exact) nodeText == query else nodeText.contains(query, ignoreCase = true)
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -1,0 +1,79 @@
+package dev.sebastiano.spectre.core
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsOwner
+import javax.swing.SwingUtilities
+
+class SemanticsReader {
+
+    fun readAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> = readOnEdt {
+        collectAllNodes(trackedWindows)
+    }
+
+    fun findByTestTag(tag: String, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
+        readAllNodes(trackedWindows).filter { it.testTag == tag }
+
+    fun findByText(
+        text: String,
+        trackedWindows: List<TrackedWindow>,
+        exact: Boolean = true,
+    ): List<AutomatorNode> =
+        readAllNodes(trackedWindows).filter { node ->
+            val nodeText = node.text ?: return@filter false
+            if (exact) nodeText == text else nodeText.contains(text, ignoreCase = true)
+        }
+
+    fun findByContentDescription(
+        description: String,
+        trackedWindows: List<TrackedWindow>,
+    ): List<AutomatorNode> =
+        readAllNodes(trackedWindows).filter { it.contentDescription == description }
+
+    fun findByRole(role: Role, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
+        readAllNodes(trackedWindows).filter { it.role == role }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun collectAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> {
+        val nodes = mutableListOf<AutomatorNode>()
+        for (trackedWindow in trackedWindows) {
+            val owners = getOwnersForWindow(trackedWindow)
+            for ((ownerIndex, owner) in owners.withIndex()) {
+                traverseTree(owner.rootSemanticsNode, trackedWindow, ownerIndex, nodes)
+            }
+        }
+        return nodes
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun getOwnersForWindow(trackedWindow: TrackedWindow): Collection<SemanticsOwner> {
+        val window = trackedWindow.window
+        if (window is ComposeWindow) return window.semanticsOwners
+
+        // For non-ComposeWindow containers, find embedded ComposePanels
+        return findComposePanels(window).flatMap { it.semanticsOwners }
+    }
+
+    private fun traverseTree(
+        node: SemanticsNode,
+        trackedWindow: TrackedWindow,
+        ownerIndex: Int,
+        result: MutableList<AutomatorNode>,
+    ) {
+        val key = NodeKey(trackedWindow.surfaceId, ownerIndex, node.id)
+        result += AutomatorNode(key = key, semanticsNode = node, trackedWindow = trackedWindow)
+        for (child in node.children) {
+            traverseTree(child, trackedWindow, ownerIndex, result)
+        }
+    }
+}
+
+private fun <T> readOnEdt(block: () -> T): T {
+    if (SwingUtilities.isEventDispatchThread()) return block()
+
+    var result: Result<T>? = null
+    SwingUtilities.invokeAndWait { result = runCatching(block) }
+    return result!!.getOrThrow()
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -21,14 +21,17 @@ class SemanticsReader {
         exact: Boolean = true,
     ): List<AutomatorNode> =
         readAllNodes(trackedWindows).filter { node ->
-            matchesText(node.text, text, exact) || matchesText(node.editableText, text, exact)
+            node.texts.any { matchesText(it, text, exact) } ||
+                matchesText(node.editableText, text, exact)
         }
 
     fun findByContentDescription(
         description: String,
         trackedWindows: List<TrackedWindow>,
     ): List<AutomatorNode> =
-        readAllNodes(trackedWindows).filter { it.contentDescription == description }
+        readAllNodes(trackedWindows).filter { node ->
+            node.contentDescriptions.any { it == description }
+        }
 
     fun findByRole(role: Role, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
         readAllNodes(trackedWindows).filter { it.role == role }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -13,28 +13,34 @@ class SemanticsReader {
     }
 
     fun findByTestTag(tag: String, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
-        readAllNodes(trackedWindows).filter { it.testTag == tag }
+        readOnEdt {
+            collectAllNodes(trackedWindows).filter { it.testTag == tag }
+        }
 
     fun findByText(
         text: String,
         trackedWindows: List<TrackedWindow>,
         exact: Boolean = true,
-    ): List<AutomatorNode> =
-        readAllNodes(trackedWindows).filter { node ->
+    ): List<AutomatorNode> = readOnEdt {
+        collectAllNodes(trackedWindows).filter { node ->
             node.texts.any { matchesText(it, text, exact) } ||
                 matchesText(node.editableText, text, exact)
         }
+    }
 
     fun findByContentDescription(
         description: String,
         trackedWindows: List<TrackedWindow>,
-    ): List<AutomatorNode> =
-        readAllNodes(trackedWindows).filter { node ->
+    ): List<AutomatorNode> = readOnEdt {
+        collectAllNodes(trackedWindows).filter { node ->
             node.contentDescriptions.any { it == description }
         }
+    }
 
     fun findByRole(role: Role, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
-        readAllNodes(trackedWindows).filter { it.role == role }
+        readOnEdt {
+            collectAllNodes(trackedWindows).filter { it.role == role }
+        }
 
     @OptIn(ExperimentalComposeUiApi::class)
     private fun collectAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> {
@@ -53,8 +59,6 @@ class SemanticsReader {
         val window = trackedWindow.window
         if (window is ComposeWindow) return window.semanticsOwners
 
-        // Use the specific ComposePanel stored in TrackedWindow to keep
-        // owners aligned with the panel used for coordinate mapping.
         val panel = trackedWindow.composePanel ?: return emptyList()
         return panel.semanticsOwners
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
@@ -1,0 +1,28 @@
+package dev.sebastiano.spectre.core
+
+import androidx.compose.ui.awt.ComposePanel
+import java.awt.Point
+import java.awt.Window
+import javax.swing.JFrame
+
+data class TrackedWindow(
+    val surfaceId: String,
+    val window: Window,
+    val composePanel: ComposePanel?,
+    val isPopup: Boolean,
+) {
+
+    /**
+     * The screen location of the Compose content origin.
+     *
+     * For ComposeWindow (a JFrame), the Compose content renders inside the content pane, which sits
+     * below the title bar. For embedded ComposePanels, the panel's own location is used. This is
+     * critical for correct coordinate mapping: boundsInWindow is relative to the content area, not
+     * the window frame.
+     */
+    val composeContentOrigin: Point
+        get() =
+            composePanel?.locationOnScreen
+                ?: (window as? JFrame)?.contentPane?.locationOnScreen
+                ?: window.locationOnScreen
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
@@ -1,0 +1,23 @@
+package dev.sebastiano.spectre.core
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeout
+
+suspend fun <T : Any> waitUntil(
+    timeout: Duration = 5.seconds,
+    pollInterval: Duration = 100.milliseconds,
+    predicate: () -> T?,
+): T =
+    withTimeout(timeout) {
+        while (true) {
+            predicate()?.let {
+                return@withTimeout it
+            }
+            delay(pollInterval)
+        }
+
+        @Suppress("UNREACHABLE_CODE") error("unreachable")
+    }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -9,81 +9,82 @@ import java.awt.Window
 class WindowTracker {
 
     @Volatile private var _trackedWindows: List<TrackedWindow> = emptyList()
-    private var pendingWindows = mutableListOf<TrackedWindow>()
-    private var surfaceIndex = 0
 
     val trackedWindows: List<TrackedWindow>
         get() = _trackedWindows
 
     fun refresh() = readOnEdt {
-        pendingWindows = mutableListOf()
-        surfaceIndex = 0
-
+        val pending = mutableListOf<TrackedWindow>()
         val topLevelWindows = Window.getWindows().filter { it.isShowing && it.owner == null }
         for (window in topLevelWindows) {
             when (window) {
-                is ComposeWindow -> trackComposeWindow(window)
-                else -> trackEmbeddedPanels(window)
+                is ComposeWindow -> trackComposeWindow(pending, window)
+                else -> trackEmbeddedPanels(pending, window)
             }
         }
-        _trackedWindows = pendingWindows.toList()
+        _trackedWindows = pending.toList()
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
-    private fun trackComposeWindow(window: ComposeWindow) {
+    private fun trackComposeWindow(pending: MutableList<TrackedWindow>, window: ComposeWindow) {
         if (window.semanticsOwners.isNotEmpty()) {
             val panel = findComposePanels(window).firstOrNull()
-            addTrackedWindow(window, panel, "window", isPopup = false)
+            addTrackedWindow(pending, window, panel, "window", isPopup = false)
         }
-        trackOwnedPopups(window)
+        trackOwnedPopups(pending, window)
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
-    private fun trackOwnedPopups(owner: Window) {
+    private fun trackOwnedPopups(pending: MutableList<TrackedWindow>, owner: Window) {
         val visibleOwned = owner.ownedWindows.filter { it.isShowing }
         for (owned in visibleOwned) {
             when (owned) {
                 is ComposeWindow -> {
                     if (owned.semanticsOwners.isNotEmpty()) {
                         val panel = findComposePanels(owned).firstOrNull()
-                        addTrackedWindow(owned, panel, "popup", isPopup = true)
+                        addTrackedWindow(pending, owned, panel, "popup", isPopup = true)
                     }
                 }
-                else -> trackActivePanels(owned, "popup", isPopup = true)
+                else -> trackActivePanels(pending, owned, "popup", isPopup = true)
             }
-            trackOwnedPopups(owned)
+            trackOwnedPopups(pending, owned)
         }
     }
 
-    private fun trackEmbeddedPanels(window: Window) {
-        trackActivePanels(window, "embedded", isPopup = false)
-        trackOwnedPopups(window)
+    private fun trackEmbeddedPanels(pending: MutableList<TrackedWindow>, window: Window) {
+        trackActivePanels(pending, window, "embedded", isPopup = false)
+        trackOwnedPopups(pending, window)
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
-    private fun trackActivePanels(window: Window, prefix: String, isPopup: Boolean) {
+    private fun trackActivePanels(
+        pending: MutableList<TrackedWindow>,
+        window: Window,
+        prefix: String,
+        isPopup: Boolean,
+    ) {
         val panels = findComposePanels(window)
         for (panel in panels) {
             if (panel.semanticsOwners.isNotEmpty()) {
-                addTrackedWindow(window, panel, prefix, isPopup)
+                addTrackedWindow(pending, window, panel, prefix, isPopup)
             }
         }
     }
 
     private fun addTrackedWindow(
+        pending: MutableList<TrackedWindow>,
         window: Window,
         panel: ComposePanel?,
         prefix: String,
         isPopup: Boolean,
     ) {
-        pendingWindows +=
+        pending +=
             TrackedWindow(
-                surfaceId = "$prefix:$surfaceIndex",
+                surfaceId = "$prefix:${pending.size}",
                 window = window,
                 composePanel = panel,
                 isPopup = isPopup,
             )
-        surfaceIndex++
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -40,25 +40,33 @@ class WindowTracker {
 
     @OptIn(ExperimentalComposeUiApi::class)
     private fun trackOwnedPopups(owner: Window) {
-        for (owned in owner.ownedWindows) {
-            if (!owned.isShowing || owned !is Container) continue
-            val panels = findComposePanels(owned)
-            val activePanel = panels.firstOrNull { it.semanticsOwners.isNotEmpty() }
-            if (activePanel != null) {
-                addTrackedWindow(owned, activePanel, "popup", isPopup = true)
+        val visibleOwned = owner.ownedWindows.filter { it.isShowing }
+        for (owned in visibleOwned) {
+            when (owned) {
+                is ComposeWindow -> {
+                    if (owned.semanticsOwners.isNotEmpty()) {
+                        val panel = findComposePanels(owned).firstOrNull()
+                        addTrackedWindow(owned, panel, "popup", isPopup = true)
+                    }
+                }
+                else -> trackActivePanels(owned, "popup", isPopup = true)
             }
         }
     }
 
-    @OptIn(ExperimentalComposeUiApi::class)
     private fun trackEmbeddedPanels(window: Window) {
-        if (window !is Container) return
-        val panels = findComposePanels(window)
-        val activePanel = panels.firstOrNull { it.semanticsOwners.isNotEmpty() }
-        if (activePanel != null) {
-            addTrackedWindow(window, activePanel, "embedded", isPopup = false)
-        }
+        trackActivePanels(window, "embedded", isPopup = false)
         trackOwnedPopups(window)
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun trackActivePanels(window: Window, prefix: String, isPopup: Boolean) {
+        val panels = findComposePanels(window)
+        for (panel in panels) {
+            if (panel.semanticsOwners.isNotEmpty()) {
+                addTrackedWindow(window, panel, prefix, isPopup)
+            }
+        }
     }
 
     private fun addTrackedWindow(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -8,18 +8,17 @@ import java.awt.Window
 
 class WindowTracker {
 
-    private val _trackedWindows = mutableListOf<TrackedWindow>()
+    @Volatile private var _trackedWindows: List<TrackedWindow> = emptyList()
+    private var pendingWindows = mutableListOf<TrackedWindow>()
     private var surfaceIndex = 0
 
     val trackedWindows: List<TrackedWindow>
-        get() = _trackedWindows.toList()
+        get() = _trackedWindows
 
     fun refresh() = readOnEdt {
-        _trackedWindows.clear()
+        pendingWindows = mutableListOf()
         surfaceIndex = 0
 
-        // Skip owned windows — they are discovered via trackOwnedPopups
-        // from their owner. Without this, popups appear twice.
         val topLevelWindows = Window.getWindows().filter { it.isShowing && it.owner == null }
         for (window in topLevelWindows) {
             when (window) {
@@ -27,6 +26,7 @@ class WindowTracker {
                 else -> trackEmbeddedPanels(window)
             }
         }
+        _trackedWindows = pendingWindows.toList()
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
@@ -51,7 +51,6 @@ class WindowTracker {
                 }
                 else -> trackActivePanels(owned, "popup", isPopup = true)
             }
-            // Recurse into owned windows to discover nested popups (popups of popups)
             trackOwnedPopups(owned)
         }
     }
@@ -77,7 +76,7 @@ class WindowTracker {
         prefix: String,
         isPopup: Boolean,
     ) {
-        _trackedWindows +=
+        pendingWindows +=
             TrackedWindow(
                 surfaceId = "$prefix:$surfaceIndex",
                 window = window,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -97,7 +97,8 @@ private fun findComposePanelsRecursive(container: Container, result: MutableList
     for (child in container.components) {
         if (child is ComposePanel) {
             result += child
-        } else if (child is Container) {
+        }
+        if (child is Container) {
             findComposePanelsRecursive(child, result)
         }
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -1,0 +1,93 @@
+package dev.sebastiano.spectre.core
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.awt.ComposeWindow
+import java.awt.Container
+import java.awt.Window
+
+class WindowTracker {
+
+    private val _trackedWindows = mutableListOf<TrackedWindow>()
+    private var surfaceIndex = 0
+
+    val trackedWindows: List<TrackedWindow>
+        get() = _trackedWindows.toList()
+
+    fun refresh() {
+        _trackedWindows.clear()
+        surfaceIndex = 0
+
+        for (window in Window.getWindows()) {
+            if (!window.isShowing) continue
+
+            when (window) {
+                is ComposeWindow -> trackComposeWindow(window)
+                else -> trackEmbeddedPanels(window)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun trackComposeWindow(window: ComposeWindow) {
+        if (window.semanticsOwners.isNotEmpty()) {
+            val panel = findComposePanels(window).firstOrNull()
+            addTrackedWindow(window, panel, "window", isPopup = false)
+        }
+        trackOwnedPopups(window)
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun trackOwnedPopups(owner: Window) {
+        for (owned in owner.ownedWindows) {
+            if (!owned.isShowing || owned !is Container) continue
+            val panels = findComposePanels(owned)
+            val activePanel = panels.firstOrNull { it.semanticsOwners.isNotEmpty() }
+            if (activePanel != null) {
+                addTrackedWindow(owned, activePanel, "popup", isPopup = true)
+            }
+        }
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun trackEmbeddedPanels(window: Window) {
+        if (window !is Container) return
+        val panels = findComposePanels(window)
+        val activePanel = panels.firstOrNull { it.semanticsOwners.isNotEmpty() }
+        if (activePanel != null) {
+            addTrackedWindow(window, activePanel, "embedded", isPopup = false)
+        }
+    }
+
+    private fun addTrackedWindow(
+        window: Window,
+        panel: ComposePanel?,
+        prefix: String,
+        isPopup: Boolean,
+    ) {
+        _trackedWindows +=
+            TrackedWindow(
+                surfaceId = "$prefix:$surfaceIndex",
+                window = window,
+                composePanel = panel,
+                isPopup = isPopup,
+            )
+        surfaceIndex++
+    }
+}
+
+fun findComposePanels(container: Container): List<ComposePanel> {
+    val result = mutableListOf<ComposePanel>()
+    findComposePanelsRecursive(container, result)
+    return result
+}
+
+private fun findComposePanelsRecursive(container: Container, result: MutableList<ComposePanel>) {
+    for (child in container.components) {
+        if (child is ComposePanel) {
+            result += child
+        } else if (child is Container) {
+            findComposePanelsRecursive(child, result)
+        }
+    }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -18,9 +18,10 @@ class WindowTracker {
         _trackedWindows.clear()
         surfaceIndex = 0
 
-        for (window in Window.getWindows()) {
-            if (!window.isShowing) continue
-
+        // Skip owned windows — they are discovered via trackOwnedPopups
+        // from their owner. Without this, popups appear twice.
+        val topLevelWindows = Window.getWindows().filter { it.isShowing && it.owner == null }
+        for (window in topLevelWindows) {
             when (window) {
                 is ComposeWindow -> trackComposeWindow(window)
                 else -> trackEmbeddedPanels(window)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -51,6 +51,8 @@ class WindowTracker {
                 }
                 else -> trackActivePanels(owned, "popup", isPopup = true)
             }
+            // Recurse into owned windows to discover nested popups (popups of popups)
+            trackOwnedPopups(owned)
         }
     }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -58,6 +58,7 @@ class WindowTracker {
         if (activePanel != null) {
             addTrackedWindow(window, activePanel, "embedded", isPopup = false)
         }
+        trackOwnedPopups(window)
     }
 
     private fun addTrackedWindow(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -14,7 +14,7 @@ class WindowTracker {
     val trackedWindows: List<TrackedWindow>
         get() = _trackedWindows.toList()
 
-    fun refresh() {
+    fun refresh() = readOnEdt {
         _trackedWindows.clear()
         surfaceIndex = 0
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/HiDpiMapperTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/HiDpiMapperTest.kt
@@ -8,62 +8,50 @@ class HiDpiMapperTest {
 
     @Test
     fun `converts compose X to AWT screen X at 1x scale`() {
-        val result = composeToAwtX(composeX = 100f, scale = 1f, panelScreenX = 50)
+        val result = composeToAwtX(composeX = 100f, scaleX = 1f, panelScreenX = 50)
         assertEquals(150, result)
     }
 
     @Test
     fun `converts compose Y to AWT screen Y at 1x scale`() {
-        val result = composeToAwtY(composeY = 200f, scale = 1f, panelScreenY = 30)
+        val result = composeToAwtY(composeY = 200f, scaleY = 1f, panelScreenY = 30)
         assertEquals(230, result)
     }
 
     @Test
     fun `divides compose X by scale at 2x HiDPI`() {
-        val result = composeToAwtX(composeX = 200f, scale = 2f, panelScreenX = 50)
+        val result = composeToAwtX(composeX = 200f, scaleX = 2f, panelScreenX = 50)
         assertEquals(150, result)
     }
 
     @Test
     fun `divides compose Y by scale at 2x HiDPI`() {
-        val result = composeToAwtY(composeY = 400f, scale = 2f, panelScreenY = 30)
+        val result = composeToAwtY(composeY = 400f, scaleY = 2f, panelScreenY = 30)
         assertEquals(230, result)
     }
 
     @Test
     fun `handles fractional scale for X`() {
-        val result = composeToAwtX(composeX = 150f, scale = 1.5f, panelScreenX = 10)
+        val result = composeToAwtX(composeX = 150f, scaleX = 1.5f, panelScreenX = 10)
         assertEquals(110, result)
     }
 
     @Test
     fun `handles fractional scale for Y`() {
-        val result = composeToAwtY(composeY = 300f, scale = 1.5f, panelScreenY = 20)
+        val result = composeToAwtY(composeY = 300f, scaleY = 1.5f, panelScreenY = 20)
         assertEquals(220, result)
     }
 
     @Test
-    fun `converts compose size by dividing by scale`() {
-        val (width, height) =
-            composeToAwtSize(composeWidth = 200f, composeHeight = 400f, scale = 2f)
-        assertEquals(100, width)
-        assertEquals(200, height)
-    }
-
-    @Test
     fun `computes center of compose bounds in AWT screen coordinates at 2x`() {
-        // Compose bounds: left=100, top=200, right=300, bottom=400
-        // Scale 2x, panel at (10, 20)
-        // AWT left = 100/2 + 10 = 60, AWT top = 200/2 + 20 = 120
-        // AWT right = 300/2 + 10 = 160, AWT bottom = 400/2 + 20 = 220
-        // Center = (110, 170)
         val result =
             composeBoundsToAwtCenter(
                 left = 100f,
                 top = 200f,
                 right = 300f,
                 bottom = 400f,
-                scale = 2f,
+                scaleX = 2f,
+                scaleY = 2f,
                 panelScreenX = 10,
                 panelScreenY = 20,
             )
@@ -72,21 +60,36 @@ class HiDpiMapperTest {
 
     @Test
     fun `computes center of compose bounds in AWT screen coordinates at 1x`() {
-        // Compose bounds: left=0, top=0, right=100, bottom=80
-        // Scale 1x, panel at (50, 50)
-        // AWT left = 0 + 50 = 50, AWT top = 0 + 50 = 50
-        // AWT right = 100 + 50 = 150, AWT bottom = 80 + 50 = 130
-        // Center = (100, 90)
         val result =
             composeBoundsToAwtCenter(
                 left = 0f,
                 top = 0f,
                 right = 100f,
                 bottom = 80f,
-                scale = 1f,
+                scaleX = 1f,
+                scaleY = 1f,
                 panelScreenX = 50,
                 panelScreenY = 50,
             )
         assertEquals(Point(100, 90), result)
+    }
+
+    @Test
+    fun `computes center with asymmetric scale factors`() {
+        // scaleX=2, scaleY=1 — X coordinates halved, Y unchanged
+        val result =
+            composeBoundsToAwtCenter(
+                left = 100f,
+                top = 100f,
+                right = 300f,
+                bottom = 200f,
+                scaleX = 2f,
+                scaleY = 1f,
+                panelScreenX = 10,
+                panelScreenY = 10,
+            )
+        // AWT X: left=60, right=160 → center=110
+        // AWT Y: top=110, bottom=210 → center=160
+        assertEquals(Point(110, 160), result)
     }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/HiDpiMapperTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/HiDpiMapperTest.kt
@@ -1,0 +1,92 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.Point
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HiDpiMapperTest {
+
+    @Test
+    fun `converts compose X to AWT screen X at 1x scale`() {
+        val result = composeToAwtX(composeX = 100f, scale = 1f, panelScreenX = 50)
+        assertEquals(150, result)
+    }
+
+    @Test
+    fun `converts compose Y to AWT screen Y at 1x scale`() {
+        val result = composeToAwtY(composeY = 200f, scale = 1f, panelScreenY = 30)
+        assertEquals(230, result)
+    }
+
+    @Test
+    fun `divides compose X by scale at 2x HiDPI`() {
+        val result = composeToAwtX(composeX = 200f, scale = 2f, panelScreenX = 50)
+        assertEquals(150, result)
+    }
+
+    @Test
+    fun `divides compose Y by scale at 2x HiDPI`() {
+        val result = composeToAwtY(composeY = 400f, scale = 2f, panelScreenY = 30)
+        assertEquals(230, result)
+    }
+
+    @Test
+    fun `handles fractional scale for X`() {
+        val result = composeToAwtX(composeX = 150f, scale = 1.5f, panelScreenX = 10)
+        assertEquals(110, result)
+    }
+
+    @Test
+    fun `handles fractional scale for Y`() {
+        val result = composeToAwtY(composeY = 300f, scale = 1.5f, panelScreenY = 20)
+        assertEquals(220, result)
+    }
+
+    @Test
+    fun `converts compose size by dividing by scale`() {
+        val (width, height) =
+            composeToAwtSize(composeWidth = 200f, composeHeight = 400f, scale = 2f)
+        assertEquals(100, width)
+        assertEquals(200, height)
+    }
+
+    @Test
+    fun `computes center of compose bounds in AWT screen coordinates at 2x`() {
+        // Compose bounds: left=100, top=200, right=300, bottom=400
+        // Scale 2x, panel at (10, 20)
+        // AWT left = 100/2 + 10 = 60, AWT top = 200/2 + 20 = 120
+        // AWT right = 300/2 + 10 = 160, AWT bottom = 400/2 + 20 = 220
+        // Center = (110, 170)
+        val result =
+            composeBoundsToAwtCenter(
+                left = 100f,
+                top = 200f,
+                right = 300f,
+                bottom = 400f,
+                scale = 2f,
+                panelScreenX = 10,
+                panelScreenY = 20,
+            )
+        assertEquals(Point(110, 170), result)
+    }
+
+    @Test
+    fun `computes center of compose bounds in AWT screen coordinates at 1x`() {
+        // Compose bounds: left=0, top=0, right=100, bottom=80
+        // Scale 1x, panel at (50, 50)
+        // AWT left = 0 + 50 = 50, AWT top = 0 + 50 = 50
+        // AWT right = 100 + 50 = 150, AWT bottom = 80 + 50 = 130
+        // Center = (100, 90)
+        val result =
+            composeBoundsToAwtCenter(
+                left = 0f,
+                top = 0f,
+                right = 100f,
+                bottom = 80f,
+                scale = 1f,
+                panelScreenX = 50,
+                panelScreenY = 50,
+            )
+        assertEquals(Point(100, 90), result)
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/NodeKeyTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/NodeKeyTest.kt
@@ -45,4 +45,11 @@ class NodeKeyTest {
     fun `parse throws on single colon`() {
         assertFailsWith<IllegalArgumentException> { NodeKey.parse("a:b") }
     }
+
+    @Test
+    fun `parse roundtrips with empty surfaceId`() {
+        val original = NodeKey(surfaceId = "", ownerIndex = 0, nodeId = 1)
+        val parsed = NodeKey.parse(original.toString())
+        assertEquals(original, parsed)
+    }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/NodeKeyTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/NodeKeyTest.kt
@@ -1,0 +1,48 @@
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class NodeKeyTest {
+
+    @Test
+    fun `toString formats as surfaceId colon ownerIndex colon nodeId`() {
+        val key = NodeKey(surfaceId = "win1", ownerIndex = 0, nodeId = 42)
+        assertEquals("win1:0:42", key.toString())
+    }
+
+    @Test
+    fun `parse roundtrips with toString`() {
+        val original = NodeKey(surfaceId = "popup:3", ownerIndex = 1, nodeId = 7)
+        val parsed = NodeKey.parse(original.toString())
+        assertEquals(original, parsed)
+    }
+
+    @Test
+    fun `parse handles surfaceId containing colons`() {
+        // surfaceId="popup:3", ownerIndex=1, nodeId=7
+        // toString = "popup:3:1:7"
+        // parse splits on last two colons
+        val parsed = NodeKey.parse("popup:3:1:7")
+        assertEquals(NodeKey(surfaceId = "popup:3", ownerIndex = 1, nodeId = 7), parsed)
+    }
+
+    @Test
+    fun `equality is structural`() {
+        val a = NodeKey(surfaceId = "main", ownerIndex = 0, nodeId = 5)
+        val b = NodeKey(surfaceId = "main", ownerIndex = 0, nodeId = 5)
+        assertEquals(a, b)
+        assertEquals(a.hashCode(), b.hashCode())
+    }
+
+    @Test
+    fun `parse throws on invalid input`() {
+        assertFailsWith<IllegalArgumentException> { NodeKey.parse("invalid") }
+    }
+
+    @Test
+    fun `parse throws on single colon`() {
+        assertFailsWith<IllegalArgumentException> { NodeKey.parse("a:b") }
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -1,0 +1,74 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.event.KeyEvent
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RobotDriverTest {
+
+    @Test
+    fun `pasteModifierKeyCode returns VK_META on macOS`() {
+        val result = pasteModifierKeyCode(isMacOs = true)
+        assertEquals(KeyEvent.VK_META, result)
+    }
+
+    @Test
+    fun `pasteModifierKeyCode returns VK_CONTROL on non-macOS`() {
+        val result = pasteModifierKeyCode(isMacOs = false)
+        assertEquals(KeyEvent.VK_CONTROL, result)
+    }
+
+    @Test
+    fun `detectMacOs reads os dot name system property`() {
+        val osName = System.getProperty("os.name").lowercase()
+        val expected = osName.contains("mac")
+        assertEquals(expected, detectMacOs())
+    }
+
+    @Test
+    fun `click does not throw when called from the EDT`() {
+        val driver = RobotDriver()
+        val latch = CountDownLatch(1)
+        var error: Throwable? = null
+
+        SwingUtilities.invokeLater {
+            try {
+                // Click at (0,0) — we don't care where, just that it doesn't throw
+                driver.click(0, 0)
+            } catch (e: Throwable) {
+                error = e
+            } finally {
+                latch.countDown()
+            }
+        }
+
+        assertTrue(latch.await(ROBOT_EDT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS), "Timed out")
+        error?.let { throw AssertionError("click from EDT should not throw", it) }
+    }
+
+    @Test
+    fun `typeText does not throw when called from the EDT`() {
+        val driver = RobotDriver()
+        val latch = CountDownLatch(1)
+        var error: Throwable? = null
+
+        SwingUtilities.invokeLater {
+            try {
+                driver.typeText("test")
+            } catch (e: Throwable) {
+                error = e
+            } finally {
+                latch.countDown()
+            }
+        }
+
+        assertTrue(latch.await(ROBOT_EDT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS), "Timed out")
+        error?.let { throw AssertionError("typeText from EDT should not throw", it) }
+    }
+}
+
+private const val ROBOT_EDT_TEST_TIMEOUT_SECONDS = 5L

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -1,7 +1,7 @@
 package dev.sebastiano.spectre.core
 
 import java.awt.GraphicsEnvironment
-import java.awt.MouseInfo
+import java.awt.Robot
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.util.concurrent.CountDownLatch
@@ -58,15 +58,13 @@ class RobotDriverTest {
     @EnabledIf("isNotHeadless")
     @Test
     fun `click does not throw when called from the EDT`() {
-        val driver = RobotDriver()
+        val driver = RobotDriver(noOpRobot())
         val latch = CountDownLatch(1)
         var error: Throwable? = null
 
         SwingUtilities.invokeLater {
             try {
-                // Click at the current pointer position to avoid moving the mouse visibly
-                val pos = MouseInfo.getPointerInfo().location
-                driver.click(pos.x, pos.y)
+                driver.click(0, 0)
             } catch (e: Throwable) {
                 error = e
             } finally {
@@ -81,7 +79,7 @@ class RobotDriverTest {
     @EnabledIf("isNotHeadless")
     @Test
     fun `typeText does not throw when called from the EDT`() {
-        val driver = RobotDriver()
+        val driver = RobotDriver(noOpRobot())
         val latch = CountDownLatch(1)
         var error: Throwable? = null
 
@@ -104,5 +102,21 @@ class RobotDriverTest {
         @JvmStatic fun isNotHeadless(): Boolean = !GraphicsEnvironment.isHeadless()
     }
 }
+
+/**
+ * A Robot subclass that suppresses all mouse and keyboard actions, for use in EDT-dispatch tests.
+ */
+private fun noOpRobot() =
+    object : Robot() {
+        override fun mouseMove(x: Int, y: Int) = Unit
+
+        override fun mousePress(buttons: Int) = Unit
+
+        override fun mouseRelease(buttons: Int) = Unit
+
+        override fun keyPress(keycode: Int) = Unit
+
+        override fun keyRelease(keycode: Int) = Unit
+    }
 
 private const val ROBOT_EDT_TEST_TIMEOUT_SECONDS = 5L

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.core
 
 import java.awt.GraphicsEnvironment
+import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -29,6 +30,28 @@ class RobotDriverTest {
         val osName = System.getProperty("os.name").lowercase()
         val expected = osName.contains("mac")
         assertEquals(expected, detectMacOs())
+    }
+
+    @Test
+    fun `modifierMaskToKeyCodes returns empty for zero mask`() {
+        assertEquals(emptyList(), modifierMaskToKeyCodes(0))
+    }
+
+    @Test
+    fun `modifierMaskToKeyCodes translates CTRL_DOWN_MASK to VK_CONTROL`() {
+        assertEquals(listOf(KeyEvent.VK_CONTROL), modifierMaskToKeyCodes(InputEvent.CTRL_DOWN_MASK))
+    }
+
+    @Test
+    fun `modifierMaskToKeyCodes translates combined Ctrl+Shift mask`() {
+        val mask = InputEvent.CTRL_DOWN_MASK or InputEvent.SHIFT_DOWN_MASK
+        val result = modifierMaskToKeyCodes(mask)
+        assertEquals(listOf(KeyEvent.VK_CONTROL, KeyEvent.VK_SHIFT), result)
+    }
+
+    @Test
+    fun `modifierMaskToKeyCodes translates META_DOWN_MASK to VK_META`() {
+        assertEquals(listOf(KeyEvent.VK_META), modifierMaskToKeyCodes(InputEvent.META_DOWN_MASK))
     }
 
     @EnabledIf("isNotHeadless")

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.core
 
+import java.awt.GraphicsEnvironment
 import java.awt.event.KeyEvent
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -7,6 +8,7 @@ import javax.swing.SwingUtilities
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.EnabledIf
 
 class RobotDriverTest {
 
@@ -29,6 +31,7 @@ class RobotDriverTest {
         assertEquals(expected, detectMacOs())
     }
 
+    @EnabledIf("isNotHeadless")
     @Test
     fun `click does not throw when called from the EDT`() {
         val driver = RobotDriver()
@@ -37,7 +40,6 @@ class RobotDriverTest {
 
         SwingUtilities.invokeLater {
             try {
-                // Click at (0,0) — we don't care where, just that it doesn't throw
                 driver.click(0, 0)
             } catch (e: Throwable) {
                 error = e
@@ -50,6 +52,7 @@ class RobotDriverTest {
         error?.let { throw AssertionError("click from EDT should not throw", it) }
     }
 
+    @EnabledIf("isNotHeadless")
     @Test
     fun `typeText does not throw when called from the EDT`() {
         val driver = RobotDriver()
@@ -68,6 +71,11 @@ class RobotDriverTest {
 
         assertTrue(latch.await(ROBOT_EDT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS), "Timed out")
         error?.let { throw AssertionError("typeText from EDT should not throw", it) }
+    }
+
+    companion object {
+
+        @JvmStatic fun isNotHeadless(): Boolean = !GraphicsEnvironment.isHeadless()
     }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.core
 
 import java.awt.GraphicsEnvironment
+import java.awt.MouseInfo
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.util.concurrent.CountDownLatch
@@ -63,7 +64,9 @@ class RobotDriverTest {
 
         SwingUtilities.invokeLater {
             try {
-                driver.click(0, 0)
+                // Click at the current pointer position to avoid moving the mouse visibly
+                val pos = MouseInfo.getPointerInfo().location
+                driver.click(pos.x, pos.y)
             } catch (e: Throwable) {
                 error = e
             } finally {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowTest.kt
@@ -1,14 +1,18 @@
 package dev.sebastiano.spectre.core
 
+import java.awt.GraphicsEnvironment
+import javax.swing.JFrame
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import org.junit.jupiter.api.condition.EnabledIf
 
+@EnabledIf("isNotHeadless")
 class TrackedWindowTest {
 
     @Test
     fun `TrackedWindow stores surfaceId and popup flag`() {
-        val window = javax.swing.JFrame("Test")
+        val window = JFrame("Test")
         val tracked =
             TrackedWindow(
                 surfaceId = "main:0",
@@ -18,11 +22,12 @@ class TrackedWindowTest {
             )
         assertEquals("main:0", tracked.surfaceId)
         assertEquals(false, tracked.isPopup)
+        window.dispose()
     }
 
     @Test
     fun `TrackedWindows with same surfaceId and window are equal`() {
-        val window = javax.swing.JFrame("Test")
+        val window = JFrame("Test")
         val a =
             TrackedWindow(
                 surfaceId = "main:0",
@@ -38,11 +43,12 @@ class TrackedWindowTest {
                 isPopup = false,
             )
         assertEquals(a, b)
+        window.dispose()
     }
 
     @Test
     fun `TrackedWindows with different surfaceId are not equal`() {
-        val window = javax.swing.JFrame("Test")
+        val window = JFrame("Test")
         val a =
             TrackedWindow(
                 surfaceId = "main:0",
@@ -58,5 +64,11 @@ class TrackedWindowTest {
                 isPopup = true,
             )
         assertNotEquals(a, b)
+        window.dispose()
+    }
+
+    companion object {
+
+        @JvmStatic fun isNotHeadless(): Boolean = !GraphicsEnvironment.isHeadless()
     }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowTest.kt
@@ -1,0 +1,62 @@
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class TrackedWindowTest {
+
+    @Test
+    fun `TrackedWindow stores surfaceId and popup flag`() {
+        val window = javax.swing.JFrame("Test")
+        val tracked =
+            TrackedWindow(
+                surfaceId = "main:0",
+                window = window,
+                composePanel = null,
+                isPopup = false,
+            )
+        assertEquals("main:0", tracked.surfaceId)
+        assertEquals(false, tracked.isPopup)
+    }
+
+    @Test
+    fun `TrackedWindows with same surfaceId and window are equal`() {
+        val window = javax.swing.JFrame("Test")
+        val a =
+            TrackedWindow(
+                surfaceId = "main:0",
+                window = window,
+                composePanel = null,
+                isPopup = false,
+            )
+        val b =
+            TrackedWindow(
+                surfaceId = "main:0",
+                window = window,
+                composePanel = null,
+                isPopup = false,
+            )
+        assertEquals(a, b)
+    }
+
+    @Test
+    fun `TrackedWindows with different surfaceId are not equal`() {
+        val window = javax.swing.JFrame("Test")
+        val a =
+            TrackedWindow(
+                surfaceId = "main:0",
+                window = window,
+                composePanel = null,
+                isPopup = false,
+            )
+        val b =
+            TrackedWindow(
+                surfaceId = "popup:1",
+                window = window,
+                composePanel = null,
+                isPopup = true,
+            )
+        assertNotEquals(a, b)
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUtilitiesTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUtilitiesTest.kt
@@ -1,0 +1,52 @@
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.test.runTest
+
+class WaitUtilitiesTest {
+
+    @Test
+    fun `returns immediately when predicate succeeds on first call`() = runTest {
+        val result = waitUntil(timeout = 5.seconds, pollInterval = 100.milliseconds) { "found" }
+        assertEquals("found", result)
+    }
+
+    @Test
+    fun `retries until predicate succeeds`() = runTest {
+        var calls = 0
+        val result =
+            waitUntil(timeout = 5.seconds, pollInterval = 10.milliseconds) {
+                calls++
+                if (calls >= 3) "found" else null
+            }
+        assertEquals("found", result)
+        assertEquals(3, calls)
+    }
+
+    @Test
+    fun `throws TimeoutCancellationException when timeout expires`() = runTest {
+        assertFailsWith<TimeoutCancellationException> {
+            waitUntil(timeout = 100.milliseconds, pollInterval = 10.milliseconds) { null }
+        }
+    }
+
+    @Test
+    fun `predicate is called multiple times before timeout`() = runTest {
+        var calls = 0
+        try {
+            waitUntil(timeout = 200.milliseconds, pollInterval = 10.milliseconds) {
+                calls++
+                null
+            }
+        } catch (_: TimeoutCancellationException) {
+            // expected
+        }
+        // With 200ms timeout and 10ms poll, we should get at least a few calls
+        assert(calls > 1) { "Expected multiple calls, got $calls" }
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowTrackerTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowTrackerTest.kt
@@ -1,14 +1,17 @@
 package dev.sebastiano.spectre.core
 
 import java.awt.Container
+import java.awt.GraphicsEnvironment
 import javax.swing.JFrame
 import javax.swing.JPanel
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.EnabledIf
 
 class WindowTrackerTest {
 
+    @EnabledIf("isNotHeadless")
     @Test
     fun `findComposePanels returns empty for plain Swing container`() {
         val frame = JFrame()
@@ -28,7 +31,6 @@ class WindowTrackerTest {
 
     @Test
     fun `findComposePanels searches nested containers`() {
-        // Build a 3-level Swing hierarchy with no ComposePanel
         val root = JPanel()
         val child = JPanel()
         val grandchild = JPanel()
@@ -36,5 +38,10 @@ class WindowTrackerTest {
         root.add(child)
         val result = findComposePanels(root)
         assertEquals(0, result.size)
+    }
+
+    companion object {
+
+        @JvmStatic fun isNotHeadless(): Boolean = !GraphicsEnvironment.isHeadless()
     }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowTrackerTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowTrackerTest.kt
@@ -1,0 +1,40 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.Container
+import javax.swing.JFrame
+import javax.swing.JPanel
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class WindowTrackerTest {
+
+    @Test
+    fun `findComposePanels returns empty for plain Swing container`() {
+        val frame = JFrame()
+        val panel = JPanel()
+        frame.contentPane.add(panel)
+        val result = findComposePanels(frame.contentPane as Container)
+        assertTrue(result.isEmpty())
+        frame.dispose()
+    }
+
+    @Test
+    fun `findComposePanels returns empty for empty container`() {
+        val panel = JPanel()
+        val result = findComposePanels(panel)
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `findComposePanels searches nested containers`() {
+        // Build a 3-level Swing hierarchy with no ComposePanel
+        val root = JPanel()
+        val child = JPanel()
+        val grandchild = JPanel()
+        child.add(grandchild)
+        root.add(child)
+        val result = findComposePanels(root)
+        assertEquals(0, result.size)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ compose-components-resources = { module = "org.jetbrains.compose.components:comp
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/App.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/App.kt
@@ -5,29 +5,62 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 
 @Composable
 fun App(modifier: Modifier = Modifier) {
     MaterialTheme {
+        var counter by remember { mutableIntStateOf(0) }
+        var inputText by remember { mutableStateOf("") }
+
         Column(
             modifier = modifier.fillMaxSize().padding(24.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            Text(text = "Spectre bootstrap", style = MaterialTheme.typography.headlineMedium)
+            Text(
+                text = "Spectre sample",
+                style = MaterialTheme.typography.headlineMedium,
+                modifier = Modifier.testTag("header"),
+            )
+
             Card(modifier = Modifier.fillMaxWidth()) {
                 Column(
                     modifier = Modifier.padding(20.dp),
                     verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
-                    Text("The repo is scaffolded for implementation.")
-                    Text("Modules in place: core, server, recording, testing, sample-desktop.")
-                    Text("Feature work has intentionally not started yet.")
+                    Button(
+                        onClick = { counter++ },
+                        modifier = Modifier.testTag("incrementButton"),
+                    ) {
+                        Text("Count: $counter")
+                    }
+
+                    OutlinedTextField(
+                        value = inputText,
+                        onValueChange = { inputText = it },
+                        label = { Text("Type something") },
+                        modifier = Modifier.fillMaxWidth().testTag("textInput"),
+                    )
+
+                    if (inputText.isNotEmpty()) {
+                        Text(
+                            text = "You typed: $inputText",
+                            modifier = Modifier.testTag("echoText"),
+                        )
+                    }
                 }
             }
         }

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
@@ -17,9 +17,11 @@ private const val CLICK_REPETITIONS = 3
 fun main() = application {
     Window(onCloseRequest = ::exitApplication, title = "Spectre") { App() }
 
-    GlobalScope.launch(Dispatchers.Default) {
-        delay(INITIAL_SETTLE_DELAY_MS)
-        runAutomatorDemo()
+    if (System.getProperty("spectre.demo") == "true") {
+        GlobalScope.launch(Dispatchers.Default) {
+            delay(INITIAL_SETTLE_DELAY_MS)
+            runAutomatorDemo()
+        }
     }
 }
 

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
@@ -2,5 +2,73 @@ package dev.sebastiano.spectre.sample
 
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import dev.sebastiano.spectre.core.ComposeAutomator
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
-fun main() = application { Window(onCloseRequest = ::exitApplication, title = "Spectre") { App() } }
+private const val INITIAL_SETTLE_DELAY_MS = 2000L
+private const val BETWEEN_ACTION_DELAY_MS = 500L
+private const val CLICK_REPETITIONS = 3
+
+@OptIn(DelicateCoroutinesApi::class)
+fun main() = application {
+    Window(onCloseRequest = ::exitApplication, title = "Spectre") { App() }
+
+    GlobalScope.launch(Dispatchers.Default) {
+        delay(INITIAL_SETTLE_DELAY_MS)
+        runAutomatorDemo()
+    }
+}
+
+@Suppress("LongMethod")
+private suspend fun runAutomatorDemo() {
+    val automator = ComposeAutomator.create()
+    automator.refreshWindows()
+
+    println("=== Spectre Automator Demo ===")
+    println("Tracked windows: ${automator.windows.size}")
+    println()
+    print(automator.printTree())
+    println()
+
+    val header = automator.findOneByTestTag("header")
+    println("Found header: ${header?.text}")
+
+    val button = automator.findOneByTestTag("incrementButton")
+    if (button != null) {
+        button.trackedWindow.window.toFront()
+        button.trackedWindow.window.requestFocus()
+        delay(BETWEEN_ACTION_DELAY_MS)
+
+        println("Clicking button $CLICK_REPETITIONS times...")
+        repeat(CLICK_REPETITIONS) {
+            automator.click(button)
+            delay(BETWEEN_ACTION_DELAY_MS)
+        }
+        delay(BETWEEN_ACTION_DELAY_MS)
+        automator.refreshWindows()
+        val allNodes = automator.allNodes()
+        allNodes
+            .filter { it.text?.startsWith("Count:") == true }
+            .forEach { println("  Found count text: ${it.text}") }
+    }
+
+    val textInput = automator.findOneByTestTag("textInput")
+    if (textInput != null) {
+        println("Found text input, clicking and typing...")
+        automator.click(textInput)
+        delay(BETWEEN_ACTION_DELAY_MS)
+        automator.typeText("Hello from Spectre!")
+        delay(BETWEEN_ACTION_DELAY_MS)
+
+        automator.refreshWindows()
+        val echo = automator.findOneByTestTag("echoText")
+        println("Echo text: ${echo?.text}")
+    }
+
+    println()
+    println("=== Demo complete ===")
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
@@ -39,8 +39,10 @@ private suspend fun runAutomatorDemo() {
 
     val button = automator.findOneByTestTag("incrementButton")
     if (button != null) {
-        button.trackedWindow.window.toFront()
-        button.trackedWindow.window.requestFocus()
+        javax.swing.SwingUtilities.invokeAndWait {
+            button.trackedWindow.window.toFront()
+            button.trackedWindow.window.requestFocus()
+        }
         delay(BETWEEN_ACTION_DELAY_MS)
 
         println("Clicking button $CLICK_REPETITIONS times...")


### PR DESCRIPTION
## Summary

- Implements in-process Compose Desktop automator from the spike gist
- HiDPI coordinate mapping (Compose → AWT/Robot), window tracking, semantics tree reading/querying, Robot-based input, wait utilities, and `ComposeAutomator` facade
- Sample app wired up with interactive UI and live automator demo
- 30 tests across 6 test classes, all TDD

## Verified end-to-end

On macOS Retina at 2x scale:
- Window discovery finds ComposeWindow with semantics tree
- Clicks land correctly on buttons (counter increments)
- Text input via clipboard paste works
- Semantics re-reading picks up updated UI state

## Bugs found and fixed during live testing

- `Robot.isAutoWaitForIdle` throws from EDT → disabled, use `autoDelay` + `runOffEdt` helper
- `window.locationOnScreen` includes title bar → use `contentPane.locationOnScreen` for JFrame
- `ComposeWindow` uses private `ComposeWindowPanel`, not `ComposePanel` → fall through to content pane

## Test plan

- [ ] CI passes (`./gradlew check`: tests, Detekt, ktfmt)
- [ ] Manual: `./gradlew :sample-desktop:run` shows automator clicking button and typing text


🤖 Generated with [Claude Code](https://claude.com/claude-code)