### PR TITLE
refactor(core)!: RobotDriver.headless() throws on input/screenshot/clipboard (#97)

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -102,8 +102,8 @@ internal constructor(
             // field's paste handler reads stale (often empty) contents and the typed characters
             // never land. Poll the clipboard until it reports our string, with a bounded budget
             // so a misbehaving clipboard adapter cannot wedge the call indefinitely. Skip the
-            // poll for adapters that don't support read-back (the headless no-op clipboard) so
-            // that path doesn't burn the full settle timeout for nothing.
+            // poll for adapters that don't support read-back so that path doesn't burn the
+            // full settle timeout against a permanently-null reader.
             if (clipboard.supportsRead) {
                 awaitClipboardContents(text, CLIPBOARD_SETTLE_TIMEOUT_MS, CLIPBOARD_SETTLE_POLL_MS)
             }
@@ -124,7 +124,7 @@ internal constructor(
                 // also wait a short interval to let the OS-side paste read complete before we
                 // clobber the clipboard contents. Skip the whole block for adapters that don't
                 // support clipboard read-back — there's no real paste handler to drain, so the
-                // sleep would just add fixed latency to every headless typeText call.
+                // sleep would just add fixed latency for nothing.
                 repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }
                 try {
                     Thread.sleep(POST_PASTE_SETTLE_MS)
@@ -245,24 +245,34 @@ internal constructor(
     companion object {
 
         /**
-         * Returns a [RobotDriver] that performs no real OS input or capture.
+         * Returns a [RobotDriver] that throws [UnsupportedOperationException] on every input,
+         * clipboard, and screenshot call. [WindowTracker] / [SemanticsReader] are untouched, so
+         * semantics-tree reads still work.
          *
-         * Intended for tests and headless CI environments where constructing a real
-         * `java.awt.Robot` (or touching the system clipboard / screen) is unavailable. Mouse and
-         * key calls are silently dropped, screenshots return a 1×1 empty image, and clipboard
-         * access is a no-op. Combine with the testing module's `ComposeAutomatorRule` /
-         * `ComposeAutomatorExtension` to exercise the rule/extension lifecycle without an EDT.
+         * Reach for this in headless CI or any context where real OS I/O is unavailable, **and**
+         * the code under test is genuinely read-only (semantics queries, rule/extension lifecycle
+         * wiring). The loud-failure contract means an accidental `automator.click(...)` /
+         * `typeText(...)` / `screenshot(...)` surfaces at the call site instead of silently
+         * dropping the operation and tripping a downstream assertion three layers later.
+         *
+         * If you do need real input or capture in a non-OS environment, use
+         * [RobotDriver.Companion.synthetic] against a known root window for synthetic AWT events,
+         * or invoke `SemanticsActions.OnClick` directly on the target node for click-only flows.
          */
         fun headless(): RobotDriver =
-            RobotDriver(NoopRobotAdapter, NoopClipboardAdapter, MacOsTccGuard.noop())
+            RobotDriver(
+                HeadlessThrowingRobotAdapter,
+                HeadlessThrowingClipboardAdapter,
+                MacOsTccGuard.noop(),
+            )
     }
 }
 
 /**
  * Builds the default [MacOsTccGuard] for a given adapter. Returns a real probe-backed guard only
  * when the adapter delegates to a real `java.awt.Robot` AND we're running on macOS — every other
- * combination (synthetic adapter, headless adapter, non-macOS host) gets the noop guard so the
- * probe never touches an OS that isn't being driven by Robot.
+ * combination (synthetic adapter, headless-throwing adapter, non-macOS host) gets the noop guard so
+ * the probe never touches an OS that isn't being driven by Robot.
  */
 internal fun defaultTccGuardFor(adapter: RobotAdapter): MacOsTccGuard =
     if (adapter.gatesMacOsTcc && detectMacOs()) {
@@ -293,8 +303,8 @@ internal interface RobotAdapter {
     /**
      * `true` when this adapter delegates input/capture to the real OS `java.awt.Robot`, and
      * therefore needs to be gated on macOS TCC entitlements (Accessibility for input, Screen
-     * Recording for capture). The synthetic and noop adapters bypass `Robot` entirely, so they
-     * declare `false` and skip the guard regardless of platform.
+     * Recording for capture). The synthetic and headless-throwing adapters bypass `Robot` entirely,
+     * so they declare `false` and skip the guard regardless of platform.
      */
     val gatesMacOsTcc: Boolean
         get() = false
@@ -319,9 +329,10 @@ internal interface RobotAdapter {
 internal interface ClipboardAdapter {
 
     /**
-     * `true` when [getContents] reads back values written by [setContents]. The headless / no-op
-     * adapter returns `false` so callers can skip clipboard-settle polling that would otherwise
-     * spin its full timeout against a permanently-null reader.
+     * `true` when [getContents] reads back values written by [setContents]. Adapters that don't
+     * read back (a one-way write-only sink, or one that always throws) should return `false` so
+     * callers can skip clipboard-settle polling that would otherwise spin its full timeout against
+     * a permanently-null or always-throwing reader.
      */
     val supportsRead: Boolean
         get() = true
@@ -341,7 +352,7 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
     override val requiresOffEdt: Boolean = true
 
     // The only adapter that actually drives the OS through Robot, so the only one that ever
-    // hits macOS TCC. Synthetic and noop adapters override the default `false`.
+    // hits macOS TCC. Synthetic and headless-throwing adapters inherit the default `false`.
     override val gatesMacOsTcc: Boolean = true
 
     override fun mouseMove(x: Int, y: Int) = robot.mouseMove(x, y)
@@ -362,43 +373,54 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
     override fun waitForIdle() = robot.waitForIdle()
 }
 
-private object NoopRobotAdapter : RobotAdapter {
+private object HeadlessThrowingRobotAdapter : RobotAdapter {
 
     override val autoDelayMs: Int = 0
 
-    // No-op input never blocks the EDT, so the worker-thread hop is unnecessary.
+    // We throw before reaching any worker-hop logic, so the off-EDT marshal is irrelevant; pick
+    // the cheaper inline path so EDT callers see the throw without a thread spin-up.
     override val requiresOffEdt: Boolean = false
 
-    override fun mouseMove(x: Int, y: Int) = Unit
+    override fun mouseMove(x: Int, y: Int): Unit = throwHeadless("mouseMove")
 
-    override fun mousePress(buttons: Int) = Unit
+    override fun mousePress(buttons: Int): Unit = throwHeadless("mousePress")
 
-    override fun mouseRelease(buttons: Int) = Unit
+    override fun mouseRelease(buttons: Int): Unit = throwHeadless("mouseRelease")
 
-    override fun keyPress(keyCode: Int) = Unit
+    override fun keyPress(keyCode: Int): Unit = throwHeadless("keyPress")
 
-    override fun keyRelease(keyCode: Int) = Unit
+    override fun keyRelease(keyCode: Int): Unit = throwHeadless("keyRelease")
 
-    override fun mouseWheel(wheelClicks: Int) = Unit
+    override fun mouseWheel(wheelClicks: Int): Unit = throwHeadless("mouseWheel")
 
-    // Always return a fresh 1×1 image regardless of region size. RobotDriver.headless() is
-    // documented as no-OS-contact (so we don't probe screen devices) and screenshot returns
-    // are conceptually owned by the caller (BufferedImage is mutable; setRGB/createGraphics
-    // are normal post-screenshot operations), so a per-call instance is required for safety.
     override fun createScreenCapture(region: Rectangle): BufferedImage =
-        BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB)
+        throwHeadless("createScreenCapture")
 
+    // waitForIdle is purely a synchronisation barrier — it produces no observable side effect, so
+    // making it a no-op keeps internal pump loops (e.g. the post-paste drain in typeText) callable
+    // without triggering throws on a path where they'd be unreachable anyway.
     override fun waitForIdle() = Unit
 }
 
-private object NoopClipboardAdapter : ClipboardAdapter {
+private object HeadlessThrowingClipboardAdapter : ClipboardAdapter {
 
+    // The driver short-circuits clipboard polling and post-paste settles when this is `false`.
+    // Even though every read/write throws, leaving it `false` keeps the typeText fast path
+    // honest: callers reach the throwing setContents directly without first burning the
+    // clipboard-settle timeout against an adapter that will never read back.
     override val supportsRead: Boolean = false
 
-    override fun getContents(): Transferable? = null
+    override fun getContents(): Transferable = throwHeadless("clipboard read")
 
-    override fun setContents(contents: Transferable) = Unit
+    override fun setContents(contents: Transferable): Unit = throwHeadless("clipboard write")
 }
+
+private fun throwHeadless(operation: String): Nothing =
+    throw UnsupportedOperationException(
+        "RobotDriver.headless() does not perform real I/O — $operation was called. Use " +
+            "RobotDriver.synthetic(rootWindow) for a synthetic-event driver, or invoke " +
+            "SemanticsActions.OnClick directly on the target node for click-only flows."
+    )
 
 internal class SystemClipboardAdapter : ClipboardAdapter {
     // Lazy: looking up the system clipboard at construction time would couple every
@@ -420,9 +442,10 @@ private fun createAwtRobot(): Robot =
     }
 
 private fun runOffEdt(robot: RobotAdapter, block: () -> Unit) {
-    // Adapters that don't need the off-EDT marshal (synthetic, no-op) can run inline even
-    // on the EDT — spawning a worker would deadlock the synthetic adapter, whose internal
-    // `SwingUtilities.invokeAndWait` would wait forever for an EDT blocked on `Thread.join()`.
+    // Adapters that don't need the off-EDT marshal (synthetic, headless-throwing) can run
+    // inline even on the EDT — spawning a worker would deadlock the synthetic adapter, whose
+    // internal `SwingUtilities.invokeAndWait` would wait forever for an EDT blocked on
+    // `Thread.join()`.
     if (!robot.requiresOffEdt || !SwingUtilities.isEventDispatchThread()) {
         block()
         return
@@ -470,10 +493,9 @@ fun detectMacOs(): Boolean = System.getProperty("os.name").lowercase().contains(
 
 private fun virtualDesktopBounds(): Rectangle {
     // GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices throws HeadlessException
-    // when the JVM is running with -Djava.awt.headless=true (e.g. CI). RobotDriver.headless()
-    // is documented as safe in that environment, so fall back to a 1×1 rectangle here so the
-    // headless path never reaches a real device probe. The NoopRobotAdapter will still produce
-    // an empty BufferedImage of that size.
+    // when the JVM is running with -Djava.awt.headless=true (e.g. CI). Fall back to a 1×1
+    // rectangle here so the bounds lookup itself doesn't throw; the underlying adapter's
+    // createScreenCapture is what decides whether the call is supported in this environment.
     if (GraphicsEnvironment.isHeadless()) return Rectangle(0, 0, 1, 1)
 
     val ge = GraphicsEnvironment.getLocalGraphicsEnvironment()

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -263,51 +263,55 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `headless driver never invokes the TCC guard probes`() {
-        // The default headless() factory wires in MacOsTccGuard.noop() which has lambda probes
-        // that return NotApplicable. We verify by exercising every public input/screenshot
-        // method — none should throw, and the noop guard never warns or short-circuits.
+    fun `headless click throws UnsupportedOperationException naming the operation`() {
         val driver = RobotDriver.headless()
-
-        driver.click(10, 20)
-        driver.doubleClick(10, 20)
-        driver.longClick(10, 20, holdFor = 1.milliseconds)
-        driver.swipe(0, 0, 5, 5, steps = 2, duration = ZERO)
-        driver.scrollWheel(0, 0, 1)
-        driver.pressKey(KeyEvent.VK_ENTER)
-        driver.typeText("noop")
-        driver.clearAndTypeText("noop")
-        driver.screenshot(Rectangle(0, 0, 4, 4))
-    }
-
-    @Test
-    fun `typeText with no-op clipboard adapter does not spin or settle for the headless path`() {
-        // RobotDriver.headless() pairs the noop robot with the noop clipboard. The clipboard
-        // never reads back what was written and the noop robot has no real paste pipeline to
-        // drain, so neither the awaitClipboardContents poll nor the post-paste settle delay
-        // should run. This test pins headless typeText latency at well under a single
-        // POST_PASTE_SETTLE_MS so a future change can't accidentally re-introduce either delay.
-        // We invoke typeText several times because per-call settle accumulates: a 50ms sleep
-        // per call would push 5 calls to 250ms+, which is what Codex P2 on PR #37 flagged.
-        val driver = RobotDriver.headless()
-        val elapsedMs =
-            kotlin.system.measureTimeMillis {
-                repeat(HEADLESS_TYPE_TEXT_INVOCATIONS) { driver.typeText("hello") }
-            }
+        val error = assertFailsWith<UnsupportedOperationException> { driver.click(0, 0) }
+        // The thrown message names the adapter operation that ran, not the public method, but it
+        // includes the alternative-driver pointers the issue calls for so the user has a clear
+        // path forward without re-reading the factory KDoc.
+        val message = checkNotNull(error.message)
         assertTrue(
-            elapsedMs < HEADLESS_TYPE_TEXT_BUDGET_MS,
-            "headless typeText × $HEADLESS_TYPE_TEXT_INVOCATIONS should return immediately " +
-                "(no clipboard wait, no post-paste settle), took ${elapsedMs}ms " +
-                "(budget ${HEADLESS_TYPE_TEXT_BUDGET_MS}ms)",
+            message.contains("RobotDriver.synthetic(rootWindow)"),
+            "Expected pointer to RobotDriver.synthetic, got: $message",
+        )
+        assertTrue(
+            message.contains("SemanticsActions.OnClick"),
+            "Expected pointer to SemanticsActions.OnClick, got: $message",
         )
     }
 
-    private companion object {
-        const val HEADLESS_TYPE_TEXT_INVOCATIONS: Int = 5
-        // Tight budget — comfortably under POST_PASTE_SETTLE_MS (50ms) × invocation count so
-        // the test fails if either the clipboard poll or the post-paste sleep ever fires for
-        // a no-op adapter.
-        const val HEADLESS_TYPE_TEXT_BUDGET_MS: Long = 30L
+    @Test
+    fun `headless typeText throws UnsupportedOperationException`() {
+        val driver = RobotDriver.headless()
+        assertFailsWith<UnsupportedOperationException> { driver.typeText("hello") }
+    }
+
+    @Test
+    fun `headless screenshot throws UnsupportedOperationException`() {
+        val driver = RobotDriver.headless()
+        assertFailsWith<UnsupportedOperationException> { driver.screenshot() }
+    }
+
+    @Test
+    fun `headless pressKey throws UnsupportedOperationException`() {
+        val driver = RobotDriver.headless()
+        assertFailsWith<UnsupportedOperationException> { driver.pressKey(KeyEvent.VK_ENTER) }
+    }
+
+    @Test
+    fun `headless scrollWheel throws UnsupportedOperationException`() {
+        val driver = RobotDriver.headless()
+        assertFailsWith<UnsupportedOperationException> {
+            driver.scrollWheel(screenX = 0, screenY = 0, wheelClicks = 1)
+        }
+    }
+
+    @Test
+    fun `headless swipe throws UnsupportedOperationException`() {
+        val driver = RobotDriver.headless()
+        assertFailsWith<UnsupportedOperationException> {
+            driver.swipe(startX = 0, startY = 0, endX = 1, endY = 1, steps = 1, duration = ZERO)
+        }
     }
 }
 

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -119,8 +119,10 @@ corresponding doc page is touched:
 - **`RobotDriver` public constructors.** `RobotDriver()` (default AWT), `RobotDriver(robot)`,
   `RobotDriver.headless()`, `RobotDriver.synthetic(rootWindow)`. The
   adapter-injecting constructor is `internal` and not for consumers.
-- **`RobotDriver.headless()` only stubs input/screenshot/clipboard side effects.**
-  It does **not** fake the live `WindowTracker`/`SemanticsReader`.
+- **`RobotDriver.headless()` throws on input/screenshot/clipboard.** Every input,
+  clipboard, and screenshot call raises `UnsupportedOperationException` so accidental
+  real-I/O calls fail at the call site. `WindowTracker`/`SemanticsReader` are
+  untouched, so semantics-tree reads still work.
 - **`typeText` is always clipboard-paste.** It writes the text, dispatches the
   platform paste shortcut, drains, then restores the previous clipboard contents.
   No per-key fallback.

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -28,11 +28,15 @@ clipboard or screen) is unavailable, swap in `RobotDriver.headless()`:
 val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
 ```
 
-`headless()` only stubs out the input/screenshot/clipboard side effects — mouse and
-key calls are silently dropped, screenshots return a 1×1 empty image, and clipboard
-operations are no-ops. It does **not** fake out the live `WindowTracker`/`SemanticsReader`, so the automator still inspects whatever Compose surfaces are
-actually on screen. For unit-style tests that need full isolation, inject test-specific
-`WindowTracker` and `SemanticsReader` instances too.
+`headless()` throws `UnsupportedOperationException` on every input, clipboard, and
+screenshot call — an accidental `automator.click(...)` / `typeText(...)` /
+`screenshot(...)` surfaces at the call site instead of silently dropping. It does
+**not** fake out the live `WindowTracker`/`SemanticsReader`, so semantics-tree
+queries still work against whatever Compose surfaces are actually on screen. Reach
+for it for read-only flows; pair it with `SemanticsActions.OnClick` (see
+[Driving input](interactions.md#real-vs-synthetic-input)) when you need to fire
+clicks without going through the OS. For unit-style tests that need full isolation,
+inject test-specific `WindowTracker` and `SemanticsReader` instances too.
 
 ## Surfaces and the semantics tree
 

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -110,7 +110,8 @@ There's a third interaction style that doesn't go through any `RobotDriver` at a
 walk the semantics tree and invoke the `SemanticsActions.OnClick` action directly on
 the EDT. This is what Compose's own test rule does internally. It's useful when:
 
-- You're using `RobotDriver.headless()` and need clicks to do something.
+- You're using `RobotDriver.headless()` (which throws on real input) and still need
+  clicks to actually do something.
 - You want clicks that are robust against window focus, occlusion, parallel test
   runs, and animation timing — semantics actions toggle state synchronously, no
   layout dependency.

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -153,10 +153,13 @@ public surface:
   target window's event queue. No real cursor motion, no global focus, doesn't fight with
   other processes. `synthetic` is a companion extension function in the
   `dev.sebastiano.spectre.core` package, so it needs an explicit import.
-- **`RobotDriver.headless()`** — a no-op adapter for tests and headless CI. Mouse/key
-  calls are silently dropped, screenshots return a 1×1 empty image, and clipboard access
-  is a no-op. Note that this only stubs out input/screenshot side effects; it does not
-  fake out the live `WindowTracker` and `SemanticsReader`. See
+- **`RobotDriver.headless()`** — for read-only flows in headless CI where real OS I/O is
+  unavailable. Every input, clipboard, and screenshot call throws
+  `UnsupportedOperationException` so an accidental `automator.click(...)` /
+  `typeText(...)` / `screenshot(...)` surfaces at the call site instead of silently
+  dropping. `WindowTracker` and `SemanticsReader` are untouched, so semantics-tree
+  reads still work — pair this with `SemanticsActions.OnClick` if you need to fire
+  clicks without going through the OS. See
   [The automator](automator.md#what-an-automator-owns) for the full picture.
 
 Pass a non-default driver via the `inProcess` factory:

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -79,7 +79,12 @@ the annotation on the property itself and JUnit wouldn't see it.
 ## Custom `AutomatorFactory`
 
 Both wrappers default to `ComposeAutomator.inProcess()`. Pass your own factory when you
-need a stub for headless CI or unit-style isolation:
+need a different driver for headless CI or unit-style isolation. `RobotDriver.headless()`
+throws on input, clipboard, and screenshot calls (see
+[Driving input](interactions.md#real-vs-synthetic-input)), so the example below is
+appropriate for tests that only exercise semantics-tree queries or rule/extension
+lifecycle — anything that needs real input should use `RobotDriver.synthetic(rootWindow)`
+or the default `RobotDriver()` instead:
 
 ```kotlin
 import dev.sebastiano.spectre.core.ComposeAutomator

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -82,11 +82,11 @@ modes follow from that:
   manager or another process actively rewriting the clipboard, the poll can time
   out and the paste lands stale. Disable clipboard managers in the test
   environment.
-- **Headless adapters skip the readback.** `RobotDriver.headless()`'s clipboard
-  adapter doesn't support read-back, so it doesn't wait and doesn't drain the EDT
-  after dispatch. That's fine for headless tests that don't really care about
-  paste, but means real-input scenarios should not be exercised against a headless
-  driver.
+- **`RobotDriver.headless()` throws on `typeText`.** It throws on every input,
+  clipboard, and screenshot call by design (see [Driving input](interactions.md#real-vs-synthetic-input)),
+  so `typeText` against a headless driver surfaces an `UnsupportedOperationException`
+  at the call site rather than silently dropping. Use `RobotDriver.synthetic(rootWindow)`
+  or the default `RobotDriver()` for any real-input scenario.
 - **Compose's paste action runs on its own dispatcher.** After the keystroke,
   Spectre pumps the EDT and sleeps briefly so the paste handler can read the
   clipboard before the previous contents are restored. If you stack many

--- a/sample-intellij-plugin/src/main/kotlin/dev/sebastiano/spectre/intellij/RunSpectreAction.kt
+++ b/sample-intellij-plugin/src/main/kotlin/dev/sebastiano/spectre/intellij/RunSpectreAction.kt
@@ -136,9 +136,9 @@ class RunSpectreAction : AnAction() {
     /**
      * Invokes the Compose `OnClick` semantics action on [node] from the EDT — equivalent to a
      * synthetic click for the purpose of toggling state, without going through the OS input stack.
-     * The `RobotDriver.headless()` we use here can't deliver real input, so we drive the semantics
-     * tree directly. This is the same pattern Compose's own `composeTestRule.onNode` uses
-     * internally. Caller is responsible for ensuring this runs on the EDT.
+     * The `RobotDriver.headless()` we use here throws on real input, so we drive the semantics tree
+     * directly. This is the same pattern Compose's own `composeTestRule.onNode` uses internally.
+     * Caller is responsible for ensuring this runs on the EDT.
      */
     private fun triggerOnClick(node: AutomatorNode) {
         val onClick = node.semanticsNode.config.getOrNull(SemanticsActions.OnClick)

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
@@ -27,8 +27,9 @@ import kotlinx.coroutines.runBlocking
  *
  * The backing [ComposeAutomator] is headless, so assertions target the client/transport contract
  * (list shapes, status-code translation, body decoding, engine lifecycle) rather than live UI
- * behaviour. The `click()` happy path is intentionally not covered here — driving a real node
- * requires a live Compose surface, which the testing module's automator rules cover separately.
+ * behaviour. Endpoints that drive real input or capture (`click()` happy path, `typeText`,
+ * `screenshot`) are intentionally not covered here — driving them requires a live Compose surface,
+ * which the testing module's automator rules cover separately.
  */
 class HttpComposeAutomatorE2ETest {
 
@@ -87,25 +88,6 @@ class HttpComposeAutomatorE2ETest {
                 message.contains("nonexistent:0:1"),
                 "Expected node key in error message, got: $message",
             )
-        }
-    }
-
-    @Test
-    fun `typeText() succeeds against a running server`() = runBlocking {
-        // No exception means the client decoded the 204 No Content response correctly. The
-        // headless RobotDriver drops the synthetic key events, so we cannot assert on the UI
-        // side effect here — that is what the in-process automator tests are for.
-        client().use { remote -> remote.typeText(text = "hello") }
-    }
-
-    @Test
-    fun `screenshot() decodes the base64 PNG envelope into a BufferedImage`() = runBlocking {
-        client().use { remote ->
-            val image = remote.screenshot()
-            // The headless RobotDriver returns a 1x1 placeholder; the assertion is just that
-            // the client successfully base64-decoded the wire payload and ImageIO accepted it.
-            assertTrue(image.width > 0, "Width should be positive, got ${image.width}")
-            assertTrue(image.height > 0, "Height should be positive, got ${image.height}")
         }
     }
 

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/ScreenshotEnvelopeTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/ScreenshotEnvelopeTest.kt
@@ -1,0 +1,35 @@
+package dev.sebastiano.spectre.server
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.util.Base64
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for the `BufferedImage → ScreenshotResponse` envelope encoding. Previously this was
+ * exercised end-to-end through the headless `RobotDriver`'s 1×1 placeholder, but the headless
+ * driver now throws on `screenshot()`, so the wire-format coverage lives here instead.
+ */
+class ScreenshotEnvelopeTest {
+
+    @Test
+    fun `toScreenshotResponse encodes the image as a base64 PNG with matching dimensions`() {
+        val image = BufferedImage(7, 11, BufferedImage.TYPE_INT_ARGB)
+
+        val response = image.toScreenshotResponse()
+
+        assertEquals(7, response.width)
+        assertEquals(11, response.height)
+        assertTrue(response.pngBase64.isNotEmpty(), "PNG payload should be present")
+
+        // The decoded image must be a valid PNG that round-trips to the original size — proves
+        // the envelope is well-formed bytes, not just non-empty base64.
+        val decoded =
+            ImageIO.read(ByteArrayInputStream(Base64.getDecoder().decode(response.pngBase64)))
+        assertEquals(7, decoded.width)
+        assertEquals(11, decoded.height)
+    }
+}

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
@@ -6,8 +6,6 @@ import dev.sebastiano.spectre.core.SemanticsReader
 import dev.sebastiano.spectre.core.WindowTracker
 import dev.sebastiano.spectre.server.dto.ClickRequest
 import dev.sebastiano.spectre.server.dto.NodesResponse
-import dev.sebastiano.spectre.server.dto.ScreenshotResponse
-import dev.sebastiano.spectre.server.dto.TypeTextRequest
 import dev.sebastiano.spectre.server.dto.WindowsResponse
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -33,6 +31,10 @@ import kotlin.test.assertTrue
  * real headless `ComposeAutomator` backing them. The automator has no Compose surfaces in this
  * environment, so the assertions are about the request/response *envelope* contract — list shapes,
  * status codes, body decoding — not about live UI behaviour.
+ *
+ * Endpoints that drive real input or capture (`typeText`, `screenshot`) are intentionally not
+ * covered here: the headless driver throws on those, and asserting that the route surfaces a 5xx is
+ * not particularly informative — the in-process automator tests cover the success path.
  */
 class SpectreServerRoundTripTest {
 
@@ -101,32 +103,6 @@ class SpectreServerRoundTripTest {
 
         assertEquals(HttpStatusCode.BadRequest, response.status)
         assertTrue(response.bodyAsText().contains("Malformed node key"))
-    }
-
-    @Test
-    fun `typeText returns 204 No Content`() = testApplication {
-        application { installSpectreRoutes(headlessAutomator()) }
-        val client = createClient { install(ContentNegotiation) { json() } }
-
-        val response =
-            client.post("/spectre/typeText") {
-                contentType(ContentType.Application.Json)
-                setBody(TypeTextRequest(text = "hello"))
-            }
-
-        assertEquals(HttpStatusCode.NoContent, response.status)
-    }
-
-    @Test
-    fun `screenshot returns a base64-encoded PNG envelope`() = testApplication {
-        application { installSpectreRoutes(headlessAutomator()) }
-        val client = createClient { install(ContentNegotiation) { json() } }
-
-        val response = client.get("/spectre/screenshot").body<ScreenshotResponse>()
-
-        assertTrue(response.pngBase64.isNotEmpty(), "PNG payload should be present")
-        assertTrue(response.width > 0, "Width should be positive")
-        assertTrue(response.height > 0, "Height should be positive")
     }
 
     @Test


### PR DESCRIPTION
Closes #97.

## Summary

- `RobotDriver.headless()` now throws `UnsupportedOperationException` on every input, clipboard, and screenshot call. The thrown message names the operation and points at `RobotDriver.synthetic(rootWindow)` and `SemanticsActions.OnClick` as alternatives.
- `WindowTracker` and `SemanticsReader` are untouched — semantics-tree reads still work, so the `headless()` factory remains the right thing for read-only flows in headless CI.
- Per the side note on this branch, no `inert()` / `noop()` factory ships. We can add one if a clear use case emerges.

## In-tree migrations

- **testing module** (`ComposeAutomatorRuleTest`, `ComposeAutomatorExtensionTest`): keep using `headless()`. They only exercise rule/extension lifecycle, never call input.
- **sample-intellij-plugin `RunSpectreAction`**: keeps using `headless()` and drives clicks via `OnClick` semantics actions, which is exactly the pattern the new throw message points at. KDoc updated to say "throws on real input" instead of "can't deliver real input".
- **server module tests**: previously verified the `typeText` 204 mapping and the `screenshot` base64 envelope by leaning on the silent no-op driver. Those success-path tests were already only marginally useful (the comments admit the assertions weren't really about the driver) — they're removed, and the envelope encoding now has direct unit coverage in the new `ScreenshotEnvelopeTest`.

## Tests

- New `RobotDriverTest` cases assert that `click`, `typeText`, `screenshot`, `pressKey`, `scrollWheel`, and `swipe` all throw `UnsupportedOperationException` from a `headless()` driver, and that the message includes the alternative-driver pointers.
- The old `typeText with no-op clipboard adapter does not spin or settle for the headless path` test is gone — it pinned behaviour we deliberately removed.

## Docs

- `docs/guide/interactions.md`, `docs/guide/automator.md`, `docs/guide/intellij.md`, `docs/guide/troubleshooting.md`, `docs/guide/junit.md`, `docs/DOCS-STYLE.md` — all swap "silently dropped" / "no-op" wording for the new throw-loudly contract and point at `synthetic` / `OnClick` as the right alternatives.

## Test plan

- [x] `./gradlew check` green locally
- [ ] CI green
- [ ] mkdocs strict build green (touched docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)