### PR TITLE
v2: AutoRecorder router (SCK or ffmpeg per call)

### DIFF
--- a/recording/README.md
+++ b/recording/README.md
@@ -15,10 +15,20 @@ capture (ScreenCaptureKit) live side by side — pick by what you need.
 - `screencapturekit.ScreenCaptureKitRecorder` — forks a bundled Swift helper that drives
   `SCStream` + `AVAssetWriter` against a single window identified by `(pid, title-substring)`.
   Captures only that window's pixels even when partially occluded, and survives the host
-  window moving across the screen. macOS only.
+  window moving across the screen. macOS only. Implements `WindowRecorder`.
+- `screencapturekit.WindowRecorder` — interface for window-targeted backends. SCK is the only
+  implementation today; future Windows / Linux backends would slot in here.
 
   Decision rationale + alternatives considered are written up in the bridge strategy doc kept
   in `.plans/`.
+
+### Auto-routing (v2)
+- `AutoRecorder` — high-level wrapper that takes both a `WindowRecorder` and a `Recorder`
+  plus a `(window?, region, output, options)` per-call signature. Picks SCK when a window
+  is supplied on macOS, falls back to ffmpeg region capture otherwise. If the SCK helper
+  isn't bundled in the jar (e.g. built on Linux running on macOS) it degrades to ffmpeg
+  with a stderr warning. Operational SCK failures (TCC denied, window not found) propagate
+  unmodified — only `HelperNotBundledException` triggers the fallback.
 
 ### Shared
 - `RecordingHandle` — `AutoCloseable`. Stop sends `q` on stdin (the documented clean-shutdown

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -1,0 +1,75 @@
+package dev.sebastiano.spectre.recording
+
+import dev.sebastiano.spectre.recording.screencapturekit.HelperNotBundledException
+import dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureKitRecorder
+import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
+import dev.sebastiano.spectre.recording.screencapturekit.WindowRecorder
+import java.awt.Rectangle
+import java.lang.ProcessHandle
+import java.nio.file.Path
+
+/**
+ * High-level recorder that picks between window-targeted SCK capture and region-based ffmpeg
+ * capture per call, so callers don't have to know which backend is appropriate.
+ *
+ * Routing logic (in order):
+ * 1. `window == null` → ffmpeg region capture. Caller doesn't have a window in mind, or is
+ *    capturing an embedded `ComposePanel` where there's no top-level window to target.
+ * 2. Non-macOS host → ffmpeg. SCK is macOS-only.
+ * 3. macOS host with a window → SCK. If SCK fails because the helper isn't bundled (e.g. a jar
+ *    built on Linux running on macOS), falls back to ffmpeg with a stderr warning so the
+ *    degradation is visible. **Only** [HelperNotBundledException] triggers fallback — operational
+ *    SCK failures (Screen Recording permission denied, target window not found, helper crashed
+ *    during init) propagate as `IllegalStateException` so the caller sees the real error rather
+ *    than getting a silently-different recording.
+ *
+ * The router always needs both a window AND a region: the region is used as the fallback when SCK
+ * isn't applicable. If you don't have a region (e.g. no clear bounds for a missing window),
+ * instantiate [ScreenCaptureKitRecorder] or [FfmpegRecorder] directly.
+ */
+class AutoRecorder
+internal constructor(
+    private val sckRecorder: WindowRecorder,
+    private val ffmpegRecorder: Recorder,
+    private val isMacOs: () -> Boolean,
+) {
+
+    constructor(
+        sckRecorder: WindowRecorder = ScreenCaptureKitRecorder(),
+        ffmpegRecorder: Recorder = FfmpegRecorder(),
+    ) : this(sckRecorder, ffmpegRecorder, ::defaultIsMacOs)
+
+    fun start(
+        window: TitledWindow?,
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions = RecordingOptions(),
+        windowOwnerPid: Long = ProcessHandle.current().pid(),
+    ): RecordingHandle {
+        if (window == null || !isMacOs()) {
+            return ffmpegRecorder.start(region, output, options)
+        }
+        return try {
+            sckRecorder.start(
+                window = window,
+                windowOwnerPid = windowOwnerPid,
+                output = output,
+                options = options,
+            )
+        } catch (e: HelperNotBundledException) {
+            // The helper isn't in the jar. This is the cross-platform-jar case (built on
+            // Linux, run on macOS) — degrade to region capture rather than throwing, but
+            // surface a stderr warning so the silent downgrade is at least visible.
+            System.err.println(
+                "AutoRecorder: SCK helper not bundled (${e.message}); falling back to ffmpeg region capture."
+            )
+            ffmpegRecorder.start(region, output, options)
+        }
+    }
+
+    private companion object {
+        @JvmStatic
+        fun defaultIsMacOs(): Boolean =
+            System.getProperty("os.name").orEmpty().lowercase().contains("mac")
+    }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
@@ -38,7 +38,7 @@ internal class HelperBinaryExtractor(
         }
         val source =
             resourceLocator()
-                ?: throw IllegalStateException(
+                ?: throw HelperNotBundledException(
                     "Bundled helper binary not found at classpath resource '$RESOURCE_PATH'. " +
                         "The recording module's macOS build stages 'spectre-screencapture' there " +
                         "via the assembleScreenCaptureKitHelper task — verify the module was " +

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperNotBundledException.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperNotBundledException.kt
@@ -1,0 +1,14 @@
+package dev.sebastiano.spectre.recording.screencapturekit
+
+/**
+ * Thrown by [HelperBinaryExtractor] when the `spectre-screencapture` helper isn't bundled in the
+ * recording module's resources. This is the cross-platform-jar case: a jar built on Linux / Windows
+ * lacks the macOS-only helper, so calling `ScreenCaptureKitRecorder` on macOS with that jar fails.
+ *
+ * Distinct from plain `IllegalStateException` so [dev.sebastiano.spectre.recording.AutoRecorder]
+ * can catch ONLY this and fall back to the region-capture recorder. Other startup failures (TCC
+ * denied, window not found, helper crashed during init) stay as `IllegalStateException` and
+ * propagate — those are caller-actionable and shouldn't be silently masked.
+ */
+class HelperNotBundledException internal constructor(message: String) :
+    IllegalStateException(message)

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -3,7 +3,6 @@ package dev.sebastiano.spectre.recording.screencapturekit
 import dev.sebastiano.spectre.recording.RecordingHandle
 import dev.sebastiano.spectre.recording.RecordingOptions
 import java.io.IOException
-import java.lang.ProcessHandle
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CountDownLatch
@@ -27,10 +26,10 @@ import java.util.concurrent.atomic.AtomicReference
  *    `FfmpegRecorder`'s shutdown contract). Title restoration happens unconditionally during stop,
  *    including the crashed-mid-recording branch.
  *
- * Why not implement [dev.sebastiano.spectre.recording.Recorder]: that interface is region-based
- * (`Rectangle`), and ScreenCaptureKit is window-targeted. A higher-level router can pick between
- * `ScreenCaptureKitRecorder` (when a `windowHandle != 0L` is available) and `FfmpegRecorder`
- * (region fallback for embedded `ComposePanel`s) — that lives outside this class.
+ * Implements [WindowRecorder] (window-targeted) rather than the region-based
+ * [dev.sebastiano.spectre.recording.Recorder] — ScreenCaptureKit is fundamentally window-attached
+ * and coordinates aren't necessary. The high-level [dev.sebastiano.spectre.recording.AutoRecorder]
+ * takes both backends and picks per call: SCK when there's a window on macOS, ffmpeg otherwise.
  *
  * macOS-only. On non-macOS hosts the helper isn't bundled; [start] fails early with a clear "helper
  * not found" error from [HelperBinaryExtractor].
@@ -39,15 +38,15 @@ class ScreenCaptureKitRecorder
 internal constructor(
     private val helperExtractor: HelperBinaryExtractor,
     private val processFactory: ProcessFactory,
-) {
+) : WindowRecorder {
 
     constructor() : this(HelperBinaryExtractor(), SystemProcessFactory)
 
-    fun start(
+    override fun start(
         window: TitledWindow,
-        windowOwnerPid: Long = ProcessHandle.current().pid(),
+        windowOwnerPid: Long,
         output: Path,
-        options: RecordingOptions = RecordingOptions(),
+        options: RecordingOptions,
     ): RecordingHandle {
         // Resolve everything that can fail without touching window state first. Anything we do
         // before `discriminator.apply()` doesn't need a restore path; anything after must

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder.kt
@@ -1,0 +1,29 @@
+package dev.sebastiano.spectre.recording.screencapturekit
+
+import dev.sebastiano.spectre.recording.RecordingHandle
+import dev.sebastiano.spectre.recording.RecordingOptions
+import java.lang.ProcessHandle
+import java.nio.file.Path
+
+/**
+ * Window-targeted recorder surface — captures the pixels of a single window identified by
+ * [TitledWindow] regardless of where on screen it sits or what's overlapping it. Implemented by
+ * [ScreenCaptureKitRecorder] on macOS; future Windows / Linux backends would implement the same
+ * interface.
+ *
+ * Distinct from `Recorder` (which is region-based) because window-targeted capture has
+ * fundamentally different ergonomics — coordinates aren't necessary, occlusion isn't a concern,
+ * window movement is automatically followed.
+ *
+ * The high-level [dev.sebastiano.spectre.recording.AutoRecorder] router takes both a
+ * [WindowRecorder] and a [dev.sebastiano.spectre.recording.Recorder] and picks the right one per
+ * call based on whether a window was supplied + the current host OS.
+ */
+interface WindowRecorder {
+    fun start(
+        window: TitledWindow,
+        windowOwnerPid: Long = ProcessHandle.current().pid(),
+        output: Path,
+        options: RecordingOptions = RecordingOptions(),
+    ): RecordingHandle
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
@@ -1,0 +1,188 @@
+package dev.sebastiano.spectre.recording
+
+import dev.sebastiano.spectre.recording.screencapturekit.HelperNotBundledException
+import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
+import dev.sebastiano.spectre.recording.screencapturekit.WindowRecorder
+import java.awt.Rectangle
+import java.io.ByteArrayOutputStream
+import java.io.PrintStream
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteIfExists
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class AutoRecorderTest {
+
+    @Test
+    fun `null window always routes to ffmpeg regardless of OS or helper availability`() {
+        val sck = StubWindowRecorder(behavior = SckBehavior.ShouldNeverBeCalled)
+        val ffmpeg = StubFfmpegRecorder()
+        val recorder = AutoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val output = tempMov()
+        try {
+            recorder.start(window = null, region = Rectangle(0, 0, 100, 100), output = output)
+
+            assertTrue(ffmpeg.startCalled, "Should fall back to ffmpeg when no window provided")
+            assertEquals(0, sck.startCallCount)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `non-mac host always routes to ffmpeg even with a window`() {
+        val sck = StubWindowRecorder(behavior = SckBehavior.ShouldNeverBeCalled)
+        val ffmpeg = StubFfmpegRecorder()
+        val window = StubTitledWindow()
+        val recorder = AutoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { false })
+        val output = tempMov()
+        try {
+            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
+
+            assertTrue(ffmpeg.startCalled)
+            assertEquals(0, sck.startCallCount)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `mac host with a window routes to SCK`() {
+        val sck = StubWindowRecorder(behavior = SckBehavior.Succeeds)
+        val ffmpeg = StubFfmpegRecorder()
+        val window = StubTitledWindow()
+        val recorder = AutoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val output = tempMov()
+        try {
+            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
+
+            assertEquals(1, sck.startCallCount)
+            assertEquals(false, ffmpeg.startCalled, "Should not fall back when SCK succeeds")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `helper-not-bundled triggers fallback to ffmpeg`() {
+        // The cross-platform-jar case: built on Linux, run on macOS — helper isn't in the
+        // jar, but the user has ffmpeg available. AutoRecorder should silently degrade to
+        // region capture rather than throwing.
+        val sck = StubWindowRecorder(behavior = SckBehavior.HelperNotBundled)
+        val ffmpeg = StubFfmpegRecorder()
+        val window = StubTitledWindow()
+        val recorder = AutoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val output = tempMov()
+        try {
+            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
+
+            assertEquals(1, sck.startCallCount, "SCK is attempted first")
+            assertTrue(ffmpeg.startCalled, "Falls back to ffmpeg when helper isn't bundled")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `non-fallback SCK failures (TCC, window-not-found) propagate without falling back`() {
+        // If SCK is bundled but fails for a caller-actionable reason (no Screen Recording
+        // permission, window doesn't exist), the user should see that error — falling back
+        // would mask a real configuration mistake.
+        val sck = StubWindowRecorder(behavior = SckBehavior.RuntimeFailure)
+        val ffmpeg = StubFfmpegRecorder()
+        val window = StubTitledWindow()
+        val recorder = AutoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val output = tempMov()
+        try {
+            assertFailsWith<IllegalStateException> {
+                recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
+            }
+            assertEquals(1, sck.startCallCount)
+            assertEquals(false, ffmpeg.startCalled, "Real SCK failures must not silently fall back")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `helper-not-bundled fallback writes a warning to stderr so the degradation is visible`() {
+        val sck = StubWindowRecorder(behavior = SckBehavior.HelperNotBundled)
+        val ffmpeg = StubFfmpegRecorder()
+        val window = StubTitledWindow()
+        val recorder = AutoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val output = tempMov()
+        val originalErr = System.err
+        val captured = ByteArrayOutputStream()
+        System.setErr(PrintStream(captured))
+        try {
+            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
+        } finally {
+            System.setErr(originalErr)
+            output.deleteIfExists()
+        }
+        val warning = captured.toString(Charsets.UTF_8)
+        assertTrue(
+            warning.contains("AutoRecorder", ignoreCase = true) ||
+                warning.contains("falling back", ignoreCase = true),
+            "Expected stderr fallback warning, got: $warning",
+        )
+    }
+
+    private fun tempMov(): Path = Files.createTempFile("spectre-auto-recorder-test-", ".mov")
+}
+
+private enum class SckBehavior {
+    Succeeds,
+    HelperNotBundled,
+    RuntimeFailure,
+    ShouldNeverBeCalled,
+}
+
+private class StubWindowRecorder(private val behavior: SckBehavior) : WindowRecorder {
+    var startCallCount: Int = 0
+        private set
+
+    override fun start(
+        window: TitledWindow,
+        windowOwnerPid: Long,
+        output: Path,
+        options: RecordingOptions,
+    ): RecordingHandle {
+        startCallCount += 1
+        return when (behavior) {
+            SckBehavior.Succeeds -> NoopHandle(output)
+            SckBehavior.HelperNotBundled ->
+                throw HelperNotBundledException("test: helper not bundled")
+            SckBehavior.RuntimeFailure -> throw IllegalStateException("test: TCC denied")
+            SckBehavior.ShouldNeverBeCalled ->
+                error("SCK was not supposed to be invoked in this test")
+        }
+    }
+}
+
+private class StubFfmpegRecorder : Recorder {
+    var startCalled: Boolean = false
+        private set
+
+    override fun start(
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): RecordingHandle {
+        startCalled = true
+        return NoopHandle(output)
+    }
+}
+
+private class StubTitledWindow : TitledWindow {
+    override var title: String? = "MyApp"
+}
+
+private class NoopHandle(override val output: Path) : RecordingHandle {
+    override val isStopped: Boolean = false
+
+    override fun stop() = Unit
+}


### PR DESCRIPTION
## Summary

Follow-up to #44. The bridge-strategy doc identified a router as a v2 completeness item — callers shouldn't have to know which backend to instantiate. This PR adds:

- `WindowRecorder` interface — mirror of the existing region-based `Recorder`. `ScreenCaptureKitRecorder` now implements it (purely additive).
- `HelperNotBundledException` — typed exception so the router can catch *only* "helper not in jar" and fall back, while operational SCK failures (TCC denied, window not found, helper crashed) still propagate.
- `AutoRecorder` — `start(window?, region, output, options)`. Routes:
  1. `window == null` → ffmpeg
  2. non-macOS → ffmpeg
  3. macOS + window → SCK; on `HelperNotBundledException`, fall back to ffmpeg with a stderr warning.

Sets up the path for v2 completeness items F2 (helper contract tests) and F3 (macOS CI), tracked separately.

## Test plan

- [x] 6 unit tests on `AutoRecorder` cover every routing branch + the fallback-warning behaviour. All green.
- [x] Full SCK suite (33 tests) still green after the additive changes to `ScreenCaptureKitRecorder` (now implements `WindowRecorder`) and `HelperBinaryExtractor` (now throws typed exception).
- [x] `./gradlew check` green project-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)