### PR TITLE
Land v1 HTTP / cross-JVM transport

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -9,7 +9,11 @@ kotlin { jvmToolchain(21) }
 dependencies {
     implementation(libs.compose.runtime)
     implementation(libs.compose.foundation)
-    implementation(libs.compose.ui)
+    // compose-ui is `api` because the public AutomatorNode surface exposes its types
+    // (Rect, SemanticsNode, Role, etc.) so downstream consumers — sample-desktop, the
+    // server module's transport conversions — must be able to compile against them
+    // without re-declaring the dependency.
+    api(libs.compose.ui)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.coroutines.swing)
     implementation(libs.androidx.tracing.wire)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -94,6 +94,32 @@ internal constructor(
             )
         }
 
+    /**
+     * Atomic snapshot of both [boundsInWindow] and [boundsOnScreen] taken in a single EDT read.
+     * Useful when callers need both forms — e.g. wire serialisation — and want them to reflect the
+     * same underlying layout state. Reading the two getters separately would issue two independent
+     * EDT bounces, between which layout could shift.
+     */
+    fun bothBounds(): BothBounds = readOnEdt {
+        val bounds = semanticsNode.boundsInWindow
+        val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
+        val contentOrigin = trackedWindow.composeContentOrigin
+        BothBounds(
+            inWindow = bounds,
+            onScreen =
+                composeBoundsToAwtRectangle(
+                    left = bounds.left,
+                    top = bounds.top,
+                    right = bounds.right,
+                    bottom = bounds.bottom,
+                    scaleX = transform.scaleX.toFloat(),
+                    scaleY = transform.scaleY.toFloat(),
+                    panelScreenX = contentOrigin.x,
+                    panelScreenY = contentOrigin.y,
+                ),
+        )
+    }
+
     val parent: AutomatorNode?
         get() = relations.parentOf(key)
 
@@ -108,6 +134,9 @@ internal constructor(
         append(")")
     }
 }
+
+/** Atomic snapshot of [AutomatorNode.boundsInWindow] and [AutomatorNode.boundsOnScreen]. */
+data class BothBounds(val inWindow: Rect, val onScreen: Rectangle)
 
 internal interface NodeRelations {
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ kotlin = "2.3.20"
 junit4 = "4.13.2"
 junit5 = "5.11.4"
 kotlinx-coroutines = "1.10.2"
+kotlinx-serialization = "1.7.3"
+ktor = "3.0.3"
 material3 = "1.10.0-alpha05"
 
 [libraries]
@@ -31,6 +33,15 @@ junit4 = { module = "junit:junit", version.ref = "junit4" }
 junit5-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "junit5" }
 junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junit5" }
 junit5-vintageEngine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
+ktor-server-core = { module = "io.ktor:ktor-server-core", version.ref = "ktor" }
+ktor-server-cio = { module = "io.ktor:ktor-server-cio", version.ref = "ktor" }
+ktor-server-contentNegotiation = { module = "io.ktor:ktor-server-content-negotiation", version.ref = "ktor" }
+ktor-server-testHost = { module = "io.ktor:ktor-server-test-host", version.ref = "ktor" }
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
@@ -38,3 +49,4 @@ composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "k
 detekt = { id = "dev.detekt", version.ref = "detekt" }
 ktfmt = { id = "com.ncorti.ktfmt.gradle", version.ref = "ktfmt" }
 kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/server/README.md
+++ b/server/README.md
@@ -1,10 +1,30 @@
 # Server
 
-Planned home for the opt-in embedded transport layer:
+Opt-in HTTP transport so a `ComposeAutomator` can be driven from a different JVM.
 
-- HTTP server for cross-JVM access
-- transport DTOs
-- client implementation
+## Public surface
 
-This module is intentionally scaffold-only right now.
+- `Application.installSpectreRoutes(automator, basePath = "/spectre")` — mount the routes on
+  any Ktor `Application` (CIO, Netty, embedded test server, etc.). The caller owns the
+  `Application` lifecycle.
+- `ComposeAutomator.http(host, port, basePath)` — companion extension that returns an
+  `HttpComposeAutomator` connected to a remote `installSpectreRoutes` host. The instance owns
+  its `HttpClient` and must be `close()`d.
+- `HttpComposeAutomator` — client class with the v1 transport surface: `windows`, `allNodes`,
+  `findByTestTag`, `click`, `typeText`, `screenshot`.
+- DTOs in `dev.sebastiano.spectre.server.dto` — kotlinx-serialization wire shapes that pin the
+  request/response contract. `DtoSerializationTest` round-trips every one.
 
