### PR TITLE
Expand sample-desktop with v1 validation scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,15 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up JDK 21
+        # Switched from `jetbrains` to `temurin` because actions/setup-java@v5's JBR index is
+        # currently missing JBR 21 — the action errors with "Could not find satisfied version
+        # for SemVer '21'. Available versions: 11_0_10..., 11_0_11...". Temurin's CI build
+        # behaviour matches what we need (no Compose Desktop runtime tests rely on JBR-only
+        # patches; the toolchain stays at 21). Revert to `jetbrains` once JBR 21 is back in
+        # the setup-java index.
         uses: actions/setup-java@v5
         with:
-          distribution: jetbrains
+          distribution: temurin
           java-version: "21"
 
       - name: Set up Gradle

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -20,7 +20,11 @@ dependencies {
     implementation(libs.compose.uiToolingPreview)
     implementation(libs.kotlinx.coroutines.swing)
     detektPlugins(libs.compose.rules.detekt)
+
+    testImplementation(libs.kotlin.testJunit5)
 }
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }
 
 compose.desktop {
     application {

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/App.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/App.kt
@@ -3,8 +3,10 @@ package dev.sebastiano.spectre.sample
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -45,7 +47,7 @@ fun App(modifier: Modifier = Modifier) {
                     style = MaterialTheme.typography.headlineMedium,
                     modifier = Modifier.testTag("header"),
                 )
-                Spacer4()
+                Spacer(modifier = Modifier.height(8.dp))
                 Row(
                     modifier = Modifier.fillMaxSize(),
                     horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -101,9 +103,4 @@ private fun ScenarioPicker(
             }
         }
     }
-}
-
-@Composable
-private fun Spacer4() {
-    androidx.compose.foundation.layout.Spacer(modifier = Modifier.padding(4.dp))
 }

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/App.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/App.kt
@@ -2,67 +2,108 @@ package dev.sebastiano.spectre.sample
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Button
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import dev.sebastiano.spectre.sample.scenarios.ALL_SCENARIOS
+import dev.sebastiano.spectre.sample.scenarios.Scenario
 
