### PR TITLE
Surface OnWindow popup semantics; quiet validation focus-stealing

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/OverlayLayerInspector.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/OverlayLayerInspector.kt
@@ -63,8 +63,7 @@ internal object OverlayLayerInspector {
         // semanticsOwnerManager::semanticsOwners` — so it has no JVM backing field and reading via
         // `getDeclaredField` returns null. The getter method exists under the conventional name
         // (`getSemanticsOwners`) and works regardless of how the property is implemented.
-        val owners =
-            invokeGetter(mediator, "getSemanticsOwners") as? Collection<SemanticsOwner>
+        val owners = invokeGetter(mediator, "getSemanticsOwners") as? Collection<SemanticsOwner>
         return owners ?: emptyList()
     }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/OverlayLayerInspector.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/OverlayLayerInspector.kt
@@ -1,0 +1,118 @@
+package dev.sebastiano.spectre.core
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.awt.ComposeWindow
+import androidx.compose.ui.semantics.SemanticsOwner
+import java.awt.Window
+
+/**
+ * Surfaces the semantics of Compose Desktop "OnWindow" popups (the `compose.layers.type=WINDOW`
+ * mode) from outside the `androidx.compose.ui` package.
+ *
+ * Compose builds OnWindow popups inside an internal `WindowComposeSceneLayer` whose `mediator` is
+ * private and whose host `JLayeredPaneWithTransparencyHack` is not a `ComposePanel`, so the public
+ * `ComposeWindow.semanticsOwners` accessor only returns the main-scene owners — popup owners are
+ * unreachable through the public API. Reading them needs reflection across three private fields:
+ * - `ComposeWindow.composePanel` (the `ComposeWindowPanel`)
+ * - `ComposeWindowPanel._composeContainer` (the `ComposeContainer`)
+ * - `ComposeContainer.layers` (the `MutableList<DesktopComposeSceneLayer>` populated by
+ *   `attachLayer` / `detachLayer`) Each `WindowComposeSceneLayer` then exposes a private `mediator:
+ *   ComposeSceneMediator?` whose `semanticsOwners` collection is what we want.
+ *
+ * Tracked as #39. The reflection is purposely concentrated here so a future change in Compose's
+ * internals can be adapted in one place — `findOverlayLayerWindows` returns an empty list rather
+ * than throwing if any field is missing or renamed, so the rest of the automator keeps working
+ * against newer Compose versions while a contributor updates this file.
+ */
+internal object OverlayLayerInspector {
+
+    /**
+     * Returns one entry per overlay-layer popup (currently the OnWindow case) hosted by the given
+     * [composeWindow]. Each entry pairs the popup's host AWT [Window] with a snapshot accessor for
+     * the popup's semantics owners. The accessor is a function rather than a captured collection so
+     * callers always observe the live state at read time.
+     *
+     * Returns an empty list if Compose's internals don't match the expected shape (e.g. the
+     * `composePanel` / `_composeContainer` / `layers` chain has been renamed) — degrade gracefully
+     * rather than crash the whole automator.
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    fun findOverlayLayerWindows(composeWindow: ComposeWindow): List<OverlayLayerEntry> {
+        val composePanel = readField(composeWindow, "composePanel") ?: return emptyList()
+        val composeContainer = readField(composePanel, "_composeContainer") ?: return emptyList()
+        val layers = readField(composeContainer, "layers") as? List<*> ?: return emptyList()
+        return layers.mapNotNull { layer -> layer?.let(::overlayLayerEntryOrNull) }
+    }
+
+    private fun overlayLayerEntryOrNull(layer: Any): OverlayLayerEntry? {
+        // Only WindowComposeSceneLayer carries a JDialog `layerWindow`; the other
+        // `DesktopComposeSceneLayer` subclasses for OnSameCanvas / OnComponent don't expose a
+        // separate window, so we filter by presence of the field name rather than by class
+        // reference (the class is internal).
+        val layerWindow = readField(layer, "layerWindow") as? Window ?: return null
+        return OverlayLayerEntry(
+            window = layerWindow,
+            semanticsOwnersAccessor = { readSemanticsOwners(layer) },
+        )
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun readSemanticsOwners(layer: Any): Collection<SemanticsOwner> {
+        val mediator = readField(layer, "mediator") ?: return emptyList()
+        // `ComposeSceneMediator.semanticsOwners` is a delegated property — `val semanticsOwners by
+        // semanticsOwnerManager::semanticsOwners` — so it has no JVM backing field and reading via
+        // `getDeclaredField` returns null. The getter method exists under the conventional name
+        // (`getSemanticsOwners`) and works regardless of how the property is implemented.
+        val owners =
+            invokeGetter(mediator, "getSemanticsOwners") as? Collection<SemanticsOwner>
+        return owners ?: emptyList()
+    }
+
+    private fun invokeGetter(target: Any, methodName: String): Any? {
+        var cls: Class<*>? = target.javaClass
+        while (cls != null) {
+            try {
+                val method = cls.getDeclaredMethod(methodName)
+                method.isAccessible = true
+                return method.invoke(target)
+            } catch (_: NoSuchMethodException) {
+                cls = cls.superclass
+            } catch (_: ReflectiveOperationException) {
+                return null
+            }
+        }
+        return null
+    }
+
+    /**
+     * Reflects [fieldName] from [target] (or any superclass), making it accessible. Returns the
+     * field value or `null` if the field is missing, the access fails, or the value is `null`. This
+     * is the only place that swallows `ReflectiveOperationException` — every other reflection call
+     * site in this file goes through here so we degrade uniformly.
+     */
+    private fun readField(target: Any, fieldName: String): Any? {
+        var cls: Class<*>? = target.javaClass
+        while (cls != null) {
+            try {
+                val field = cls.getDeclaredField(fieldName)
+                field.isAccessible = true
+                return field.get(target)
+            } catch (_: NoSuchFieldException) {
+                cls = cls.superclass
+            } catch (_: ReflectiveOperationException) {
+                return null
+            }
+        }
+        return null
+    }
+}
+
+/**
+ * One overlay-layer popup discovered through reflection. The semantics owners are read lazily so
+ * each call returns the live collection — Compose's mediator updates `semanticsOwners` as the
+ * popup's content recomposes.
+ */
+internal data class OverlayLayerEntry(
+    val window: Window,
+    val semanticsOwnersAccessor: () -> Collection<SemanticsOwner>,
+)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -97,6 +97,12 @@ class SemanticsReader {
 
     @OptIn(ExperimentalComposeUiApi::class)
     private fun getOwnersForWindow(trackedWindow: TrackedWindow): Collection<SemanticsOwner> {
+        // Reflective overlay-layer accessor wins when present — those tracked windows are the
+        // OnWindow popup case (`compose.layers.type=WINDOW`) where neither the host JDialog is a
+        // ComposeWindow nor its content tree contains a ComposePanel.
+        trackedWindow.overlaySemanticsOwners?.let {
+            return it()
+        }
         val window = trackedWindow.window
         if (window is ComposeWindow) return window.semanticsOwners
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
@@ -1,17 +1,42 @@
 package dev.sebastiano.spectre.core
 
+import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.semantics.SemanticsOwner
 import java.awt.Point
 import java.awt.Rectangle
 import java.awt.Window
 import javax.swing.JFrame
 
-data class TrackedWindow(
+data class TrackedWindow
+@OptIn(ExperimentalComposeUiApi::class)
+internal constructor(
     val surfaceId: String,
     val window: Window,
     val composePanel: ComposePanel?,
     val isPopup: Boolean,
+    /**
+     * Reflective override that lets `WindowTracker` plug in a non-`ComposePanel` semantics source
+     * for Compose Desktop's `OnWindow` popup layers (`compose.layers.type=WINDOW`). Compose hosts
+     * those popups inside an internal `WindowComposeSceneLayer` whose mediator isn't reachable
+     * through any public API; `OverlayLayerInspector` resolves them by reflection and
+     * `SemanticsReader` dispatches to this accessor. `null` for every other tracked window — the
+     * existing `composePanel` / `ComposeWindow` paths handle those.
+     */
+    internal val overlaySemanticsOwners: (() -> Collection<SemanticsOwner>)? = null,
 ) {
+
+    /**
+     * Stable public constructor preserved for source compatibility with anything that builds a
+     * `TrackedWindow` directly (notably `core`'s own unit tests).
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    constructor(
+        surfaceId: String,
+        window: Window,
+        composePanel: ComposePanel?,
+        isPopup: Boolean,
+    ) : this(surfaceId, window, composePanel, isPopup, overlaySemanticsOwners = null)
 
     /**
      * The screen location of the Compose content origin.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -39,12 +39,27 @@ class WindowTracker {
             val panel = findComposePanels(window).firstOrNull()
             addTrackedWindow(pending, window, panel, "window", isPopup = false)
         }
-        trackOwnedPopups(pending, window)
+        // Compose Desktop's `OnWindow` popup layer hosts the popup inside an internal
+        // `WindowComposeSceneLayer` whose `JDialog` won't be discovered as a `ComposePanel` host
+        // (its content sits in a private `JLayeredPaneWithTransparencyHack`, not a ComposePanel).
+        // Surface those layers through the reflective `OverlayLayerInspector` so each one becomes
+        // its own tracked window with a semantics accessor that points at the layer's mediator.
+        val overlayLayers = OverlayLayerInspector.findOverlayLayerWindows(window)
+        for (layer in overlayLayers) {
+            if (layer.semanticsOwnersAccessor().isNotEmpty()) {
+                addOverlayTrackedWindow(pending, layer)
+            }
+        }
+        trackOwnedPopups(pending, window, skip = overlayLayers.mapTo(HashSet()) { it.window })
     }
 
     @OptIn(ExperimentalComposeUiApi::class)
-    private fun trackOwnedPopups(pending: MutableList<TrackedWindow>, owner: Window) {
-        val visibleOwned = owner.ownedWindows.filter { it.isShowing }
+    private fun trackOwnedPopups(
+        pending: MutableList<TrackedWindow>,
+        owner: Window,
+        skip: Set<Window> = emptySet(),
+    ) {
+        val visibleOwned = owner.ownedWindows.filter { it.isShowing && it !in skip }
         for (owned in visibleOwned) {
             when (owned) {
                 is ComposeWindow -> {
@@ -55,7 +70,7 @@ class WindowTracker {
                 }
                 else -> trackActivePanels(pending, owned, "popup", isPopup = true)
             }
-            trackOwnedPopups(pending, owned)
+            trackOwnedPopups(pending, owned, skip)
         }
     }
 
@@ -92,6 +107,21 @@ class WindowTracker {
                 window = window,
                 composePanel = panel,
                 isPopup = isPopup,
+            )
+    }
+
+    @OptIn(ExperimentalComposeUiApi::class)
+    private fun addOverlayTrackedWindow(
+        pending: MutableList<TrackedWindow>,
+        layer: OverlayLayerEntry,
+    ) {
+        pending +=
+            TrackedWindow(
+                surfaceId = "overlay:${pending.size}",
+                window = layer.window,
+                composePanel = null,
+                isPopup = true,
+                overlaySemanticsOwners = layer.semanticsOwnersAccessor,
             )
     }
 }

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -56,12 +56,19 @@ tasks.withType<Test>().configureEach { useJUnitPlatform() }
 // Trade-off: macOS restricts NSPasteboard access for UI-element processes, so the
 // clipboard-driven `typeText` validation can't run under this flag. That single test is gated
 // on `spectre.sample.fixture.uiElement` and skips itself when the flag is on; everything else
-// runs as normal. To exercise the typeText path locally, run
-// `:sample-desktop:validationTest --tests '*typeText*' -Dspectre.sample.fixture.uiElement=false`
-// (or just drop the `applyValidationJvmArgs` from the task).
+// runs as normal.
+//
+// Both flags fall through to the Gradle JVM's own system properties when set explicitly, so
+// `./gradlew :sample-desktop:validationTest -Dapple.awt.UIElement=false
+// -Dspectre.sample.fixture.uiElement=false` actually disables UI-element mode for one run and
+// lets the typeText assertion execute. Without the override we default to "true" and stay quiet.
+val uiElementOverride: Provider<String> =
+    providers.systemProperty("apple.awt.UIElement").orElse("true")
+val spectreUiElementFlagOverride: Provider<String> =
+    providers.systemProperty("spectre.sample.fixture.uiElement").orElse(uiElementOverride)
 val applyValidationJvmArgs: Test.() -> Unit = {
-    systemProperty("apple.awt.UIElement", "true")
-    systemProperty("spectre.sample.fixture.uiElement", "true")
+    systemProperty("apple.awt.UIElement", uiElementOverride.get())
+    systemProperty("spectre.sample.fixture.uiElement", spectreUiElementFlagOverride.get())
 }
 
 val validationTest by

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -55,20 +55,24 @@ tasks.withType<Test>().configureEach { useJUnitPlatform() }
 //
 // Trade-off: macOS restricts NSPasteboard access for UI-element processes, so the
 // clipboard-driven `typeText` validation can't run under this flag. That single test is gated
-// on `spectre.sample.fixture.uiElement` and skips itself when the flag is on; everything else
-// runs as normal.
+// on `spectre.sample.fixture.uiElement` (which mirrors `apple.awt.UIElement` so JVM-level
+// invocations not going through this build script — IDE / CI — still gate correctly) and skips
+// itself when the flag is on; everything else runs as normal.
 //
-// Both flags fall through to the Gradle JVM's own system properties when set explicitly, so
-// `./gradlew :sample-desktop:validationTest -Dapple.awt.UIElement=false
-// -Dspectre.sample.fixture.uiElement=false` actually disables UI-element mode for one run and
-// lets the typeText assertion execute. Without the override we default to "true" and stay quiet.
-val uiElementOverride: Provider<String> =
-    providers.systemProperty("apple.awt.UIElement").orElse("true")
-val spectreUiElementFlagOverride: Provider<String> =
-    providers.systemProperty("spectre.sample.fixture.uiElement").orElse(uiElementOverride)
+// Both flags collapse to a single override: if the user passes EITHER
+// `-Dapple.awt.UIElement=...` or `-Dspectre.sample.fixture.uiElement=...` to Gradle, that value
+// drives BOTH worker-JVM properties. That way
+// `./gradlew :sample-desktop:validationTest -Dspectre.sample.fixture.uiElement=false`
+// actually exercises the typeText path (the worker JVM gets `apple.awt.UIElement=false` too,
+// which restores NSPasteboard access). Defaults to "true" when neither is set.
+val uiElementMode: Provider<String> =
+    providers
+        .systemProperty("spectre.sample.fixture.uiElement")
+        .orElse(providers.systemProperty("apple.awt.UIElement"))
+        .orElse("true")
 val applyValidationJvmArgs: Test.() -> Unit = {
-    systemProperty("apple.awt.UIElement", uiElementOverride.get())
-    systemProperty("spectre.sample.fixture.uiElement", spectreUiElementFlagOverride.get())
+    systemProperty("apple.awt.UIElement", uiElementMode.get())
+    systemProperty("spectre.sample.fixture.uiElement", uiElementMode.get())
 }
 
 val validationTest by

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -48,6 +48,22 @@ dependencies {
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }
 
+// Mark every validation-driven worker JVM as a macOS UI element. AppKit treats UI-element
+// processes as background-only — no Dock icon, no menu bar, and (the part the user cares about)
+// no focus-grab when a window is shown. The synthetic input driver dispatches AWT events
+// directly so it doesn't need the window in the foreground.
+//
+// Trade-off: macOS restricts NSPasteboard access for UI-element processes, so the
+// clipboard-driven `typeText` validation can't run under this flag. That single test is gated
+// on `spectre.sample.fixture.uiElement` and skips itself when the flag is on; everything else
+// runs as normal. To exercise the typeText path locally, run
+// `:sample-desktop:validationTest --tests '*typeText*' -Dspectre.sample.fixture.uiElement=false`
+// (or just drop the `applyValidationJvmArgs` from the task).
+val applyValidationJvmArgs: Test.() -> Unit = {
+    systemProperty("apple.awt.UIElement", "true")
+    systemProperty("spectre.sample.fixture.uiElement", "true")
+}
+
 val validationTest by
     tasks.registering(Test::class) {
         description =
@@ -63,6 +79,7 @@ val validationTest by
         forkEvery = 1
         // Re-render the picker / spawn the window inside each test method via the fixture's poll
         // loop. The 10-second startupTimeout is enough headroom for cold JVM warmup on CI hardware.
+        applyValidationJvmArgs()
     }
 
 // Compose Desktop reads `compose.layers.type` once at composition init, so popup-layer-variant
@@ -83,21 +100,15 @@ fun popupLayerTask(suffix: String, layerType: String) =
         forkEvery = 1
         filter { includeTestsMatching("$popupLayerVariantTaskName") }
         systemProperty("compose.layers.type", layerType)
+        applyValidationJvmArgs()
     }
 
 val validationTestLayerComponent = popupLayerTask("Component", "COMPONENT")
-
-// `OnWindow` (Compose Desktop's `compose.layers.type=WINDOW`) is intentionally NOT registered
-// here yet. Compose builds OnWindow popups inside an internal `JLayeredPaneWithTransparencyHack`
-// rather than a `ComposePanel`, so neither `WindowTracker` nor `SemanticsReader` can surface
-// the popup's semantics owner without a deeper rework. Tracked separately as a follow-up — see
-// https://github.com/rock3r/spectre/issues/7 for the deferred checklist item.
+val validationTestLayerWindow = popupLayerTask("Window", "WINDOW")
 
 // Default layer (`OnSameCanvas`) gets its own task so the aggregate `validationTestPopupLayers`
 // below can guarantee SAME_CANVAS coverage on its own — running just the aggregate must NOT
-// silently skip the default mode (Codex P2 on PR #40 flagged that running the aggregate alone
-// would miss SAME_CANVAS regressions because the default is otherwise only exercised by the
-// broader `:validationTest` task).
+// silently skip the default mode.
 val validationTestLayerSameCanvas =
     tasks.register("validationTestLayerSameCanvas", Test::class) {
         description =
@@ -108,15 +119,20 @@ val validationTestLayerSameCanvas =
         useJUnitPlatform()
         forkEvery = 1
         filter { includeTestsMatching(popupLayerVariantTaskName) }
+        applyValidationJvmArgs()
     }
 
 @Suppress("UNUSED_VARIABLE")
 val validationTestPopupLayers by tasks.registering {
     description =
-        "Runs PopupLayerVariantsValidationTest under every Compose layer type Spectre " +
-            "currently supports (OnSameCanvas + OnComponent). OnWindow is deferred — see #39."
+        "Runs PopupLayerVariantsValidationTest under all three Compose layer types " +
+            "(OnSameCanvas, OnComponent, OnWindow)."
     group = "verification"
-    dependsOn(validationTestLayerSameCanvas, validationTestLayerComponent)
+    dependsOn(
+        validationTestLayerSameCanvas,
+        validationTestLayerComponent,
+        validationTestLayerWindow,
+    )
 }
 
 compose.desktop {

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue8FidelityValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue8FidelityValidationTest.kt
@@ -118,6 +118,15 @@ class Issue8FidelityValidationTest {
     @Test
     @Order(3)
     fun `typeText writes characters into the focused text field`() {
+        // The default validation Gradle tasks boot the worker JVM as a macOS UI element so the
+        // spawned window doesn't pop to the front while tests run, but UI-element processes get
+        // restricted NSPasteboard access — Cmd+V never sees the value `typeText` writes. Skip
+        // here when that's the active mode; run with `-Dspectre.sample.fixture.uiElement=false`
+        // (and accept one focus-grab) to exercise the paste path locally.
+        assumeFalse(
+            sampleFixtureRunsAsUiElement,
+            "Skipped under apple.awt.UIElement=true (NSPasteboard restricted)",
+        )
         with(fixture.automator) {
             navigateToScenario("scenario.focus")
             val target = waitForTestTag("focus.field.third")

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
@@ -114,3 +114,13 @@ class SampleAppFixture(
         val SHUTDOWN_TIMEOUT: Duration = 5.seconds
     }
 }
+
+/**
+ * `true` when the validation Gradle task booted this JVM as a macOS UI element
+ * (`apple.awt.UIElement=true`), in which case AppKit suppresses the spawned window's focus-grab /
+ * Dock icon but also restricts NSPasteboard access. Tests that rely on the clipboard (currently
+ * only `Issue8FidelityValidationTest.typeText`) gate themselves on this so the focus-quiet workflow
+ * stays the default while the paste fidelity test still runs when the property is explicitly off.
+ */
+val sampleFixtureRunsAsUiElement: Boolean
+    get() = System.getProperty("spectre.sample.fixture.uiElement", "false").toBoolean()

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
@@ -116,11 +116,18 @@ class SampleAppFixture(
 }
 
 /**
- * `true` when the validation Gradle task booted this JVM as a macOS UI element
- * (`apple.awt.UIElement=true`), in which case AppKit suppresses the spawned window's focus-grab /
- * Dock icon but also restricts NSPasteboard access. Tests that rely on the clipboard (currently
- * only `Issue8FidelityValidationTest.typeText`) gate themselves on this so the focus-quiet workflow
- * stays the default while the paste fidelity test still runs when the property is explicitly off.
+ * `true` when this JVM was booted as a macOS UI element (`apple.awt.UIElement=true`), in which case
+ * AppKit suppresses the spawned window's focus-grab / Dock icon but also restricts NSPasteboard
+ * access. Tests that rely on the clipboard (currently only `Issue8FidelityValidationTest.typeText`)
+ * gate themselves on this so the focus-quiet workflow stays the default while the paste fidelity
+ * test still runs when the property is explicitly off.
+ *
+ * We check `apple.awt.UIElement` directly (the actual AWT switch) in addition to the
+ * `spectre.sample.fixture.uiElement` mirror flag the validation Gradle tasks set. Either being
+ * truthy is enough to skip — that way running validation from an IDE / CI with just the AWT
+ * property still skips the test instead of attempting a paste that AppKit will silently drop.
  */
 val sampleFixtureRunsAsUiElement: Boolean
-    get() = System.getProperty("spectre.sample.fixture.uiElement", "false").toBoolean()
+    get() =
+        System.getProperty("apple.awt.UIElement", "false").toBoolean() ||
+            System.getProperty("spectre.sample.fixture.uiElement", "false").toBoolean()


### PR DESCRIPTION
Closes [#39](https://github.com/rock3r/spectre/issues/39).

## OnWindow popup discovery

Compose Desktop's `compose.layers.type=WINDOW` mode hosts the popup inside an internal `WindowComposeSceneLayer` whose `mediator` is private and whose host JDialog content is a `JLayeredPaneWithTransparencyHack` (not a `ComposePanel`). The public `ComposeWindow.semanticsOwners` accessor only returns the main-scene owners — popup owners are unreachable through any public API.

- New `OverlayLayerInspector` (in `core`) reflects through `ComposeWindow.composePanel → ComposeWindowPanel._composeContainer → ComposeContainer.layers → WindowComposeSceneLayer.{layerWindow, mediator}` and reads `ComposeSceneMediator.semanticsOwners`. The property is delegated and has no JVM backing field, so the read goes through the `getSemanticsOwners()` getter rather than `getDeclaredField`. Reflection failures degrade to an empty list — Compose can rename internals without crashing the rest of the automator.
- `TrackedWindow` gains an internal `overlaySemanticsOwners` accessor; `WindowTracker` adds an `overlay:N`-prefixed entry per reflected layer (and skips the matching JDialog from the regular `trackOwnedPopups` walk so we don't double-count). `SemanticsReader` dispatches to the accessor when present.
- `:sample-desktop:validationTestLayerWindow` Gradle task is back and `:sample-desktop:validationTestPopupLayers` aggregates all three layer modes (SameCanvas + Component + Window).

## Validation focus-stealing fix

User-requested: all validation Gradle tasks now set `apple.awt.UIElement=true`. AppKit treats UI-element processes as background-only — the spawned window stops grabbing focus, the Dock icon never appears, no front-pop while tests run. Synthetic input dispatch is unaffected.

Trade-off: macOS restricts NSPasteboard access for UI-element processes, which breaks the clipboard-driven `typeText` validation (Cmd+V never sees the value `setContents` wrote). The single test reads the new `sampleFixtureRunsAsUiElement` flag and `assumeFalse`-skips itself when UIElement mode is active. To exercise the paste path locally:

```
./gradlew :sample-desktop:validationTest --tests '*typeText*' \
  -Dspectre.sample.fixture.uiElement=false
```

(One focus-grab during that single run; everything else stays quiet.)

## Test plan

- [x] `./gradlew check` — green
- [x] 3/3 cold runs of `:sample-desktop:validationTest + :sample-desktop:validationTestPopupLayers` on local macOS — 16 tests ran, typeText cleanly skipped, 3 layer-variant runs (SameCanvas + Component + **Window**) pass.

Closes #39