### PR TITLE
docs: refresh IU/IC framing in :sample-intellij-plugin uiTest

### DIFF
--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -197,11 +197,11 @@ val uiTest by
         group = "verification"
         description =
             "IDE-hosted UI test for the Spectre sample plugin (intellij-ide-starter, #42). " +
-                "Boots an IntelliJ Ultimate IDE (2026.1.1) in a child process, installs the " +
-                "plugin from the local buildPlugin output, invokes `RunSpectreAction`, and " +
-                "asserts the expected semantics tags appear in idea.log. NOT wired into " +
-                ":check — opt-in. (IU rather than IC because IC 2026.1.x isn't on the public " +
-                "release feed yet.)"
+                "Boots an IntelliJ IDEA 2026.1.1 in a child process, installs the plugin from " +
+                "the local buildPlugin output, invokes `RunSpectreAction`, and asserts the " +
+                "expected semantics tags appear in idea.log. NOT wired into :check — opt-in. " +
+                "Targets IU because JetBrains stopped shipping a distinct IC distribution as " +
+                "of 253.x — IU is the unified IDEA product."
         useJUnitPlatform()
         testClassesDirs = uiTestSourceSet.output.classesDirs
         classpath = uiTestSourceSet.runtimeClasspath

--- a/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/RunSpectreUiTest.kt
+++ b/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/RunSpectreUiTest.kt
@@ -25,12 +25,12 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 /**
- * IDE-hosted validation for #42: boots a real IntelliJ Ultimate IDE via `intellij-ide-starter`,
- * installs the locally-built `:sample-intellij-plugin` zip, invokes `RunSpectreAction`, and asserts
- * the action's `[Spectre]` log lines mention every tagged node from
- * `SpectreSampleToolWindowContent`. (We'd prefer Community for parity with downstream OSS users,
- * but JetBrains hasn't released IC 2026.1.x yet — see the inline note on `IdeProductProvider.IU`
- * below.)
+ * IDE-hosted validation for #42: boots a real IntelliJ IDEA via `intellij-ide-starter`, installs
+ * the locally-built `:sample-intellij-plugin` zip, invokes `RunSpectreAction`, and asserts the
+ * action's `[Spectre]` log lines mention every tagged node from `SpectreSampleToolWindowContent`.
+ * As of the 253.x (2026.1.x) line, JetBrains stopped shipping a distinct IntelliJ Community Edition
+ * — IDEA Ultimate is now the unified product under a freemium licence, so this test naturally
+ * targets IU.
  *
  * Counterpart to the manual `./gradlew :sample-intellij-plugin:runIde` smoke that landed with #43 —
  * same assertions, no human in the loop. CI runs this only when the plugin or recording sources
@@ -58,22 +58,15 @@ class RunSpectreUiTest {
             Starter.newContext(
                     CurrentTestMethod.hyphenateWithClass(),
                     // The plugin compiles against IntelliJ IDEA 2026.1.1 (build
-                    // 261.23567.138 = IU). Ideally we'd test against IC for parity with
-                    // OSS distribution, but JetBrains hasn't released IC 2026.1.x to the
-                    // public download feed yet — latest published IC release is 2025.2.6.1
-                    // (build 252.28539.33), which doesn't match our plugin's compile
-                    // target. Using IU here means the IDE matches what `runIde` boots; the
-                    // plugin's classloader sees the SAME bundled Compose / Jewel / skiko
-                    // jars locally and in this test, so a plugin-load regression that only
-                    // surfaces against 2026.1's bundled modules is caught here.
+                    // 261.23567.138 = IU). As of the 253.x line JetBrains stopped shipping a
+                    // distinct Community Edition — IU is the unified IDEA product under a
+                    // freemium licence — so `IdeProductProvider.IU` is the only thing
+                    // ide-starter has for 2026.1.x and this test targets it directly.
                     //
                     // We do NOT call `setLicense(...)` — invokeAction-only flows against
-                    // an empty project don't need an Ultimate license. If the IDE later
-                    // refuses to start because of license validation, that's the signal
-                    // to wire `LICENSE_KEY` from a CI secret.
-                    //
-                    // Switch to `IdeProductProvider.IC` once IC 2026.1.x ships on the
-                    // public release feed.
+                    // an empty project don't need a paid licence. If the IDE later refuses
+                    // to start because of licence validation, that's the signal to wire
+                    // `LICENSE_KEY` from a CI secret.
                     TestCase(
                         IdeProductProvider.IU.copy(
                             buildType = "release",


### PR DESCRIPTION
## Summary

As of the 253.x (2026.1.x) line, JetBrains stopped shipping a distinct IntelliJ Community Edition — IDEA Ultimate is the unified product under a freemium licence. PR #50's \`uiTest\` carried four "switch to IC once 2026.1.x ships" comments that pre-date that change and are now permanently stale (IC 2026.1.x is never coming).

This is a docs-only refresh: updates the file KDoc on \`RunSpectreUiTest\`, the inline \`IdeProductProvider\` note, and the Gradle task description. **No test behaviour changes.**

## Test plan

- [x] Full \`./gradlew check\` green on Windows JBR 21
- [x] No production-code touched

Closes #63 (filed earlier in the v3 wrap-up sweep before I was reminded of the 253.x consolidation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)