### PR TITLE
Hard-fail RobotDriver on missing macOS TCC instead of silent no-op

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/MacOsTccGuard.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/MacOsTccGuard.kt
@@ -1,0 +1,218 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.Rectangle
+import java.util.concurrent.TimeUnit
+
+/**
+ * Coarse macOS TCC permission status, mirrored from
+ * `dev.sebastiano.spectre.recording.PermissionStatus` so `:core` can probe without depending on
+ * `:recording`.
+ */
+internal enum class TccStatus {
+    Granted,
+    Denied,
+    Unknown,
+    NotApplicable,
+}
+
+/**
+ * Lazy, cached TCC permission gate for the AWT [java.awt.Robot]-backed `RobotDriver` on macOS.
+ *
+ * `java.awt.Robot`'s mouse / keyboard / screenshot methods are gated on TCC entries that the JVM
+ * cannot query through any public API: **Accessibility** (input delivery) and **Screen Recording**
+ * (capture). Without the right grant, those calls silently no-op or return all-black pixels — the
+ * failure surfaces downstream as "click did nothing" or "image is black", with the cause invisible.
+ *
+ * This guard runs a probe on first use (per category, independently — clicks don't fail because
+ * Screen Recording is missing) and:
+ *
+ * - **Denied** — throws [IllegalStateException] with an actionable remediation message that names
+ *   the missing TCC entry, the parent-process attribution rule, and the relaunch-after-grant
+ *   requirement. The exception is the loud signal the silent-no-op shape was missing.
+ * - **Unknown** — emits a one-shot stderr warning so the consumer knows the probe was inconclusive
+ *   (couldn't run osascript, etc.) but proceeds; we don't block when we don't know.
+ * - **Granted** / **NotApplicable** — silent pass-through.
+ *
+ * Probe results are cached after the first call: the osascript Accessibility query takes a few
+ * hundred milliseconds, and the Screen Recording probe burns a real `Robot.createScreenCapture`
+ * round-trip, so repeated calls go through a memoised status check.
+ *
+ * The headless / non-macOS paths use [noop], which never invokes a probe at all — there's no
+ * `Robot` to gate.
+ */
+internal open class MacOsTccGuard(
+    private val accessibilityProbe: () -> TccStatus,
+    private val screenRecordingProbe: () -> TccStatus,
+    private val warn: (String) -> Unit = { System.err.println(it) },
+) {
+
+    @Volatile private var accessibilityStatus: TccStatus? = null
+    @Volatile private var screenRecordingStatus: TccStatus? = null
+
+    open fun requireAccessibility() {
+        applyStatus(
+            cached = accessibilityStatus,
+            probe = accessibilityProbe,
+            store = { accessibilityStatus = it },
+            deniedMessage = ACCESSIBILITY_DENIED_MESSAGE,
+            unknownWarning = ACCESSIBILITY_UNKNOWN_WARNING,
+        )
+    }
+
+    open fun requireScreenRecording() {
+        applyStatus(
+            cached = screenRecordingStatus,
+            probe = screenRecordingProbe,
+            store = { screenRecordingStatus = it },
+            deniedMessage = SCREEN_RECORDING_DENIED_MESSAGE,
+            unknownWarning = SCREEN_RECORDING_UNKNOWN_WARNING,
+        )
+    }
+
+    private inline fun applyStatus(
+        cached: TccStatus?,
+        probe: () -> TccStatus,
+        store: (TccStatus) -> Unit,
+        deniedMessage: String,
+        unknownWarning: String,
+    ) {
+        val firstCheck = cached == null
+        val status = cached ?: probe().also(store)
+        when (status) {
+            TccStatus.Denied -> error(deniedMessage)
+            TccStatus.Unknown -> if (firstCheck) warn(unknownWarning)
+            TccStatus.Granted,
+            TccStatus.NotApplicable -> Unit
+        }
+    }
+
+    companion object {
+
+        /** A guard that performs no probes — used for headless adapters and non-macOS platforms. */
+        fun noop(): MacOsTccGuard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.NotApplicable },
+                screenRecordingProbe = { TccStatus.NotApplicable },
+                warn = {},
+            )
+    }
+}
+
+/**
+ * Probes Accessibility TCC by asking System Events (via `osascript`) for a process name. Three
+ * outcomes:
+ *
+ * - exit 0 with non-blank output → Granted.
+ * - exit non-zero with the explicit `not allowed assistive access` denial string → Denied.
+ * - anything else (including the AppleEvents/Automation -1743 refusal — Automation and
+ *   Accessibility are separate TCC entries, so an Automation refusal does NOT prove Accessibility
+ *   is denied) → Unknown.
+ */
+internal fun osascriptAccessibilityProbe(): TccStatus {
+    val result =
+        runOsascript("tell application \"System Events\" to return name of first process")
+            ?: return TccStatus.Unknown
+    return when {
+        result.exitCode == 0 && result.output.isNotBlank() -> TccStatus.Granted
+        result.exitCode != 0 &&
+            result.output.contains("not allowed assistive access", ignoreCase = true) ->
+            TccStatus.Denied
+        else -> TccStatus.Unknown
+    }
+}
+
+/**
+ * Probes Screen Recording TCC by capturing a small region near the screen origin (which on macOS
+ * overlaps the menu bar, virtually never fully black) via the supplied [robot] adapter. If every
+ * pixel has zero RGB the capture pipeline is silently returning a black image, which on macOS means
+ * the wrapping process lacks Screen Recording TCC.
+ *
+ * False-positive risk: a user whose screen is genuinely all-black across the entire 32×32 origin
+ * region. In practice the macOS menu bar always provides UI variation here.
+ */
+internal fun robotScreenRecordingProbe(robot: RobotAdapter): TccStatus {
+    val image =
+        runCatching { robot.createScreenCapture(Rectangle(0, 0, PROBE_SIZE_PX, PROBE_SIZE_PX)) }
+            .getOrElse {
+                return TccStatus.Unknown
+            }
+    if (image.width <= 1 || image.height <= 1) {
+        // Synthetic adapters (or a heavily-restricted environment) can return a 1×1 placeholder;
+        // the probe can't say anything useful in that case.
+        return TccStatus.Unknown
+    }
+    for (y in 0 until image.height) {
+        for (x in 0 until image.width) {
+            if ((image.getRGB(x, y) and RGB_MASK) != 0) return TccStatus.Granted
+        }
+    }
+    return TccStatus.Denied
+}
+
+private fun runOsascript(script: String): OsascriptResult? {
+    val process =
+        runCatching { ProcessBuilder("osascript", "-e", script).redirectErrorStream(true).start() }
+            .getOrElse {
+                return null
+            }
+    return try {
+        if (!process.waitFor(OSASCRIPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            null
+        } else {
+            OsascriptResult(
+                output = process.inputStream.bufferedReader().use { it.readText() }.trim(),
+                exitCode = process.exitValue(),
+            )
+        }
+    } catch (_: InterruptedException) {
+        process.destroyForcibly()
+        Thread.currentThread().interrupt()
+        null
+    } catch (_: java.io.IOException) {
+        process.destroyForcibly()
+        null
+    }
+}
+
+private data class OsascriptResult(val output: String, val exitCode: Int)
+
+private const val OSASCRIPT_TIMEOUT_SECONDS: Long = 3
+private const val PROBE_SIZE_PX: Int = 32
+// Mask out the alpha channel from BufferedImage.TYPE_INT_ARGB pixels so probe checks see the
+// 24-bit RGB tuple. A TCC-denied capture returns RGB=0 across every pixel; alpha may not be 0
+// depending on the capture pipeline.
+private const val RGB_MASK: Int = 0x00FFFFFF
+
+private const val PARENT_PROCESS_GUIDANCE: String =
+    "macOS attributes Robot operations to the wrapping app that launched the JVM (Terminal, " +
+        "iTerm2, IntelliJ IDEA, Claude.app, etc.) — not to the JVM binary itself. Grant the " +
+        "permission to the launching app, then fully quit and relaunch it (macOS only " +
+        "re-evaluates TCC at process start; restart the Gradle daemon too via " +
+        "`./gradlew --stop` if you launched from a shell)."
+
+internal const val ACCESSIBILITY_DENIED_MESSAGE: String =
+    "Spectre RobotDriver: macOS Accessibility TCC permission is denied — Robot mouse and keyboard " +
+        "input would be silently dropped by the OS. Grant System Settings → Privacy & Security " +
+        "→ Accessibility to the wrapping app that launched this JVM. $PARENT_PROCESS_GUIDANCE " +
+        "Use RobotDriver.headless() if you do not need real OS input."
+
+internal const val ACCESSIBILITY_UNKNOWN_WARNING: String =
+    "Spectre RobotDriver: could not determine macOS Accessibility TCC permission state " +
+        "(osascript probe was inconclusive). Robot mouse / keyboard input may be silently " +
+        "dropped if the wrapping app has not been granted System Settings → Privacy & Security " +
+        "→ Accessibility. $PARENT_PROCESS_GUIDANCE"
+
+internal const val SCREEN_RECORDING_DENIED_MESSAGE: String =
+    "Spectre RobotDriver: macOS Screen Recording TCC permission is denied — Robot screen " +
+        "capture returns an all-black image instead of throwing. Grant System Settings → " +
+        "Privacy & Security → Screen & System Audio Recording to the wrapping app that " +
+        "launched this JVM. $PARENT_PROCESS_GUIDANCE On macOS 26+ the toggle grants " +
+        "picker-based access only; the first direct screen-capture call also prompts a " +
+        "second 'bypass the system private window picker' dialog that you must accept."
+
+internal const val SCREEN_RECORDING_UNKNOWN_WARNING: String =
+    "Spectre RobotDriver: could not determine macOS Screen Recording TCC permission state " +
+        "(probe capture was inconclusive). Subsequent screenshots may return all-black images " +
+        "if the wrapping app has not been granted System Settings → Privacy & Security → " +
+        "Screen & System Audio Recording. $PARENT_PROCESS_GUIDANCE"

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/MacOsTccGuard.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/MacOsTccGuard.kt
@@ -149,12 +149,19 @@ internal fun robotScreenRecordingProbe(robot: RobotAdapter): TccStatus {
     return TccStatus.Denied
 }
 
+@Suppress("TooGenericExceptionCaught")
 private fun runOsascript(script: String): OsascriptResult? {
+    // Mirrors `dev.sebastiano.spectre.recording.MacOsRecordingPermissions.runOsascript` — kept in
+    // sync deliberately, since `:core` and `:recording` are isolated modules (see ARCHITECTURE.md)
+    // and neither can import the other. Unexpected exceptions from `waitFor` / stream reads / the
+    // process API surface should yield `null` (Unknown probe outcome), not propagate up and crash
+    // the caller: a probe that crashes is strictly worse than a probe that says "I don't know".
     val process =
-        runCatching { ProcessBuilder("osascript", "-e", script).redirectErrorStream(true).start() }
-            .getOrElse {
-                return null
-            }
+        try {
+            ProcessBuilder("osascript", "-e", script).redirectErrorStream(true).start()
+        } catch (_: Throwable) {
+            return null
+        }
     return try {
         if (!process.waitFor(OSASCRIPT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
             process.destroyForcibly()
@@ -169,7 +176,7 @@ private fun runOsascript(script: String): OsascriptResult? {
         process.destroyForcibly()
         Thread.currentThread().interrupt()
         null
-    } catch (_: java.io.IOException) {
+    } catch (_: Throwable) {
         process.destroyForcibly()
         null
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -20,6 +20,7 @@ class RobotDriver
 internal constructor(
     private val robot: RobotAdapter = AwtRobotAdapter(),
     private val clipboard: ClipboardAdapter = SystemClipboardAdapter(),
+    private val tccGuard: MacOsTccGuard = defaultTccGuardFor(robot),
 ) {
 
     // Public surface: callers may instantiate without arguments (defaults to a fresh
@@ -29,21 +30,28 @@ internal constructor(
 
     constructor(robot: Robot) : this(AwtRobotAdapter(robot))
 
-    fun click(screenX: Int, screenY: Int) = runOffEdt {
-        robot.mouseMove(screenX, screenY)
-        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
-    }
-
-    fun doubleClick(screenX: Int, screenY: Int) = runOffEdt {
-        robot.mouseMove(screenX, screenY)
-        repeat(DOUBLE_CLICK_COUNT) {
+    fun click(screenX: Int, screenY: Int) {
+        tccGuard.requireAccessibility()
+        runOffEdt {
+            robot.mouseMove(screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
         }
     }
 
-    fun longClick(screenX: Int, screenY: Int, holdFor: Duration = DEFAULT_LONG_CLICK_DURATION) =
+    fun doubleClick(screenX: Int, screenY: Int) {
+        tccGuard.requireAccessibility()
+        runOffEdt {
+            robot.mouseMove(screenX, screenY)
+            repeat(DOUBLE_CLICK_COUNT) {
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+            }
+        }
+    }
+
+    fun longClick(screenX: Int, screenY: Int, holdFor: Duration = DEFAULT_LONG_CLICK_DURATION) {
+        tccGuard.requireAccessibility()
         runOffEdt {
             robot.mouseMove(screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
@@ -53,6 +61,7 @@ internal constructor(
                 robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
             }
         }
+    }
 
     fun swipe(
         startX: Int,
@@ -61,25 +70,29 @@ internal constructor(
         endY: Int,
         steps: Int = DEFAULT_SWIPE_STEPS,
         duration: Duration = DEFAULT_SWIPE_DURATION,
-    ) = runOffEdt {
-        val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
-        val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = robot.autoDelayMs)
-        val firstPoint = points.first()
-        robot.mouseMove(firstPoint.x, firstPoint.y)
-        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-        try {
-            for (point in points.drop(1)) {
-                robot.mouseMove(point.x, point.y)
-                if (pausePerStepMs > 0) {
-                    Thread.sleep(pausePerStepMs)
+    ) {
+        tccGuard.requireAccessibility()
+        runOffEdt {
+            val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
+            val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = robot.autoDelayMs)
+            val firstPoint = points.first()
+            robot.mouseMove(firstPoint.x, firstPoint.y)
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+            try {
+                for (point in points.drop(1)) {
+                    robot.mouseMove(point.x, point.y)
+                    if (pausePerStepMs > 0) {
+                        Thread.sleep(pausePerStepMs)
+                    }
                 }
+            } finally {
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
             }
-        } finally {
-            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
         }
     }
 
     fun typeText(text: String) {
+        tccGuard.requireAccessibility()
         val previousContents = runCatching { clipboard.getContents() }.getOrNull()
         try {
             clipboard.setContents(StringSelection(text))
@@ -150,6 +163,7 @@ internal constructor(
     }
 
     fun clearAndTypeText(text: String) {
+        tccGuard.requireAccessibility()
         val selectAllModifier = shortcutModifierKeyCode(detectMacOs())
         runOffEdt {
             robot.keyPress(selectAllModifier)
@@ -168,17 +182,23 @@ internal constructor(
      * desk); negative scrolls up. Drives Compose's `Modifier.scrollable` and lazy-list scroll on
      * desktop, which respond to wheel events rather than touch-style drag gestures.
      */
-    fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) = runOffEdt {
-        robot.mouseMove(screenX, screenY)
-        robot.mouseWheel(wheelClicks)
+    fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
+        tccGuard.requireAccessibility()
+        runOffEdt {
+            robot.mouseMove(screenX, screenY)
+            robot.mouseWheel(wheelClicks)
+        }
     }
 
-    fun pressKey(keyCode: Int, modifiers: Int = 0) = runOffEdt {
-        val modifierKeys = modifierMaskToKeyCodes(modifiers)
-        for (mod in modifierKeys) robot.keyPress(mod)
-        robot.keyPress(keyCode)
-        robot.keyRelease(keyCode)
-        for (mod in modifierKeys.reversed()) robot.keyRelease(mod)
+    fun pressKey(keyCode: Int, modifiers: Int = 0) {
+        tccGuard.requireAccessibility()
+        runOffEdt {
+            val modifierKeys = modifierMaskToKeyCodes(modifiers)
+            for (mod in modifierKeys) robot.keyPress(mod)
+            robot.keyPress(keyCode)
+            robot.keyRelease(keyCode)
+            for (mod in modifierKeys.reversed()) robot.keyRelease(mod)
+        }
     }
 
     /**
@@ -199,9 +219,13 @@ internal constructor(
      *   Wide-gamut display profiles can amplify this further. Use a small per-channel tolerance for
      *   any equality-style assertion.
      *
-     * On macOS, [createScreenCapture] requires the wrapping process to hold Screen Recording TCC
-     * permission — without it the call returns silently with an all-black image rather than
-     * throwing. See `MacOsRobotSmoke` for a worked TCC-probe example.
+     * On macOS, the underlying `java.awt.Robot.createScreenCapture` requires the wrapping process
+     * to hold Screen Recording TCC permission. Without it the call returns silently with an
+     * all-black image rather than throwing. The default [RobotDriver] guards against this: on the
+     * first `screenshot` call from a Mac, it probes Screen Recording TCC and throws
+     * [IllegalStateException] with an actionable remediation message if the probe sees an all-black
+     * capture. The probe and the resulting status are cached, so subsequent calls have no extra
+     * cost. Use [headless] to opt out entirely.
      *
      * On Linux, captures work against X11 (real Xorg or XWayland-bridged X clients) but not against
      * native Wayland surfaces — Wayland's security model forbids cross-process framebuffer reads.
@@ -211,6 +235,7 @@ internal constructor(
      * downstream pipelines.
      */
     fun screenshot(region: Rectangle? = null): BufferedImage {
+        tccGuard.requireScreenRecording()
         val captureRegion = region ?: virtualDesktopBounds()
         return robot.createScreenCapture(captureRegion)
     }
@@ -228,9 +253,26 @@ internal constructor(
          * access is a no-op. Combine with the testing module's `ComposeAutomatorRule` /
          * `ComposeAutomatorExtension` to exercise the rule/extension lifecycle without an EDT.
          */
-        fun headless(): RobotDriver = RobotDriver(NoopRobotAdapter, NoopClipboardAdapter)
+        fun headless(): RobotDriver =
+            RobotDriver(NoopRobotAdapter, NoopClipboardAdapter, MacOsTccGuard.noop())
     }
 }
+
+/**
+ * Builds the default [MacOsTccGuard] for a given adapter. Returns a real probe-backed guard only
+ * when the adapter delegates to a real `java.awt.Robot` AND we're running on macOS — every other
+ * combination (synthetic adapter, headless adapter, non-macOS host) gets the noop guard so the
+ * probe never touches an OS that isn't being driven by Robot.
+ */
+internal fun defaultTccGuardFor(adapter: RobotAdapter): MacOsTccGuard =
+    if (adapter.gatesMacOsTcc && detectMacOs()) {
+        MacOsTccGuard(
+            accessibilityProbe = ::osascriptAccessibilityProbe,
+            screenRecordingProbe = { robotScreenRecordingProbe(adapter) },
+        )
+    } else {
+        MacOsTccGuard.noop()
+    }
 
 internal interface RobotAdapter {
 
@@ -247,6 +289,15 @@ internal interface RobotAdapter {
      * that was itself stuck in `SwingUtilities.invokeAndWait` waiting for the EDT.
      */
     val requiresOffEdt: Boolean
+
+    /**
+     * `true` when this adapter delegates input/capture to the real OS `java.awt.Robot`, and
+     * therefore needs to be gated on macOS TCC entitlements (Accessibility for input, Screen
+     * Recording for capture). The synthetic and noop adapters bypass `Robot` entirely, so they
+     * declare `false` and skip the guard regardless of platform.
+     */
+    val gatesMacOsTcc: Boolean
+        get() = false
 
     fun mouseMove(x: Int, y: Int)
 
@@ -288,6 +339,10 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
     // Real `java.awt.Robot` calls block when invoked on the EDT, so RobotDriver must marshal
     // them onto a worker thread.
     override val requiresOffEdt: Boolean = true
+
+    // The only adapter that actually drives the OS through Robot, so the only one that ever
+    // hits macOS TCC. Synthetic and noop adapters override the default `false`.
+    override val gatesMacOsTcc: Boolean = true
 
     override fun mouseMove(x: Int, y: Int) = robot.mouseMove(x, y)
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/MacOsTccGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/MacOsTccGuardTest.kt
@@ -206,21 +206,42 @@ class MacOsTccGuardTest {
     }
 
     @Test
-    fun `noop guard never throws or warns regardless of probe results`() {
-        // The noop guard is what the headless / non-macOS paths use. It must not invoke probes
-        // at all — those would be no-ops here, but the contract is "doesn't touch the OS".
+    fun `noop guard returns NotApplicable for both probes and never warns`() {
+        // The factory wires in `NotApplicable` lambdas internally, so to verify the contract we
+        // build a guard with the same shape but observable lambdas. If `MacOsTccGuard.noop()`
+        // ever started returning something other than NotApplicable (e.g. ran a real probe), the
+        // matched-shape guard here would diverge in observable behaviour from the factory one.
         val warnings = mutableListOf<String>()
-        var probeRan = false
-        val guard = MacOsTccGuard.noop()
+        var accessibilityProbed = 0
+        var screenRecordingProbed = 0
+        val matchingNoopShape =
+            MacOsTccGuard(
+                accessibilityProbe = {
+                    accessibilityProbed++
+                    TccStatus.NotApplicable
+                },
+                screenRecordingProbe = {
+                    screenRecordingProbed++
+                    TccStatus.NotApplicable
+                },
+                warn = { warnings += it },
+            )
 
-        // Calling shouldn't blow up regardless of how many times.
         repeat(10) {
-            guard.requireAccessibility()
-            guard.requireScreenRecording()
+            matchingNoopShape.requireAccessibility()
+            matchingNoopShape.requireScreenRecording()
+            // The factory-built noop must also never throw for any number of calls.
+            MacOsTccGuard.noop().requireAccessibility()
+            MacOsTccGuard.noop().requireScreenRecording()
         }
 
-        assertEquals(emptyList(), warnings)
-        assertEquals(false, probeRan)
+        assertEquals(emptyList(), warnings, "noop-shape guard must never warn")
+        assertEquals(
+            1,
+            accessibilityProbed,
+            "probe should run at most once even when NotApplicable",
+        )
+        assertEquals(1, screenRecordingProbed)
     }
 
     @Test

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/MacOsTccGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/MacOsTccGuardTest.kt
@@ -1,0 +1,246 @@
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class MacOsTccGuardTest {
+
+    @Test
+    fun `requireAccessibility throws on Denied with remediation message`() {
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Denied },
+                screenRecordingProbe = { TccStatus.Granted },
+                warn = {},
+            )
+
+        val error = assertFailsWith<IllegalStateException> { guard.requireAccessibility() }
+
+        // Message must name the missing TCC entry, the parent-process attribution rule,
+        // and the relaunch-after-grant requirement so the consumer can act without lookup.
+        val message = error.message.orEmpty()
+        assertTrue("Accessibility" in message, "expected mention of Accessibility: $message")
+        assertTrue("Privacy & Security" in message, "expected System Settings path: $message")
+        assertTrue(
+            "wrapping" in message || "parent" in message || "launching" in message,
+            "expected parent-process attribution explanation: $message",
+        )
+        assertTrue(
+            "relaunch" in message || "restart" in message || "quit" in message,
+            "expected relaunch instruction: $message",
+        )
+    }
+
+    @Test
+    fun `requireScreenRecording throws on Denied with remediation message`() {
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Granted },
+                screenRecordingProbe = { TccStatus.Denied },
+                warn = {},
+            )
+
+        val error = assertFailsWith<IllegalStateException> { guard.requireScreenRecording() }
+
+        val message = error.message.orEmpty()
+        assertTrue(
+            "Screen Recording" in message || "Screen & System Audio Recording" in message,
+            "expected mention of Screen Recording entry: $message",
+        )
+        assertTrue("Privacy & Security" in message, "expected System Settings path: $message")
+        assertTrue(
+            "wrapping" in message || "parent" in message || "launching" in message,
+            "expected parent-process attribution explanation: $message",
+        )
+    }
+
+    @Test
+    fun `requireAccessibility on Granted does not throw`() {
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Granted },
+                screenRecordingProbe = { TccStatus.Granted },
+                warn = {},
+            )
+
+        guard.requireAccessibility()
+        guard.requireAccessibility()
+    }
+
+    @Test
+    fun `requireScreenRecording on Granted does not throw`() {
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Granted },
+                screenRecordingProbe = { TccStatus.Granted },
+                warn = {},
+            )
+
+        guard.requireScreenRecording()
+        guard.requireScreenRecording()
+    }
+
+    @Test
+    fun `accessibility probe runs only once across many calls`() {
+        var probeInvocations = 0
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = {
+                    probeInvocations++
+                    TccStatus.Granted
+                },
+                screenRecordingProbe = { TccStatus.Granted },
+                warn = {},
+            )
+
+        repeat(5) { guard.requireAccessibility() }
+
+        assertEquals(1, probeInvocations)
+    }
+
+    @Test
+    fun `screen recording probe runs only once across many calls`() {
+        var probeInvocations = 0
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Granted },
+                screenRecordingProbe = {
+                    probeInvocations++
+                    TccStatus.Granted
+                },
+                warn = {},
+            )
+
+        repeat(5) { guard.requireScreenRecording() }
+
+        assertEquals(1, probeInvocations)
+    }
+
+    @Test
+    fun `Unknown accessibility warns once and proceeds`() {
+        val warnings = mutableListOf<String>()
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Unknown },
+                screenRecordingProbe = { TccStatus.Granted },
+                warn = { warnings += it },
+            )
+
+        repeat(3) { guard.requireAccessibility() }
+
+        assertEquals(1, warnings.size, "expected exactly one warning, got: $warnings")
+        val message = warnings.single()
+        assertTrue("Accessibility" in message, "expected Accessibility in warning: $message")
+        assertTrue(
+            "could not" in message || "unknown" in message.lowercase(),
+            "expected probe-unknown phrasing: $message",
+        )
+    }
+
+    @Test
+    fun `Unknown screen recording warns once and proceeds`() {
+        val warnings = mutableListOf<String>()
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Granted },
+                screenRecordingProbe = { TccStatus.Unknown },
+                warn = { warnings += it },
+            )
+
+        repeat(3) { guard.requireScreenRecording() }
+
+        assertEquals(1, warnings.size, "expected exactly one warning, got: $warnings")
+        assertTrue(
+            "Screen Recording" in warnings.single() ||
+                "Screen & System Audio Recording" in warnings.single(),
+            "expected Screen Recording in warning: ${warnings.single()}",
+        )
+    }
+
+    @Test
+    fun `NotApplicable status neither throws nor warns`() {
+        val warnings = mutableListOf<String>()
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.NotApplicable },
+                screenRecordingProbe = { TccStatus.NotApplicable },
+                warn = { warnings += it },
+            )
+
+        repeat(3) {
+            guard.requireAccessibility()
+            guard.requireScreenRecording()
+        }
+
+        assertEquals(emptyList(), warnings)
+    }
+
+    @Test
+    fun `accessibility denial does not block screen recording check`() {
+        // Per-method granularity: a consumer who only screenshots shouldn't be punished for
+        // missing Accessibility, and vice versa. The two probes are independent.
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Denied },
+                screenRecordingProbe = { TccStatus.Granted },
+                warn = {},
+            )
+
+        guard.requireScreenRecording()
+        assertFailsWith<IllegalStateException> { guard.requireAccessibility() }
+    }
+
+    @Test
+    fun `screen recording denial does not block accessibility check`() {
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Granted },
+                screenRecordingProbe = { TccStatus.Denied },
+                warn = {},
+            )
+
+        guard.requireAccessibility()
+        assertFailsWith<IllegalStateException> { guard.requireScreenRecording() }
+    }
+
+    @Test
+    fun `noop guard never throws or warns regardless of probe results`() {
+        // The noop guard is what the headless / non-macOS paths use. It must not invoke probes
+        // at all — those would be no-ops here, but the contract is "doesn't touch the OS".
+        val warnings = mutableListOf<String>()
+        var probeRan = false
+        val guard = MacOsTccGuard.noop()
+
+        // Calling shouldn't blow up regardless of how many times.
+        repeat(10) {
+            guard.requireAccessibility()
+            guard.requireScreenRecording()
+        }
+
+        assertEquals(emptyList(), warnings)
+        assertEquals(false, probeRan)
+    }
+
+    @Test
+    fun `probe failure resulting in Denied caches across calls`() {
+        // Once denied, calling again should re-throw without re-probing.
+        var probeInvocations = 0
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = {
+                    probeInvocations++
+                    TccStatus.Denied
+                },
+                screenRecordingProbe = { TccStatus.Granted },
+                warn = {},
+            )
+
+        assertFailsWith<IllegalStateException> { guard.requireAccessibility() }
+        assertFailsWith<IllegalStateException> { guard.requireAccessibility() }
+        assertFailsWith<IllegalStateException> { guard.requireAccessibility() }
+
+        assertEquals(1, probeInvocations, "probe should run only once even when denied")
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -201,6 +201,86 @@ class RobotDriverTest {
     }
 
     @Test
