### PR TITLE
Automate IJ plugin UI validation via intellij-ide-starter (#42)

### DIFF
--- a/.github/workflows/ide-uitest.yml
+++ b/.github/workflows/ide-uitest.yml
@@ -1,0 +1,106 @@
+name: IDE UI test
+
+# Runs the intellij-ide-starter UI test (#42) — boots a real IntelliJ Ultimate 2026.1.1 IDE in
+# a child process (IC 2026.1.x isn't published to the release feed yet), installs the
+# freshly-built `:sample-intellij-plugin` zip, invokes `RunSpectreAction`
+# via the Driver, and asserts every tagged Compose node from `SpectreSampleToolWindowContent`
+# appears in `idea.log`.
+#
+# Why this is its own workflow (not part of `ci.yml`):
+#   - First run downloads ~1 GB IDE installer (cached afterwards via the `ide-starter-cache`
+#     step below).
+#   - Even cached, each scenario boots a real IDE — multi-second startup cost per test.
+#   - macOS runner: the test invokes the IDE's bundled skiko + Jewel + Compose modules. Linux
+#     runners would need `xvfb-run` plus a software-GL stack, and any rendering quirk in that
+#     stack would shift the failure mode away from "regression in our plugin code". macOS
+#     gives us the same Compose runtime everyone develops against and matches the manual
+#     `runIde` smoke that landed with PR #43.
+#   - Path filter keeps unrelated PRs from paying the macOS-runner cost.
+#
+# Local invocation: `./gradlew :sample-intellij-plugin:uiTest`.
+
+on:
+  pull_request:
+    paths:
+      # Plugin sources whose breakage would surface here.
+      - "sample-intellij-plugin/**"
+      # `:core` / `:recording` provide the in-process Spectre automator the action drives;
+      # changes there can regress what the IDE-hosted run discovers.
+      - "core/**"
+      - "recording/**"
+      # Catalog/build glue that affects ide-starter dependency resolution or plugin packaging.
+      - "gradle/libs.versions.toml"
+      - "settings.gradle.kts"
+      - "build.gradle.kts"
+      - ".github/workflows/ide-uitest.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "sample-intellij-plugin/**"
+      - "core/**"
+      - "recording/**"
+      - "gradle/libs.versions.toml"
+      - "settings.gradle.kts"
+      - "build.gradle.kts"
+      - ".github/workflows/ide-uitest.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  uitest:
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        # Same toolchain as the rest of the project (see ci.yml for the temurin-vs-jbr note —
+        # JBR 21 is currently missing from setup-java's index, so temurin is the working choice).
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      # ide-starter writes IDE installers and extracted builds under `out/ide-tests/{installers,cache}`
+      # — re-using these between runs cuts the cold-start cost from ~10 minutes (DMG download +
+      # mount + copy) to ~30 seconds (existence check). The per-run sandbox lives under
+      # `out/ide-tests/tests/...` and is intentionally NOT cached: it's per-test-method scratch space
+      # that includes the IDE config, indexes, and idea.log, all of which must be fresh each run.
+      #
+      # Cache key includes the IDE build number so a version bump in `libs.versions.toml`
+      # (`ideStarter` / `intellijIdea`) busts the cache rather than silently re-using stale bits.
+      - name: Restore ide-starter cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            out/ide-tests/installers
+            out/ide-tests/cache
+          key: ide-starter-${{ runner.os }}-${{ hashFiles('gradle/libs.versions.toml') }}
+          restore-keys: |
+            ide-starter-${{ runner.os }}-
+
+      - name: Run IDE UI test
+        run: ./gradlew :sample-intellij-plugin:uiTest
+
+      # Capture artefacts on failure so post-mortem doesn't require re-running the test.
+      # `idea.log`, screenshots, and the test reports cover the three angles a regression here
+      # typically has: IDE-side activity, what the IDE looked like at failure time, and which
+      # JUnit assertion tripped.
+      - name: Upload failure artefacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ide-uitest-artifacts
+          path: |
+            sample-intellij-plugin/build/reports/tests/uiTest/
+            sample-intellij-plugin/build/test-results/uiTest/
+            out/ide-tests/tests/**/log/idea.log
+            out/ide-tests/tests/**/log/screenshots/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,11 @@ composeMultiplatform = "1.10.3"
 composeRules = "0.5.6"
 detekt = "2.0.0-alpha.2"
 intellijIdea = "2026.1.1"
+# JetBrains' intellij-ide-starter for the #42 IDE-hosted UI test. Pinned to the same build
+# our IDE itself runs (2026.1.1 == 261.23567.138) so the framework matches the IDE's
+# internal API surface. Deliberately NOT `LATEST-EAP-SNAPSHOT` — JetBrains' own examples use
+# that for their nightly cycle but we need reproducibility against beta+ build stability.
+ideStarter = "261.23567.138"
 jewel = "0.35.0-261.23567.138"
 jewelBridge = "261.23567.138"
 ktfmt = "0.26.0"
@@ -48,6 +53,16 @@ ktor-server-testHost = { module = "io.ktor:ktor-server-test-host", version.ref =
 
 jewel-ideLafBridge = { module = "com.jetbrains.intellij.platform:jewel-ide-laf-bridge", version.ref = "jewelBridge" }
 jewel-ui = { module = "org.jetbrains.jewel:jewel-ui", version.ref = "jewel" }
+
+# intellij-ide-starter (#42). Coords sourced from
+# https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/tools/ —
+# require the JetBrains releases repo declared in settings.gradle.kts.
+ideStarter-squashed = { module = "com.jetbrains.intellij.tools:ide-starter-squashed", version.ref = "ideStarter" }
+ideStarter-junit5 = { module = "com.jetbrains.intellij.tools:ide-starter-junit5", version.ref = "ideStarter" }
+ideStarter-driver = { module = "com.jetbrains.intellij.tools:ide-starter-driver", version.ref = "ideStarter" }
+ideStarter-driverClient = { module = "com.jetbrains.intellij.driver:driver-client", version.ref = "ideStarter" }
+ideStarter-driverSdk = { module = "com.jetbrains.intellij.driver:driver-sdk", version.ref = "ideStarter" }
+ideStarter-driverModel = { module = "com.jetbrains.intellij.driver:driver-model", version.ref = "ideStarter" }
 
 [plugins]
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }

--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -138,4 +138,82 @@ tasks.named<JavaExec>("runIde") {
 // `buildPlugin` (and its dependencies) generate the plugin distribution zip. Strip from `check`
 // so the regular CI loop stays fast — a contributor opting into the plugin runs `runIde`
 // explicitly. Verification of the plugin descriptor still happens via `verifyPluginStructure`.
-tasks.named("check") { dependsOn("verifyPluginStructure") }
+//
+// `detektUiTest` is hooked into `:check` so the uiTest source set is statically validated on every
+// PR even though `:uiTest` itself (which boots a real IDE) is opt-in — keeps the linter from going
+// stale on a source set that only runs in the dedicated `ide-uitest.yml` CI job.
+tasks.named("check") { dependsOn("verifyPluginStructure", "detektUiTest") }
+
+// --- intellij-ide-starter UI test (issue #42) ----------------------------------------------
+//
+// The default `:check` is fast and runs on every PR. The IDE-hosted UI test is opt-in via a
+// dedicated `uiTest` task because:
+//   - First run downloads ~1 GB IDE Community installer (cached afterwards).
+//   - Even cached, the test boots a real IDE process per scenario; multi-second startup.
+//   - Failures here are environmental (display, sandbox cleanup, ide-starter cache state)
+//     more often than logic, so blocking PRs on them is the wrong default.
+//
+// CI runs this only when `recording/**`, `sample-intellij-plugin/**`, or this build file
+// changes (gated in `.github/workflows/ide-uitest.yml`). Local invocation:
+//   ./gradlew :sample-intellij-plugin:uiTest
+//
+// The test JVM needs the built plugin zip path and the IDE log directory base path. Both
+// are wired here as system properties so the test code stays declarative.
+val uiTestSourceSet =
+    sourceSets.create("uiTest") {
+        java.srcDir("src/uiTest/kotlin")
+        resources.srcDir("src/uiTest/resources")
+        compileClasspath += sourceSets["main"].output
+        runtimeClasspath += sourceSets["main"].output
+    }
+
+val uiTestImplementation by configurations.getting { extendsFrom(configurations["implementation"]) }
+
+val uiTestRuntimeOnly by configurations.getting { extendsFrom(configurations["runtimeOnly"]) }
+
+dependencies {
+    "uiTestImplementation"(libs.junit5.api)
+    "uiTestImplementation"(libs.ideStarter.squashed)
+    "uiTestImplementation"(libs.ideStarter.junit5)
+    "uiTestImplementation"(libs.ideStarter.driver)
+    "uiTestImplementation"(libs.ideStarter.driverClient)
+    "uiTestImplementation"(libs.ideStarter.driverSdk)
+    "uiTestImplementation"(libs.ideStarter.driverModel)
+    "uiTestImplementation"(libs.kotlinx.coroutines.core)
+    "uiTestRuntimeOnly"(libs.junit5.engine)
+    // Gradle 8+ test execution needs junit-platform-launcher on the test runtime classpath
+    // OR `useJUnitPlatform()` on a task that pulls it via convention. The Test task we
+    // configure below does call `useJUnitPlatform()`, but JUnit's own launcher isn't pulled
+    // in transitively from `junit-jupiter-engine` — wire it explicitly so the executor can
+    // boot.
+    "uiTestRuntimeOnly"("org.junit.platform:junit-platform-launcher")
+}
+
+val buildPluginTask = tasks.named<Zip>("buildPlugin")
+val pluginZipProvider = buildPluginTask.flatMap { it.archiveFile }
+
+val uiTest by
+    tasks.registering(Test::class) {
+        group = "verification"
+        description =
+            "IDE-hosted UI test for the Spectre sample plugin (intellij-ide-starter, #42). " +
+                "Boots an IntelliJ Ultimate IDE (2026.1.1) in a child process, installs the " +
+                "plugin from the local buildPlugin output, invokes `RunSpectreAction`, and " +
+                "asserts the expected semantics tags appear in idea.log. NOT wired into " +
+                ":check — opt-in. (IU rather than IC because IC 2026.1.x isn't on the public " +
+                "release feed yet.)"
+        useJUnitPlatform()
+        testClassesDirs = uiTestSourceSet.output.classesDirs
+        classpath = uiTestSourceSet.runtimeClasspath
+        // Plugin zip needs to exist before the test fires. `buildPlugin` is the canonical
+        // upstream task; depending on `prepareSandbox` instead would skip the
+        // pluginConfiguration validation that surfaces e.g. malformed plugin.xml early.
+        dependsOn(buildPluginTask)
+        // `path.to.build.plugin` is the system property the ide-starter sample tests use to
+        // point at a locally-built plugin zip — we follow the same convention so the test
+        // code reads naturally for anyone familiar with the JetBrains examples.
+        // Resolved from buildPlugin's actual archive output rather than hardcoding the
+        // filename, which depends on Gradle archive-naming conventions
+        // (`<project>-<version>.zip`, not the plugin's display name).
+        systemProperty("path.to.build.plugin", pluginZipProvider.get().asFile.absolutePath)
+    }

--- a/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/RunSpectreUiTest.kt
+++ b/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/RunSpectreUiTest.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.atomic.AtomicReference
 import kotlin.io.path.createDirectories
 import kotlin.io.path.exists
 import kotlin.io.path.readText
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.minutes
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -229,9 +229,12 @@ class RunSpectreUiTest {
         const val LOG_POLL_DEADLINE_MS: Long = 30_000
         const val POLL_INTERVAL_MS: Long = 250
 
-        // First-open of an empty project on a cold ide-starter cache hits indexing for ~10–20s
-        // (sass.scss / WorkspaceFileIndex iterators). 60s gives generous headroom while still
-        // bounding the wait so a stuck indexer doesn't hang CI.
-        val INDICATOR_QUIESCENCE_TIMEOUT = 60.seconds
+        // First-open of an empty project triggers an indexing burst (sass.scss /
+        // WorkspaceFileIndex iterators / JDK cataloging). On a local cached run this takes
+        // 10–20s; on the GH macOS runner with a fresh ide-starter cache it has come in over
+        // 90s (the whole `:uiTest` job clocks ~8 min cold), so 60s was below the runner's
+        // p99 and timed out in CI even though it was fine locally. 3 min gives CI enough
+        // headroom while still bounding the wait so a stuck indexer doesn't hang the job.
+        val INDICATOR_QUIESCENCE_TIMEOUT = 3.minutes
     }
 }

--- a/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/RunSpectreUiTest.kt
+++ b/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/RunSpectreUiTest.kt
@@ -1,0 +1,237 @@
+package dev.sebastiano.spectre.intellij.uitest
+
+import com.intellij.driver.sdk.invokeGlobalBackendAction
+import com.intellij.driver.sdk.singleProject
+import com.intellij.driver.sdk.waitForIndicators
+import com.intellij.driver.sdk.waitForProjectOpen
+import com.intellij.ide.starter.driver.engine.runIdeWithDriver
+import com.intellij.ide.starter.ide.IdeProductProvider
+import com.intellij.ide.starter.junit5.hyphenateWithClass
+import com.intellij.ide.starter.models.TestCase
+import com.intellij.ide.starter.plugins.PluginConfigurator
+import com.intellij.ide.starter.project.LocalProjectInfo
+import com.intellij.ide.starter.runner.CurrentTestMethod
+import com.intellij.ide.starter.runner.IDERunContext
+import com.intellij.ide.starter.runner.Starter
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * IDE-hosted validation for #42: boots a real IntelliJ Ultimate IDE via `intellij-ide-starter`,
+ * installs the locally-built `:sample-intellij-plugin` zip, invokes `RunSpectreAction`, and asserts
+ * the action's `[Spectre]` log lines mention every tagged node from
+ * `SpectreSampleToolWindowContent`. (We'd prefer Community for parity with downstream OSS users,
+ * but JetBrains hasn't released IC 2026.1.x yet — see the inline note on `IdeProductProvider.IU`
+ * below.)
+ *
+ * Counterpart to the manual `./gradlew :sample-intellij-plugin:runIde` smoke that landed with #43 —
+ * same assertions, no human in the loop. CI runs this only when the plugin or recording sources
+ * change (path filter in `.github/workflows/ide-uitest.yml`); locally it's `./gradlew
+ * :sample-intellij-plugin:uiTest`.
+ *
+ * The bridge between the test JVM and the IDE process is the IDE's own `idea.log`. The test JVM has
+ * direct disk access to the sandbox system dir, so after the action's `thisLogger().info("[Spectre]
+ * ...")` calls flush we can grep the file for the expected node tags. No remote-robot HTTP server,
+ * no XPath UI driving — just the action's declarative log surface.
+ */
+class RunSpectreUiTest {
+
+    // Camel-case method name (rather than the Spectre convention of backtick prose names) keeps
+    // detekt's `FunctionNaming` rule happy: its built-in excludes cover `**/test/**` etc. but
+    // `**/uiTest/**` isn't on that list, and we don't want to widen the project-wide config just
+    // for one method. The `@DisplayName` annotation surfaces the readable name in test reports.
+    @Test
+    @DisplayName("RunSpectreAction discovers every tagged node from the sample tool window")
+    fun runSpectreActionDiscoversEveryTaggedNodeFromTheSampleToolWindow() {
+        val pluginPath = pluginZipPath()
+        val tempProject = createEmptyProject()
+
+        val testContext =
+            Starter.newContext(
+                    CurrentTestMethod.hyphenateWithClass(),
+                    // The plugin compiles against IntelliJ IDEA 2026.1.1 (build
+                    // 261.23567.138 = IU). Ideally we'd test against IC for parity with
+                    // OSS distribution, but JetBrains hasn't released IC 2026.1.x to the
+                    // public download feed yet — latest published IC release is 2025.2.6.1
+                    // (build 252.28539.33), which doesn't match our plugin's compile
+                    // target. Using IU here means the IDE matches what `runIde` boots; the
+                    // plugin's classloader sees the SAME bundled Compose / Jewel / skiko
+                    // jars locally and in this test, so a plugin-load regression that only
+                    // surfaces against 2026.1's bundled modules is caught here.
+                    //
+                    // We do NOT call `setLicense(...)` — invokeAction-only flows against
+                    // an empty project don't need an Ultimate license. If the IDE later
+                    // refuses to start because of license validation, that's the signal
+                    // to wire `LICENSE_KEY` from a CI secret.
+                    //
+                    // Switch to `IdeProductProvider.IC` once IC 2026.1.x ships on the
+                    // public release feed.
+                    TestCase(
+                        IdeProductProvider.IU.copy(
+                            buildType = "release",
+                            buildNumber = IDE_BUILD_NUMBER,
+                        ),
+                        LocalProjectInfo(tempProject),
+                    ),
+                )
+                .apply { PluginConfigurator(this).installPluginFromPath(pluginPath) }
+
+        // ide-starter writes the IDE's `idea.log` to `IDERunContext.logsDir`, which is
+        // `<testHome>/<launchName>/log` — a SIBLING of `<testHome>/system`, not a child of it.
+        // (Earlier iterations resolved this from `paths.systemDir.resolve("log")` and ended up
+        // pointing at an empty `<testHome>/system/log/` that the IDE never writes to — confirmed
+        // by inspecting the JVM options inside the actual log: `-Didea.log.path=<launchDir>/log`
+        // and `-Didea.system.path=<launchDir>/system` are siblings.)
+        //
+        // The Driver-lambda receiver doesn't expose run-context paths, so we capture the
+        // `IDERunContext` from `runIdeWithDriver`'s `configure` block (which fires before the
+        // IDE process is spawned) and read its `logsDir` from inside the driver block.
+        val capturedRunContext = AtomicReference<IDERunContext>()
+
+        testContext
+            .runIdeWithDriver(configure = { capturedRunContext.set(this) })
+            .useDriverAndCloseIde {
+                val ideLog =
+                    requireNotNull(capturedRunContext.get()) {
+                            "IDERunContext was never captured — runIdeWithDriver's configure " +
+                                "block didn't fire before the driver block."
+                        }
+                        .logsDir
+                        .resolve("idea.log")
+
+                // Wait for the empty project we passed via `LocalProjectInfo` to finish
+                // opening before firing the action. Without this the action races
+                // `ProjectActivity` execution and `e.project` is unreliable.
+                waitForProjectOpen()
+
+                // Wait for indexing / Resolving / Analyzing-project indicators to settle.
+                // First-open of an empty project still triggers a brief indexing burst that
+                // dominates the EDT; the action's popup-discovery poll is bounded at ~3s and
+                // will time out if Compose recomposition is starved by indexing during the
+                // toggle → popup transition. (We saw exactly this fail mode locally: initial
+                // counter / toggle nodes appeared, but `ide.popup.body` never did within
+                // budget.) Waiting for indicators here moves the action invocation to a
+                // quiescent IDE.
+                waitForIndicators(timeout = INDICATOR_QUIESCENCE_TIMEOUT)
+
+                // `invokeGlobalBackendAction(...)` plumbs `singleProject()` through to the
+                // action's data context, so `RunSpectreAction.actionPerformed` sees a
+                // non-null `e.project`. The simpler `invokeAction(...)` route does NOT
+                // populate the project key (no focused IDE frame in driver-only flows), so
+                // the action would early-return on its `e.project ?: return` guard — which
+                // is the right behaviour for the interactive Tools-menu path but useless to
+                // us here.
+                //
+                // `now = false`: the action self-defers to a pooled background thread for
+                // the polling loop (PR #43 fix), so blocking the EDT here would deadlock
+                // the very recomposition the action waits for.
+                invokeGlobalBackendAction(SPECTRE_ACTION_ID, singleProject(), now = false)
+
+                // Wait for the action's `[Spectre] (with popup)` lines to appear. Bounded so a
+                // regression doesn't hang CI; covers the action's full poll budget (~3s) plus a
+                // generous margin for IDE first-paint + ToolWindow activation.
+                val captured = waitForSpectreLog(ideLog, deadlineMs = LOG_POLL_DEADLINE_MS)
+
+                assertTrue(captured.isNotEmpty()) {
+                    "Expected `[Spectre]` log lines in $ideLog within ${LOG_POLL_DEADLINE_MS}ms; " +
+                        "RunSpectreAction either didn't fire or didn't reach its dump phase."
+                }
+                EXPECTED_TAGS.forEach { tag ->
+                    assertTrue(captured.any { it.contains(tag) }) {
+                        "Expected tagged node `$tag` in [Spectre] log lines but didn't find it. " +
+                            "Captured (${captured.size} lines):\n" +
+                            captured.joinToString("\n")
+                    }
+                }
+            }
+    }
+
+    /** Reads the path the Gradle `uiTest` task wires via `-Dpath.to.build.plugin`. */
+    private fun pluginZipPath(): Path {
+        val raw =
+            requireNotNull(System.getProperty("path.to.build.plugin")) {
+                "System property `path.to.build.plugin` is not set — run via " +
+                    "`./gradlew :sample-intellij-plugin:uiTest` so the Gradle task points at " +
+                    "the locally-built plugin zip."
+            }
+        val path = Path.of(raw)
+        require(path.exists()) {
+            "Plugin zip $path does not exist. Run `:sample-intellij-plugin:buildPlugin` first."
+        }
+        return path
+    }
+
+    /**
+     * Creates a throwaway project directory under the JVM's tmpdir. ide-starter `LocalProjectInfo`
+     * requires a project root to open; the IDE doesn't care that there's no `.idea/` — it'll create
+     * one. We just need a stable on-disk anchor so the IDE has SOMETHING to open (avoids the
+     * welcome screen, which doesn't host our tool window).
+     */
+    private fun createEmptyProject(): Path {
+        val base = Path.of(System.getProperty("java.io.tmpdir"), "spectre-uitest-project")
+        base.createDirectories()
+        return Files.createTempDirectory(base, "project-").also { dir ->
+            dir.toFile().deleteOnExit()
+        }
+    }
+
+    /**
+     * Polls [logPath] until at least one `[Spectre] (with popup)` line appears (proves the action
+     * ran the popup-discovery path) or [deadlineMs] elapses. Returns the matching lines (or empty
+     * if the deadline was hit). Uses small file reads so the IDE's still-open log handle isn't a
+     * problem on Windows.
+     */
+    private fun waitForSpectreLog(logPath: Path, deadlineMs: Long): List<String> {
+        val deadline = System.currentTimeMillis() + deadlineMs
+        var captured: List<String> = emptyList()
+        while (System.currentTimeMillis() < deadline) {
+            captured =
+                if (logPath.exists()) {
+                    logPath.readText().lineSequence().filter { it.contains("[Spectre]") }.toList()
+                } else {
+                    emptyList()
+                }
+            if (captured.any { it.contains("[Spectre] (with popup)") }) return captured
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        return captured
+    }
+
+    private companion object {
+        // IntelliJ IDEA 2026.1.1 build number (resolves to IU here — see comment on the
+        // `IdeProductProvider.IU` use above). Must stay in lockstep with `intellijIdea` in
+        // `gradle/libs.versions.toml` — bumping that version means updating this constant to
+        // the matching build (find it under
+        // https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/).
+        const val IDE_BUILD_NUMBER = "261.23567.138"
+        const val SPECTRE_ACTION_ID = "dev.sebastiano.spectre.sample.RunSpectre"
+        // Matches every test-tagged node the manual smoke proved discoverable in PR #43.
+        // Keep this list aligned with `SpectreSampleToolWindowContent`'s `Modifier.testTag`
+        // values — drifting one without the other means the test silently passes against an
+        // outdated tool window.
+        val EXPECTED_TAGS =
+            listOf(
+                "ide.counter.button",
+                "ide.counter.text",
+                "ide.popup.toggleButton",
+                "ide.popup.body",
+                "ide.popup.text",
+                "ide.popup.dismissButton",
+            )
+        const val LOG_POLL_DEADLINE_MS: Long = 30_000
+        const val POLL_INTERVAL_MS: Long = 250
+
+        // First-open of an empty project on a cold ide-starter cache hits indexing for ~10–20s
+        // (sass.scss / WorkspaceFileIndex iterators). 60s gives generous headroom while still
+        // bounding the wait so a stuck indexer doesn't hang CI.
+        val INDICATOR_QUIESCENCE_TIMEOUT = 60.seconds
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -41,6 +41,28 @@ dependencyResolutionManagement {
         maven("https://maven.pkg.jetbrains.space/public/p/compose/dev") {
             mavenContent { includeGroup("org.jetbrains.skiko") }
         }
+
+        // intellij-ide-starter and the Driver API are only published to JetBrains' own
+        // releases mirror — the IDE-build-numbered versions we pin (e.g. `261.23567.138`)
+        // never make it to Maven Central. Scope the lookup to the two relevant groups so
+        // every other module's resolution still goes through Maven Central first. Used by
+        // the `:sample-intellij-plugin` UI test only.
+        maven("https://www.jetbrains.com/intellij-repository/releases") {
+            mavenContent {
+                includeGroup("com.jetbrains.intellij.tools")
+                includeGroup("com.jetbrains.intellij.driver")
+            }
+        }
+
+        // Transitive dependency mirror used by intellij-ide-starter (its kodein-di / fus /
+        // teamcity-rest deps live here, not Maven Central). Scoped via `includeGroupByRegex`
+        // to avoid bleeding into other modules' resolution.
+        maven("https://cache-redirector.jetbrains.com/intellij-dependencies") {
+            mavenContent {
+                includeGroupByRegex("com\\.jetbrains\\..*")
+                includeGroupByRegex("org\\.jetbrains\\.intellij\\..*")
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Closes #42.

## Summary
- New `:sample-intellij-plugin:uiTest` task boots a real IntelliJ Ultimate 2026.1.1 in a child process via `intellij-ide-starter`, installs the locally-built plugin zip, fires `RunSpectreAction` through the Driver API, and asserts every `Modifier.testTag` from `SpectreSampleToolWindowContent` lands in `idea.log`. Counterpart to the manual `runIde` smoke from #43 — same assertions, no human in the loop.
- Driver-invoked path uses `invokeGlobalBackendAction(SPECTRE_ACTION_ID, singleProject(), now = false)` so the action sees a non-null `e.project`. The simpler `invokeAction(...)` would route via a synthetic AnActionEvent with no focused frame, leaving `e.project` null and tripping the action's `e.project ?: return` guard.
- Test waits for `waitForProjectOpen()` + `waitForIndicators()` before firing the action — first-open indexing was starving Compose recomposition during the popup-toggle → popup-body transition (the action's poll budget is 3s; indexing was eating the whole window).
- Dedicated `.github/workflows/ide-uitest.yml` runs on macOS, gated on changes to plugin/core/recording/build sources. Caches `out/ide-tests/{installers,cache}` so warm runs are ~30s instead of ~10min cold. Fails-only artefact upload (`idea.log`, screenshots, JUnit reports) for post-mortem.
- `detektUiTest` is wired into `:check` even though `:uiTest` itself isn't, so the source set's static analysis stays current on every PR.

## Why IU not IC
JetBrains hasn't published IC 2026.1.x to the release feed yet (latest IC release is 2025.2.6.1, which doesn't match our plugin's compile target). IU 2026.1.1 IS published and matches the bundled Compose / Jewel / skiko jars our plugin loads at runtime — so a regression that only surfaces against 2026.1's bundled modules is caught here. Switch to IC once 2026.1.x ships there. Inline comment in the test calls this out.

## Test plan
- [x] `./gradlew :sample-intellij-plugin:uiTest` passes locally (~50s warm; ~10min cold)
- [x] `./gradlew check` clean (covers detektUiTest + ktfmtCheckUiTest)
- [x] All six expected tags (`ide.counter.{button,text}` + `ide.popup.{toggleButton,body,text,dismissButton}`) appear in the captured `[Spectre]` log lines
- [ ] CI green: `IDE UI test` workflow exercises the path on macos-latest with the cache primed

🤖 Generated with [Claude Code](https://claude.com/claude-code)