### PR TITLE
v2: helper contract tests + fail-fast output-path validation

### DIFF
--- a/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCapture.swift
@@ -182,6 +182,12 @@ final class Recorder {
         // source resumed — silently dropping the signal.
         installSigtermHandler()
 
+        // Validate output path before doing any expensive setup. Catches the common
+        // typo case (caller passed a directory path) without first paying the SCK init
+        // + window discovery cost. Pure precondition check, doesn't depend on a window
+        // existing.
+        try validateOutputPath(args.output)
+
         let target = try await discoverTargetWindow()
         try await startCapture(targetWindow: target)
         await waitForStop()
@@ -215,6 +221,22 @@ final class Recorder {
             .max(by: { $0.1 < $1.1 })?
             .0
         return dominant?.backingScaleFactor ?? NSScreen.main?.backingScaleFactor ?? 2.0
+    }
+
+    /// Refuse to overwrite a directory if the caller mistakenly passed one as `--output`.
+    /// AVAssetWriter would later fail on this anyway, but `try? FileManager.removeItem` would
+    /// silently `rm -rf` the directory first — much worse failure mode for a typo. Run this
+    /// up-front in `run()` so we fail fast on a precondition error before paying for SCK init
+    /// and window discovery.
+    private func validateOutputPath(_ url: URL) throws {
+        var isDir: ObjCBool = false
+        if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue {
+            throw CLIError(
+                code: 2,
+                message:
+                    "--output points at an existing directory (\(url.path)); refusing to overwrite. Pass a file path."
+            )
+        }
     }
 
     private func discoverTargetWindow() async throws -> SCWindow {
@@ -276,21 +298,9 @@ final class Recorder {
         config.queueDepth = 8
         config.pixelFormat = kCVPixelFormatType_32BGRA
 
-        // Refuse to delete a directory the caller mistakenly handed us as `--output`. AVAssetWriter
-        // would also fail in that case, but blowing away an entire directory tree first because of
-        // a typo is a much worse failure mode. Only remove a regular file (or a symlink, which is
-        // probably fine).
-        var isDir: ObjCBool = false
-        if FileManager.default.fileExists(atPath: args.output.path, isDirectory: &isDir) {
-            if isDir.boolValue {
-                throw CLIError(
-                    code: 2,
-                    message:
-                        "--output points at an existing directory (\(args.output.path)); refusing to overwrite. Pass a file path."
-                )
-            }
-            try? FileManager.default.removeItem(at: args.output)
-        }
+        // Output path was already validated up-front in `run()`; here we only need to
+        // remove a stale file (if any) before AVAssetWriter opens it.
+        try? FileManager.default.removeItem(at: args.output)
 
         let writer = try AVAssetWriter(outputURL: args.output, fileType: .mov)
         let videoSettings: [String: Any] = [

--- a/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCapture.swift
@@ -298,8 +298,13 @@ final class Recorder {
         config.queueDepth = 8
         config.pixelFormat = kCVPixelFormatType_32BGRA
 
-        // Output path was already validated up-front in `run()`; here we only need to
-        // remove a stale file (if any) before AVAssetWriter opens it.
+        // Re-validate the output path immediately before removing whatever's there. The
+        // up-front `validateOutputPath` call in `run()` happens before window discovery, so
+        // a directory could theoretically appear at the path during the discovery window.
+        // Without this re-check, the unconditional `removeItem` would silently `rm -rf`
+        // that directory tree — the destructive failure mode the guard is supposed to
+        // prevent. Cheap stat call; runs once per recording start.
+        try validateOutputPath(args.output)
         try? FileManager.default.removeItem(at: args.output)
 
         let writer = try AVAssetWriter(outputURL: args.output, fileType: .mov)

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitHelperContractTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitHelperContractTest.kt
@@ -1,0 +1,231 @@
+package dev.sebastiano.spectre.recording.screencapturekit
+
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * End-to-end contract tests against the real bundled `spectre-screencapture` Swift binary.
+ *
+ * The JVM-side `ScreenCaptureKitRecorderTest` exercises the recorder lifecycle with fake processes;
+ * that catches regressions on our side but can't catch protocol drift between the Kotlin code and
+ * the Swift helper (e.g. someone renames a CLI flag in main.swift but forgets to update
+ * [HelperArguments]). These tests `Process`-out to the real binary with intentionally-bad argv and
+ * assert the documented exit codes. Validates the CLI surface without needing SCK / TCC, so they
+ * can run on any macOS host with the helper bundled.
+ *
+ * Skipped on non-macOS — the helper isn't built / bundled there.
+ */
+class ScreenCaptureKitHelperContractTest {
+
+    private lateinit var helper: Path
+    private lateinit var output: Path
+
+    @BeforeTest
+    fun setUp() {
+        assumeTrue(
+            System.getProperty("os.name").orEmpty().lowercase().contains("mac"),
+            "Helper binary is only bundled on macOS hosts",
+        )
+        helper = HelperBinaryExtractor().extract()
+        output = Files.createTempFile("spectre-helper-contract-", ".mov")
+        // Delete the placeholder createTempFile leaves behind so paths-that-don't-exist tests
+        // start from a clean slate.
+        output.deleteIfExists()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        if (::output.isInitialized) output.deleteIfExists()
+    }
+
+    @Test
+    fun `helper exits 2 when invoked with no arguments`() {
+        val exit = runHelper(emptyList())
+        assertEquals(2, exit, "Missing required args must exit 2")
+    }
+
+    @Test
+    fun `helper exits 2 on non-integer pid`() {
+        val exit =
+            runHelper(
+                listOf(
+                    "--pid",
+                    "not-a-number",
+                    "--title-contains",
+                    "anything",
+                    "--output",
+                    output.toString(),
+                )
+            )
+        assertEquals(2, exit, "Non-integer --pid must exit 2")
+    }
+
+    @Test
+    fun `helper exits 2 on empty title-contains`() {
+        val exit =
+            runHelper(listOf("--pid", "1", "--title-contains", "", "--output", output.toString()))
+        assertEquals(2, exit, "Empty --title-contains must exit 2")
+    }
+
+    @Test
+    fun `helper exits 2 on missing output`() {
+        val exit = runHelper(listOf("--pid", "1", "--title-contains", "anything"))
+        assertEquals(2, exit, "Missing --output must exit 2")
+    }
+
+    @Test
+    fun `helper exits 2 on unknown argument`() {
+        val exit =
+            runHelper(
+                listOf(
+                    "--pid",
+                    "1",
+                    "--title-contains",
+                    "anything",
+                    "--output",
+                    output.toString(),
+                    "--unknown-flag",
+                    "value",
+                )
+            )
+        assertEquals(2, exit, "Unknown flag must exit 2")
+    }
+
+    @Test
+    fun `helper exits 2 on negative discovery-timeout`() {
+        val exit =
+            runHelper(
+                listOf(
+                    "--pid",
+                    "1",
+                    "--title-contains",
+                    "x",
+                    "--output",
+                    output.toString(),
+                    "--discovery-timeout-ms",
+                    "-1",
+                )
+            )
+        assertEquals(2, exit, "Negative --discovery-timeout-ms must exit 2")
+    }
+
+    @Test
+    fun `helper exits 2 on non-positive fps`() {
+        val exit =
+            runHelper(
+                listOf(
+                    "--pid",
+                    "1",
+                    "--title-contains",
+                    "x",
+                    "--output",
+                    output.toString(),
+                    "--fps",
+                    "0",
+                )
+            )
+        assertEquals(2, exit, "fps == 0 must exit 2")
+    }
+
+    @Test
+    fun `helper exits 2 on non-boolean cursor`() {
+        val exit =
+            runHelper(
+                listOf(
+                    "--pid",
+                    "1",
+                    "--title-contains",
+                    "x",
+                    "--output",
+                    output.toString(),
+                    "--cursor",
+                    "1",
+                )
+            )
+        assertEquals(2, exit, "--cursor accepts only 'true' or 'false', not '1'")
+    }
+
+    @Test
+    fun `helper exits 2 when output points at an existing directory`() {
+        val outputDir = Files.createTempDirectory("spectre-helper-contract-dir-")
+        try {
+            val exit =
+                runHelper(
+                    listOf(
+                        "--pid",
+                        "1",
+                        "--title-contains",
+                        "x",
+                        "--output",
+                        outputDir.toString(),
+                        "--discovery-timeout-ms",
+                        "100",
+                    )
+                )
+            assertEquals(2, exit, "--output pointing at a directory must exit 2 with refusal")
+            // Critical: the directory must NOT have been deleted (early helper would `rm -rf`
+            // it).
+            assertTrue(Files.isDirectory(outputDir), "Helper must not delete the output directory")
+        } finally {
+            outputDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `helper exits 3 when no window matches the discriminator`() {
+        // pid 1 on macOS is launchd, which has no windows by definition. Even if it did, the
+        // discriminator "spectre-contract-test-no-such-window-xyz" guarantees no match.
+        val exit =
+            runHelper(
+                listOf(
+                    "--pid",
+                    "1",
+                    "--title-contains",
+                    "spectre-contract-test-no-such-window-xyz",
+                    "--output",
+                    output.toString(),
+                    "--discovery-timeout-ms",
+                    "200",
+                )
+            )
+        assertEquals(3, exit, "Unmatched window discriminator must exit 3 within the timeout")
+    }
+
+    /**
+     * Spawns the helper with the given argv (the helper path is prepended automatically) and waits
+     * for it to exit, returning the exit code. Bounded wait so a hanging helper doesn't stall the
+     * test indefinitely.
+     */
+    private fun runHelper(args: List<String>): Int {
+        val argv = listOf(helper.toString()) + args
+        val process =
+            ProcessBuilder(argv)
+                .redirectInput(ProcessBuilder.Redirect.PIPE)
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+        try {
+            check(process.waitFor(HELPER_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                "Helper did not exit within ${HELPER_TIMEOUT_SECONDS}s for argv=$argv"
+            }
+        } catch (e: IOException) {
+            process.destroyForcibly()
+            throw e
+        }
+        return process.exitValue()
+    }
+
+    private companion object {
+        const val HELPER_TIMEOUT_SECONDS: Long = 5
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #44/#45. JVM-side `ScreenCaptureKitRecorderTest` uses fake processes — great for our regressions, but blind to JVM↔Swift protocol drift. This PR adds end-to-end contract tests that exec the real bundled binary with intentionally-bad argv and assert the documented exit codes.

Also moves the helper's output-path validation from `startCapture()` to a new `validateOutputPath()` called early in `run()`. Previously a caller passing a directory as `--output` got exit 3 (window not found) before exit 2 (precondition failure) — failing fast on preconditions matches the documented exit-code semantics and is what the new contract test expects.

## Test plan

- [x] 10 new contract tests, all green on macOS. Skipped on non-macOS via `assumeTrue` (helper isn't bundled there).
- [x] Full SCK suite (33 tests) still green.
- [x] `./gradlew check` green project-wide.

## Notes

Independent of #45 (AutoRecorder router). Either order is fine to merge; small chance of textual conflict in the helper Swift if both touch `startCapture` ordering, but #45 doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)