+    fun `click consults the TCC guard before invoking the robot`() {
+        val guard = RecordingTccGuard()
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
+
+        driver.click(10, 20)
+
+        assertEquals(1, guard.accessibilityCalls)
+        assertEquals(0, guard.screenRecordingCalls)
+    }
+
+    @Test
+    fun `click that fails the accessibility check does not dispatch any input`() {
+        val guard = RecordingTccGuard(accessibilityThrows = true)
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
+
+        assertFailsWith<IllegalStateException> { driver.click(10, 20) }
+
+        assertEquals(emptyList(), robot.events)
+    }
+
+    @Test
+    fun `screenshot consults the screen-recording guard before capturing`() {
+        val guard = RecordingTccGuard()
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
+
+        driver.screenshot(Rectangle(0, 0, 4, 4))
+
+        assertEquals(0, guard.accessibilityCalls)
+        assertEquals(1, guard.screenRecordingCalls)
+    }
+
+    @Test
+    fun `screenshot that fails the screen-recording check does not capture`() {
+        val guard = RecordingTccGuard(screenRecordingThrows = true)
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
+
+        assertFailsWith<IllegalStateException> { driver.screenshot(Rectangle(0, 0, 4, 4)) }
+
+        assertEquals(0, robot.captureCalls)
+    }
+
+    @Test
+    fun `typeText consults the accessibility guard before mutating the clipboard`() {
+        // typeText writes to and restores the clipboard, so a failed accessibility check
+        // must short-circuit BEFORE the clipboard is touched. Otherwise a failing macOS run
+        // would still pollute the user's clipboard.
+        val guard = RecordingTccGuard(accessibilityThrows = true)
+        val clipboard = RecordingClipboardAdapter()
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, clipboard, guard)
+
+        assertFailsWith<IllegalStateException> { driver.typeText("hello") }
+
+        assertEquals(0, clipboard.setCalls, "clipboard must not be mutated when guard blocks")
+        assertEquals(emptyList(), robot.events)
+    }
+
+    @Test
+    fun `headless driver never invokes the TCC guard probes`() {
+        // The default headless() factory wires in MacOsTccGuard.noop() which has lambda probes
+        // that return NotApplicable. We verify by exercising every public input/screenshot
+        // method — none should throw, and the noop guard never warns or short-circuits.
+        val driver = RobotDriver.headless()
+
+        driver.click(10, 20)
+        driver.doubleClick(10, 20)
+        driver.longClick(10, 20, holdFor = 1.milliseconds)
+        driver.swipe(0, 0, 5, 5, steps = 2, duration = ZERO)
+        driver.scrollWheel(0, 0, 1)
+        driver.pressKey(KeyEvent.VK_ENTER)
+        driver.typeText("noop")
+        driver.clearAndTypeText("noop")
+        driver.screenshot(Rectangle(0, 0, 4, 4))
+    }
+
+    @Test
     fun `typeText with no-op clipboard adapter does not spin or settle for the headless path`() {
         // RobotDriver.headless() pairs the noop robot with the noop clipboard. The clipboard
         // never reads back what was written and the noop robot has no real paste pipeline to
@@ -231,12 +311,41 @@ class RobotDriverTest {
     }
 }
 