+## v1 scope
+
+Endpoints land the most-used queries and actions. Advanced features — `registerIdlingResource`,
+`waitForIdle` / `waitForVisualIdle`, `withTracing`, `printTree` — are intentionally
+in-process-only:
+
+- Idling resources are JVM objects without a serializable shape; HTTP-side polling would need a
+  pluggable driver design out of scope for v1.
+- `withTracing` requires a `Tracer` instance the server can't accept across processes.
+- The wait helpers are stateful long-poll semantics that the v1 transport doesn't model.
+
+The contract test suite (`DtoSerializationTest`, `SpectreServerRoundTripTest`) covers the wire
+boundary; runtime parity against a live Compose UI is part of the validation issues.

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -11,14 +11,16 @@ dependencies {
     api(projects.core)
     api(libs.kotlinx.serialization.json)
 
-    // Server runtime is `implementation` so consumers hosting the automator inherit it via
-    // `api(projects.core)` + `implementation(projects.server)` only when they actually want the
-    // server side. The `installSpectreRoutes` extension and `HttpComposeAutomator` client are
-    // both reachable transitively from the public API.
-    implementation(libs.ktor.server.core)
-    implementation(libs.ktor.server.cio)
+    // ktor-server-core is `api` because installSpectreRoutes uses
+    // io.ktor.server.application.Application
+    // in its public signature — consumers calling the extension must see that type on their
+    // compile classpath. The remaining server-side bits (content-negotiation plugin, JSON
+    // serializer) are wiring details and stay `implementation`.
+    api(libs.ktor.server.core)
     implementation(libs.ktor.server.contentNegotiation)
     implementation(libs.ktor.serialization.json)
+    // Client side uses CIO as the engine factory. ktor-server-cio is intentionally not pulled
+    // in: installSpectreRoutes is engine-agnostic, so consumers bring their own server engine.
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.cio)
     implementation(libs.ktor.client.contentNegotiation)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,12 +1,35 @@
 plugins {
     alias(libs.plugins.detekt)
-    alias(libs.plugins.ktfmt)
     alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.ktfmt)
 }
 
 kotlin { jvmToolchain(21) }
 
 dependencies {
-    implementation(projects.core)
+    api(projects.core)
+    api(libs.kotlinx.serialization.json)
+
+    // Server runtime is `implementation` so consumers hosting the automator inherit it via
+    // `api(projects.core)` + `implementation(projects.server)` only when they actually want the
+    // server side. The `installSpectreRoutes` extension and `HttpComposeAutomator` client are
+    // both reachable transitively from the public API.
+    implementation(libs.ktor.server.core)
+    implementation(libs.ktor.server.cio)
+    implementation(libs.ktor.server.contentNegotiation)
+    implementation(libs.ktor.serialization.json)
+    implementation(libs.ktor.client.core)
+    implementation(libs.ktor.client.cio)
+    implementation(libs.ktor.client.contentNegotiation)
     implementation(libs.kotlinx.coroutines.core)
+    detektPlugins(libs.compose.rules.detekt)
+
+    testImplementation(libs.kotlin.testJunit5)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.ktor.server.testHost)
+    testImplementation(libs.ktor.client.contentNegotiation)
+    testImplementation(libs.ktor.serialization.json)
 }
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
@@ -94,7 +94,16 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
         const val DEFAULT_PORT: Int = 9274
 
         internal fun create(host: String, port: Int, basePath: String): HttpComposeAutomator =
-            HttpComposeAutomator(baseUrl = "http://$host:$port$basePath")
+            HttpComposeAutomator(baseUrl = normaliseBaseUrl(host, port, basePath))
+
+        // Normalise basePath so callers can pass any of `""`, `"/spectre"`, `"spectre"`,
+        // `"/spectre/"`, `"api/v1/spectre"`, etc. without producing a malformed URL like
+        // `http://localhost:9274api/v1/spectre/...`. The result always has exactly one leading
+        // slash (or is empty) and never has a trailing slash.
+        internal fun normaliseBaseUrl(host: String, port: Int, basePath: String): String {
+            val normalisedPath = basePath.trim('/').let { if (it.isEmpty()) "" else "/$it" }
+            return "http://$host:$port$normalisedPath"
+        }
     }
 }
 

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
@@ -10,7 +10,6 @@ import dev.sebastiano.spectre.server.dto.WindowSummaryDto
 import dev.sebastiano.spectre.server.dto.WindowsResponse
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.engine.HttpClientEngine
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.get
@@ -38,10 +37,13 @@ import javax.imageio.ImageIO
  * The instance owns its [HttpClient] and must be `close()`d to release pooled connections. Use `use
  * { ... }` from `kotlin.AutoCloseable` for scoped lifecycles.
  */
