### PR TITLE
Skip post-paste settle for no-op clipboard adapters

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -101,7 +101,7 @@ internal constructor(
                 robot.keyRelease(KeyEvent.VK_V)
                 robot.keyRelease(modifier)
             }
-            if (!SwingUtilities.isEventDispatchThread()) {
+            if (!SwingUtilities.isEventDispatchThread() && clipboard.supportsRead) {
                 // Drain queued AWT events (KEY_PRESSED/RELEASED + Compose's input pipeline) so
                 // the paste handler has a chance to read the clipboard before we restore it.
                 // Without this, the finally block can clobber the clipboard mid-paste and the
@@ -109,7 +109,9 @@ internal constructor(
                 // One waitForIdle pump is not enough: Compose's paste action runs on its own
                 // coroutine dispatcher which posts back to the EDT, so we pump a few times and
                 // also wait a short interval to let the OS-side paste read complete before we
-                // clobber the clipboard contents.
+                // clobber the clipboard contents. Skip the whole block for adapters that don't
+                // support clipboard read-back — there's no real paste handler to drain, so the
+                // sleep would just add fixed latency to every headless typeText call.
                 repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }
                 try {
                     Thread.sleep(POST_PASTE_SETTLE_MS)

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -201,23 +201,33 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `typeText with no-op clipboard adapter does not spin the settle timeout`() {
+    fun `typeText with no-op clipboard adapter does not spin or settle for the headless path`() {
         // RobotDriver.headless() pairs the noop robot with the noop clipboard. The clipboard
-        // never reads back what was written, so the post-fix awaitClipboardContents loop would
-        // burn its full timeout (1 second) on every typeText call. The supportsRead opt-out
-        // skips the poll for adapters that explicitly can't satisfy it; this test pins that
-        // contract so a future change can't accidentally regress headless typeText latency.
+        // never reads back what was written and the noop robot has no real paste pipeline to
+        // drain, so neither the awaitClipboardContents poll nor the post-paste settle delay
+        // should run. This test pins headless typeText latency at well under a single
+        // POST_PASTE_SETTLE_MS so a future change can't accidentally re-introduce either delay.
+        // We invoke typeText several times because per-call settle accumulates: a 50ms sleep
+        // per call would push 5 calls to 250ms+, which is what Codex P2 on PR #37 flagged.
         val driver = RobotDriver.headless()
-        val elapsedMs = kotlin.system.measureTimeMillis { driver.typeText("hello") }
+        val elapsedMs =
+            kotlin.system.measureTimeMillis {
+                repeat(HEADLESS_TYPE_TEXT_INVOCATIONS) { driver.typeText("hello") }
+            }
         assertTrue(
             elapsedMs < HEADLESS_TYPE_TEXT_BUDGET_MS,
-            "headless typeText should return immediately (no clipboard wait), " +
-                "took ${elapsedMs}ms (budget ${HEADLESS_TYPE_TEXT_BUDGET_MS}ms)",
+            "headless typeText × $HEADLESS_TYPE_TEXT_INVOCATIONS should return immediately " +
+                "(no clipboard wait, no post-paste settle), took ${elapsedMs}ms " +
+                "(budget ${HEADLESS_TYPE_TEXT_BUDGET_MS}ms)",
         )
     }
 
     private companion object {
-        const val HEADLESS_TYPE_TEXT_BUDGET_MS: Long = 250L
+        const val HEADLESS_TYPE_TEXT_INVOCATIONS: Int = 5
+        // Tight budget — comfortably under POST_PASTE_SETTLE_MS (50ms) × invocation count so
+        // the test fails if either the clipboard poll or the post-paste sleep ever fires for
+        // a no-op adapter.
+        const val HEADLESS_TYPE_TEXT_BUDGET_MS: Long = 30L
     }
 }
 


### PR DESCRIPTION
## Summary

Codex P2 follow-up to [#37](https://github.com/rock3r/spectre/pull/37): `RobotDriver.typeText` always ran the post-paste settle block (EDT pumps + 50ms `Thread.sleep` + EDT pumps) for off-EDT callers, even when the clipboard adapter has no read-back. With `RobotDriver.headless()` the noop clipboard has no real paste pipeline to drain, so the sleep just added a guaranteed 50ms delay to every call — accumulating in headless / server flows that invoke `typeText` frequently.

Gate the settle block on `clipboard.supportsRead` (already set to `false` on `NoopClipboardAdapter` for the same reason that skipped the pre-paste poll, in #37). Headless `typeText` now returns immediately with no clipboard wait and no settle delay.

## Test plan

- [x] Existing headless typeText test tightened to exercise 5 invocations against a 30ms total budget. Failed before the fix (514ms observed = ~50ms × 5 sleeps + EDT-pump overhead), passes after.
- [x] `./gradlew :core:test` — full core suite green (LatentClipboardAdapter integration tests still pass).
- [x] `./gradlew check` — green.