### PR TITLE
v3: Windows recording via ffmpeg gdigrab (#22)

### DIFF
--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -235,3 +235,15 @@ tasks.register<JavaExec>("runScreenCaptureKitSmoke") {
     classpath = sourceSets["test"].runtimeClasspath
     mainClass.set("dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureKitRecorderSmoke")
 }
+
+// Manual smoke entry point — opens a JFrame, records it for ~3s via FfmpegRecorder bound to
+// the Windows gdigrab backend, prints the resulting file path + size. Mirrors the SCK smoke
+// for the Windows recording path (#22). Lives in the test source set so it can use the
+// internal FfmpegBackend / FfmpegRecorder.withBackend hooks.
+tasks.register<JavaExec>("runFfmpegGdigrabSmoke") {
+    group = "verification"
+    description = "Boots a JFrame, records it for ~3s via gdigrab, prints output stats."
+    onlyIf { OperatingSystem.current().isWindows }
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.sebastiano.spectre.recording.FfmpegGdigrabSmoke")
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -15,7 +15,13 @@ import java.nio.file.Path
  * Routing logic (in order):
  * 1. `window == null` → ffmpeg region capture. Caller doesn't have a window in mind, or is
  *    capturing an embedded `ComposePanel` where there's no top-level window to target.
- * 2. Non-macOS host → ffmpeg. SCK is macOS-only.
+ * 2. Non-macOS host → ffmpeg region capture. SCK is macOS-only. On Windows the underlying
+ *    [FfmpegRecorder] uses the gdigrab device (selected by [FfmpegBackend.detect]) — it captures
+ *    the requested region by virtual-desktop offset rather than by window handle. Title-based
+ *    gdigrab capture exists as a building block in `FfmpegCli.gdigrabWindowCapture` but is not yet
+ *    wired through this router; callers wanting it must spawn ffmpeg directly. The region path is
+ *    the documented fallback when the target window title is missing, ambiguous, or points at a
+ *    Jewel-in-IDE tool window with no top-level title.
  * 3. macOS host with a window → SCK. If SCK fails because the helper isn't bundled (e.g. a jar
  *    built on Linux running on macOS), falls back to ffmpeg with a stderr warning so the
  *    degradation is visible. **Only** [HelperNotBundledException] triggers fallback — operational

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegBackend.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegBackend.kt
@@ -1,0 +1,70 @@
+package dev.sebastiano.spectre.recording
+
+import java.awt.Rectangle
+import java.nio.file.Path
+
+/**
+ * Picks the platform-appropriate `ffmpeg` argv builder for [FfmpegRecorder].
+ *
+ * Each backend wraps the native capture device that ffmpeg exposes on its host OS:
+ * - [MacOsAvfoundation] — `-f avfoundation` with crop-filter region selection. Requires the macOS
+ *   Screen Recording permission.
+ * - [WindowsGdigrab] — `-f gdigrab` with input-side `-offset_x`/`-offset_y`/`-video_size` region
+ *   selection. No equivalent of macOS's TCC permission gate, but the window must be visible.
+ *
+ * The backend is selected at [FfmpegRecorder] construction time via [detect], which inspects
+ * `os.name` (the same approach the rest of the module uses — see `MacOsRecordingPermissions`).
+ * Tests inject a specific backend directly so the produced argv is deterministic regardless of the
+ * host OS.
+ */
+internal sealed interface FfmpegBackend {
+
+    /** Builds the ffmpeg argv for a region capture in this backend's coordinate space. */
+    fun buildRegionArgv(
+        ffmpegPath: Path,
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): List<String>
+
+    object MacOsAvfoundation : FfmpegBackend {
+        override fun buildRegionArgv(
+            ffmpegPath: Path,
+            region: Rectangle,
+            output: Path,
+            options: RecordingOptions,
+        ): List<String> = FfmpegCli.avfoundationRegionCapture(ffmpegPath, region, output, options)
+    }
+
+    object WindowsGdigrab : FfmpegBackend {
+        override fun buildRegionArgv(
+            ffmpegPath: Path,
+            region: Rectangle,
+            output: Path,
+            options: RecordingOptions,
+        ): List<String> = FfmpegCli.gdigrabRegionCapture(ffmpegPath, region, output, options)
+    }
+
+    companion object {
+
+        /**
+         * Resolves the backend for the current OS. macOS → [MacOsAvfoundation]; Windows →
+         * [WindowsGdigrab]. Any other host (Linux, BSD) throws [UnsupportedOperationException] with
+         * a message naming the OS — the v4 Linux backend (X11Grab / Wayland) lands here when
+         * implemented.
+         */
+        fun detect(): FfmpegBackend {
+            val osName = System.getProperty("os.name").orEmpty()
+            return when {
+                osName.lowercase().contains("mac") -> MacOsAvfoundation
+                osName.lowercase().contains("windows") -> WindowsGdigrab
+                else ->
+                    throw UnsupportedOperationException(
+                        "FfmpegRecorder has no backend for os.name=\"$osName\". " +
+                            "Supported: macOS (avfoundation), Windows (gdigrab). " +
+                            "Linux X11Grab/Wayland support is tracked under v4."
+                    )
+            }
+        }
+    }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
@@ -4,14 +4,17 @@ import java.awt.Rectangle
 import java.nio.file.Path
 
 /**
- * Builds the `ffmpeg` argv for a region capture against the avfoundation device on macOS.
+ * Builds `ffmpeg` argv lists for the recording backends Spectre supports.
  *
- * Pure function — no I/O, no process spawn — so the argv is unit-testable in isolation. The actual
+ * Pure functions — no I/O, no process spawn — so the argv is unit-testable in isolation. The actual
  * subprocess lifecycle lives in [FfmpegRecorder].
  *
- * The resulting command captures the macOS main display (`-i 1` selects the screen capture device
- * per the spike plan), crops it to [region] via the `crop` video filter, and pipes the result
- * through the chosen codec into [output].
+ * Backends:
+ * - [avfoundationRegionCapture] — macOS region capture via the avfoundation device, with cropping
+ *   applied as a video filter.
+ * - [gdigrabRegionCapture] — Windows region capture via the gdigrab device, with the region
+ *   selected on the input side via offsets and `-video_size` (no crop filter).
+ * - [gdigrabWindowCapture] — Windows title-based window capture via the gdigrab device.
  */
 internal object FfmpegCli {
 
@@ -60,6 +63,96 @@ internal object FfmpegCli {
             // Crop filter to the requested region.
             add("-vf")
             add("crop=${region.width}:${region.height}:${region.x}:${region.y}")
+            add("-c:v")
+            add(options.codec)
+            add(output.toString())
+        }
+    }
+
+    /**
+     * Builds the argv for a Windows region capture via the gdigrab device.
+     *
+     * gdigrab carves the region on the *input* side via `-offset_x`, `-offset_y`, and
+     * `-video_size`, so no `crop` filter is needed. Negative offsets are accepted: Windows'
+     * virtual-desktop coordinate space puts non-primary monitors at negative coordinates if they're
+     * positioned to the left of (or above) the primary display, and gdigrab's docs explicitly
+     * support that case.
+     *
+     * [RecordingOptions.screenIndex] is intentionally unused here — gdigrab targets the entire
+     * virtual desktop with `-i desktop`, and callers select a specific monitor by translating its
+     * bounds into the region origin.
+     */
+    fun gdigrabRegionCapture(
+        ffmpegPath: Path,
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): List<String> {
+        require(region.width > 0 && region.height > 0) {
+            "region must have positive dimensions, was ${region.width}x${region.height}"
+        }
+        return buildList {
+            add(ffmpegPath.toString())
+            add("-loglevel")
+            add("warning")
+            add("-y")
+            // gdigrab input options must precede `-i`. -framerate is the capture rate;
+            // -draw_mouse toggles cursor compositing on the captured frames; -offset_x /
+            // -offset_y / -video_size select the region on the input side, so we don't need
+            // a crop filter and can't fall into avfoundation's silent-clamp pitfall.
+            add("-f")
+            add("gdigrab")
+            add("-framerate")
+            add(options.frameRate.toString())
+            add("-draw_mouse")
+            add(if (options.captureCursor) "1" else "0")
+            add("-offset_x")
+            add(region.x.toString())
+            add("-offset_y")
+            add(region.y.toString())
+            add("-video_size")
+            add("${region.width}x${region.height}")
+            add("-i")
+            add("desktop")
+            add("-c:v")
+            add(options.codec)
+            add(output.toString())
+        }
+    }
+
+    /**
+     * Builds the argv for a Windows title-based window capture via the gdigrab device.
+     *
+     * Title matching is exact and case-sensitive, and the window must be visible (not minimised).
+     * For Compose Desktop top-level windows this works. Jewel-in-IDE tool windows have no top-level
+     * title to match against — callers in that scenario must fall back to [gdigrabRegionCapture]
+     * using the panel's screen bounds.
+     */
+    fun gdigrabWindowCapture(
+        ffmpegPath: Path,
+        windowTitle: String,
+        output: Path,
+        options: RecordingOptions,
+    ): List<String> {
+        require(windowTitle.isNotBlank()) {
+            "windowTitle must not be blank — gdigrab's `title=` form treats an empty title as " +
+                "the desktop and would record the wrong surface"
+        }
+        return buildList {
+            add(ffmpegPath.toString())
+            add("-loglevel")
+            add("warning")
+            add("-y")
+            add("-f")
+            add("gdigrab")
+            add("-framerate")
+            add(options.frameRate.toString())
+            add("-draw_mouse")
+            add(if (options.captureCursor) "1" else "0")
+            add("-i")
+            // The full string after `title=` is the match key, including any spaces. Each argv
+            // element is a separate token, so we don't need (and must not add) shell quoting.
+            add("title=$windowTitle")
             add("-c:v")
             add(options.codec)
             add(output.toString())

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -42,13 +42,19 @@ class FfmpegRecorder
 internal constructor(
     private val ffmpegPath: Path,
     private val processFactory: ProcessFactory,
-    private val backend: FfmpegBackend,
+    // Provider — resolved on first [start] call rather than at construction time. Eagerly
+    // calling `FfmpegBackend.detect()` from the public constructor would make `FfmpegRecorder()`
+    // (and `AutoRecorder()`'s default ffmpegRecorder) throw immediately on Linux/BSD even when
+    // recording is never attempted, breaking call sites that instantiate recorders during app
+    // startup. Deferring keeps construction OS-agnostic and surfaces the unsupported-host error
+    // only at the point of use.
+    private val backendProvider: () -> FfmpegBackend,
 ) : Recorder {
 
     constructor(
         ffmpegPath: Path = resolveFfmpegPath(),
         processFactory: ProcessFactory = SystemProcessFactory,
-    ) : this(ffmpegPath, processFactory, FfmpegBackend.detect())
+    ) : this(ffmpegPath, processFactory, FfmpegBackend::detect)
 
     init {
         require(Files.isExecutable(ffmpegPath) || ffmpegPath == PROBE_PATH) {
@@ -61,7 +67,7 @@ internal constructor(
         output: Path,
         options: RecordingOptions,
     ): RecordingHandle {
-        val argv = backend.buildRegionArgv(ffmpegPath, region, output, options)
+        val argv = backendProvider().buildRegionArgv(ffmpegPath, region, output, options)
         Files.createDirectories(output.toAbsolutePath().parent ?: output.toAbsolutePath())
         val process = processFactory.start(argv)
         // Fail fast: ffmpeg dies almost instantly on common configuration errors (missing
@@ -146,7 +152,7 @@ internal constructor(
         internal fun withBackend(
             backend: FfmpegBackend,
             ffmpegPath: Path = resolveFfmpegPath(),
-        ): FfmpegRecorder = FfmpegRecorder(ffmpegPath, SystemProcessFactory, backend)
+        ): FfmpegRecorder = FfmpegRecorder(ffmpegPath, SystemProcessFactory, { backend })
 
         /**
          * Best-effort lookup for a `ffmpeg` binary on PATH. Returns the resolved absolute path if

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -18,23 +18,37 @@ import java.util.concurrent.atomic.AtomicReference
  * the binary is resolved via [resolveFfmpegPath]; callers can override the lookup by passing an
  * explicit [ffmpegPath] (useful in tests and for non-PATH installs).
  *
- * Platform support (v1, per the spike plan):
- * - macOS: avfoundation device with region cropping. `RecordingOptions.captureCursor` controls
- *   whether the cursor is baked into frames. **Requires macOS Screen Recording permission for the
- *   JVM process** (see [MacOsRecordingPermissions]).
- * - Windows / Linux: explicitly out of scope for v1; deferred to v3 / v4.
+ * Platform support:
+ * - macOS: avfoundation device with crop-filter region selection. `RecordingOptions.captureCursor`
+ *   controls whether the cursor is baked into frames. **Requires macOS Screen Recording permission
+ *   for the JVM process** (see [MacOsRecordingPermissions]).
+ * - Windows: gdigrab device with input-side region selection (`-offset_x`/`-offset_y`/
+ *   `-video_size`). No equivalent TCC permission gate, but gdigrab can't capture minimised windows.
+ * - Linux / BSD: not yet implemented — [FfmpegBackend.detect] throws on those hosts. Tracked under
+ *   v4.
  *
- * Window-targeted capture (`windowHandle != 0`) — i.e. ScreenCaptureKit on macOS — is deferred to
- * v2 (#18). Embedded ComposePanel surfaces with `windowHandle == 0L` always fall through to region
- * capture, which is what this recorder does.
+ * The platform backend is picked at construction time via [FfmpegBackend.detect] and can be
+ * overridden via the internal constructor for tests (so the produced argv is deterministic
+ * regardless of the host OS).
+ *
+ * Window-targeted capture (`windowHandle != 0`) — i.e. ScreenCaptureKit on macOS — is handled by a
+ * separate `WindowRecorder` and routed by [AutoRecorder]. Embedded ComposePanel surfaces with
+ * `windowHandle == 0L` always fall through to region capture, which is what this recorder does.
  *
  * The [processFactory] seam exists so the lifecycle can be unit-tested without spawning a real
  * `ffmpeg` (a fake factory can return a `Process`-like stand-in driven by an in-memory pipe).
  */
-class FfmpegRecorder(
-    private val ffmpegPath: Path = resolveFfmpegPath(),
-    private val processFactory: ProcessFactory = SystemProcessFactory,
+class FfmpegRecorder
+internal constructor(
+    private val ffmpegPath: Path,
+    private val processFactory: ProcessFactory,
+    private val backend: FfmpegBackend,
 ) : Recorder {
+
+    constructor(
+        ffmpegPath: Path = resolveFfmpegPath(),
+        processFactory: ProcessFactory = SystemProcessFactory,
+    ) : this(ffmpegPath, processFactory, FfmpegBackend.detect())
 
     init {
         require(Files.isExecutable(ffmpegPath) || ffmpegPath == PROBE_PATH) {
@@ -47,15 +61,16 @@ class FfmpegRecorder(
         output: Path,
         options: RecordingOptions,
     ): RecordingHandle {
-        val argv = FfmpegCli.avfoundationRegionCapture(ffmpegPath, region, output, options)
+        val argv = backend.buildRegionArgv(ffmpegPath, region, output, options)
         Files.createDirectories(output.toAbsolutePath().parent ?: output.toAbsolutePath())
         val process = processFactory.start(argv)
         // Fail fast: ffmpeg dies almost instantly on common configuration errors (missing
-        // Screen Recording permission, invalid codec, unavailable avfoundation device). The
-        // Recorder.start contract promises frames are landing by return, so a process that
-        // has already exited must surface as an error rather than a "success" handle that
-        // later produces nothing. Interruption during the probe must also clean up the
-        // spawned ffmpeg before propagating, otherwise we leak an orphan subprocess.
+        // macOS Screen Recording permission, invalid codec, unavailable avfoundation/gdigrab
+        // device, gdigrab title= miss). The Recorder.start contract promises frames are
+        // landing by return, so a process that has already exited must surface as an error
+        // rather than a "success" handle that later produces nothing. Interruption during
+        // the probe must also clean up the spawned ffmpeg before propagating, otherwise we
+        // leak an orphan subprocess.
         val exitedDuringProbe =
             try {
                 process.waitFor(STARTUP_PROBE_MILLIS, TimeUnit.MILLISECONDS)
@@ -86,8 +101,9 @@ class FfmpegRecorder(
         if (exitedDuringProbe) {
             throw IllegalStateException(
                 "ffmpeg exited immediately (code ${process.exitValue()}) — recording did not start. " +
-                    "Common causes: missing Screen Recording permission, invalid codec, or " +
-                    "unavailable avfoundation device. Argv: $argv"
+                    "Common causes: missing macOS Screen Recording permission, invalid codec, " +
+                    "unavailable avfoundation/gdigrab device, or a Windows gdigrab `title=` that " +
+                    "matches no visible window. Argv: $argv"
             )
         }
         return FfmpegRecordingHandle(process, output)
@@ -120,6 +136,17 @@ class FfmpegRecorder(
         // immediately rather than at start() time, but prevents the strict isExecutable check
         // from blocking the no-binary path used in tests / probing.
         internal val PROBE_PATH: Path = Paths.get("ffmpeg")
+
+        /**
+         * Builds an [FfmpegRecorder] bound to a specific [backend], using the system process
+         * factory and an auto-resolved ffmpeg path. Internal so tests / smokes can pin the backend
+         * without depending on the host OS — callers outside the module use the public constructor
+         * whose backend is detected automatically.
+         */
+        internal fun withBackend(
+            backend: FfmpegBackend,
+            ffmpegPath: Path = resolveFfmpegPath(),
+        ): FfmpegRecorder = FfmpegRecorder(ffmpegPath, SystemProcessFactory, backend)
 
         /**
          * Best-effort lookup for a `ffmpeg` binary on PATH. Returns the resolved absolute path if

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
@@ -120,6 +120,177 @@ class FfmpegCliTest {
             )
         }
     }
+
+    // -----------------------------------------------------------------------
+    // gdigrabRegionCapture (Windows): -f gdigrab -i desktop with input-side
+    // -offset_x / -offset_y / -video_size. Unlike avfoundation we do *not*
+    // use the `crop` video filter — gdigrab's input-side region selection is
+    // documented to support negative offsets for non-primary monitors that
+    // sit to the left/above the primary display in Windows' virtual desktop
+    // coordinate space, so we allow them.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `gdigrab region argv starts with the ffmpeg path`() {
+        val argv = FfmpegCli.gdigrabRegionCapture(ffmpeg, region, output, RecordingOptions())
+        assertEquals(ffmpeg.toString(), argv.first())
+    }
+
+    @Test
+    fun `gdigrab region argv selects gdigrab device with framerate and cursor flag`() {
+        val argv =
+            FfmpegCli.gdigrabRegionCapture(
+                ffmpeg,
+                region,
+                output,
+                RecordingOptions(frameRate = 60, captureCursor = false),
+            )
+        assertContainsSequence(argv, listOf("-f", "gdigrab"))
+        assertContainsSequence(argv, listOf("-framerate", "60"))
+        // gdigrab uses -draw_mouse (input option) for cursor capture, not avfoundation's
+        // -capture_cursor.
+        assertContainsSequence(argv, listOf("-draw_mouse", "0"))
+        // The full virtual desktop is selected with `-i desktop`; the region is carved out
+        // via input-side offsets and -video_size, not a crop filter.
+        assertContainsSequence(argv, listOf("-i", "desktop"))
+    }
+
+    @Test
+    fun `gdigrab region argv emits offset and video_size matching the requested region`() {
+        val argv = FfmpegCli.gdigrabRegionCapture(ffmpeg, region, output, RecordingOptions())
+        assertContainsSequence(argv, listOf("-offset_x", "100"))
+        assertContainsSequence(argv, listOf("-offset_y", "200"))
+        assertContainsSequence(argv, listOf("-video_size", "640x480"))
+        // No `-vf crop=...` — gdigrab does input-side region selection, so the crop filter
+        // would be redundant and would re-introduce the silent-clamp pitfall avfoundation has.
+        assertTrue("-vf" !in argv, "Should not use a crop filter for gdigrab: $argv")
+    }
+
+    @Test
+    fun `gdigrab region argv allows negative offsets for non-primary monitors`() {
+        // Windows' virtual desktop spans all monitors. A monitor positioned to the left of
+        // the primary display has negative X coords; ffmpeg's gdigrab input handles this and
+        // the docs explicitly call out the use case. Don't reject what ffmpeg supports.
+        val negative = Rectangle(-1920, 0, 1920, 1080)
+        val argv = FfmpegCli.gdigrabRegionCapture(ffmpeg, negative, output, RecordingOptions())
+        assertContainsSequence(argv, listOf("-offset_x", "-1920"))
+        assertContainsSequence(argv, listOf("-offset_y", "0"))
+        assertContainsSequence(argv, listOf("-video_size", "1920x1080"))
+    }
+
+    @Test
+    fun `gdigrab region argv applies the configured codec and output path`() {
+        val argv =
+            FfmpegCli.gdigrabRegionCapture(
+                ffmpeg,
+                region,
+                output,
+                RecordingOptions(codec = "libx264"),
+            )
+        assertContainsSequence(argv, listOf("-c:v", "libx264"))
+        assertEquals(output.toString(), argv.last())
+    }
+
+    @Test
+    fun `gdigrab region argv always passes -y to overwrite the output file`() {
+        val argv = FfmpegCli.gdigrabRegionCapture(ffmpeg, region, output, RecordingOptions())
+        assertTrue("-y" in argv, "Should pass -y to overwrite: $argv")
+    }
+
+    @Test
+    fun `gdigrab region argv quiets ffmpeg log noise via -loglevel warning`() {
+        val argv = FfmpegCli.gdigrabRegionCapture(ffmpeg, region, output, RecordingOptions())
+        assertContainsSequence(argv, listOf("-loglevel", "warning"))
+    }
+
+    @Test
+    fun `gdigrab region argv rejects non-positive dimensions`() {
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.gdigrabRegionCapture(
+                ffmpeg,
+                Rectangle(0, 0, 0, 100),
+                output,
+                RecordingOptions(),
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.gdigrabRegionCapture(
+                ffmpeg,
+                Rectangle(0, 0, 100, 0),
+                output,
+                RecordingOptions(),
+            )
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // gdigrabWindowCapture (Windows): -f gdigrab -i title=<exact title>.
+    // Title matching is exact and case-sensitive; the window must be visible
+    // (not minimised). For Compose Desktop top-level windows this works; for
+    // Jewel-in-IDE tool windows it doesn't (no top-level title) — callers
+    // must fall back to gdigrabRegionCapture in that scenario.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `gdigrab window argv starts with the ffmpeg path`() {
+        val argv = FfmpegCli.gdigrabWindowCapture(ffmpeg, "MyApp", output, RecordingOptions())
+        assertEquals(ffmpeg.toString(), argv.first())
+    }
+
+    @Test
+    fun `gdigrab window argv selects gdigrab with title-based input`() {
+        val argv =
+            FfmpegCli.gdigrabWindowCapture(
+                ffmpeg,
+                "Spectre Sample",
+                output,
+                RecordingOptions(frameRate = 60, captureCursor = true),
+            )
+        assertContainsSequence(argv, listOf("-f", "gdigrab"))
+        assertContainsSequence(argv, listOf("-framerate", "60"))
+        assertContainsSequence(argv, listOf("-draw_mouse", "1"))
+        // gdigrab's title input form: `title=<exact title>` — the entire string after
+        // `title=` is the match key, including any spaces.
+        assertContainsSequence(argv, listOf("-i", "title=Spectre Sample"))
+    }
+
+    @Test
+    fun `gdigrab window argv applies the configured codec and output path`() {
+        val argv =
+            FfmpegCli.gdigrabWindowCapture(
+                ffmpeg,
+                "MyApp",
+                output,
+                RecordingOptions(codec = "libx264"),
+            )
+        assertContainsSequence(argv, listOf("-c:v", "libx264"))
+        assertEquals(output.toString(), argv.last())
+    }
+
+    @Test
+    fun `gdigrab window argv always passes -y to overwrite the output file`() {
+        val argv = FfmpegCli.gdigrabWindowCapture(ffmpeg, "MyApp", output, RecordingOptions())
+        assertTrue("-y" in argv, "Should pass -y to overwrite: $argv")
+    }
+
+    @Test
+    fun `gdigrab window argv quiets ffmpeg log noise via -loglevel warning`() {
+        val argv = FfmpegCli.gdigrabWindowCapture(ffmpeg, "MyApp", output, RecordingOptions())
+        assertContainsSequence(argv, listOf("-loglevel", "warning"))
+    }
+
+    @Test
+    fun `gdigrab window argv rejects blank window titles`() {
+        // gdigrab's title= with an empty title resolves to "the desktop title" and produces
+        // confusing output. Reject blank up-front so the caller's misconfiguration surfaces
+        // here instead of as a silent recording of the wrong surface.
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.gdigrabWindowCapture(ffmpeg, "", output, RecordingOptions())
+        }
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.gdigrabWindowCapture(ffmpeg, "   ", output, RecordingOptions())
+        }
+    }
 }
 
 private fun assertContainsSequence(argv: List<String>, expected: List<String>) {

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegGdigrabSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegGdigrabSmoke.kt
@@ -1,0 +1,146 @@
+@file:JvmName("FfmpegGdigrabSmoke")
+
+package dev.sebastiano.spectre.recording
+
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.Font
+import java.awt.Robot
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.imageio.ImageIO
+import javax.swing.JFrame
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/**
+ * Manual end-to-end smoke for the Windows `gdigrab` recording path. Run via `./gradlew
+ * :recording:runFfmpegGdigrabSmoke` — opens a small JFrame, records it for ~3 seconds via
+ * [FfmpegRecorder] bound to [FfmpegBackend.WindowsGdigrab], prints the resulting file path + size.
+ * Eyeball the .mp4 to confirm the window content + cursor capture + frame timing look right.
+ *
+ * Uses a plain Swing JFrame rather than Compose so this stays inside the recording module's
+ * dependency boundary, mirroring [screencapturekit.ScreenCaptureKitRecorderSmoke].
+ */
+fun main() {
+    var exitCode = 0
+    try {
+        runSmoke()
+    } catch (t: Throwable) {
+        // Print full stack as a single multiline string rather than .printStackTrace() so the
+        // detekt PrintStackTrace rule isn't tripped — this is a manual smoke entry point, not
+        // production code.
+        System.err.println("Smoke failed: ${t.message}\n${t.stackTraceToString()}")
+        exitCode = 1
+    } finally {
+        exitProcess(exitCode)
+    }
+}
+
+private fun runSmoke() {
+    val output = Path.of(System.getProperty("java.io.tmpdir"), "spectre-gdigrab-smoke.mp4")
+    val midRecordingPng = Path.of(System.getProperty("java.io.tmpdir"), "spectre-gdigrab-smoke.png")
+    Files.deleteIfExists(output)
+    Files.deleteIfExists(midRecordingPng)
+
+    val (frame, label) = openSmokeWindow()
+    Thread.sleep(WINDOW_SETTLE_MS)
+
+    // Force the WindowsGdigrab backend regardless of host so this smoke is meaningful even
+    // when launched from a script that doesn't pass through OperatingSystem.current().isWindows.
+    val recorder = FfmpegRecorder.withBackend(FfmpegBackend.WindowsGdigrab)
+    val frameBoundsAtStart = frame.bounds
+    val handle =
+        recorder.start(
+            region = frameBoundsAtStart,
+            output = output,
+            options = RecordingOptions(frameRate = 30, captureCursor = true),
+        )
+
+    println("Recording started → $output (pid=${ProcessHandle.current().pid()})")
+
+    var ticks = 0
+    val animator =
+        Thread.ofPlatform().daemon().name("spectre-gdigrab-smoke-animator").start {
+            val deadline = System.nanoTime() + RECORD_DURATION_MS * 1_000_000L
+            while (System.nanoTime() < deadline && !Thread.currentThread().isInterrupted) {
+                ticks += 1
+                val current = ticks
+                SwingUtilities.invokeLater { label.text = "tick=$current" }
+                Thread.sleep(ANIMATION_INTERVAL_MS.toLong())
+            }
+        }
+
+    // Halfway through, take a JVM-side `Robot` screenshot of the JFrame's bounds. If THAT
+    // shows the tick text, Swing is painting and any blankness in the .mp4 is on the gdigrab
+    // side. If it does NOT, Swing isn't painting and we have a UI bug to chase.
+    Thread.sleep(RECORD_DURATION_MS / 2)
+    val frameBounds = frame.bounds
+    val robotShot = Robot().createScreenCapture(frameBounds)
+    ImageIO.write(robotShot, "png", File(midRecordingPng.toString()))
+    println("Robot screenshot of JFrame bounds $frameBounds → $midRecordingPng")
+
+    animator.join()
+    println("Animation done — ticks fired: $ticks")
+
+    handle.stop()
+    val sizeBytes = if (Files.exists(output)) Files.size(output) else -1
+    println("Recording stopped → $output ($sizeBytes bytes)")
+
+    SwingUtilities.invokeLater {
+        frame.isVisible = false
+        frame.dispose()
+    }
+}
+
+private fun openSmokeWindow(): Pair<JFrame, JLabel> {
+    val ready = CountDownLatch(1)
+    var frameRef: JFrame? = null
+    var labelRef: JLabel? = null
+    SwingUtilities.invokeLater {
+        val label =
+            JLabel("tick=0", SwingConstants.CENTER).apply {
+                font = Font(Font.SANS_SERIF, Font.BOLD, LABEL_FONT_SIZE)
+                foreground = Color.BLACK
+            }
+        val panel =
+            JPanel(BorderLayout()).apply {
+                background = Color.WHITE
+                isOpaque = true
+                add(label, BorderLayout.CENTER)
+            }
+        val frame =
+            JFrame("Spectre gdigrab smoke").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                contentPane = panel
+                preferredSize = Dimension(WINDOW_WIDTH, WINDOW_HEIGHT)
+                pack()
+                setLocationRelativeTo(null)
+                isVisible = true
+                toFront()
+                requestFocus()
+            }
+        frameRef = frame
+        labelRef = label
+        ready.countDown()
+    }
+    check(ready.await(WINDOW_OPEN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        "JFrame never came up within ${WINDOW_OPEN_TIMEOUT_SECONDS}s"
+    }
+    return frameRef!! to labelRef!!
+}
+
+private const val WINDOW_WIDTH = 480
+private const val WINDOW_HEIGHT = 240
+private const val WINDOW_SETTLE_MS = 500L
+private const val WINDOW_OPEN_TIMEOUT_SECONDS = 5L
+private const val RECORD_DURATION_MS = 3_000L
+private const val ANIMATION_INTERVAL_MS = 50
+private const val LABEL_FONT_SIZE = 48

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
@@ -63,8 +63,9 @@ class FfmpegRecorderTest {
     @Test
     fun `start creates the output parent directory`() {
         val factory = RecordingProcessFactory()
-        val recorder =
-            FfmpegRecorder(ffmpegPath = FfmpegRecorder.PROBE_PATH, processFactory = factory)
+        // Inject MacOsAvfoundation so this lifecycle test is deterministic on Linux/Windows CI
+        // runners — the public ctor's lazy detect() would throw on Linux when start() runs.
+        val recorder = ffmpegRecorderForBackend(FfmpegBackend.MacOsAvfoundation, factory)
         val baseDir = Files.createTempDirectory("spectre-recording-test-")
         val nested = baseDir.resolve("nested/subdir/output.mp4")
         try {
@@ -79,8 +80,7 @@ class FfmpegRecorderTest {
     fun `stop sends q on stdin and waits for the process`() {
         val process = FakeProcess()
         val factory = ProcessFactoryReturning(process)
-        val recorder =
-            FfmpegRecorder(ffmpegPath = FfmpegRecorder.PROBE_PATH, processFactory = factory)
+        val recorder = ffmpegRecorderForBackend(FfmpegBackend.MacOsAvfoundation, factory)
         val output = Files.createTempFile("spectre-recording-test-", ".mp4")
         try {
             val handle = recorder.start(Rectangle(0, 0, 50, 50), output, RecordingOptions())
@@ -100,9 +100,9 @@ class FfmpegRecorderTest {
     fun `stop is idempotent`() {
         val process = FakeProcess()
         val recorder =
-            FfmpegRecorder(
-                ffmpegPath = FfmpegRecorder.PROBE_PATH,
-                processFactory = ProcessFactoryReturning(process),
+            ffmpegRecorderForBackend(
+                FfmpegBackend.MacOsAvfoundation,
+                ProcessFactoryReturning(process),
             )
         val output = Files.createTempFile("spectre-recording-test-", ".mp4")
         try {
@@ -119,9 +119,9 @@ class FfmpegRecorderTest {
     fun `close delegates to stop`() {
         val process = FakeProcess()
         val recorder =
-            FfmpegRecorder(
-                ffmpegPath = FfmpegRecorder.PROBE_PATH,
-                processFactory = ProcessFactoryReturning(process),
+            ffmpegRecorderForBackend(
+                FfmpegBackend.MacOsAvfoundation,
+                ProcessFactoryReturning(process),
             )
         val output = Files.createTempFile("spectre-recording-test-", ".mp4")
         try {
@@ -154,9 +154,9 @@ class FfmpegRecorderTest {
         // succeeding and leaving the caller to trust a truncated output file.
         val process = CrashedAfterStartFakeProcess()
         val recorder =
-            FfmpegRecorder(
-                ffmpegPath = FfmpegRecorder.PROBE_PATH,
-                processFactory = ProcessFactoryReturning(process),
+            ffmpegRecorderForBackend(
+                FfmpegBackend.MacOsAvfoundation,
+                ProcessFactoryReturning(process),
             )
         val output = Files.createTempFile("spectre-recording-test-", ".mp4")
         try {
@@ -179,9 +179,9 @@ class FfmpegRecorderTest {
         // Recording permission, invalid codec, unavailable device. Recorder.start must surface
         // these as errors rather than returning a handle that produces an empty file.
         val recorder =
-            FfmpegRecorder(
-                ffmpegPath = FfmpegRecorder.PROBE_PATH,
-                processFactory = ProcessFactoryReturning(InstantlyExitingFakeProcess()),
+            ffmpegRecorderForBackend(
+                FfmpegBackend.MacOsAvfoundation,
+                ProcessFactoryReturning(InstantlyExitingFakeProcess()),
             )
         val output = Files.createTempFile("spectre-recording-test-", ".mp4")
         try {
@@ -190,6 +190,32 @@ class FfmpegRecorderTest {
                     recorder.start(Rectangle(0, 0, 100, 100), output, RecordingOptions())
                 }
                 .also { assertTrue(it.message?.contains("exited immediately") == true) }
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `construction does not resolve the backend so unsupported hosts can build a recorder`() {
+        // Codex regression report on PR #51: prior to deferred resolution, an Ubuntu CI runner
+        // (or a Linux/BSD developer box) would see `FfmpegRecorder()` throw at construction
+        // because `FfmpegBackend.detect()` rejects non-mac/non-Windows hosts. AutoRecorder's
+        // default ffmpegRecorder argument would crash app startup even when recording was never
+        // attempted. Pin: the backend lambda must NOT be invoked during construction.
+        var resolveCount = 0
+        val recorder =
+            FfmpegRecorder(FfmpegRecorder.PROBE_PATH, RecordingProcessFactory()) {
+                resolveCount += 1
+                throw UnsupportedOperationException("backend not resolvable for this host")
+            }
+        assertEquals(0, resolveCount, "Backend must be resolved lazily, not at construction time")
+        // Sanity: the resolver does fire on first start(), preserving the failure surface.
+        val output = Files.createTempFile("spectre-recording-test-", ".mp4")
+        try {
+            kotlin.test.assertFailsWith<UnsupportedOperationException> {
+                recorder.start(Rectangle(0, 0, 10, 10), output, RecordingOptions())
+            }
+            assertEquals(1, resolveCount, "Backend must resolve exactly once on first start()")
         } finally {
             output.deleteIfExists()
         }
@@ -210,7 +236,7 @@ class FfmpegRecorderTest {
 private fun ffmpegRecorderForBackend(
     backend: FfmpegBackend,
     factory: FfmpegRecorder.ProcessFactory,
-): FfmpegRecorder = FfmpegRecorder(FfmpegRecorder.PROBE_PATH, factory, backend)
+): FfmpegRecorder = FfmpegRecorder(FfmpegRecorder.PROBE_PATH, factory, { backend })
 
 private class RecordingProcessFactory : FfmpegRecorder.ProcessFactory {
     var lastArgv: List<String> = emptyList()

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
@@ -19,10 +19,9 @@ import kotlin.test.assertTrue
 class FfmpegRecorderTest {
 
     @Test
-    fun `start spawns the subprocess with the avfoundation argv`() {
+    fun `start with the macOS backend spawns the subprocess with avfoundation argv`() {
         val factory = RecordingProcessFactory()
-        val recorder =
-            FfmpegRecorder(ffmpegPath = FfmpegRecorder.PROBE_PATH, processFactory = factory)
+        val recorder = ffmpegRecorderForBackend(FfmpegBackend.MacOsAvfoundation, factory)
         val output = Files.createTempFile("spectre-recording-test-", ".mp4")
         try {
             recorder.start(Rectangle(0, 0, 100, 100), output, RecordingOptions())
@@ -30,6 +29,31 @@ class FfmpegRecorderTest {
             val argv = factory.lastArgv
             assertTrue(argv.isNotEmpty(), "Process factory should have been invoked")
             assertTrue("avfoundation" in argv, "Argv should select avfoundation: $argv")
+            assertEquals(output.toString(), argv.last(), "Argv should end with the output path")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `start with the Windows backend spawns the subprocess with gdigrab argv`() {
+        // Issue #22: the recorder must build a Windows-flavoured argv when constructed against
+        // the WindowsGdigrab backend. This test pins the dispatch end-to-end so the existing
+        // lifecycle plumbing (process factory, startup probe, handle) doesn't accidentally
+        // regress to the avfoundation path on Windows hosts.
+        val factory = RecordingProcessFactory()
+        val recorder = ffmpegRecorderForBackend(FfmpegBackend.WindowsGdigrab, factory)
+        val output = Files.createTempFile("spectre-recording-test-", ".mp4")
+        try {
+            recorder.start(Rectangle(0, 0, 100, 100), output, RecordingOptions())
+
+            val argv = factory.lastArgv
+            assertTrue(argv.isNotEmpty(), "Process factory should have been invoked")
+            assertTrue("gdigrab" in argv, "Argv should select gdigrab: $argv")
+            assertTrue(
+                "avfoundation" !in argv,
+                "Windows backend must not emit avfoundation argv: $argv",
+            )
             assertEquals(output.toString(), argv.last(), "Argv should end with the output path")
         } finally {
             output.deleteIfExists()
@@ -179,6 +203,14 @@ class FfmpegRecorderTest {
         }
     }
 }
+
+// Constructs an FfmpegRecorder bound to a specific backend, regardless of the host OS. Tests
+// rely on the internal three-arg constructor so produced argv stays deterministic across
+// macOS / Windows / CI runners.
+private fun ffmpegRecorderForBackend(
+    backend: FfmpegBackend,
+    factory: FfmpegRecorder.ProcessFactory,
+): FfmpegRecorder = FfmpegRecorder(FfmpegRecorder.PROBE_PATH, factory, backend)
 
 private class RecordingProcessFactory : FfmpegRecorder.ProcessFactory {
     var lastArgv: List<String> = emptyList()


### PR DESCRIPTION
## Summary

- Adds OS-aware ffmpeg backend dispatch (`FfmpegBackend` sealed interface) so `:recording` builds gdigrab argv on Windows instead of hardcoding avfoundation.
- New `FfmpegCli.gdigrabRegionCapture` (input-side `-offset_x`/`-offset_y`/`-video_size`, allows negative offsets for non-primary monitors) + `gdigrabWindowCapture` (`-i title=<exact>`, rejects blank).
- Manual smoke main (`:recording:runFfmpegGdigrabSmoke`) mirrors the SCK smoke for hand-validation.
- Closes #22.

## What's wired

- `FfmpegRecorder` picks the backend via `FfmpegBackend.detect()` from `os.name` at construction. Tests inject a backend explicitly so produced argv stays deterministic across hosts.
- `AutoRecorder`'s Windows branch is documented (it now goes through gdigrab region capture). Title-based gdigrab is exposed as a building block in `FfmpegCli` but not yet wired through the router — region capture is the documented fallback when a title is missing/ambiguous, or for Jewel-in-IDE tool windows that have no top-level title.
- Linux/BSD throw `UnsupportedOperationException` from `detect()` with a v4 pointer.

## Test plan

- [x] 14 new gdigrab argv tests in `FfmpegCliTest` (window + region forms, codec, framerate, cursor, negative offsets, blank-title rejection, etc.)
- [x] Parallel macOS/Windows backend dispatch tests in `FfmpegRecorderTest`
- [x] Full `./gradlew check` green on Windows (JBR 21.0.9)
- [x] `./gradlew :recording:runFfmpegGdigrabSmoke` end-to-end against a real JFrame → 18 KB mp4, content/cursor verified visually
- [ ] Mac CI workflow runs the existing avfoundation tests (the `MacOsAvfoundation` dispatch path is unchanged)
- [ ] HiDPI parity smoke at 125%/150%/200% — tracked under #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)