### PR TITLE
test(robot): port real-Robot smokes to macOS + Linux, wire Linux into CI

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -106,6 +106,34 @@ jobs:
             --continue
         shell: bash
 
+      - name: Run real-Robot Linux smoke under Xvfb
+        # Counterpart to the manual `runWindowsRobotSmoke` (which stays manual on the Windows
+        # workflow because hosted Windows runners don't reliably handle the alwaysOnTop window
+        # manipulation the smoke needs). Linux + Xvfb is the one host configuration where a
+        # real `java.awt.Robot` smoke runs cleanly in CI: Xvfb gives us a real Xorg display,
+        # the smoke's Wayland gate stays out of the picture (no XDG_SESSION_TYPE=wayland, no
+        # WAYLAND_DISPLAY, no wayland-* socket in XDG_RUNTIME_DIR), and Robot input + screen
+        # capture work end-to-end.
+        #
+        # Extending this workflow rather than adding a sibling because the runner setup
+        # (Xvfb + JDK 21 + Gradle + Rust) is identical and the path filters already cover
+        # `sample-desktop/**`. A separate workflow file would just duplicate that setup with
+        # no scope difference.
+        #
+        # The smoke's main() exits 0/1 based on PASS/FAIL via exitProcess, so Gradle's
+        # JavaExec propagates failure naturally — no XML-verifier needed (unlike the test
+        # tasks above).
+        #
+        # The unfocused variant (`runLinuxRobotUnfocusedSmoke`) is NOT wired in here yet:
+        # focus / click-to-focus semantics under Xvfb are minimal-WM territory and likely
+        # behave differently from a real KWin / Mutter session. Run it manually on a
+        # developer Linux machine first to bank findings; once the unfocused-smoke KDoc has a
+        # real findings list (not the TBD placeholders) we can revisit adding it here.
+        if: always()
+        run: |
+          xvfb-run -a ./gradlew :sample-desktop:runLinuxRobotSmoke
+        shell: bash
+
       - name: Verify validation tests passed via JUnit XML
         # Source-of-truth check that mirrors validation-windows.yml's two-pass verifier:
         #

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -198,3 +198,49 @@ tasks.register<JavaExec>("runWindowsRobotUnfocusedSmoke") {
     classpath = sourceSets["test"].runtimeClasspath
     mainClass.set("dev.sebastiano.spectre.sample.WindowsRobotUnfocusedSmoke")
 }