-class HttpComposeAutomator
-internal constructor(private val baseUrl: String, engine: HttpClientEngine) : AutoCloseable {
+class HttpComposeAutomator internal constructor(private val baseUrl: String) : AutoCloseable {
 
-    private val client: HttpClient = HttpClient(engine) { install(ContentNegotiation) { json() } }
+    // HttpClient(CIO) — the engine *factory* form — makes the client own the engine, so
+    // close() shuts down both the client and the underlying CIO engine (its connection pool
+    // and selector threads). Passing a pre-built engine instance via HttpClient(engine) would
+    // leak the engine on close, since Ktor only auto-closes engines it constructed itself.
+    private val client: HttpClient = HttpClient(CIO) { install(ContentNegotiation) { json() } }
 
     suspend fun windows(): List<WindowSummaryDto> =
         client.get("$baseUrl/windows").body<WindowsResponse>().windows
@@ -91,13 +93,8 @@ internal constructor(private val baseUrl: String, engine: HttpClientEngine) : Au
         /** Default port suggested by the gist's HTTP example. */
         const val DEFAULT_PORT: Int = 9274
 
-        internal fun create(
-            host: String,
-            port: Int,
-            basePath: String,
-            engine: HttpClientEngine = CIO.create(),
-        ): HttpComposeAutomator =
-            HttpComposeAutomator(baseUrl = "http://$host:$port$basePath", engine = engine)
+        internal fun create(host: String, port: Int, basePath: String): HttpComposeAutomator =
+            HttpComposeAutomator(baseUrl = "http://$host:$port$basePath")
     }
 }
 

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
@@ -1,0 +1,113 @@
+package dev.sebastiano.spectre.server
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.server.dto.ClickRequest
+import dev.sebastiano.spectre.server.dto.NodeSnapshotDto
+import dev.sebastiano.spectre.server.dto.NodesResponse
+import dev.sebastiano.spectre.server.dto.ScreenshotResponse
+import dev.sebastiano.spectre.server.dto.TypeTextRequest
+import dev.sebastiano.spectre.server.dto.WindowSummaryDto
+import dev.sebastiano.spectre.server.dto.WindowsResponse
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.contentType
+import io.ktor.http.isSuccess
+import io.ktor.serialization.kotlinx.json.json
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.util.Base64
+import javax.imageio.ImageIO
+
+/**
+ * Cross-JVM client for a `ComposeAutomator` running behind [installSpectreRoutes].
+ *
+ * Created via the companion extension `ComposeAutomator.http(host, port)` (see
+ * [HttpFactory.kt][http]). The v1 client surface mirrors the in-process automator's most-used
+ * queries and actions; advanced features (idling resources, `withTracing`, `waitForVisualIdle`)
+ * remain in-process only and are documented as such.
+ *
+ * The instance owns its [HttpClient] and must be `close()`d to release pooled connections. Use `use
+ * { ... }` from `kotlin.AutoCloseable` for scoped lifecycles.
+ */
+class HttpComposeAutomator
+internal constructor(private val baseUrl: String, engine: HttpClientEngine) : AutoCloseable {
+
+    private val client: HttpClient = HttpClient(engine) { install(ContentNegotiation) { json() } }
+
+    suspend fun windows(): List<WindowSummaryDto> =
+        client.get("$baseUrl/windows").body<WindowsResponse>().windows
+
+    suspend fun allNodes(): List<NodeSnapshotDto> =
+        client.get("$baseUrl/nodes").body<NodesResponse>().nodes
+
+    suspend fun findByTestTag(tag: String): List<NodeSnapshotDto> =
+        client.get("$baseUrl/nodes") { parameter("testTag", tag) }.body<NodesResponse>().nodes
+
+    suspend fun click(nodeKey: String) {
+        val response =
+            client.post("$baseUrl/click") {
+                contentType(ContentType.Application.Json)
+                setBody(ClickRequest(nodeKey = nodeKey))
+            }
+        check(response.status.isSuccess()) {
+            "click failed: ${response.status} ${response.bodyAsText()}"
+        }
+    }
+
+    suspend fun typeText(text: String) {
+        val response =
+            client.post("$baseUrl/typeText") {
+                contentType(ContentType.Application.Json)
+                setBody(TypeTextRequest(text = text))
+            }
+        check(response.status.isSuccess()) {
+            "typeText failed: ${response.status} ${response.bodyAsText()}"
+        }
+    }
+
+    suspend fun screenshot(): BufferedImage {
+        val response = client.get("$baseUrl/screenshot").body<ScreenshotResponse>()
+        val bytes = Base64.getDecoder().decode(response.pngBase64)
+        return checkNotNull(ImageIO.read(ByteArrayInputStream(bytes))) {
+            "Server returned an image we could not decode"
+        }
+    }
+
+    override fun close() {
+        client.close()
+    }
+
+    companion object {
+
+        /** Default port suggested by the gist's HTTP example. */
+        const val DEFAULT_PORT: Int = 9274
+
+        internal fun create(
+            host: String,
+            port: Int,
+            basePath: String,
+            engine: HttpClientEngine = CIO.create(),
+        ): HttpComposeAutomator =
+            HttpComposeAutomator(baseUrl = "http://$host:$port$basePath", engine = engine)
+    }
+}
+
+/**
+ * Companion extension matching the gist's intended public surface `ComposeAutomator.http(host,
+ * port)`. Returns an [HttpComposeAutomator] connected to the remote process; the caller is
+ * responsible for closing it.
+ */
+fun ComposeAutomator.Companion.http(
+    host: String = "localhost",
+    port: Int = HttpComposeAutomator.DEFAULT_PORT,
+    basePath: String = "/spectre",
+): HttpComposeAutomator = HttpComposeAutomator.create(host = host, port = port, basePath = basePath)

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -73,7 +73,15 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
     post("/click") {
         automator.refreshWindows()
         val request = call.receive<ClickRequest>()
-        val key = NodeKey.parse(request.nodeKey)
+        // NodeKey.parse throws on malformed input — surface that as a client error (400)
+        // rather than letting it bubble up as a generic 500.
+        val key =
+            try {
+                NodeKey.parse(request.nodeKey)
+            } catch (e: IllegalArgumentException) {
+                call.respond(HttpStatusCode.BadRequest, "Malformed node key: ${e.message}")
+                return@post
+            }
         val node = automator.allNodes().firstOrNull { it.key == key }
         if (node == null) {
             call.respond(HttpStatusCode.NotFound, "No node with key ${request.nodeKey}")

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -35,11 +35,21 @@ import javax.imageio.ImageIO
  * (idling resources, withTracing, waitForVisualIdle) are in-process only because they either
  * require live JVM objects (Tracer, IdlingResource) or stateful long-poll semantics that are out of
  * scope for the v1 transport.
+ *
+ * ## ContentNegotiation contract
+ *
+ * The Spectre routes exchange JSON DTOs, so a JSON-capable [ContentNegotiation] plugin must be
+ * present on the application by the time the routes serve traffic.
+ *
+ * - If [ContentNegotiation] is **not** installed, this function installs it with the kotlinx JSON
+ *   converter automatically.
+ * - If [ContentNegotiation] **is** already installed (because the host application configured it
+ *   for its own routes), this function leaves it alone. The host is responsible for ensuring the
+ *   existing configuration includes a JSON converter — Ktor's plugin model does not let us merge
+ *   converters into an already-installed plugin, and re-installing would throw a duplicate-plugin
+ *   exception. Without JSON support the routes will fail at request time with a 415/500.
  */
 fun Application.installSpectreRoutes(automator: ComposeAutomator, basePath: String = "/spectre") {
-    // Hosts may already have ContentNegotiation installed for their own routes; Ktor throws a
-    // duplicate-plugin exception on a second install. Only install when absent so the route
-    // mount is safe to call from any application configuration.
     if (pluginOrNull(ContentNegotiation) == null) {
         install(ContentNegotiation) { json() }
     }

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -1,0 +1,99 @@
+package dev.sebastiano.spectre.server
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.NodeKey
+import dev.sebastiano.spectre.server.dto.ClickRequest
+import dev.sebastiano.spectre.server.dto.NodesResponse
+import dev.sebastiano.spectre.server.dto.ScreenshotResponse
+import dev.sebastiano.spectre.server.dto.TypeTextRequest
+import dev.sebastiano.spectre.server.dto.WindowsResponse
+import dev.sebastiano.spectre.server.dto.toDto
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.route
+import io.ktor.server.routing.routing
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.util.Base64
+import javax.imageio.ImageIO
+
+/**
+ * Mounts the Spectre HTTP transport on this Ktor [Application], backed by the supplied in-process
+ * [automator]. All routes live under [basePath] (default `/spectre`).
+ *
+ * The route surface is intentionally a v1 subset of the public automator API — windows, nodes by
+ * tag, click, typeText, screenshot — enough to drive cross-JVM smoke tests. Advanced features
+ * (idling resources, withTracing, waitForVisualIdle) are in-process only because they either
+ * require live JVM objects (Tracer, IdlingResource) or stateful long-poll semantics that are out of
+ * scope for the v1 transport.
+ */
+fun Application.installSpectreRoutes(automator: ComposeAutomator, basePath: String = "/spectre") {
+    install(ContentNegotiation) { json() }
+    routing { route(basePath) { spectreRoutes(automator) } }
+}
+
+private fun Route.spectreRoutes(automator: ComposeAutomator) {
+    get("/windows") {
+        automator.refreshWindows()
+        val response =
+            WindowsResponse(
+                windows = automator.windows.mapIndexed { index, window -> window.toDto(index) }
+            )
+        call.respond(response)
+    }
+
+    get("/nodes") {
+        val testTag = call.request.queryParameters["testTag"]
+        val nodes =
+            if (testTag != null) {
+                automator.findByTestTag(testTag)
+            } else {
+                automator.allNodes()
+            }
+        call.respond(NodesResponse(nodes = nodes.map { it.toDto() }))
+    }
+
+    post("/click") {
+        val request = call.receive<ClickRequest>()
+        val key = NodeKey.parse(request.nodeKey)
+        val node = automator.allNodes().firstOrNull { it.key == key }
+        if (node == null) {
+            call.respond(HttpStatusCode.NotFound, "No node with key ${request.nodeKey}")
+            return@post
+        }
+        automator.click(node)
+        call.respond(HttpStatusCode.NoContent)
+    }
+
+    post("/typeText") {
+        val request = call.receive<TypeTextRequest>()
+        automator.typeText(request.text)
+        call.respond(HttpStatusCode.NoContent)
+    }
+
+    get("/screenshot") {
+        val image = automator.screenshot()
+        call.respond(image.toScreenshotResponse())
+    }
+}
+
+internal fun BufferedImage.toScreenshotResponse(): ScreenshotResponse {
+    val bytes =
+        ByteArrayOutputStream().use { stream ->
+            ImageIO.write(this, "png", stream)
+            stream.toByteArray()
+        }
+    return ScreenshotResponse(
+        pngBase64 = Base64.getEncoder().encodeToString(bytes),
+        width = width,
+        height = height,
+    )
+}

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -12,6 +12,7 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
+import io.ktor.server.application.pluginOrNull
 import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
@@ -36,7 +37,12 @@ import javax.imageio.ImageIO
  * scope for the v1 transport.
  */
 fun Application.installSpectreRoutes(automator: ComposeAutomator, basePath: String = "/spectre") {
-    install(ContentNegotiation) { json() }
+    // Hosts may already have ContentNegotiation installed for their own routes; Ktor throws a
+    // duplicate-plugin exception on a second install. Only install when absent so the route
+    // mount is safe to call from any application configuration.
+    if (pluginOrNull(ContentNegotiation) == null) {
+        install(ContentNegotiation) { json() }
+    }
     routing { route(basePath) { spectreRoutes(automator) } }
 }
 
@@ -51,6 +57,9 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
     }
 
     get("/nodes") {
+        // Query handlers always refresh first: in-process callers control when to refresh, but
+        // remote callers expect a request to reflect current state without an explicit prelude.
+        automator.refreshWindows()
         val testTag = call.request.queryParameters["testTag"]
         val nodes =
             if (testTag != null) {
@@ -62,6 +71,7 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
     }
 
     post("/click") {
+        automator.refreshWindows()
         val request = call.receive<ClickRequest>()
         val key = NodeKey.parse(request.nodeKey)
         val node = automator.allNodes().firstOrNull { it.key == key }

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
@@ -12,8 +12,13 @@ internal fun TrackedWindow.toDto(index: Int): WindowSummaryDto =
         composeSurfaceBounds = composeSurfaceBoundsOnScreen.toDto(),
     )
 
-internal fun AutomatorNode.toDto(): NodeSnapshotDto =
-    NodeSnapshotDto(
+internal fun AutomatorNode.toDto(): NodeSnapshotDto {
+    // Snapshot live bounds once. AutomatorNode.boundsInWindow is a getter that bounces to the
+    // EDT each call, so reading .left, .top, .right, .bottom separately would issue six
+    // independent reads — layout could shift between them and produce an internally
+    // inconsistent rectangle (e.g. negative width).
+    val rect = boundsInWindow
+    return NodeSnapshotDto(
         key = key.toString(),
         testTag = testTag,
         texts = texts,
@@ -25,13 +30,14 @@ internal fun AutomatorNode.toDto(): NodeSnapshotDto =
         isSelected = isSelected,
         boundsInWindow =
             RectangleDto(
-                x = boundsInWindow.left.toDouble(),
-                y = boundsInWindow.top.toDouble(),
-                width = (boundsInWindow.right - boundsInWindow.left).toDouble(),
-                height = (boundsInWindow.bottom - boundsInWindow.top).toDouble(),
+                x = rect.left.toDouble(),
+                y = rect.top.toDouble(),
+                width = (rect.right - rect.left).toDouble(),
+                height = (rect.bottom - rect.top).toDouble(),
             ),
         boundsOnScreen = boundsOnScreen.toDto(),
     )
+}
 
 internal fun Rectangle.toDto(): RectangleDto =
     RectangleDto(
@@ -40,6 +46,3 @@ internal fun Rectangle.toDto(): RectangleDto =
         width = width.toDouble(),
         height = height.toDouble(),
     )
-
-internal fun RectangleDto.toAwt(): Rectangle =
-    Rectangle(x.toInt(), y.toInt(), width.toInt(), height.toInt())

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
@@ -13,11 +13,13 @@ internal fun TrackedWindow.toDto(index: Int): WindowSummaryDto =
     )
 
 internal fun AutomatorNode.toDto(): NodeSnapshotDto {
-    // Snapshot live bounds once. AutomatorNode.boundsInWindow is a getter that bounces to the
-    // EDT each call, so reading .left, .top, .right, .bottom separately would issue six
-    // independent reads — layout could shift between them and produce an internally
-    // inconsistent rectangle (e.g. negative width).
-    val rect = boundsInWindow
+    // bothBounds() reads in-window and on-screen bounds in a single EDT round-trip so the two
+    // rectangles in the DTO are guaranteed to come from the same underlying layout state.
+    // Calling the individual `boundsInWindow` / `boundsOnScreen` getters separately would
+    // issue independent EDT bounces and could produce a spatially inconsistent snapshot if
+    // layout shifted between the two reads.
+    val bounds = bothBounds()
+    val inWindow = bounds.inWindow
     return NodeSnapshotDto(
         key = key.toString(),
         testTag = testTag,
@@ -30,12 +32,12 @@ internal fun AutomatorNode.toDto(): NodeSnapshotDto {
         isSelected = isSelected,
         boundsInWindow =
             RectangleDto(
-                x = rect.left.toDouble(),
-                y = rect.top.toDouble(),
-                width = (rect.right - rect.left).toDouble(),
-                height = (rect.bottom - rect.top).toDouble(),
+                x = inWindow.left.toDouble(),
+                y = inWindow.top.toDouble(),
+                width = (inWindow.right - inWindow.left).toDouble(),
+                height = (inWindow.bottom - inWindow.top).toDouble(),
             ),
-        boundsOnScreen = boundsOnScreen.toDto(),
+        boundsOnScreen = bounds.onScreen.toDto(),
     )
 }
 

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
@@ -1,0 +1,45 @@
+package dev.sebastiano.spectre.server.dto
+
+import dev.sebastiano.spectre.core.AutomatorNode
+import dev.sebastiano.spectre.core.TrackedWindow
+import java.awt.Rectangle
+
+internal fun TrackedWindow.toDto(index: Int): WindowSummaryDto =
+    WindowSummaryDto(
+        index = index,
+        surfaceId = surfaceId,
+        isPopup = isPopup,
+        composeSurfaceBounds = composeSurfaceBoundsOnScreen.toDto(),
+    )
+
+internal fun AutomatorNode.toDto(): NodeSnapshotDto =
+    NodeSnapshotDto(
+        key = key.toString(),
+        testTag = testTag,
+        texts = texts,
+        contentDescriptions = contentDescriptions,
+        editableText = editableText,
+        role = role?.toString(),
+        isFocused = isFocused,
+        isDisabled = isDisabled,
+        isSelected = isSelected,
+        boundsInWindow =
+            RectangleDto(
+                x = boundsInWindow.left.toDouble(),
+                y = boundsInWindow.top.toDouble(),
+                width = (boundsInWindow.right - boundsInWindow.left).toDouble(),
+                height = (boundsInWindow.bottom - boundsInWindow.top).toDouble(),
+            ),
+        boundsOnScreen = boundsOnScreen.toDto(),
+    )
+
+internal fun Rectangle.toDto(): RectangleDto =
+    RectangleDto(
+        x = x.toDouble(),
+        y = y.toDouble(),
+        width = width.toDouble(),
+        height = height.toDouble(),
+    )
+
+internal fun RectangleDto.toAwt(): Rectangle =
+    Rectangle(x.toInt(), y.toInt(), width.toInt(), height.toInt())

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Dtos.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Dtos.kt
@@ -1,0 +1,64 @@
+package dev.sebastiano.spectre.server.dto
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire shape for a tracked window.
+ *
+ * Mirrors the in-process `TrackedWindow` minus the live AWT references (which can't cross a JVM
+ * boundary). The `index` field matches the position in the in-process `windows` list, so HTTP
+ * callers can address a specific window the same way in-process callers do.
+ */
+@Serializable
+data class WindowSummaryDto(
+    val index: Int,
+    val surfaceId: String,
+    val isPopup: Boolean,
+    val composeSurfaceBounds: RectangleDto,
+)
+
+/**
+ * Wire shape for a single semantics node.
+ *
+ * Captures the set of properties that are useful for cross-JVM queries and assertions: the compound
+ * `key` (matches `NodeKey.toString()`), text/content-description/role/state flags, and both
+ * window-local and screen bounds. Fields that don't HTTP cleanly (the underlying `SemanticsNode`,
+ * the live `TrackedWindow`) are intentionally omitted — callers that need them have to use the
+ * in-process automator.
+ */
+@Serializable
+data class NodeSnapshotDto(
+    val key: String,
+    val testTag: String? = null,
+    val texts: List<String> = emptyList(),
+    val contentDescriptions: List<String> = emptyList(),
+    val editableText: String? = null,
+    val role: String? = null,
+    val isFocused: Boolean = false,
+    val isDisabled: Boolean = false,
+    val isSelected: Boolean = false,
+    val boundsInWindow: RectangleDto,
+    val boundsOnScreen: RectangleDto,
+)
+
+/**
+ * AWT rectangle in screen / window coordinates. Doubles are used for the in-window form to preserve
+ * sub-pixel precision; the on-screen form is rounded into ints by callers when feeding Robot APIs.
+ */
+@Serializable
+data class RectangleDto(val x: Double, val y: Double, val width: Double, val height: Double)
+
+/** Request body for `POST /click`. */
+@Serializable data class ClickRequest(val nodeKey: String)
+
+/** Request body for `POST /typeText`. */
+@Serializable data class TypeTextRequest(val text: String)
+
+/** Response body for `GET /screenshot` — the captured image as base64-encoded PNG bytes. */
+@Serializable data class ScreenshotResponse(val pngBase64: String, val width: Int, val height: Int)
+
+/** Response body for `GET /nodes` and similar list endpoints. */
+@Serializable data class NodesResponse(val nodes: List<NodeSnapshotDto>)
+
+/** Response body for `GET /windows`. */
+@Serializable data class WindowsResponse(val windows: List<WindowSummaryDto>)

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorTest.kt
@@ -1,0 +1,43 @@
+package dev.sebastiano.spectre.server
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HttpComposeAutomatorTest {
+
+    @Test
+    fun `normaliseBaseUrl produces the same canonical URL for every basePath variant`() {
+        val expected = "http://localhost:9274/spectre"
+        assertEquals(expected, HttpComposeAutomator.normaliseBaseUrl("localhost", 9274, "/spectre"))
+        assertEquals(expected, HttpComposeAutomator.normaliseBaseUrl("localhost", 9274, "spectre"))
+        assertEquals(
+            expected,
+            HttpComposeAutomator.normaliseBaseUrl("localhost", 9274, "/spectre/"),
+        )
+        assertEquals(expected, HttpComposeAutomator.normaliseBaseUrl("localhost", 9274, "spectre/"))
+    }
+
+    @Test
+    fun `normaliseBaseUrl handles a multi-segment basePath`() {
+        assertEquals(
+            "http://localhost:9274/api/v1/spectre",
+            HttpComposeAutomator.normaliseBaseUrl("localhost", 9274, "api/v1/spectre"),
+        )
+        assertEquals(
+            "http://localhost:9274/api/v1/spectre",
+            HttpComposeAutomator.normaliseBaseUrl("localhost", 9274, "/api/v1/spectre/"),
+        )
+    }
+
+    @Test
+    fun `normaliseBaseUrl handles an empty basePath`() {
+        assertEquals(
+            "http://localhost:9274",
+            HttpComposeAutomator.normaliseBaseUrl("localhost", 9274, ""),
+        )
+        assertEquals(
+            "http://localhost:9274",
+            HttpComposeAutomator.normaliseBaseUrl("localhost", 9274, "/"),
+        )
+    }
+}

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
@@ -89,6 +89,21 @@ class SpectreServerRoundTripTest {
     }
 
     @Test
+    fun `click against a malformed node key returns 400`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val response =
+            client.post("/spectre/click") {
+                contentType(ContentType.Application.Json)
+                setBody(ClickRequest(nodeKey = "not-a-valid-key"))
+            }
+
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertTrue(response.bodyAsText().contains("Malformed node key"))
+    }
+
+    @Test
     fun `typeText returns 204 No Content`() = testApplication {
         application { installSpectreRoutes(headlessAutomator()) }
         val client = createClient { install(ContentNegotiation) { json() } }

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
@@ -19,6 +19,8 @@ import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.install as serverInstall
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
 import io.ktor.server.testing.testApplication
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -120,4 +122,20 @@ class SpectreServerRoundTripTest {
         val response = client.get("/api/v1/spectre/windows").body<WindowsResponse>()
         assertEquals(emptyList(), response.windows)
     }
+
+    @Test
+    fun `installSpectreRoutes is safe when ContentNegotiation is already installed`() =
+        testApplication {
+            application {
+                // Host configures ContentNegotiation for its own routes. The route installer
+                // must reuse it rather than calling install() again, which would throw a
+                // duplicate-plugin exception at startup.
+                serverInstall(ServerContentNegotiation) { json() }
+                installSpectreRoutes(headlessAutomator())
+            }
+            val client = createClient { install(ContentNegotiation) { json() } }
+
+            val response = client.get("/spectre/windows").body<WindowsResponse>()
+            assertEquals(emptyList(), response.windows)
+        }
 }

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
@@ -1,0 +1,123 @@
+package dev.sebastiano.spectre.server
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.core.SemanticsReader
+import dev.sebastiano.spectre.core.WindowTracker
+import dev.sebastiano.spectre.server.dto.ClickRequest
+import dev.sebastiano.spectre.server.dto.NodesResponse
+import dev.sebastiano.spectre.server.dto.ScreenshotResponse
+import dev.sebastiano.spectre.server.dto.TypeTextRequest
+import dev.sebastiano.spectre.server.dto.WindowsResponse
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.testing.testApplication
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end test for the HTTP transport.
+ *
+ * Drives the real route handlers through Ktor's `testApplication` (no real network sockets) with a
+ * real headless `ComposeAutomator` backing them. The automator has no Compose surfaces in this
+ * environment, so the assertions are about the request/response *envelope* contract — list shapes,
+ * status codes, body decoding — not about live UI behaviour.
+ */
+class SpectreServerRoundTripTest {
+
+    private fun headlessAutomator(): ComposeAutomator =
+        ComposeAutomator.inProcess(
+            windowTracker = WindowTracker(),
+            semanticsReader = SemanticsReader(),
+            robotDriver = RobotDriver.headless(),
+        )
+
+    @Test
+    fun `windows endpoint returns an empty list for an empty automator`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val response = client.get("/spectre/windows").body<WindowsResponse>()
+
+        assertEquals(emptyList(), response.windows)
+    }
+
+    @Test
+    fun `nodes endpoint returns an empty list when no windows are tracked`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val response = client.get("/spectre/nodes").body<NodesResponse>()
+
+        assertEquals(emptyList(), response.nodes)
+    }
+
+    @Test
+    fun `nodes endpoint accepts a testTag query parameter`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val response = client.get("/spectre/nodes?testTag=Send").body<NodesResponse>()
+
+        assertEquals(emptyList(), response.nodes)
+    }
+
+    @Test
+    fun `click against an unknown node key returns 404`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val response =
+            client.post("/spectre/click") {
+                contentType(ContentType.Application.Json)
+                setBody(ClickRequest(nodeKey = "nonexistent:0:1"))
+            }
+
+        assertEquals(HttpStatusCode.NotFound, response.status)
+        assertTrue(response.bodyAsText().contains("nonexistent:0:1"))
+    }
+
+    @Test
+    fun `typeText returns 204 No Content`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val response =
+            client.post("/spectre/typeText") {
+                contentType(ContentType.Application.Json)
+                setBody(TypeTextRequest(text = "hello"))
+            }
+
+        assertEquals(HttpStatusCode.NoContent, response.status)
+    }
+
+    @Test
+    fun `screenshot returns a base64-encoded PNG envelope`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val response = client.get("/spectre/screenshot").body<ScreenshotResponse>()
+
+        assertTrue(response.pngBase64.isNotEmpty(), "PNG payload should be present")
+        assertTrue(response.width > 0, "Width should be positive")
+        assertTrue(response.height > 0, "Height should be positive")
+    }
+
+    @Test
+    fun `routes can be mounted at a custom base path`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator(), basePath = "/api/v1/spectre") }
+        val client = createClient { install(ContentNegotiation) { json() } }
+
+        val response = client.get("/api/v1/spectre/windows").body<WindowsResponse>()
+        assertEquals(emptyList(), response.windows)
+    }
+}

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/dto/DtoSerializationTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/dto/DtoSerializationTest.kt
@@ -1,0 +1,93 @@
+package dev.sebastiano.spectre.server.dto
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Contract tests for the wire DTOs.
+ *
+ * The HTTP transport's stability rests on these classes round-tripping through kotlinx
+ * serialization without surprises. If a field is renamed, removed, or stops serializing the way it
+ * used to, these tests fail loudly so the change is deliberate and the wire contract stays in sync
+ * between server and client.
+ */
+class DtoSerializationTest {
+
+    private val json = Json { encodeDefaults = false }
+
+    @Test
+    fun `RectangleDto round-trips`() {
+        val original = RectangleDto(x = 1.5, y = 2.5, width = 100.0, height = 200.0)
+        assertEquals(original, json.decodeFromString<RectangleDto>(json.encodeToString(original)))
+    }
+
+    @Test
+    fun `WindowSummaryDto round-trips`() {
+        val original =
+            WindowSummaryDto(
+                index = 0,
+                surfaceId = "main",
+                isPopup = false,
+                composeSurfaceBounds = RectangleDto(0.0, 0.0, 1280.0, 800.0),
+            )
+        assertEquals(
+            original,
+            json.decodeFromString<WindowSummaryDto>(json.encodeToString(original)),
+        )
+    }
+
+    @Test
+    fun `NodeSnapshotDto round-trips with all fields populated`() {
+        val original =
+            NodeSnapshotDto(
+                key = "main:0:42",
+                testTag = "Send",
+                texts = listOf("Click me"),
+                contentDescriptions = listOf("Send button"),
+                editableText = null,
+                role = "Button",
+                isFocused = true,
+                isDisabled = false,
+                isSelected = true,
+                boundsInWindow = RectangleDto(10.0, 20.0, 80.0, 30.0),
+                boundsOnScreen = RectangleDto(110.0, 220.0, 80.0, 30.0),
+            )
+        assertEquals(
+            original,
+            json.decodeFromString<NodeSnapshotDto>(json.encodeToString(original)),
+        )
+    }
+
+    @Test
+    fun `NodeSnapshotDto round-trips with default-only fields`() {
+        // Defaults must survive a round-trip even when the encoded form omits them.
+        val original =
+            NodeSnapshotDto(
+                key = "popup:0:1",
+                boundsInWindow = RectangleDto(0.0, 0.0, 1.0, 1.0),
+                boundsOnScreen = RectangleDto(0.0, 0.0, 1.0, 1.0),
+            )
+        val encoded = json.encodeToString(original)
+        assertEquals(original, json.decodeFromString<NodeSnapshotDto>(encoded))
+    }
+
+    @Test
+    fun `request and response envelopes round-trip`() {
+        assertEquals(
+            ClickRequest("main:0:42"),
+            json.decodeFromString(json.encodeToString(ClickRequest("main:0:42"))),
+        )
+        assertEquals(
+            TypeTextRequest("hello"),
+            json.decodeFromString(json.encodeToString(TypeTextRequest("hello"))),
+        )
+        val screenshot = ScreenshotResponse(pngBase64 = "iVBORw0=", width = 100, height = 200)
+        assertEquals(screenshot, json.decodeFromString(json.encodeToString(screenshot)))
+        val nodes = NodesResponse(nodes = emptyList())
+        assertEquals(nodes, json.decodeFromString(json.encodeToString(nodes)))
+        val windows = WindowsResponse(windows = emptyList())
+        assertEquals(windows, json.decodeFromString(json.encodeToString(windows)))
+    }
+}


