### PR TITLE
docs(test): bank Linux Robot smoke findings + wire unfocused into CI

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -124,14 +124,26 @@ jobs:
         # JavaExec propagates failure naturally — no XML-verifier needed (unlike the test
         # tasks above).
         #
-        # The unfocused variant (`runLinuxRobotUnfocusedSmoke`) is NOT wired in here yet:
-        # focus / click-to-focus semantics under Xvfb are minimal-WM territory and likely
-        # behave differently from a real KWin / Mutter session. Run it manually on a
-        # developer Linux machine first to bank findings; once the unfocused-smoke KDoc has a
-        # real findings list (not the TBD placeholders) we can revisit adding it here.
+        # The unfocused variant (`runLinuxRobotUnfocusedSmoke`) runs as a separate step
+        # below — split for independent failure attribution (so a regression in one doesn't
+        # mask the other in the workflow summary).
         if: always()
         run: |
           xvfb-run -a ./gradlew :sample-desktop:runLinuxRobotSmoke
+        shell: bash
+
+      - name: Run real-Robot Linux unfocused smoke under Xvfb
+        # Companion to the focused-smoke step above, exercising the `RobotDriver` path against
+        # a deliberately-unfocused Compose window with a sibling distractor JFrame holding focus.
+        # Wired in once the unfocused-smoke KDoc gained a real findings list (validated on
+        # Ubuntu 24.04 GNOME under both XWayland and Xvfb — see `LinuxRobotUnfocusedSmoke.kt`'s
+        # KDoc for the banked observations).
+        #
+        # `if: always()` so a focused-smoke failure above doesn't skip this — both smokes get
+        # a fair chance to surface their own diagnostic output on every run.
+        if: always()
+        run: |
+          xvfb-run -a ./gradlew :sample-desktop:runLinuxRobotUnfocusedSmoke
         shell: bash
 
       - name: Verify validation tests passed via JUnit XML

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
@@ -24,12 +24,30 @@ import kotlin.system.exitProcess
  * input is dropped at the protocol layer, not by the JVM. Same constraint Spectre's `LinuxX11Grab`
  * documents from #77.
  *
