### PR TITLE
ci: add Linux to ide-uitest.yml matrix

### DIFF
--- a/.github/workflows/ide-uitest.yml
+++ b/.github/workflows/ide-uitest.yml
@@ -9,11 +9,17 @@ name: IDE UI test
 #   - First run downloads ~1 GB IDE installer (cached afterwards via the `ide-starter-cache`
 #     step below).
 #   - Even cached, each scenario boots a real IDE — multi-second startup cost per test.
-#   - The OS matrix (macos-latest + windows-latest) covers both supported Spectre platforms.
-#     Linux is intentionally excluded — it would need `xvfb-run` plus a software-GL stack, and
-#     any rendering quirk in that stack would shift the failure mode away from "regression in
-#     our plugin code". macOS + Windows give us the same Compose runtime everyone develops
-#     against and match the manual `runIde` smokes.
+#   - The OS matrix covers all three desktop platforms Spectre supports — macOS + Windows +
+#     Linux. The Linux leg runs under `xvfb-run` (Xorg virtual framebuffer; no compositor, no
+#     real GPU) and ships the same apt + Rust toolchain setup as `validation-linux.yml`
+#     because `:sample-intellij-plugin` pulls in `:recording`, whose `processResources`
+#     builds the Rust helper on Linux hosts (#80).
+#
+#     Linux was originally excluded over rendering-stack risk; re-included once the Linux
+#     Wayland recording path landed in #82, on the principle that platforms we claim to
+#     support should be in the IDE-hosted matrix too. If skiko-under-xvfb starts producing
+#     flakes that don't reproduce on real Linux hardware, document the symptom here and
+#     take the leg back out.
 #   - Path filter keeps unrelated PRs from paying the IDE-runner cost.
 #
 # Local invocation: `./gradlew :sample-intellij-plugin:uiTest`.
@@ -50,11 +56,11 @@ permissions:
 jobs:
   uitest:
     strategy:
-      # `fail-fast: false` so a Windows-side regression doesn't cancel the macOS run mid-flight
-      # (or vice versa). Each platform's failure deserves its own diagnostic / artefact dump.
+      # `fail-fast: false` so a regression on one OS doesn't cancel the other legs mid-flight.
+      # Each platform's failure deserves its own diagnostic / artefact dump.
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-latest, ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -72,6 +78,26 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v5
 
+      - name: Install Xvfb + libdbus + pkg-config (Linux only)
+        # Linux runners need three things macOS / Windows don't:
+        #   - Xvfb so the IDE has a display (no real screen on the runner; we run gradle
+        #     under `xvfb-run` below).
+        #   - libdbus-1-dev + pkg-config for the spectre-wayland-helper Rust build that
+        #     :recording's processResources kicks off on Linux hosts (#80). The IDE plugin
+        #     depends on :recording transitively, so the helper has to build before the
+        #     plugin zip is assembled.
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libdbus-1-dev pkg-config
+
+      - name: Set up Rust (Linux only, for spectre-wayland-helper)
+        # Mirrors the dtolnay/rust-toolchain@stable usage in ci.yml + validation-linux.yml.
+        # macOS / Windows runners don't run the cargo task (it's gated on `isLinux` in
+        # recording/build.gradle.kts) so they don't need Rust.
+        if: runner.os == 'Linux'
+        uses: dtolnay/rust-toolchain@stable
+
       # ide-starter writes IDE installers and extracted builds under
       # `out/ide-tests/{installers,cache}` — re-using these between runs cuts the cold-start
       # cost from ~10 minutes (DMG/EXE download + extract) to ~30 seconds (existence check).
@@ -79,10 +105,10 @@ jobs:
       # cached: it's per-test-method scratch space that includes the IDE config, indexes, and
       # idea.log, all of which must be fresh each run.
       #
-      # Cache key includes the runner OS so Windows and macOS get separate caches (different
-      # installer formats, different extracted layouts), and the IDE build number from
-      # libs.versions.toml so a version bump busts the cache rather than silently re-using
-      # stale bits.
+      # Cache key includes the runner OS so each platform gets its own cache (different
+      # installer formats — DMG / exe / tar.gz — and different extracted layouts), and the
+      # IDE build number from libs.versions.toml so a version bump busts the cache rather
+      # than silently re-using stale bits.
       - name: Restore ide-starter cache
         uses: actions/cache@v4
         with:
@@ -93,11 +119,22 @@ jobs:
           restore-keys: |
             ide-starter-${{ runner.os }}-
 
-      - name: Run IDE UI test
+      - name: Run IDE UI test (macOS / Windows)
+        if: runner.os != 'Linux'
         run: ./gradlew :sample-intellij-plugin:uiTest
         # Use bash explicitly on Windows so the `./gradlew` invocation is identical across the
-        # matrix. Default Windows shell is pwsh which has different path-resolution semantics
-        # for `./` prefixes; bash keeps the script identical to ci.yml + windows.yml.
+        # non-Linux legs. Default Windows shell is pwsh which has different path-resolution
+        # semantics for `./` prefixes; bash keeps the script identical to ci.yml + windows.yml.
+        shell: bash
+
+      - name: Run IDE UI test under Xvfb (Linux)
+        # Linux runners ship without a display server. `xvfb-run -a` provisions a virtual
+        # Xorg server for the lifetime of the wrapped command, sets `DISPLAY` automatically,
+        # and tears it down on exit. The IDE boots into that virtual display the same way it
+        # would into a real one — no compositor in the loop, so the failure surface is just
+        # skiko-on-software-GL rather than skiko + Mutter / KWin / etc.
+        if: runner.os == 'Linux'
+        run: xvfb-run -a ./gradlew :sample-intellij-plugin:uiTest
         shell: bash
 
       # Capture artefacts on failure so post-mortem doesn't require re-running the test.


### PR DESCRIPTION
## Summary

Follow-up to #82. Re-includes the Linux leg in the IDE-hosted UI test workflow now that the Linux Wayland recording path has shipped. Spectre claims four desktop platforms (macOS, Windows, Linux Xorg, Linux Wayland); the IDE-hosted matrix should exercise the IDE plugin path on all three runner OSes to keep coverage symmetric.

## What changed

`.github/workflows/ide-uitest.yml`:

- Added `ubuntu-latest` to the matrix.
- Linux-only step: `apt install xvfb libdbus-1-dev pkg-config`.
- Linux-only step: `dtolnay/rust-toolchain@stable` (`:sample-intellij-plugin` depends on `:recording`, whose `processResources` builds the Rust Wayland helper on Linux).
- Split "Run IDE UI test" into two steps: macOS / Windows run as before, Linux runs `xvfb-run -a ./gradlew :sample-intellij-plugin:uiTest`.
- Updated the rationale comment at the top of the workflow.

## Why now (vs. why originally excluded)

The original comment cited "rendering quirk in xvfb + software-GL would shift failure mode away from regression in our plugin code." That risk hasn't disappeared, but `validation-linux.yml` has been running `:sample-desktop:validationTest*` under the same `xvfb-run` setup since v4 with no rendering-stack flakes, so the empirical evidence is weaker than the original justification implied. The escape hatch is documented inline — if Linux starts flaking under skiko-on-xvfb, take the leg back out and document the symptom in the workflow comment.

## Test plan

- [ ] `uitest (ubuntu-latest)` job runs and passes
- [ ] `uitest (macos-latest)` and `uitest (windows-latest)` continue to pass (untouched)
- [ ] No accidental scope expansion on the path filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rock3r/codesmith/spectre/pr/83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->