### PR TITLE
feat: Linux x11grab recording backend (#75)

### DIFF
--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -247,3 +247,14 @@ tasks.register<JavaExec>("runFfmpegGdigrabSmoke") {
     classpath = sourceSets["test"].runtimeClasspath
     mainClass.set("dev.sebastiano.spectre.recording.FfmpegGdigrabSmoke")
 }
+
+// Manual smoke for the Linux x11grab path (#75). Counterpart to the gdigrab/SCK smokes.
+// Requires a working X display (`DISPLAY` env var) — Wayland-only sessions without XWayland
+// will fail at ffmpeg-spawn time, which is the right failure mode for a manual smoke.
+tasks.register<JavaExec>("runFfmpegX11GrabSmoke") {
+    group = "verification"
+    description = "Boots a JFrame, records it for ~3s via x11grab, prints output stats."
+    onlyIf { OperatingSystem.current().isLinux }
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.sebastiano.spectre.recording.FfmpegX11GrabSmoke")
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -28,9 +28,10 @@ import java.nio.file.Path
  *    path (see step 4).
  * 4. Non-macOS host without an applicable [windowsWindowRecorder] OR with a blank/null title →
  *    ffmpeg region capture. The region path is the documented fallback when the target window title
- *    is missing, ambiguous, or points at a tool window with no top-level title. On Windows the
- *    underlying [FfmpegRecorder] uses gdigrab region selection ([FfmpegBackend.detect] picks the
- *    backend); on Linux it currently throws via [FfmpegBackend.detect] — tracked under v4.
+ *    is missing, ambiguous, or points at a tool window with no top-level title. The underlying
+ *    [FfmpegRecorder]'s [FfmpegBackend.detect] picks the platform device: gdigrab on Windows,
+ *    x11grab on Linux. Wayland-without-XWayland sessions surface as a clear ffmpeg-side "cannot
+ *    open display" at spawn time — Wayland-native capture is a separate, future backend.
  *
  * The router always needs both a window AND a region: the region is used as the fallback when the
  * window-targeted path isn't applicable. If you don't have a region (e.g. no clear bounds for a

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegBackend.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegBackend.kt
@@ -11,6 +11,9 @@ import java.nio.file.Path
  *   Screen Recording permission.
  * - [WindowsGdigrab] — `-f gdigrab` with input-side `-offset_x`/`-offset_y`/`-video_size` region
  *   selection. No equivalent of macOS's TCC permission gate, but the window must be visible.
+ * - [LinuxX11Grab] — `-f x11grab` with input-side `-video_size` and the `<display>+x,y` URL form
+ *   for region selection. Reads the `DISPLAY` env var at argv build time, falling back to `:0.0`.
+ *   X11 only — Wayland session capture needs PipeWire + xdg-desktop-portal and isn't covered.
  *
  * The backend is selected at [FfmpegRecorder] construction time via [detect], which inspects
  * `os.name` (the same approach the rest of the module uses — see `MacOsRecordingPermissions`).
@@ -45,24 +48,43 @@ internal sealed interface FfmpegBackend {
         ): List<String> = FfmpegCli.gdigrabRegionCapture(ffmpegPath, region, output, options)
     }
 
+    object LinuxX11Grab : FfmpegBackend {
+        override fun buildRegionArgv(
+            ffmpegPath: Path,
+            region: Rectangle,
+            output: Path,
+            options: RecordingOptions,
+        ): List<String> {
+            // X11's display name is conventionally read from the `DISPLAY` env var. Most desktop
+            // sessions set it (`:0`, `:0.0`, `:1`, etc.); over SSH-without-X-forwarding it's
+            // unset. Fall back to `:0.0` so a misconfigured environment produces a clear
+            // ffmpeg-side "cannot open display" error rather than a confusing argv NPE.
+            val display = System.getenv("DISPLAY")?.takeIf { it.isNotBlank() } ?: ":0.0"
+            return FfmpegCli.x11grabRegionCapture(ffmpegPath, region, output, options, display)
+        }
+    }
+
     companion object {
 
         /**
          * Resolves the backend for the current OS. macOS → [MacOsAvfoundation]; Windows →
-         * [WindowsGdigrab]. Any other host (Linux, BSD) throws [UnsupportedOperationException] with
-         * a message naming the OS — the v4 Linux backend (X11Grab / Wayland) lands here when
-         * implemented.
+         * [WindowsGdigrab]; Linux → [LinuxX11Grab]. Any other host (BSD, Solaris) throws
+         * [UnsupportedOperationException] with a message naming the OS.
+         *
+         * Linux's selection is X11-only — a host running a Wayland session without XWayland will
+         * see x11grab fail at ffmpeg-spawn time. Wayland-native capture (PipeWire +
+         * xdg-desktop-portal) is a separate backend tracked as a follow-up.
          */
         fun detect(): FfmpegBackend {
             val osName = System.getProperty("os.name").orEmpty()
             return when {
                 osName.lowercase().contains("mac") -> MacOsAvfoundation
                 osName.lowercase().contains("windows") -> WindowsGdigrab
+                osName.lowercase().contains("linux") -> LinuxX11Grab
                 else ->
                     throw UnsupportedOperationException(
                         "FfmpegRecorder has no backend for os.name=\"$osName\". " +
-                            "Supported: macOS (avfoundation), Windows (gdigrab). " +
-                            "Linux X11Grab/Wayland support is tracked under v4."
+                            "Supported: macOS (avfoundation), Windows (gdigrab), Linux (x11grab)."
                     )
             }
         }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegCli.kt
@@ -15,6 +15,8 @@ import java.nio.file.Path
  * - [gdigrabRegionCapture] — Windows region capture via the gdigrab device, with the region
  *   selected on the input side via offsets and `-video_size` (no crop filter).
  * - [gdigrabWindowCapture] — Windows title-based window capture via the gdigrab device.
+ * - [x11grabRegionCapture] — Linux X11 region capture via the x11grab device, with the region
+ *   selected on the input side via the `<display>+x,y` URL form and `-video_size`.
  */
 internal object FfmpegCli {
 
@@ -153,6 +155,65 @@ internal object FfmpegCli {
             // The full string after `title=` is the match key, including any spaces. Each argv
             // element is a separate token, so we don't need (and must not add) shell quoting.
             add("title=$windowTitle")
+            add("-c:v")
+            add(options.codec)
+            add(output.toString())
+        }
+    }
+
+    /**
+     * Builds the argv for a Linux X11 region capture via the x11grab device.
+     *
+     * x11grab takes the display + offset baked into the input URL (`<display>+x,y`) and the size
+     * via `-video_size`, mirroring gdigrab's input-side approach. No crop filter, no silent-clamp
+     * pitfall. Negative offsets are accepted: X11 multi-monitor setups can position monitors at any
+     * coordinate within the screen's pixel space, and ffmpeg's x11grab is documented to support
+     * negative offsets up to the display's `XDisplayWidth`/`XDisplayHeight` bounds.
+     *
+     * [displayName] is the X display selector, normally read from the `DISPLAY` env var (e.g. `:0`,
+     * `:0.0`, `:1`). Callers from Spectre go through [FfmpegBackend.LinuxX11Grab] which handles the
+     * env read; this function takes it explicitly so the argv stays a pure function of its inputs.
+     *
+     * X11-only: a Wayland session without XWayland produces ffmpeg "cannot open display" at spawn
+     * time. Wayland-native capture (PipeWire + xdg-desktop-portal) is a separate backend.
+     *
+     * [RecordingOptions.screenIndex] is intentionally unused here — X11 multi-monitor presents as a
+     * single combined display, and the region's origin already encodes which monitor is targeted.
+     */
+    fun x11grabRegionCapture(
+        ffmpegPath: Path,
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+        displayName: String,
+    ): List<String> {
+        require(region.width > 0 && region.height > 0) {
+            "region must have positive dimensions, was ${region.width}x${region.height}"
+        }
+        require(displayName.isNotBlank()) {
+            "displayName must not be blank — pass the X display selector (e.g. \":0\", \":0.0\")"
+        }
+        return buildList {
+            add(ffmpegPath.toString())
+            add("-loglevel")
+            add("warning")
+            add("-y")
+            // x11grab input options must precede `-i`. -framerate is the capture rate;
+            // -draw_mouse toggles cursor compositing on the captured frames; -video_size sets
+            // the captured area dimensions. The offset goes into the `-i` URL after `+`.
+            add("-f")
+            add("x11grab")
+            add("-framerate")
+            add(options.frameRate.toString())
+            add("-draw_mouse")
+            add(if (options.captureCursor) "1" else "0")
+            add("-video_size")
+            add("${region.width}x${region.height}")
+            add("-i")
+            // x11grab's URL form is `<display>+<x>,<y>` (e.g. `:0.0+100,200`). The offset is
+            // part of the input URL itself, not a separate `-offset_x`/`-offset_y` pair like
+            // gdigrab — that's an x11grab-specific quirk in ffmpeg's input device API.
+            add("$displayName+${region.x},${region.y}")
             add("-c:v")
             add(options.codec)
             add(output.toString())

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegCliTest.kt
@@ -291,6 +291,129 @@ class FfmpegCliTest {
             FfmpegCli.gdigrabWindowCapture(ffmpeg, "   ", output, RecordingOptions())
         }
     }
+
+    // -----------------------------------------------------------------------
+    // x11grabRegionCapture (Linux): -f x11grab with the offset baked into the
+    // input URL (`<display>+x,y`) and -video_size for the captured area. Like
+    // gdigrab this uses input-side region selection — no crop filter, no
+    // silent-clamp pitfall.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `x11grab region argv starts with the ffmpeg path`() {
+        val argv = FfmpegCli.x11grabRegionCapture(ffmpeg, region, output, RecordingOptions(), ":0")
+        assertEquals(ffmpeg.toString(), argv.first())
+    }
+
+    @Test
+    fun `x11grab region argv selects x11grab device with framerate and cursor flag`() {
+        val argv =
+            FfmpegCli.x11grabRegionCapture(
+                ffmpeg,
+                region,
+                output,
+                RecordingOptions(frameRate = 60, captureCursor = false),
+                ":0",
+            )
+        assertContainsSequence(argv, listOf("-f", "x11grab"))
+        assertContainsSequence(argv, listOf("-framerate", "60"))
+        // x11grab uses -draw_mouse (input option) for cursor capture, matching gdigrab.
+        assertContainsSequence(argv, listOf("-draw_mouse", "0"))
+    }
+
+    @Test
+    fun `x11grab region argv bakes offset into the input URL after the display name`() {
+        // The x11grab URL form is `<display>+<x>,<y>` — the offset is part of the input URL,
+        // unlike gdigrab's separate `-offset_x` / `-offset_y` pair. Verifying the exact form
+        // here so a refactor that drops the `+` or swaps the comma surfaces in tests.
+        val argv =
+            FfmpegCli.x11grabRegionCapture(ffmpeg, region, output, RecordingOptions(), ":0.0")
+        assertContainsSequence(argv, listOf("-video_size", "640x480"))
+        assertContainsSequence(argv, listOf("-i", ":0.0+100,200"))
+        // No `-vf crop=...` — x11grab handles the region on the input side.
+        assertTrue("-vf" !in argv, "Should not use a crop filter for x11grab: $argv")
+    }
+
+    @Test
+    fun `x11grab region argv honours the requested display name`() {
+        // Multi-seat / multi-display X setups put each session on a different display number
+        // (`:0`, `:1`, `:2`...). Make sure the value the caller passes ends up in the input URL.
+        val argv = FfmpegCli.x11grabRegionCapture(ffmpeg, region, output, RecordingOptions(), ":1")
+        assertContainsSequence(argv, listOf("-i", ":1+100,200"))
+    }
+
+    @Test
+    fun `x11grab region argv allows negative offsets for non-primary monitors`() {
+        // X11 with XRandR composites monitors into one virtual screen; depending on the user's
+        // arrangement a monitor can sit at any offset within that combined space, including
+        // negative coords if it's positioned to the left/above. ffmpeg's x11grab handles
+        // negative offsets within the display's bounds.
+        val negative = Rectangle(-1920, 0, 1920, 1080)
+        val argv =
+            FfmpegCli.x11grabRegionCapture(ffmpeg, negative, output, RecordingOptions(), ":0.0")
+        assertContainsSequence(argv, listOf("-video_size", "1920x1080"))
+        assertContainsSequence(argv, listOf("-i", ":0.0+-1920,0"))
+    }
+
+    @Test
+    fun `x11grab region argv applies the configured codec and output path`() {
+        val argv =
+            FfmpegCli.x11grabRegionCapture(
+                ffmpeg,
+                region,
+                output,
+                RecordingOptions(codec = "libx264"),
+                ":0",
+            )
+        assertContainsSequence(argv, listOf("-c:v", "libx264"))
+        assertEquals(output.toString(), argv.last())
+    }
+
+    @Test
+    fun `x11grab region argv always passes -y to overwrite the output file`() {
+        val argv = FfmpegCli.x11grabRegionCapture(ffmpeg, region, output, RecordingOptions(), ":0")
+        assertTrue("-y" in argv, "Should pass -y to overwrite: $argv")
+    }
+
+    @Test
+    fun `x11grab region argv quiets ffmpeg log noise via -loglevel warning`() {
+        val argv = FfmpegCli.x11grabRegionCapture(ffmpeg, region, output, RecordingOptions(), ":0")
+        assertContainsSequence(argv, listOf("-loglevel", "warning"))
+    }
+
+    @Test
+    fun `x11grab region argv rejects non-positive dimensions`() {
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.x11grabRegionCapture(
+                ffmpeg,
+                Rectangle(0, 0, 0, 100),
+                output,
+                RecordingOptions(),
+                ":0",
+            )
+        }
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.x11grabRegionCapture(
+                ffmpeg,
+                Rectangle(0, 0, 100, 0),
+                output,
+                RecordingOptions(),
+                ":0",
+            )
+        }
+    }
+
+    @Test
+    fun `x11grab region argv rejects blank display name`() {
+        // A blank display selector is a configuration error, not a meaningful default — surface
+        // it here rather than letting ffmpeg report "cannot open display +0,0" at spawn time.
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.x11grabRegionCapture(ffmpeg, region, output, RecordingOptions(), "")
+        }
+        assertFailsWith<IllegalArgumentException> {
+            FfmpegCli.x11grabRegionCapture(ffmpeg, region, output, RecordingOptions(), "   ")
+        }
+    }
 }
 
 private fun assertContainsSequence(argv: List<String>, expected: List<String>) {

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegX11GrabSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegX11GrabSmoke.kt
@@ -1,0 +1,152 @@
+@file:JvmName("FfmpegX11GrabSmoke")
+
+package dev.sebastiano.spectre.recording
+
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.Font
+import java.awt.Robot
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.imageio.ImageIO
+import javax.swing.JFrame
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/**
+ * Manual end-to-end smoke for the Linux `x11grab` recording path. Run via `./gradlew
+ * :recording:runFfmpegX11GrabSmoke` — opens a small JFrame, records it for ~3 seconds via
+ * [FfmpegRecorder] bound to [FfmpegBackend.LinuxX11Grab], prints the resulting file path + size.
+ * Eyeball the .mp4 to confirm window content + cursor capture + frame timing look right.
+ *
+ * Counterpart to [FfmpegGdigrabSmoke] (Windows) and `ScreenCaptureKitRecorderSmoke` (macOS). Uses a
+ * plain Swing JFrame rather than Compose so this stays inside the recording module's dependency
+ * boundary.
+ *
+ * Requires an X display (the `DISPLAY` env var must point at a running X server). Wayland-only
+ * sessions without XWayland will fail at ffmpeg-spawn time with a "cannot open display" error —
+ * that's the right failure mode for a smoke; native Wayland capture is a separate backend.
+ */
+fun main() {
+    var exitCode = 0
+    try {
+        runSmoke()
+    } catch (t: Throwable) {
+        // Print full stack as a single multiline string rather than .printStackTrace() so the
+        // detekt PrintStackTrace rule isn't tripped — manual smoke entry point, not production.
+        System.err.println("Smoke failed: ${t.message}\n${t.stackTraceToString()}")
+        exitCode = 1
+    } finally {
+        exitProcess(exitCode)
+    }
+}
+
+private fun runSmoke() {
+    val output = Path.of(System.getProperty("java.io.tmpdir"), "spectre-x11grab-smoke.mp4")
+    val midRecordingPng = Path.of(System.getProperty("java.io.tmpdir"), "spectre-x11grab-smoke.png")
+    Files.deleteIfExists(output)
+    Files.deleteIfExists(midRecordingPng)
+
+    val (frame, label) = openSmokeWindow()
+    Thread.sleep(WINDOW_SETTLE_MS)
+
+    // Force the LinuxX11Grab backend regardless of host so this smoke is meaningful even when
+    // launched from a script that doesn't pre-check the OS. (The Gradle task is gated on Linux,
+    // but invoking the main directly from an IDE on macOS shouldn't silently fall through to
+    // avfoundation and produce a confusing recording.)
+    val recorder = FfmpegRecorder.withBackend(FfmpegBackend.LinuxX11Grab)
+    val frameBoundsAtStart = frame.bounds
+    val handle =
+        recorder.start(
+            region = frameBoundsAtStart,
+            output = output,
+            options = RecordingOptions(frameRate = 30, captureCursor = true),
+        )
+
+    println("Recording started → $output (pid=${ProcessHandle.current().pid()})")
+
+    var ticks = 0
+    val animator =
+        Thread.ofPlatform().daemon().name("spectre-x11grab-smoke-animator").start {
+            val deadline = System.nanoTime() + RECORD_DURATION_MS * 1_000_000L
+            while (System.nanoTime() < deadline && !Thread.currentThread().isInterrupted) {
+                ticks += 1
+                val current = ticks
+                SwingUtilities.invokeLater { label.text = "tick=$current" }
+                Thread.sleep(ANIMATION_INTERVAL_MS.toLong())
+            }
+        }
+
+    // Halfway through, take a JVM-side `Robot` screenshot of the JFrame's bounds. If THAT
+    // shows the tick text, Swing is painting and any blankness in the .mp4 is on the x11grab
+    // side. If it does NOT, Swing isn't painting and we have a UI bug to chase.
+    Thread.sleep(RECORD_DURATION_MS / 2)
+    val frameBounds = frame.bounds
+    val robotShot = Robot().createScreenCapture(frameBounds)
+    ImageIO.write(robotShot, "png", File(midRecordingPng.toString()))
+    println("Robot screenshot of JFrame bounds $frameBounds → $midRecordingPng")
+
+    animator.join()
+    println("Animation done — ticks fired: $ticks")
+
+    handle.stop()
+    val sizeBytes = if (Files.exists(output)) Files.size(output) else -1
+    println("Recording stopped → $output ($sizeBytes bytes)")
+
+    SwingUtilities.invokeLater {
+        frame.isVisible = false
+        frame.dispose()
+    }
+}
+
+private fun openSmokeWindow(): Pair<JFrame, JLabel> {
+    val ready = CountDownLatch(1)
+    var frameRef: JFrame? = null
+    var labelRef: JLabel? = null
+    SwingUtilities.invokeLater {
+        val label =
+            JLabel("tick=0", SwingConstants.CENTER).apply {
+                font = Font(Font.SANS_SERIF, Font.BOLD, LABEL_FONT_SIZE)
+                foreground = Color.BLACK
+            }
+        val panel =
+            JPanel(BorderLayout()).apply {
+                background = Color.WHITE
+                isOpaque = true
+                add(label, BorderLayout.CENTER)
+            }
+        val frame =
+            JFrame("Spectre x11grab smoke").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                contentPane = panel
+                preferredSize = Dimension(WINDOW_WIDTH, WINDOW_HEIGHT)
+                pack()
+                setLocationRelativeTo(null)
+                isVisible = true
+                toFront()
+                requestFocus()
+            }
+        frameRef = frame
+        labelRef = label
+        ready.countDown()
+    }
+    check(ready.await(WINDOW_OPEN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        "JFrame never came up within ${WINDOW_OPEN_TIMEOUT_SECONDS}s"
+    }
+    return frameRef!! to labelRef!!
+}
+
+private const val WINDOW_WIDTH = 480
+private const val WINDOW_HEIGHT = 240
+private const val WINDOW_SETTLE_MS = 500L
+private const val WINDOW_OPEN_TIMEOUT_SECONDS = 5L
+private const val RECORD_DURATION_MS = 3_000L
+private const val ANIMATION_INTERVAL_MS = 50
+private const val LABEL_FONT_SIZE = 48


### PR DESCRIPTION
## Summary

Closes #75. Adds the third `FfmpegBackend` variant — `LinuxX11Grab` — so calling `FfmpegRecorder.start()` on Linux works instead of throwing `UnsupportedOperationException`. Mirrors the Windows gdigrab work from #22 / #55.

## Changes

- **`FfmpegBackend.LinuxX11Grab`** reads the `DISPLAY` env var (falls back to `:0.0`) and delegates to a new `FfmpegCli.x11grabRegionCapture` argv builder.
- **`FfmpegBackend.detect()`** now picks `LinuxX11Grab` on `os.name=linux*`. The unsupported-OS exception lists the new backend.
- **`FfmpegCli.x11grabRegionCapture`** — pure argv builder. x11grab uses input-side region selection like gdigrab, but the offset is baked into the input URL as `<display>+x,y` (an x11grab-specific quirk; gdigrab uses separate `-offset_x`/`-offset_y`), with `-video_size` for dimensions. No crop filter, no silent-clamp pitfall.
- **`AutoRecorder` KDoc** dropped the stale "Linux throws via `FfmpegBackend.detect` — tracked under v4" wording. Routing was already correct, Linux just needed the backend wired.

## Tests

9 new cases in `FfmpegCliTest` mirroring the gdigrab block: device/framerate/cursor flag, URL-form offset baking, display-name threading, negative offsets allowed for non-primary monitors, codec/output, `-y`, `-loglevel`, dimension validation, blank-display rejection. Pure argv assertions, so they run on every host (CI, macOS, Windows) just like the gdigrab ones do.

`FfmpegX11GrabSmoke` + `:recording:runFfmpegX11GrabSmoke` parallel the gdigrab pair. Validated end-to-end on Hyper-V Ubuntu 22.04 today: 60 animation ticks captured into a valid 4.5 KB mp4, `file` reports `ISO Media, MP4 Base Media v1`.

## Out of scope (follow-ups)

- **Wayland-native capture** (PipeWire + xdg-desktop-portal) — separate backend. Wayland-only sessions without XWayland surface as a clear ffmpeg "cannot open display" at spawn time, which is the right failure mode for a v4 first cut.
- **Linux validation tests in CI** — `:sample-desktop:validationTest*` were green out-of-the-box on the VM. A Linux equivalent of `validation-windows.yml` would shift that into CI; deferring until/unless we see drift.
- **Linux IDE-hosted UI test** — `ide-uitest.yml` still skips Linux on purpose. Adding it would need `xvfb-run` + a software GL stack and was explicitly excluded in the workflow's preamble.

## Test plan

- [x] `:recording:check` green on Linux (Hyper-V Ubuntu 22.04, JDK 21).
- [x] `:recording:check` green on Windows (local).
- [x] `runFfmpegX11GrabSmoke` produces a valid mp4 against a real X display.
- [ ] CI: Linux `:check`, macOS `:check`, Windows `:check`, `ide-uitest` matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)