### PR TITLE
Build the testing module: JUnit 4 rule + JUnit 5 extension

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -283,6 +283,13 @@ fun interpolateSwipePoints(
 fun detectMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
 
 private fun virtualDesktopBounds(): Rectangle {
+    // GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices throws HeadlessException
+    // when the JVM is running with -Djava.awt.headless=true (e.g. CI). RobotDriver.headless()
+    // is documented as safe in that environment, so fall back to a 1×1 rectangle here so the
+    // headless path never reaches a real device probe. The NoopRobotAdapter will still produce
+    // an empty BufferedImage of that size.
+    if (GraphicsEnvironment.isHeadless()) return Rectangle(0, 0, 1, 1)
+
     val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
     val devices = ge.screenDevices
     var bounds = devices.first().defaultConfiguration.bounds

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -200,12 +200,12 @@ private object NoopRobotAdapter : RobotAdapter {
 
     override fun keyRelease(keyCode: Int) = Unit
 
-    override fun createScreenCapture(region: Rectangle): BufferedImage =
-        BufferedImage(
-            region.width.coerceAtLeast(1),
-            region.height.coerceAtLeast(1),
-            BufferedImage.TYPE_INT_ARGB,
-        )
+    // Always return a 1×1 sentinel image regardless of region size. RobotDriver.headless() is
+    // explicitly documented as no-OS-contact, so we should not allocate a full virtual-desktop
+    // BufferedImage on headful machines that happen to use the headless factory.
+    private val sentinelImage = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+
+    override fun createScreenCapture(region: Rectangle): BufferedImage = sentinelImage
 
     override fun waitForIdle() = Unit
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -200,12 +200,12 @@ private object NoopRobotAdapter : RobotAdapter {
 
     override fun keyRelease(keyCode: Int) = Unit
 
-    // Always return a 1×1 sentinel image regardless of region size. RobotDriver.headless() is
-    // explicitly documented as no-OS-contact, so we should not allocate a full virtual-desktop
-    // BufferedImage on headful machines that happen to use the headless factory.
-    private val sentinelImage = BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
-
-    override fun createScreenCapture(region: Rectangle): BufferedImage = sentinelImage
+    // Always return a fresh 1×1 image regardless of region size. RobotDriver.headless() is
+    // documented as no-OS-contact (so we don't probe screen devices) and screenshot returns
+    // are conceptually owned by the caller (BufferedImage is mutable; setRGB/createGraphics
+    // are normal post-screenshot operations), so a per-call instance is required for safety.
+    override fun createScreenCapture(region: Rectangle): BufferedImage =
+        BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
 
     override fun waitForIdle() = Unit
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -123,6 +123,20 @@ internal constructor(
         val captureRegion = region ?: virtualDesktopBounds()
         return robot.createScreenCapture(captureRegion)
     }
+
+    companion object {
+
+        /**
+         * Returns a [RobotDriver] that performs no real OS input or capture.
+         *
+         * Intended for tests and headless CI environments where constructing a real
+         * `java.awt.Robot` (or touching the system clipboard / screen) is unavailable. Mouse and
+         * key calls are silently dropped, screenshots return a 1×1 empty image, and clipboard
+         * access is a no-op. Combine with the testing module's `ComposeAutomatorRule` /
+         * `ComposeAutomatorExtension` to exercise the rule/extension lifecycle without an EDT.
+         */
+        fun headless(): RobotDriver = RobotDriver(NoopRobotAdapter, NoopClipboardAdapter)
+    }
 }
 
 internal interface RobotAdapter {
@@ -170,6 +184,37 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
         robot.createScreenCapture(region)
 
     override fun waitForIdle() = robot.waitForIdle()
+}
+
+private object NoopRobotAdapter : RobotAdapter {
+
+    override val autoDelayMs: Int = 0
+
+    override fun mouseMove(x: Int, y: Int) = Unit
+
+    override fun mousePress(buttons: Int) = Unit
+
+    override fun mouseRelease(buttons: Int) = Unit
+
+    override fun keyPress(keyCode: Int) = Unit
+
+    override fun keyRelease(keyCode: Int) = Unit
+
+    override fun createScreenCapture(region: Rectangle): BufferedImage =
+        BufferedImage(
+            region.width.coerceAtLeast(1),
+            region.height.coerceAtLeast(1),
+            BufferedImage.TYPE_INT_ARGB,
+        )
+
+    override fun waitForIdle() = Unit
+}
+
+private object NoopClipboardAdapter : ClipboardAdapter {
+
+    override fun getContents(): Transferable? = null
+
+    override fun setContents(contents: Transferable) = Unit
 }
 
 private class SystemClipboardAdapter : ClipboardAdapter {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,8 @@ composeRules = "0.5.6"
 detekt = "2.0.0-alpha.2"
 ktfmt = "0.26.0"
 kotlin = "2.3.20"
+junit4 = "4.13.2"
+junit5 = "5.11.4"
 kotlinx-coroutines = "1.10.2"
 material3 = "1.10.0-alpha05"
 
@@ -25,6 +27,10 @@ compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-previ
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-swing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+junit5-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
+junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
+junit5-vintageEngine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }

--- a/testing/README.md
+++ b/testing/README.md
@@ -1,10 +1,31 @@
 # Testing
 
-Planned home for test ergonomics:
+Test ergonomics for Spectre.
 
-- JUnit 4 rule / helpers
-- JUnit 5 extension / helpers
-- shared smoke-test fixtures
+## Public API
 
-This module is intentionally scaffold-only right now.
+- `ComposeAutomatorRule` — JUnit 4 rule that owns a per-test `ComposeAutomator` instance.
+- `ComposeAutomatorExtension` — JUnit 5 extension with the same lifecycle plus parameter
+  resolution for `ComposeAutomator` test method parameters.
+- `AutomatorFactory` — typealias for the `() -> ComposeAutomator` lambda the rule and extension
+  use to build their per-test instances.
 
+Both wrappers default to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
+or focused unit testing can pass a custom factory built around `RobotDriver.headless()` (see the
+`newHeadlessAutomator()` fixture in this module's tests for the recipe).
+
+## JUnit dependency model
+
+`junit:junit` and `org.junit.jupiter:junit-jupiter-api` are both `compileOnly`. Consumers pick
+whichever JUnit they're already using and pull in the matching test dependency themselves; the
+testing module never forces both onto the test classpath.
+
+## Cross-boundary contracts
+
+Contract tests pin the wire-level guarantees that cross module boundaries:
+
+- `NodeKeyContractTest` — round-trip and parse safety for the `surfaceId:ownerIndex:nodeId`
+  string form that future HTTP transport and recording integrations will rely on.
+
+More contract tests will land here as cross-module surfaces grow (HTTP transport in #9,
+recording integration in #10).

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -7,8 +7,19 @@ plugins {
 kotlin { jvmToolchain(21) }
 
 dependencies {
-    implementation(projects.core)
+    api(projects.core)
+    // JUnit 4 and JUnit Jupiter are compileOnly so consumers pick whichever they're already
+    // using; the testing module itself only references their public APIs.
+    compileOnly(libs.junit4)
+    compileOnly(libs.junit5.api)
+    detektPlugins(libs.compose.rules.detekt)
+
     testImplementation(libs.kotlin.testJunit5)
+    testImplementation(libs.junit4)
+    testImplementation(libs.junit5.api)
+    testRuntimeOnly(libs.junit5.engine)
+    // Lets us run the JUnit 4 rule via the JUnit Platform launcher in our own tests.
+    testRuntimeOnly(libs.junit5.vintageEngine)
 }
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutomatorFactory.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutomatorFactory.kt
@@ -1,0 +1,12 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+
+/**
+ * Factory for building a [ComposeAutomator] inside a test fixture.
+ *
+ * The default `{ ComposeAutomator.inProcess() }` is suitable for live UI tests against a real AWT
+ * display. Headless or unit-style tests that only need the test ergonomics (rule/extension
+ * plumbing) without a real Robot/EDT can supply a custom factory that returns a stub or a fake.
+ */
+typealias AutomatorFactory = () -> ComposeAutomator

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -33,9 +33,13 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * The [factory] defaults to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
  * or focused unit testing can supply their own factory.
  */
-class ComposeAutomatorExtension(
-    private val factory: AutomatorFactory = { ComposeAutomator.inProcess() }
-) : BeforeEachCallback, AfterEachCallback, ParameterResolver {
+class ComposeAutomatorExtension(private val factory: AutomatorFactory) :
+    BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    // Explicit no-arg secondary constructor so JUnit 5's @ExtendWith — which reflectively
+    // calls the no-arg constructor — can instantiate the extension. Kotlin's default-parameter
+    // primary constructor does not emit a true JVM no-arg overload without @JvmOverloads.
+    constructor() : this({ ComposeAutomator.inProcess() })
 
     private var instance: ComposeAutomator? = null
 
@@ -60,10 +64,12 @@ class ComposeAutomatorExtension(
         extensionContext: ExtensionContext,
     ): Boolean =
         parameterContext.parameter.type == ComposeAutomator::class.java &&
-            // Constructor injection happens before beforeEach, so the per-test instance does not
-            // exist yet. Restrict resolution to method/lifecycle parameters where the instance
-            // is guaranteed to be available.
-            parameterContext.declaringExecutable is Method
+            parameterContext.declaringExecutable is Method &&
+            // Restrict resolution to per-test method invocations. Constructor parameters and
+            // @BeforeAll / @AfterAll lifecycle hooks run outside the per-test window, when
+            // `instance` is null; rejecting them lets other resolvers handle those slots and
+            // avoids surfacing IllegalStateException to the runner.
+            extensionContext.testMethod.isPresent
 
     override fun resolveParameter(
         parameterContext: ParameterContext,

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -1,0 +1,66 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolver
+
+/**
+ * JUnit 5 extension that owns a per-test [ComposeAutomator] instance.
+ *
+ * Usage:
+ * ```
+ * @RegisterExtension val automatorExt = ComposeAutomatorExtension()
+ *
+ * @Test fun something() {
+ *     val node = automatorExt.automator.findOneByTestTag("Send")
+ *     ...
+ * }
+ * ```
+ *
+ * The extension also implements [ParameterResolver], so tests can take a [ComposeAutomator]
+ * parameter and have it injected automatically:
+ * ```
+ * @ExtendWith(ComposeAutomatorExtension::class)
+ * class MyTest {
+ *     @Test fun something(automator: ComposeAutomator) { ... }
+ * }
+ * ```
+ *
+ * The [factory] defaults to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
+ * or focused unit testing can supply their own factory.
+ */
+class ComposeAutomatorExtension(
+    private val factory: AutomatorFactory = { ComposeAutomator.inProcess() }
+) : BeforeEachCallback, AfterEachCallback, ParameterResolver {
+
+    private var instance: ComposeAutomator? = null
+
+    val automator: ComposeAutomator
+        get() =
+            checkNotNull(instance) {
+                "ComposeAutomatorExtension.automator accessed outside of a running test"
+            }
+
+    override fun beforeEach(context: ExtensionContext) {
+        instance = factory()
+    }
+
+    override fun afterEach(context: ExtensionContext) {
+        // Future hook: when the automator gains lifecycle-aware resources (recordings,
+        // background pollers, etc.) tear them down here.
+        instance = null
+    }
+
+    override fun supportsParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext,
+    ): Boolean = parameterContext.parameter.type == ComposeAutomator::class.java
+
+    override fun resolveParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext,
+    ): Any = automator
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.testing
 
 import dev.sebastiano.spectre.core.ComposeAutomator
+import java.lang.reflect.Method
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
@@ -57,7 +58,12 @@ class ComposeAutomatorExtension(
     override fun supportsParameter(
         parameterContext: ParameterContext,
         extensionContext: ExtensionContext,
-    ): Boolean = parameterContext.parameter.type == ComposeAutomator::class.java
+    ): Boolean =
+        parameterContext.parameter.type == ComposeAutomator::class.java &&
+            // Constructor injection happens before beforeEach, so the per-test instance does not
+            // exist yet. Restrict resolution to method/lifecycle parameters where the instance
+            // is guaranteed to be available.
+            parameterContext.declaringExecutable is Method
 
     override fun resolveParameter(
         parameterContext: ParameterContext,

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -11,18 +11,18 @@ import org.junit.jupiter.api.extension.ParameterResolver
 /**
  * JUnit 5 extension that owns a per-test [ComposeAutomator] instance.
  *
- * Usage:
+ * Usage with `@RegisterExtension` (the safest pattern — one extension instance per test class):
  * ```
- * @RegisterExtension val automatorExt = ComposeAutomatorExtension()
+ * @JvmField @RegisterExtension val automatorExt = ComposeAutomatorExtension()
  *
  * @Test fun something() {
  *     val node = automatorExt.automator.findOneByTestTag("Send")
- *     ...
  * }
  * ```
  *
  * The extension also implements [ParameterResolver], so tests can take a [ComposeAutomator]
- * parameter and have it injected automatically:
+ * parameter and have it injected automatically. This is the parallel-execution-safe form, because
+ * each test resolves its own automator from the per-invocation [ExtensionContext.Store]:
  * ```
  * @ExtendWith(ComposeAutomatorExtension::class)
  * class MyTest {
@@ -32,6 +32,12 @@ import org.junit.jupiter.api.extension.ParameterResolver
  *
  * The [factory] defaults to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
  * or focused unit testing can supply their own factory.
+ *
+ * Concurrency: the per-test instance is keyed in [ExtensionContext.Store], so parameter resolution
+ * remains correct even when JUnit 5 reuses one extension instance across parallel methods. The
+ * [automator] property accessor returns the most recently created instance and is intended for the
+ * typical sequential `@RegisterExtension` flow; callers running tests in parallel should rely on
+ * parameter injection instead.
  */
 class ComposeAutomatorExtension(private val factory: AutomatorFactory) :
     BeforeEachCallback, AfterEachCallback, ParameterResolver {
@@ -41,22 +47,25 @@ class ComposeAutomatorExtension(private val factory: AutomatorFactory) :
     // primary constructor does not emit a true JVM no-arg overload without @JvmOverloads.
     constructor() : this({ ComposeAutomator.inProcess() })
 
-    private var instance: ComposeAutomator? = null
+    @Volatile private var lastInstance: ComposeAutomator? = null
 
     val automator: ComposeAutomator
         get() =
-            checkNotNull(instance) {
+            checkNotNull(lastInstance) {
                 "ComposeAutomatorExtension.automator accessed outside of a running test"
             }
 
     override fun beforeEach(context: ExtensionContext) {
-        instance = factory()
+        val automator = factory()
+        context.getStore(NAMESPACE).put(STORE_KEY, automator)
+        lastInstance = automator
     }
 
     override fun afterEach(context: ExtensionContext) {
         // Future hook: when the automator gains lifecycle-aware resources (recordings,
         // background pollers, etc.) tear them down here.
-        instance = null
+        context.getStore(NAMESPACE).remove(STORE_KEY)
+        lastInstance = null
     }
 
     override fun supportsParameter(
@@ -66,13 +75,27 @@ class ComposeAutomatorExtension(private val factory: AutomatorFactory) :
         parameterContext.parameter.type == ComposeAutomator::class.java &&
             parameterContext.declaringExecutable is Method &&
             // Restrict resolution to per-test method invocations. Constructor parameters and
-            // @BeforeAll / @AfterAll lifecycle hooks run outside the per-test window, when
-            // `instance` is null; rejecting them lets other resolvers handle those slots and
-            // avoids surfacing IllegalStateException to the runner.
+            // @BeforeAll / @AfterAll lifecycle hooks run outside the per-test window, when no
+            // instance is in the Store; rejecting them lets other resolvers handle those slots
+            // and avoids surfacing IllegalStateException to the runner.
             extensionContext.testMethod.isPresent
 
     override fun resolveParameter(
         parameterContext: ParameterContext,
         extensionContext: ExtensionContext,
-    ): Any = automator
+    ): Any =
+        checkNotNull(
+            extensionContext.getStore(NAMESPACE).get(STORE_KEY, ComposeAutomator::class.java)
+        ) {
+            "ComposeAutomator parameter requested but no per-test instance is registered"
+        }
+
+    private companion object {
+        // Per-extension-class namespace + a fixed key — JUnit 5 already scopes Store entries to
+        // the current ExtensionContext, so the (namespace, key) pair is enough to keep parallel
+        // test invocations from clobbering each other.
+        val NAMESPACE: ExtensionContext.Namespace =
+            ExtensionContext.Namespace.create(ComposeAutomatorExtension::class.java)
+        const val STORE_KEY: String = "automator"
+    }
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -19,9 +19,12 @@ import org.junit.rules.ExternalResource
  * The [factory] defaults to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
  * or focused unit testing can supply their own factory.
  */
-class ComposeAutomatorRule(
-    private val factory: AutomatorFactory = { ComposeAutomator.inProcess() }
-) : ExternalResource() {
+class ComposeAutomatorRule(private val factory: AutomatorFactory) : ExternalResource() {
+
+    // Explicit no-arg secondary constructor so JUnit 4 callers can write
+    // `@get:Rule val r = ComposeAutomatorRule()` without relying on Kotlin's
+    // default-parameter constructor synthesis (consistent with ComposeAutomatorExtension).
+    constructor() : this({ ComposeAutomator.inProcess() })
 
     private var instance: ComposeAutomator? = null
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -1,0 +1,43 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import org.junit.rules.ExternalResource
+
+/**
+ * JUnit 4 [org.junit.Rule] that owns a per-test [ComposeAutomator] instance.
+ *
+ * Usage:
+ * ```
+ * @get:Rule val automatorRule = ComposeAutomatorRule()
+ *
+ * @Test fun something() {
+ *     val node = automatorRule.automator.findOneByTestTag("Send")
+ *     ...
+ * }
+ * ```
+ *
+ * The [factory] defaults to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
+ * or focused unit testing can supply their own factory.
+ */
+class ComposeAutomatorRule(
+    private val factory: AutomatorFactory = { ComposeAutomator.inProcess() }
+) : ExternalResource() {
+
+    private var instance: ComposeAutomator? = null
+
+    val automator: ComposeAutomator
+        get() =
+            checkNotNull(instance) {
+                "ComposeAutomatorRule.automator accessed outside of a running test"
+            }
+
+    public override fun before() {
+        instance = factory()
+    }
+
+    public override fun after() {
+        // Future hook: when the automator gains lifecycle-aware resources (recordings,
+        // background pollers, etc.) tear them down here.
+        instance = null
+    }
+}

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtensionTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtensionTest.kt
@@ -1,0 +1,37 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class ComposeAutomatorExtensionTest {
+
+    private val factoryCalls = mutableListOf<ComposeAutomator>()
+
+    @JvmField
+    @RegisterExtension
+    val automatorExt =
+        ComposeAutomatorExtension(
+            factory = {
+                val instance = newHeadlessAutomator()
+                factoryCalls += instance
+                instance
+            }
+        )
+
+    @Test
+    fun `automator is initialised before each test runs`() {
+        // The extension runs beforeEach; touching the property here proves the lifecycle hook
+        // resolved the factory and stored the instance.
+        assertSame(factoryCalls.first(), automatorExt.automator)
+    }
+
+    @Test
+    fun `each test gets its own automator instance`() {
+        // The extension recreates the instance before every method, so factoryCalls.size for
+        // the *current* execution is exactly 1.
+        assertEquals(1, factoryCalls.size)
+    }
+}

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRuleTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRuleTest.kt
@@ -1,0 +1,61 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.core.SemanticsReader
+import dev.sebastiano.spectre.core.WindowTracker
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
+import org.junit.Rule
+import org.junit.Test
+
+class ComposeAutomatorRuleTest {
+
+    private val factoryCalls = mutableListOf<ComposeAutomator>()
+
+    @get:Rule
+    val automatorRule =
+        ComposeAutomatorRule(
+            factory = {
+                val instance = newHeadlessAutomator()
+                factoryCalls += instance
+                instance
+            }
+        )
+
+    @Test
+    fun `automator is initialised before the test runs`() {
+        // Touching the property must succeed once the rule's before() has run.
+        assertSame(factoryCalls.first(), automatorRule.automator)
+    }
+
+    @Test
+    fun `each test gets its own automator instance`() {
+        // The rule recreates the instance before every method, so factoryCalls.size for the
+        // *current* execution is exactly 1.
+        assertEquals(1, factoryCalls.size)
+    }
+
+    @Test
+    fun `accessing automator after the rule tears down throws`() {
+        // We can't observe after() from inside the test body, so simulate the access pattern
+        // with a manually-driven rule.
+        val standalone = ComposeAutomatorRule(factory = ::newHeadlessAutomator)
+        standalone.before()
+        standalone.after()
+
+        val error = assertFailsWith<IllegalStateException> { standalone.automator }
+        assertEquals(
+            "ComposeAutomatorRule.automator accessed outside of a running test",
+            error.message,
+        )
+    }
+}
+
+internal fun newHeadlessAutomator(): ComposeAutomator =
+    ComposeAutomator.inProcess(
+        windowTracker = WindowTracker(),
+        semanticsReader = SemanticsReader(),
+        robotDriver = RobotDriver.headless(),
+    )

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/NodeKeyContractTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/NodeKeyContractTest.kt
@@ -1,0 +1,49 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.NodeKey
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Cross-boundary contract test for [NodeKey].
+ *
+ * The NodeKey string form is the wire identity that crosses every Spectre boundary that needs to
+ * reference a node — between the in-process API and downstream test code, between the future HTTP
+ * transport (#9) and any client, and between recordings/screenshots and the nodes they were
+ * captured against. This test pins the round-trip contract so any implementation change has to be
+ * deliberate.
+ */
+class NodeKeyContractTest {
+
+    @Test
+    fun `toString uses surface colon owner colon node form`() {
+        val key = NodeKey(surfaceId = "main", ownerIndex = 0, nodeId = 42)
+        assertEquals("main:0:42", key.toString())
+    }
+
+    @Test
+    fun `parse round-trips a simple key`() {
+        val key = NodeKey(surfaceId = "popup", ownerIndex = 1, nodeId = 7)
+        assertEquals(key, NodeKey.parse(key.toString()))
+    }
+
+    @Test
+    fun `parse preserves colons embedded in the surface id`() {
+        // Surface IDs come from the host application and may contain colons (window titles,
+        // composite ids, etc.). Parsing splits from the right so the surface portion stays
+        // intact regardless of how many colons it contains.
+        val key = NodeKey(surfaceId = "tool:window:1", ownerIndex = 2, nodeId = 99)
+        val round = NodeKey.parse(key.toString())
+        assertEquals(key, round)
+        assertEquals("tool:window:1", round.surfaceId)
+        assertEquals(2, round.ownerIndex)
+        assertEquals(99, round.nodeId)
+    }
+
+    @Test
+    fun `parse rejects malformed strings`() {
+        assertFailsWith<IllegalArgumentException> { NodeKey.parse("only-surface") }
+        assertFailsWith<IllegalArgumentException> { NodeKey.parse("missing-node:0") }
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the testing module scaffold with the v1 test ergonomics surface from the gist.
- `ComposeAutomatorRule` (JUnit 4) and `ComposeAutomatorExtension` (JUnit 5) own a per-test `ComposeAutomator` instance via a swappable `AutomatorFactory`. Default factory is `ComposeAutomator.inProcess()`; tests that need a stub for headless CI supply their own.
- The JUnit 5 extension also implements `ParameterResolver` so tests can take a `ComposeAutomator` parameter.
- `RobotDriver.headless()` is added to core as a public no-op factory so the testing module's own tests (and any downstream headless test) can build a real `ComposeAutomator` without touching AWT.
- `NodeKeyContractTest` pins the wire-level `surfaceId:ownerIndex:nodeId` round-trip that future HTTP transport (#9) and recordings (#10) will rely on.

JUnit dependency model: `junit:junit` and `org.junit.jupiter:junit-jupiter-api` are both `compileOnly`. Consumers pick whichever they're already using.

Closes #11.

## Test plan
- [x] `./gradlew :testing:check :core:check` — green (9 testing tests + full core suite)
- [x] `ComposeAutomatorRuleTest` covers per-test instance lifecycle and error message when the property is touched outside a running test
- [x] `ComposeAutomatorExtensionTest` covers per-test lifecycle via JUnit 5 `@RegisterExtension`
- [x] `NodeKeyContractTest` covers `toString` form, parse round-trip, embedded-colon surface ids, and malformed input
- [ ] Behavioural validation against a live Compose surface remains part of #12 / #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)