### PR TITLE
Land v1 recording: ffmpeg avfoundation region capture (macOS)

### DIFF
--- a/recording/README.md
+++ b/recording/README.md
@@ -1,10 +1,37 @@
 # Recording
 
-Planned home for screen capture and recording support:
+Phase 1 screen recording for Spectre scenarios.
 
-- ffmpeg-driven region capture
-- macOS-specific window capture helpers
-- recording lifecycle APIs
+## Public surface
 
-This module is intentionally scaffold-only right now.
+- `Recorder` — interface; produces a `RecordingHandle` for an in-progress capture.
+- `FfmpegRecorder` — v1 default. Shells out to a system `ffmpeg` and captures the requested
+  region via the macOS avfoundation device. Resolves the binary via PATH (`resolveFfmpegPath()`)
+  by default; pass `ffmpegPath` to override (testing, non-PATH installs).
+- `RecordingHandle` — `AutoCloseable`. Stop sends `q` on stdin (ffmpeg's documented clean-shutdown
+  signal), waits up to 5 s for a graceful exit, then SIGTERM / SIGKILL fallback.
+- `RecordingOptions` — frame rate, cursor capture, codec.
+- `MacOsRecordingPermissions.diagnose()` — best-effort startup diagnostic for Screen Recording
+  and Accessibility permissions; full native detection (`CGPreflightScreenCaptureAccess`,
+  `AXIsProcessTrusted`) is deferred to v2 alongside the ScreenCaptureKit work in #18.
 
