### PR TITLE
v3: validate popup discovery on Windows; skip JBR-broken layer (#23)

### DIFF
--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/PopupLayerVariantsValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/PopupLayerVariantsValidationTest.kt
@@ -30,6 +30,23 @@ class PopupLayerVariantsValidationTest {
     @BeforeAll
     fun start() {
         assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        // Issue #23 finding: on Windows + JBR 21.0.9, `compose.layers.type=WINDOW` triggers a
+        // fatal native crash in skiko-windows-x64.dll during the first `SkiaLayer.update`
+        // (PictureRecorder.finishRecordingAsPicture). The crash kills the worker JVM before
+        // the test can run, so Gradle reports the suite as a non-informative `<skipped/>`
+        // with the test executor's "Could not write 127.0.0.1:NNNN" error. Until JBR / skiko
+        // ships a fix, gate the Window-mode variant out of the Windows runner cleanly so the
+        // suite reports the actual reason and the rest of the test class still validates the
+        // SameCanvas + Component layer modes Windows users can actually use today.
+        val isOnWindowLayer = layerType.equals("WINDOW", ignoreCase = true)
+        val isWindowsHost =
+            System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
+        assumeFalse(
+            isOnWindowLayer && isWindowsHost,
+            "compose.layers.type=WINDOW currently crashes JBR's skiko-windows-x64.dll on " +
+                "Windows; SameCanvas + Component modes work and cover the same WindowTracker " +
+                "discovery paths.",
+        )
         fixture.start()
     }
 

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
@@ -105,8 +105,15 @@ class SampleAppFixture(
     }
 
     fun stop() {
+        // Robust against `start()` never having been called: a JUnit `assumeFalse` in @BeforeAll
+        // skips the suite but @AfterAll still runs, so this method may be invoked even though
+        // `thread` was never initialized. Without the guard, that lifecycle path tripped on the
+        // `lateinit` access and surfaced as a confusing `initializationError` instead of the
+        // intended skip outcome.
         exitFn?.invoke()
-        thread.join(SHUTDOWN_TIMEOUT.inWholeMilliseconds)
+        if (::thread.isInitialized) {
+            thread.join(SHUTDOWN_TIMEOUT.inWholeMilliseconds)
+        }
     }
 
     private companion object {


### PR DESCRIPTION
## Summary

Closes #23. Runs the existing `validationTestPopupLayers` suite on Windows + JBR 21.0.9 and reports findings:

| `compose.layers.type` | Windows | macOS |
|---|---|---|
| `SAME_CANVAS` | ✅ PASS | ✅ PASS (existing) |
| `COMPONENT` | ✅ PASS | ✅ PASS (existing) |
| `WINDOW` | ❌ JBR/skiko crash — gated out | ✅ PASS (existing) |

`WindowTracker` and `SemanticsReader` need **zero changes** — the two layer modes that work on Windows exercise the same popup-discovery paths Spectre cares about, and they pass cleanly via the synthetic-input automator.

## What landed

1. **`PopupLayerVariantsValidationTest`** gains an `Assumptions.assumeFalse` that skips the OnWindow variant on Windows hosts with a clear reason. macOS keeps full coverage; Windows reports a clean skip instead of a confusing `<skipped/>` plus test-executor protocol noise from the crashed JVM.
2. **`SampleAppFixture.stop()`** guards against the `lateinit thread` access when `start()` was never called — the @AfterAll path that fires on `assumeFalse`-aborted suites was tripping with `kotlin.UninitializedPropertyAccessException` and masking the real skip outcome.

## What's the JBR crash?

Captured in three independent runs (different PIDs, identical signature):

```
EXCEPTION_ACCESS_VIOLATION (0xc0000005) at pc=0x00007ff89093ab9b
JRE: JBR-21.0.9+1-1038.76-nomod
Frame: skiko-windows-x64.dll+0x6ab9b
Stack:
  org.jetbrains.skia.PictureRecorderKt._nFinishRecordingAsPicture
  org.jetbrains.skia.PictureRecorder.finishRecordingAsPicture
  org.jetbrains.skiko.SkiaLayer.update$skiko
  org.jetbrains.skiko.redrawer.AWTRedrawer.update
```

The crash fires regardless of the `apple.awt.UIElement` system property and doesn't require the popup to be opened — it triggers during the first composition's render under `compose.layers.type=WINDOW`. This is a JBR/skiko issue, not Spectre's. **Tracked in #56**: drop the skip when JBR fixes it.

## Out of scope (tracked as follow-ups)

- **Jewel custom popup renderer** validation on Windows — needs the IntelliJ plugin running on Windows; gated on the macOS-only `ide-uitest.yml` workflow today. Tracked: **#57**.
- **`Window.getOwnedWindows()` semantics** — exercised implicitly by the SameCanvas/Component passing tests, no Frame-chrome ghost windows observed in the trackedWindows lists. Will revisit if a concrete failure surfaces. (Not separately filed — covered by overall regression coverage.)
- **IntelliJ-hosted ComposePanel discovery on Windows** — same constraint as the Jewel popup renderer; tracked under **#57**.
- **OnWindow popup mode JBR/skiko crash on Windows** — JBR-side bug. Tracked: **#56**.

## Test plan

- [x] `./gradlew :sample-desktop:validationTestPopupLayers` on Windows 11 / JBR 21
  - `validationTestLayerComponent` → 1/1 PASS
  - `validationTestLayerSameCanvas` → 1/1 PASS
  - `validationTestLayerWindow` → 1 SKIPPED (assumeFalse with reason)
- [x] Full `./gradlew check` green on Windows
- [x] No production-code changes (`WindowTracker`, `SemanticsReader`, `OverlayLayerInspector` untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)