- * Findings from running this on Linux (placeholder — bank empirical results here on first real run,
- * mirroring the Windows smoke's findings list):
+ * Findings from running this on Ubuntu 24.04 (Hyper-V VM, GNOME Wayland session) and on the GitHub
+ * `ubuntu-latest` runner under Xvfb:
  *
- * 1. (TBD — Xvfb + KWin + Mutter foreground / focus behaviour with `isAlwaysOnTop`)
- * 2. (TBD — cold-JVM warmup click necessity under Xvfb)
- * 3. (TBD — clipboard-paste path on X11 vs the macOS NSPasteboard latency budget)
+ * 1. **Three Linux session modes, all valid.** Validated empirically:
+ *     - **XWayland** (Wayland session with `DISPLAY=:0` set): the gate stays out (DISPLAY is set,
+ *       so the abort branch doesn't trigger), the JFrame becomes an XWayland client, and Robot
+ *       input flows through XWayland's X11 protocol. 6/6 PASS. This is the most common mode for
+ *       modern Linux desktops (GNOME / KDE Plasma default to Wayland with XWayland for legacy X
+ *       clients), so end users on a typical Linux box get this path.
+ *     - **Pure Wayland** (Wayland session with `DISPLAY` unset, no XWayland fallback): gate fires,
+ *       smoke exits 2 with the remediation message before constructing the JFrame. Verified by
+ *       running `env -u DISPLAY bash …` from a GNOME Wayland terminal.
+ *     - **Headless Xvfb** (no Wayland indicators, `xvfb-run -a` provides a virtual Xorg display):
+ *       gate stays out, smoke runs against the virtual framebuffer with no visible window. 6/6
+ *       PASS. This is the CI mode in `validation-linux.yml`.
+ * 2. **Cold-JVM warmup click is unnecessary under Xvfb but kept for parity.** Empirically the first
+ *    Robot click lands cleanly on Xvfb (the late-attach race that flakes Windows ~half the time was
+ *    not observed across multiple CI runs). The rig keeps the warmup unconditionally because
+ *    removing it asymmetrically across platforms would obscure the Windows justification, and the
+ *    cost is one extra click per smoke (~250ms).
+ * 3. **Clipboard-paste path works through XWayland.** The `typeText` clipboard-poll budget
+ *    (`CLIPBOARD_SETTLE_TIMEOUT_MS = 1_000L`) tuned for macOS NSPasteboard latency was never
+ *    approached on X11 — observed settle is essentially synchronous. The path validates with
+ *    XWayland transparently bridging clipboard ownership.
  *
  * What this *doesn't* exercise:
  * - Native Wayland input — gated above; not testable without a synthetic compositor that grants the

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
@@ -49,8 +49,8 @@ import kotlin.system.exitProcess
  * - **Pure Wayland** (Wayland session with `DISPLAY` unset): gate fires, smoke exits before
  *   constructing the JFrame.
  * - **Headless Xvfb**: 4/4 PASS against the virtual framebuffer; matches the focused smoke's CI
- *   path. Wiring this variant into `validation-linux.yml` is now eligible (the previous "stays
- *   manual until findings replace TBDs" condition is satisfied) and a separate change.
+ *   path. Wired into `validation-linux.yml` as its own step alongside the focused smoke (split for
+ *   independent failure attribution).
  */
 fun main() {
     var exitCode = 0

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
@@ -21,16 +21,36 @@ import kotlin.system.exitProcess
  * Same gate as [LinuxRobotSmoke]: aborts with exit 2 on pure Wayland (Robot input is dropped at the
  * protocol layer; would report 0/N PASS for opaque reasons).
  *
- * Findings from running this on Linux (placeholder — bank empirical results here on first real run,
- * mirroring the Windows unfocused smoke's findings list):
+ * Findings from running this on Ubuntu 24.04 (Hyper-V VM, GNOME Wayland session, validated under
+ * both the XWayland bridge and headless Xvfb):
  *
- * 1. (TBD — does focus actually leave the SUT after the distractor's `requestFocus()` under KWin /
- *    Mutter / Xvfb? WMs honour focus requests differently than Windows.)
- * 2. (TBD — pressKey-on-unfocused-SUT behaviour: dropped, or routed to focus owner?)
- * 3. (TBD — click-to-focus semantics: does the first click both register AND transfer focus, or is
- *    a separate activation click required on the user's WM?)
- * 4. (TBD — typeText-after-focus-click stability under Xorg's clipboard semantics — XSelection
- *    timing differs from Windows OLE clipboard.)
+ * 1. **Focus actually leaves the SUT after the distractor's `requestFocus()`.** Validated on
+ *    Mutter-via-XWayland (GNOME Wayland's X11 server) and on Xvfb's minimal WM. The starting-state
+ *    scenario reports `sut.isFocused=false distractor.isFocused=true` reliably across runs — no
+ *    additional `toFront()` ceremony or sleep-after-focus-request was needed beyond what the rig
+ *    already provides.
+ * 2. **pressKey on an unfocused SUT is dropped, not routed to the focus owner.** The empty-text
+ *    field stays empty (`before="" after=""`) when keystrokes arrive while the distractor holds
+ *    focus, matching Windows behaviour. This is the OS / WM enforcing focus, not a Spectre quirk —
+ *    `java.awt.Robot` injects at the X server layer, the X server delivers to the focused window,
+ *    XWayland routes to the X-side focus owner.
+ * 3. **A single click on the unfocused counter both registers AND transfers focus.** No separate
+ *    activation click is needed — `clickCount 0 → 1` increments AND `sut.isFocused false → true` in
+ *    the same scenario step, on both XWayland and Xvfb. (Reflects the X11 click-to-focus
+ *    convention; differs from macOS, where the first click on an inactive app traditionally
+ *    activates without delivering — to be verified separately when MacOsRobotUnfocusedSmoke runs.)
+ * 4. **typeText-after-focus-click works through XSelection on XWayland.** No clipboard-settle
+ *    pressure observed; the existing `CLIPBOARD_SETTLE_TIMEOUT_MS = 1_000L` budget tuned for macOS
+ *    NSPasteboard latency is never approached on X11. Both XWayland and Xvfb produce the expected
+ *    text after the focus-handoff click.
+ *
+ * Three Linux session modes validated (mirrors [LinuxRobotSmoke]'s focused-smoke findings):
+ * - **XWayland** (Wayland session with `DISPLAY=:0` set): 4/4 PASS through XWayland's X11 bridge.
+ * - **Pure Wayland** (Wayland session with `DISPLAY` unset): gate fires, smoke exits before
+ *   constructing the JFrame.
+ * - **Headless Xvfb**: 4/4 PASS against the virtual framebuffer; matches the focused smoke's CI
+ *   path. Wiring this variant into `validation-linux.yml` is now eligible (the previous "stays
+ *   manual until findings replace TBDs" condition is satisfied) and a separate change.
  */
 fun main() {
     var exitCode = 0


### PR DESCRIPTION
## Summary
- Bank empirical findings from running both Linux Robot smokes against three session modes on Ubuntu 24.04 (Hyper-V VM, GNOME Wayland) — replaces the TBD placeholders in both KDocs.
- Wire `runLinuxRobotUnfocusedSmoke` into `validation-linux.yml` as its own step alongside the focused smoke, now that the "stays manual until findings replace TBDs" condition is satisfied.

## Two commits

### `69a2d33` — docs: bank Linux Robot smoke findings
Pure KDoc; zero non-comment lines changed. Replaces all TBD placeholders in `LinuxRobotSmoke.kt` and `LinuxRobotUnfocusedSmoke.kt` with empirical results:

| Mode | Focused | Unfocused |
|---|---|---|
| **XWayland** (DISPLAY=:0 from Wayland session) | 6/6 PASS through XWayland's X11 bridge | 4/4 PASS |
| **Pure Wayland** (DISPLAY unset) | gate fires → exit 2 | gate fires → exit 2 |
| **Headless Xvfb** (matches CI) | 6/6 PASS | 4/4 PASS |

Also banks: cold-JVM warmup is unnecessary under Xvfb but kept for parity with Windows; clipboard-poll budget tuned for macOS NSPasteboard is never approached on X11 (XWayland XSelection is essentially synchronous); X11 click-to-focus convention means a single click both registers AND transfers focus on the unfocused SUT.

### `1fcd3dc` — ci(test): wire unfocused smoke into validation-linux
New workflow step `Run real-Robot Linux unfocused smoke under Xvfb` runs `xvfb-run -a ./gradlew :sample-desktop:runLinuxRobotUnfocusedSmoke` right after the focused-smoke step. Split into its own step (rather than chained) for independent failure attribution — a regression in one variant won't mask the other in the workflow summary. `if: always()` so both get a fair shot even if one fails.

After this lands, `validation-linux.yml` exercises **10 real-Robot scenarios per CI run** (6 focused + 4 unfocused) on every PR touching `core/**`, `sample-desktop/**`, `recording/**`, `testing/**`, or `gradle/**`.

## Verified locally (Windows host)
- `:sample-desktop:compileTestKotlin` ✅
- `:sample-desktop:ktfmtCheckTest` ✅
- `:sample-desktop:detekt` ✅

## Test plan
- [ ] Linux CI runs both new steps; both report PASS (6/6 + 4/4).
- [ ] Workflow summary shows two distinct steps so a future regression in one variant is visually distinguishable.
- [ ] Windows / macOS workflows still green (no behavioural code changes; KDoc + workflow only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/rock3r/codesmith/spectre/pr/92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->