### PR TITLE
Close v1 #7 / #8 / #14 — popup variants, runtime correctness, recording docs

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticInput.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticInput.kt
@@ -327,9 +327,18 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
         }
 
     private fun allWindows(): List<Window> {
-        val collected = mutableListOf<Window>()
+        val collected = LinkedHashSet<Window>()
         collectWindowTree(rootWindow, collected)
-        return collected
+        // Also include every other visible top-level Window (and its owned tree). Popups in
+        // Compose Desktop's `OnWindow` layer mode and any Swing JDialog with a default
+        // (`SharedOwnerFrame`) parent become top-level windows that are NOT in the spawned
+        // root's `ownedWindows` chain — without this, synthetic input can't reach them.
+        for (other in Window.getWindows()) {
+            if (other.isShowing && other.owner == null && other !== rootWindow) {
+                collectWindowTree(other, collected)
+            }
+        }
+        return collected.toList()
     }
 }
 
@@ -363,7 +372,7 @@ private fun modifierMaskFor(keyCode: Int): Int =
         else -> 0
     }
 
-private fun collectWindowTree(window: Window, into: MutableList<Window>) {
+private fun collectWindowTree(window: Window, into: MutableCollection<Window>) {
     into += window
     for (child in window.ownedWindows) {
         collectWindowTree(child, into)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticInput.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticInput.kt
@@ -329,12 +329,14 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
     private fun allWindows(): List<Window> {
         val collected = LinkedHashSet<Window>()
         collectWindowTree(rootWindow, collected)
-        // Also include every other visible top-level Window (and its owned tree). Popups in
-        // Compose Desktop's `OnWindow` layer mode and any Swing JDialog with a default
-        // (`SharedOwnerFrame`) parent become top-level windows that are NOT in the spawned
-        // root's `ownedWindows` chain — without this, synthetic input can't reach them.
+        // Walk every other top-level window (and its owned tree). The visibility check is
+        // applied per-window inside `collectWindowTree` rather than at the top level: Swing's
+        // `SharedOwnerFrame` (parent of `JDialog(null, …)`) is itself a top-level window that
+        // is NOT showing, but its owned dialogs may be — so filtering hidden top-levels out
+        // here would drop those dialogs and synthetic input would silently miss them, even
+        // though `WindowTracker` correctly surfaces them.
         for (other in Window.getWindows()) {
-            if (other.isShowing && other.owner == null && other !== rootWindow) {
+            if (other.owner == null && other !== rootWindow) {
                 collectWindowTree(other, collected)
             }
         }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -15,11 +15,19 @@ class WindowTracker {
 
     fun refresh() = readOnEdt {
         val pending = mutableListOf<TrackedWindow>()
-        val topLevelWindows = Window.getWindows().filter { it.isShowing && it.owner == null }
+        // Iterate every top-level window (`owner == null`) regardless of visibility — Swing's
+        // `SharedOwnerFrame` is a hidden parent for `JDialog(null as Frame?, ...)`, so filtering
+        // by `isShowing` here would drop the dialog along with it. Visibility is enforced per
+        // candidate further down (a hidden parent only contributes through its visible
+        // descendants).
+        val topLevelWindows = Window.getWindows().filter { it.owner == null }
         for (window in topLevelWindows) {
-            when (window) {
-                is ComposeWindow -> trackComposeWindow(pending, window)
-                else -> trackEmbeddedPanels(pending, window)
+            when {
+                window is ComposeWindow && window.isShowing -> trackComposeWindow(pending, window)
+                window.isShowing -> trackEmbeddedPanels(pending, window)
+                // Hidden parent (e.g. SharedOwnerFrame) — skip its own panels but still walk its
+                // owned dialogs in case any of them are showing.
+                else -> trackOwnedPopups(pending, window)
             }
         }
         _trackedWindows = pending.toList()

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -1,0 +1,73 @@
+# Recording limitations (v1)
+
+Spectre's v1 recording (`recording` module) shells out to a system `ffmpeg` binary using
+`avfoundation` on macOS. This is deliberately the simplest possible capture path so v1 can ship
+quickly; the trade-offs below are the known consequences. Most of them go away under the
+window-targeted ScreenCaptureKit backend tracked in v2 (#18).
+
+## Platform
+
+- **macOS only**. v1 implements `avfoundation` region capture and nothing else.
+- **Windows** (`gdigrab`) is deferred to v3.
+- **Linux** (`x11grab` / Wayland) is deferred to v4.
+
+## Capture mode
+
+- **Region capture, not window capture**. v1 records a fixed `Rectangle` of the virtual desktop —
+  whatever pixels the screen happens to be showing inside that region land in the file. The region
+  is bound at `Recorder.start(...)` time and does not follow a window; the v2 work surfaces a
+  proper window-targeted backend via ScreenCaptureKit.
+- **Embedded `ComposePanel` surfaces always fall through to region capture.** Window-targeted
+  capture is gated on a non-zero `windowHandle`, which Spectre populates only for top-level
+  `ComposeWindow`s. A panel embedded inside an IntelliJ tool window, a `JFrame`, a `JDialog`, or a
+  `SwingPanel` host inside Compose has `windowHandle == 0L` and gets the region path. Practical
+  consequences:
+  - Anything that visually overlaps the panel — other windows, the menu bar, OS notifications, a
+    floating popup that escapes the panel's bounds — appears in the recording.
+  - The captured region is the panel's screen-space bounds at start. If the host window moves or
+    resizes while recording, the panel's pixels drift out of the captured rectangle and you record
+    whatever is now under the original rectangle (often empty desktop).
+  - Off-screen panels record black frames.
+
+## What window movement / popups do during a recording
+
+- **Window movement isn't followed**. Move the host window after `start(...)` and the recording
+  keeps capturing the original screen rectangle. Stop and restart to follow the new position.
+- **Popups that escape the captured region are partially clipped**. Compose Desktop's `OnWindow`
+  popup layer renders in a separate top-level OS window; if that popup pops up outside the recorded
+  rectangle the recording will not include it. `OnSameCanvas` and `OnComponent` popups stay inside
+  the panel/window bounds and are recorded as long as the panel itself is.
+
+## HiDPI / Retina
+
+- The recorded resolution is the **screen-pixel** size of the region, not the dp size. A 400×300dp
+  region on a 2× display becomes an 800×600 pixel video.
+- `Rectangle` coordinates passed to `start(...)` are in screen pixels. If you derive the region
+  from `AutomatorNode.boundsOnScreen` you get the right thing for free; if you derive it from
+  `boundsInWindow` you have to apply the density yourself.
+
+## Permissions and process lifecycle
+
+- The JVM process needs **macOS Screen Recording permission** (`MacOsRecordingPermissions`
+  documents the path). Without it, `ffmpeg` exits during the startup probe and `Recorder.start`
+  surfaces an error rather than handing back a handle.
+- The `ffmpeg` subprocess is spawned eagerly: by the time `start(...)` returns, frames are
+  landing in the output file. A failure to spawn (binary not on PATH, codec unavailable, AVFoundation
+  device busy) surfaces as an exception from `start(...)`, not as a silent "successful" handle.
+- The handle MUST be stopped (`RecordingHandle.stop(...)`) for the file to be flushed cleanly. A
+  JVM exit without stop leaves a partial / non-finalised file and an orphaned subprocess.
+
+## What's NOT a v1 limitation
+
+- Cursor capture is configurable via `RecordingOptions.captureCursor` and works under the region
+  path. The cursor pixels are baked into the frames; there is no overlay you can toggle in
+  post-processing.
+- Audio capture is intentionally absent — v1 records video only. Adding audio is a follow-up.
+
+## Pointers for v2
+
+- Window-targeted capture via ScreenCaptureKit (#18) removes the "anything overlapping the region
+  appears in the video" class of problems for top-level windows.
+- A separate path for embedded panels would need to render the panel into a frame buffer and feed
+  that to `ffmpeg` on stdin (the synthetic-screenshot path in `SyntheticRobotAdapter` is the
+  blueprint). Tracked outside v1.

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -93,13 +93,30 @@ val validationTestLayerComponent = popupLayerTask("Component", "COMPONENT")
 // the popup's semantics owner without a deeper rework. Tracked separately as a follow-up — see
 // https://github.com/rock3r/spectre/issues/7 for the deferred checklist item.
 
+// Default layer (`OnSameCanvas`) gets its own task so the aggregate `validationTestPopupLayers`
+// below can guarantee SAME_CANVAS coverage on its own — running just the aggregate must NOT
+// silently skip the default mode (Codex P2 on PR #40 flagged that running the aggregate alone
+// would miss SAME_CANVAS regressions because the default is otherwise only exercised by the
+// broader `:validationTest` task).
+val validationTestLayerSameCanvas =
+    tasks.register("validationTestLayerSameCanvas", Test::class) {
+        description =
+            "Runs PopupLayerVariantsValidationTest with the default OnSameCanvas layer mode."
+        group = "verification"
+        testClassesDirs = sourceSets["validation"].output.classesDirs
+        classpath = sourceSets["validation"].runtimeClasspath
+        useJUnitPlatform()
+        forkEvery = 1
+        filter { includeTestsMatching(popupLayerVariantTaskName) }
+    }
+
 @Suppress("UNUSED_VARIABLE")
 val validationTestPopupLayers by tasks.registering {
     description =
-        "Runs PopupLayerVariantsValidationTest under each Compose layer type Spectre " +
-            "currently supports (OnSameCanvas via :validationTest, OnComponent via this task)."
+        "Runs PopupLayerVariantsValidationTest under every Compose layer type Spectre " +
+            "currently supports (OnSameCanvas + OnComponent). OnWindow is deferred — see #39."
     group = "verification"
-    dependsOn(validationTestLayerComponent)
+    dependsOn(validationTestLayerSameCanvas, validationTestLayerComponent)
 }
 
 compose.desktop {

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -65,6 +65,43 @@ val validationTest by
         // loop. The 10-second startupTimeout is enough headroom for cold JVM warmup on CI hardware.
     }
 
+// Compose Desktop reads `compose.layers.type` once at composition init, so popup-layer-variant
+// coverage needs a separate JVM per layer mode. Each task below filters to
+// `PopupLayerVariantsValidationTest` and sets the layer-type system property for the worker.
+// `validationTest` (above) covers the default `OnSameCanvas` path, so we only register the
+// non-default variants here — and aggregate them under `validationTestPopupLayers`.
+val popupLayerVariantTaskName =
+    "dev.sebastiano.spectre.sample.validation.PopupLayerVariantsValidationTest"
+
+fun popupLayerTask(suffix: String, layerType: String) =
+    tasks.register("validationTestLayer$suffix", Test::class) {
+        description = "Runs PopupLayerVariantsValidationTest with -Dcompose.layers.type=$layerType."
+        group = "verification"
+        testClassesDirs = sourceSets["validation"].output.classesDirs
+        classpath = sourceSets["validation"].runtimeClasspath
+        useJUnitPlatform { includeTags() } // accept all
+        forkEvery = 1
+        filter { includeTestsMatching("$popupLayerVariantTaskName") }
+        systemProperty("compose.layers.type", layerType)
+    }
+
+val validationTestLayerComponent = popupLayerTask("Component", "COMPONENT")
+
+// `OnWindow` (Compose Desktop's `compose.layers.type=WINDOW`) is intentionally NOT registered
+// here yet. Compose builds OnWindow popups inside an internal `JLayeredPaneWithTransparencyHack`
+// rather than a `ComposePanel`, so neither `WindowTracker` nor `SemanticsReader` can surface
+// the popup's semantics owner without a deeper rework. Tracked separately as a follow-up — see
+// https://github.com/rock3r/spectre/issues/7 for the deferred checklist item.
+
+@Suppress("UNUSED_VARIABLE")
+val validationTestPopupLayers by tasks.registering {
+    description =
+        "Runs PopupLayerVariantsValidationTest under each Compose layer type Spectre " +
+            "currently supports (OnSameCanvas via :validationTest, OnComponent via this task)."
+    group = "verification"
+    dependsOn(validationTestLayerComponent)
+}
+
 compose.desktop {
     application {
         mainClass = "dev.sebastiano.spectre.sample.MainKt"

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/AnimationScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/AnimationScenario.kt
@@ -1,0 +1,90 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+
+/**
+ * Scenario: continuously running infinite animation alongside an event-driven settle target.
+ *
+ * Validation for #8 (wait contract under real animations / background work) drives this to confirm
+ * that `eventually { ... }` against a settle-time predicate still completes even while a separate
+ * part of the UI is animating forever — the wait helper should not block forever because the
+ * animation never "settles".
+ *
+ * Tags: `anim.spinner` (infinite rotation), `anim.toggleButton`, `anim.settled` (only present after
+ * the user toggles the settle button).
+ */
+val AnimationScenario: Scenario =
+    Scenario(
+        title = "Infinite animation + event-driven settle",
+        testTag = "scenario.animation",
+        unblocks = "#8 wait-contract correctness while a background animation never settles.",
+        content = { AnimationContent() },
+    )
+
+@Composable
+private fun AnimationContent() {
+    var settled by remember { mutableStateOf(false) }
+    val transition = rememberInfiniteTransition()
+    val angle by
+        transition.animateFloat(
+            initialValue = 0f,
+            targetValue = 360f,
+            animationSpec =
+                infiniteRepeatable(animation = tween(SPIN_PERIOD_MS, easing = LinearEasing)),
+        )
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                "A perpetually rotating square. The wait helper should still observe " +
+                    "event-driven settles (button click → `anim.settled` appears) without " +
+                    "blocking on the never-settling animation."
+            )
+            Box(
+                modifier =
+                    Modifier.size(48.dp)
+                        .rotate(angle)
+                        .background(MaterialTheme.colorScheme.primary)
+                        .testTag("anim.spinner")
+            )
+            Button(onClick = { settled = true }, modifier = Modifier.testTag("anim.toggleButton")) {
+                Text(if (settled) "Settled" else "Settle")
+            }
+            if (settled) {
+                Text(
+                    "Settled — predicate target observed.",
+                    modifier = Modifier.testTag("anim.settled"),
+                )
+            }
+        }
+    }
+}
+
+private const val SPIN_PERIOD_MS: Int = 800

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/DualPanelScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/DualPanelScenario.kt
@@ -8,9 +8,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.SwingPanel
 import androidx.compose.ui.platform.testTag
@@ -40,7 +37,6 @@ val DualPanelScenario: Scenario =
 
 @Composable
 private fun DualPanelContent() {
-    val counter by remember { mutableIntStateOf(0) }
     Card(modifier = Modifier.fillMaxWidth()) {
         Column(
             modifier = Modifier.padding(20.dp),
@@ -54,10 +50,7 @@ private fun DualPanelContent() {
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.spacedBy(16.dp),
             ) {
-                Text(
-                    text = "Left pane (Compose) — counter $counter",
-                    modifier = Modifier.testTag("dual.left.text"),
-                )
+                Text(text = "Left pane (Compose)", modifier = Modifier.testTag("dual.left.text"))
                 SwingPanel(
                     modifier = Modifier.fillMaxWidth().testTag("dual.right.swingHost"),
                     factory = {

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/DualPanelScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/DualPanelScenario.kt
@@ -1,0 +1,72 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.SwingPanel
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import javax.swing.JLabel
+import javax.swing.SwingConstants
+
+/**
+ * Scenario: same-window extra semantics roots.
+ *
+ * Renders a Compose tree alongside a `SwingPanel` host (which is itself a Swing component embedded
+ * in the Compose hierarchy). Validation for #7 confirms that `WindowTracker` surfaces both the
+ * primary Compose panel and the embedded panel as first-class entries in `windows`, so that
+ * `findOneByTestTag` resolves nodes from either subtree without the test caring which root owns the
+ * node.
+ *
+ * Tags: `dual.left.text`, `dual.right.swing.label` (the Swing label has no Compose semantics — we
+ * tag the surrounding Compose Text instead so the assertion has something to anchor on).
+ */
+val DualPanelScenario: Scenario =
+    Scenario(
+        title = "Same-window dual roots (Compose + SwingPanel)",
+        testTag = "scenario.dualpanel",
+        unblocks = "#7 same-window extra semantics roots discovered as first-class entries.",
+        content = { DualPanelContent() },
+    )
+
+@Composable
+private fun DualPanelContent() {
+    val counter by remember { mutableIntStateOf(0) }
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                "Compose root on the left, an embedded SwingPanel on the right. Both should be " +
+                    "reachable through the automator's `windows` snapshot."
+            )
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                Text(
+                    text = "Left pane (Compose) — counter $counter",
+                    modifier = Modifier.testTag("dual.left.text"),
+                )
+                SwingPanel(
+                    modifier = Modifier.fillMaxWidth().testTag("dual.right.swingHost"),
+                    factory = {
+                        JLabel("Right pane (Swing JLabel)", SwingConstants.CENTER).apply {
+                            name = "dual.right.swing.label"
+                        }
+                    },
+                )
+            }
+        }
+    }
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/JDialogScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/JDialogScenario.kt
@@ -1,0 +1,112 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import java.awt.BorderLayout
+import java.awt.Dimension
+import javax.swing.JDialog
+import javax.swing.SwingUtilities
+
+/**
+ * Scenario: a Swing `JDialog` hosting a Compose `ComposePanel` with tagged content.
+ *
+ * Validation for #7 (`ComposePanel.semanticsOwners` for JDialog-hosted popup content) drives this
+ * to confirm that:
+ * - `WindowTracker` surfaces the JDialog as a tracked window
+ * - `findOneByTestTag` resolves nodes inside the dialog's `ComposePanel` semantics owner
+ *
+ * Tags: `jdialog.toggleButton` (in main), `jdialog.body` and `jdialog.dismissButton` (in dialog).
+ */
+val JDialogScenario: Scenario =
+    Scenario(
+        title = "JDialog hosting ComposePanel",
+        testTag = "scenario.jdialog",
+        unblocks = "#7 ComposePanel.semanticsOwners coverage for JDialog-hosted popup content.",
+        content = { JDialogContent() },
+    )
+
+@Composable
+private fun JDialogContent() {
+    var dialogOpen by remember { mutableStateOf(false) }
+    var dialogRef by remember { mutableStateOf<JDialog?>(null) }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text(
+                "Open a Swing JDialog hosting a Compose ComposePanel. The automator should " +
+                    "surface the dialog as its own tracked window with discoverable Compose nodes."
+            )
+            Button(
+                onClick = { dialogOpen = !dialogOpen },
+                modifier = Modifier.testTag("jdialog.toggleButton"),
+            ) {
+                Text(if (dialogOpen) "Close JDialog" else "Open JDialog")
+            }
+        }
+    }
+
+    DisposableEffect(dialogOpen) {
+        if (dialogOpen) {
+            // Parent the dialog to the currently-visible top-level ComposeWindow rather than
+            // letting Swing fall back to its hidden `SharedOwnerFrame`. The synthetic input
+            // driver discovers popup targets by walking `rootWindow.ownedWindows`, so a
+            // `null`-owned JDialog would be invisible to it (and to any owner-relative API like
+            // `setLocationRelativeTo(parent)`).
+            val parent =
+                java.awt.Frame.getFrames().firstOrNull { it.isShowing && it !is JDialog }
+                    as? java.awt.Frame
+            val dialog =
+                JDialog(parent, "Spectre — JDialog popup", false).apply {
+                    val composePanel = ComposePanel()
+                    composePanel.setContent {
+                        JDialogPanelContent(onDismiss = { dialogOpen = false })
+                    }
+                    contentPane.layout = BorderLayout()
+                    contentPane.add(composePanel, BorderLayout.CENTER)
+                    preferredSize = Dimension(DIALOG_WIDTH_PX, DIALOG_HEIGHT_PX)
+                    pack()
+                    setLocationRelativeTo(parent)
+                    isVisible = true
+                }
+            dialogRef = dialog
+        }
+        onDispose {
+            dialogRef?.let { d -> SwingUtilities.invokeLater { d.dispose() } }
+            dialogRef = null
+        }
+    }
+}
+
+private const val DIALOG_WIDTH_PX: Int = 360
+private const val DIALOG_HEIGHT_PX: Int = 180
+
+@Composable
+private fun JDialogPanelContent(onDismiss: () -> Unit) {
+    Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+            "Hello from a JDialog-hosted ComposePanel",
+            modifier = Modifier.testTag("jdialog.body"),
+        )
+        Button(onClick = onDismiss, modifier = Modifier.testTag("jdialog.dismissButton")) {
+            Text("Dismiss")
+        }
+    }
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/RecompositionStressScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/RecompositionStressScenario.kt
@@ -1,0 +1,78 @@
+package dev.sebastiano.spectre.sample.scenarios
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.delay
+
+/**
+ * Scenario: heavy recomposition stress.
+ *
+ * When `running` is true the scenario renders a fluctuating number of items (cycles 0..32 every
+ * 16ms via a coroutine inside `LaunchedEffect`) so the semantics tree mutates rapidly. Validation
+ * for #8 (thread safety under heavy recomposition / streaming updates) drives this and asserts that
+ * repeated `refreshWindows()` + `findOneByTestTag` calls don't crash, don't return stale or
+ * mid-mutation snapshots, and consistently see at least the always-present ticker text node.
+ *
+ * Tags: `recomp.toggleButton`, `recomp.ticker`, `recomp.item.<i>` for each currently-rendered item.
+ */
+val RecompositionStressScenario: Scenario =
+    Scenario(
+        title = "Recomposition stress",
+        testTag = "scenario.recomposition",
+        unblocks = "#8 thread-safety / snapshot coherence under heavy recomposition.",
+        content = { RecompositionStressContent() },
+    )
+
+private const val MAX_ITEMS: Int = 32
+private const val STEP_DELAY_MS: Long = 16L
+
+@Composable
+private fun RecompositionStressContent() {
+    var running by remember { mutableStateOf(false) }
+    var tick by remember { mutableIntStateOf(0) }
+
+    LaunchedEffect(running) {
+        if (!running) return@LaunchedEffect
+        while (true) {
+            tick = (tick + 1) % (MAX_ITEMS + 1)
+            delay(STEP_DELAY_MS)
+        }
+    }
+
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(
+            modifier = Modifier.padding(20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                "Toggle the ticker to churn the semantics tree at ~60Hz. " +
+                    "Reading via the automator should never crash or return mid-mutation state."
+            )
+            Button(
+                onClick = { running = !running },
+                modifier = Modifier.testTag("recomp.toggleButton"),
+            ) {
+                Text(if (running) "Stop" else "Start")
+            }
+            Text(text = "Tick: $tick", modifier = Modifier.testTag("recomp.ticker"))
+            for (i in 0 until tick) {
+                Text(text = "Item #$i", modifier = Modifier.testTag("recomp.item.$i"))
+            }
+        }
+    }
+}

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/Scenarios.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/Scenarios.kt
@@ -14,4 +14,8 @@ val ALL_SCENARIOS: List<Scenario> =
         FocusScenario,
         ScrollScenario,
         HiDpiScenario,
+        DualPanelScenario,
+        JDialogScenario,
+        RecompositionStressScenario,
+        AnimationScenario,
     )

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue7CompletionValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue7CompletionValidationTest.kt
@@ -1,0 +1,79 @@
+package dev.sebastiano.spectre.sample.validation
+
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+
+/**
+ * Closes the remaining v1 checklist items on #7 that don't depend on the IntelliJ/Jewel host:
+ * - same-window extra semantics roots (Compose + embedded SwingPanel) are surfaced
+ * - JDialog-hosted `ComposePanel` content is discoverable via the automator
+ *
+ * Popup-layer-variant coverage (`OnSameCanvas`/`OnComponent`/`OnWindow`) lives in
+ * [`PopupLayerVariantsValidationTest`] because it requires the JVM-startup `-Dcompose.layers.type=`
+ * flag and runs through dedicated Gradle subtasks.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class Issue7CompletionValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre #7 completion")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    @Order(1)
+    fun `dual-panel scenario surfaces both Compose roots`() {
+        with(fixture.automator) {
+            navigateToScenario("scenario.dualpanel")
+            // Both nodes live in the same Window but the SwingPanel host installs an extra
+            // semantics root. The assertion is "both reachable via the same automator query"
+            // — we don't care which root owns each, only that the automator surfaces them.
+            val left = waitForTestTag("dual.left.text")
+            val swingHost = waitForTestTag("dual.right.swingHost")
+            assertNotNull(left.text, "Left Compose pane should expose its text")
+            // The SwingPanel itself shows up as a Compose node (the bridge composable owns the
+            // testTag) — proves the automator walks past the bridge into the Compose tree.
+            assertNotNull(swingHost, "SwingPanel host node should be discoverable")
+        }
+    }
+
+    @Test
+    @Order(2)
+    fun `JDialog hosting ComposePanel exposes its tree to the automator`() {
+        with(fixture.automator) {
+            navigateToScenario("scenario.jdialog")
+            val initialWindows = windows.size
+            click(waitForTestTag("jdialog.toggleButton"))
+            // The JDialog enters the AWT hierarchy a frame or two after the Swing call returns,
+            // and the Compose semantics owner inside its embedded ComposePanel attaches
+            // asynchronously. Wait until both the window count grew AND the body resolves.
+            eventually(description = "jdialog window registered + body discoverable") {
+                if (windows.size > initialWindows && findOneByTestTag("jdialog.body") != null) Unit
+                else null
+            }
+            val body = waitForTestTag("jdialog.body")
+            assertNotNull(body.text, "JDialog body text should be readable through ComposePanel")
+            // Tear down — the dialog's DisposableEffect closes it once the toggle goes false.
+            click(waitForTestTag("jdialog.dismissButton"))
+            // Wait for the body to disappear from the semantics tree — the JDialog frame may take
+            // a beat longer to fully dispose (Swing posts the dispose via invokeLater and macOS
+            // can leave the AWT peer around briefly), so we only assert on the Compose-level
+            // discoverability, not the raw windows count.
+            waitUntilGone("jdialog.body")
+        }
+    }
+}

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue8CompletionValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue8CompletionValidationTest.kt
@@ -1,0 +1,98 @@
+package dev.sebastiano.spectre.sample.validation
+
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+
+/**
+ * Closes the remaining v1 checklist items on #8: thread safety / snapshot coherence under heavy
+ * recomposition, and the wait-contract correctness while a background animation never settles.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class Issue8CompletionValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre #8 completion")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    @Order(1)
+    fun `automator reads coherent snapshots while the tree mutates at 60 Hz`() {
+        with(fixture.automator) {
+            navigateToScenario("scenario.recomposition")
+            click(waitForTestTag("recomp.toggleButton"))
+
+            // Hammer refreshWindows + findOneByTestTag for a few seconds. The ticker text node
+            // is the always-present anchor — every read must succeed without throwing and must
+            // return either null (mid-mutation snapshot dropped the node briefly, very rare) or
+            // a node carrying a coherent ticker label. The list under the ticker mutates from
+            // 0..32 items every 16ms, so we never assert on the item count — only that the
+            // automator never throws and the ticker stays observable.
+            val deadline = TimeSource.Monotonic.markNow() + STRESS_DURATION
+            var iterations = 0
+            var nullSnapshots = 0
+            while (deadline.hasNotPassedNow()) {
+                refreshWindows()
+                val ticker = findOneByTestTag("recomp.ticker")
+                if (ticker == null) nullSnapshots++ else assertNotNull(ticker.text)
+                // Walk the items list — we don't care which indices exist, just that the read
+                // doesn't crash on a list whose size changed mid-read.
+                allNodes()
+                iterations++
+            }
+            click(waitForTestTag("recomp.toggleButton"))
+
+            assertTrue(iterations > MIN_STRESS_ITERATIONS, "Stress loop did $iterations iterations")
+            // A null snapshot here and there is acceptable (the ticker text is briefly absent
+            // during a recomposition window), but the vast majority of reads must succeed.
+            assertTrue(
+                nullSnapshots < iterations / 4,
+                "Too many null ticker snapshots: $nullSnapshots / $iterations iterations",
+            )
+        }
+    }
+
+    @Test
+    @Order(2)
+    fun `eventually settles on event-driven targets while a background animation never settles`() {
+        with(fixture.automator) {
+            navigateToScenario("scenario.animation")
+            // The spinner is rotating forever — confirm it's there but don't wait for it to stop.
+            assertNotNull(waitForTestTag("anim.spinner"))
+            // anim.settled does not exist yet. The wait helper must not block forever just
+            // because the animation is running; eventually() should return as soon as the
+            // event-driven node appears.
+            click(waitForTestTag("anim.toggleButton"))
+            val settled =
+                eventually(description = "anim.settled appears", timeout = 5.seconds) {
+                    findOneByTestTag("anim.settled")
+                }
+            assertNotNull(
+                settled.text,
+                "Settled marker should expose its text once the click lands",
+            )
+        }
+    }
+
+    private companion object {
+        val STRESS_DURATION = 3.seconds
+        const val MIN_STRESS_ITERATIONS: Int = 30
+    }
+}

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/PopupLayerVariantsValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/PopupLayerVariantsValidationTest.kt
@@ -1,0 +1,57 @@
+package dev.sebastiano.spectre.sample.validation
+
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Closes #7's popup-layer-variant checklist by exercising the same popup discovery flow under each
+ * value of Compose Desktop's `compose.layers.type` JVM-startup property:
+ * - unset / `SAME_CANVAS` → popup renders in the same Skia canvas as its parent (default).
+ * - `COMPONENT` → popup renders in a sibling AWT `Component` inside the same `Window`.
+ * - `WINDOW` → popup renders in its own top-level OS window owned by the parent.
+ *
+ * The property is consulted by Compose at composition init, so it cannot be flipped per-test — each
+ * variant gets its own JVM via the dedicated `validationTestLayer*` Gradle tasks. This test itself
+ * is shape-identical across all three modes; the variant only changes how Compose lays out the
+ * popup under the hood. Spectre's contract is that the popup body resolves regardless of mode.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class PopupLayerVariantsValidationTest {
+
+    private val layerType: String =
+        System.getProperty("compose.layers.type", "").ifBlank { "SAME_CANVAS" }
+    private val fixture = SampleAppFixture(title = "Spectre #7 popup layer ($layerType)")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `popup body resolves under the active layer type`() {
+        with(fixture.automator) {
+            navigateToScenario("scenario.popup")
+            click(waitForTestTag("popup.toggleButton"))
+            val body = waitForTestTag("popup.body")
+            assertNotNull(
+                body,
+                "Popup body should be discoverable under compose.layers.type=$layerType",
+            )
+            assertNotNull(
+                findOneByTestTag("popup.text"),
+                "Popup text node should be discoverable under compose.layers.type=$layerType",
+            )
+            // Tear down so the next class's fixture starts clean.
+            click(waitForTestTag("popup.dismissButton"))
+            waitUntilGone("popup.body")
+        }
+    }
+}


### PR DESCRIPTION
Closes the remaining v1 checklist on [#7](https://github.com/rock3r/spectre/issues/7), [#8](https://github.com/rock3r/spectre/issues/8), and [#14](https://github.com/rock3r/spectre/issues/14) (excluding the items already deferred to [#13](https://github.com/rock3r/spectre/issues/13) Jewel/IntelliJ surface and the new [#39](https://github.com/rock3r/spectre/issues/39) OnWindow popup-layer follow-up).

## #7 — multi-window / popup tracking

- `DualPanelScenario` + `Issue7CompletionValidationTest`: same-window extra semantics roots (Compose tree alongside an embedded `SwingPanel` host) — both subtrees discoverable via the automator.
- `JDialogScenario` + `Issue7CompletionValidationTest`: Swing `JDialog` hosting a `ComposePanel`. Required teaching `WindowTracker` to walk hidden top-level frames (Swing's `SharedOwnerFrame`, parent of `null`-owned JDialogs) so their visible owned dialogs become tracked windows. `SyntheticInput` also now includes every visible top-level window in its hit-test pool so input reaches popups not in `rootWindow.ownedWindows`.
- `PopupLayerVariantsValidationTest`: same popup discovery flow, parameterised by `compose.layers.type`. Default `OnSameCanvas` covered by `:validationTest`; new `:validationTestLayerComponent` Gradle task forks a JVM with `-Dcompose.layers.type=COMPONENT`. Aggregate `:validationTestPopupLayers` runs both.
- `OnWindow` (`-Dcompose.layers.type=WINDOW`) intentionally deferred — Compose hosts that popup inside an internal `JLayeredPaneWithTransparencyHack`, not a `ComposePanel`, and surfacing it needs a deeper rework. Tracked as [#39](https://github.com/rock3r/spectre/issues/39).

## #8 — runtime correctness

- `RecompositionStressScenario` cycles 0..32 items every 16 ms; `Issue8CompletionValidationTest` hammers `refreshWindows` + `findOneByTestTag` + `allNodes` for 3 s and asserts the automator never throws and the always-present ticker stays observable across the vast majority of reads.
- `AnimationScenario` runs an infinite spinner alongside an event-driven settle target; the test confirms `eventually` resolves the event-driven node without blocking on the never-settling animation.

## #14 — perf / docs

- `docs/RECORDING-LIMITATIONS.md` documents what the v1 region-capture recorder can and can't do for embedded ComposePanel surfaces (overlap, window movement, HiDPI mapping, permissions, lifecycle), and points at v2 ([#18](https://github.com/rock3r/spectre/issues/18)) for the ScreenCaptureKit window-targeted backend.

## Test plan

- [x] `./gradlew check` — green
- [x] `./gradlew :sample-desktop:validationTest :sample-desktop:validationTestPopupLayers --rerun-tasks --no-build-cache` — 16 + 1 tests, **3/3 cold runs all green** on local macOS

Closes #7
Closes #8
Closes #14