### PR TITLE
ci: make Windows ide-uitest a required merge gate (#71)

### DIFF
--- a/.github/workflows/ide-uitest.yml
+++ b/.github/workflows/ide-uitest.yml
@@ -56,13 +56,6 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
-    # Windows is **informational** for now: the GitHub-hosted Windows runner runs as
-    # `runneradmin` (elevated), the JetBrains Daemon's de-elevation step fails repeatedly,
-    # and project open hangs silently for 2-3+ minutes — bumping `waitForProjectOpen`'s
-    # timeout to 3 minutes was insufficient. macOS gates the merge; Windows surfaces issues
-    # without blocking until the underlying environment fight is resolved. Tracked as
-    # https://github.com/rock3r/spectre/issues/71.
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary

- Drops `continue-on-error: ${{ matrix.os == 'windows-latest' }}` (and the explanatory comment block) from the `uitest` job in [`.github/workflows/ide-uitest.yml`](.github/workflows/ide-uitest.yml) so Windows is now a real merge gate alongside macOS.
- Follow-up to [#73](https://github.com/rock3r/spectre/pull/73), which fixed the Windows-side hang at the source: jetbrainsd discovery / URI handling disabled, project path resolved to its long form so `Starter.newContext`'s auto-trust matches at runtime, and `idea.trust.all.projects=true` set as belt-and-braces.

The Windows leg passed on [#73](https://github.com/rock3r/spectre/pull/73)'s round-3 run and on the post-merge push to `main`, so it's safe to demote it from informational to required.

## Test plan

- [x] No-op locally — the only change is a workflow-level YAML edit.
- [ ] Confirm both `uitest (macos-latest)` and `uitest (windows-latest)` show as required checks on this PR (no `continue-on-error` skip).
- [ ] Merge once both go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)