+
+// Linux counterparts to the Windows Robot smokes — same six-scenario rig (see
+// `RobotSmokeRig.kt`) gated against pure Wayland sessions (java.awt.Robot drops cross-process
+// synthetic input on Wayland). CI wiring lives in `validation-linux.yml`, which runs the
+// focused smoke under `xvfb-run`; the unfocused variant stays manual unless empirical Xvfb
+// behaviour proves stable.
+tasks.register<JavaExec>("runLinuxRobotSmoke") {
+    group = "verification"
+    description = "Drives a Compose window via real RobotDriver on Linux; PASS/FAIL per scenario."
+    onlyIf { OperatingSystem.current().isLinux }
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.sebastiano.spectre.sample.LinuxRobotSmoke")
+}
+
+tasks.register<JavaExec>("runLinuxRobotUnfocusedSmoke") {
+    group = "verification"
+    description =
+        "Drives Robot at an unfocused Compose window on Linux; pins click-to-focus + " +
+            "keystroke semantics."
+    onlyIf { OperatingSystem.current().isLinux }
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.sebastiano.spectre.sample.LinuxRobotUnfocusedSmoke")
+}
+
+// macOS counterparts to the Windows Robot smokes. NOT wired into CI — GitHub-hosted macos-*
+// runners don't grant java.awt.Robot the Accessibility TCC permission required to dispatch
+// real synthetic input (same constraint that already prevents SCK end-to-end testing on
+// macos.yml). The smoke probes TCC at startup and exits 2 with a remediation message if input
+// is being dropped; manual run only on a developer Mac after granting Accessibility.
+tasks.register<JavaExec>("runMacOsRobotSmoke") {
+    group = "verification"
+    description = "Drives a Compose window via real RobotDriver on macOS; PASS/FAIL per scenario."
+    onlyIf { OperatingSystem.current().isMacOsX }
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.sebastiano.spectre.sample.MacOsRobotSmoke")
+}
+
+tasks.register<JavaExec>("runMacOsRobotUnfocusedSmoke") {
+    group = "verification"
+    description =
+        "Drives Robot at an unfocused Compose window on macOS; pins click-to-focus + " +
+            "keystroke semantics."
+    onlyIf { OperatingSystem.current().isMacOsX }
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.sebastiano.spectre.sample.MacOsRobotUnfocusedSmoke")
+}

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
@@ -1,0 +1,139 @@
+@file:JvmName("LinuxRobotSmoke")
+
+package dev.sebastiano.spectre.sample
+
+import androidx.compose.ui.awt.ComposePanel
+import dev.sebastiano.spectre.core.RobotDriver
+import java.awt.Dimension
+import java.io.File
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/**
+ * Manual + CI smoke for [RobotDriver] on Linux. Run via `./gradlew
+ * :sample-desktop:runLinuxRobotSmoke` (locally needs a working `DISPLAY`; CI runs it under
+ * `xvfb-run` from `validation-linux.yml`). Mirrors [WindowsRobotSmoke] — same six scenarios via the
+ * shared [runFocusedScenarios] rig — and reports PASS/FAIL per scenario.
+ *
+ * **Wayland gate.** Native Wayland forbids cross-process synthetic input, so `java.awt.Robot` only
+ * works against X11 (real Xorg or XWayland-bridged X clients). When `XDG_SESSION_TYPE=wayland` AND
+ * `DISPLAY` is unset (no XWayland fallback), the smoke aborts with exit code 2 before constructing
+ * the JFrame — running the assertions under Wayland would silently produce 0/6 PASS because Robot
+ * input is dropped at the protocol layer, not by the JVM. Same constraint Spectre's `LinuxX11Grab`
+ * documents from #77.
+ *
+ * Findings from running this on Linux (placeholder — bank empirical results here on first real run,
+ * mirroring the Windows smoke's findings list):
+ *
+ * 1. (TBD — Xvfb + KWin + Mutter foreground / focus behaviour with `isAlwaysOnTop`)
+ * 2. (TBD — cold-JVM warmup click necessity under Xvfb)
+ * 3. (TBD — clipboard-paste path on X11 vs the macOS NSPasteboard latency budget)
+ *
+ * What this *doesn't* exercise:
+ * - Native Wayland input — gated above; not testable without a synthetic compositor that grants the
+ *   JVM input-injection permission.
+ * - HiDPI / fractional-scale Linux — out of scope for #20; covered (or to be covered) under the
+ *   HiDPI-mapper validation tests instead.
+ * - Jewel/IntelliJ tool-window text fields — `:sample-intellij-plugin`'s territory.
+ */
+fun main() {
+    var exitCode = 0
+    try {
+        val abort = checkWaylandGate()
+        if (abort != null) {
+            System.err.println(abort)
+            exitProcess(2)
+        }
+        exitCode = runSmoke()
+    } catch (t: Throwable) {
+        System.err.println("Smoke crashed: ${t.message}\n${t.stackTraceToString()}")
+        exitCode = 2
+    } finally {
+        exitProcess(exitCode)
+    }
+}
+
+// Wayland forbids cross-process synthetic input; java.awt.Robot only works against X11. If we
+// detect a pure-Wayland session with no XWayland fallback (DISPLAY unset), abort early with a
+// clear remediation rather than running the scenarios and reporting 0/6 PASS for opaque
+// reasons. Same gate Spectre's LinuxX11Grab uses from #77.
+internal fun checkWaylandGate(): String? {
+    val xdgSessionType = System.getenv("XDG_SESSION_TYPE")?.lowercase()
+    val waylandDisplay = System.getenv("WAYLAND_DISPLAY")
+    val xdgRuntimeDir = System.getenv("XDG_RUNTIME_DIR")
+    val display = System.getenv("DISPLAY")
+    val waylandSocketPresent =
+        xdgRuntimeDir != null &&
+            File(xdgRuntimeDir).listFiles()?.any { it.name.startsWith("wayland-") } == true
+    val waylandIndicator =
+        xdgSessionType == "wayland" || !waylandDisplay.isNullOrEmpty() || waylandSocketPresent
+    if (waylandIndicator && display.isNullOrEmpty()) {
+        return buildString {
+            appendLine(
+                "LinuxRobotSmoke aborting: pure-Wayland session detected and no XWayland fallback."
+            )
+            appendLine(
+                "  XDG_SESSION_TYPE=$xdgSessionType WAYLAND_DISPLAY=$waylandDisplay " +
+                    "wayland-socket-present=$waylandSocketPresent DISPLAY=$display"
+            )
+            appendLine(
+                "  Wayland forbids cross-process synthetic input — java.awt.Robot drops events " +
+                    "at the protocol layer, so running here would report 0/6 PASS."
+            )
+            appendLine(
+                "  Remediation: run under Xorg (set DISPLAY to an X11 server, or use xvfb-run " +
+                    "to start a virtual Xorg display)."
+            )
+        }
+    }
+    return null
+}
+
+private fun runSmoke(): Int {
+    val state = SmokeState()
+    val frameRef = AtomicReference<JFrame>()
+    SwingUtilities.invokeLater {
+        val composePanel =
+            ComposePanel().apply {
+                preferredSize = Dimension(SMOKE_PANEL_WIDTH, SMOKE_PANEL_HEIGHT)
+                setContent { SmokeContent(state) }
+            }
+        val frame =
+            JFrame("Spectre Robot smoke (Linux)").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                contentPane = composePanel
+                pack()
+                setLocationRelativeTo(null)
+                // Keep alwaysOnTop on Linux too — KWin / Mutter / i3 honour it differently than
+                // Windows but it never hurts, and on Xvfb (where focus stacking is minimal) it's
+                // a no-op. First real-run findings should bank empirical WM behaviour here.
+                isAlwaysOnTop = true
+                isVisible = true
+                toFront()
+                requestFocus()
+            }
+        state.frame = frame
+        state.composePanel = composePanel
+        frameRef.set(frame)
+    }
+
+    waitForFrame(frameRef)
+    waitForLayout(state)
+    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+
+    printEnvironment("LinuxRobotSmoke", state)
+
+    val driver = RobotDriver()
+    warmupRobot(driver, state)
+    val results = runFocusedScenarios(driver, state, typeTextExpected = "hello linux")
+    val exitCode = printResults("LinuxRobotSmoke", results)
+
+    SwingUtilities.invokeLater {
+        state.frame?.isVisible = false
+        state.frame?.dispose()
+    }
+
+    return exitCode
+}

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
@@ -95,7 +95,7 @@ private fun runSmoke(): Int {
     waitForFrame(sutRef)
     waitForFrame(distractorRef)
     waitForLayout(state)
-    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+    Thread.sleep(POST_LAYOUT_UNFOCUSED_WARMUP_MS)
 
     val driver = RobotDriver()
     val distractor = requireNotNull(distractorRef.get()) { "distractor frame missing" }

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
@@ -1,0 +1,118 @@
+@file:JvmName("LinuxRobotUnfocusedSmoke")
+
+package dev.sebastiano.spectre.sample
+
+import androidx.compose.ui.awt.ComposePanel
+import dev.sebastiano.spectre.core.RobotDriver
+import java.awt.Color as AwtColor
+import java.awt.Dimension
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JFrame
+import javax.swing.JLabel
+import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/**
+ * Manual smoke for [RobotDriver] driven at a deliberately-unfocused Compose window on Linux.
+ * Companion to [LinuxRobotSmoke] / [WindowsRobotUnfocusedSmoke]. Run via `./gradlew
+ * :sample-desktop:runLinuxRobotUnfocusedSmoke`.
+ *
+ * Same gate as [LinuxRobotSmoke]: aborts with exit 2 on pure Wayland (Robot input is dropped at the
+ * protocol layer; would report 0/N PASS for opaque reasons).
+ *
+ * Findings from running this on Linux (placeholder — bank empirical results here on first real run,
+ * mirroring the Windows unfocused smoke's findings list):
+ *
+ * 1. (TBD — does focus actually leave the SUT after the distractor's `requestFocus()` under KWin /
+ *    Mutter / Xvfb? WMs honour focus requests differently than Windows.)
+ * 2. (TBD — pressKey-on-unfocused-SUT behaviour: dropped, or routed to focus owner?)
+ * 3. (TBD — click-to-focus semantics: does the first click both register AND transfer focus, or is
+ *    a separate activation click required on the user's WM?)
+ * 4. (TBD — typeText-after-focus-click stability under Xorg's clipboard semantics — XSelection
+ *    timing differs from Windows OLE clipboard.)
+ */
+fun main() {
+    var exitCode = 0
+    try {
+        val abort = checkWaylandGate()
+        if (abort != null) {
+            System.err.println(abort)
+            exitProcess(2)
+        }
+        exitCode = runSmoke()
+    } catch (t: Throwable) {
+        System.err.println("Smoke crashed: ${t.message}\n${t.stackTraceToString()}")
+        exitCode = 2
+    } finally {
+        exitProcess(exitCode)
+    }
+}
+
+private fun runSmoke(): Int {
+    val state = SmokeState()
+    val sutRef = AtomicReference<JFrame>()
+    val distractorRef = AtomicReference<JFrame>()
+
+    SwingUtilities.invokeLater {
+        val composePanel =
+            ComposePanel().apply {
+                preferredSize = Dimension(SMOKE_PANEL_WIDTH, SMOKE_PANEL_HEIGHT)
+                setContent { SmokeContent(state) }
+            }
+        val sut =
+            JFrame("Spectre unfocused-robot SUT (Linux)").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                contentPane = composePanel
+                pack()
+                setLocation(SUT_X, SUT_Y)
+                isAlwaysOnTop = true
+                isVisible = true
+            }
+        state.frame = sut
+        state.composePanel = composePanel
+        sutRef.set(sut)
+
+        val distractor =
+            JFrame("distractor").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                preferredSize = Dimension(DISTRACTOR_WIDTH, DISTRACTOR_HEIGHT)
+                contentPane =
+                    JLabel("distractor — focus stealer", SwingConstants.CENTER).apply {
+                        background = AwtColor.YELLOW
+                        isOpaque = true
+                    }
+                pack()
+                setLocation(DISTRACTOR_X, DISTRACTOR_Y)
+                isAlwaysOnTop = true
+                isVisible = true
+                toFront()
+                requestFocus()
+            }
+        distractorRef.set(distractor)
+    }
+
+    waitForFrame(sutRef)
+    waitForFrame(distractorRef)
+    waitForLayout(state)
+    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+
+    val driver = RobotDriver()
+    val distractor = requireNotNull(distractorRef.get()) { "distractor frame missing" }
+    val results = runUnfocusedScenarios(driver, state, distractor)
+    val exitCode = printResults("LinuxRobotUnfocusedSmoke", results)
+
+    SwingUtilities.invokeLater {
+        sutRef.get()?.dispose()
+        distractorRef.get()?.dispose()
+    }
+
+    return exitCode
+}
+
+private const val SUT_X = 600
+private const val SUT_Y = 400
+private const val DISTRACTOR_WIDTH = 320
+private const val DISTRACTOR_HEIGHT = 200
+private const val DISTRACTOR_X = 80
+private const val DISTRACTOR_Y = 80

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotSmoke.kt
@@ -1,0 +1,168 @@
+@file:JvmName("MacOsRobotSmoke")
+
+package dev.sebastiano.spectre.sample
+
+import androidx.compose.ui.awt.ComposePanel
+import dev.sebastiano.spectre.core.RobotDriver
+import java.awt.Dimension
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/**
+ * Manual smoke for [RobotDriver] on macOS. Run via `./gradlew :sample-desktop:runMacOsRobotSmoke`.
+ * Mirrors [WindowsRobotSmoke] / [LinuxRobotSmoke] — same six scenarios via the shared
+ * [runFocusedScenarios] rig — and reports PASS/FAIL per scenario.
+ *
+ * **TCC permission gate.** `java.awt.Robot.mousePress` on modern macOS requires the JVM process to
+ * hold **Accessibility** permission (System Settings → Privacy & Security → Accessibility), even
+ * for input into its own window. Screenshots additionally require **Screen Recording**. Without
+ * these permissions, events are silently dropped — the smoke would appear to run but report 0/6
+ * PASS for opaque reasons. There's no clean API to query TCC state, so the smoke fires a probe
+ * click against the counter; if `clickCount` doesn't increment it prints a remediation message
+ * naming the JVM binary path and exits with code 2 BEFORE running the scenario suite.
+ *
+ * **No CI for this smoke.** GitHub-hosted `macos-*` runners don't grant TCC Accessibility, so this
+ * smoke can't run there — same constraint that already keeps SCK end-to-end recording tests off the
+ * macos.yml workflow ("CI runners don't have Screen Recording TCC"). The Gradle task is gated
+ * `onlyIf isMacOsX` and intended to be run manually on a developer Mac after granting the JVM
+ * Accessibility permission.
+ *
+ * **Modifier key.** `RobotDriver` uses `shortcutModifierKeyCode(detectMacOs())` internally for
+ * `typeText` / `clearAndTypeText`, so those run as Cmd+V / Cmd+A on macOS. The shared rig's
+ * `scenarioShortcut` uses the same helper, so the Ctrl+S → Cmd+S translation happens automatically
+ * without per-platform conditionals here.
+ *
+ * Findings from running this on macOS (placeholder — bank empirical results here on first real run,
+ * mirroring the Windows smoke's findings list):
+ *
+ * 1. (TBD — does macOS need the alwaysOnTop foreground hack? AppKit has no foreground-stealing-
+ *    prevention analogous to Windows, so plain `toFront()` may suffice. Default to alwaysOnTop for
+ *    safety and revise after empirical observation.)
+ * 2. (TBD — NSPasteboard latency budget under typeText: the existing
+ *    `CLIPBOARD_SETTLE_TIMEOUT_MS=1000` was tuned partly for macOS — confirm it holds on cold JVM +
+ *    freshly-woken machine.)
+ * 3. (TBD — Cmd+S shortcut delivery: `pressKey(VK_S, META_DOWN_MASK)` should fire the Compose
+ *    `onPreviewKeyEvent` handler the same way Ctrl+S does on Windows; the handler accepts either
+ *    `isCtrlPressed || isMetaPressed`, so a regression here would isolate to Robot's modifier-mask
+ *    path, not the smoke's content.)
+ *
+ * What this *doesn't* exercise:
+ * - SCK / screen recording — that's `:recording`'s territory and gated on the macos.yml workflow's
+ *   contract test, not on real frame capture.
+ * - Background-app input (`apple.awt.UIElement=true` mode used by `validationTest`) — this smoke
+ *   runs as a regular foreground app; the UI-element mode bypasses TCC by going through synthetic
+ *   AWT events instead of real Robot input.
+ */
+fun main() {
+    var exitCode = 0
+    try {
+        exitCode = runSmoke()
+    } catch (t: Throwable) {
+        System.err.println("Smoke crashed: ${t.message}\n${t.stackTraceToString()}")
+        exitCode = 2
+    } finally {
+        exitProcess(exitCode)
+    }
+}
+
+private fun runSmoke(): Int {
+    val state = SmokeState()
+    val frameRef = AtomicReference<JFrame>()
+    SwingUtilities.invokeLater {
+        val composePanel =
+            ComposePanel().apply {
+                preferredSize = Dimension(SMOKE_PANEL_WIDTH, SMOKE_PANEL_HEIGHT)
+                setContent { SmokeContent(state) }
+            }
+        val frame =
+            JFrame("Spectre Robot smoke (macOS)").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                contentPane = composePanel
+                pack()
+                setLocationRelativeTo(null)
+                // Default to alwaysOnTop for safety. macOS has no foreground-stealing-prevention
+                // (unlike Windows), but keeping the fixture predictable regardless of host
+                // configuration costs nothing at the OS level. Findings should bank whether
+                // this is actually needed once the smoke runs on a real Mac.
+                isAlwaysOnTop = true
+                isVisible = true
+                toFront()
+                requestFocus()
+            }
+        state.frame = frame
+        state.composePanel = composePanel
+        frameRef.set(frame)
+    }
+
+    waitForFrame(frameRef)
+    waitForLayout(state)
+    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+
+    printEnvironment("MacOsRobotSmoke", state)
+
+    val driver = RobotDriver()
+    val tccAbort = probeTccAccessibility(driver, state)
+    if (tccAbort != null) {
+        System.err.println(tccAbort)
+        SwingUtilities.invokeLater {
+            state.frame?.isVisible = false
+            state.frame?.dispose()
+        }
+        return 2
+    }
+
+    val results = runFocusedScenarios(driver, state, typeTextExpected = "hello macos")
+    val exitCode = printResults("MacOsRobotSmoke", results)
+
+    SwingUtilities.invokeLater {
+        state.frame?.isVisible = false
+        state.frame?.dispose()
+    }
+
+    return exitCode
+}
+
+// macOS silently drops Robot events when the JVM lacks Accessibility TCC — there's no API to
+// query the permission, so probe by firing a click and observing whether the counter ticks. If
+// it doesn't, return a remediation message for the caller to print and use as exit reason.
+// The probe click counts toward `clickCount`, so the rig's scenarios capture their own deltas
+// (this prime click is effectively the macOS analogue of the cold-JVM warmup click on Windows
+// + an effective TCC check).
+internal fun probeTccAccessibility(driver: RobotDriver, state: SmokeState): String? {
+    val target = awtCenter(state, state.counterBounds)
+    if (target == null) {
+        return "TCC probe skipped: counter target rect not available; cannot infer permission state."
+    }
+    val before = state.clickCount
+    driver.click(target.x, target.y)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    val after = state.clickCount
+    if (after > before) return null
+    val javaHome = System.getProperty("java.home")
+    return buildString {
+        appendLine(
+            "MacOsRobotSmoke aborting: probe click did NOT register (clickCount $before → $after)."
+        )
+        appendLine(
+            "  This almost always means the JVM running this smoke lacks macOS Accessibility " +
+                "permission (TCC), so java.awt.Robot input is being silently dropped."
+        )
+        appendLine("  JVM binary: $javaHome/bin/java")
+        appendLine("  Remediation:")
+        appendLine(
+            "    1. Open System Settings → Privacy & Security → Accessibility, click +, and " +
+                "add the JVM binary above (or the wrapping app — IntelliJ, Terminal — that " +
+                "spawned it)."
+        )
+        appendLine(
+            "    2. For the screenshot scenario (not exercised here), also add the JVM under " +
+                "Privacy & Security → Screen Recording."
+        )
+        appendLine(
+            "    3. Quit and re-launch Gradle / IntelliJ after granting; macOS only " +
+                "re-evaluates TCC at process start."
+        )
+    }
+}

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
@@ -94,7 +94,7 @@ private fun runSmoke(): Int {
     waitForFrame(sutRef)
     waitForFrame(distractorRef)
     waitForLayout(state)
-    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+    Thread.sleep(POST_LAYOUT_UNFOCUSED_WARMUP_MS)
 
     val driver = RobotDriver()
     // Reuse the focused smoke's TCC probe — the unfocused SUT can still receive Robot input

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
@@ -1,0 +1,139 @@
+@file:JvmName("MacOsRobotUnfocusedSmoke")
+
+package dev.sebastiano.spectre.sample
+
+import androidx.compose.ui.awt.ComposePanel
+import dev.sebastiano.spectre.core.RobotDriver
+import java.awt.Color as AwtColor
+import java.awt.Dimension
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JFrame
+import javax.swing.JLabel
+import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/**
+ * Manual smoke for [RobotDriver] driven at a deliberately-unfocused Compose window on macOS.
+ * Companion to [MacOsRobotSmoke] / [WindowsRobotUnfocusedSmoke]. Run via `./gradlew
+ * :sample-desktop:runMacOsRobotUnfocusedSmoke`.
+ *
+ * Same TCC gate as [MacOsRobotSmoke]: probes the SUT counter first; if the click does not
+ * increment, prints a remediation message and exits 2 (java.awt.Robot is being silently dropped
+ * because the JVM lacks Accessibility permission). No CI here — GitHub-hosted macos-* runners don't
+ * grant TCC, same constraint that already keeps SCK end-to-end tests off macos.yml.
+ *
+ * Findings from running this on macOS (placeholder — bank empirical results here on first real run,
+ * mirroring the Windows unfocused smoke's findings list):
+ *
+ * 1. (TBD — does NSWindow's `orderFront:` followed by another window's activation actually leave
+ *    the SUT visible-but-unfocused, or does the WM force one or the other?)
+ * 2. (TBD — pressKey-on-unfocused-SUT behaviour: macOS routes synthetic key events to the
+ *    front-most app, so this may behave differently from Windows where the SUT's focus owner is
+ *    empty.)
+ * 3. (TBD — macOS click-to-focus semantics: AppKit traditionally requires a separate activation
+ *    click for inactive apps before in-app interactions count, unlike Windows "first click is
+ *    free". Empirical observation needed.)
+ * 4. (TBD — typeText-after-focus-click stability under NSPasteboard.)
+ */
+fun main() {
+    var exitCode = 0
+    try {
+        exitCode = runSmoke()
+    } catch (t: Throwable) {
+        System.err.println("Smoke crashed: ${t.message}\n${t.stackTraceToString()}")
+        exitCode = 2
+    } finally {
+        exitProcess(exitCode)
+    }
+}
+
+private fun runSmoke(): Int {
+    val state = SmokeState()
+    val sutRef = AtomicReference<JFrame>()
+    val distractorRef = AtomicReference<JFrame>()
+
+    SwingUtilities.invokeLater {
+        val composePanel =
+            ComposePanel().apply {
+                preferredSize = Dimension(SMOKE_PANEL_WIDTH, SMOKE_PANEL_HEIGHT)
+                setContent { SmokeContent(state) }
+            }
+        val sut =
+            JFrame("Spectre unfocused-robot SUT (macOS)").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                contentPane = composePanel
+                pack()
+                setLocation(SUT_X, SUT_Y)
+                isAlwaysOnTop = true
+                isVisible = true
+            }
+        state.frame = sut
+        state.composePanel = composePanel
+        sutRef.set(sut)
+
+        val distractor =
+            JFrame("distractor").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                preferredSize = Dimension(DISTRACTOR_WIDTH, DISTRACTOR_HEIGHT)
+                contentPane =
+                    JLabel("distractor — focus stealer", SwingConstants.CENTER).apply {
+                        background = AwtColor.YELLOW
+                        isOpaque = true
+                    }
+                pack()
+                setLocation(DISTRACTOR_X, DISTRACTOR_Y)
+                isAlwaysOnTop = true
+                isVisible = true
+                toFront()
+                requestFocus()
+            }
+        distractorRef.set(distractor)
+    }
+
+    waitForFrame(sutRef)
+    waitForFrame(distractorRef)
+    waitForLayout(state)
+    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+
+    val driver = RobotDriver()
+    // Reuse the focused smoke's TCC probe — the unfocused SUT can still receive Robot input
+    // routing in principle, but if the JVM lacks Accessibility permission EVERY click is
+    // dropped and the assertions become meaningless. Fail loudly with the same remediation.
+    // The probe click also functions as the Windows-style cold-JVM warmup click; subsequent
+    // assertions capture their own deltas so the prime click doesn't skew them.
+    val tccAbort = probeTccAccessibility(driver, state)
+    if (tccAbort != null) {
+        System.err.println(tccAbort)
+        SwingUtilities.invokeLater {
+            sutRef.get()?.dispose()
+            distractorRef.get()?.dispose()
+        }
+        return 2
+    }
+    // The TCC probe transferred focus to the SUT — re-focus the distractor so the unfocused
+    // scenarios run from the documented starting state.
+    val distractor = requireNotNull(distractorRef.get()) { "distractor frame missing" }
+    SwingUtilities.invokeLater {
+        distractor.toFront()
+        distractor.requestFocus()
+    }
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+
+    val results = runUnfocusedScenarios(driver, state, distractor)
+    val exitCode = printResults("MacOsRobotUnfocusedSmoke", results)
+
+    SwingUtilities.invokeLater {
+        sutRef.get()?.dispose()
+        distractorRef.get()?.dispose()
+    }
+
+    return exitCode
+}
+
+private const val SUT_X = 600
+private const val SUT_Y = 400
+private const val DISTRACTOR_WIDTH = 320
+private const val DISTRACTOR_HEIGHT = 200
+private const val DISTRACTOR_X = 80
+private const val DISTRACTOR_Y = 80

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
@@ -466,5 +466,10 @@ internal const val SMOKE_PANEL_HEIGHT = 320
 internal const val WINDOW_OPEN_TIMEOUT_MS = 5_000L
 internal const val LAYOUT_TIMEOUT_MS = 5_000L
 internal const val POST_LAYOUT_WARMUP_MS = 500L
