### PR TITLE
[v1] Complete in-process core API ergonomics

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.semantics.getOrNull
 import java.awt.Point
+import java.awt.Rectangle
 
 data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) {
 
@@ -29,10 +30,12 @@ data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) 
     }
 }
 
-class AutomatorNode(
+class AutomatorNode
+internal constructor(
     val key: NodeKey,
     val semanticsNode: SemanticsNode,
     val trackedWindow: TrackedWindow,
+    private val relations: NodeRelations = EmptyNodeRelations,
 ) {
 
     // Eagerly snapshot all semantics properties at construction time (which runs on
@@ -54,20 +57,41 @@ class AutomatorNode(
 
     val centerOnScreen: Point
         get() = readOnEdt {
-            val bounds = semanticsNode.boundsInWindow
             val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
             val contentOrigin = trackedWindow.composeContentOrigin
             composeBoundsToAwtCenter(
-                left = bounds.left,
-                top = bounds.top,
-                right = bounds.right,
-                bottom = bounds.bottom,
+                left = boundsInWindow.left,
+                top = boundsInWindow.top,
+                right = boundsInWindow.right,
+                bottom = boundsInWindow.bottom,
                 scaleX = transform.scaleX.toFloat(),
                 scaleY = transform.scaleY.toFloat(),
                 panelScreenX = contentOrigin.x,
                 panelScreenY = contentOrigin.y,
             )
         }
+
+    val boundsOnScreen: Rectangle
+        get() = readOnEdt {
+            val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
+            val contentOrigin = trackedWindow.composeContentOrigin
+            composeBoundsToAwtRectangle(
+                left = boundsInWindow.left,
+                top = boundsInWindow.top,
+                right = boundsInWindow.right,
+                bottom = boundsInWindow.bottom,
+                scaleX = transform.scaleX.toFloat(),
+                scaleY = transform.scaleY.toFloat(),
+                panelScreenX = contentOrigin.x,
+                panelScreenY = contentOrigin.y,
+            )
+        }
+
+    val parent: AutomatorNode?
+        get() = relations.parentOf(key)
+
+    val children: List<AutomatorNode>
+        get() = relations.childrenOf(key)
 
     override fun toString(): String = buildString {
         append("AutomatorNode(key=$key")
@@ -76,4 +100,18 @@ class AutomatorNode(
         role?.let { append(", role=$it") }
         append(")")
     }
+}
+
+internal interface NodeRelations {
+
+    fun parentOf(key: NodeKey): AutomatorNode?
+
+    fun childrenOf(key: NodeKey): List<AutomatorNode>
+}
+
+private object EmptyNodeRelations : NodeRelations {
+
+    override fun parentOf(key: NodeKey): AutomatorNode? = null
+
+    override fun childrenOf(key: NodeKey): List<AutomatorNode> = emptyList()
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -53,17 +53,23 @@ internal constructor(
     val isDisabled: Boolean = semanticsNode.config.getOrNull(SemanticsProperties.Disabled) != null
     val isFocused: Boolean = semanticsNode.config.getOrNull(SemanticsProperties.Focused) == true
     val isSelected: Boolean = semanticsNode.config.getOrNull(SemanticsProperties.Selected) == true
-    val boundsInWindow: Rect = semanticsNode.boundsInWindow
+
+    // Geometry is always read live: layout can change between node lookup and action,
+    // so a snapshot would let click/screenshot drift to stale coordinates after scrolling
+    // or recomposition-driven repositioning.
+    val boundsInWindow: Rect
+        get() = readOnEdt { semanticsNode.boundsInWindow }
 
     val centerOnScreen: Point
         get() = readOnEdt {
+            val bounds = semanticsNode.boundsInWindow
             val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
             val contentOrigin = trackedWindow.composeContentOrigin
             composeBoundsToAwtCenter(
-                left = boundsInWindow.left,
-                top = boundsInWindow.top,
-                right = boundsInWindow.right,
-                bottom = boundsInWindow.bottom,
+                left = bounds.left,
+                top = bounds.top,
+                right = bounds.right,
+                bottom = bounds.bottom,
                 scaleX = transform.scaleX.toFloat(),
                 scaleY = transform.scaleY.toFloat(),
                 panelScreenX = contentOrigin.x,
@@ -73,13 +79,14 @@ internal constructor(
 
     val boundsOnScreen: Rectangle
         get() = readOnEdt {
+            val bounds = semanticsNode.boundsInWindow
             val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
             val contentOrigin = trackedWindow.composeContentOrigin
             composeBoundsToAwtRectangle(
-                left = boundsInWindow.left,
-                top = boundsInWindow.top,
-                right = boundsInWindow.right,
-                bottom = boundsInWindow.bottom,
+                left = bounds.left,
+                top = bounds.top,
+                right = bounds.right,
+                bottom = bounds.bottom,
                 scaleX = transform.scaleX.toFloat(),
                 scaleY = transform.scaleY.toFloat(),
                 panelScreenX = contentOrigin.x,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorTree.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorTree.kt
@@ -1,0 +1,57 @@
+package dev.sebastiano.spectre.core
+
+import androidx.compose.ui.semantics.Role
+
+class AutomatorTree internal constructor(private val windows: List<AutomatorWindow>) {
+
+    fun windows(): List<AutomatorWindow> = windows
+
+    fun window(windowIndex: Int): AutomatorWindow = windows[windowIndex]
+
+    fun allNodes(): List<AutomatorNode> = windows.flatMap(AutomatorWindow::allNodes)
+
+    fun roots(): List<AutomatorNode> = windows.flatMap(AutomatorWindow::roots)
+}
+
+class AutomatorWindow
+internal constructor(
+    val windowIndex: Int,
+    val trackedWindow: TrackedWindow,
+    private val nodes: List<AutomatorNode>,
+) {
+
+    val surfaceId: String = trackedWindow.surfaceId
+    val isPopup: Boolean = trackedWindow.isPopup
+
+    fun allNodes(): List<AutomatorNode> = nodes
+
+    fun roots(): List<AutomatorNode> = nodes.filter { it.parent == null }
+
+    fun findByTestTag(tag: String): List<AutomatorNode> = nodes.filter { it.testTag == tag }
+
+    fun findOneByTestTag(tag: String): AutomatorNode? = findByTestTag(tag).firstOrNull()
+
+    fun findByText(query: TextQuery): List<AutomatorNode> = nodes.filter { node ->
+        node.texts.any(query::matches) || query.matches(node.editableText)
+    }
+
+    fun findByText(text: String, exact: Boolean = true): List<AutomatorNode> =
+        findByText(
+            if (exact) {
+                TextQuery.exact(text)
+            } else {
+                TextQuery.substring(text, ignoreCase = true)
+            }
+        )
+
+    fun findOneByText(query: TextQuery): AutomatorNode? = findByText(query).firstOrNull()
+
+    fun findOneByText(text: String, exact: Boolean = true): AutomatorNode? =
+        findByText(text, exact).firstOrNull()
+
+    fun findByContentDescription(description: String): List<AutomatorNode> = nodes.filter { node ->
+        node.contentDescriptions.any { it == description }
+    }
+
+    fun findByRole(role: Role): List<AutomatorNode> = nodes.filter { it.role == role }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -156,8 +156,8 @@ private constructor(
 
     fun printTree(): String {
         return readOnEdt {
-            refreshWindows()
             buildString {
+                // tree() already refreshes windows before reading semantics nodes.
                 for (window in tree().windows()) {
                     val kind = if (window.isPopup) "popup" else "main"
                     appendLine("Window ${window.windowIndex} ($kind): ${window.surfaceId}")

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -2,17 +2,16 @@ package dev.sebastiano.spectre.core
 
 import androidx.compose.ui.semantics.Role
 import java.awt.Rectangle
+import java.awt.event.KeyEvent
 import java.awt.image.BufferedImage
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-class ComposeAutomator
-private constructor(
-    private val windowTracker: WindowTracker,
-    private val semanticsReader: SemanticsReader,
-    private val robotDriver: RobotDriver,
-) {
+sealed class ComposeAutomatorQueries {
+
+    protected abstract val windowTracker: WindowTracker
+    protected abstract val semanticsReader: SemanticsReader
 
     val windows: List<TrackedWindow>
         get() = windowTracker.trackedWindows
@@ -21,6 +20,20 @@ private constructor(
         windowTracker.refresh()
     }
 
+    fun tree(): AutomatorTree {
+        refreshWindows()
+        val windowScopes = windows.mapIndexed { index, trackedWindow ->
+            AutomatorWindow(
+                windowIndex = index,
+                trackedWindow = trackedWindow,
+                nodes = semanticsReader.readAllNodes(listOf(trackedWindow)),
+            )
+        }
+        return AutomatorTree(windowScopes)
+    }
+
+    fun tree(windowIndex: Int): AutomatorWindow = tree().window(windowIndex)
+
     fun allNodes(): List<AutomatorNode> = semanticsReader.readAllNodes(windows)
 
     fun findByTestTag(tag: String): List<AutomatorNode> =
@@ -28,8 +41,13 @@ private constructor(
 
     fun findOneByTestTag(tag: String): AutomatorNode? = findByTestTag(tag).firstOrNull()
 
+    fun findByText(query: TextQuery): List<AutomatorNode> =
+        semanticsReader.findByText(query, windows)
+
     fun findByText(text: String, exact: Boolean = true): List<AutomatorNode> =
         semanticsReader.findByText(text, windows, exact)
+
+    fun findOneByText(query: TextQuery): AutomatorNode? = findByText(query).firstOrNull()
 
     fun findOneByText(text: String, exact: Boolean = true): AutomatorNode? =
         findByText(text, exact).firstOrNull()
@@ -38,6 +56,11 @@ private constructor(
         semanticsReader.findByContentDescription(description, windows)
 
     fun findByRole(role: Role): List<AutomatorNode> = semanticsReader.findByRole(role, windows)
+}
+
+sealed class ComposeAutomatorInteractions : ComposeAutomatorQueries() {
+
+    protected abstract val robotDriver: RobotDriver
 
     fun click(node: AutomatorNode) {
         val center = node.centerOnScreen
@@ -49,15 +72,64 @@ private constructor(
         robotDriver.doubleClick(center.x, center.y)
     }
 
+    fun longClick(node: AutomatorNode, holdFor: Duration = 500.milliseconds) {
+        val center = node.centerOnScreen
+        robotDriver.longClick(center.x, center.y, holdFor)
+    }
+
+    fun swipe(
+        startX: Int,
+        startY: Int,
+        endX: Int,
+        endY: Int,
+        steps: Int = 12,
+        duration: Duration = 200.milliseconds,
+    ) {
+        robotDriver.swipe(startX, startY, endX, endY, steps, duration)
+    }
+
+    fun swipe(
+        from: AutomatorNode,
+        to: AutomatorNode,
+        steps: Int = 12,
+        duration: Duration = 200.milliseconds,
+    ) {
+        val fromCenter = from.centerOnScreen
+        val toCenter = to.centerOnScreen
+        swipe(fromCenter.x, fromCenter.y, toCenter.x, toCenter.y, steps, duration)
+    }
+
     fun typeText(text: String) {
         robotDriver.typeText(text)
+    }
+
+    fun clearAndTypeText(node: AutomatorNode, text: String) {
+        click(node)
+        robotDriver.clearAndTypeText(text)
     }
 
     fun pressKey(keyCode: Int, modifiers: Int = 0) {
         robotDriver.pressKey(keyCode, modifiers)
     }
 
+    fun pressEnter() {
+        robotDriver.pressKey(KeyEvent.VK_ENTER)
+    }
+
     fun screenshot(region: Rectangle? = null): BufferedImage = robotDriver.screenshot(region)
+
+    fun screenshot(node: AutomatorNode): BufferedImage = robotDriver.screenshot(node.boundsOnScreen)
+
+    fun screenshot(windowIndex: Int): BufferedImage =
+        robotDriver.screenshot(tree(windowIndex).trackedWindow.composeSurfaceBoundsOnScreen)
+}
+
+class ComposeAutomator
+private constructor(
+    override val windowTracker: WindowTracker,
+    override val semanticsReader: SemanticsReader,
+    override val robotDriver: RobotDriver,
+) : ComposeAutomatorInteractions() {
 
     suspend fun waitForNode(
         tag: String? = null,
@@ -67,7 +139,6 @@ private constructor(
     ): AutomatorNode {
         require(tag != null || text != null) { "Either tag or text must be specified" }
         return waitUntil(timeout = timeout, pollInterval = pollInterval) {
-            // Wrap snapshot + filter in readOnEdt so semantics property reads are thread-safe
             readOnEdt {
                 refreshWindows()
                 allNodes().firstOrNull { node ->
@@ -82,13 +153,11 @@ private constructor(
         return readOnEdt {
             refreshWindows()
             buildString {
-                for ((windowIndex, trackedWindow) in windows.withIndex()) {
-                    val kind = if (trackedWindow.isPopup) "popup" else "main"
-                    appendLine("Window $windowIndex ($kind): ${trackedWindow.surfaceId}")
-                    val allNodes = semanticsReader.readAllNodes(listOf(trackedWindow))
-                    val roots = allNodes.filter { it.semanticsNode.parent == null }
-                    for (root in roots) {
-                        appendNodeTree(root, allNodes, depth = 1)
+                for (window in tree().windows()) {
+                    val kind = if (window.isPopup) "popup" else "main"
+                    appendLine("Window ${window.windowIndex} ($kind): ${window.surfaceId}")
+                    for (root in window.roots()) {
+                        appendNodeTree(root, depth = 1)
                     }
                 }
             }
@@ -102,14 +171,16 @@ private constructor(
             semanticsReader: SemanticsReader = SemanticsReader(),
             robotDriver: RobotDriver = RobotDriver(),
         ): ComposeAutomator = ComposeAutomator(windowTracker, semanticsReader, robotDriver)
+
+        fun inProcess(
+            windowTracker: WindowTracker = WindowTracker(),
+            semanticsReader: SemanticsReader = SemanticsReader(),
+            robotDriver: RobotDriver = RobotDriver(),
+        ): ComposeAutomator = create(windowTracker, semanticsReader, robotDriver)
     }
 }
 
-private fun StringBuilder.appendNodeTree(
-    node: AutomatorNode,
-    allNodes: List<AutomatorNode>,
-    depth: Int,
-) {
+private fun StringBuilder.appendNodeTree(node: AutomatorNode, depth: Int) {
     append("  ".repeat(depth))
     append("[${node.key.nodeId}]")
     node.testTag?.let { append(" testTag=\"$it\"") }
@@ -118,12 +189,7 @@ private fun StringBuilder.appendNodeTree(
     if (node.isFocused) append(" focused")
     if (node.isDisabled) append(" disabled")
     appendLine()
-    // Match children by full NodeKey (ownerIndex + nodeId) to avoid cross-owner collisions
-    for (child in node.semanticsNode.children) {
-        val childKey = NodeKey(node.key.surfaceId, node.key.ownerIndex, child.id)
-        val childNode = allNodes.find { it.key == childKey }
-        if (childNode != null) {
-            appendNodeTree(childNode, allNodes, depth + 1)
-        }
+    for (child in node.children) {
+        appendNodeTree(child, depth + 1)
     }
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -120,8 +120,13 @@ sealed class ComposeAutomatorInteractions : ComposeAutomatorQueries() {
 
     fun screenshot(node: AutomatorNode): BufferedImage = robotDriver.screenshot(node.boundsOnScreen)
 
-    fun screenshot(windowIndex: Int): BufferedImage =
-        robotDriver.screenshot(tree(windowIndex).trackedWindow.composeSurfaceBoundsOnScreen)
+    fun screenshot(windowIndex: Int): BufferedImage {
+        refreshWindows()
+        val trackedWindow =
+            windows.getOrNull(windowIndex)
+                ?: error("No tracked window at index $windowIndex (have ${windows.size})")
+        return robotDriver.screenshot(trackedWindow.composeSurfaceBoundsOnScreen)
+    }
 }
 
 class ComposeAutomator

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -166,17 +166,11 @@ private constructor(
 
     companion object {
 
-        fun create(
-            windowTracker: WindowTracker = WindowTracker(),
-            semanticsReader: SemanticsReader = SemanticsReader(),
-            robotDriver: RobotDriver = RobotDriver(),
-        ): ComposeAutomator = ComposeAutomator(windowTracker, semanticsReader, robotDriver)
-
         fun inProcess(
             windowTracker: WindowTracker = WindowTracker(),
             semanticsReader: SemanticsReader = SemanticsReader(),
             robotDriver: RobotDriver = RobotDriver(),
-        ): ComposeAutomator = create(windowTracker, semanticsReader, robotDriver)
+        ): ComposeAutomator = ComposeAutomator(windowTracker, semanticsReader, robotDriver)
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
@@ -1,6 +1,9 @@
 package dev.sebastiano.spectre.core
 
 import java.awt.Point
+import java.awt.Rectangle
+import kotlin.math.ceil
+import kotlin.math.floor
 
 /**
  * Converts a Compose X coordinate to an AWT screen X coordinate.
@@ -32,3 +35,27 @@ fun composeBoundsToAwtCenter(
     val awtBottom = composeToAwtY(bottom, scaleY, panelScreenY)
     return Point((awtLeft + awtRight) / 2, (awtTop + awtBottom) / 2)
 }
+
+fun composeBoundsToAwtRectangle(
+    left: Float,
+    top: Float,
+    right: Float,
+    bottom: Float,
+    scaleX: Float,
+    scaleY: Float,
+    panelScreenX: Int,
+    panelScreenY: Int,
+): Rectangle {
+    val awtLeft = floor((left / scaleX).toDouble()).toInt() + panelScreenX
+    val awtTop = floor((top / scaleY).toDouble()).toInt() + panelScreenY
+    val awtRight = ceil((right / scaleX).toDouble()).toInt() + panelScreenX
+    val awtBottom = ceil((bottom / scaleY).toDouble()).toInt() + panelScreenY
+    return Rectangle(
+        awtLeft,
+        awtTop,
+        (awtRight - awtLeft).coerceAtLeast(MIN_CAPTURE_SIZE_PX),
+        (awtBottom - awtTop).coerceAtLeast(MIN_CAPTURE_SIZE_PX),
+    )
+}
+
+private const val MIN_CAPTURE_SIZE_PX = 1

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -53,7 +53,7 @@ internal constructor(
         duration: Duration = DEFAULT_SWIPE_DURATION,
     ) = runOffEdt {
         val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
-        val pausePerStepMs = (duration.inWholeMilliseconds / points.size).coerceAtLeast(0)
+        val pausePerStepMs = swipePauseMillis(duration, steps)
         val firstPoint = points.first()
         robot.mouseMove(firstPoint.x, firstPoint.y)
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
@@ -195,6 +195,11 @@ fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
     if (mask and InputEvent.SHIFT_DOWN_MASK != 0) add(KeyEvent.VK_SHIFT)
     if (mask and InputEvent.ALT_DOWN_MASK != 0) add(KeyEvent.VK_ALT)
     if (mask and InputEvent.META_DOWN_MASK != 0) add(KeyEvent.VK_META)
+}
+
+internal fun swipePauseMillis(duration: Duration, steps: Int): Long {
+    require(steps > 0) { "steps must be positive" }
+    return (duration.inWholeMilliseconds / steps).coerceAtLeast(0)
 }
 
 fun interpolateSwipePoints(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -45,8 +45,11 @@ internal constructor(
         runOffEdt {
             robot.mouseMove(screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-            Thread.sleep(holdFor.inWholeMilliseconds)
-            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+            try {
+                Thread.sleep(holdFor.inWholeMilliseconds)
+            } finally {
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+            }
         }
 
     fun swipe(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -20,6 +20,11 @@ internal constructor(
     private val clipboard: ClipboardAdapter = SystemClipboardAdapter(),
 ) {
 
+    // Public surface: callers may instantiate without arguments (defaults to a fresh
+    // AWT Robot + system clipboard) or hand in an existing Robot. The internal
+    // adapter-injecting constructor is reserved for tests within this module.
+    constructor() : this(AwtRobotAdapter(), SystemClipboardAdapter())
+
     constructor(robot: Robot) : this(AwtRobotAdapter(robot))
 
     fun click(screenX: Int, screenY: Int) = runOffEdt {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -53,7 +53,7 @@ internal constructor(
         duration: Duration = DEFAULT_SWIPE_DURATION,
     ) = runOffEdt {
         val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
-        val pausePerStepMs = swipePauseMillis(duration, steps)
+        val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = DEFAULT_AUTO_DELAY_MS)
         val firstPoint = points.first()
         robot.mouseMove(firstPoint.x, firstPoint.y)
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
@@ -71,7 +71,7 @@ internal constructor(
         try {
             clipboard.setContents(StringSelection(text))
             runOffEdt {
-                val modifier = pasteModifierKeyCode(detectMacOs())
+                val modifier = shortcutModifierKeyCode(detectMacOs())
                 robot.keyPress(modifier)
                 robot.keyPress(KeyEvent.VK_V)
                 robot.keyRelease(KeyEvent.VK_V)
@@ -157,7 +157,10 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
 }
 
 private class SystemClipboardAdapter : ClipboardAdapter {
-    private val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+    // Lazy: looking up the system clipboard at construction time would couple every
+    // RobotDriver instantiation to clipboard availability, breaking mouse/screenshot-only
+    // automation runs in restricted environments.
+    private val clipboard by lazy { Toolkit.getDefaultToolkit().systemClipboard }
 
     override fun getContents(): Transferable? = clipboard.getContents(null)
 
@@ -184,9 +187,6 @@ private fun runOffEdt(block: () -> Unit) {
     result!!.getOrThrow()
 }
 
-fun pasteModifierKeyCode(isMacOs: Boolean): Int =
-    if (isMacOs) KeyEvent.VK_META else KeyEvent.VK_CONTROL
-
 fun shortcutModifierKeyCode(isMacOs: Boolean): Int =
     if (isMacOs) KeyEvent.VK_META else KeyEvent.VK_CONTROL
 
@@ -197,9 +197,10 @@ fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
     if (mask and InputEvent.META_DOWN_MASK != 0) add(KeyEvent.VK_META)
 }
 
-internal fun swipePauseMillis(duration: Duration, steps: Int): Long {
+internal fun swipePauseMillis(duration: Duration, steps: Int, autoDelayMs: Int): Long {
     require(steps > 0) { "steps must be positive" }
-    return (duration.inWholeMilliseconds / steps).coerceAtLeast(0)
+    val perStepBudgetMs = duration.inWholeMilliseconds / steps
+    return (perStepBudgetMs - autoDelayMs).coerceAtLeast(0)
 }
 
 fun interpolateSwipePoints(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -1,22 +1,26 @@
 package dev.sebastiano.spectre.core
 
 import java.awt.GraphicsEnvironment
+import java.awt.Point
 import java.awt.Rectangle
 import java.awt.Robot
 import java.awt.Toolkit
 import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.awt.image.BufferedImage
 import javax.swing.SwingUtilities
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 
-class RobotDriver(
-    private val robot: Robot =
-        Robot().apply {
-            autoDelay = DEFAULT_AUTO_DELAY_MS
-            isAutoWaitForIdle = false
-        }
+class RobotDriver
+internal constructor(
+    private val robot: RobotAdapter = AwtRobotAdapter(),
+    private val clipboard: ClipboardAdapter = SystemClipboardAdapter(),
 ) {
+
+    constructor(robot: Robot) : this(AwtRobotAdapter(robot))
 
     fun click(screenX: Int, screenY: Int) = runOffEdt {
         robot.mouseMove(screenX, screenY)
@@ -26,17 +30,46 @@ class RobotDriver(
 
     fun doubleClick(screenX: Int, screenY: Int) = runOffEdt {
         robot.mouseMove(screenX, screenY)
-        repeat(2) {
+        repeat(DOUBLE_CLICK_COUNT) {
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
         }
     }
 
+    fun longClick(screenX: Int, screenY: Int, holdFor: Duration = DEFAULT_LONG_CLICK_DURATION) =
+        runOffEdt {
+            robot.mouseMove(screenX, screenY)
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+            Thread.sleep(holdFor.inWholeMilliseconds)
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+        }
+
+    fun swipe(
+        startX: Int,
+        startY: Int,
+        endX: Int,
+        endY: Int,
+        steps: Int = DEFAULT_SWIPE_STEPS,
+        duration: Duration = DEFAULT_SWIPE_DURATION,
+    ) = runOffEdt {
+        val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
+        val pausePerStepMs = (duration.inWholeMilliseconds / points.size).coerceAtLeast(0)
+        val firstPoint = points.first()
+        robot.mouseMove(firstPoint.x, firstPoint.y)
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+        for (point in points.drop(1)) {
+            robot.mouseMove(point.x, point.y)
+            if (pausePerStepMs > 0) {
+                Thread.sleep(pausePerStepMs)
+            }
+        }
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+    }
+
     fun typeText(text: String) {
-        val clipboard = Toolkit.getDefaultToolkit().systemClipboard
-        val previousContents = runCatching { clipboard.getContents(null) }.getOrNull()
+        val previousContents = runCatching { clipboard.getContents() }.getOrNull()
         try {
-            clipboard.setContents(StringSelection(text), null)
+            clipboard.setContents(StringSelection(text))
             runOffEdt {
                 val modifier = pasteModifierKeyCode(detectMacOs())
                 robot.keyPress(modifier)
@@ -44,18 +77,27 @@ class RobotDriver(
                 robot.keyRelease(KeyEvent.VK_V)
                 robot.keyRelease(modifier)
             }
-            // Wait for the EDT to finish processing the paste event before restoring
-            // the clipboard. waitForIdle() is safe only when NOT on the EDT; when
-            // called from the EDT, runOffEdt blocks the EDT so waitForIdle would
-            // deadlock. EDT callers are unsupported and accept the restore race.
             if (!SwingUtilities.isEventDispatchThread()) {
                 robot.waitForIdle()
             }
         } finally {
             if (previousContents != null) {
-                runCatching { clipboard.setContents(previousContents, null) }
+                runCatching { clipboard.setContents(previousContents) }
             }
         }
+    }
+
+    fun clearAndTypeText(text: String) {
+        val selectAllModifier = shortcutModifierKeyCode(detectMacOs())
+        runOffEdt {
+            robot.keyPress(selectAllModifier)
+            robot.keyPress(KeyEvent.VK_A)
+            robot.keyRelease(KeyEvent.VK_A)
+            robot.keyRelease(selectAllModifier)
+            robot.keyPress(KeyEvent.VK_BACK_SPACE)
+            robot.keyRelease(KeyEvent.VK_BACK_SPACE)
+        }
+        typeText(text)
     }
 
     fun pressKey(keyCode: Int, modifiers: Int = 0) = runOffEdt {
@@ -72,14 +114,64 @@ class RobotDriver(
     }
 }
 
-/**
- * Robot actions must not run on the EDT because Robot.waitForIdle() would deadlock. When called
- * from the EDT, this dispatches the block to a temporary thread and waits for it to complete.
- *
- * Note: isAutoWaitForIdle is disabled to avoid the Robot internally calling waitForIdle() (which
- * would still deadlock if the spawned thread tried it). The autoDelay provides a small pause
- * between events instead.
- */
+internal interface RobotAdapter {
+
+    fun mouseMove(x: Int, y: Int)
+
+    fun mousePress(buttons: Int)
+
+    fun mouseRelease(buttons: Int)
+
+    fun keyPress(keyCode: Int)
+
+    fun keyRelease(keyCode: Int)
+
+    fun createScreenCapture(region: Rectangle): BufferedImage
+
+    fun waitForIdle()
+}
+
+internal interface ClipboardAdapter {
+
+    fun getContents(): Transferable?
+
+    fun setContents(contents: Transferable)
+}
+
+private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : RobotAdapter {
+
+    override fun mouseMove(x: Int, y: Int) = robot.mouseMove(x, y)
+
+    override fun mousePress(buttons: Int) = robot.mousePress(buttons)
+
+    override fun mouseRelease(buttons: Int) = robot.mouseRelease(buttons)
+
+    override fun keyPress(keyCode: Int) = robot.keyPress(keyCode)
+
+    override fun keyRelease(keyCode: Int) = robot.keyRelease(keyCode)
+
+    override fun createScreenCapture(region: Rectangle): BufferedImage =
+        robot.createScreenCapture(region)
+
+    override fun waitForIdle() = robot.waitForIdle()
+}
+
+private class SystemClipboardAdapter : ClipboardAdapter {
+    private val clipboard = Toolkit.getDefaultToolkit().systemClipboard
+
+    override fun getContents(): Transferable? = clipboard.getContents(null)
+
+    override fun setContents(contents: Transferable) {
+        clipboard.setContents(contents, null)
+    }
+}
+
+private fun createAwtRobot(): Robot =
+    Robot().apply {
+        autoDelay = DEFAULT_AUTO_DELAY_MS
+        isAutoWaitForIdle = false
+    }
+
 private fun runOffEdt(block: () -> Unit) {
     if (!SwingUtilities.isEventDispatchThread()) {
         block()
@@ -95,10 +187,9 @@ private fun runOffEdt(block: () -> Unit) {
 fun pasteModifierKeyCode(isMacOs: Boolean): Int =
     if (isMacOs) KeyEvent.VK_META else KeyEvent.VK_CONTROL
 
-/**
- * Translates an AWT modifier bitmask (e.g. [InputEvent.CTRL_DOWN_MASK]) into individual key codes
- * that Robot can press/release.
- */
+fun shortcutModifierKeyCode(isMacOs: Boolean): Int =
+    if (isMacOs) KeyEvent.VK_META else KeyEvent.VK_CONTROL
+
 fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
     if (mask and InputEvent.CTRL_DOWN_MASK != 0) add(KeyEvent.VK_CONTROL)
     if (mask and InputEvent.SHIFT_DOWN_MASK != 0) add(KeyEvent.VK_SHIFT)
@@ -106,13 +197,27 @@ fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
     if (mask and InputEvent.META_DOWN_MASK != 0) add(KeyEvent.VK_META)
 }
 
+fun interpolateSwipePoints(
+    startX: Int,
+    startY: Int,
+    endX: Int,
+    endY: Int,
+    steps: Int,
+): List<Point> {
+    require(steps > 0) { "steps must be positive" }
+    return buildList {
+        for (step in 0..steps) {
+            val progress = step.toFloat() / steps
+            add(Point(lerp(startX, endX, progress), lerp(startY, endY, progress)))
+        }
+    }
+}
+
 fun detectMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
 
 private fun virtualDesktopBounds(): Rectangle {
     val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
     val devices = ge.screenDevices
-    // Seed with the first device's bounds to avoid Rectangle() defaulting to (0,0)
-    // which would incorrectly include the origin in multi-monitor offset setups
     var bounds = devices.first().defaultConfiguration.bounds
     for (i in 1 until devices.size) {
         bounds = bounds.union(devices[i].defaultConfiguration.bounds)
@@ -120,4 +225,11 @@ private fun virtualDesktopBounds(): Rectangle {
     return bounds
 }
 
+private fun lerp(start: Int, end: Int, progress: Float): Int =
+    (start + ((end - start) * progress)).toInt()
+
 private const val DEFAULT_AUTO_DELAY_MS = 10
+private const val DOUBLE_CLICK_COUNT = 2
+private const val DEFAULT_SWIPE_STEPS = 12
+private val DEFAULT_SWIPE_DURATION: Duration = 200.milliseconds
+private val DEFAULT_LONG_CLICK_DURATION: Duration = 500.milliseconds

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -65,13 +65,16 @@ internal constructor(
         val firstPoint = points.first()
         robot.mouseMove(firstPoint.x, firstPoint.y)
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-        for (point in points.drop(1)) {
-            robot.mouseMove(point.x, point.y)
-            if (pausePerStepMs > 0) {
-                Thread.sleep(pausePerStepMs)
+        try {
+            for (point in points.drop(1)) {
+                robot.mouseMove(point.x, point.y)
+                if (pausePerStepMs > 0) {
+                    Thread.sleep(pausePerStepMs)
+                }
             }
+        } finally {
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
         }
-        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
     }
 
     fun typeText(text: String) {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -53,7 +53,7 @@ internal constructor(
         duration: Duration = DEFAULT_SWIPE_DURATION,
     ) = runOffEdt {
         val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
-        val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = DEFAULT_AUTO_DELAY_MS)
+        val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = robot.autoDelayMs)
         val firstPoint = points.first()
         robot.mouseMove(firstPoint.x, firstPoint.y)
         robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
@@ -116,6 +116,8 @@ internal constructor(
 
 internal interface RobotAdapter {
 
+    val autoDelayMs: Int
+
     fun mouseMove(x: Int, y: Int)
 
     fun mousePress(buttons: Int)
@@ -139,6 +141,9 @@ internal interface ClipboardAdapter {
 }
 
 private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : RobotAdapter {
+
+    override val autoDelayMs: Int
+        get() = robot.autoDelay
 
     override fun mouseMove(x: Int, y: Int) = robot.mouseMove(x, y)
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -69,13 +69,14 @@ class SemanticsReader {
             }
         }
 
+        val parentKeyByNodeKey = entries.associate { it.key to it.parentKey }
         val nodeKeysByParentKey =
             entries.groupBy(keySelector = NodeEntry::parentKey, valueTransform = NodeEntry::key)
         val nodesByKey = mutableMapOf<NodeKey, AutomatorNode>()
         val relations =
             object : NodeRelations {
                 override fun parentOf(key: NodeKey): AutomatorNode? =
-                    entries.firstOrNull { it.key == key }?.parentKey?.let(nodesByKey::get)
+                    parentKeyByNodeKey[key]?.let(nodesByKey::get)
 
                 override fun childrenOf(key: NodeKey): List<AutomatorNode> =
                     nodeKeysByParentKey[key].orEmpty().mapNotNull(nodesByKey::get)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -17,16 +17,27 @@ class SemanticsReader {
             collectAllNodes(trackedWindows).filter { it.testTag == tag }
         }
 
+    fun findByText(query: TextQuery, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
+        readOnEdt {
+            collectAllNodes(trackedWindows).filter { node ->
+                node.texts.any(query::matches) || query.matches(node.editableText)
+            }
+        }
+
     fun findByText(
         text: String,
         trackedWindows: List<TrackedWindow>,
         exact: Boolean = true,
-    ): List<AutomatorNode> = readOnEdt {
-        collectAllNodes(trackedWindows).filter { node ->
-            node.texts.any { matchesText(it, text, exact) } ||
-                matchesText(node.editableText, text, exact)
-        }
-    }
+    ): List<AutomatorNode> =
+        findByText(
+            query =
+                if (exact) {
+                    TextQuery.exact(text)
+                } else {
+                    TextQuery.substring(text, ignoreCase = true)
+                },
+            trackedWindows = trackedWindows,
+        )
 
     fun findByContentDescription(
         description: String,
@@ -44,14 +55,43 @@ class SemanticsReader {
 
     @OptIn(ExperimentalComposeUiApi::class)
     private fun collectAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> {
-        val nodes = mutableListOf<AutomatorNode>()
+        val entries = mutableListOf<NodeEntry>()
         for (trackedWindow in trackedWindows) {
             val owners = getOwnersForWindow(trackedWindow)
             for ((ownerIndex, owner) in owners.withIndex()) {
-                traverseTree(owner.rootSemanticsNode, trackedWindow, ownerIndex, nodes)
+                traverseTree(
+                    owner.rootSemanticsNode,
+                    trackedWindow,
+                    ownerIndex,
+                    parentKey = null,
+                    entries,
+                )
             }
         }
-        return nodes
+
+        val nodeKeysByParentKey =
+            entries.groupBy(keySelector = NodeEntry::parentKey, valueTransform = NodeEntry::key)
+        val nodesByKey = mutableMapOf<NodeKey, AutomatorNode>()
+        val relations =
+            object : NodeRelations {
+                override fun parentOf(key: NodeKey): AutomatorNode? =
+                    entries.firstOrNull { it.key == key }?.parentKey?.let(nodesByKey::get)
+
+                override fun childrenOf(key: NodeKey): List<AutomatorNode> =
+                    nodeKeysByParentKey[key].orEmpty().mapNotNull(nodesByKey::get)
+            }
+
+        for (entry in entries) {
+            nodesByKey[entry.key] =
+                AutomatorNode(
+                    key = entry.key,
+                    semanticsNode = entry.node,
+                    trackedWindow = entry.trackedWindow,
+                    relations = relations,
+                )
+        }
+
+        return entries.mapNotNull { entry -> nodesByKey[entry.key] }
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
@@ -67,17 +107,21 @@ class SemanticsReader {
         node: SemanticsNode,
         trackedWindow: TrackedWindow,
         ownerIndex: Int,
-        result: MutableList<AutomatorNode>,
+        parentKey: NodeKey?,
+        result: MutableList<NodeEntry>,
     ) {
         val key = NodeKey(trackedWindow.surfaceId, ownerIndex, node.id)
-        result += AutomatorNode(key = key, semanticsNode = node, trackedWindow = trackedWindow)
+        result +=
+            NodeEntry(key = key, node = node, trackedWindow = trackedWindow, parentKey = parentKey)
         for (child in node.children) {
-            traverseTree(child, trackedWindow, ownerIndex, result)
+            traverseTree(child, trackedWindow, ownerIndex, parentKey = key, result)
         }
     }
 }
 
-private fun matchesText(nodeText: String?, query: String, exact: Boolean): Boolean {
-    if (nodeText == null) return false
-    return if (exact) nodeText == query else nodeText.contains(query, ignoreCase = true)
-}
+private data class NodeEntry(
+    val key: NodeKey,
+    val node: SemanticsNode,
+    val trackedWindow: TrackedWindow,
+    val parentKey: NodeKey?,
+)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TextQuery.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TextQuery.kt
@@ -1,0 +1,30 @@
+package dev.sebastiano.spectre.core
+
+data class TextQuery(
+    val value: String,
+    val matchType: TextMatchType = TextMatchType.Exact,
+    val ignoreCase: Boolean = false,
+) {
+
+    fun matches(candidate: String?): Boolean {
+        if (candidate == null) return false
+        return when (matchType) {
+            TextMatchType.Exact -> candidate.equals(value, ignoreCase = ignoreCase)
+            TextMatchType.Substring -> candidate.contains(value, ignoreCase = ignoreCase)
+        }
+    }
+
+    companion object {
+
+        fun exact(value: String, ignoreCase: Boolean = false): TextQuery =
+            TextQuery(value = value, matchType = TextMatchType.Exact, ignoreCase = ignoreCase)
+
+        fun substring(value: String, ignoreCase: Boolean = false): TextQuery =
+            TextQuery(value = value, matchType = TextMatchType.Substring, ignoreCase = ignoreCase)
+    }
+}
+
+enum class TextMatchType {
+    Exact,
+    Substring,
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.core
 
 import androidx.compose.ui.awt.ComposePanel
 import java.awt.Point
+import java.awt.Rectangle
 import java.awt.Window
 import javax.swing.JFrame
 
@@ -25,4 +26,10 @@ data class TrackedWindow(
             composePanel?.locationOnScreen
                 ?: (window as? JFrame)?.contentPane?.locationOnScreen
                 ?: window.locationOnScreen
+
+    val composeSurfaceBoundsOnScreen: Rectangle
+        get() =
+            composePanel?.let { Rectangle(it.locationOnScreen, it.size) }
+                ?: (window as? JFrame)?.contentPane?.let { Rectangle(it.locationOnScreen, it.size) }
+                ?: Rectangle(window.locationOnScreen, window.size)
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
@@ -28,8 +28,9 @@ data class TrackedWindow(
                 ?: window.locationOnScreen
 
     val composeSurfaceBoundsOnScreen: Rectangle
-        get() =
+        get() = readOnEdt {
             composePanel?.let { Rectangle(it.locationOnScreen, it.size) }
                 ?: (window as? JFrame)?.contentPane?.let { Rectangle(it.locationOnScreen, it.size) }
                 ?: Rectangle(window.locationOnScreen, window.size)
+        }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/HiDpiMapperTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/HiDpiMapperTest.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.core
 
 import java.awt.Point
+import java.awt.Rectangle
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -91,5 +92,56 @@ class HiDpiMapperTest {
         // AWT X: left=60, right=160 → center=110
         // AWT Y: top=110, bottom=210 → center=160
         assertEquals(Point(110, 160), result)
+    }
+
+    @Test
+    fun `computes capture rectangle in AWT screen coordinates`() {
+        val result =
+            composeBoundsToAwtRectangle(
+                left = 100f,
+                top = 200f,
+                right = 300f,
+                bottom = 500f,
+                scaleX = 2f,
+                scaleY = 2f,
+                panelScreenX = 10,
+                panelScreenY = 20,
+            )
+
+        assertEquals(Rectangle(60, 120, 100, 150), result)
+    }
+
+    @Test
+    fun `capture rectangle is at least one pixel in each dimension`() {
+        val result =
+            composeBoundsToAwtRectangle(
+                left = 10f,
+                top = 20f,
+                right = 10.4f,
+                bottom = 20.4f,
+                scaleX = 1f,
+                scaleY = 1f,
+                panelScreenX = 0,
+                panelScreenY = 0,
+            )
+
+        assertEquals(Rectangle(10, 20, 1, 1), result)
+    }
+
+    @Test
+    fun `capture rectangle rounds outward to preserve trailing edge pixels`() {
+        val result =
+            composeBoundsToAwtRectangle(
+                left = 10.2f,
+                top = 5.1f,
+                right = 20.8f,
+                bottom = 9.9f,
+                scaleX = 1f,
+                scaleY = 1f,
+                panelScreenX = 0,
+                panelScreenY = 0,
+            )
+
+        assertEquals(Rectangle(10, 5, 11, 5), result)
     }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/NodeKeyTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/NodeKeyTest.kt
@@ -52,4 +52,12 @@ class NodeKeyTest {
         val parsed = NodeKey.parse(original.toString())
         assertEquals(original, parsed)
     }
+
+    @Test
+    fun `owner index participates in node identity`() {
+        val ownerZero = NodeKey(surfaceId = "window:0", ownerIndex = 0, nodeId = 42)
+        val ownerOne = NodeKey(surfaceId = "window:0", ownerIndex = 1, nodeId = 42)
+
+        kotlin.test.assertNotEquals(ownerZero, ownerOne)
+    }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -11,18 +11,19 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.ZERO
+import kotlin.time.Duration.Companion.milliseconds
 
 class RobotDriverTest {
 
     @Test
-    fun `pasteModifierKeyCode returns VK_META on macOS`() {
-        val result = pasteModifierKeyCode(isMacOs = true)
+    fun `shortcutModifierKeyCode returns VK_META on macOS`() {
+        val result = shortcutModifierKeyCode(isMacOs = true)
         assertEquals(KeyEvent.VK_META, result)
     }
 
     @Test
-    fun `pasteModifierKeyCode returns VK_CONTROL on non-macOS`() {
-        val result = pasteModifierKeyCode(isMacOs = false)
+    fun `shortcutModifierKeyCode returns VK_CONTROL on non-macOS`() {
+        val result = shortcutModifierKeyCode(isMacOs = false)
         assertEquals(KeyEvent.VK_CONTROL, result)
     }
 
@@ -30,6 +31,26 @@ class RobotDriverTest {
     fun `shortcutModifierKeyCode matches platform shortcut key`() {
         val expected = if (detectMacOs()) KeyEvent.VK_META else KeyEvent.VK_CONTROL
         assertEquals(expected, shortcutModifierKeyCode(detectMacOs()))
+    }
+
+    @Test
+    fun `swipePauseMillis subtracts autoDelay from per-step pause`() {
+        // 200ms over 10 steps = 20ms/step, minus 10ms Robot autoDelay per move = 10ms.
+        val pause = swipePauseMillis(duration = 200.milliseconds, steps = 10, autoDelayMs = 10)
+        assertEquals(10L, pause)
+    }
+
+    @Test
+    fun `swipePauseMillis clamps to zero when autoDelay exceeds the per-step budget`() {
+        // 50ms over 10 steps = 5ms/step, minus 10ms autoDelay would be negative.
+        val pause = swipePauseMillis(duration = 50.milliseconds, steps = 10, autoDelayMs = 10)
+        assertEquals(0L, pause)
+    }
+
+    @Test
+    fun `swipePauseMillis returns zero for zero duration`() {
+        val pause = swipePauseMillis(duration = ZERO, steps = 5, autoDelayMs = 10)
+        assertEquals(0L, pause)
     }
 
     @Test

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -138,7 +138,7 @@ class RobotDriverTest {
     }
 }
 
-private class RecordingRobotAdapter : RobotAdapter {
+private class RecordingRobotAdapter(override val autoDelayMs: Int = 0) : RobotAdapter {
     val events = mutableListOf<String>()
 
     override fun mouseMove(x: Int, y: Int) {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -1,16 +1,16 @@
 package dev.sebastiano.spectre.core
 
-import java.awt.GraphicsEnvironment
-import java.awt.Robot
+import java.awt.Point
+import java.awt.Rectangle
+import java.awt.datatransfer.Transferable
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
-import javax.swing.SwingUtilities
+import java.awt.image.BufferedImage
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-import org.junit.jupiter.api.condition.EnabledIf
+import kotlin.time.Duration.Companion.ZERO
 
 class RobotDriverTest {
 
@@ -24,6 +24,12 @@ class RobotDriverTest {
     fun `pasteModifierKeyCode returns VK_CONTROL on non-macOS`() {
         val result = pasteModifierKeyCode(isMacOs = false)
         assertEquals(KeyEvent.VK_CONTROL, result)
+    }
+
+    @Test
+    fun `shortcutModifierKeyCode matches platform shortcut key`() {
+        val expected = if (detectMacOs()) KeyEvent.VK_META else KeyEvent.VK_CONTROL
+        assertEquals(expected, shortcutModifierKeyCode(detectMacOs()))
     }
 
     @Test
@@ -55,68 +61,103 @@ class RobotDriverTest {
         assertEquals(listOf(KeyEvent.VK_META), modifierMaskToKeyCodes(InputEvent.META_DOWN_MASK))
     }
 
-    @EnabledIf("isNotHeadless")
     @Test
-    fun `click does not throw when called from the EDT`() {
-        val driver = RobotDriver(noOpRobot())
-        val latch = CountDownLatch(1)
-        var error: Throwable? = null
+    fun `interpolateSwipePoints includes both endpoints`() {
+        val result =
+            interpolateSwipePoints(startX = 10, startY = 20, endX = 40, endY = 50, steps = 3)
 
-        SwingUtilities.invokeLater {
-            try {
-                driver.click(0, 0)
-            } catch (e: Throwable) {
-                error = e
-            } finally {
-                latch.countDown()
-            }
-        }
-
-        assertTrue(latch.await(ROBOT_EDT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS), "Timed out")
-        error?.let { throw AssertionError("click from EDT should not throw", it) }
+        assertEquals(listOf(Point(10, 20), Point(20, 30), Point(30, 40), Point(40, 50)), result)
     }
 
-    @EnabledIf("isNotHeadless")
     @Test
-    fun `typeText does not throw when called from the EDT`() {
-        val driver = RobotDriver(noOpRobot())
-        val latch = CountDownLatch(1)
-        var error: Throwable? = null
-
-        SwingUtilities.invokeLater {
-            try {
-                driver.typeText("test")
-            } catch (e: Throwable) {
-                error = e
-            } finally {
-                latch.countDown()
+    fun `interpolateSwipePoints rejects non-positive steps`() {
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                interpolateSwipePoints(startX = 0, startY = 0, endX = 10, endY = 10, steps = 0)
             }
-        }
 
-        assertTrue(latch.await(ROBOT_EDT_TEST_TIMEOUT_SECONDS, TimeUnit.SECONDS), "Timed out")
-        error?.let { throw AssertionError("typeText from EDT should not throw", it) }
+        assertTrue(error.message?.contains("steps") == true)
     }
 
-    companion object {
+    @Test
+    fun `click moves and presses left button`() {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
 
-        @JvmStatic fun isNotHeadless(): Boolean = !GraphicsEnvironment.isHeadless()
+        driver.click(10, 20)
+
+        assertEquals(
+            listOf(
+                "move(10,20)",
+                "press(${InputEvent.BUTTON1_DOWN_MASK})",
+                "release(${InputEvent.BUTTON1_DOWN_MASK})",
+            ),
+            robot.events,
+        )
+    }
+
+    @Test
+    fun `swipe presses drags and releases in order`() {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.swipe(startX = 10, startY = 20, endX = 40, endY = 50, steps = 3, duration = ZERO)
+
+        assertEquals(
+            listOf(
+                "move(10,20)",
+                "press(${InputEvent.BUTTON1_DOWN_MASK})",
+                "move(20,30)",
+                "move(30,40)",
+                "move(40,50)",
+                "release(${InputEvent.BUTTON1_DOWN_MASK})",
+            ),
+            robot.events,
+        )
     }
 }
 
-/**
- * A Robot subclass that suppresses all mouse and keyboard actions, for use in EDT-dispatch tests.
- */
-private fun noOpRobot() =
-    object : Robot() {
-        override fun mouseMove(x: Int, y: Int) = Unit
+private class RecordingRobotAdapter : RobotAdapter {
+    val events = mutableListOf<String>()
 
-        override fun mousePress(buttons: Int) = Unit
-
-        override fun mouseRelease(buttons: Int) = Unit
-
-        override fun keyPress(keycode: Int) = Unit
-
-        override fun keyRelease(keycode: Int) = Unit
+    override fun mouseMove(x: Int, y: Int) {
+        events += "move($x,$y)"
     }
 
-private const val ROBOT_EDT_TEST_TIMEOUT_SECONDS = 5L
+    override fun mousePress(buttons: Int) {
+        events += "press($buttons)"
+    }
+
+    override fun mouseRelease(buttons: Int) {
+        events += "release($buttons)"
+    }
+
+    override fun keyPress(keyCode: Int) {
+        events += "keyPress($keyCode)"
+    }
+
+    override fun keyRelease(keyCode: Int) {
+        events += "keyRelease($keyCode)"
+    }
+
+    override fun createScreenCapture(region: Rectangle): BufferedImage =
+        BufferedImage(
+            region.width.coerceAtLeast(1),
+            region.height.coerceAtLeast(1),
+            BufferedImage.TYPE_INT_ARGB,
+        )
+
+    override fun waitForIdle() {
+        events += "waitForIdle()"
+    }
+}
+
+private class RecordingClipboardAdapter : ClipboardAdapter {
+    private var current: Transferable? = null
+
+    override fun getContents(): Transferable? = current
+
+    override fun setContents(contents: Transferable) {
+        current = contents
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SwipeTimingTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SwipeTimingTest.kt
@@ -1,0 +1,21 @@
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Duration.Companion.milliseconds
+
+class SwipeTimingTest {
+
+    @Test
+    fun `swipe pause uses gesture steps instead of point count`() {
+        val pauseMs = swipePauseMillis(200.milliseconds, steps = 12)
+
+        assertEquals(16, pauseMs)
+    }
+
+    @Test
+    fun `swipe pause rejects non-positive steps`() {
+        assertFailsWith<IllegalArgumentException> { swipePauseMillis(200.milliseconds, steps = 0) }
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SwipeTimingTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SwipeTimingTest.kt
@@ -9,13 +9,16 @@ class SwipeTimingTest {
 
     @Test
     fun `swipe pause uses gesture steps instead of point count`() {
-        val pauseMs = swipePauseMillis(200.milliseconds, steps = 12)
+        // 200ms / 12 steps = 16ms/step, with no Robot autoDelay overhead to subtract.
+        val pauseMs = swipePauseMillis(200.milliseconds, steps = 12, autoDelayMs = 0)
 
         assertEquals(16, pauseMs)
     }
 
     @Test
     fun `swipe pause rejects non-positive steps`() {
-        assertFailsWith<IllegalArgumentException> { swipePauseMillis(200.milliseconds, steps = 0) }
+        assertFailsWith<IllegalArgumentException> {
+            swipePauseMillis(200.milliseconds, steps = 0, autoDelayMs = 0)
+        }
     }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/TextQueryTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/TextQueryTest.kt
@@ -1,0 +1,46 @@
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class TextQueryTest {
+
+    @Test
+    fun `exact query matches only exact text by default`() {
+        val query = TextQuery.exact("Spectre")
+
+        assertTrue(query.matches("Spectre"))
+        assertFalse(query.matches("spectre"))
+        assertFalse(query.matches("Spectre sample"))
+    }
+
+    @Test
+    fun `exact query can ignore case`() {
+        val query = TextQuery.exact("Spectre", ignoreCase = true)
+
+        assertTrue(query.matches("spectre"))
+    }
+
+    @Test
+    fun `substring query matches contained text`() {
+        val query = TextQuery.substring("ectr")
+
+        assertTrue(query.matches("Spectre"))
+        assertFalse(query.matches("Sceptre"))
+    }
+
+    @Test
+    fun `substring query can ignore case`() {
+        val query = TextQuery.substring("ECTR", ignoreCase = true)
+
+        assertTrue(query.matches("Spectre"))
+    }
+
+    @Test
+    fun `query never matches null text`() {
+        val query = TextQuery.substring("Spectre")
+
+        assertFalse(query.matches(null))
+    }
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
@@ -27,7 +27,7 @@ fun main() = application {
 
 @Suppress("LongMethod")
 private suspend fun runAutomatorDemo() {
-    val automator = ComposeAutomator.create()
+    val automator = ComposeAutomator.inProcess()
     automator.refreshWindows()
 
     println("=== Spectre Automator Demo ===")


### PR DESCRIPTION
## Summary
- add the intended in-process entrypoint and richer text query matching
- expose tree/window traversal helpers, node parent/children access, and screenshot ergonomics
- add missing node interaction helpers and swipe support for the in-process core API

Closes #5.

## Verification
- ./gradlew --no-configuration-cache :core:ktfmtFormat :core:detekt :core:compileTestKotlin
- ./gradlew --no-configuration-cache :core:test --tests 'dev.sebastiano.spectre.core.TextQueryTest' --tests 'dev.sebastiano.spectre.core.HiDpiMapperTest' --tests 'dev.sebastiano.spectre.core.NodeKeyTest' --rerun-tasks

## Notes
- Per request, I skipped local verification work on RobotDriverTest.