+/**
+ * Sample harness shell.
+ *
+ * Renders a left-side picker listing every [Scenario] and a right-side pane showing the currently
+ * selected scenario's content. The picker is a `LazyColumn` so the list itself is realistic for
+ * bounds-drift testing. Each picker entry is a `TextButton` with the scenario's stable testTag, so
+ * automation flows can navigate by tag.
+ */
 @Composable
 fun App(modifier: Modifier = Modifier) {
     MaterialTheme {
-        var counter by remember { mutableIntStateOf(0) }
-        var inputText by remember { mutableStateOf("") }
-
-        Column(
-            modifier = modifier.fillMaxSize().padding(24.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp),
-        ) {
-            Text(
-                text = "Spectre sample",
-                style = MaterialTheme.typography.headlineMedium,
-                modifier = Modifier.testTag("header"),
-            )
-
-            Card(modifier = Modifier.fillMaxWidth()) {
-                Column(
-                    modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp),
+        var selected by remember { mutableStateOf(ALL_SCENARIOS.first()) }
+        Surface(modifier = modifier.fillMaxSize()) {
+            Column(modifier = Modifier.fillMaxSize().padding(16.dp)) {
+                Text(
+                    text = "Spectre sample",
+                    style = MaterialTheme.typography.headlineMedium,
+                    modifier = Modifier.testTag("header"),
+                )
+                Spacer4()
+                Row(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalArrangement = Arrangement.spacedBy(16.dp),
                 ) {
-                    Button(
-                        onClick = { counter++ },
-                        modifier = Modifier.testTag("incrementButton"),
-                    ) {
-                        Text("Count: $counter")
-                    }
-
-                    OutlinedTextField(
-                        value = inputText,
-                        onValueChange = { inputText = it },
-                        label = { Text("Type something") },
-                        modifier = Modifier.fillMaxWidth().testTag("textInput"),
+                    ScenarioPicker(
+                        selected = selected,
+                        onSelect = { selected = it },
+                        modifier = Modifier.width(260.dp),
                     )
-
-                    if (inputText.isNotEmpty()) {
-                        Text(
-                            text = "You typed: $inputText",
-                            modifier = Modifier.testTag("echoText"),
-                        )
+                    Card(modifier = Modifier.fillMaxSize()) {
+                        Column(
+                            modifier = Modifier.padding(16.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                        ) {
+                            Text(
+                                text = selected.title,
+                                style = MaterialTheme.typography.titleLarge,
+                                modifier = Modifier.testTag("scenario.title"),
+                            )
+                            Text(
+                                text = selected.unblocks,
+                                style = MaterialTheme.typography.bodySmall,
+                                modifier = Modifier.testTag("scenario.unblocks"),
+                            )
+                            HorizontalDivider()
+                            selected.content()
+                        }
                     }
                 }
             }
         }
     }
+}
+
+@Composable
+private fun ScenarioPicker(
+    selected: Scenario,
+    onSelect: (Scenario) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Card(modifier = modifier) {
+        LazyColumn(modifier = Modifier.padding(8.dp).testTag("scenario.picker")) {
+            items(ALL_SCENARIOS) { scenario ->
+                TextButton(
+                    onClick = { onSelect(scenario) },
+                    modifier = Modifier.fillMaxWidth().testTag(scenario.testTag),
+                ) {
+                    Text(
+                        text = if (scenario == selected) "▸ ${scenario.title}" else scenario.title,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Spacer4() {
+    androidx.compose.foundation.layout.Spacer(modifier = Modifier.padding(4.dp))
 }

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/CounterScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/CounterScenario.kt
@@ -1,0 +1,60 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * Scenario: counter button + text input.
+ *
+ * The original Spectre demo surface — kept as the v0 baseline so the demo flow in `Main.kt` still
+ * has something to exercise. Tags: `incrementButton`, `textInput`, `echoText`.
+ */
+val CounterScenario: Scenario =
+    Scenario(
+        title = "Counter + text input",
+        testTag = "scenario.counter",
+        unblocks = "Baseline (#5 click + typeText paths).",
+        content = { CounterContent() },
+    )
+
+@Composable
+private fun CounterContent() {
+    var counter by remember { mutableIntStateOf(0) }
+    var inputText by remember { mutableStateOf("") }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Button(onClick = { counter++ }, modifier = Modifier.testTag("incrementButton")) {
+                Text("Count: $counter")
+            }
+
+            OutlinedTextField(
+                value = inputText,
+                onValueChange = { inputText = it },
+                label = { Text("Type something") },
+                modifier = Modifier.fillMaxWidth().testTag("textInput"),
+            )
+
+            if (inputText.isNotEmpty()) {
+                Text(text = "You typed: $inputText", modifier = Modifier.testTag("echoText"))
+            }
+        }
+    }
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/FocusScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/FocusScenario.kt
@@ -1,0 +1,88 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * Scenario: explicit focus management.
+ *
+ * Three text fields with a "Focus second field" button. Validation for #8 (focus runtime behaviour,
+ * especially around Robot input on macOS) checks that:
+ * - the per-field `isFocused` flag in `AutomatorNode` reflects the actual focus state
+ * - clicking the button transfers focus correctly via `FocusRequester`
+ * - typing after the focus jump lands in the right field
+ *
+ * Tags: `focus.field.first|second|third`, `focus.jumpButton`.
+ */
+val FocusScenario: Scenario =
+    Scenario(
+        title = "Focus traversal",
+        testTag = "scenario.focus",
+        unblocks = "#8 focus state surfacing, Robot input fidelity after explicit focus jumps.",
+        content = { FocusContent() },
+    )
+
+@Composable
+private fun FocusContent() {
+    val firstFocus = remember { FocusRequester() }
+    val secondFocus = remember { FocusRequester() }
+    val thirdFocus = remember { FocusRequester() }
+    var first by remember { mutableStateOf("") }
+    var second by remember { mutableStateOf("") }
+    var third by remember { mutableStateOf("") }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Three focusable fields. The button explicitly requests focus on the second.")
+
+            OutlinedTextField(
+                value = first,
+                onValueChange = { first = it },
+                label = { Text("First") },
+                modifier =
+                    Modifier.fillMaxWidth().focusRequester(firstFocus).testTag("focus.field.first"),
+            )
+            OutlinedTextField(
+                value = second,
+                onValueChange = { second = it },
+                label = { Text("Second") },
+                modifier =
+                    Modifier.fillMaxWidth()
+                        .focusRequester(secondFocus)
+                        .testTag("focus.field.second"),
+            )
+            OutlinedTextField(
+                value = third,
+                onValueChange = { third = it },
+                label = { Text("Third") },
+                modifier =
+                    Modifier.fillMaxWidth().focusRequester(thirdFocus).testTag("focus.field.third"),
+            )
+            Button(
+                onClick = { secondFocus.requestFocus() },
+                modifier = Modifier.testTag("focus.jumpButton"),
+            ) {
+                Text("Focus second field")
+            }
+        }
+    }
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/HiDpiScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/HiDpiScenario.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -44,7 +45,10 @@ private fun HiDpiContent() {
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Text("Two known-position targets. Use these to validate Retina coordinate maths.")
-            Box(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            // Explicit height so the parent Box covers both targets — Modifier.offset shifts
+            // placement without expanding the parent's measured size, so without a fixed
+            // height the second target at y = 80.dp would render outside the Card and clip.
+            Box(modifier = Modifier.fillMaxWidth().height(160.dp).padding(16.dp)) {
                 HiDpiTarget(offsetXDp = 40, offsetYDp = 0)
                 HiDpiTarget(offsetXDp = 200, offsetYDp = 80)
             }

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/HiDpiScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/HiDpiScenario.kt
@@ -1,0 +1,71 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * Scenario: known-position widgets for HiDPI coordinate validation.
+ *
+ * Two squares positioned at fixed dp offsets from the parent's top-left corner. Validation for #8
+ * (HiDPI mapping on Retina) drives this to confirm:
+ * - `AutomatorNode.boundsOnScreen` for `hidpi.target.<x>x<y>` matches the on-screen pixel position
+ *   once converted via [HiDpiMapper]
+ * - the computed `centerOnScreen` lands inside the right pixel after `boundsInWindow ÷ density`
+ *
+ * Tags: `hidpi.target.<dpX>x<dpY>`.
+ */
+val HiDpiScenario: Scenario =
+    Scenario(
+        title = "HiDPI coordinate targets",
+        testTag = "scenario.hidpi",
+        unblocks = "#8 boundsInWindow → screen pixel mapping on Retina.",
+        content = { HiDpiContent() },
+    )
+
+@Composable
+private fun HiDpiContent() {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Two known-position targets. Use these to validate Retina coordinate maths.")
+            Box(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+                HiDpiTarget(offsetXDp = 40, offsetYDp = 0)
+                HiDpiTarget(offsetXDp = 200, offsetYDp = 80)
+            }
+        }
+    }
+}
+
+@Composable
+private fun HiDpiTarget(offsetXDp: Int, offsetYDp: Int) {
+    Box(
+        modifier =
+            Modifier.offset(x = offsetXDp.dp, y = offsetYDp.dp)
+                .size(48.dp)
+                .background(MaterialTheme.colorScheme.primary)
+                .testTag("hidpi.target.${offsetXDp}x${offsetYDp}"),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            "${offsetXDp},${offsetYDp}",
+            color = MaterialTheme.colorScheme.onPrimary,
+            style = MaterialTheme.typography.bodySmall,
+        )
+    }
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/MultiWindowScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/MultiWindowScenario.kt
@@ -1,0 +1,85 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.window.rememberWindowState
+
+/**
+ * Scenario: multi-window — opens a secondary `Window` for popup-as-separate-window validation.
+ *
+ * Spectre's `WindowTracker` discovers extra `Window` instances via `Window.getOwnedWindows()` /
+ * platform-specific introspection. Validation for #7 drives this scenario to confirm:
+ * - the secondary window's `TrackedWindow.surfaceId` is distinct from the main window
+ * - nodes inside the secondary window are addressable by `findByTestTag` after a `refreshWindows()`
+ * - the `isPopup` flag matches the actual window kind (true for the secondary `Window` here, since
+ *   CMP exposes it as a popup-class window when launched from inside a parent composition)
+ *
+ * Tags: `multiwindow.toggleButton`, `multiwindow.secondary.text`,
+ * `multiwindow.secondary.dismissButton`.
+ */
+val MultiWindowScenario: Scenario =
+    Scenario(
+        title = "Multi-window (secondary Window)",
+        testTag = "scenario.multiwindow",
+        unblocks = "#7 multi-window discovery, #8 surfaceId stability across windows.",
+        content = { MultiWindowContent() },
+    )
+
+@Composable
+private fun MultiWindowContent() {
+    var open by remember { mutableStateOf(false) }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Opens a separate Compose Window. WindowTracker should discover both surfaces.")
+            Button(
+                onClick = { open = !open },
+                modifier = Modifier.testTag("multiwindow.toggleButton"),
+            ) {
+                Text(if (open) "Close secondary window" else "Open secondary window")
+            }
+        }
+    }
+
+    if (open) {
+        val state = rememberWindowState(width = 320.dp, height = 200.dp)
+        Window(
+            onCloseRequest = { open = false },
+            state = state,
+            title = "Spectre — secondary window",
+        ) {
+            Column(
+                modifier = Modifier.fillMaxSize().padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                Text(
+                    text = "I am a secondary window",
+                    modifier = Modifier.testTag("multiwindow.secondary.text"),
+                )
+                Button(
+                    onClick = { open = false },
+                    modifier = Modifier.testTag("multiwindow.secondary.dismissButton"),
+                ) {
+                    Text("Close me")
+                }
+            }
+        }
+    }
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/PopupScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/PopupScenario.kt
@@ -1,0 +1,91 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
+import androidx.compose.ui.window.PopupProperties
+
+/**
+ * Scenario: in-canvas popup.
+ *
+ * Renders a `Popup` composable above the main content. Validation for #7 (multi-window/popup
+ * support) drives this to confirm the automator surfaces the popup's semantics owner regardless of
+ * the active layer mode (`OnSameCanvas` vs `OnComponent` vs `OnWindow`).
+ *
+ * Tags: `popup.toggleButton`, `popup.body`, `popup.dismissButton`.
+ */
+val PopupScenario: Scenario =
+    Scenario(
+        title = "Popup (in-canvas)",
+        testTag = "scenario.popup",
+        unblocks = "#7 popup discovery, #8 popup-bound geometry.",
+        content = { PopupContent() },
+    )
+
+@Composable
+private fun PopupContent() {
+    var visible by remember { mutableStateOf(false) }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                "Click the button to show a popup. The popup's tree is owned by a separate semantics root."
+            )
+
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Button(
+                    onClick = { visible = !visible },
+                    modifier = Modifier.testTag("popup.toggleButton"),
+                ) {
+                    Text(if (visible) "Hide popup" else "Show popup")
+                }
+
+                if (visible) {
+                    Popup(
+                        properties = PopupProperties(focusable = true),
+                        onDismissRequest = { visible = false },
+                    ) {
+                        Surface(
+                            modifier = Modifier.padding(16.dp).testTag("popup.body"),
+                            tonalElevation = 4.dp,
+                        ) {
+                            Column(
+                                modifier = Modifier.padding(16.dp),
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                            ) {
+                                Text(
+                                    "Hello from a popup",
+                                    modifier = Modifier.testTag("popup.text"),
+                                )
+                                Button(
+                                    onClick = { visible = false },
+                                    modifier = Modifier.testTag("popup.dismissButton"),
+                                ) {
+                                    Text("Dismiss")
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/Scenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/Scenario.kt
@@ -1,0 +1,21 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.runtime.Composable
+
+/**
+ * One picker entry in the sample's scenario list.
+ *
+ * Each scenario exercises a specific Spectre v1 capability: popup discovery, focus traversal,
+ * scrollable trees, HiDPI coordinate mapping, multi-window tracking, and so on. The [testTag] is
+ * the stable identifier the validation passes (#7, #8, #12, #14) navigate by.
+ */
+data class Scenario(
+    /** Display name shown in the picker. */
+    val title: String,
+    /** Stable testTag used by automation — must not change between releases. */
+    val testTag: String,
+    /** Human-readable note pointing at the issues this scenario unblocks. */
+    val unblocks: String,
+    /** Composable rendering the scenario's UI. */
+    val content: @Composable () -> Unit,
+)

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/Scenarios.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/Scenarios.kt
@@ -1,0 +1,17 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+/**
+ * Catalogue of every scenario shipped by the sample harness.
+ *
+ * The order here is the order rendered in the picker. New scenarios should be appended at the end
+ * so existing test recipes can keep referring to entries by index without breaking.
+ */
+val ALL_SCENARIOS: List<Scenario> =
+    listOf(
+        CounterScenario,
+        PopupScenario,
+        MultiWindowScenario,
+        FocusScenario,
+        ScrollScenario,
+        HiDpiScenario,
+    )

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/ScrollScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/ScrollScenario.kt
@@ -1,0 +1,69 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.Card
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * Scenario: scrollable list with many items.
+ *
+ * Renders a `LazyColumn` of [SCROLL_ITEM_COUNT] entries. Validation for #14 (nice-to-validate perf
+ * checks) drives this to measure:
+ * - tree-traversal cost on large semantics trees
+ * - bounds drift while scrolling (the live `boundsInWindow` snapshot in `AutomatorNode` means click
+ *   coordinates should follow the visible item even mid-scroll)
+ * - LazyColumn add/remove churn across `refreshWindows()` calls
+ *
+ * Tags: `scroll.list`, `scroll.item.<index>` for each visible item.
+ */
+val ScrollScenario: Scenario =
+    Scenario(
+        title = "Scrollable list",
+        testTag = "scenario.scroll",
+        unblocks = "#14 large-tree perf; #8 bounds-drift validation while scrolling.",
+        content = { ScrollContent() },
+    )
+
+private const val SCROLL_ITEM_COUNT: Int = 200
+
+@Composable
+private fun ScrollContent() {
+    val state = rememberLazyListState()
+    val items = remember { (0 until SCROLL_ITEM_COUNT).toList() }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text("$SCROLL_ITEM_COUNT items. Scroll to exercise tree refresh + live bounds.")
+            HorizontalDivider()
+            LazyColumn(
+                state = state,
+                modifier = Modifier.fillMaxSize().testTag("scroll.list"),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                items(items) { index ->
+                    Text(
+                        text = "Item #$index",
+                        modifier =
+                            Modifier.fillMaxWidth().padding(8.dp).testTag("scroll.item.$index"),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/scenarios/ScenariosTest.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/scenarios/ScenariosTest.kt
@@ -1,0 +1,50 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Catalogue tests.
+ *
+ * The scenario testTags are part of Spectre's test contract — validation passes (#7, #8, #14)
+ * navigate by them. These checks pin the catalogue shape so any reshuffle becomes a deliberate
+ * change.
+ */
+class ScenariosTest {
+
+    @Test
+    fun `every scenario testTag is unique`() {
+        val tags = ALL_SCENARIOS.map { it.testTag }
+        assertEquals(tags.size, tags.toSet().size, "Duplicate testTag in scenario catalogue: $tags")
+    }
+
+    @Test
+    fun `every scenario testTag uses the scenario prefix`() {
+        for (scenario in ALL_SCENARIOS) {
+            assertTrue(
+                scenario.testTag.startsWith("scenario."),
+                "Scenario '${scenario.title}' testTag '${scenario.testTag}' should start with 'scenario.'",
+            )
+        }
+    }
+
+    @Test
+    fun `catalogue includes the v1 baseline scenarios`() {
+        val titles = ALL_SCENARIOS.map { it.title }
+        assertTrue("Counter + text input" in titles)
+        assertTrue("Popup (in-canvas)" in titles)
+        assertTrue("Multi-window (secondary Window)" in titles)
+        assertTrue("Focus traversal" in titles)
+        assertTrue("Scrollable list" in titles)
+        assertTrue("HiDPI coordinate targets" in titles)
+    }
+
+    @Test
+    fun `the counter scenario sits first so the legacy demo flow continues to find it`() {
+        // Main.kt's spectre.demo flow targets the incrementButton / textInput / echoText tags
+        // owned by CounterScenario. App.kt selects the first scenario by default, so keeping
+        // CounterScenario at index 0 preserves that flow.
+        assertEquals(CounterScenario, ALL_SCENARIOS.first())
+    }
+}


### PR DESCRIPTION
## Summary
- Replaces the single-page demo with a scenario-picker harness so the remaining v1 validation issues (#7, #8, #14) have concrete UI to drive against on a live macOS Compose surface.
- Six scenarios in `dev.sebastiano.spectre.sample.scenarios`: counter (baseline), Compose Popup, secondary Window, focus traversal with FocusRequester, LazyColumn (200 items), HiDPI fixed-position targets.
- Each scenario has a stable `scenario.<name>` testTag so automation flows can navigate by tag. Inner element tags are documented at the top of each scenario file.

## Why
The remaining four validation issues (#7, #8, #14) all need real Compose UI on Retina hardware. Previously the sample only had a counter button — too thin to exercise popup discovery, multi-window tracking, focus state, scroll-induced bounds drift, or HiDPI coordinate conversion. This PR builds the harness once so each validation pass can pick its scenario and drive predictable testTags.

Closes #12.

## Test plan
- [x] `./gradlew :sample-desktop:check` — green (compile + ktfmt + detekt + new ScenariosTest)
- [x] `ScenariosTest` (4) pins the catalogue: unique testTags, `scenario.` prefix on all entries, every v1 baseline scenario present, CounterScenario at index 0 so `Main.kt`'s `-Dspectre.demo=true` flow keeps working
- [ ] Manual launch (`./gradlew :sample-desktop:run`) on a Retina display — left for hands-on validation alongside #7 / #8 / #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)