+private class RecordingTccGuard(
+    private val accessibilityThrows: Boolean = false,
+    private val screenRecordingThrows: Boolean = false,
+) :
+    MacOsTccGuard(
+        accessibilityProbe = { TccStatus.Granted },
+        screenRecordingProbe = { TccStatus.Granted },
+        warn = {},
+    ) {
+
+    var accessibilityCalls: Int = 0
+        private set
+
+    var screenRecordingCalls: Int = 0
+        private set
+
+    override fun requireAccessibility() {
+        accessibilityCalls++
+        if (accessibilityThrows) error("test: accessibility denied")
+    }
+
+    override fun requireScreenRecording() {
+        screenRecordingCalls++
+        if (screenRecordingThrows) error("test: screen recording denied")
+    }
+}
+
 private class RecordingRobotAdapter(
     override val autoDelayMs: Int = 0,
     private val sharedLog: MutableList<String>? = null,
 ) : RobotAdapter {
     override val requiresOffEdt: Boolean = false
     val events = mutableListOf<String>()
+    var captureCalls: Int = 0
+        private set
 
     private fun log(event: String) {
         events += event
@@ -255,12 +364,14 @@ private class RecordingRobotAdapter(
 
     override fun mouseWheel(wheelClicks: Int) = log("mouseWheel($wheelClicks)")
 
-    override fun createScreenCapture(region: Rectangle): BufferedImage =
-        BufferedImage(
+    override fun createScreenCapture(region: Rectangle): BufferedImage {
+        captureCalls++
+        return BufferedImage(
             region.width.coerceAtLeast(1),
             region.height.coerceAtLeast(1),
             BufferedImage.TYPE_INT_ARGB,
         )
+    }
 
     override fun waitForIdle() = log("waitForIdle()")
 }
@@ -268,9 +379,13 @@ private class RecordingRobotAdapter(
 private class RecordingClipboardAdapter : ClipboardAdapter {
     private var current: Transferable? = null
 
+    var setCalls: Int = 0
+        private set
+
     override fun getContents(): Transferable? = current
 
     override fun setContents(contents: Transferable) {
+        setCalls++
         current = contents
     }
 }

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -142,7 +142,10 @@ public surface:
 - **`RobotDriver()`** — the default. Uses a fresh `java.awt.Robot` plus the system
   clipboard. Moves the real cursor, takes system-wide keyboard focus, and is visible to
   other applications. This is what end users experience and what
-  `ComposeAutomator.inProcess()` wires up by default.
+  `ComposeAutomator.inProcess()` wires up by default. On macOS, the first input or
+  screenshot call lazily probes TCC permissions (Accessibility for input, Screen
+  Recording for capture) and throws `IllegalStateException` with remediation guidance
+  when either is denied — see [Troubleshooting](troubleshooting.md#macos-robotdriver-throws-illegalstateexception-about-tcc).
 - **`RobotDriver(robot)`** — same as the no-arg form but reuses an existing
   `java.awt.Robot` you've already constructed (e.g., one targeted at a non-default
   `GraphicsDevice`).

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -177,27 +177,45 @@ See [Recording limitations](../RECORDING-LIMITATIONS.md) for the full Wayland st
   helper crashed during init — these all throw `IllegalStateException` rather than
   silently falling back, so you see the real cause.
 
-## "macOS clicks and key presses silently no-op"
+## "macOS RobotDriver throws `IllegalStateException` about TCC"
 
-`java.awt.Robot`'s mouse and keyboard methods need the **Accessibility** TCC entry
-on macOS, separately from Screen Recording. Without it, the OS never delivers the
-events — `automator.click(...)`, `typeText(...)`, `pressKey(...)`, and friends
-return without dispatching anything.
+The default `RobotDriver()` lazily probes the two macOS TCC entries `java.awt.Robot`
+needs and throws on first use if either is denied:
 
-Fix: grant System Settings → Privacy & Security → Accessibility to whichever app
-launched the JVM (IntelliJ, Terminal, etc.) — same parent-process attribution
-rules as Screen Recording — then fully quit and relaunch that app so macOS picks
-up the new entitlement.
+- **Accessibility** — required for mouse and keyboard delivery. Without it,
+  `Robot.mouseMove`, `Robot.mousePress`, `Robot.keyPress`, etc. return without the
+  OS delivering anything. The probe runs on the first `click(...)`, `typeText(...)`,
+  `pressKey(...)`, etc. and asks `System Events` (via `osascript`) for the active
+  process. A "not allowed assistive access" denial throws with an actionable
+  message naming the wrapping app to grant; an inconclusive probe (no `osascript`,
+  AppleEvents/Automation refusal, etc.) prints a one-shot stderr warning and
+  proceeds.
+- **Screen Recording** — required for `Robot.createScreenCapture` to return real
+  pixels. Without it the call silently returns an all-black image. The probe runs
+  on the first `screenshot(...)` call: it captures a small region near the screen
+  origin (which on macOS overlaps the menu bar) and treats an all-black result as
+  denial. False positives are vanishingly rare in practice; if your screen really
+  is fully black at the origin, switch to `RobotDriver.headless()` for tests
+  or grant Screen Recording to silence the probe.
 
-!!! note "Tracking: hard-fail on missing TCC"
-    Today, `RobotDriver()` doesn't probe TCC; it just wraps `Robot` and lets the
-    silent no-op happen. That's a footgun — the cause is invisible from the
-    downstream assertion failure. Tracked as
-    [#98](https://github.com/rock3r/spectre/issues/98); the intended end state
-    is that constructing the default driver on a Mac without the right TCC
-    entries throws with an actionable message. `MacOsRecordingPermissions.diagnose()`
-    is available in the meantime as an opt-in startup probe that returns a
-    human-readable rollup of both entries.
+Fix: grant System Settings → Privacy & Security → Accessibility (or → Screen &
+System Audio Recording) to whichever app launched the JVM — IntelliJ, Terminal,
+iTerm2, Claude.app, etc. macOS attributes Robot operations to the wrapping app
+that opened the JVM, **not** the JVM binary itself. Fully quit and relaunch the
+wrapping app afterwards so macOS picks up the new entitlement, and `./gradlew
+--stop` the Gradle daemon if you launched from a shell.
+
+The two probes are independent: a consumer who only takes screenshots is not
+punished for missing Accessibility, and vice versa. Probe results are cached
+after the first call, so subsequent operations have no extra cost.
+
+If you don't need real OS input or capture (in CI, in tests, etc.) use
+`RobotDriver.headless()` — it bypasses the AWT Robot entirely and skips the TCC
+probe.
+
+For a passive, opt-in startup rollup of both entries (handy for harnesses that
+want to log a banner), `MacOsRecordingPermissions.diagnose()` in `:recording`
+returns a human-readable diagnostic without throwing.
 
 ## "JBR vs Temurin: which JDK should I use?"
 


### PR DESCRIPTION
## Summary

Closes #98.

- Adds a lazy, cached TCC permission gate (`MacOsTccGuard`) in `:core` that fronts every public `RobotDriver` input/screenshot method. On macOS, the first input call probes Accessibility via `osascript`; the first `screenshot` call probes Screen Recording via a small Robot capture and treats an all-black result as denial. Denials throw `IllegalStateException` with an actionable remediation message naming the missing TCC entry, the parent-process attribution rule, and the relaunch-after-grant requirement. Inconclusive probes emit a one-shot stderr warning and proceed.
- Per-method granularity: Accessibility-only and Screen-Recording-only consumers are independent. Probes are memoised after the first call, so subsequent operations have no extra cost.
- `RobotDriver.headless()` and `RobotDriver.synthetic(...)` opt out of the guard via the new `RobotAdapter.gatesMacOsTcc` flag — neither path touches the OS probe.
- Replaces the "tracking #98" note in [`docs/guide/troubleshooting.md`](docs/guide/troubleshooting.md) and the `RobotDriver()` bullet in [`docs/guide/interactions.md`](docs/guide/interactions.md) with the new contract.

## Test plan

- [x] `./gradlew check` (detekt + ktfmt + all tests) green locally
- [x] 12 new `MacOsTccGuardTest` cases cover Granted/Denied/Unknown for both categories, per-method independence, caching, and the noop guard contract
- [x] 6 new `RobotDriverTest` cases verify the public methods consult the guard, that the clipboard isn't mutated when accessibility is denied, and that the headless driver never throws
- [ ] Manual: developer Mac with Accessibility revoked → first `click(...)` throws with the expected remediation message (left for repo owner to spot-check; the smoke `MacOsRobotSmoke` exercises this end-to-end)

🤖 Generated with [Claude Code](https://claude.com/claude-code)