+// Unfocused smokes spawn a sibling distractor JFrame and exercise focus transfers between two
+// AWT windows; the AWT input handlers attach a few frames later than the focused case, so the
+// original WindowsRobotUnfocusedSmoke used 600ms here. Restored as a separate constant after
+// the rig refactor standardised on 500ms — the focus-transfer settle is the why.
+internal const val POST_LAYOUT_UNFOCUSED_WARMUP_MS = 600L
 internal const val POST_CLICK_SETTLE_MS = 250L
 internal const val POST_TYPE_SETTLE_MS = 800L

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
@@ -1,0 +1,470 @@
+package dev.sebastiano.spectre.sample
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
+import androidx.compose.ui.layout.boundsInWindow
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.unit.dp
+import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.core.composeBoundsToAwtCenter
+import dev.sebastiano.spectre.core.detectMacOs
+import dev.sebastiano.spectre.core.shortcutModifierKeyCode
+import java.awt.Window
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JFrame
+
+internal class SmokeState {
+    var frame: JFrame? = null
+    var composePanel: ComposePanel? = null
+
+    @Volatile var clickCount: Int = 0
+    @Volatile var textValue: TextFieldValue = TextFieldValue("")
+    @Volatile var shortcutFiredCount: Int = 0
+    @Volatile var counterBounds: Rect = Rect.Zero
+    @Volatile var textFieldBounds: Rect = Rect.Zero
+}
+
+@Composable
+internal fun SmokeContent(state: SmokeState) {
+    var localCount by remember { mutableIntStateOf(0) }
+    var localText by remember { mutableStateOf(TextFieldValue("")) }
+    Column(
+        modifier =
+            Modifier.fillMaxWidth().background(Color.White).padding(16.dp).onPreviewKeyEvent { event
+                ->
+                if (
+                    event.type == KeyEventType.KeyDown &&
+                        event.key == Key.S &&
+                        (event.isCtrlPressed || event.isMetaPressed)
+                ) {
+                    state.shortcutFiredCount += 1
+                    true
+                } else false
+            },
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        BasicText("Spectre Robot smoke — driven by RobotDriver(), not synthetic.")
+        BasicText("clickCount = $localCount")
+        Box(
+            modifier =
+                Modifier.height(48.dp)
+                    .fillMaxWidth()
+                    .clickable {
+                        localCount += 1
+                        state.clickCount = localCount
+                    }
+                    .background(Color(red = 0x33, green = 0x66, blue = 0xCC))
+                    .padding(12.dp)
+                    .onGloballyPositioned { coords ->
+                        state.counterBounds = coords.boundsInWindow()
+                    }
+        ) {
+            BasicText("counter button (click via Robot)")
+        }
+        // BasicTextField lays out at its intrinsic single-line height by default; without
+        // forcing a larger hit area, a Robot click aimed at the wrapper Box's center lands in
+        // empty padding below the text input and never focuses the field. Make the
+        // BasicTextField fill the wrapper so the entire visible area accepts focus on click.
+        BasicTextField(
+            value = localText,
+            onValueChange = {
+                localText = it
+                state.textValue = it
+            },
+            modifier =
+                Modifier.fillMaxWidth()
+                    .height(48.dp)
+                    .background(Color(red = 0xEE, green = 0xEE, blue = 0xEE))
+                    .padding(8.dp)
+                    .onGloballyPositioned { coords ->
+                        state.textFieldBounds = coords.boundsInWindow()
+                    },
+        )
+        BasicText("textValue = \"${state.textValue.text}\"")
+        BasicText("shortcutFiredCount = ${state.shortcutFiredCount}")
+    }
+}
+
+internal data class ScenarioResult(val label: String, val passed: Boolean, val detail: String)
+
+internal fun waitForFrame(ref: AtomicReference<JFrame>) {
+    val deadline = System.nanoTime() + WINDOW_OPEN_TIMEOUT_MS * 1_000_000L
+    while (System.nanoTime() < deadline) {
+        val frame = ref.get()
+        if (frame != null && frame.isShowing) return
+        Thread.sleep(50)
+    }
+    error("frame never showed within ${WINDOW_OPEN_TIMEOUT_MS}ms")
+}
+
+internal fun waitForLayout(state: SmokeState) {
+    val deadline = System.nanoTime() + LAYOUT_TIMEOUT_MS * 1_000_000L
+    while (System.nanoTime() < deadline) {
+        val counter = state.counterBounds
+        val textField = state.textFieldBounds
+        val ready =
+            counter.width > 0f &&
+                counter.height > 0f &&
+                textField.width > 0f &&
+                textField.height > 0f
+        if (ready) return
+        Thread.sleep(50)
+    }
+    error(
+        "Compose targets never laid out within ${LAYOUT_TIMEOUT_MS}ms; " +
+            "counterBounds=${state.counterBounds} textFieldBounds=${state.textFieldBounds}"
+    )
+}
+
+internal fun printEnvironment(label: String, state: SmokeState) {
+    val frame = state.frame
+    val panel = state.composePanel
+    println("--- $label environment ---")
+    println(
+        "os.name=\"${System.getProperty("os.name")}\" os.version=\"${System.getProperty("os.version")}\""
+    )
+    if (frame != null) {
+        val gc = frame.graphicsConfiguration
+        println(
+            "frame.bounds=${frame.bounds} isFocused=${frame.isFocused} " +
+                "isAlwaysOnTop=${frame.isAlwaysOnTop} isShowing=${frame.isShowing}"
+        )
+        if (gc != null) {
+            println(
+                "frame.gc.scaleX=${gc.defaultTransform.scaleX} scaleY=${gc.defaultTransform.scaleY} " +
+                    "bounds=${gc.bounds}"
+            )
+        }
+    }
+    if (panel != null) {
+        val loc =
+            try {
+                panel.locationOnScreen
+            } catch (_: java.awt.IllegalComponentStateException) {
+                null
+            }
+        println("panel.size=(w=${panel.width},h=${panel.height}) panel.locationOnScreen=$loc")
+    }
+    println("counterBounds(Compose px)=${state.counterBounds}")
+    println("textFieldBounds(Compose px)=${state.textFieldBounds}")
+    println("--- /environment ---")
+}
+
+internal fun awtCenter(state: SmokeState, rect: Rect): java.awt.Point? {
+    if (rect.width <= 0f || rect.height <= 0f) return null
+    val frame = state.frame ?: return null
+    val panel = state.composePanel ?: return null
+    val gc = (frame as Window).graphicsConfiguration ?: return null
+    val xform = gc.defaultTransform
+    val panelLoc =
+        try {
+            panel.locationOnScreen
+        } catch (_: java.awt.IllegalComponentStateException) {
+            return null
+        }
+    return composeBoundsToAwtCenter(
+        left = rect.left,
+        top = rect.top,
+        right = rect.right,
+        bottom = rect.bottom,
+        scaleX = xform.scaleX.toFloat(),
+        scaleY = xform.scaleY.toFloat(),
+        panelScreenX = panelLoc.x,
+        panelScreenY = panelLoc.y,
+    )
+}
+
+internal fun warmupRobot(driver: RobotDriver, state: SmokeState) {
+    // Click on the counter button, fire-and-forget. counterBounds is non-zero by here
+    // (waitForLayout already proved it). Each scenario captures its own `before` snapshot,
+    // so we don't need to reset state — the warmup click just primes the input pipeline.
+    val target = awtCenter(state, state.counterBounds) ?: return
+    driver.click(target.x, target.y)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+}
+
+internal fun focusOwnerSummary(state: SmokeState): String {
+    val focused = java.awt.KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
+    return focused?.let { "${it.javaClass.simpleName}@${System.identityHashCode(it)}" }
+        ?: "null (frame.isFocused=${state.frame?.isFocused})"
+}
+
+internal fun scenarioCounterClick(driver: RobotDriver, state: SmokeState): ScenarioResult {
+    val before = state.clickCount
+    val target = awtCenter(state, state.counterBounds)
+    if (target == null) {
+        return ScenarioResult("mouseMove + click on counter", false, "no target rect available")
+    }
+    driver.click(target.x, target.y)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    val after = state.clickCount
+    return ScenarioResult(
+        "mouseMove + click on counter",
+        passed = after == before + 1,
+        detail = "clickCount $before → $after at (${target.x},${target.y})",
+    )
+}
+
+internal fun scenarioCounterDoubleClick(driver: RobotDriver, state: SmokeState): ScenarioResult {
+    val before = state.clickCount
+    val target = awtCenter(state, state.counterBounds)
+    if (target == null) {
+        return ScenarioResult("doubleClick on counter", false, "no target rect available")
+    }
+    driver.doubleClick(target.x, target.y)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    val after = state.clickCount
+    return ScenarioResult(
+        "doubleClick on counter",
+        passed = after == before + 2,
+        detail = "clickCount $before → $after",
+    )
+}
+
+internal fun scenarioPressKeySingleChar(driver: RobotDriver, state: SmokeState): ScenarioResult {
+    // Baseline for the typeText scenario: if the BasicTextField is focused after a click and
+    // accepts direct keystrokes (no clipboard involved), the focus path works and any
+    // typeText failure isolates to the clipboard-paste path.
+    val target = awtCenter(state, state.textFieldBounds)
+    if (target == null) {
+        return ScenarioResult("pressKey 'h' into BasicTextField", false, "no target rect available")
+    }
+    driver.click(target.x, target.y)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    val before = state.textValue.text
+    driver.pressKey(java.awt.event.KeyEvent.VK_H)
+    Thread.sleep(POST_TYPE_SETTLE_MS)
+    val after = state.textValue.text
+    return ScenarioResult(
+        "pressKey 'h' into BasicTextField",
+        passed = after.length == before.length + 1,
+        detail = "before=\"$before\" after=\"$after\"",
+    )
+}
+
+internal fun scenarioTypeText(
+    driver: RobotDriver,
+    state: SmokeState,
+    expected: String,
+): ScenarioResult {
+    val target = awtCenter(state, state.textFieldBounds)
+    if (target == null) {
+        return ScenarioResult("typeText into BasicTextField", false, "no target rect available")
+    }
+    driver.click(target.x, target.y)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    val focusOwnerBefore = focusOwnerSummary(state)
+    driver.typeText(expected)
+    Thread.sleep(POST_TYPE_SETTLE_MS)
+    val actual = state.textValue.text
+    // Exact equality: the field starts empty (typeText runs first in the scenario order
+    // before any keystroke leaves state behind), so the only correct outcome is the typed
+    // string — substring match would mask paste-doubling or stray-keypress bugs.
+    val passed = actual == expected
+    val detail = "text=\"$actual\" expected=\"$expected\" focusOwner=$focusOwnerBefore"
+    return ScenarioResult("typeText into BasicTextField", passed = passed, detail = detail)
+}
+
+internal fun scenarioClearAndTypeText(driver: RobotDriver, state: SmokeState): ScenarioResult {
+    val expected = "replaced"
+    val target = awtCenter(state, state.textFieldBounds)
+    if (target == null) {
+        return ScenarioResult("clearAndTypeText", false, "no target rect available")
+    }
+    driver.click(target.x, target.y)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    driver.clearAndTypeText(expected)
+    Thread.sleep(POST_TYPE_SETTLE_MS)
+    val actual = state.textValue.text
+    return ScenarioResult(
+        "clearAndTypeText",
+        passed = actual == expected,
+        detail = "text=\"$actual\" expected=\"$expected\"",
+    )
+}
+
+internal fun scenarioShortcut(driver: RobotDriver, state: SmokeState): ScenarioResult {
+    state.shortcutFiredCount = 0
+    val before = state.shortcutFiredCount
+    // Click somewhere inside the panel first to ensure focus is on the Compose root.
+    val anchor = awtCenter(state, state.counterBounds)
+    if (anchor != null) {
+        driver.click(anchor.x, anchor.y)
+        Thread.sleep(POST_CLICK_SETTLE_MS)
+    }
+    // Use the platform-aware modifier so the same scenario exercises Ctrl+S on Windows/Linux
+    // and Cmd+S on macOS — `shortcutModifierKeyCode` is what RobotDriver itself uses for
+    // typeText/clearAndTypeText, so the smoke proves the same modifier-mask → keyCode path
+    // Spectre callers use for shortcut keystrokes.
+    val modifierMask =
+        if (detectMacOs()) java.awt.event.InputEvent.META_DOWN_MASK
+        else java.awt.event.InputEvent.CTRL_DOWN_MASK
+    driver.pressKey(java.awt.event.KeyEvent.VK_S, modifierMask)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    val after = state.shortcutFiredCount
+    val modifierLabel = if (detectMacOs()) "Cmd+S" else "Ctrl+S"
+    return ScenarioResult(
+        "$modifierLabel shortcut via pressKey",
+        passed = after == before + 1,
+        detail =
+            "shortcutFiredCount $before → $after (modifier keyCode=" +
+                "${shortcutModifierKeyCode(detectMacOs())})",
+    )
+}
+
+internal fun runFocusedScenarios(
+    driver: RobotDriver,
+    state: SmokeState,
+    typeTextExpected: String,
+): List<ScenarioResult> {
+    val results = mutableListOf<ScenarioResult>()
+    // Order matters: typeText asserts exact equality on a freshly-empty field, so it has to
+    // run before any keystroke that would have left state in the BasicTextField. After that,
+    // pressKey appends one character (verifying focus + raw keystrokes), and clearAndTypeText
+    // wipes and re-types (verifying the Ctrl+A / Cmd+A + Backspace path).
+    results += scenarioCounterClick(driver, state)
+    results += scenarioCounterDoubleClick(driver, state)
+    results += scenarioTypeText(driver, state, expected = typeTextExpected)
+    results += scenarioPressKeySingleChar(driver, state)
+    results += scenarioClearAndTypeText(driver, state)
+    results += scenarioShortcut(driver, state)
+    return results
+}
+
+internal fun scenarioStartsUnfocused(state: SmokeState, distractor: JFrame?): ScenarioResult {
+    val sut = state.frame
+    val sutFocused = sut?.isFocused == true
+    val distractorFocused = distractor?.isFocused == true
+    return ScenarioResult(
+        "starting state: distractor focused, SUT not focused",
+        passed = !sutFocused && distractorFocused,
+        detail = "sut.isFocused=$sutFocused distractor.isFocused=$distractorFocused",
+    )
+}
+
+internal fun scenarioPressKeyOnUnfocusedField(
+    driver: RobotDriver,
+    state: SmokeState,
+): ScenarioResult {
+    // SUT is unfocused — no Compose component holds keyboard focus on the SUT side. Pressing
+    // a character key should NOT modify the text field. If it does, focus must have leaked
+    // somewhere we don't expect (or Robot is targeting the distractor's contents instead).
+    val before = state.textValue.text
+    driver.pressKey(java.awt.event.KeyEvent.VK_X)
+    Thread.sleep(POST_TYPE_SETTLE_MS)
+    val after = state.textValue.text
+    return ScenarioResult(
+        "pressKey on unfocused SUT does NOT alter the text field",
+        passed = after == before,
+        detail = "before=\"$before\" after=\"$after\" sut.isFocused=${state.frame?.isFocused}",
+    )
+}
+
+internal fun scenarioClickOnUnfocusedCounter(
+    driver: RobotDriver,
+    state: SmokeState,
+): ScenarioResult {
+    val target = awtCenter(state, state.counterBounds)
+    if (target == null) {
+        return ScenarioResult("click on unfocused counter", false, "no target rect available")
+    }
+    val before = state.clickCount
+    val sutFocusedBefore = state.frame?.isFocused == true
+    driver.click(target.x, target.y)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    val after = state.clickCount
+    val sutFocusedAfter = state.frame?.isFocused == true
+    return ScenarioResult(
+        "click on unfocused counter increments + transfers focus",
+        passed = after == before + 1 && sutFocusedAfter,
+        detail =
+            "clickCount $before → $after; sut.isFocused $sutFocusedBefore → $sutFocusedAfter " +
+                "at (${target.x},${target.y})",
+    )
+}
+
+internal fun scenarioTypeTextAfterFocusClick(
+    driver: RobotDriver,
+    state: SmokeState,
+): ScenarioResult {
+    val expected = "post-focus paste"
+    val target = awtCenter(state, state.textFieldBounds)
+    if (target == null) {
+        return ScenarioResult("typeText after focus-handoff click", false, "no target rect")
+    }
+    driver.click(target.x, target.y)
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    driver.clearAndTypeText(expected)
+    Thread.sleep(POST_TYPE_SETTLE_MS)
+    val actual = state.textValue.text
+    return ScenarioResult(
+        "typeText after focus-handoff click",
+        passed = actual == expected,
+        detail = "text=\"$actual\" expected=\"$expected\"",
+    )
+}
+
+internal fun runUnfocusedScenarios(
+    driver: RobotDriver,
+    state: SmokeState,
+    distractor: JFrame,
+): List<ScenarioResult> {
+    val results = mutableListOf<ScenarioResult>()
+    results += scenarioStartsUnfocused(state, distractor)
+    // Robot warmup click on the *distractor* — primes the input pipeline (the same cold-JVM
+    // dropped-first-click flake the focused smoke documents) without clicking SUT, because
+    // clicking SUT would transfer focus to it and ruin the unfocused starting state.
+    val distractorBounds = distractor.bounds
+    driver.click(distractorBounds.centerX.toInt(), distractorBounds.centerY.toInt())
+    Thread.sleep(POST_CLICK_SETTLE_MS)
+    results += scenarioPressKeyOnUnfocusedField(driver, state)
+    results += scenarioClickOnUnfocusedCounter(driver, state)
+    results += scenarioTypeTextAfterFocusClick(driver, state)
+    return results
+}
+
+internal fun printResults(label: String, results: List<ScenarioResult>): Int {
+    println()
+    println("--- $label results ---")
+    results.forEach {
+        println("  ${it.label}: ${if (it.passed) "PASS" else "FAIL"} — ${it.detail}")
+    }
+    val passed = results.count { it.passed }
+    val total = results.size
+    println("--- $passed/$total passed ---")
+    return if (passed == total) 0 else 1
+}
+
+internal const val SMOKE_PANEL_WIDTH = 540
+internal const val SMOKE_PANEL_HEIGHT = 320
+internal const val WINDOW_OPEN_TIMEOUT_MS = 5_000L
+internal const val LAYOUT_TIMEOUT_MS = 5_000L
+internal const val POST_LAYOUT_WARMUP_MS = 500L
+internal const val POST_CLICK_SETTLE_MS = 250L
+internal const val POST_TYPE_SETTLE_MS = 800L

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotSmoke.kt
@@ -2,41 +2,9 @@
 
 package dev.sebastiano.spectre.sample
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposePanel
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.input.key.Key
-import androidx.compose.ui.input.key.KeyEventType
-import androidx.compose.ui.input.key.isCtrlPressed
-import androidx.compose.ui.input.key.isMetaPressed
-import androidx.compose.ui.input.key.key
-import androidx.compose.ui.input.key.onPreviewKeyEvent
-import androidx.compose.ui.input.key.type
-import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.unit.dp
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.composeBoundsToAwtCenter
 import java.awt.Dimension
