### PR TITLE
ci: add macos-check workflow for OS-matrix parity with windows.yml

### DIFF
--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -1,0 +1,70 @@
+name: macOS check
+
+# Runs the JVM checks on a real macOS host for full-OS-matrix parity with `ci.yml` (ubuntu)
+# and `windows.yml` (Windows). The existing `macos.yml` is *focused* — it builds the SCK Swift
+# helper and runs `:recording:check` only, gated on `recording/**`. That doesn't catch macOS-
+# specific regressions in `core/`, `server/`, `sample-desktop/`, or `testing/`.
+#
+# The split into two macOS workflows is intentional: `macos.yml` stays small + fast and only
+# fires when the recording surface changes, while this `macos-check` job mirrors the broader
+# path filter from `windows.yml` so any PR likely to affect cross-OS behaviour gets exercised
+# on a real mac runner. macOS-* runners are slower and more expensive than ubuntu, so the path
+# filter keeps unrelated PRs (docs, plugin-only, etc.) out of this job.
+#
+# Notes:
+#   - `:recording:check` runs here too as a side effect of `:check`, so this overlaps with
+#     `macos.yml`'s focused job. That's OK — the focused job is faster + has its own Swift
+#     helper-build step, so it stays the primary signal for recording-only changes.
+#   - End-to-end SCK recording isn't exercised here either (CI runners don't have Screen
+#     Recording TCC); the helper contract test stays unchanged.
+
+on:
+  pull_request:
+    paths:
+      - "core/**"
+      - "recording/**"
+      - "sample-desktop/**"
+      - "server/**"
+      - "testing/**"
+      - "build.gradle.kts"
+      - "settings.gradle.kts"
+      - "gradle/**"
+      - ".github/workflows/macos-check.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "core/**"
+      - "recording/**"
+      - "sample-desktop/**"
+      - "server/**"
+      - "testing/**"
+      - "build.gradle.kts"
+      - "settings.gradle.kts"
+      - "gradle/**"
+      - ".github/workflows/macos-check.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  check-macos:
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        # Same Temurin choice as ci.yml + windows.yml — JBR 21 isn't currently in setup-java's
+        # index. Revert to `jetbrains` here too once setup-java's JBR 21 entry returns.
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Run checks
+        run: ./gradlew check


### PR DESCRIPTION
## Summary

PR #60 added \`windows.yml\` running full \`./gradlew check\` on \`windows-latest\` with broad path filters. \`macos.yml\` stays focused on the SCK helper (\`:recording:check\`, gated narrowly on \`recording/**\`) — that's fast Swift-toolchain coverage but it doesn't catch macOS-specific regressions in \`core/\`, \`server/\`, \`sample-desktop/\`, or \`testing/\`.

PR #60 itself proved the gap visually:

> *(rock3r's screenshot of #60's checks page: CI ✓, Bugbot ✓, Windows ✓, **no macOS check fired**.)*

This adds \`.github/workflows/macos-check.yml\` mirroring \`windows.yml\`'s shape: \`macos-latest\` runner, full \`:check\`, broad path filter on the JVM modules likely to affect cross-OS behaviour. The OS matrix becomes:

| Workflow | Runner | Task | Path filter | Purpose |
|---|---|---|---|---|
| \`ci.yml\` | ubuntu-latest | \`:check\` | always | unconditional ground truth |
| \`macos.yml\` | macos-latest | \`:recording:check\` + Swift helper build | \`recording/**\` | focused SCK helper validation |
| \`macos-check.yml\` | macos-latest | \`:check\` | broad | macOS parity with Windows |
| \`windows.yml\` | windows-latest | \`:check\` | broad | Windows parity (PR #60) |
| \`ide-uitest.yml\` | macos-latest | \`:sample-intellij-plugin:uiTest\` | plugin/core/recording | IDE-hosted Jewel coverage |

Two macOS workflows is deliberate — the focused \`recording-macos\` job stays the primary signal for recording-only changes (faster, builds the Swift helper as a separate step), this one widens to general parity.

## Test plan

- [x] YAML structure mirrors \`windows.yml\` (same path filters, same setup steps, same Temurin distribution)
- [ ] First run of the workflow against this PR — the workflow is self-validating: it'll trigger because this PR touches \`.github/workflows/macos-check.yml\`. Either it passes or surfaces what's missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)