+## v1 scope
+
+| Capability | Status |
+|---|---|
+| macOS region capture (avfoundation) | ✅ this module |
+| Embedded `ComposePanel` (`windowHandle == 0L`) | ✅ falls through to region capture |
+| ScreenCaptureKit window-targeted capture | ⏸ v2 (#18) |
+| Windows `gdigrab` recording | ⏸ v3 (#22) |
+| Linux `x11grab` / pipewire recording | ⏸ v4 (#27) |
+
+## Permissions
+
+The JVM running Spectre needs two macOS permissions for recording to work:
+- **Screen Recording** — for ffmpeg's avfoundation capture and for AWT `Robot` screenshots.
+- **Accessibility** — for AWT `Robot` mouse / keyboard control.
+
+Grant them under **System Settings → Privacy & Security**, targeting whichever process is hosting
+Spectre (your IDE, your test runner, or a standalone `java`). Restart the JVM after granting —
+macOS does not refresh TCC entitlements live. `MacOsRecordingPermissions.diagnose()` returns a
+human-readable summary you can dump at startup to surface this to developers.

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -7,7 +7,8 @@ plugins {
 kotlin { jvmToolchain(21) }
 
 dependencies {
-    api(projects.core)
+    // recording is intentionally isolated per docs/ARCHITECTURE.md — it has its own native /
+    // ffmpeg boundary and shares no types with core. No projects.core dependency here.
     implementation(libs.kotlinx.coroutines.core)
     detektPlugins(libs.compose.rules.detekt)
 

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -6,4 +6,13 @@ plugins {
 
 kotlin { jvmToolchain(21) }
 
-dependencies { implementation(libs.kotlinx.coroutines.core) }
+dependencies {
+    api(projects.core)
+    implementation(libs.kotlinx.coroutines.core)
+    detektPlugins(libs.compose.rules.detekt)
+
+    testImplementation(libs.kotlin.testJunit5)
+    testImplementation(libs.kotlinx.coroutines.test)
+}
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
@@ -1,0 +1,53 @@
+package dev.sebastiano.spectre.recording
+
+import java.awt.Rectangle
+import java.nio.file.Path
+
+/**
+ * Builds the `ffmpeg` argv for a region capture against the avfoundation device on macOS.
+ *
+ * Pure function — no I/O, no process spawn — so the argv is unit-testable in isolation. The actual
+ * subprocess lifecycle lives in [FfmpegRecorder].
+ *
+ * The resulting command captures the macOS main display (`-i 1` selects the screen capture device
+ * per the spike plan), crops it to [region] via the `crop` video filter, and pipes the result
+ * through the chosen codec into [output].
+ */
+internal object FfmpegCli {
+
+    fun avfoundationRegionCapture(
+        ffmpegPath: Path,
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): List<String> {
+        require(region.width > 0 && region.height > 0) {
+            "region must have positive dimensions, was ${region.width}x${region.height}"
+        }
+        return buildList {
+            add(ffmpegPath.toString())
+            // Quiet ffmpeg's stderr noise to warnings+errors so callers' logs stay readable.
+            add("-loglevel")
+            add("warning")
+            // Always overwrite — the caller named the output file deliberately and expects it
+            // to be replaced if it already exists.
+            add("-y")
+            // avfoundation source: input frame rate, optional cursor capture, then the device
+            // selector (display index 1 = main display per the FFmpeg avfoundation docs).
+            add("-f")
+            add("avfoundation")
+            add("-framerate")
+            add(options.frameRate.toString())
+            add("-capture_cursor")
+            add(if (options.captureCursor) "1" else "0")
+            add("-i")
+            add("1")
+            // Crop filter to the requested region.
+            add("-vf")
+            add("crop=${region.width}:${region.height}:${region.x}:${region.y}")
+            add("-c:v")
+            add(options.codec)
+            add(output.toString())
+        }
+    }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
@@ -24,6 +24,15 @@ internal object FfmpegCli {
         require(region.width > 0 && region.height > 0) {
             "region must have positive dimensions, was ${region.width}x${region.height}"
         }
+        // ffmpeg's `crop` filter silently clamps negative offsets to zero, which would record
+        // the wrong region without any error signal. Reject negative coordinates outright so
+        // misalignment surfaces here. Multi-monitor setups can produce negative AWT screen
+        // coordinates for a secondary display; callers in that situation should translate
+        // into the primary screen's coordinate space (or use ScreenCaptureKit window capture
+        // when that lands in v2).
+        require(region.x >= 0 && region.y >= 0) {
+            "region origin must be non-negative for ffmpeg crop, was (${region.x}, ${region.y})"
+        }
         return buildList {
             add(ffmpegPath.toString())
             // Quiet ffmpeg's stderr noise to warnings+errors so callers' logs stay readable.

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
@@ -33,7 +33,10 @@ internal object FfmpegCli {
             // to be replaced if it already exists.
             add("-y")
             // avfoundation source: input frame rate, optional cursor capture, then the device
-            // selector (display index 1 = main display per the FFmpeg avfoundation docs).
+            // selector. We use the device *name* `Capture screen 0` rather than a numeric
+            // index — index 1 is wrong on Macs without a built-in camera (Mac Mini, Mac Pro,
+            // external-display setups) where the screen sits at index 0. The name form is
+            // stable across hardware and is the form FFmpeg's avfoundation docs recommend.
             add("-f")
             add("avfoundation")
             add("-framerate")
@@ -41,7 +44,7 @@ internal object FfmpegCli {
             add("-capture_cursor")
             add(if (options.captureCursor) "1" else "0")
             add("-i")
-            add("1")
+            add("Capture screen 0")
             // Crop filter to the requested region.
             add("-vf")
             add("crop=${region.width}:${region.height}:${region.x}:${region.y}")

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
@@ -42,10 +42,13 @@ internal object FfmpegCli {
             // to be replaced if it already exists.
             add("-y")
             // avfoundation source: input frame rate, optional cursor capture, then the device
-            // selector. We use the device *name* `Capture screen 0` rather than a numeric
-            // index — index 1 is wrong on Macs without a built-in camera (Mac Mini, Mac Pro,
-            // external-display setups) where the screen sits at index 0. The name form is
+            // selector. We use the device *name* `Capture screen N` rather than a numeric
+            // index in the global device list — that global index would be wrong on Macs
+            // without a built-in camera (Mac Mini, Mac Pro, external-display setups) where
+            // index 0 in the global list is the screen, not the camera. The name form is
             // stable across hardware and is the form FFmpeg's avfoundation docs recommend.
+            // The screen index inside the name comes from RecordingOptions.screenIndex —
+            // multi-monitor users override it to point at a non-primary display.
             add("-f")
             add("avfoundation")
             add("-framerate")
@@ -53,7 +56,7 @@ internal object FfmpegCli {
             add("-capture_cursor")
             add(if (options.captureCursor) "1" else "0")
             add("-i")
-            add("Capture screen 0")
+            add("Capture screen ${options.screenIndex}")
             // Crop filter to the requested region.
             add("-vf")
             add("crop=${region.width}:${region.height}:${region.x}:${region.y}")

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -173,6 +173,14 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
                 }
             if (!terminatedAfterDestroy) {
                 process.destroyForcibly()
+                // destroyForcibly() is asynchronous on the JVM. Wait once more so the post-
+                // stop world really has the process gone (otherwise isStopped=true could be
+                // observable while ffmpeg is still finalising the output file).
+                try {
+                    process.waitFor(FORCE_KILL_SECONDS, TimeUnit.SECONDS)
+                } catch (_: InterruptedException) {
+                    interrupted = true
+                }
             }
         }
         if (interrupted) Thread.currentThread().interrupt()

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -8,6 +8,7 @@ import java.nio.file.Paths
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Default [Recorder] backed by a system `ffmpeg` binary.
@@ -144,17 +145,20 @@ class FfmpegRecorder(
 private class FfmpegRecordingHandle(private val process: Process, override val output: Path) :
     RecordingHandle {
 
-    // Two-state lifecycle so concurrent observers see an accurate `isStopped`:
+    // Three-state lifecycle so concurrent observers see an accurate `isStopped`:
     //   - stopInitiated: CAS guard so the cleanup runs exactly once.
-    //   - finished: CountDownLatch that flips only after the cleanup completes (or throws).
-    // A concurrent stop() finds stopInitiated already true, then blocks on `finished` so it
-    // returns at the same time as the original stop() — and isStopped reflects "process has
-    // actually exited" rather than "stop has been entered".
+    //   - finished:      CountDownLatch that releases waiters once the first cleanup attempt
+    //                    completes (success or failure).
+    //   - result:        Result<Unit> set by the first cleanup. isStopped reflects this — it
+    //                    is true only on success. Concurrent callers replay the same failure
+    //                    so a leaked-orphan situation is observable to every caller, not just
+    //                    the first.
     private val stopInitiated = AtomicBoolean(false)
     private val finished = CountDownLatch(1)
+    private val result = AtomicReference<Result<Unit>?>()
 
     override val isStopped: Boolean
-        get() = finished.count == 0L
+        get() = result.get()?.isSuccess == true
 
     // Tracks whether stop() *itself* sent SIGTERM/SIGKILL to ffmpeg. Used to decide whether a
     // signal-shaped exit code (255 / 137 / 143) is "ours" (expected, not a crash) or external
@@ -163,13 +167,21 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
 
     override fun stop() {
         if (!stopInitiated.compareAndSet(false, true)) {
-            // Another thread is already running the cleanup. Block until it finishes so
-            // both callers observe a consistent post-stop world (file flushed, process gone).
+            // Another thread is already running the cleanup. Block until it finishes, then
+            // replay the same outcome — including any exception — so concurrent callers do
+            // not silently observe a "stopped" state that the first call actually failed to
+            // achieve.
             finished.await()
+            result.get()?.getOrThrow()
             return
         }
+        @Suppress("TooGenericExceptionCaught")
         try {
             stopInternal()
+            result.set(Result.success(Unit))
+        } catch (t: Throwable) {
+            result.set(Result.failure(t))
+            throw t
         } finally {
             finished.countDown()
         }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -48,6 +48,18 @@ class FfmpegRecorder(
         val argv = FfmpegCli.avfoundationRegionCapture(ffmpegPath, region, output, options)
         Files.createDirectories(output.toAbsolutePath().parent ?: output.toAbsolutePath())
         val process = processFactory.start(argv)
+        // Fail fast: ffmpeg dies almost instantly on common configuration errors (missing
+        // Screen Recording permission, invalid codec, unavailable avfoundation device). The
+        // Recorder.start contract promises frames are landing by return, so a process that
+        // has already exited must surface as an error rather than a "success" handle that
+        // later produces nothing.
+        if (process.waitFor(STARTUP_PROBE_MILLIS, TimeUnit.MILLISECONDS)) {
+            throw IllegalStateException(
+                "ffmpeg exited immediately (code ${process.exitValue()}) — recording did not start. " +
+                    "Common causes: missing Screen Recording permission, invalid codec, or " +
+                    "unavailable avfoundation device. Argv: $argv"
+            )
+        }
         return FfmpegRecordingHandle(process, output)
     }
 
@@ -155,3 +167,5 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
         const val FORCE_KILL_SECONDS: Long = 2
     }
 }
+
+private const val STARTUP_PROBE_MILLIS: Long = 200

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -5,6 +5,7 @@ import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -65,13 +66,20 @@ class FfmpegRecorder(
                 // during this wait means the JVM is being torn down anyway, and the daemon
                 // semantics of subprocesses will let it die with the JVM.
                 @Suppress("TooGenericExceptionCaught", "SwallowedException")
-                try {
-                    process.waitFor(FORCE_KILL_DURING_START_SECONDS, TimeUnit.SECONDS)
-                } catch (_: Throwable) {
-                    // Best effort — the interrupt below carries the cancellation signal
-                    // upstream regardless.
-                }
+                val terminated =
+                    try {
+                        process.waitFor(FORCE_KILL_DURING_START_SECONDS, TimeUnit.SECONDS)
+                    } catch (_: Throwable) {
+                        false
+                    }
                 Thread.currentThread().interrupt()
+                if (!terminated) {
+                    throw IllegalStateException(
+                        "ffmpeg refused to die after destroyForcibly() during start() interrupt — " +
+                            "leaking an orphan recorder is not safe; output at $output is in an " +
+                            "undefined state."
+                    )
+                }
                 throw e
             }
         if (exitedDuringProbe) {
@@ -136,10 +144,17 @@ class FfmpegRecorder(
 private class FfmpegRecordingHandle(private val process: Process, override val output: Path) :
     RecordingHandle {
 
-    private val stopped = AtomicBoolean(false)
+    // Two-state lifecycle so concurrent observers see an accurate `isStopped`:
+    //   - stopInitiated: CAS guard so the cleanup runs exactly once.
+    //   - finished: CountDownLatch that flips only after the cleanup completes (or throws).
+    // A concurrent stop() finds stopInitiated already true, then blocks on `finished` so it
+    // returns at the same time as the original stop() — and isStopped reflects "process has
+    // actually exited" rather than "stop has been entered".
+    private val stopInitiated = AtomicBoolean(false)
+    private val finished = CountDownLatch(1)
 
     override val isStopped: Boolean
-        get() = stopped.get()
+        get() = finished.count == 0L
 
     // Tracks whether stop() *itself* sent SIGTERM/SIGKILL to ffmpeg. Used to decide whether a
     // signal-shaped exit code (255 / 137 / 143) is "ours" (expected, not a crash) or external
@@ -147,7 +162,20 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
     private var sentSignalOurselves: Boolean = false
 
     override fun stop() {
-        if (!stopped.compareAndSet(false, true)) return
+        if (!stopInitiated.compareAndSet(false, true)) {
+            // Another thread is already running the cleanup. Block until it finishes so
+            // both callers observe a consistent post-stop world (file flushed, process gone).
+            finished.await()
+            return
+        }
+        try {
+            stopInternal()
+        } finally {
+            finished.countDown()
+        }
+    }
+
+    private fun stopInternal() {
         if (!process.isAlive) {
             // ffmpeg already exited — could be a clean prior stop, or a mid-recording crash
             // (disk full, encoder error, device failure). The handle is the only error

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -1,0 +1,133 @@
+package dev.sebastiano.spectre.recording
+
+import java.awt.Rectangle
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Default [Recorder] backed by a system `ffmpeg` binary.
+ *
+ * Spawns `ffmpeg` as a subprocess on [start] and returns a [RecordingHandle] that signals the
+ * subprocess to flush and exit cleanly when the caller stops the recording. The expected path to
+ * the binary is resolved via [resolveFfmpegPath]; callers can override the lookup by passing an
+ * explicit [ffmpegPath] (useful in tests and for non-PATH installs).
+ *
+ * Platform support (v1, per the spike plan):
+ * - macOS: avfoundation device with region cropping. `RecordingOptions.captureCursor` controls
+ *   whether the cursor is baked into frames. **Requires macOS Screen Recording permission for the
+ *   JVM process** (see [MacOsRecordingPermissions]).
+ * - Windows / Linux: explicitly out of scope for v1; deferred to v3 / v4.
+ *
+ * Window-targeted capture (`windowHandle != 0`) — i.e. ScreenCaptureKit on macOS — is deferred to
+ * v2 (#18). Embedded ComposePanel surfaces with `windowHandle == 0L` always fall through to region
+ * capture, which is what this recorder does.
+ *
+ * The [processFactory] seam exists so the lifecycle can be unit-tested without spawning a real
+ * `ffmpeg` (a fake factory can return a `Process`-like stand-in driven by an in-memory pipe).
+ */
+class FfmpegRecorder(
+    private val ffmpegPath: Path = resolveFfmpegPath(),
+    private val processFactory: ProcessFactory = SystemProcessFactory,
+) : Recorder {
+
+    init {
+        require(Files.isExecutable(ffmpegPath) || ffmpegPath == PROBE_PATH) {
+            "ffmpeg binary not executable at $ffmpegPath"
+        }
+    }
+
+    override fun start(
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): RecordingHandle {
+        val argv = FfmpegCli.avfoundationRegionCapture(ffmpegPath, region, output, options)
+        Files.createDirectories(output.toAbsolutePath().parent ?: output.toAbsolutePath())
+        val process = processFactory.start(argv)
+        return FfmpegRecordingHandle(process, output)
+    }
+
+    /** Indirection over `ProcessBuilder.start()` so tests can drive the subprocess lifecycle. */
+    interface ProcessFactory {
+        fun start(argv: List<String>): Process
+    }
+
+    private object SystemProcessFactory : ProcessFactory {
+        override fun start(argv: List<String>): Process =
+            ProcessBuilder(argv)
+                .redirectErrorStream(true)
+                // ffmpeg listens for `q` on stdin to flush + exit cleanly. We need PIPE so we
+                // can send it from RecordingHandle.stop().
+                .redirectInput(ProcessBuilder.Redirect.PIPE)
+                .start()
+    }
+
+    companion object {
+
+        // Sentinel returned by resolveFfmpegPath() when no binary is found. Constructing an
+        // FfmpegRecorder against this path lets the caller see the explicit failure message
+        // immediately rather than at start() time, but prevents the strict isExecutable check
+        // from blocking the no-binary path used in tests / probing.
+        internal val PROBE_PATH: Path = Paths.get("ffmpeg")
+
+        /**
+         * Best-effort lookup for a `ffmpeg` binary on PATH. Returns the resolved absolute path if
+         * found, or [PROBE_PATH] (the unresolved name) if not — callers that try to instantiate
+         * [FfmpegRecorder] with [PROBE_PATH] will get a clear error explaining the missing binary
+         * at use time.
+         */
+        fun resolveFfmpegPath(): Path = which("ffmpeg") ?: PROBE_PATH
+
+        private fun which(executable: String): Path? {
+            val pathEnv = System.getenv("PATH") ?: return null
+            val separator = System.getProperty("path.separator") ?: ":"
+            for (dir in pathEnv.split(separator)) {
+                if (dir.isBlank()) continue
+                val candidate = Paths.get(dir, executable)
+                if (Files.isExecutable(candidate)) return candidate.toAbsolutePath()
+            }
+            return null
+        }
+    }
+}
+
+private class FfmpegRecordingHandle(private val process: Process, override val output: Path) :
+    RecordingHandle {
+
+    private val stopped = AtomicBoolean(false)
+
+    override val isStopped: Boolean
+        get() = stopped.get()
+
+    override fun stop() {
+        if (!stopped.compareAndSet(false, true)) return
+        if (!process.isAlive) return
+        // Send 'q' on stdin: ffmpeg's documented clean-shutdown signal. The subprocess flushes
+        // its mux buffer, finalises the output file, and exits. SIGTERM as a fallback for
+        // stalled processes.
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            process.outputStream?.use { it.write('q'.code) }
+        } catch (_: IOException) {
+            // ffmpeg may have already exited; the waitFor below confirms.
+        } catch (t: Throwable) {
+            // Any failure here still goes to the SIGTERM fallback.
+            if (t is InterruptedException) Thread.currentThread().interrupt()
+        }
+        if (!process.waitFor(SHUTDOWN_GRACE_SECONDS, TimeUnit.SECONDS)) {
+            process.destroy()
+            if (!process.waitFor(FORCE_KILL_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+            }
+        }
+    }
+
+    private companion object {
+        const val SHUTDOWN_GRACE_SECONDS: Long = 5
+        const val FORCE_KILL_SECONDS: Long = 2
+    }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -189,8 +189,11 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
             } catch (_: Throwable) {
                 return
             }
-        // ffmpeg returns 255 on SIGTERM (our own destroy()), so don't treat that as a crash.
-        if (exit != 0 && exit != FFMPEG_SIGTERM_EXIT) {
+        // ffmpeg returns 255 on SIGTERM (destroy()) and 137 on SIGKILL (destroyForcibly() —
+        // the standard 128+9 Unix convention). Both are signals stop() may have sent itself
+        // along the SIGTERM/SIGKILL fallback path, so neither is a crash from the caller's
+        // perspective.
+        if (exit != 0 && exit != FFMPEG_SIGTERM_EXIT && exit != FFMPEG_SIGKILL_EXIT) {
             throw IllegalStateException(
                 "ffmpeg exited with code $exit during recording — output at $output may be " +
                     "truncated or missing. Common causes: disk full, encoder error, device " +
@@ -203,6 +206,7 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
         const val SHUTDOWN_GRACE_SECONDS: Long = 5
         const val FORCE_KILL_SECONDS: Long = 2
         const val FFMPEG_SIGTERM_EXIT: Int = 255
+        const val FFMPEG_SIGKILL_EXIT: Int = 137 // 128 + 9 (SIGKILL) per POSIX convention
     }
 }
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -131,7 +131,14 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
 
     override fun stop() {
         if (!stopped.compareAndSet(false, true)) return
-        if (!process.isAlive) return
+        if (!process.isAlive) {
+            // ffmpeg already exited — could be a clean prior stop, or a mid-recording crash
+            // (disk full, encoder error, device failure). The handle is the only error
+            // boundary callers see, so a non-zero exit must surface as an error rather than
+            // letting the caller trust a truncated or missing output file.
+            failIfFfmpegCrashed()
+            return
+        }
         // Send 'q' on stdin: ffmpeg's documented clean-shutdown signal. The subprocess flushes
         // its mux buffer, finalises the output file, and exits. SIGTERM / SIGKILL as fallback
         // for stalled processes.
@@ -169,11 +176,33 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
             }
         }
         if (interrupted) Thread.currentThread().interrupt()
+        failIfFfmpegCrashed()
+    }
+
+    private fun failIfFfmpegCrashed() {
+        // exitValue throws IllegalThreadStateException if the process is still alive; we only
+        // call this from paths that have already established the process exited.
+        val exit =
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                process.exitValue()
+            } catch (_: Throwable) {
+                return
+            }
+        // ffmpeg returns 255 on SIGTERM (our own destroy()), so don't treat that as a crash.
+        if (exit != 0 && exit != FFMPEG_SIGTERM_EXIT) {
+            throw IllegalStateException(
+                "ffmpeg exited with code $exit during recording — output at $output may be " +
+                    "truncated or missing. Common causes: disk full, encoder error, device " +
+                    "failure during capture."
+            )
+        }
     }
 
     private companion object {
         const val SHUTDOWN_GRACE_SECONDS: Long = 5
         const val FORCE_KILL_SECONDS: Long = 2
+        const val FFMPEG_SIGTERM_EXIT: Int = 255
     }
 }
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -129,6 +129,11 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
     override val isStopped: Boolean
         get() = stopped.get()
 
+    // Tracks whether stop() *itself* sent SIGTERM/SIGKILL to ffmpeg. Used to decide whether a
+    // signal-shaped exit code (255 / 137 / 143) is "ours" (expected, not a crash) or external
+    // (CI/test harness/OS killed ffmpeg, which IS an error from the caller's perspective).
+    private var sentSignalOurselves: Boolean = false
+
     override fun stop() {
         if (!stopped.compareAndSet(false, true)) return
         if (!process.isAlive) {
@@ -163,6 +168,7 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
                 false
             }
         if (!gracefulExit) {
+            sentSignalOurselves = true
             process.destroy()
             val terminatedAfterDestroy =
                 try {
@@ -184,6 +190,15 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
             }
         }
         if (interrupted) Thread.currentThread().interrupt()
+        if (process.isAlive) {
+            // Even after destroyForcibly(), ffmpeg refused to die within the wait window.
+            // Surface this as a hard failure rather than letting the caller observe
+            // isStopped=true while the process is still mutating the output file.
+            throw IllegalStateException(
+                "ffmpeg did not exit after destroyForcibly() within ${FORCE_KILL_SECONDS}s — " +
+                    "output at $output is in an undefined state."
+            )
+        }
         failIfFfmpegCrashed()
     }
 
@@ -197,15 +212,23 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
             } catch (_: Throwable) {
                 return
             }
-        // ffmpeg returns 255 on SIGTERM (destroy()) and 137 on SIGKILL (destroyForcibly() —
-        // the standard 128+9 Unix convention). Both are signals stop() may have sent itself
-        // along the SIGTERM/SIGKILL fallback path, so neither is a crash from the caller's
-        // perspective.
-        if (exit != 0 && exit != FFMPEG_SIGTERM_EXIT && exit != FFMPEG_SIGKILL_EXIT) {
+        if (exit == 0) return
+        // 255 (ffmpeg-on-SIGTERM), 143 (POSIX 128+15 SIGTERM if ffmpeg's signal handler
+        // didn't run), and 137 (POSIX 128+9 SIGKILL) are *only* exempted when stop() sent
+        // the signal itself — see sentSignalOurselves. Otherwise they signify external
+        // termination (CI / test harness / OS killing ffmpeg) which IS a crash from the
+        // caller's perspective: the recording was interrupted and the output is likely
+        // truncated.
+        val isExpectedSelfSignal =
+            sentSignalOurselves &&
+                (exit == FFMPEG_SIGTERM_EXIT ||
+                    exit == POSIX_SIGTERM_EXIT ||
+                    exit == FFMPEG_SIGKILL_EXIT)
+        if (!isExpectedSelfSignal) {
             throw IllegalStateException(
                 "ffmpeg exited with code $exit during recording — output at $output may be " +
                     "truncated or missing. Common causes: disk full, encoder error, device " +
-                    "failure during capture."
+                    "failure during capture, or external termination."
             )
         }
     }
@@ -214,7 +237,8 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
         const val SHUTDOWN_GRACE_SECONDS: Long = 5
         const val FORCE_KILL_SECONDS: Long = 2
         const val FFMPEG_SIGTERM_EXIT: Int = 255
-        const val FFMPEG_SIGKILL_EXIT: Int = 137 // 128 + 9 (SIGKILL) per POSIX convention
+        const val POSIX_SIGTERM_EXIT: Int = 143 // 128 + 15 (SIGTERM)
+        const val FFMPEG_SIGKILL_EXIT: Int = 137 // 128 + 9 (SIGKILL)
     }
 }
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -52,8 +52,17 @@ class FfmpegRecorder(
         // Screen Recording permission, invalid codec, unavailable avfoundation device). The
         // Recorder.start contract promises frames are landing by return, so a process that
         // has already exited must surface as an error rather than a "success" handle that
-        // later produces nothing.
-        if (process.waitFor(STARTUP_PROBE_MILLIS, TimeUnit.MILLISECONDS)) {
+        // later produces nothing. Interruption during the probe must also clean up the
+        // spawned ffmpeg before propagating, otherwise we leak an orphan subprocess.
+        val exitedDuringProbe =
+            try {
+                process.waitFor(STARTUP_PROBE_MILLIS, TimeUnit.MILLISECONDS)
+            } catch (e: InterruptedException) {
+                process.destroyForcibly()
+                Thread.currentThread().interrupt()
+                throw e
+            }
+        if (exitedDuringProbe) {
             throw IllegalStateException(
                 "ffmpeg exited immediately (code ${process.exitValue()}) — recording did not start. " +
                     "Common causes: missing Screen Recording permission, invalid codec, or " +

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -59,6 +59,18 @@ class FfmpegRecorder(
                 process.waitFor(STARTUP_PROBE_MILLIS, TimeUnit.MILLISECONDS)
             } catch (e: InterruptedException) {
                 process.destroyForcibly()
+                // destroyForcibly() is asynchronous — wait once more so the orphan ffmpeg
+                // really has gone before we propagate the interrupt to the caller. We
+                // explicitly do NOT catch InterruptedException here: another interrupt
+                // during this wait means the JVM is being torn down anyway, and the daemon
+                // semantics of subprocesses will let it die with the JVM.
+                @Suppress("TooGenericExceptionCaught", "SwallowedException")
+                try {
+                    process.waitFor(FORCE_KILL_DURING_START_SECONDS, TimeUnit.SECONDS)
+                } catch (_: Throwable) {
+                    // Best effort — the interrupt below carries the cancellation signal
+                    // upstream regardless.
+                }
                 Thread.currentThread().interrupt()
                 throw e
             }
@@ -243,3 +255,4 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
 }
 
 private const val STARTUP_PROBE_MILLIS: Long = 200
+private const val FORCE_KILL_DURING_START_SECONDS: Long = 2

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -59,7 +59,12 @@ class FfmpegRecorder(
     private object SystemProcessFactory : ProcessFactory {
         override fun start(argv: List<String>): Process =
             ProcessBuilder(argv)
-                .redirectErrorStream(true)
+                // Discard ffmpeg's stdout and stderr. We never consume them, and leaving them
+                // on the default pipe means a noisy ffmpeg run can fill the pipe buffer and
+                // deadlock the encoder. DISCARD routes the streams to /dev/null at the OS
+                // level so ffmpeg can write freely without backpressure.
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
                 // ffmpeg listens for `q` on stdin to flush + exit cleanly. We need PIPE so we
                 // can send it from RecordingHandle.stop().
                 .redirectInput(ProcessBuilder.Redirect.PIPE)
@@ -107,8 +112,8 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
         if (!stopped.compareAndSet(false, true)) return
         if (!process.isAlive) return
         // Send 'q' on stdin: ffmpeg's documented clean-shutdown signal. The subprocess flushes
-        // its mux buffer, finalises the output file, and exits. SIGTERM as a fallback for
-        // stalled processes.
+        // its mux buffer, finalises the output file, and exits. SIGTERM / SIGKILL as fallback
+        // for stalled processes.
         @Suppress("TooGenericExceptionCaught")
         try {
             process.outputStream?.use { it.write('q'.code) }
@@ -118,12 +123,31 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
             // Any failure here still goes to the SIGTERM fallback.
             if (t is InterruptedException) Thread.currentThread().interrupt()
         }
-        if (!process.waitFor(SHUTDOWN_GRACE_SECONDS, TimeUnit.SECONDS)) {
+        // Catch InterruptedException around every waitFor so cancellation never short-circuits
+        // the SIGTERM/SIGKILL fallback path. We still call destroyForcibly() in that case so
+        // ffmpeg can't outlive us, then re-set the interrupt flag for the caller to observe.
+        var interrupted = false
+        val gracefulExit =
+            try {
+                process.waitFor(SHUTDOWN_GRACE_SECONDS, TimeUnit.SECONDS)
+            } catch (_: InterruptedException) {
+                interrupted = true
+                false
+            }
+        if (!gracefulExit) {
             process.destroy()
-            if (!process.waitFor(FORCE_KILL_SECONDS, TimeUnit.SECONDS)) {
+            val terminatedAfterDestroy =
+                try {
+                    process.waitFor(FORCE_KILL_SECONDS, TimeUnit.SECONDS)
+                } catch (_: InterruptedException) {
+                    interrupted = true
+                    false
+                }
+            if (!terminatedAfterDestroy) {
                 process.destroyForcibly()
             }
         }
+        if (interrupted) Thread.currentThread().interrupt()
     }
 
     private companion object {

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
@@ -1,0 +1,119 @@
+package dev.sebastiano.spectre.recording
+
+import java.util.concurrent.TimeUnit
+
+/**
+ * Best-effort startup diagnostics for the macOS permissions Spectre needs.
+ *
+ * The Spectre automator interacts with the OS in two ways that gated by macOS TCC permissions:
+ * - **Screen Recording** — required for [FfmpegRecorder]'s avfoundation device and for AWT
+ *   `Robot.createScreenCapture` (so [dev.sebastiano.spectre.core.RobotDriver]'s screenshot path on
+ *   macOS).
+ * - **Accessibility (input control)** — required for AWT `Robot` to actually move the mouse and
+ *   synthesize key events. Without it, mouse/key calls silently no-op.
+ *
+ * Detecting these without JNI is awkward — the canonical native APIs
+ * (`CGPreflightScreenCaptureAccess`, `AXIsProcessTrusted`) live in CoreGraphics /
+ * ApplicationServices and aren't reachable from pure JVM. v1 ships the diagnostic surface as
+ * documentation plus a probe-style heuristic via the `tccutil`/`osascript` CLIs where available;
+ * full native detection is deferred to v2 once the ScreenCaptureKit work brings in JNI/Panama
+ * bindings anyway.
+ */
+object MacOsRecordingPermissions {
+
+    /**
+     * Returns a human-readable diagnostic that downstream tooling can dump at startup. On non-macOS
+     * platforms returns [PermissionStatus.NotApplicable]. On macOS, runs a best-effort probe via
+     * `osascript` if available, otherwise returns [PermissionStatus.Unknown] with guidance text.
+     */
+    fun diagnose(): PermissionDiagnostic {
+        if (!isMacOs()) return PermissionDiagnostic(NOT_MAC_MESSAGE, PermissionStatus.NotApplicable)
+        val screen = probeScreenRecordingPermission()
+        val accessibility = probeAccessibilityPermission()
+        return PermissionDiagnostic(
+            message =
+                buildString {
+                    appendLine("Spectre macOS permission diagnostics:")
+                    appendLine("  Screen Recording   : ${screen.label}")
+                    appendLine("  Accessibility       : ${accessibility.label}")
+                    appendLine()
+                    appendLine(GUIDANCE)
+                },
+            status = combine(screen, accessibility),
+        )
+    }
+
+    private fun probeScreenRecordingPermission(): PermissionStatus =
+        runOsascript(
+                // CGPreflightScreenCaptureAccess via the AppleScript bridge isn't directly
+                // available — the cheap proxy is to ask whether the JVM process has been granted
+                // the right via `do shell script` on `tccutil reset` (which prompts on missing
+                // permission). We use a read-only path: System Events' "tell" returns success
+                // when accessibility is allowed; for screen recording there's no AppleScript
+                // proxy, so we fall back to PermissionStatus.Unknown.
+                // This keeps v1 honest: we return Unknown rather than pretending we know.
+                "return \"unknown\""
+            )
+            .let { PermissionStatus.Unknown }
+
+    private fun probeAccessibilityPermission(): PermissionStatus {
+        val output =
+            runOsascript("tell application \"System Events\" to return name of first process")
+        return when {
+            output == null -> PermissionStatus.Unknown
+            output.contains("not allowed assistive access", ignoreCase = true) ->
+                PermissionStatus.Denied
+            output.isNotBlank() -> PermissionStatus.Granted
+            else -> PermissionStatus.Unknown
+        }
+    }
+
+    /** Combine multiple statuses into a single rollup using the worst-known value. */
+    private fun combine(vararg statuses: PermissionStatus): PermissionStatus =
+        when {
+            statuses.any { it == PermissionStatus.Denied } -> PermissionStatus.Denied
+            statuses.any { it == PermissionStatus.Unknown } -> PermissionStatus.Unknown
+            statuses.all { it == PermissionStatus.Granted } -> PermissionStatus.Granted
+            else -> PermissionStatus.NotApplicable
+        }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun runOsascript(script: String): String? =
+        try {
+            val process =
+                ProcessBuilder("osascript", "-e", script).redirectErrorStream(true).start()
+            if (!process.waitFor(OSASCRIPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                null
+            } else {
+                process.inputStream.bufferedReader().use { it.readText() }.trim()
+            }
+        } catch (_: Throwable) {
+            null
+        }
+
+    private fun isMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
+
+    private const val OSASCRIPT_TIMEOUT_SECONDS: Long = 3
+
+    private const val NOT_MAC_MESSAGE: String =
+        "Spectre macOS permission diagnostics: not applicable on this platform."
+
+    private const val GUIDANCE: String =
+        "If a status is Denied or Unknown, grant the JVM (your IDE / your test runner / java)\n" +
+            "the relevant permission under System Settings → Privacy & Security:\n" +
+            "  - Screen Recording: required for ffmpeg avfoundation capture and for Robot screenshots.\n" +
+            "  - Accessibility:    required for Robot mouse/keyboard control.\n" +
+            "Restart the JVM after granting; macOS does not refresh TCC entitlements live."
+}
+
+/** Coarse permission status we can detect without JNI. */
+enum class PermissionStatus(val label: String) {
+    Granted("granted"),
+    Denied("denied"),
+    Unknown("unknown (could not detect — see guidance)"),
+    NotApplicable("not applicable on this platform"),
+}
+
+/** Result of [MacOsRecordingPermissions.diagnose]. */
+data class PermissionDiagnostic(val message: String, val status: PermissionStatus)

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
@@ -87,10 +87,14 @@ object MacOsRecordingPermissions {
         }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun runOsascript(script: String): OsascriptResult? =
-        try {
-            val process =
+    private fun runOsascript(script: String): OsascriptResult? {
+        val process =
+            try {
                 ProcessBuilder("osascript", "-e", script).redirectErrorStream(true).start()
+            } catch (_: Throwable) {
+                return null
+            }
+        return try {
             if (!process.waitFor(OSASCRIPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
                 null
@@ -100,9 +104,17 @@ object MacOsRecordingPermissions {
                     exitCode = process.exitValue(),
                 )
             }
+        } catch (_: InterruptedException) {
+            // Cancellation is meaningful upstream — surface the interrupt so callers'
+            // timeout/cancellation logic can react instead of silently swallowing it.
+            process.destroyForcibly()
+            Thread.currentThread().interrupt()
+            null
         } catch (_: Throwable) {
+            process.destroyForcibly()
             null
         }
+    }
 
     private data class OsascriptResult(val output: String, val exitCode: Int)
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit
  *
  * The Spectre automator interacts with the OS in two ways that gated by macOS TCC permissions:
  * - **Screen Recording** — required for [FfmpegRecorder]'s avfoundation device and for AWT
- *   `Robot.createScreenCapture` (so [dev.sebastiano.spectre.core.RobotDriver]'s screenshot path on
+ *   `Robot.createScreenCapture` (which is what the core RobotDriver's screenshot path uses on
  *   macOS).
  * - **Accessibility (input control)** — required for AWT `Robot` to actually move the mouse and
  *   synthesize key events. Without it, mouse/key calls silently no-op.

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
@@ -43,27 +43,36 @@ object MacOsRecordingPermissions {
         )
     }
 
-    private fun probeScreenRecordingPermission(): PermissionStatus =
-        runOsascript(
-                // CGPreflightScreenCaptureAccess via the AppleScript bridge isn't directly
-                // available — the cheap proxy is to ask whether the JVM process has been granted
-                // the right via `do shell script` on `tccutil reset` (which prompts on missing
-                // permission). We use a read-only path: System Events' "tell" returns success
-                // when accessibility is allowed; for screen recording there's no AppleScript
-                // proxy, so we fall back to PermissionStatus.Unknown.
-                // This keeps v1 honest: we return Unknown rather than pretending we know.
-                "return \"unknown\""
-            )
-            .let { PermissionStatus.Unknown }
+    private fun probeScreenRecordingPermission(): PermissionStatus {
+        // CGPreflightScreenCaptureAccess lives in CoreGraphics and isn't reachable from pure
+        // JVM. There's no AppleScript proxy for the Screen Recording TCC entry either, so for
+        // v1 we honestly report Unknown rather than pretending we know — full native detection
+        // is deferred to v2 alongside the ScreenCaptureKit JNI/Panama work.
+        return PermissionStatus.Unknown
+    }
 
     private fun probeAccessibilityPermission(): PermissionStatus {
-        val output =
+        // Run the script and ask runOsascript to surface the exit status separately. Common
+        // Automation-permission failures on macOS Ventura+ produce non-blank output (e.g.
+        // "execution error: Not authorized to send Apple events to System Events. (-1743)")
+        // with a non-zero exit code, so a successful-looking output without the matching exit
+        // code must be reported as Unknown rather than Granted.
+        val result =
             runOsascript("tell application \"System Events\" to return name of first process")
         return when {
-            output == null -> PermissionStatus.Unknown
-            output.contains("not allowed assistive access", ignoreCase = true) ->
-                PermissionStatus.Denied
-            output.isNotBlank() -> PermissionStatus.Granted
+            result == null -> PermissionStatus.Unknown
+            result.exitCode != 0 -> {
+                if (
+                    result.output.contains("not allowed assistive access", ignoreCase = true) ||
+                        result.output.contains("Not authorized", ignoreCase = true) ||
+                        result.output.contains("-1743") // Apple Events authorization
+                ) {
+                    PermissionStatus.Denied
+                } else {
+                    PermissionStatus.Unknown
+                }
+            }
+            result.output.isNotBlank() -> PermissionStatus.Granted
             else -> PermissionStatus.Unknown
         }
     }
@@ -78,7 +87,7 @@ object MacOsRecordingPermissions {
         }
 
     @Suppress("TooGenericExceptionCaught")
-    private fun runOsascript(script: String): String? =
+    private fun runOsascript(script: String): OsascriptResult? =
         try {
             val process =
                 ProcessBuilder("osascript", "-e", script).redirectErrorStream(true).start()
@@ -86,11 +95,16 @@ object MacOsRecordingPermissions {
                 process.destroyForcibly()
                 null
             } else {
-                process.inputStream.bufferedReader().use { it.readText() }.trim()
+                OsascriptResult(
+                    output = process.inputStream.bufferedReader().use { it.readText() }.trim(),
+                    exitCode = process.exitValue(),
+                )
             }
         } catch (_: Throwable) {
             null
         }
+
+    private data class OsascriptResult(val output: String, val exitCode: Int)
 
     private fun isMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
@@ -52,21 +52,19 @@ object MacOsRecordingPermissions {
     }
 
     private fun probeAccessibilityPermission(): PermissionStatus {
-        // Run the script and ask runOsascript to surface the exit status separately. Common
-        // Automation-permission failures on macOS Ventura+ produce non-blank output (e.g.
-        // "execution error: Not authorized to send Apple events to System Events. (-1743)")
-        // with a non-zero exit code, so a successful-looking output without the matching exit
-        // code must be reported as Unknown rather than Granted.
+        // The probe asks System Events for a process name. Three outcomes:
+        //   - exit 0 with non-blank output: Accessibility is granted.
+        //   - exit non-zero with the explicit Accessibility denial string: Denied.
+        //   - exit non-zero with anything else (including the AppleEvents/Automation
+        //     authorisation error -1743 / "Not authorized to send Apple events to System
+        //     Events"): Unknown — Automation and Accessibility are separate macOS TCC
+        //     entries, so an Automation refusal does NOT prove Accessibility is denied.
         val result =
             runOsascript("tell application \"System Events\" to return name of first process")
         return when {
             result == null -> PermissionStatus.Unknown
             result.exitCode != 0 -> {
-                if (
-                    result.output.contains("not allowed assistive access", ignoreCase = true) ||
-                        result.output.contains("Not authorized", ignoreCase = true) ||
-                        result.output.contains("-1743") // Apple Events authorization
-                ) {
+                if (result.output.contains("not allowed assistive access", ignoreCase = true)) {
                     PermissionStatus.Denied
                 } else {
                     PermissionStatus.Unknown

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/Recorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/Recorder.kt
@@ -1,0 +1,26 @@
+package dev.sebastiano.spectre.recording
+
+import java.awt.Rectangle
+import java.nio.file.Path
+
+/**
+ * Captures a region of the screen to a video file.
+ *
+ * The v1 default is [FfmpegRecorder] which shells out to a system `ffmpeg` binary. Tests and
+ * advanced consumers can swap in their own [Recorder] implementation (e.g. an in-memory frame
+ * accumulator, or the future ScreenCaptureKit-backed window-targeted recorder tracked in v2).
+ */
+interface Recorder {
+
+    /**
+     * Begin recording [region] to [output]. Returns a [RecordingHandle] that the caller stops to
+     * finalise the file. Implementations must spawn whatever they need eagerly so that callers can
+     * drive the UI immediately afterwards — by the time `start` returns, frames should be landing
+     * in the output file.
+     */
+    fun start(
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions = RecordingOptions(),
+    ): RecordingHandle
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingHandle.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingHandle.kt
@@ -1,0 +1,25 @@
+package dev.sebastiano.spectre.recording
+
+import java.nio.file.Path
+
+/**
+ * Handle to an in-progress recording.
+ *
+ * Call [stop] (or use the recorder's [AutoCloseable] form) to flush the pending frames and finalise
+ * the file at [output]. Stopping a handle that has already been stopped is a no-op.
+ */
+interface RecordingHandle : AutoCloseable {
+
+    /** The destination file the recorder is writing to. */
+    val output: Path
+
+    /** True once [stop] has been called and the recorder has flushed/exited. */
+    val isStopped: Boolean
+
+    /** Flush, terminate the underlying recording process/pipeline, and finalise [output]. */
+    fun stop()
+
+    override fun close() {
+        stop()
+    }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
@@ -14,16 +14,28 @@ data class RecordingOptions(
      * encoders work too if the platform supports them.
      */
     val codec: String = DEFAULT_CODEC,
+    /**
+     * Index of the macOS display to capture from, used to build ffmpeg's avfoundation device name
+     * `Capture screen $screenIndex`. Defaults to `0` — the primary display. Multi-monitor users
+     * whose target region lives on a secondary display must set this to the matching index
+     * (typically the AWT `GraphicsDevice` index of the screen, but verify by running `ffmpeg -f
+     * avfoundation -list_devices true -i ""` once and matching the "Capture screen N" entries
+     * against your physical display arrangement). The crop coordinates in the region are
+     * interpreted relative to the chosen screen's top-left.
+     */
+    val screenIndex: Int = DEFAULT_SCREEN_INDEX,
 ) {
 
     init {
         require(frameRate > 0) { "frameRate must be positive, was $frameRate" }
         require(codec.isNotBlank()) { "codec must not be blank" }
+        require(screenIndex >= 0) { "screenIndex must be non-negative, was $screenIndex" }
     }
 
     companion object {
 
         const val DEFAULT_FRAME_RATE: Int = 30
         const val DEFAULT_CODEC: String = "libx264"
+        const val DEFAULT_SCREEN_INDEX: Int = 0
     }
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
@@ -1,0 +1,29 @@
+package dev.sebastiano.spectre.recording
+
+/**
+ * Knobs for [Recorder.start]. Defaults are chosen to match the spike-plan recommendations for
+ * scenario-level test recordings: 30fps, cursor visible, hardware-accelerated H.264 on macOS where
+ * available.
+ */
+data class RecordingOptions(
+    val frameRate: Int = DEFAULT_FRAME_RATE,
+    val captureCursor: Boolean = true,
+    /**
+     * H.264 encoder name. Leaves room for swapping `h264_videotoolbox` (macOS hw accel) for
+     * `libx264` (cross-platform software fallback) without restructuring the API. Other ffmpeg
+     * encoders work too if the platform supports them.
+     */
+    val codec: String = DEFAULT_CODEC,
+) {
+
+    init {
+        require(frameRate > 0) { "frameRate must be positive, was $frameRate" }
+        require(codec.isNotBlank()) { "codec must not be blank" }
+    }
+
+    companion object {
+
+        const val DEFAULT_FRAME_RATE: Int = 30
+        const val DEFAULT_CODEC: String = "libx264"
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
@@ -32,7 +32,8 @@ class FfmpegCliTest {
         assertContainsSequence(argv, listOf("-f", "avfoundation"))
         assertContainsSequence(argv, listOf("-framerate", "60"))
         assertContainsSequence(argv, listOf("-capture_cursor", "0"))
-        assertContainsSequence(argv, listOf("-i", "1"))
+        // Device name (not numeric index) — stable across hardware with/without built-in cameras.
+        assertContainsSequence(argv, listOf("-i", "Capture screen 0"))
     }
 
     @Test

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
@@ -1,0 +1,93 @@
+package dev.sebastiano.spectre.recording
+
+import java.awt.Rectangle
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class FfmpegCliTest {
+
+    private val ffmpeg: Path = Path.of("/usr/local/bin/ffmpeg")
+    private val output: Path = Path.of("/tmp/spectre/out.mp4")
+    private val region = Rectangle(100, 200, 640, 480)
+
+    @Test
+    fun `argv starts with the ffmpeg path`() {
+        val argv = FfmpegCli.avfoundationRegionCapture(ffmpeg, region, output, RecordingOptions())
+        assertEquals(ffmpeg.toString(), argv.first())
+    }
+
+    @Test
+    fun `argv selects avfoundation device with the configured framerate and cursor flag`() {
+        val argv =
+            FfmpegCli.avfoundationRegionCapture(
+                ffmpeg,
+                region,
+                output,
+                RecordingOptions(frameRate = 60, captureCursor = false),
+            )
+
+        assertContainsSequence(argv, listOf("-f", "avfoundation"))
+        assertContainsSequence(argv, listOf("-framerate", "60"))
+        assertContainsSequence(argv, listOf("-capture_cursor", "0"))
+        assertContainsSequence(argv, listOf("-i", "1"))
+    }
+
+    @Test
+    fun `argv emits a crop filter matching the requested region`() {
+        val argv = FfmpegCli.avfoundationRegionCapture(ffmpeg, region, output, RecordingOptions())
+        assertContainsSequence(argv, listOf("-vf", "crop=640:480:100:200"))
+    }
+
+    @Test
+    fun `argv applies the configured codec and output path`() {
+        val argv =
+            FfmpegCli.avfoundationRegionCapture(
+                ffmpeg,
+                region,
+                output,
+                RecordingOptions(codec = "h264_videotoolbox"),
+            )
+        assertContainsSequence(argv, listOf("-c:v", "h264_videotoolbox"))
+        assertEquals(output.toString(), argv.last())
+    }
+
+    @Test
+    fun `argv always passes -y to overwrite the output file`() {
+        val argv = FfmpegCli.avfoundationRegionCapture(ffmpeg, region, output, RecordingOptions())
+        assertTrue("-y" in argv, "Should pass -y to overwrite: $argv")
+    }
+
+    @Test
+    fun `argv quiets ffmpeg log noise via -loglevel warning`() {
+        val argv = FfmpegCli.avfoundationRegionCapture(ffmpeg, region, output, RecordingOptions())
+        assertContainsSequence(argv, listOf("-loglevel", "warning"))
+    }
+
+    @Test
+    fun `non-positive region dimensions are rejected`() {
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.avfoundationRegionCapture(
+                ffmpeg,
+                Rectangle(0, 0, 0, 100),
+                output,
+                RecordingOptions(),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.avfoundationRegionCapture(
+                ffmpeg,
+                Rectangle(0, 0, 100, 0),
+                output,
+                RecordingOptions(),
+            )
+        }
+    }
+}
+
+private fun assertContainsSequence(argv: List<String>, expected: List<String>) {
+    val matched = argv.windowed(expected.size).any { it == expected }
+    check(matched) { "Expected $expected to appear contiguously in $argv" }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
@@ -43,6 +43,19 @@ class FfmpegCliTest {
     }
 
     @Test
+    fun `argv selects the requested screen index`() {
+        val argv =
+            FfmpegCli.avfoundationRegionCapture(
+                ffmpeg,
+                region,
+                output,
+                RecordingOptions(screenIndex = 2),
+            )
+        // Multi-monitor: the device name carries the requested screen index.
+        assertContainsSequence(argv, listOf("-i", "Capture screen 2"))
+    }
+
+    @Test
     fun `argv applies the configured codec and output path`() {
         val argv =
             FfmpegCli.avfoundationRegionCapture(

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
@@ -68,6 +68,27 @@ class FfmpegCliTest {
     }
 
     @Test
+    fun `negative region origin is rejected`() {
+        // ffmpeg's crop filter would silently clamp these — surface the alignment problem here.
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.avfoundationRegionCapture(
+                ffmpeg,
+                Rectangle(-1, 0, 100, 100),
+                output,
+                RecordingOptions(),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.avfoundationRegionCapture(
+                ffmpeg,
+                Rectangle(0, -10, 100, 100),
+                output,
+                RecordingOptions(),
+            )
+        }
+    }
+
+    @Test
     fun `non-positive region dimensions are rejected`() {
         assertFailsWith<IllegalArgumentException> {
             FfmpegCli.avfoundationRegionCapture(

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
@@ -123,6 +123,28 @@ class FfmpegRecorderTest {
     }
 
     @Test
+    fun `start throws when the spawned ffmpeg exits immediately`() {
+        // Simulates the common "ffmpeg dies right after spawn" failure modes — missing Screen
+        // Recording permission, invalid codec, unavailable device. Recorder.start must surface
+        // these as errors rather than returning a handle that produces an empty file.
+        val recorder =
+            FfmpegRecorder(
+                ffmpegPath = FfmpegRecorder.PROBE_PATH,
+                processFactory = ProcessFactoryReturning(InstantlyExitingFakeProcess()),
+            )
+        val output = Files.createTempFile("spectre-recording-test-", ".mp4")
+        try {
+            kotlin.test
+                .assertFailsWith<IllegalStateException> {
+                    recorder.start(Rectangle(0, 0, 100, 100), output, RecordingOptions())
+                }
+                .also { assertTrue(it.message?.contains("exited immediately") == true) }
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
     fun `constructor with non-executable explicit path throws`() {
         val nonexistent = Path.of("/this/path/does/not/exist/ffmpeg")
         kotlin.test.assertFailsWith<IllegalArgumentException> {
@@ -182,10 +204,13 @@ private class FakeProcess : Process() {
         return 0
     }
 
+    // Honest "did the process exit within the timeout?" — alive => no (false), dead => yes
+    // (true). The startup probe in FfmpegRecorder.start() needs the false signal to allow the
+    // recording handle through; stop() needs the true signal once 'q' on stdin has flipped
+    // alive=false via the OutputStream.close() callback.
     override fun waitFor(timeout: Long, unit: TimeUnit): Boolean {
         waitForCalled = true
-        alive = false
-        return true
+        return !alive
     }
 
     override fun exitValue(): Int = 0
@@ -201,4 +226,37 @@ private class FakeProcess : Process() {
     override fun toHandle(): ProcessHandle = ProcessHandle.current()
 
     override fun onExit(): CompletableFuture<Process> = CompletableFuture.completedFuture(this)
+}
+
+/**
+ * A FakeProcess that reports as already-exited from the moment it is created. Used to drive the
+ * "ffmpeg died right after spawn" branch of FfmpegRecorder.start.
+ */
+private class InstantlyExitingFakeProcess : Process() {
+
+    override fun getOutputStream(): OutputStream = ByteArrayOutputStream()
+
+    override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun waitFor(): Int = EXIT_CODE
+
+    override fun waitFor(timeout: Long, unit: TimeUnit): Boolean = true
+
+    override fun exitValue(): Int = EXIT_CODE
+
+    override fun destroy() = Unit
+
+    override fun isAlive(): Boolean = false
+
+    override fun pid(): Long = 0
+
+    override fun toHandle(): ProcessHandle = ProcessHandle.current()
+
+    override fun onExit(): CompletableFuture<Process> = CompletableFuture.completedFuture(this)
+
+    private companion object {
+        const val EXIT_CODE: Int = 1
+    }
 }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
@@ -123,6 +123,33 @@ class FfmpegRecorderTest {
     }
 
     @Test
+    fun `stop throws if ffmpeg crashed mid-recording`() {
+        // Simulate a crash during capture: process started OK, then ffmpeg dies non-cleanly
+        // (e.g. disk full) before stop() is called. The handle is the only error boundary
+        // exposed to callers, so stop() must surface the non-zero exit instead of silently
+        // succeeding and leaving the caller to trust a truncated output file.
+        val process = CrashedAfterStartFakeProcess()
+        val recorder =
+            FfmpegRecorder(
+                ffmpegPath = FfmpegRecorder.PROBE_PATH,
+                processFactory = ProcessFactoryReturning(process),
+            )
+        val output = Files.createTempFile("spectre-recording-test-", ".mp4")
+        try {
+            val handle = recorder.start(Rectangle(0, 0, 50, 50), output, RecordingOptions())
+            // Drive the crash *after* start succeeded — start's own probe reports the process
+            // alive (waitFor returns false), then we flip alive to false to mimic a runtime
+            // crash with non-zero exit code.
+            process.crash(exitCode = 1)
+            kotlin.test
+                .assertFailsWith<IllegalStateException> { handle.stop() }
+                .also { assertTrue(it.message?.contains("exited with code 1") == true) }
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
     fun `start throws when the spawned ffmpeg exits immediately`() {
         // Simulates the common "ffmpeg dies right after spawn" failure modes — missing Screen
         // Recording permission, invalid codec, unavailable device. Recorder.start must surface
@@ -214,6 +241,47 @@ private class FakeProcess : Process() {
     }
 
     override fun exitValue(): Int = 0
+
+    override fun destroy() {
+        alive = false
+    }
+
+    override fun isAlive(): Boolean = alive
+
+    override fun pid(): Long = 0
+
+    override fun toHandle(): ProcessHandle = ProcessHandle.current()
+
+    override fun onExit(): CompletableFuture<Process> = CompletableFuture.completedFuture(this)
+}
+
+/**
+ * A FakeProcess that starts alive (so start()'s startup probe sees it as healthy) and can be
+ * flipped to exited via [crash]. Used to drive the "ffmpeg crashed mid-recording" branch of
+ * FfmpegRecordingHandle.stop.
+ */
+private class CrashedAfterStartFakeProcess : Process() {
+
+    private var alive: Boolean = true
+    private var exit: Int = 0
+
+    fun crash(exitCode: Int) {
+        alive = false
+        exit = exitCode
+    }
+
+    override fun getOutputStream(): OutputStream = ByteArrayOutputStream()
+
+    override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun waitFor(): Int = exit
+
+    override fun waitFor(timeout: Long, unit: TimeUnit): Boolean = !alive
+
+    override fun exitValue(): Int =
+        if (alive) throw IllegalThreadStateException("still running") else exit
 
     override fun destroy() {
         alive = false

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
@@ -1,0 +1,204 @@
+package dev.sebastiano.spectre.recording
+
+import java.awt.Rectangle
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.lang.ProcessHandle
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.deleteIfExists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FfmpegRecorderTest {
+
+    @Test
+    fun `start spawns the subprocess with the avfoundation argv`() {
+        val factory = RecordingProcessFactory()
+        val recorder =
+            FfmpegRecorder(ffmpegPath = FfmpegRecorder.PROBE_PATH, processFactory = factory)
+        val output = Files.createTempFile("spectre-recording-test-", ".mp4")
+        try {
+            recorder.start(Rectangle(0, 0, 100, 100), output, RecordingOptions())
+
+            val argv = factory.lastArgv
+            assertTrue(argv.isNotEmpty(), "Process factory should have been invoked")
+            assertTrue("avfoundation" in argv, "Argv should select avfoundation: $argv")
+            assertEquals(output.toString(), argv.last(), "Argv should end with the output path")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `start creates the output parent directory`() {
+        val factory = RecordingProcessFactory()
+        val recorder =
+            FfmpegRecorder(ffmpegPath = FfmpegRecorder.PROBE_PATH, processFactory = factory)
+        val baseDir = Files.createTempDirectory("spectre-recording-test-")
+        val nested = baseDir.resolve("nested/subdir/output.mp4")
+        try {
+            recorder.start(Rectangle(0, 0, 50, 50), nested, RecordingOptions())
+            assertTrue(Files.isDirectory(nested.parent), "Parent directory must be created")
+        } finally {
+            nested.parent.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `stop sends q on stdin and waits for the process`() {
+        val process = FakeProcess()
+        val factory = ProcessFactoryReturning(process)
+        val recorder =
+            FfmpegRecorder(ffmpegPath = FfmpegRecorder.PROBE_PATH, processFactory = factory)
+        val output = Files.createTempFile("spectre-recording-test-", ".mp4")
+        try {
+            val handle = recorder.start(Rectangle(0, 0, 50, 50), output, RecordingOptions())
+            assertFalse(handle.isStopped)
+
+            handle.stop()
+
+            assertTrue(handle.isStopped)
+            assertEquals("q", process.stdinSentText, "Should signal ffmpeg by writing 'q' to stdin")
+            assertTrue(process.waitForCalled, "Should wait for the process to exit cleanly")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `stop is idempotent`() {
+        val process = FakeProcess()
+        val recorder =
+            FfmpegRecorder(
+                ffmpegPath = FfmpegRecorder.PROBE_PATH,
+                processFactory = ProcessFactoryReturning(process),
+            )
+        val output = Files.createTempFile("spectre-recording-test-", ".mp4")
+        try {
+            val handle = recorder.start(Rectangle(0, 0, 10, 10), output, RecordingOptions())
+            handle.stop()
+            handle.stop() // second call must not throw or send a second 'q'
+            assertEquals("q", process.stdinSentText, "Stop should send 'q' exactly once")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `close delegates to stop`() {
+        val process = FakeProcess()
+        val recorder =
+            FfmpegRecorder(
+                ffmpegPath = FfmpegRecorder.PROBE_PATH,
+                processFactory = ProcessFactoryReturning(process),
+            )
+        val output = Files.createTempFile("spectre-recording-test-", ".mp4")
+        try {
+            val handle = recorder.start(Rectangle(0, 0, 10, 10), output, RecordingOptions())
+            handle.use { /* AutoCloseable scope */ }
+            assertTrue(handle.isStopped)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `resolveFfmpegPath returns PROBE_PATH when ffmpeg is not on PATH`() {
+        // We can't reliably test the positive path in CI (ffmpeg may or may not be installed),
+        // but the negative-path sentinel is observable: PROBE_PATH equals Paths.get("ffmpeg").
+        // resolveFfmpegPath() returns either an absolute resolved path *or* PROBE_PATH.
+        val resolved = FfmpegRecorder.resolveFfmpegPath()
+        // Either the resolved path is absolute (we found ffmpeg) or it equals the sentinel.
+        assertTrue(
+            resolved.isAbsolute || resolved == FfmpegRecorder.PROBE_PATH,
+            "resolveFfmpegPath should return an absolute path or PROBE_PATH, got $resolved",
+        )
+    }
+
+    @Test
+    fun `constructor with non-executable explicit path throws`() {
+        val nonexistent = Path.of("/this/path/does/not/exist/ffmpeg")
+        kotlin.test.assertFailsWith<IllegalArgumentException> {
+            FfmpegRecorder(ffmpegPath = nonexistent)
+        }
+    }
+}
+
+private class RecordingProcessFactory : FfmpegRecorder.ProcessFactory {
+    var lastArgv: List<String> = emptyList()
+        private set
+
+    override fun start(argv: List<String>): Process {
+        lastArgv = argv
+        return FakeProcess()
+    }
+}
+
+private class ProcessFactoryReturning(private val process: Process) :
+    FfmpegRecorder.ProcessFactory {
+    override fun start(argv: List<String>): Process = process
+}
+
+/**
+ * Minimal in-memory `Process` stand-in. Only models the surface FfmpegRecorder uses: stdin,
+ * isAlive, waitFor, destroy / destroyForcibly. The real ffmpeg subprocess shape is huge, but none
+ * of the rest is touched by the recorder lifecycle.
+ */
+private class FakeProcess : Process() {
+    private val stdinBuffer = ByteArrayOutputStream()
+    private var alive = true
+    var waitForCalled: Boolean = false
+        private set
+
+    val stdinSentText: String
+        get() = stdinBuffer.toString(Charsets.UTF_8)
+
+    override fun getOutputStream(): OutputStream =
+        object : OutputStream() {
+            override fun write(b: Int) {
+                stdinBuffer.write(b)
+            }
+
+            override fun close() {
+                // Simulate ffmpeg exiting after the 'q' on stdin closes its input.
+                alive = false
+            }
+        }
+
+    override fun getInputStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun waitFor(): Int {
+        waitForCalled = true
+        alive = false
+        return 0
+    }
+
+    override fun waitFor(timeout: Long, unit: TimeUnit): Boolean {
+        waitForCalled = true
+        alive = false
+        return true
+    }
+
+    override fun exitValue(): Int = 0
+
+    override fun destroy() {
+        alive = false
+    }
+
+    override fun isAlive(): Boolean = alive
+
+    override fun pid(): Long = 0
+
+    override fun toHandle(): ProcessHandle = ProcessHandle.current()
+
+    override fun onExit(): CompletableFuture<Process> = CompletableFuture.completedFuture(this)
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissionsTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissionsTest.kt
@@ -1,0 +1,33 @@
+package dev.sebastiano.spectre.recording
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MacOsRecordingPermissionsTest {
+
+    @Test
+    fun `non-macOS platforms report NotApplicable`() {
+        if (System.getProperty("os.name").lowercase().contains("mac")) return
+        val diag = MacOsRecordingPermissions.diagnose()
+        assertEquals(PermissionStatus.NotApplicable, diag.status)
+        assertTrue(diag.message.contains("not applicable"))
+    }
+
+    @Test
+    fun `diagnose always returns a non-empty message`() {
+        // Regardless of platform, the diagnostic message must be non-blank — downstream tooling
+        // dumps it at startup and we want a useful line either way.
+        val diag = MacOsRecordingPermissions.diagnose()
+        assertTrue(diag.message.isNotBlank())
+    }
+
+    @Test
+    fun `PermissionStatus labels are stable user-facing strings`() {
+        // These are surfaced verbatim in the diagnostic message.
+        assertEquals("granted", PermissionStatus.Granted.label)
+        assertEquals("denied", PermissionStatus.Denied.label)
+        assertTrue(PermissionStatus.Unknown.label.startsWith("unknown"))
+        assertEquals("not applicable on this platform", PermissionStatus.NotApplicable.label)
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/RecordingOptionsTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/RecordingOptionsTest.kt
@@ -16,4 +16,9 @@ class RecordingOptionsTest {
         assertFailsWith<IllegalArgumentException> { RecordingOptions(codec = "") }
         assertFailsWith<IllegalArgumentException> { RecordingOptions(codec = "   ") }
     }
+
+    @Test
+    fun `negative screenIndex is rejected`() {
+        assertFailsWith<IllegalArgumentException> { RecordingOptions(screenIndex = -1) }
+    }
 }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/RecordingOptionsTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/RecordingOptionsTest.kt
@@ -1,0 +1,19 @@
+package dev.sebastiano.spectre.recording
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class RecordingOptionsTest {
+
+    @Test
+    fun `non-positive frameRate is rejected`() {
+        assertFailsWith<IllegalArgumentException> { RecordingOptions(frameRate = 0) }
+        assertFailsWith<IllegalArgumentException> { RecordingOptions(frameRate = -10) }
+    }
+
+    @Test
+    fun `blank codec is rejected`() {
+        assertFailsWith<IllegalArgumentException> { RecordingOptions(codec = "") }
+        assertFailsWith<IllegalArgumentException> { RecordingOptions(codec = "   ") }
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the recording module scaffold with the v1 capture surface.
- `Recorder` interface, `FfmpegRecorder` default (shells out to a system `ffmpeg`), `RecordingHandle` lifecycle (`AutoCloseable`, sends `q` on stdin then SIGTERM/SIGKILL fallback), `RecordingOptions` (frame rate, cursor, codec).
- `FfmpegCli.avfoundationRegionCapture` is a pure function that builds the argv — fully unit-tested.
- `MacOsRecordingPermissions.diagnose()` returns a startup-friendly diagnostic for Screen Recording + Accessibility permissions; full native detection deferred to v2 alongside the ScreenCaptureKit work.
- Embedded ComposePanel surfaces (`windowHandle == 0L`) fall through to region capture.

## v1 scope vs deferred
| Capability | Status |
|---|---|
| macOS region capture (avfoundation) | ✅ this PR |
| Embedded ComposePanel fallback | ✅ region capture (no special path) |
| ScreenCaptureKit window-targeted capture | ⏸ v2 (#18) |
| Windows `gdigrab` | ⏸ v3 (#22) |
| Linux `x11grab` / pipewire | ⏸ v4 (#27) |

Closes #10.

## Test plan
- [x] `./gradlew :recording:check` — green
- [x] `FfmpegCliTest` (7) — argv shape, crop coords, codec/cursor/framerate flags, `-y` overwrite, quiet loglevel, region validation
- [x] `RecordingOptionsTest` (2) — input validation
- [x] `FfmpegRecorderTest` (7) — start spawns subprocess; parent dirs created; `stop()` writes `q` and waits; stop is idempotent; AutoCloseable `.use{}` delegates; `resolveFfmpegPath()` sentinel; non-executable explicit path rejected
- [x] `MacOsRecordingPermissionsTest` (3) — non-macOS reports NotApplicable, diagnose always returns non-empty message, status labels are stable
- [ ] Live ffmpeg startup latency / warmup behaviour (acknowledged in #10 but needs real macOS env — deferred to validation pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)