### PR TITLE
ci: add Windows runner workflow (mirror of macos.yml)

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,77 @@
+name: Windows
+
+# Runs the JVM checks on a real Windows host so Spectre's v3 Windows code paths
+# (recording/FfmpegBackend gdigrab argv, core/HiDpiMapper validation tests, sample-desktop
+# Robot+popup smokes) get exercised end-to-end. The Linux `ci.yml` workflow already runs the
+# same `:check` task, but it can't catch:
+#   - argv-builder behaviour that diverges between gdigrab (Windows) and avfoundation (macOS)
+#     when the host OS picks a different FfmpegBackend by default.
+#   - Compose Desktop renderer regressions that only surface under skiko-windows-x64.dll.
+#   - Any future Windows-conditional test that an `os.name` check would skip on Linux.
+# Without this job, those regressions reach an end user before they reach CI.
+#
+# Notes:
+#   - The Windows-gated manual smokes (`:sample-desktop:runWindowsHiDpiDiagnostic`,
+#     `:sample-desktop:runWindowsRobotSmoke`, `:recording:runFfmpegGdigrabSmoke`) are *not*
+#     wired into `:check` and therefore not executed here — they require an interactive
+#     display + alwaysOnTop window manipulation that GitHub-hosted Windows runners don't
+#     reliably provide. They stay manual.
+#   - The validation `validationTestPopupLayers` task is also opt-in and not part of `:check`.
+#     The OnWindow popup variant currently crashes JBR's skiko on Windows (see #23); the test
+#     class `Assumptions.assumeFalse`-skips that variant on Windows hosts.
+#   - Job is gated on changes likely to affect Windows behaviour so unrelated PRs don't pay
+#     the windows-runner cost. Mirrors the path-filter pattern from `macos.yml`.
+
+on:
+  pull_request:
+    paths:
+      - "core/**"
+      - "recording/**"
+      - "sample-desktop/**"
+      - "server/**"
+      - "testing/**"
+      - "build.gradle.kts"
+      - "settings.gradle.kts"
+      - "gradle/**"
+      - ".github/workflows/windows.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "core/**"
+      - "recording/**"
+      - "sample-desktop/**"
+      - "server/**"
+      - "testing/**"
+      - "build.gradle.kts"
+      - "settings.gradle.kts"
+      - "gradle/**"
+      - ".github/workflows/windows.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check-windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        # Same Temurin choice as `ci.yml` — JBR 21 isn't currently in setup-java's index, and
+        # the toolchain version is what matters here (production code targets 21). Local dev
+        # keeps using JBR 21 via `JAVA_HOME`; revert to `jetbrains` here too once setup-java's
+        # JBR 21 entry returns.
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Run checks
+        run: ./gradlew check
+        shell: bash


### PR DESCRIPTION
## Summary

v3 added Windows-specific code paths (`FfmpegBackend.WindowsGdigrab` argv builder, `HiDpiMapper` Windows scenario tests, sample-desktop Robot + popup layer smokes), but CI only runs on `ubuntu-latest`. Bugbot caught one such regression on PR #51 (`FfmpegBackend.detect()` throwing at construction broke every `FfmpegRecorder` lifecycle test on the Linux runner) — exactly the kind of thing a Windows runner would catch before review.

Adds `.github/workflows/windows.yml`: a path-filtered `windows-latest` job that runs `./gradlew check`. Mirrors `macos.yml`'s pattern of gating on path changes likely to affect platform behaviour so unrelated PRs don't pay the windows-runner cost.

## Out of scope (tracked as follow-ups)

- **Windows-gated manual smokes** (`runWindowsHiDpiDiagnostic`, `runWindowsRobotSmoke`, `runFfmpegGdigrabSmoke`) — need an interactive display + alwaysOnTop window manipulation; GitHub-hosted Windows runners don't reliably provide that. They stay manual.
- **`:sample-desktop:validationTest*` opt-in tasks on Windows CI** — these pass locally on Windows for SameCanvas + Component popup modes, plus the Issue7/Issue8 multi-window flows. Wiring them into CI needs separate care: there's a known post-test "Could not write 127.0.0.1:NNNN" Gradle test-executor flake on Windows that masks the BUILD result even when tests pass cleanly. Tracked: **#58**.
- **`ide-uitest.yml` widening to Windows** — macOS-only today; unblocks Jewel popup + Robot text field validation on Windows. Tracked: **#57**.

## Test plan

- [x] YAML syntax validates locally (Gradle build still green on the worktree)
- [ ] First run of the workflow against this PR — the workflow is self-validating: it'll run on this PR's push to `feature/windows-ci` and either pass or surface what's missing
- [ ] Subsequent regressions: any PR touching `core/`, `recording/`, `sample-desktop/`, `server/`, `testing/`, or the Gradle config triggers it

🤖 Generated with [Claude Code](https://claude.com/claude-code)