### PR TITLE
Skip runOffEdt for synthetic adapter (fix EDT deadlock)

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -135,6 +135,8 @@ internal constructor(
         return robot.createScreenCapture(captureRegion)
     }
 
+    private fun runOffEdt(block: () -> Unit) = runOffEdt(robot, block)
+
     companion object {
 
         /**
@@ -153,6 +155,18 @@ internal constructor(
 internal interface RobotAdapter {
 
     val autoDelayMs: Int
+
+    /**
+     * `true` when the adapter's input methods must run off the AWT EDT — the real
+     * `java.awt.Robot.mouseMove`/`keyPress` block when called from the EDT, so [RobotDriver]
+     * marshals them onto a worker thread.
+     *
+     * `false` when the adapter dispatches to its own thread internally (synthetic, headless), in
+     * which case [RobotDriver] runs the call inline. The worker-thread path used to deadlock
+     * synthetic callers invoked from the EDT: the EDT-blocking `Thread.join()` waited for a worker
+     * that was itself stuck in `SwingUtilities.invokeAndWait` waiting for the EDT.
+     */
+    val requiresOffEdt: Boolean
 
     fun mouseMove(x: Int, y: Int)
 
@@ -183,6 +197,10 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
     override val autoDelayMs: Int
         get() = robot.autoDelay
 
+    // Real `java.awt.Robot` calls block when invoked on the EDT, so RobotDriver must marshal
+    // them onto a worker thread.
+    override val requiresOffEdt: Boolean = true
+
     override fun mouseMove(x: Int, y: Int) = robot.mouseMove(x, y)
 
     override fun mousePress(buttons: Int) = robot.mousePress(buttons)
@@ -204,6 +222,9 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
 private object NoopRobotAdapter : RobotAdapter {
 
     override val autoDelayMs: Int = 0
+
+    // No-op input never blocks the EDT, so the worker-thread hop is unnecessary.
+    override val requiresOffEdt: Boolean = false
 
     override fun mouseMove(x: Int, y: Int) = Unit
 
@@ -253,8 +274,11 @@ private fun createAwtRobot(): Robot =
         isAutoWaitForIdle = false
     }
 
-private fun runOffEdt(block: () -> Unit) {
-    if (!SwingUtilities.isEventDispatchThread()) {
+private fun runOffEdt(robot: RobotAdapter, block: () -> Unit) {
+    // Adapters that don't need the off-EDT marshal (synthetic, no-op) can run inline even
+    // on the EDT — spawning a worker would deadlock the synthetic adapter, whose internal
+    // `SwingUtilities.invokeAndWait` would wait forever for an EDT blocked on `Thread.join()`.
+    if (!robot.requiresOffEdt || !SwingUtilities.isEventDispatchThread()) {
         block()
         return
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticInput.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticInput.kt
@@ -43,6 +43,13 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
     // The wait loop in ComposeAutomator handles synchronisation via waitForIdle / fingerprints.
     override val autoDelayMs: Int = 0
 
+    // The synthetic adapter's `dispatchMouse` / `dispatchKey` / `createScreenCapture` already
+    // marshal to the EDT via `runOnEdt` when needed. RobotDriver's worker-thread hop is therefore
+    // both unnecessary and harmful here: an EDT caller would block on `Thread.join()` while the
+    // worker thread blocked on `SwingUtilities.invokeAndWait`, deadlocking the whole pipeline
+    // (Codex P1 on PR #35).
+    override val requiresOffEdt: Boolean = false
+
     @Volatile private var lastX: Int = 0
     @Volatile private var lastY: Int = 0
     @Volatile private var pressedButtons: Int = 0
@@ -333,13 +340,11 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
  * `performMeasureAndLayout called during measure layout` errors and dropped events surface
  * immediately when this runs from another thread, so we cannot bypass the marshal.
  *
- * Codex (P1 on 638764f) flagged that this still deadlocks when a caller routes through
- * `RobotDriver.runOffEdt` from an EDT thread (the worker awaits an EDT that's blocked on its own
- * `Thread.join()`). An attempt to satisfy the deadlock by running inline on any thread broke
- * Compose's input pipeline outright (above). Documenting the trade-off and tracking a proper fix as
- * a follow-up: the deadlock only fires for callers that invoke automator methods from a UI callback
- * (an unusual pattern in test code), and the right home for the fix is `RobotDriver.runOffEdt`
- * (rewire to a non-blocking handoff), not the synthetic adapter.
+ * The earlier deadlock (Codex P1 on PR #35) — where a caller routed through `RobotDriver.runOffEdt`
+ * from an EDT thread had its worker block on `invokeAndWait` while the EDT itself was blocked on
+ * `Thread.join()` — is fixed at the `RobotDriver` layer: [SyntheticRobotAdapter.requiresOffEdt] is
+ * `false`, so the worker hop is skipped and `runOnEdt` runs the block directly when the caller is
+ * already the EDT.
  */
 private fun runOnEdt(block: () -> Unit) {
     if (SwingUtilities.isEventDispatchThread()) {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -139,6 +139,7 @@ class RobotDriverTest {
 }
 
 private class RecordingRobotAdapter(override val autoDelayMs: Int = 0) : RobotAdapter {
+    override val requiresOffEdt: Boolean = false
     val events = mutableListOf<String>()
 
     override fun mouseMove(x: Int, y: Int) {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputTest.kt
@@ -1,0 +1,147 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.GraphicsEnvironment
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.swing.JFrame
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+
+class SyntheticInputTest {
+
+    /**
+     * Regression test for the EDT deadlock between [RobotDriver]'s `runOffEdt` and the synthetic
+     * adapter's `runOnEdt`.
+     *
+     * Before the fix, `RobotDriver.runOffEdt` always spawned a worker and `Thread.join()`-ed on it
+     * even when the underlying [RobotAdapter] was the synthetic one. The synthetic adapter then
+     * called `SwingUtilities.invokeAndWait` to marshal the dispatch back to the EDT — which was
+     * blocked on the join. Calls from a UI callback (any code path that runs `automator.click(...)`
+     * inside `SwingUtilities.invokeAndWait { ... }`) would deadlock indefinitely.
+     *
+     * The synthetic adapter doesn't need the off-EDT worker (it does its own EDT marshalling inside
+     * `runOnEdt`), so [RobotAdapter.requiresOffEdt] now lets `runOffEdt` skip the worker thread for
+     * synthetic and headless adapters.
+     *
+     * Uses a plain Swing [JFrame] rather than a Compose `Window` because:
+     * - the deadlock is purely an AWT/EDT scheduling bug; it surfaces identically for any AWT
+     *   window the synthetic adapter targets
+     * - core's test classpath doesn't pull in compose-desktop (`Window`/`application` belong to
+     *   `compose.desktop.currentOs`), and adding it would require the Compose compiler plugin too.
+     *   The end-to-end Compose path is already covered by the sample-desktop validation tests.
+     */
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `click from EDT does not deadlock with synthetic adapter`() {
+        assumeFalse(GraphicsEnvironment.isHeadless())
+
+        val frame = createTestFrame()
+        try {
+            val targetCenter = frame.targetCenterOnScreen()
+            val driver = RobotDriver.synthetic(frame.frame)
+            val invokeAndWaitFinished = CountDownLatch(1)
+
+            // Run the click on a non-EDT thread that itself blocks the EDT via invokeAndWait.
+            // This mirrors the production deadlock: a UI callback (EDT) drives an automator
+            // method, which drives the synthetic adapter's EDT marshalling.
+            val driverThread =
+                Thread(
+                        {
+                            SwingUtilities.invokeAndWait {
+                                driver.click(targetCenter.first, targetCenter.second)
+                            }
+                            invokeAndWaitFinished.countDown()
+                        },
+                        "synthetic-click-deadlock-test",
+                    )
+                    .apply { isDaemon = true }
+            driverThread.start()
+
+            val completed = invokeAndWaitFinished.await(DEADLOCK_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            assertTrue(completed, "RobotDriver.click from the EDT deadlocked")
+            assertTrue(
+                frame.target.clickLatch.await(2, TimeUnit.SECONDS),
+                "Synthetic click was not dispatched",
+            )
+        } finally {
+            // Use invokeLater (not invokeAndWait) for cleanup so a deadlocked EDT — the
+            // pre-fix failure mode — doesn't also deadlock the cleanup path. The frame is
+            // a daemon-thread JVM resource; it will go away with the JVM if the EDT can't
+            // process the dispose now.
+            SwingUtilities.invokeLater {
+                frame.frame.isVisible = false
+                frame.frame.dispose()
+            }
+        }
+    }
+
+    private fun createTestFrame(): TestFrame {
+        val target = ClickTargetPanel()
+        var frame: JFrame? = null
+        SwingUtilities.invokeAndWait {
+            frame =
+                JFrame("SyntheticInputTest").apply {
+                    defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                    isUndecorated = true
+                    contentPane.layout = BorderLayout()
+                    contentPane.add(target, BorderLayout.CENTER)
+                    size = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
+                    setLocation(FRAME_OFFSET_PX, FRAME_OFFSET_PX)
+                    isVisible = true
+                }
+        }
+        // Wait until the frame is showing so locationOnScreen is valid.
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(SHOW_TIMEOUT_SECONDS)
+        while (System.nanoTime() < deadline && !target.isShowing) {
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        check(target.isShowing) { "Test JFrame did not become visible" }
+        return TestFrame(frame!!, target)
+    }
+
+    private fun TestFrame.targetCenterOnScreen(): Pair<Int, Int> {
+        var center = 0 to 0
+        SwingUtilities.invokeAndWait {
+            val origin = target.locationOnScreen
+            center = (origin.x + target.width / 2) to (origin.y + target.height / 2)
+        }
+        return center
+    }
+
+    private class TestFrame(val frame: JFrame, val target: ClickTargetPanel)
+
+    private class ClickTargetPanel : JPanel() {
+        val clickLatch = CountDownLatch(1)
+
+        init {
+            preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
+            addMouseListener(
+                object : MouseAdapter() {
+                    override fun mouseClicked(e: MouseEvent) {
+                        clickLatch.countDown()
+                    }
+                }
+            )
+        }
+    }
+
+    private companion object {
+        // Backstop in case the production fix regresses — `@Timeout` aborts the test rather
+        // than letting a blocked EDT pin the JVM forever (the EDT is non-daemon, so a stuck
+        // SwingUtilities.invokeAndWait would otherwise prevent JVM exit).
+        const val TIMEOUT_SECONDS: Long = 15L
+        const val DEADLOCK_TIMEOUT_SECONDS: Long = 5L
+        const val SHOW_TIMEOUT_SECONDS: Long = 5L
+        const val POLL_INTERVAL_MS: Long = 25L
+        const val FRAME_SIZE_PX: Int = 200
+        const val FRAME_OFFSET_PX: Int = 100
+    }
+}


### PR DESCRIPTION
## Summary

- `RobotDriver.runOffEdt` always spawned a worker and `Thread.join()`-ed on it, deadlocking any call from the AWT EDT when the underlying adapter was the synthetic one (the worker blocked on `SwingUtilities.invokeAndWait`, which waited for the EDT that was blocked on the join).
- Add `RobotAdapter.requiresOffEdt`. `AwtRobotAdapter` keeps it `true` (real Robot blocks on the EDT); `SyntheticRobotAdapter` and `NoopRobotAdapter` return `false`. `runOffEdt` now runs the block inline for adapters that don't need the worker hop.
- Adds `SyntheticInputTest` regression test that drives `RobotDriver.synthetic.click(...)` from inside `SwingUtilities.invokeAndWait { ... }` and asserts the call returns within seconds.

Codex P1 follow-up to PR #35 (commit f01ecd2).

## Notes

The regression test uses a plain Swing `JFrame` rather than a Compose `Window`. The deadlock is purely an AWT/EDT scheduling bug — it surfaces identically for any AWT window the synthetic adapter targets — and core's test classpath doesn't include compose-desktop (`Window`/`application` belong to `compose.desktop.currentOs`, which would also pull in the Compose compiler plugin). The end-to-end Compose path is already covered by sample-desktop's validation suite.

## Test plan

- [x] `./gradlew check` passes locally
- [x] New test passes 5x consecutively with `--rerun-tasks --no-build-cache`
- [x] Confirmed the new test deadlocks (and so reliably fails) without the production fix in place
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)