-import java.awt.Window
 import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
@@ -108,7 +76,7 @@ private fun runSmoke(): Int {
     SwingUtilities.invokeLater {
         val composePanel =
             ComposePanel().apply {
-                preferredSize = Dimension(PANEL_WIDTH, PANEL_HEIGHT)
+                preferredSize = Dimension(SMOKE_PANEL_WIDTH, SMOKE_PANEL_HEIGHT)
                 setContent { SmokeContent(state) }
             }
         val frame =
@@ -146,7 +114,7 @@ private fun runSmoke(): Int {
     // race without wasting time on cold-JVM boots that took longer to lay out anyway.
     Thread.sleep(POST_LAYOUT_WARMUP_MS)
 
-    printEnvironment(state)
+    printEnvironment("WindowsRobotSmoke", state)
 
     val driver = RobotDriver()
     // Cold-JVM warmup: the very first Robot mouse event after a freshly-shown alwaysOnTop
@@ -155,326 +123,13 @@ private fun runSmoke(): Int {
     // 0 → 2 on the same button. Fire one sacrificial click outside the assertion-bearing
     // scenarios so the production scenarios run on a warm input pipeline.
     warmupRobot(driver, state)
-    val results = mutableListOf<ScenarioResult>()
-
-    // Order matters: typeText asserts exact equality on a freshly-empty field, so it has to
-    // run before any keystroke that would have left state in the BasicTextField. After that,
-    // pressKey appends one character (verifying focus + raw keystrokes), and clearAndTypeText
-    // wipes and re-types (verifying the Ctrl+A + Backspace path).
-    results += scenarioCounterClick(driver, state)
-    results += scenarioCounterDoubleClick(driver, state)
-    results += scenarioTypeText(driver, state)
-    results += scenarioPressKeySingleChar(driver, state)
-    results += scenarioClearAndTypeText(driver, state)
-    results += scenarioCtrlSShortcut(driver, state)
-
-    println()
-    println("--- WindowsRobotSmoke results ---")
-    results.forEach {
-        println("  ${it.label}: ${if (it.passed) "PASS" else "FAIL"} — ${it.detail}")
-    }
-    val passed = results.count { it.passed }
-    val total = results.size
-    println("--- $passed/$total passed ---")
+    val results = runFocusedScenarios(driver, state, typeTextExpected = "hello windows")
+    val exitCode = printResults("WindowsRobotSmoke", results)
 
     SwingUtilities.invokeLater {
         state.frame?.isVisible = false
         state.frame?.dispose()
     }
 
-    return if (passed == total) 0 else 1
+    return exitCode
 }
-
-private fun printEnvironment(state: SmokeState) {
-    val frame = state.frame
-    val panel = state.composePanel
-    println("--- WindowsRobotSmoke environment ---")
-    println(
-        "os.name=\"${System.getProperty("os.name")}\" os.version=\"${System.getProperty("os.version")}\""
-    )
-    if (frame != null) {
-        val gc = frame.graphicsConfiguration
-        println(
-            "frame.bounds=${frame.bounds} isFocused=${frame.isFocused} " +
-                "isAlwaysOnTop=${frame.isAlwaysOnTop} isShowing=${frame.isShowing}"
-        )
-        if (gc != null) {
-            println(
-                "frame.gc.scaleX=${gc.defaultTransform.scaleX} scaleY=${gc.defaultTransform.scaleY} " +
-                    "bounds=${gc.bounds}"
-            )
-        }
-    }
-    if (panel != null) {
-        val loc =
-            try {
-                panel.locationOnScreen
-            } catch (_: java.awt.IllegalComponentStateException) {
-                null
-            }
-        println("panel.size=(w=${panel.width},h=${panel.height}) panel.locationOnScreen=$loc")
-    }
-    println("counterBounds(Compose px)=${state.counterBounds}")
-    println("textFieldBounds(Compose px)=${state.textFieldBounds}")
-    println("--- /environment ---")
-}
-
-private fun waitForFrame(ref: AtomicReference<JFrame>) {
-    val deadline = System.nanoTime() + WINDOW_OPEN_TIMEOUT_MS * 1_000_000L
-    while (System.nanoTime() < deadline) {
-        val frame = ref.get()
-        if (frame != null && frame.isShowing) return
-        Thread.sleep(50)
-    }
-    error("frame never showed within ${WINDOW_OPEN_TIMEOUT_MS}ms")
-}
-
-private fun warmupRobot(driver: RobotDriver, state: SmokeState) {
-    // Click on the counter button, fire-and-forget. counterBounds is non-zero by here
-    // (waitForLayout already proved it). Each scenario captures its own `before` snapshot,
-    // so we don't need to reset state — the warmup click just primes the input pipeline.
-    val target = awtCenter(state, state.counterBounds) ?: return
-    driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-}
-
-private fun waitForLayout(state: SmokeState) {
-    val deadline = System.nanoTime() + LAYOUT_TIMEOUT_MS * 1_000_000L
-    while (System.nanoTime() < deadline) {
-        val counter = state.counterBounds
-        val textField = state.textFieldBounds
-        val ready =
-            counter.width > 0f &&
-                counter.height > 0f &&
-                textField.width > 0f &&
-                textField.height > 0f
-        if (ready) return
-        Thread.sleep(50)
-    }
-    error(
-        "Compose targets never laid out within ${LAYOUT_TIMEOUT_MS}ms; " +
-            "counterBounds=${state.counterBounds} textFieldBounds=${state.textFieldBounds}"
-    )
-}
-
-private data class ScenarioResult(val label: String, val passed: Boolean, val detail: String)
-
-private fun scenarioCounterClick(driver: RobotDriver, state: SmokeState): ScenarioResult {
-    val before = state.clickCount
-    val target = awtCenter(state, state.counterBounds)
-    if (target == null) {
-        return ScenarioResult("mouseMove + click on counter", false, "no target rect available")
-    }
-    driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-    val after = state.clickCount
-    return ScenarioResult(
-        "mouseMove + click on counter",
-        passed = after == before + 1,
-        detail = "clickCount $before → $after at (${target.x},${target.y})",
-    )
-}
-
-private fun scenarioCounterDoubleClick(driver: RobotDriver, state: SmokeState): ScenarioResult {
-    val before = state.clickCount
-    val target = awtCenter(state, state.counterBounds)
-    if (target == null) {
-        return ScenarioResult("doubleClick on counter", false, "no target rect available")
-    }
-    driver.doubleClick(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-    val after = state.clickCount
-    return ScenarioResult(
-        "doubleClick on counter",
-        passed = after == before + 2,
-        detail = "clickCount $before → $after",
-    )
-}
-
-private fun scenarioPressKeySingleChar(driver: RobotDriver, state: SmokeState): ScenarioResult {
-    // Baseline for the typeText scenario: if the BasicTextField is focused after a click and
-    // accepts direct keystrokes (no clipboard involved), the focus path works and any
-    // typeText failure isolates to the clipboard-paste path.
-    val target = awtCenter(state, state.textFieldBounds)
-    if (target == null) {
-        return ScenarioResult("pressKey 'h' into BasicTextField", false, "no target rect available")
-    }
-    driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-    val before = state.textValue.text
-    driver.pressKey(java.awt.event.KeyEvent.VK_H)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
-    val after = state.textValue.text
-    return ScenarioResult(
-        "pressKey 'h' into BasicTextField",
-        passed = after.length == before.length + 1,
-        detail = "before=\"$before\" after=\"$after\"",
-    )
-}
-
-private fun scenarioTypeText(driver: RobotDriver, state: SmokeState): ScenarioResult {
-    val expected = "hello windows"
-    val target = awtCenter(state, state.textFieldBounds)
-    if (target == null) {
-        return ScenarioResult("typeText into BasicTextField", false, "no target rect available")
-    }
-    driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-    val focusOwnerBefore = focusOwnerSummary(state)
-    driver.typeText(expected)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
-    val actual = state.textValue.text
-    // Exact equality: the field starts empty (typeText runs first in the scenario order
-    // before any keystroke leaves state behind), so the only correct outcome is the typed
-    // string — substring match would mask paste-doubling or stray-keypress bugs.
-    val passed = actual == expected
-    val detail = "text=\"$actual\" expected=\"$expected\" focusOwner=$focusOwnerBefore"
-    return ScenarioResult("typeText into BasicTextField", passed = passed, detail = detail)
-}
-
-private fun focusOwnerSummary(state: SmokeState): String {
-    val focused = java.awt.KeyboardFocusManager.getCurrentKeyboardFocusManager().focusOwner
-    return focused?.let { "${it.javaClass.simpleName}@${System.identityHashCode(it)}" }
-        ?: "null (frame.isFocused=${state.frame?.isFocused})"
-}
-
-private fun scenarioClearAndTypeText(driver: RobotDriver, state: SmokeState): ScenarioResult {
-    val expected = "replaced"
-    val target = awtCenter(state, state.textFieldBounds)
-    if (target == null) {
-        return ScenarioResult("clearAndTypeText", false, "no target rect available")
-    }
-    driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-    driver.clearAndTypeText(expected)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
-    val actual = state.textValue.text
-    return ScenarioResult(
-        "clearAndTypeText",
-        passed = actual == expected,
-        detail = "text=\"$actual\" expected=\"$expected\"",
-    )
-}
-
-private fun scenarioCtrlSShortcut(driver: RobotDriver, state: SmokeState): ScenarioResult {
-    state.shortcutFiredCount = 0
-    val before = state.shortcutFiredCount
-    // Click somewhere inside the panel first to ensure focus is on the Compose root.
-    val anchor = awtCenter(state, state.counterBounds)
-    if (anchor != null) {
-        driver.click(anchor.x, anchor.y)
-        Thread.sleep(POST_CLICK_SETTLE_MS)
-    }
-    driver.pressKey(java.awt.event.KeyEvent.VK_S, java.awt.event.InputEvent.CTRL_DOWN_MASK)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-    val after = state.shortcutFiredCount
-    return ScenarioResult(
-        "Ctrl+S shortcut via pressKey",
-        passed = after == before + 1,
-        detail = "shortcutFiredCount $before → $after",
-    )
-}
-
-private fun awtCenter(state: SmokeState, rect: Rect): java.awt.Point? {
-    if (rect.width <= 0f || rect.height <= 0f) return null
-    val frame = state.frame ?: return null
-    val panel = state.composePanel ?: return null
-    val gc = (frame as Window).graphicsConfiguration ?: return null
-    val xform = gc.defaultTransform
-    val panelLoc =
-        try {
-            panel.locationOnScreen
-        } catch (_: java.awt.IllegalComponentStateException) {
-            return null
-        }
-    return composeBoundsToAwtCenter(
-        left = rect.left,
-        top = rect.top,
-        right = rect.right,
-        bottom = rect.bottom,
-        scaleX = xform.scaleX.toFloat(),
-        scaleY = xform.scaleY.toFloat(),
-        panelScreenX = panelLoc.x,
-        panelScreenY = panelLoc.y,
-    )
-}
-
-private class SmokeState {
-    var frame: JFrame? = null
-    var composePanel: ComposePanel? = null
-
-    @Volatile var clickCount: Int = 0
-    @Volatile var textValue: TextFieldValue = TextFieldValue("")
-    @Volatile var shortcutFiredCount: Int = 0
-    @Volatile var counterBounds: Rect = Rect.Zero
-    @Volatile var textFieldBounds: Rect = Rect.Zero
-}
-
-@Composable
-private fun SmokeContent(state: SmokeState) {
-    var localCount by remember { mutableIntStateOf(0) }
-    var localText by remember { mutableStateOf(TextFieldValue("")) }
-    Column(
-        modifier =
-            Modifier.fillMaxWidth().background(Color.White).padding(16.dp).onPreviewKeyEvent { event
-                ->
-                if (
-                    event.type == KeyEventType.KeyDown &&
-                        event.key == Key.S &&
-                        (event.isCtrlPressed || event.isMetaPressed)
-                ) {
-                    state.shortcutFiredCount += 1
-                    true
-                } else false
-            },
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        BasicText("Spectre Robot smoke — driven by RobotDriver(), not synthetic.")
-        BasicText("clickCount = $localCount")
-        Box(
-            modifier =
-                Modifier.height(48.dp)
-                    .fillMaxWidth()
-                    .clickable {
-                        localCount += 1
-                        state.clickCount = localCount
-                    }
-                    .background(Color(red = 0x33, green = 0x66, blue = 0xCC))
-                    .padding(12.dp)
-                    .onGloballyPositioned { coords ->
-                        state.counterBounds = coords.boundsInWindow()
-                    }
-        ) {
-            BasicText("counter button (click via Robot)")
-        }
-        // BasicTextField lays out at its intrinsic single-line height by default; without
-        // forcing a larger hit area, a Robot click aimed at the wrapper Box's center lands in
-        // empty padding below the text input and never focuses the field. Make the
-        // BasicTextField fill the wrapper so the entire visible area accepts focus on click.
-        BasicTextField(
-            value = localText,
-            onValueChange = {
-                localText = it
-                state.textValue = it
-            },
-            modifier =
-                Modifier.fillMaxWidth()
-                    .height(48.dp)
-                    .background(Color(red = 0xEE, green = 0xEE, blue = 0xEE))
-                    .padding(8.dp)
-                    .onGloballyPositioned { coords ->
-                        state.textFieldBounds = coords.boundsInWindow()
-                    },
-        )
-        BasicText("textValue = \"${state.textValue.text}\"")
-        BasicText("shortcutFiredCount = ${state.shortcutFiredCount}")
-    }
-}
-
-private const val PANEL_WIDTH = 540
-private const val PANEL_HEIGHT = 320
-private const val WINDOW_OPEN_TIMEOUT_MS = 5_000L
-private const val LAYOUT_TIMEOUT_MS = 5_000L
-private const val POST_LAYOUT_WARMUP_MS = 500L
-private const val POST_CLICK_SETTLE_MS = 250L
-private const val POST_TYPE_SETTLE_MS = 800L

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
@@ -115,7 +115,7 @@ private fun runSmoke(): Int {
     waitForFrame(sutRef)
     waitForFrame(distractorRef)
     waitForLayout(state)
-    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+    Thread.sleep(POST_LAYOUT_UNFOCUSED_WARMUP_MS)
 
     val driver = RobotDriver()
     val distractor = requireNotNull(distractorRef.get()) { "distractor frame missing" }

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
@@ -2,35 +2,10 @@
 
 package dev.sebastiano.spectre.sample
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.BasicText
-import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.awt.ComposePanel
-import androidx.compose.ui.geometry.Rect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.layout.boundsInWindow
-import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.unit.dp
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.composeBoundsToAwtCenter
 import java.awt.Color as AwtColor
 import java.awt.Dimension
-import java.awt.Window
 import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import javax.swing.JLabel
@@ -92,7 +67,7 @@ fun main() {
 }
 
 private fun runSmoke(): Int {
-    val state = UnfocusedSmokeState()
+    val state = SmokeState()
     val sutRef = AtomicReference<JFrame>()
     val distractorRef = AtomicReference<JFrame>()
 
@@ -102,8 +77,8 @@ private fun runSmoke(): Int {
         // to be the focus owner after both are on screen.
         val composePanel =
             ComposePanel().apply {
-                preferredSize = Dimension(PANEL_WIDTH, PANEL_HEIGHT)
-                setContent { UnfocusedSmokeContent(state) }
+                preferredSize = Dimension(SMOKE_PANEL_WIDTH, SMOKE_PANEL_HEIGHT)
+                setContent { SmokeContent(state) }
             }
         val sut =
             JFrame("Spectre unfocused-robot SUT").apply {
@@ -143,250 +118,21 @@ private fun runSmoke(): Int {
     Thread.sleep(POST_LAYOUT_WARMUP_MS)
 
     val driver = RobotDriver()
-    val results = mutableListOf<UnfocusedScenarioResult>()
-
-    // Pin the unfocused starting state. If this ever flips on a future Windows / JBR build
-    // the rest of the assertions become meaningless (we'd be testing the focused path under
-    // an unfocused-named smoke), so fail loudly here.
-    results += scenarioStartsUnfocused(state, distractorRef.get())
-
-    // Robot warmup click on the *distractor* — we want to prime the input pipeline (the same
-    // cold-JVM dropped-first-click flake the focused smoke documents) without clicking SUT,
-    // because clicking SUT would transfer focus to it and ruin the unfocused starting state.
     val distractor = requireNotNull(distractorRef.get()) { "distractor frame missing" }
-    val distractorBounds = distractor.bounds
-    driver.click(distractorBounds.centerX.toInt(), distractorBounds.centerY.toInt())
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-
-    results += scenarioPressKeyOnUnfocusedField(driver, state)
-    results += scenarioClickOnUnfocusedCounter(driver, state)
-    results += scenarioTypeTextAfterFocusClick(driver, state)
-
-    println()
-    println("--- WindowsRobotUnfocusedSmoke results ---")
-    results.forEach {
-        println("  ${it.label}: ${if (it.passed) "PASS" else "FAIL"} — ${it.detail}")
-    }
-    val passed = results.count { it.passed }
-    val total = results.size
-    println("--- $passed/$total passed ---")
+    val results = runUnfocusedScenarios(driver, state, distractor)
+    val exitCode = printResults("WindowsRobotUnfocusedSmoke", results)
 
     SwingUtilities.invokeLater {
         sutRef.get()?.dispose()
         distractorRef.get()?.dispose()
     }
 
-    return if (passed == total) 0 else 1
+    return exitCode
 }
 
-private fun waitForFrame(ref: AtomicReference<JFrame>) {
-    val deadline = System.nanoTime() + WINDOW_OPEN_TIMEOUT_MS * 1_000_000L
-    while (System.nanoTime() < deadline) {
-        val frame = ref.get()
-        if (frame != null && frame.isShowing) return
-        Thread.sleep(50)
-    }
-    error("frame never showed within ${WINDOW_OPEN_TIMEOUT_MS}ms")
-}
-
-private fun waitForLayout(state: UnfocusedSmokeState) {
-    val deadline = System.nanoTime() + LAYOUT_TIMEOUT_MS * 1_000_000L
-    while (System.nanoTime() < deadline) {
-        val counter = state.counterBounds
-        val textField = state.textFieldBounds
-        val ready =
-            counter.width > 0f &&
-                counter.height > 0f &&
-                textField.width > 0f &&
-                textField.height > 0f
-        if (ready) return
-        Thread.sleep(50)
-    }
-    error(
-        "Compose targets never laid out within ${LAYOUT_TIMEOUT_MS}ms; " +
-            "counterBounds=${state.counterBounds} textFieldBounds=${state.textFieldBounds}"
-    )
-}
-
-private data class UnfocusedScenarioResult(
-    val label: String,
-    val passed: Boolean,
-    val detail: String,
-)
-
-private fun scenarioStartsUnfocused(
-    state: UnfocusedSmokeState,
-    distractor: JFrame?,
-): UnfocusedScenarioResult {
-    val sut = state.frame
-    val sutFocused = sut?.isFocused == true
-    val distractorFocused = distractor?.isFocused == true
-    return UnfocusedScenarioResult(
-        "starting state: distractor focused, SUT not focused",
-        passed = !sutFocused && distractorFocused,
-        detail = "sut.isFocused=$sutFocused distractor.isFocused=$distractorFocused",
-    )
-}
-
-private fun scenarioPressKeyOnUnfocusedField(
-    driver: RobotDriver,
-    state: UnfocusedSmokeState,
-): UnfocusedScenarioResult {
-    // SUT is unfocused — no Compose component holds keyboard focus on the SUT side. Pressing
-    // a character key should NOT modify the text field. If it does, focus must have leaked
-    // somewhere we don't expect (or Robot is targeting the distractor's contents instead).
-    val before = state.textValue.text
-    driver.pressKey(java.awt.event.KeyEvent.VK_X)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
-    val after = state.textValue.text
-    return UnfocusedScenarioResult(
-        "pressKey on unfocused SUT does NOT alter the text field",
-        passed = after == before,
-        detail = "before=\"$before\" after=\"$after\" sut.isFocused=${state.frame?.isFocused}",
-    )
-}
-
-private fun scenarioClickOnUnfocusedCounter(
-    driver: RobotDriver,
-    state: UnfocusedSmokeState,
-): UnfocusedScenarioResult {
-    val target = awtCenter(state, state.counterBounds)
-    if (target == null) {
-        return UnfocusedScenarioResult(
-            "click on unfocused counter",
-            false,
-            "no target rect available",
-        )
-    }
-    val before = state.clickCount
-    val sutFocusedBefore = state.frame?.isFocused == true
-    driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-    val after = state.clickCount
-    val sutFocusedAfter = state.frame?.isFocused == true
-    return UnfocusedScenarioResult(
-        "click on unfocused counter increments + transfers focus",
-        passed = after == before + 1 && sutFocusedAfter,
-        detail =
-            "clickCount $before → $after; sut.isFocused $sutFocusedBefore → $sutFocusedAfter " +
-                "at (${target.x},${target.y})",
-    )
-}
-
-private fun scenarioTypeTextAfterFocusClick(
-    driver: RobotDriver,
-    state: UnfocusedSmokeState,
-): UnfocusedScenarioResult {
-    val expected = "post-focus paste"
-    val target = awtCenter(state, state.textFieldBounds)
-    if (target == null) {
-        return UnfocusedScenarioResult(
-            "typeText after focus-handoff click",
-            false,
-            "no target rect",
-        )
-    }
-    driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
-    driver.clearAndTypeText(expected)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
-    val actual = state.textValue.text
-    return UnfocusedScenarioResult(
-        "typeText after focus-handoff click",
-        passed = actual == expected,
-        detail = "text=\"$actual\" expected=\"$expected\"",
-    )
-}
-
-private fun awtCenter(state: UnfocusedSmokeState, rect: Rect): java.awt.Point? {
-    if (rect.width <= 0f || rect.height <= 0f) return null
-    val frame = state.frame ?: return null
-    val panel = state.composePanel ?: return null
-    val gc = (frame as Window).graphicsConfiguration ?: return null
-    val xform = gc.defaultTransform
-    val panelLoc =
-        try {
-            panel.locationOnScreen
-        } catch (_: java.awt.IllegalComponentStateException) {
-            return null
-        }
-    return composeBoundsToAwtCenter(
-        left = rect.left,
-        top = rect.top,
-        right = rect.right,
-        bottom = rect.bottom,
-        scaleX = xform.scaleX.toFloat(),
-        scaleY = xform.scaleY.toFloat(),
-        panelScreenX = panelLoc.x,
-        panelScreenY = panelLoc.y,
-    )
-}
-
-private class UnfocusedSmokeState {
-    var frame: JFrame? = null
-    var composePanel: ComposePanel? = null
-
-    @Volatile var clickCount: Int = 0
-    @Volatile var textValue: TextFieldValue = TextFieldValue("")
-    @Volatile var counterBounds: Rect = Rect.Zero
-    @Volatile var textFieldBounds: Rect = Rect.Zero
-}
-
-@Composable
-private fun UnfocusedSmokeContent(state: UnfocusedSmokeState) {
-    var localCount by remember { mutableIntStateOf(0) }
-    var localText by remember { mutableStateOf(TextFieldValue("")) }
-    Column(
-        modifier = Modifier.fillMaxWidth().background(Color.White).padding(16.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        BasicText("Spectre unfocused-robot smoke — driven by RobotDriver, distractor steals focus.")
-        BasicText("clickCount = $localCount")
-        Box(
-            modifier =
-                Modifier.height(48.dp)
-                    .fillMaxWidth()
-                    .clickable {
-                        localCount += 1
-                        state.clickCount = localCount
-                    }
-                    .background(Color(red = 0x33, green = 0x66, blue = 0xCC))
-                    .padding(12.dp)
-                    .onGloballyPositioned { coords ->
-                        state.counterBounds = coords.boundsInWindow()
-                    }
-        ) {
-            BasicText("counter button (click via Robot while unfocused)")
-        }
-        BasicTextField(
-            value = localText,
-            onValueChange = {
-                localText = it
-                state.textValue = it
-            },
-            modifier =
-                Modifier.fillMaxWidth()
-                    .height(48.dp)
-                    .background(Color(red = 0xEE, green = 0xEE, blue = 0xEE))
-                    .padding(8.dp)
-                    .onGloballyPositioned { coords ->
-                        state.textFieldBounds = coords.boundsInWindow()
-                    },
-        )
-        BasicText("textValue = \"${state.textValue.text}\"")
-    }
-}
-
-private const val PANEL_WIDTH = 540
-private const val PANEL_HEIGHT = 280
 private const val SUT_X = 600
 private const val SUT_Y = 400
 private const val DISTRACTOR_WIDTH = 320
 private const val DISTRACTOR_HEIGHT = 200
 private const val DISTRACTOR_X = 80
 private const val DISTRACTOR_Y = 80
-private const val WINDOW_OPEN_TIMEOUT_MS = 5_000L
-private const val LAYOUT_TIMEOUT_MS = 5_000L
-private const val POST_LAYOUT_WARMUP_MS = 600L
-private const val POST_CLICK_SETTLE_MS = 250L
-private const val POST_TYPE_SETTLE_MS = 800L


### PR DESCRIPTION
## Summary
- Extracts the shared rig from `WindowsRobotSmoke` / `WindowsRobotUnfocusedSmoke` into `RobotSmokeRig.kt`, then adds Linux + macOS counterparts that reuse it.
- Wires the Linux focused smoke into `validation-linux.yml` under `xvfb-run` so real-`java.awt.Robot` regressions surface in CI on every PR — first time any platform's real-Robot path runs in CI.
- macOS smoke stays manual (TCC can't be granted on hosted `macos-*` runners, same constraint that already keeps SCK end-to-end recording off `macos.yml`).

## What's in the box

| File | Purpose |
| --- | --- |
| `RobotSmokeRig.kt` (new) | Shared `SmokeState`, `SmokeContent`, env dump, `awtCenter`, `waitForFrame`/`waitForLayout`, the six focused scenarios, the four unfocused scenarios, results printer. Uses `shortcutModifierKeyCode(detectMacOs())` so Ctrl+S → Cmd+S translation is automatic. |
| `LinuxRobotSmoke.kt` / `LinuxRobotUnfocusedSmoke.kt` (new) | Wayland gate: `XDG_SESSION_TYPE=wayland` ∨ `WAYLAND_DISPLAY` set ∨ `wayland-*` socket present, AND `DISPLAY` unset → exit 2 with remediation. Robot can't drive native Wayland; same constraint Spectre's `LinuxX11Grab` already documents from #77. |
| `MacOsRobotSmoke.kt` / `MacOsRobotUnfocusedSmoke.kt` (new) | TCC probe: fires a click at the counter; if `clickCount` doesn't tick, prints `java.home` + System Settings remediation and exits 2 before running scenarios. |
| `WindowsRobotSmoke.kt` / `WindowsRobotUnfocusedSmoke.kt` (modified) | Bodies slimmed (355→135, 266→138). KDocs + banked findings preserved verbatim. |
| `sample-desktop/build.gradle.kts` | Four new `JavaExec` tasks gated `onlyIf isLinux/isMacOsX`, mirroring the Windows pair. |
| `.github/workflows/validation-linux.yml` | One new step: `xvfb-run -a ./gradlew :sample-desktop:runLinuxRobotSmoke`. The unfocused variant intentionally stays out of CI until first-run findings replace the TBD placeholders — Xvfb's minimal WM is unlikely to match real KWin/Mutter focus behaviour. |

## CI signal we're hoping to get from this PR
- **Linux Xvfb**: first real validation that the Wayland gate logic correctly stays out of the picture under Xvfb, that `runLinuxRobotSmoke` reports 6/6 PASS, and that the alwaysOnTop + cold-JVM warmup pattern ports cleanly to a real Xorg session.
- **Windows runner**: the existing `windows.yml` `:check` should still pass — this PR refactors the Windows smokes' bodies but doesn't touch their behaviour or main()s.
- **bugbot**: independent eyes on the heuristic TCC probe (could false-positive if AppKit's "first click on inactive app activates without delivering" applies to a freshly-shown alwaysOnTop JFrame), the Wayland gate's environment-variable logic, and the rig extraction.

## Verified locally (Windows host)
- `:sample-desktop:compileTestKotlin` ✅
- `:sample-desktop:ktfmtCheckTest` ✅
- `:sample-desktop:detekt` ✅
- Cannot validate Linux/macOS runtime behaviour from this host — the Linux CI run on this PR is the first real test.

## Test plan
- [ ] Linux CI step (`Run real-Robot Linux smoke under Xvfb`) reports 6/6 PASS.
- [ ] Windows `:check` workflow still green (refactor preserves behaviour).
- [ ] Manual run of `runLinuxRobotSmoke` on a developer Linux box (KWin or Mutter) — bank findings into the smoke's KDoc, replace TBD placeholders.
- [ ] Manual run of `runLinuxRobotUnfocusedSmoke` on the same box — if stable, follow up with a small PR adding it to CI.
- [ ] Manual run of `runMacOsRobotSmoke` on a developer Mac (after granting Accessibility TCC) — confirm probe doesn't false-positive, bank findings.
- [ ] Manual run of `runMacOsRobotUnfocusedSmoke` on the same Mac — verify the focus-handoff pattern works on AppKit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rock3r/codesmith/spectre/pr/91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->