### PR DESCRIPTION
## Summary
- Adds the opt-in HTTP transport: a `ComposeAutomator` running in one JVM can now be driven from another via `ComposeAutomator.http(host, port)`.
- Server side: `Application.installSpectreRoutes(automator, basePath = \"/spectre\")` Ktor extension. Mounts `GET /windows`, `GET /nodes` (with optional `?testTag=`), `POST /click`, `POST /typeText`, `GET /screenshot`.
- Client side: `HttpComposeAutomator` (AutoCloseable) with the matching v1 surface. Created via the companion extension `ComposeAutomator.Companion.http(...)`.
- DTOs in `dev.sebastiano.spectre.server.dto` are kotlinx-serialization data classes pinning the wire contract.
- Pre-existing API leak fixed: `core` now declares `compose-ui` as `api` (was `implementation`) since `AutomatorNode.boundsInWindow` returns `androidx.compose.ui.geometry.Rect`.

## v1 scope
The endpoints land the most-used queries and actions. The following stay in-process-only and are documented in `server/README.md`:
- `registerIdlingResource` / `waitForIdle` / `waitForVisualIdle` (JVM objects + long-poll semantics out of scope for v1 transport)
- `withTracing` (needs a JVM `Tracer` instance the server can't accept across processes)
- `printTree` (debug helper; not transport-essential)

Closes #9.

## Test plan
- [x] `./gradlew check` — all modules green
- [x] `DtoSerializationTest` (5) — every DTO round-trips through kotlinx-serialization, including default-only and fully-populated variants
- [x] `SpectreServerRoundTripTest` (7) — Ktor `testApplication` exercises the real route handlers against a headless `ComposeAutomator`: list shapes, status codes, body decoding, custom base path, 404 for unknown node keys
- [ ] Live cross-JVM smoke against `sample-desktop` is part of #12 (sample harness coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)