### PR TITLE
v3: validate HiDpiMapper on Windows DPI scaling (#21)

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
@@ -12,6 +12,14 @@ import kotlin.math.floor
  * units. The conversion divides by scale, then adds the panel's screen offset.
  *
  * Formula from IntelliJ remote-driver's ComposeXpathDataModelExtension.
+ *
+ * Validated on Windows 11 + JBR 21 across 100/125/150/200% per-monitor DPI scaling, including the
+ * mixed-DPI multi-monitor case where the secondary display sits at negative virtual-desktop
+ * coordinates (#21). `GraphicsConfiguration.defaultTransform.scaleX` returns the actual Windows
+ * percentage (1.0/1.25/1.5/2.0) and `LocalDensity.current` tracks it synchronously when the window
+ * crosses a DPI boundary, so the same formula is correct on Windows with no platform branch —
+ * `panelScreenX` simply carries any negative offset through. Empirical scenarios are pinned in
+ * `WindowsHiDpiScenariosTest`.
  */
 fun composeToAwtX(composeX: Float, scaleX: Float, panelScreenX: Int): Int =
     (composeX / scaleX).toInt() + panelScreenX

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowsHiDpiScenariosTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowsHiDpiScenariosTest.kt
@@ -1,0 +1,150 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.Point
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Pins [HiDpiMapper] against scenarios captured by [WindowsHiDpiDiagnostic] on a real Windows 11
+ * box with mixed-DPI monitors (Display0 at 200%, x=-3840; Display1 at user-toggled 100/125/150%,
+ * x=0). Each test uses the *exact* `boundsInWindow` / `panelScreenX` / `panelScreenY` values
+ * observed on that hardware so a future regression — say, a refactor that swaps the conversion
+ * direction or special-cases negative offsets — fails immediately on the affected scenario.
+ *
+ * The data is from [WindowsHiDpiDiagnostic] snapshots dated 2026-04-29; if Compose / JBR ever
+ * change how `boundsInWindow` reports physical pixels under Windows DPI scaling, these tests will
+ * need re-capturing — which is the right signal, not a maintenance burden.
+ *
+ * The point is *not* re-testing the math (the unit tests in [HiDpiMapperTest] do that with
+ * synthetic values). It's pinning the Windows reality so we don't drift away from it accidentally.
+ */
+class WindowsHiDpiScenariosTest {
+
+    @Test
+    fun `Display1 at 100 pct with the panel partially off-screen left`() {
+        // panelScreenX is negative because the window was dragged so its left edge fell off
+        // Display1's left side (which still ends at x=0; the negative space belongs to Display0).
+        // The HiDpiMapper formula must add the negative offset cleanly — it has no special-case
+        // for negative panelScreenX/Y, and this test pins that.
+        val center =
+            composeBoundsToAwtCenter(
+                left = 16.0f,
+                top = 226.0f,
+                right = 584.0f,
+                bottom = 339.0f,
+                scaleX = 1.0f,
+                scaleY = 1.0f,
+                panelScreenX = -227,
+                panelScreenY = 571,
+            )
+        assertEquals(Point(73, 853), center)
+
+        val rect =
+            composeBoundsToAwtRectangle(
+                left = 16.0f,
+                top = 226.0f,
+                right = 584.0f,
+                bottom = 339.0f,
+                scaleX = 1.0f,
+                scaleY = 1.0f,
+                panelScreenX = -227,
+                panelScreenY = 571,
+            )
+        assertEquals(Rectangle(-211, 797, 568, 113), rect)
+    }
+
+    @Test
+    fun `Display0 at 200 pct with the panel at large negative virtual-desktop X`() {
+        // Display0 is the non-primary 200% monitor positioned to the left of the primary, so its
+        // bounds start at x=-3840. After dragging the diagnostic window onto it, both the GC's
+        // defaultTransform and Compose's LocalDensity report 2.0, and `boundsInWindow` doubles —
+        // it returns Compose physical pixels, not AWT scaled units.
+        val center =
+            composeBoundsToAwtCenter(
+                left = 32.0f,
+                top = 446.0f,
+                right = 1176.0f,
+                bottom = 686.0f,
+                scaleX = 2.0f,
+                scaleY = 2.0f,
+                panelScreenX = -2592,
+                panelScreenY = 312,
+            )
+        assertEquals(Point(-2290, 595), center)
+
+        val rect =
+            composeBoundsToAwtRectangle(
+                left = 32.0f,
+                top = 446.0f,
+                right = 1176.0f,
+                bottom = 686.0f,
+                scaleX = 2.0f,
+                scaleY = 2.0f,
+                panelScreenX = -2592,
+                panelScreenY = 312,
+            )
+        assertEquals(Rectangle(-2576, 535, 572, 120), rect)
+    }
+
+    @Test
+    fun `Display1 at 125 pct Windows scale`() {
+        // 125% is a fractional scale Windows specifically supports. Compose's density also
+        // reports 1.25 (no rounding to the nearest integer), and the AWT-output math matches
+        // what HiDpiMapper produces.
+        val center =
+            composeBoundsToAwtCenter(
+                left = 20.0f,
+                top = 278.0f,
+                right = 733.0f,
+                bottom = 426.0f,
+                scaleX = 1.25f,
+                scaleY = 1.25f,
+                panelScreenX = 471,
+                panelScreenY = 597,
+            )
+        assertEquals(Point(772, 878), center)
+
+        val rect =
+            composeBoundsToAwtRectangle(
+                left = 20.0f,
+                top = 278.0f,
+                right = 733.0f,
+                bottom = 426.0f,
+                scaleX = 1.25f,
+                scaleY = 1.25f,
+                panelScreenX = 471,
+                panelScreenY = 597,
+            )
+        assertEquals(Rectangle(487, 819, 571, 119), rect)
+    }
+
+    @Test
+    fun `Display1 at 150 pct Windows scale`() {
+        val center =
+            composeBoundsToAwtCenter(
+                left = 24.0f,
+                top = 336.0f,
+                right = 879.0f,
+                bottom = 512.0f,
+                scaleX = 1.5f,
+                scaleY = 1.5f,
+                panelScreenX = 394,
+                panelScreenY = 503,
+            )
+        assertEquals(Point(695, 785), center)
+
+        val rect =
+            composeBoundsToAwtRectangle(
+                left = 24.0f,
+                top = 336.0f,
+                right = 879.0f,
+                bottom = 512.0f,
+                scaleX = 1.5f,
+                scaleY = 1.5f,
+                panelScreenX = 394,
+                panelScreenY = 503,
+            )
+        assertEquals(Rectangle(410, 727, 570, 118), rect)
+    }
+}

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
@@ -156,4 +157,17 @@ compose.desktop {
             packageVersion = "1.0.0"
         }
     }
+}
+
+// Manual diagnostic — opens a JFrame containing a ComposePanel, prints per-monitor scale +
+// LocalDensity + boundsInWindow chain on each Reprint click. Used to gather Windows DPI
+// scaling data for issue #21 (validate HiDpiMapper across 100/125/150/200% per-monitor DPI).
+// Lives in the test source set so it can pull in test infra freely without affecting the
+// production application bundle.
+tasks.register<JavaExec>("runWindowsHiDpiDiagnostic") {
+    group = "verification"
+    description = "Boots a Compose JFrame and prints DPI scale + density on each Reprint click."
+    onlyIf { OperatingSystem.current().isWindows }
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.sebastiano.spectre.sample.WindowsHiDpiDiagnostic")
 }

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsHiDpiDiagnostic.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsHiDpiDiagnostic.kt
@@ -160,15 +160,17 @@ private fun DiagnosticContent(state: DiagnosticState) {
         BasicText("clicks = $clickCount")
         // Clickable Box stands in for a Material button — :sample-desktop has Material3, but
         // the diagnostic stays foundation-only so it's portable to any module that pulls in
-        // compose-foundation.
+        // compose-foundation. `clickable` is applied *before* `padding` so the entire blue
+        // background is the hit target — otherwise edge clicks land in the padding inset and
+        // silently fail.
         Box(
             modifier =
-                Modifier.background(Color(red = 0x33, green = 0x66, blue = 0xCC))
-                    .padding(12.dp)
-                    .clickable {
+                Modifier.clickable {
                         clickCount += 1
                         printSnapshot(state, density.density, density.fontScale, trackedBounds)
                     }
+                    .background(Color(red = 0x33, green = 0x66, blue = 0xCC))
+                    .padding(12.dp)
         ) {
             BasicText("Reprint")
         }

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsHiDpiDiagnostic.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsHiDpiDiagnostic.kt
@@ -1,0 +1,260 @@
+@file:JvmName("WindowsHiDpiDiagnostic")
+
+package dev.sebastiano.spectre.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.dp
+import dev.sebastiano.spectre.core.composeBoundsToAwtCenter
+import dev.sebastiano.spectre.core.composeBoundsToAwtRectangle
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.GraphicsEnvironment
+import java.awt.IllegalComponentStateException
+import java.awt.Window
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/**
+ * Manual diagnostic for [dev.sebastiano.spectre.core.HiDpiMapper] on Windows DPI scaling. Run via
+ * `./gradlew :sample-desktop:runWindowsHiDpiDiagnostic` — opens a JFrame containing a ComposePanel
+ * with a "Reprint" button. Each click writes a snapshot to stdout with everything Spectre's
+ * coordinate-mapping math depends on, sampled at that moment.
+ *
+ * What each snapshot captures:
+ * - host: `os.name`, `os.version` (printed once at boot)
+ * - per-monitor `defaultTransform.scaleX/Y` for every `GraphicsDevice` (boot + each click — the
+ *   per-click reprint is what catches a re-enumerated device list after a DPI change)
+ * - the JFrame's *current* `graphicsConfiguration.defaultTransform.scaleX/Y` (the monitor it's on
+ *   right now, which may differ from the GC at construction time if the user dragged it)
+ * - the embedded `ComposePanel`'s `locationOnScreen` + size in AWT pixels
+ * - Compose's `LocalDensity.current.density` + `fontScale` (what the running composition sees)
+ * - the `boundsInWindow` of a single tracked Compose box, plus the panel-relative AWT-pixel
+ *   conversion that [composeBoundsToAwtCenter] / [composeBoundsToAwtRectangle] would produce
+ *
+ * The intent is for the operator to:
+ * 1. Run on a 100% scale monitor, click Reprint, paste the block.
+ * 2. Drag the window to a 125%/150%/200% monitor, click Reprint, paste again.
+ * 3. Per-monitor mixed-DPI: drag from 100% → 200% (or vice versa), click Reprint mid-drag and again
+ *    after settling. We want to know if the GC and density update synchronously or with a delay.
+ *
+ * No assertions, no test harness — this is a data-gathering tool for issue #21. The goal is to
+ * discover whether the [dev.sebastiano.spectre.core.HiDpiMapper] formula needs a Windows-specific
+ * branch or a per-axis tweak.
+ */
+fun main() {
+    var exitCode = 0
+    try {
+        runDiagnostic()
+    } catch (t: Throwable) {
+        System.err.println("Diagnostic failed: ${t.message}\n${t.stackTraceToString()}")
+        exitCode = 1
+    } finally {
+        exitProcess(exitCode)
+    }
+}
+
+private fun runDiagnostic() {
+    println("--- WindowsHiDpiDiagnostic boot ---")
+    println(
+        "host: os.name=\"${System.getProperty("os.name")}\", " +
+            "os.version=\"${System.getProperty("os.version")}\""
+    )
+    printAllMonitors()
+
+    val frameRef = AtomicReference<JFrame>()
+    val state = DiagnosticState()
+    SwingUtilities.invokeLater {
+        val composePanel =
+            ComposePanel().apply {
+                preferredSize = Dimension(PANEL_WIDTH, PANEL_HEIGHT)
+                setContent { DiagnosticContent(state) }
+            }
+        val frame =
+            JFrame("Spectre HiDPI diagnostic").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                layout = BorderLayout()
+                add(composePanel, BorderLayout.CENTER)
+                pack()
+                setLocationRelativeTo(null)
+                isVisible = true
+            }
+        state.frame = frame
+        state.composePanel = composePanel
+        frameRef.set(frame)
+    }
+
+    // Block the main thread until the diagnostic window closes. Without this, `main()` returns
+    // immediately, the JVM tears down the EDT, and the diagnostic frame disappears before the
+    // user can click anything.
+    waitForFrameDisposed(frameRef)
+    println("--- WindowsHiDpiDiagnostic done ---")
+}
+
+private fun waitForFrameDisposed(ref: AtomicReference<JFrame>) {
+    while (true) {
+        val frame = ref.get()
+        if (frame != null && !frame.isDisplayable) return
+        Thread.sleep(WAIT_POLL_MS)
+    }
+}
+
+private fun printAllMonitors() {
+    val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()
+    val devices = ge.screenDevices
+    println("monitors:")
+    for ((idx, device) in devices.withIndex()) {
+        val gc = device.defaultConfiguration
+        val bounds = gc.bounds
+        val xform = gc.defaultTransform
+        val isDefault = device == ge.defaultScreenDevice
+        println(
+            "  [$idx] id=\"${device.iDstring}\" " +
+                "default=$isDefault " +
+                "bounds=(x=${bounds.x},y=${bounds.y},w=${bounds.width},h=${bounds.height}) " +
+                "defaultTransform.scaleX=${xform.scaleX} " +
+                "defaultTransform.scaleY=${xform.scaleY}"
+        )
+    }
+}
+
+private class DiagnosticState {
+    var frame: JFrame? = null
+    var composePanel: ComposePanel? = null
+}
+
+@Composable
+private fun DiagnosticContent(state: DiagnosticState) {
+    val density = LocalDensity.current
+    var trackedBounds by remember { mutableStateOf(Rect.Zero) }
+    var clickCount by remember { mutableIntStateOf(0) }
+    Column(
+        modifier = Modifier.fillMaxSize().background(Color.White).padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        BasicText("Spectre HiDPI diagnostic — click Reprint and paste stdout.")
+        BasicText("LocalDensity.density = ${density.density}")
+        BasicText("LocalDensity.fontScale = ${density.fontScale}")
+        BasicText("trackedBounds (Compose px) = $trackedBounds")
+        BasicText("clicks = $clickCount")
+        // Clickable Box stands in for a Material button — :sample-desktop has Material3, but
+        // the diagnostic stays foundation-only so it's portable to any module that pulls in
+        // compose-foundation.
+        Box(
+            modifier =
+                Modifier.background(Color(red = 0x33, green = 0x66, blue = 0xCC))
+                    .padding(12.dp)
+                    .clickable {
+                        clickCount += 1
+                        printSnapshot(state, density.density, density.fontScale, trackedBounds)
+                    }
+        ) {
+            BasicText("Reprint")
+        }
+        Box(
+            modifier =
+                Modifier.background(Color(red = 0xCC, green = 0xEE, blue = 0xFF))
+                    .fillMaxSize()
+                    .onGloballyPositioned { coords -> trackedBounds = coords.boundsInWindow() }
+        ) {
+            BasicText("tracked box (boundsInWindow → printed)", modifier = Modifier.padding(8.dp))
+        }
+    }
+}
+
+private fun printSnapshot(
+    state: DiagnosticState,
+    density: Float,
+    fontScale: Float,
+    trackedBounds: Rect,
+) {
+    val frame = state.frame
+    val panel = state.composePanel
+    println()
+    println("--- snapshot ---")
+    if (frame == null || panel == null) {
+        println("ERROR: frame or panel was null at snapshot time")
+        return
+    }
+    printAllMonitors()
+    val frameGc = (frame as Window).graphicsConfiguration
+    val frameXform = frameGc?.defaultTransform
+    val panelLoc =
+        try {
+            panel.locationOnScreen
+        } catch (_: IllegalComponentStateException) {
+            null
+        }
+    println(
+        "frame.gc.bounds=(x=${frameGc?.bounds?.x},y=${frameGc?.bounds?.y}," +
+            "w=${frameGc?.bounds?.width},h=${frameGc?.bounds?.height})"
+    )
+    println("frame.gc.defaultTransform.scaleX=${frameXform?.scaleX} scaleY=${frameXform?.scaleY}")
+    println("panel.size=(w=${panel.width},h=${panel.height})")
+    println(
+        "panel.locationOnScreen=(x=${panelLoc?.x},y=${panelLoc?.y}) " +
+            "(null means not currently displayable)"
+    )
+    println("compose.density=$density compose.fontScale=$fontScale")
+    println(
+        "trackedBounds(Compose px)=" +
+            "(left=${trackedBounds.left},top=${trackedBounds.top}," +
+            "right=${trackedBounds.right},bottom=${trackedBounds.bottom})"
+    )
+    if (frameXform != null && panelLoc != null) {
+        val scaleX = frameXform.scaleX.toFloat()
+        val scaleY = frameXform.scaleY.toFloat()
+        val center =
+            composeBoundsToAwtCenter(
+                left = trackedBounds.left,
+                top = trackedBounds.top,
+                right = trackedBounds.right,
+                bottom = trackedBounds.bottom,
+                scaleX = scaleX,
+                scaleY = scaleY,
+                panelScreenX = panelLoc.x,
+                panelScreenY = panelLoc.y,
+            )
+        val rect =
+            composeBoundsToAwtRectangle(
+                left = trackedBounds.left,
+                top = trackedBounds.top,
+                right = trackedBounds.right,
+                bottom = trackedBounds.bottom,
+                scaleX = scaleX,
+                scaleY = scaleY,
+                panelScreenX = panelLoc.x,
+                panelScreenY = panelLoc.y,
+            )
+        println("HiDpiMapper.composeBoundsToAwtCenter=$center")
+        println("HiDpiMapper.composeBoundsToAwtRectangle=$rect")
+    } else {
+        println("HiDpiMapper.* skipped (gc xform or panel location was null)")
+    }
+    println("--- /snapshot ---")
+}
+
+private const val PANEL_WIDTH = 600
+private const val PANEL_HEIGHT = 360
+private const val WAIT_POLL_MS = 200L


### PR DESCRIPTION
## Summary

Closes #21. After running `:sample-desktop:runWindowsHiDpiDiagnostic` on a real Windows 11 box (mixed-DPI: Display0 at 200% with x=-3840 negative origin, Display1 toggled across 100/125/150%), the verdict is **`HiDpiMapper` needs zero formula changes for Windows**.

## What landed

- New `:sample-desktop:runWindowsHiDpiDiagnostic` Gradle task (Windows-only) that opens a `ComposePanel` and prints per-monitor `defaultTransform`, `LocalDensity`, and the AWT-coord conversion on each click. Useful tooling for future per-DPI debugging.
- `WindowsHiDpiScenariosTest` pins the four observed scenarios (100% off-screen-left, 200% large-negative-X, 125%, 150%) as direct input → output assertions. Future refactors that swap direction or special-case negatives fail immediately on the affected scenario.
- KDoc on `HiDpiMapper` records the validation footprint.

## Empirical findings (data → answers from the strategy doc's open questions)

| Question | Answer |
|---|---|
| At Windows 125%, does `GraphicsConfiguration.defaultTransform.scaleX` return 1.25 or 1.0? | **1.25** — JBR DPI manifest is correct |
| Does `Window.getGraphicsConfiguration()` return the GC of the *current* monitor, or the construction-time GC? | **Current** — drag updates the GC |
| Does Compose's `LocalDensity.current` ever drift from GraphicsConfiguration after a DPI change? | **No** — tracks synchronously |
| Does the formula need a per-axis branch on Windows? | **No** — `scaleX` always equals `scaleY` in Windows uniform scaling |

## Test plan

- [x] `WindowsHiDpiScenariosTest` (4 new tests pinning the captured scenarios)
- [x] `HiDpiMapperTest` still green (no behavioural change to the production formula)
- [x] Full `./gradlew check` green on Windows JBR 21
- [x] Diagnostic ran cleanly at 100/125/150/200% across two monitors

🤖 Generated with [Claude Code](https://claude.com/claude-code)