### PR TITLE
refactor(core)!: suspend RobotDriver/ComposeAutomator interaction APIs (#93)

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -69,22 +69,22 @@ sealed class ComposeAutomatorInteractions : ComposeAutomatorQueries() {
 
     protected abstract val robotDriver: RobotDriver
 
-    fun click(node: AutomatorNode) {
+    suspend fun click(node: AutomatorNode) {
         val center = node.centerOnScreen
         robotDriver.click(center.x, center.y)
     }
 
-    fun doubleClick(node: AutomatorNode) {
+    suspend fun doubleClick(node: AutomatorNode) {
         val center = node.centerOnScreen
         robotDriver.doubleClick(center.x, center.y)
     }
 
-    fun longClick(node: AutomatorNode, holdFor: Duration = 500.milliseconds) {
+    suspend fun longClick(node: AutomatorNode, holdFor: Duration = 500.milliseconds) {
         val center = node.centerOnScreen
         robotDriver.longClick(center.x, center.y, holdFor)
     }
 
-    fun swipe(
+    suspend fun swipe(
         startX: Int,
         startY: Int,
         endX: Int,
@@ -95,7 +95,7 @@ sealed class ComposeAutomatorInteractions : ComposeAutomatorQueries() {
         robotDriver.swipe(startX, startY, endX, endY, steps, duration)
     }
 
-    fun swipe(
+    suspend fun swipe(
         from: AutomatorNode,
         to: AutomatorNode,
         steps: Int = 12,
@@ -111,25 +111,25 @@ sealed class ComposeAutomatorInteractions : ComposeAutomatorQueries() {
      * lower in the list); negative scrolls up. Drives Compose's `Modifier.scrollable` /
      * `LazyColumn` on desktop, which respond to wheel events rather than touch-style drags.
      */
-    fun scrollWheel(node: AutomatorNode, wheelClicks: Int) {
+    suspend fun scrollWheel(node: AutomatorNode, wheelClicks: Int) {
         val center = node.centerOnScreen
         robotDriver.scrollWheel(center.x, center.y, wheelClicks)
     }
 
-    fun typeText(text: String) {
+    suspend fun typeText(text: String) {
         robotDriver.typeText(text)
     }
 
-    fun clearAndTypeText(node: AutomatorNode, text: String) {
+    suspend fun clearAndTypeText(node: AutomatorNode, text: String) {
         click(node)
         robotDriver.clearAndTypeText(text)
     }
 
-    fun pressKey(keyCode: Int, modifiers: Int = 0) {
+    suspend fun pressKey(keyCode: Int, modifiers: Int = 0) {
         robotDriver.pressKey(keyCode, modifiers)
     }
 
-    fun pressEnter() {
+    suspend fun pressEnter() {
         robotDriver.pressKey(KeyEvent.VK_ENTER)
     }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -15,6 +15,9 @@ import java.awt.image.BufferedImage
 import javax.swing.SwingUtilities
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 
 class RobotDriver
 internal constructor(
@@ -30,7 +33,7 @@ internal constructor(
 
     constructor(robot: Robot) : this(AwtRobotAdapter(robot))
 
-    fun click(screenX: Int, screenY: Int) {
+    suspend fun click(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
             robot.mouseMove(screenX, screenY)
@@ -39,7 +42,7 @@ internal constructor(
         }
     }
 
-    fun doubleClick(screenX: Int, screenY: Int) {
+    suspend fun doubleClick(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
             robot.mouseMove(screenX, screenY)
@@ -50,20 +53,24 @@ internal constructor(
         }
     }
 
-    fun longClick(screenX: Int, screenY: Int, holdFor: Duration = DEFAULT_LONG_CLICK_DURATION) {
+    suspend fun longClick(
+        screenX: Int,
+        screenY: Int,
+        holdFor: Duration = DEFAULT_LONG_CLICK_DURATION,
+    ) {
         tccGuard.requireAccessibility()
         runOffEdt {
             robot.mouseMove(screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             try {
-                Thread.sleep(holdFor.inWholeMilliseconds)
+                delay(holdFor)
             } finally {
                 robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
             }
         }
     }
 
-    fun swipe(
+    suspend fun swipe(
         startX: Int,
         startY: Int,
         endX: Int,
@@ -82,7 +89,7 @@ internal constructor(
                 for (point in points.drop(1)) {
                     robot.mouseMove(point.x, point.y)
                     if (pausePerStepMs > 0) {
-                        Thread.sleep(pausePerStepMs)
+                        delay(pausePerStepMs.milliseconds)
                     }
                 }
             } finally {
@@ -91,56 +98,58 @@ internal constructor(
         }
     }
 
-    fun typeText(text: String) {
+    suspend fun typeText(text: String) {
         tccGuard.requireAccessibility()
-        val previousContents = runCatching { clipboard.getContents() }.getOrNull()
-        try {
-            clipboard.setContents(StringSelection(text))
-            // OS pasteboard writes (notably macOS NSPasteboard) are asynchronous: setContents
-            // returns immediately, but readers can observe the previous value for a short
-            // window. If we dispatch Cmd+V before the pasteboard surfaces our text, the focused
-            // field's paste handler reads stale (often empty) contents and the typed characters
-            // never land. Poll the clipboard until it reports our string, with a bounded budget
-            // so a misbehaving clipboard adapter cannot wedge the call indefinitely. Skip the
-            // poll for adapters that don't support read-back so that path doesn't burn the
-            // full settle timeout against a permanently-null reader.
-            if (clipboard.supportsRead) {
-                awaitClipboardContents(text, CLIPBOARD_SETTLE_TIMEOUT_MS, CLIPBOARD_SETTLE_POLL_MS)
-            }
-            runOffEdt {
+        runOffEdt {
+            val previousContents = runCatching { clipboard.getContents() }.getOrNull()
+            try {
+                clipboard.setContents(StringSelection(text))
+                // OS pasteboard writes (notably macOS NSPasteboard) are asynchronous:
+                // setContents returns immediately, but readers can observe the previous value
+                // for a short window. If we dispatch Cmd+V before the pasteboard surfaces our
+                // text, the focused field's paste handler reads stale (often empty) contents
+                // and the typed characters never land. Poll the clipboard until it reports our
+                // string, with a bounded budget so a misbehaving clipboard adapter cannot
+                // wedge the call indefinitely. Skip the poll for adapters that don't support
+                // read-back so that path doesn't burn the full settle timeout against a
+                // permanently-null reader.
+                if (clipboard.supportsRead) {
+                    awaitClipboardContents(
+                        text,
+                        CLIPBOARD_SETTLE_TIMEOUT_MS,
+                        CLIPBOARD_SETTLE_POLL_MS,
+                    )
+                }
                 val modifier = shortcutModifierKeyCode(detectMacOs())
                 robot.keyPress(modifier)
                 robot.keyPress(KeyEvent.VK_V)
                 robot.keyRelease(KeyEvent.VK_V)
                 robot.keyRelease(modifier)
-            }
-            if (!SwingUtilities.isEventDispatchThread() && clipboard.supportsRead) {
-                // Drain queued AWT events (KEY_PRESSED/RELEASED + Compose's input pipeline) so
-                // the paste handler has a chance to read the clipboard before we restore it.
-                // Without this, the finally block can clobber the clipboard mid-paste and the
-                // field receives empty text — the exact symptom that flaked the live validation.
-                // One waitForIdle pump is not enough: Compose's paste action runs on its own
-                // coroutine dispatcher which posts back to the EDT, so we pump a few times and
-                // also wait a short interval to let the OS-side paste read complete before we
-                // clobber the clipboard contents. Skip the whole block for adapters that don't
-                // support clipboard read-back — there's no real paste handler to drain, so the
-                // sleep would just add fixed latency for nothing.
-                repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }
-                try {
-                    Thread.sleep(POST_PASTE_SETTLE_MS)
-                } catch (_: InterruptedException) {
-                    Thread.currentThread().interrupt()
+                if (clipboard.supportsRead) {
+                    // Drain queued AWT events (KEY_PRESSED/RELEASED + Compose's input
+                    // pipeline) so the paste handler has a chance to read the clipboard before
+                    // we restore it. Without this, the finally block can clobber the clipboard
+                    // mid-paste and the field receives empty text — the exact symptom that
+                    // flaked the live validation. One waitForIdle pump is not enough:
+                    // Compose's paste action runs on its own coroutine dispatcher which posts
+                    // back to the EDT, so we pump a few times and also wait a short interval
+                    // to let the OS-side paste read complete before we clobber the clipboard
+                    // contents. Skip the whole block for adapters that don't support
+                    // clipboard read-back — there's no real paste handler to drain, so the
+                    // delay would just add fixed latency for nothing.
+                    repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }
+                    delay(POST_PASTE_SETTLE_MS.milliseconds)
+                    repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }
                 }
-                repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }
-            }
-        } finally {
-            if (previousContents != null) {
-                runCatching { clipboard.setContents(previousContents) }
+            } finally {
+                if (previousContents != null) {
+                    runCatching { clipboard.setContents(previousContents) }
+                }
             }
         }
     }
 
-    private fun awaitClipboardContents(expected: String, timeoutMs: Long, pollMs: Long) {
+    private suspend fun awaitClipboardContents(expected: String, timeoutMs: Long, pollMs: Long) {
         val deadline = System.nanoTime() + timeoutMs * NANOS_PER_MILLI
         while (true) {
             val current =
@@ -153,16 +162,11 @@ internal constructor(
                     .getOrNull() as? String
             if (current == expected) return
             if (System.nanoTime() >= deadline) return
-            try {
-                Thread.sleep(pollMs)
-            } catch (_: InterruptedException) {
-                Thread.currentThread().interrupt()
-                return
-            }
+            delay(pollMs.milliseconds)
         }
     }
 
-    fun clearAndTypeText(text: String) {
+    suspend fun clearAndTypeText(text: String) {
         tccGuard.requireAccessibility()
         val selectAllModifier = shortcutModifierKeyCode(detectMacOs())
         runOffEdt {
@@ -182,7 +186,7 @@ internal constructor(
      * desk); negative scrolls up. Drives Compose's `Modifier.scrollable` and lazy-list scroll on
      * desktop, which respond to wheel events rather than touch-style drag gestures.
      */
-    fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
+    suspend fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
             robot.mouseMove(screenX, screenY)
@@ -190,7 +194,7 @@ internal constructor(
         }
     }
 
-    fun pressKey(keyCode: Int, modifiers: Int = 0) {
+    suspend fun pressKey(keyCode: Int, modifiers: Int = 0) {
         tccGuard.requireAccessibility()
         runOffEdt {
             val modifierKeys = modifierMaskToKeyCodes(modifiers)
@@ -240,7 +244,7 @@ internal constructor(
         return robot.createScreenCapture(captureRegion)
     }
 
-    private fun runOffEdt(block: () -> Unit) = runOffEdt(robot, block)
+    private suspend fun runOffEdt(block: suspend () -> Unit) = runOffEdt(robot, block)
 
     companion object {
 
@@ -441,20 +445,19 @@ private fun createAwtRobot(): Robot =
         isAutoWaitForIdle = false
     }
 
-private fun runOffEdt(robot: RobotAdapter, block: () -> Unit) {
+private suspend fun runOffEdt(robot: RobotAdapter, block: suspend () -> Unit) {
     // Adapters that don't need the off-EDT marshal (synthetic, headless-throwing) can run
-    // inline even on the EDT — spawning a worker would deadlock the synthetic adapter, whose
-    // internal `SwingUtilities.invokeAndWait` would wait forever for an EDT blocked on
-    // `Thread.join()`.
+    // inline even on the EDT — switching to another dispatcher would force the synthetic
+    // adapter to bounce IO → EDT for every dispatch when the caller is already on the EDT,
+    // and used to deadlock the older thread-spawning marshal entirely (the EDT-blocking
+    // `Thread.join()` waited for a worker stuck in `SwingUtilities.invokeAndWait`).
     if (!robot.requiresOffEdt || !SwingUtilities.isEventDispatchThread()) {
         block()
         return
     }
-    var result: Result<Unit>? = null
-    val thread = Thread({ result = runCatching(block) }, "spectre-robot")
-    thread.start()
-    thread.join()
-    result!!.getOrThrow()
+    // Real `java.awt.Robot` calls block. `Dispatchers.IO` is sized for blocking I/O work and
+    // suspends the calling EDT coroutine without parking the EDT thread.
+    withContext(Dispatchers.IO) { block() }
 }
 
 fun shortcutModifierKeyCode(isMacOs: Boolean): Int =

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -125,7 +125,7 @@ internal constructor(
                 robot.keyPress(KeyEvent.VK_V)
                 robot.keyRelease(KeyEvent.VK_V)
                 robot.keyRelease(modifier)
-                if (clipboard.supportsRead) {
+                if (clipboard.supportsRead && !SwingUtilities.isEventDispatchThread()) {
                     // Drain queued AWT events (KEY_PRESSED/RELEASED + Compose's input
                     // pipeline) so the paste handler has a chance to read the clipboard before
                     // we restore it. Without this, the finally block can clobber the clipboard
@@ -134,9 +134,12 @@ internal constructor(
                     // Compose's paste action runs on its own coroutine dispatcher which posts
                     // back to the EDT, so we pump a few times and also wait a short interval
                     // to let the OS-side paste read complete before we clobber the clipboard
-                    // contents. Skip the whole block for adapters that don't support
-                    // clipboard read-back — there's no real paste handler to drain, so the
-                    // delay would just add fixed latency for nothing.
+                    // contents. Skip the whole block when called on the EDT (the synthetic
+                    // adapter's runOffEdt short-circuit lets it stay on EDT), where
+                    // waitForIdle is a no-op and the post-paste settle would just add wall-
+                    // clock latency for nothing — same skip the pre-suspend code applied. Skip
+                    // for adapters that don't support clipboard read-back too — there's no real
+                    // paste handler to drain.
                     repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }
                     delay(POST_PASTE_SETTLE_MS.milliseconds)
                     repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.test.runTest
 
 class RobotDriverTest {
 
@@ -103,7 +104,7 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `click moves and presses left button`() {
+    fun `click moves and presses left button`() = runTest {
         val robot = RecordingRobotAdapter()
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
 
@@ -120,34 +121,36 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `typeText waits for the clipboard to reflect the new text before dispatching paste`() {
-        // Simulate a slow OS pasteboard: the first N reads after setContents still return the
-        // previous value. typeText must not press Cmd+V until the clipboard has settled, otherwise
-        // the paste handler reads stale contents.
-        val clipboard = LatentClipboardAdapter(latencyReads = 3)
-        clipboard.setContentsImmediate(StringSelection("previous"))
-        val driver = RobotDriver(clipboard.robotAdapter, clipboard)
+    fun `typeText waits for the clipboard to reflect the new text before dispatching paste`() =
+        runTest {
+            // Simulate a slow OS pasteboard: the first N reads after setContents still return the
+            // previous value. typeText must not press Cmd+V until the clipboard has settled,
+            // otherwise the paste handler reads stale contents.
+            val clipboard = LatentClipboardAdapter(latencyReads = 3)
+            clipboard.setContentsImmediate(StringSelection("previous"))
+            val driver = RobotDriver(clipboard.robotAdapter, clipboard)
 
-        driver.typeText("spectre")
+            driver.typeText("spectre")
 
-        // The first key event must come AFTER the clipboard has the new value. Reconstruct by
-        // looking at the recorded order: each call to clipboard.getContents() interleaves with
-        // robot events, and we check the clipboard read at the moment of the first keyPress.
-        val firstKeyPressIndex = clipboard.eventLog.indexOfFirst { it.startsWith("robot:keyPress") }
-        check(firstKeyPressIndex >= 0) { "Expected a keyPress event in ${clipboard.eventLog}" }
-        val readsBeforePaste =
-            clipboard.eventLog.subList(0, firstKeyPressIndex).count {
-                it == "clipboard:get=spectre"
-            }
-        assertTrue(
-            readsBeforePaste >= 1,
-            "typeText must observe the new clipboard contents at least once before pressing " +
-                "Cmd+V (event log: ${clipboard.eventLog})",
-        )
-    }
+            // The first key event must come AFTER the clipboard has the new value. Reconstruct by
+            // looking at the recorded order: each call to clipboard.getContents() interleaves with
+            // robot events, and we check the clipboard read at the moment of the first keyPress.
+            val firstKeyPressIndex =
+                clipboard.eventLog.indexOfFirst { it.startsWith("robot:keyPress") }
+            check(firstKeyPressIndex >= 0) { "Expected a keyPress event in ${clipboard.eventLog}" }
+            val readsBeforePaste =
+                clipboard.eventLog.subList(0, firstKeyPressIndex).count {
+                    it == "clipboard:get=spectre"
+                }
+            assertTrue(
+                readsBeforePaste >= 1,
+                "typeText must observe the new clipboard contents at least once before pressing " +
+                    "Cmd+V (event log: ${clipboard.eventLog})",
+            )
+        }
 
     @Test
-    fun `typeText pumps the EDT after key release before restoring the clipboard`() {
+    fun `typeText pumps the EDT after key release before restoring the clipboard`() = runTest {
         // The OS paste handler reads the clipboard asynchronously after Cmd+V is released, so
         // restoring the previous contents synchronously can clobber the value before the paste
         // lands. typeText must give the AWT event queue (and any post-press settle) a chance to
@@ -181,7 +184,7 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `swipe presses drags and releases in order`() {
+    fun `swipe presses drags and releases in order`() = runTest {
         val robot = RecordingRobotAdapter()
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
 
@@ -201,7 +204,7 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `click consults the TCC guard before invoking the robot`() {
+    fun `click consults the TCC guard before invoking the robot`() = runTest {
         val guard = RecordingTccGuard()
         val robot = RecordingRobotAdapter()
         val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
@@ -213,7 +216,7 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `click that fails the accessibility check does not dispatch any input`() {
+    fun `click that fails the accessibility check does not dispatch any input`() = runTest {
         val guard = RecordingTccGuard(accessibilityThrows = true)
         val robot = RecordingRobotAdapter()
         val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
@@ -247,7 +250,7 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `typeText consults the accessibility guard before mutating the clipboard`() {
+    fun `typeText consults the accessibility guard before mutating the clipboard`() = runTest {
         // typeText writes to and restores the clipboard, so a failed accessibility check
         // must short-circuit BEFORE the clipboard is touched. Otherwise a failing macOS run
         // would still pollute the user's clipboard.
@@ -263,7 +266,7 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `headless click throws UnsupportedOperationException naming the operation`() {
+    fun `headless click throws UnsupportedOperationException naming the operation`() = runTest {
         val driver = RobotDriver.headless()
         val error = assertFailsWith<UnsupportedOperationException> { driver.click(0, 0) }
         // The thrown message names the adapter operation that ran, not the public method, but it
@@ -281,7 +284,7 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `headless typeText throws UnsupportedOperationException`() {
+    fun `headless typeText throws UnsupportedOperationException`() = runTest {
         val driver = RobotDriver.headless()
         assertFailsWith<UnsupportedOperationException> { driver.typeText("hello") }
     }
@@ -293,13 +296,13 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `headless pressKey throws UnsupportedOperationException`() {
+    fun `headless pressKey throws UnsupportedOperationException`() = runTest {
         val driver = RobotDriver.headless()
         assertFailsWith<UnsupportedOperationException> { driver.pressKey(KeyEvent.VK_ENTER) }
     }
 
     @Test
-    fun `headless scrollWheel throws UnsupportedOperationException`() {
+    fun `headless scrollWheel throws UnsupportedOperationException`() = runTest {
         val driver = RobotDriver.headless()
         assertFailsWith<UnsupportedOperationException> {
             driver.scrollWheel(screenX = 0, screenY = 0, wheelClicks = 1)
@@ -307,7 +310,7 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `headless swipe throws UnsupportedOperationException`() {
+    fun `headless swipe throws UnsupportedOperationException`() = runTest {
         val driver = RobotDriver.headless()
         assertFailsWith<UnsupportedOperationException> {
             driver.swipe(startX = 0, startY = 0, endX = 1, endY = 1, steps = 1, duration = ZERO)

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputTest.kt
@@ -11,6 +11,7 @@ import javax.swing.JFrame
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
@@ -21,15 +22,18 @@ class SyntheticInputTest {
      * Regression test for the EDT deadlock between [RobotDriver]'s `runOffEdt` and the synthetic
      * adapter's `runOnEdt`.
      *
-     * Before the fix, `RobotDriver.runOffEdt` always spawned a worker and `Thread.join()`-ed on it
-     * even when the underlying [RobotAdapter] was the synthetic one. The synthetic adapter then
-     * called `SwingUtilities.invokeAndWait` to marshal the dispatch back to the EDT — which was
-     * blocked on the join. Calls from a UI callback (any code path that runs `automator.click(...)`
-     * inside `SwingUtilities.invokeAndWait { ... }`) would deadlock indefinitely.
+     * Before the original fix, `RobotDriver.runOffEdt` always spawned a worker and
+     * `Thread.join()`-ed on it even when the underlying [RobotAdapter] was the synthetic one. The
+     * synthetic adapter then called `SwingUtilities.invokeAndWait` to marshal the dispatch back to
+     * the EDT — which was blocked on the join. Calls from a UI callback (any code path that runs
+     * `automator.click(...)` inside `SwingUtilities.invokeAndWait { ... }`) would deadlock
+     * indefinitely.
      *
      * The synthetic adapter doesn't need the off-EDT worker (it does its own EDT marshalling inside
-     * `runOnEdt`), so [RobotAdapter.requiresOffEdt] now lets `runOffEdt` skip the worker thread for
-     * synthetic and headless adapters.
+     * `runOnEdt`), so [RobotAdapter.requiresOffEdt] lets `runOffEdt` skip the dispatcher switch
+     * (today: `withContext(Dispatchers.IO)`) for synthetic and headless adapters. The suspend
+     * conversion in #93 preserved that contract — calling `driver.click(...)` from an EDT coroutine
+     * via `runBlocking` still runs the synthetic dispatch inline on the EDT.
      *
      * Uses a plain Swing [JFrame] rather than a Compose `Window` because:
      * - the deadlock is purely an AWT/EDT scheduling bug; it surfaces identically for any AWT
@@ -56,7 +60,14 @@ class SyntheticInputTest {
                 Thread(
                         {
                             SwingUtilities.invokeAndWait {
-                                driver.click(targetCenter.first, targetCenter.second)
+                                // runBlocking on EDT is a deliberate choice here — the test
+                                // pins the contract that a synthetic-adapter click invoked from
+                                // an EDT coroutine does not deadlock. With requiresOffEdt = false
+                                // for the synthetic adapter, runOffEdt skips the dispatcher
+                                // switch and the synthetic adapter inlines its own runOnEdt.
+                                runBlocking {
+                                    driver.click(targetCenter.first, targetCenter.second)
+                                }
                             }
                             invokeAndWaitFinished.countDown()
                         },

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -142,8 +142,12 @@ description, or role — see [Finding nodes](selectors.md).
   click via `java.awt.Robot`.
 
 The `withContext(Dispatchers.Default)` wrapper keeps the wait helpers off the AWT event
-dispatch thread. Calling them from the EDT is rejected at runtime — see
-[Synchronization](synchronization.md).
+dispatch thread. `waitForIdle` / `waitForVisualIdle` reject EDT callers at runtime —
+see [Synchronization](synchronization.md). The interaction methods (`click`,
+`typeText`, …) are themselves `suspend` and marshal their blocking AWT work onto
+`Dispatchers.IO` internally, so they don't need the wrap; a normal JUnit test that
+already runs off the EDT could equivalently drop the `withContext(Dispatchers.Default)`
+block entirely.
 
 ## Where to go next
 

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -3,6 +3,20 @@
 The interaction layer of `ComposeAutomator` sits on top of `RobotDriver` and dispatches
 mouse, keyboard, and clipboard input to whatever surface the target node lives in.
 
+All interaction methods (`click`, `doubleClick`, `longClick`, `swipe`, `scrollWheel`,
+`typeText`, `clearAndTypeText`, `pressKey`, `pressEnter`) are `suspend` — call them
+from a coroutine. They marshal blocking AWT/Robot work onto `Dispatchers.IO`
+internally, so a caller on `Dispatchers.Main` (the AWT EDT) yields cleanly while real
+input is dispatched. Internal sleeps use `delay` rather than `Thread.sleep`, so a
+cancelled coroutine cancels mid-`longClick` / mid-`swipe` rather than parking the
+worker thread until the hold completes.
+
+`screenshot` stays sync — it's a single framebuffer read, no blocking I/O to bury
+behind a coroutine boundary.
+
+The snippets below are written as if they sit inside a suspend block (e.g. a JUnit
+test wrapped in `runBlocking { … }`).
+
 ## Mouse: clicks and drags
 
 ```kotlin

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
@@ -10,6 +10,8 @@ import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -142,7 +144,7 @@ private suspend fun runSmokeSuspend(): Int {
 
     waitForFrame(frameRef)
     waitForLayout(state)
-    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+    delay(POST_LAYOUT_WARMUP_MS.milliseconds)
 
     printEnvironment("LinuxRobotSmoke", state)
 

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
 
 /**
  * Manual + CI smoke for [RobotDriver] on Linux. Run via `./gradlew
@@ -109,7 +110,9 @@ internal fun checkWaylandGate(): String? {
     return null
 }
 
-private fun runSmoke(): Int {
+private fun runSmoke(): Int = runBlocking { runSmokeSuspend() }
+
+private suspend fun runSmokeSuspend(): Int {
     val state = SmokeState()
     val frameRef = AtomicReference<JFrame>()
     SwingUtilities.invokeLater {

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
@@ -12,6 +12,7 @@ import javax.swing.JLabel
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
 
 /**
  * Manual smoke for [RobotDriver] driven at a deliberately-unfocused Compose window on Linux.
@@ -69,7 +70,9 @@ fun main() {
     }
 }
 
-private fun runSmoke(): Int {
+private fun runSmoke(): Int = runBlocking { runSmokeSuspend() }
+
+private suspend fun runSmokeSuspend(): Int {
     val state = SmokeState()
     val sutRef = AtomicReference<JFrame>()
     val distractorRef = AtomicReference<JFrame>()

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
@@ -12,6 +12,8 @@ import javax.swing.JLabel
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -118,7 +120,7 @@ private suspend fun runSmokeSuspend(): Int {
     waitForFrame(sutRef)
     waitForFrame(distractorRef)
     waitForLayout(state)
-    Thread.sleep(POST_LAYOUT_UNFOCUSED_WARMUP_MS)
+    delay(POST_LAYOUT_UNFOCUSED_WARMUP_MS.milliseconds)
 
     val driver = RobotDriver()
     val distractor = requireNotNull(distractorRef.get()) { "distractor frame missing" }

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotSmoke.kt
@@ -9,6 +9,9 @@ import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
 
 /**
  * Manual smoke for [RobotDriver] on macOS. Run via `./gradlew :sample-desktop:runMacOsRobotSmoke`.
@@ -88,7 +91,9 @@ fun main() {
     }
 }
 
-private fun runSmoke(): Int {
+private fun runSmoke(): Int = runBlocking { runSmokeSuspend() }
+
+private suspend fun runSmokeSuspend(): Int {
     val state = SmokeState()
     val frameRef = AtomicReference<JFrame>()
     SwingUtilities.invokeLater {
@@ -149,14 +154,14 @@ private fun runSmoke(): Int {
 // The probe click counts toward `clickCount`, so the rig's scenarios capture their own deltas
 // (this prime click is effectively the macOS analogue of the cold-JVM warmup click on Windows
 // + an effective TCC check).
-internal fun probeTccAccessibility(driver: RobotDriver, state: SmokeState): String? {
+internal suspend fun probeTccAccessibility(driver: RobotDriver, state: SmokeState): String? {
     val target = awtCenter(state, state.counterBounds)
     if (target == null) {
         return "TCC probe skipped: counter target rect not available; cannot infer permission state."
     }
     val before = state.clickCount
     driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     val after = state.clickCount
     if (after > before) return null
     val javaHome = System.getProperty("java.home")

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotSmoke.kt
@@ -122,7 +122,7 @@ private suspend fun runSmokeSuspend(): Int {
 
     waitForFrame(frameRef)
     waitForLayout(state)
-    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+    delay(POST_LAYOUT_WARMUP_MS.milliseconds)
 
     printEnvironment("MacOsRobotSmoke", state)
 

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
@@ -12,6 +12,8 @@ import javax.swing.JLabel
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -121,7 +123,7 @@ private suspend fun runSmokeSuspend(): Int {
         distractor.toFront()
         distractor.requestFocus()
     }
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
 
     val results = runUnfocusedScenarios(driver, state, distractor)
     val exitCode = printResults("MacOsRobotUnfocusedSmoke", results)

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
@@ -12,6 +12,7 @@ import javax.swing.JLabel
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
 
 /**
  * Manual smoke for [RobotDriver] driven at a deliberately-unfocused Compose window on macOS.
@@ -48,7 +49,9 @@ fun main() {
     }
 }
 
-private fun runSmoke(): Int {
+private fun runSmoke(): Int = runBlocking { runSmokeSuspend() }
+
+private suspend fun runSmokeSuspend(): Int {
     val state = SmokeState()
     val sutRef = AtomicReference<JFrame>()
     val distractorRef = AtomicReference<JFrame>()

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
@@ -40,6 +40,8 @@ import java.awt.Window
 import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import kotlin.math.abs
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 
 internal class SmokeState {
     var frame: JFrame? = null
@@ -223,13 +225,13 @@ internal fun awtCenter(state: SmokeState, rect: Rect): java.awt.Point? {
     )
 }
 
-internal fun warmupRobot(driver: RobotDriver, state: SmokeState) {
+internal suspend fun warmupRobot(driver: RobotDriver, state: SmokeState) {
     // Click on the counter button, fire-and-forget. counterBounds is non-zero by here
     // (waitForLayout already proved it). Each scenario captures its own `before` snapshot,
     // so we don't need to reset state — the warmup click just primes the input pipeline.
     val target = awtCenter(state, state.counterBounds) ?: return
     driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
 }
 
 internal fun focusOwnerSummary(state: SmokeState): String {
@@ -238,14 +240,14 @@ internal fun focusOwnerSummary(state: SmokeState): String {
         ?: "null (frame.isFocused=${state.frame?.isFocused})"
 }
 
-internal fun scenarioCounterClick(driver: RobotDriver, state: SmokeState): ScenarioResult {
+internal suspend fun scenarioCounterClick(driver: RobotDriver, state: SmokeState): ScenarioResult {
     val before = state.clickCount
     val target = awtCenter(state, state.counterBounds)
     if (target == null) {
         return ScenarioResult("mouseMove + click on counter", false, "no target rect available")
     }
     driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     val after = state.clickCount
     return ScenarioResult(
         "mouseMove + click on counter",
@@ -254,14 +256,17 @@ internal fun scenarioCounterClick(driver: RobotDriver, state: SmokeState): Scena
     )
 }
 
-internal fun scenarioCounterDoubleClick(driver: RobotDriver, state: SmokeState): ScenarioResult {
+internal suspend fun scenarioCounterDoubleClick(
+    driver: RobotDriver,
+    state: SmokeState,
+): ScenarioResult {
     val before = state.clickCount
     val target = awtCenter(state, state.counterBounds)
     if (target == null) {
         return ScenarioResult("doubleClick on counter", false, "no target rect available")
     }
     driver.doubleClick(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     val after = state.clickCount
     return ScenarioResult(
         "doubleClick on counter",
@@ -270,7 +275,10 @@ internal fun scenarioCounterDoubleClick(driver: RobotDriver, state: SmokeState):
     )
 }
 
-internal fun scenarioPressKeySingleChar(driver: RobotDriver, state: SmokeState): ScenarioResult {
+internal suspend fun scenarioPressKeySingleChar(
+    driver: RobotDriver,
+    state: SmokeState,
+): ScenarioResult {
     // Baseline for the typeText scenario: if the BasicTextField is focused after a click and
     // accepts direct keystrokes (no clipboard involved), the focus path works and any
     // typeText failure isolates to the clipboard-paste path.
@@ -279,10 +287,10 @@ internal fun scenarioPressKeySingleChar(driver: RobotDriver, state: SmokeState):
         return ScenarioResult("pressKey 'h' into BasicTextField", false, "no target rect available")
     }
     driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     val before = state.textValue.text
     driver.pressKey(java.awt.event.KeyEvent.VK_H)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
+    delay(POST_TYPE_SETTLE_MS.milliseconds)
     val after = state.textValue.text
     return ScenarioResult(
         "pressKey 'h' into BasicTextField",
@@ -291,7 +299,7 @@ internal fun scenarioPressKeySingleChar(driver: RobotDriver, state: SmokeState):
     )
 }
 
-internal fun scenarioTypeText(
+internal suspend fun scenarioTypeText(
     driver: RobotDriver,
     state: SmokeState,
     expected: String,
@@ -301,10 +309,10 @@ internal fun scenarioTypeText(
         return ScenarioResult("typeText into BasicTextField", false, "no target rect available")
     }
     driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     val focusOwnerBefore = focusOwnerSummary(state)
     driver.typeText(expected)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
+    delay(POST_TYPE_SETTLE_MS.milliseconds)
     val actual = state.textValue.text
     // Exact equality: the field starts empty (typeText runs first in the scenario order
     // before any keystroke leaves state behind), so the only correct outcome is the typed
@@ -314,16 +322,19 @@ internal fun scenarioTypeText(
     return ScenarioResult("typeText into BasicTextField", passed = passed, detail = detail)
 }
 
-internal fun scenarioClearAndTypeText(driver: RobotDriver, state: SmokeState): ScenarioResult {
+internal suspend fun scenarioClearAndTypeText(
+    driver: RobotDriver,
+    state: SmokeState,
+): ScenarioResult {
     val expected = "replaced"
     val target = awtCenter(state, state.textFieldBounds)
     if (target == null) {
         return ScenarioResult("clearAndTypeText", false, "no target rect available")
     }
     driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     driver.clearAndTypeText(expected)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
+    delay(POST_TYPE_SETTLE_MS.milliseconds)
     val actual = state.textValue.text
     return ScenarioResult(
         "clearAndTypeText",
@@ -332,14 +343,14 @@ internal fun scenarioClearAndTypeText(driver: RobotDriver, state: SmokeState): S
     )
 }
 
-internal fun scenarioShortcut(driver: RobotDriver, state: SmokeState): ScenarioResult {
+internal suspend fun scenarioShortcut(driver: RobotDriver, state: SmokeState): ScenarioResult {
     state.shortcutFiredCount = 0
     val before = state.shortcutFiredCount
     // Click somewhere inside the panel first to ensure focus is on the Compose root.
     val anchor = awtCenter(state, state.counterBounds)
     if (anchor != null) {
         driver.click(anchor.x, anchor.y)
-        Thread.sleep(POST_CLICK_SETTLE_MS)
+        delay(POST_CLICK_SETTLE_MS.milliseconds)
     }
     // Use the platform-aware modifier so the same scenario exercises Ctrl+S on Windows/Linux
     // and Cmd+S on macOS — `shortcutModifierKeyCode` is what RobotDriver itself uses for
@@ -349,7 +360,7 @@ internal fun scenarioShortcut(driver: RobotDriver, state: SmokeState): ScenarioR
         if (detectMacOs()) java.awt.event.InputEvent.META_DOWN_MASK
         else java.awt.event.InputEvent.CTRL_DOWN_MASK
     driver.pressKey(java.awt.event.KeyEvent.VK_S, modifierMask)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     val after = state.shortcutFiredCount
     val modifierLabel = if (detectMacOs()) "Cmd+S" else "Ctrl+S"
     return ScenarioResult(
@@ -361,7 +372,7 @@ internal fun scenarioShortcut(driver: RobotDriver, state: SmokeState): ScenarioR
     )
 }
 
-internal fun scenarioScreenshot(driver: RobotDriver, state: SmokeState): ScenarioResult {
+internal suspend fun scenarioScreenshot(driver: RobotDriver, state: SmokeState): ScenarioResult {
     val target = awtCenter(state, state.colorPatchBounds)
     if (target == null) {
         return ScenarioResult("screenshot of color patch", false, "no target rect available")
@@ -431,7 +442,7 @@ private fun colourWithinTolerance(a: Int, b: Int, perChannel: Int): Boolean {
     return abs(ar - br) <= perChannel && abs(ag - bg) <= perChannel && abs(ab - bb) <= perChannel
 }
 
-internal fun runFocusedScenarios(
+internal suspend fun runFocusedScenarios(
     driver: RobotDriver,
     state: SmokeState,
     typeTextExpected: String,
@@ -455,7 +466,10 @@ internal fun runFocusedScenarios(
     return results
 }
 
-internal fun scenarioStartsUnfocused(state: SmokeState, distractor: JFrame?): ScenarioResult {
+internal suspend fun scenarioStartsUnfocused(
+    state: SmokeState,
+    distractor: JFrame?,
+): ScenarioResult {
     val sut = state.frame
     val sutFocused = sut?.isFocused == true
     val distractorFocused = distractor?.isFocused == true
@@ -466,7 +480,7 @@ internal fun scenarioStartsUnfocused(state: SmokeState, distractor: JFrame?): Sc
     )
 }
 
-internal fun scenarioPressKeyOnUnfocusedField(
+internal suspend fun scenarioPressKeyOnUnfocusedField(
     driver: RobotDriver,
     state: SmokeState,
 ): ScenarioResult {
@@ -475,7 +489,7 @@ internal fun scenarioPressKeyOnUnfocusedField(
     // somewhere we don't expect (or Robot is targeting the distractor's contents instead).
     val before = state.textValue.text
     driver.pressKey(java.awt.event.KeyEvent.VK_X)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
+    delay(POST_TYPE_SETTLE_MS.milliseconds)
     val after = state.textValue.text
     return ScenarioResult(
         "pressKey on unfocused SUT does NOT alter the text field",
@@ -484,7 +498,7 @@ internal fun scenarioPressKeyOnUnfocusedField(
     )
 }
 
-internal fun scenarioClickOnUnfocusedCounter(
+internal suspend fun scenarioClickOnUnfocusedCounter(
     driver: RobotDriver,
     state: SmokeState,
 ): ScenarioResult {
@@ -495,7 +509,7 @@ internal fun scenarioClickOnUnfocusedCounter(
     val before = state.clickCount
     val sutFocusedBefore = state.frame?.isFocused == true
     driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     val after = state.clickCount
     val sutFocusedAfter = state.frame?.isFocused == true
     return ScenarioResult(
@@ -507,7 +521,7 @@ internal fun scenarioClickOnUnfocusedCounter(
     )
 }
 
-internal fun scenarioTypeTextAfterFocusClick(
+internal suspend fun scenarioTypeTextAfterFocusClick(
     driver: RobotDriver,
     state: SmokeState,
 ): ScenarioResult {
@@ -517,9 +531,9 @@ internal fun scenarioTypeTextAfterFocusClick(
         return ScenarioResult("typeText after focus-handoff click", false, "no target rect")
     }
     driver.click(target.x, target.y)
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     driver.clearAndTypeText(expected)
-    Thread.sleep(POST_TYPE_SETTLE_MS)
+    delay(POST_TYPE_SETTLE_MS.milliseconds)
     val actual = state.textValue.text
     return ScenarioResult(
         "typeText after focus-handoff click",
@@ -528,7 +542,7 @@ internal fun scenarioTypeTextAfterFocusClick(
     )
 }
 
-internal fun runUnfocusedScenarios(
+internal suspend fun runUnfocusedScenarios(
     driver: RobotDriver,
     state: SmokeState,
     distractor: JFrame,
@@ -540,7 +554,7 @@ internal fun runUnfocusedScenarios(
     // clicking SUT would transfer focus to it and ruin the unfocused starting state.
     val distractorBounds = distractor.bounds
     driver.click(distractorBounds.centerX.toInt(), distractorBounds.centerY.toInt())
-    Thread.sleep(POST_CLICK_SETTLE_MS)
+    delay(POST_CLICK_SETTLE_MS.milliseconds)
     results += scenarioPressKeyOnUnfocusedField(driver, state)
     results += scenarioClickOnUnfocusedCounter(driver, state)
     results += scenarioTypeTextAfterFocusClick(driver, state)

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotSmoke.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
 
 /**
  * Manual smoke for [RobotDriver] on Windows. Run via `./gradlew
@@ -72,7 +73,9 @@ fun main() {
     }
 }
 
-private fun runSmoke(): Int {
+private fun runSmoke(): Int = runBlocking { runSmokeSuspend() }
+
+private suspend fun runSmokeSuspend(): Int {
     val state = SmokeState()
     val frameRef = AtomicReference<JFrame>()
     SwingUtilities.invokeLater {

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotSmoke.kt
@@ -9,6 +9,8 @@ import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -117,7 +119,7 @@ private suspend fun runSmokeSuspend(): Int {
     // mouse-input handlers attach a few frames later — empirically the first Robot click can
     // arrive before they're wired and gets dropped. A short warmup after layout closes that
     // race without wasting time on cold-JVM boots that took longer to lay out anyway.
-    Thread.sleep(POST_LAYOUT_WARMUP_MS)
+    delay(POST_LAYOUT_WARMUP_MS.milliseconds)
 
     printEnvironment("WindowsRobotSmoke", state)
 

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
@@ -12,6 +12,7 @@ import javax.swing.JLabel
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
 
 /**
  * Manual smoke for #59: drive [RobotDriver] against a Compose window that is **deliberately not the
@@ -66,7 +67,9 @@ fun main() {
     }
 }
 
-private fun runSmoke(): Int {
+private fun runSmoke(): Int = runBlocking { runSmokeSuspend() }
+
+private suspend fun runSmokeSuspend(): Int {
     val state = SmokeState()
     val sutRef = AtomicReference<JFrame>()
     val distractorRef = AtomicReference<JFrame>()

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
@@ -12,6 +12,8 @@ import javax.swing.JLabel
 import javax.swing.SwingConstants
 import javax.swing.SwingUtilities
 import kotlin.system.exitProcess
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 
 /**
@@ -118,7 +120,7 @@ private suspend fun runSmokeSuspend(): Int {
     waitForFrame(sutRef)
     waitForFrame(distractorRef)
     waitForLayout(state)
-    Thread.sleep(POST_LAYOUT_UNFOCUSED_WARMUP_MS)
+    delay(POST_LAYOUT_UNFOCUSED_WARMUP_MS.milliseconds)
 
     val driver = RobotDriver()
     val distractor = requireNotNull(distractorRef.get()) { "distractor frame missing" }

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/AutomatorAssertions.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/AutomatorAssertions.kt
@@ -6,6 +6,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.delay
 
 /**
  * Polls [block] until it returns a non-null value or [timeout] elapses, refreshing the automator's
@@ -15,11 +16,11 @@ import kotlin.time.TimeSource
  * Tests use this anywhere the UI mutates asynchronously — popups opening, secondary windows
  * appearing, scenario navigation completing.
  */
-fun <T : Any> ComposeAutomator.eventually(
+suspend fun <T : Any> ComposeAutomator.eventually(
     description: String,
     timeout: Duration = 5.seconds,
     pollInterval: Duration = 50.milliseconds,
-    block: ComposeAutomator.() -> T?,
+    block: suspend ComposeAutomator.() -> T?,
 ): T {
     val deadline = TimeSource.Monotonic.markNow() + timeout
     var lastError: Throwable? = null
@@ -32,19 +33,22 @@ fun <T : Any> ComposeAutomator.eventually(
         } catch (t: Throwable) {
             lastError = t
         }
-        Thread.sleep(pollInterval.inWholeMilliseconds)
+        delay(pollInterval)
     }
     throw AssertionError("Timeout after $timeout waiting for: $description", lastError)
 }
 
 /** Wait for a node with the given testTag to appear and return it. */
-fun ComposeAutomator.waitForTestTag(tag: String, timeout: Duration = 5.seconds): AutomatorNode =
+suspend fun ComposeAutomator.waitForTestTag(
+    tag: String,
+    timeout: Duration = 5.seconds,
+): AutomatorNode =
     eventually(description = "node with testTag '$tag'", timeout = timeout) {
         findOneByTestTag(tag)
     }
 
 /** Wait until no node with the given testTag is present. */
-fun ComposeAutomator.waitUntilGone(tag: String, timeout: Duration = 5.seconds) {
+suspend fun ComposeAutomator.waitUntilGone(tag: String, timeout: Duration = 5.seconds) {
     eventually(description = "no node with testTag '$tag'", timeout = timeout) {
         if (findOneByTestTag(tag) == null) Unit else null
     }
@@ -61,7 +65,7 @@ fun ComposeAutomator.waitUntilGone(tag: String, timeout: Duration = 5.seconds) {
  * doesn't change), the click is still observable through the picker entry's selected-state "▸ "
  * prefix — so we accept either a title-change OR a picker entry that's now marked selected.
  */
-fun ComposeAutomator.navigateToScenario(scenarioTag: String) {
+suspend fun ComposeAutomator.navigateToScenario(scenarioTag: String) {
     val pickerEntryBefore = waitForTestTag(scenarioTag)
     val previousTitle = findOneByTestTag("scenario.title")?.text
     val pickerWasSelected = pickerEntryBefore.text?.startsWith("▸") == true

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue14PerfValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue14PerfValidationTest.kt
@@ -5,6 +5,7 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.BeforeAll
@@ -39,7 +40,7 @@ class Issue14PerfValidationTest {
 
     @Test
     @Order(1)
-    fun `tree traversal over a 200-item LazyColumn stays under the budget`() {
+    fun `tree traversal over a 200-item LazyColumn stays under the budget`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.scroll")
             waitForTestTag("scroll.list")
@@ -73,7 +74,7 @@ class Issue14PerfValidationTest {
 
     @Test
     @Order(2)
-    fun `popup discoverability latency stays under the budget`() {
+    fun `popup discoverability latency stays under the budget`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.popup")
             val toggle = waitForTestTag("popup.toggleButton")
@@ -107,7 +108,7 @@ class Issue14PerfValidationTest {
 
     @Test
     @Order(3)
-    fun `screenshot warmup completes within a reasonable budget`() {
+    fun `screenshot warmup completes within a reasonable budget`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.counter")
             val button = waitForTestTag("incrementButton")

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue7CompletionValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue7CompletionValidationTest.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.sample.validation
 import java.awt.GraphicsEnvironment
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.BeforeAll
@@ -36,7 +37,7 @@ class Issue7CompletionValidationTest {
 
     @Test
     @Order(1)
-    fun `dual-panel scenario surfaces both Compose roots`() {
+    fun `dual-panel scenario surfaces both Compose roots`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.dualpanel")
             // Both nodes live in the same Window but the SwingPanel host installs an extra
@@ -53,7 +54,7 @@ class Issue7CompletionValidationTest {
 
     @Test
     @Order(2)
-    fun `JDialog hosting ComposePanel exposes its tree to the automator`() {
+    fun `JDialog hosting ComposePanel exposes its tree to the automator`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.jdialog")
             val initialWindows = windows.size

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue8CompletionValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue8CompletionValidationTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.BeforeAll
@@ -34,7 +35,7 @@ class Issue8CompletionValidationTest {
 
     @Test
     @Order(1)
-    fun `automator reads coherent snapshots while the tree mutates at 60 Hz`() {
+    fun `automator reads coherent snapshots while the tree mutates at 60 Hz`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.recomposition")
             click(waitForTestTag("recomp.toggleButton"))
@@ -71,25 +72,27 @@ class Issue8CompletionValidationTest {
 
     @Test
     @Order(2)
-    fun `eventually settles on event-driven targets while a background animation never settles`() {
-        with(fixture.automator) {
-            navigateToScenario("scenario.animation")
-            // The spinner is rotating forever — confirm it's there but don't wait for it to stop.
-            assertNotNull(waitForTestTag("anim.spinner"))
-            // anim.settled does not exist yet. The wait helper must not block forever just
-            // because the animation is running; eventually() should return as soon as the
-            // event-driven node appears.
-            click(waitForTestTag("anim.toggleButton"))
-            val settled =
-                eventually(description = "anim.settled appears", timeout = 5.seconds) {
-                    findOneByTestTag("anim.settled")
-                }
-            assertNotNull(
-                settled.text,
-                "Settled marker should expose its text once the click lands",
-            )
+    fun `eventually settles on event-driven targets while a background animation never settles`() =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.animation")
+                // The spinner is rotating forever — confirm it's there but don't wait for it to
+                // stop.
+                assertNotNull(waitForTestTag("anim.spinner"))
+                // anim.settled does not exist yet. The wait helper must not block forever just
+                // because the animation is running; eventually() should return as soon as the
+                // event-driven node appears.
+                click(waitForTestTag("anim.toggleButton"))
+                val settled =
+                    eventually(description = "anim.settled appears", timeout = 5.seconds) {
+                        findOneByTestTag("anim.settled")
+                    }
+                assertNotNull(
+                    settled.text,
+                    "Settled marker should expose its text once the click lands",
+                )
+            }
         }
-    }
 
     private companion object {
         val STRESS_DURATION = 3.seconds

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue8FidelityValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue8FidelityValidationTest.kt
@@ -8,6 +8,7 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.BeforeAll
@@ -45,7 +46,7 @@ class Issue8FidelityValidationTest {
 
     @Test
     @Order(1)
-    fun `HiDPI target bounds reflect real on-screen geometry`() {
+    fun `HiDPI target bounds reflect real on-screen geometry`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.hidpi")
             val target1 = waitForTestTag("hidpi.target.40x0")
@@ -89,7 +90,7 @@ class Issue8FidelityValidationTest {
 
     @Test
     @Order(2)
-    fun `focus jump button transfers isFocused to the second field`() {
+    fun `focus jump button transfers isFocused to the second field`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.focus")
             val firstField = waitForTestTag("focus.field.first")
@@ -117,7 +118,7 @@ class Issue8FidelityValidationTest {
 
     @Test
     @Order(3)
-    fun `typeText writes characters into the focused text field`() {
+    fun `typeText writes characters into the focused text field`() = runBlocking {
         // The default validation Gradle tasks boot the worker JVM as a macOS UI element so the
         // spawned window doesn't pop to the front while tests run, but UI-element processes get
         // restricted NSPasteboard access — Cmd+V never sees the value `typeText` writes. Skip
@@ -165,30 +166,34 @@ class Issue8FidelityValidationTest {
 
     @Test
     @Order(4)
-    fun `scrolling shifts boundsOnScreen so click coordinates follow the visible item`() {
-        with(fixture.automator) {
-            navigateToScenario("scenario.scroll")
-            val item0Initial = waitForTestTag("scroll.item.0")
-            val initialY = item0Initial.boundsOnScreen.y
-            val list = waitForTestTag("scroll.list")
+    fun `scrolling shifts boundsOnScreen so click coordinates follow the visible item`() =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.scroll")
+                val item0Initial = waitForTestTag("scroll.item.0")
+                val initialY = item0Initial.boundsOnScreen.y
+                val list = waitForTestTag("scroll.list")
 
-            // Compose Desktop scrollables respond to wheel input, not drag — issue several wheel
-            // ticks to push the LazyColumn down past item.0's row height.
-            repeat(WHEEL_TICKS_TO_SCROLL) { scrollWheel(list, wheelClicks = 1) }
+                // Compose Desktop scrollables respond to wheel input, not drag — issue several
+                // wheel
+                // ticks to push the LazyColumn down past item.0's row height.
+                repeat(WHEEL_TICKS_TO_SCROLL) { scrollWheel(list, wheelClicks = 1) }
 
-            // After scrolling, item.0 either moves up (its boundsOnScreen.y decreases) or leaves
-            // the viewport entirely (LazyColumn unrenders it). Both prove the live-bounds contract:
-            // the snapshot is fresh, not cached at first observation.
-            eventually(description = "item.0 shifted up or left the viewport") {
-                val current = findOneByTestTag("scroll.item.0")
-                when {
-                    current == null -> Unit // item unrendered — also valid
-                    current.boundsOnScreen.y < initialY -> Unit
-                    else -> null
+                // After scrolling, item.0 either moves up (its boundsOnScreen.y decreases) or
+                // leaves
+                // the viewport entirely (LazyColumn unrenders it). Both prove the live-bounds
+                // contract:
+                // the snapshot is fresh, not cached at first observation.
+                eventually(description = "item.0 shifted up or left the viewport") {
+                    val current = findOneByTestTag("scroll.item.0")
+                    when {
+                        current == null -> Unit // item unrendered — also valid
+                        current.boundsOnScreen.y < initialY -> Unit
+                        else -> null
+                    }
                 }
             }
         }
-    }
 
     private companion object {
         const val WHEEL_TICKS_TO_SCROLL: Int = 10

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/MultiWindowAndPopupValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/MultiWindowAndPopupValidationTest.kt
@@ -4,6 +4,7 @@ import java.awt.GraphicsEnvironment
 import kotlin.test.Test
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.BeforeAll
@@ -38,7 +39,7 @@ class MultiWindowAndPopupValidationTest {
 
     @Test
     @Order(1)
-    fun `popup body is discoverable when popup is open`() {
+    fun `popup body is discoverable when popup is open`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.popup")
             val toggleButton = waitForTestTag("popup.toggleButton")
@@ -56,7 +57,7 @@ class MultiWindowAndPopupValidationTest {
 
     @Test
     @Order(2)
-    fun `popup nodes disappear after dismiss`() {
+    fun `popup nodes disappear after dismiss`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.popup")
             click(waitForTestTag("popup.toggleButton"))
@@ -68,7 +69,7 @@ class MultiWindowAndPopupValidationTest {
 
     @Test
     @Order(3)
-    fun `secondary Window appears in tracked windows when opened`() {
+    fun `secondary Window appears in tracked windows when opened`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.multiwindow")
             // Capture the main window's surfaceIds BEFORE opening the secondary — the order

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/PopupLayerVariantsValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/PopupLayerVariantsValidationTest.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.sample.validation
 import java.awt.GraphicsEnvironment
 import kotlin.test.Test
 import kotlin.test.assertNotNull
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.BeforeAll
@@ -60,7 +61,7 @@ class PopupLayerVariantsValidationTest {
     @AfterAll fun stop() = fixture.stop()
 
     @Test
-    fun `popup body resolves under the active layer type`() {
+    fun `popup body resolves under the active layer type`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.popup")
             click(waitForTestTag("popup.toggleButton"))


### PR DESCRIPTION
Closes #93.

## Summary

- `RobotDriver` and `ComposeAutomator` interaction methods are now `suspend`. `screenshot` stays sync.
- `Thread.sleep` in interaction code replaced with `delay`, so cancelling a coroutine mid-`longClick` / mid-`swipe` actually cancels.
- `runOffEdt` reroutes its EDT-marshal from a worker-thread + `Thread.join()` to `withContext(Dispatchers.IO)`. The `requiresOffEdt` short-circuit is preserved so synthetic / headless adapters still run inline (the SyntheticInput EDT-deadlock regression test stays meaningful).

## Migrations

- **`:server`** route handlers (already suspend) flow straight through.
- **`:sample-desktop`** Robot smoke rig: scenario functions and `runFocusedScenarios` / `runUnfocusedScenarios` are `suspend`; each platform smoke's `runSmoke()` wraps the suspend body in `runBlocking`.
- **`:sample-intellij-plugin`** `RunSpectreAction` only uses semantics queries — no API change needed.

## Tests

- `RobotDriverTest` cases that exercise interaction methods wrap in `runTest`.
- `SyntheticInputTest` pins the EDT-deadlock regression with `runBlocking { driver.click(...) }` inside `invokeAndWait`.

## Docs

- `interactions.md` — callout that interaction methods are `suspend` and use `Dispatchers.IO` + `delay` internally.
- `getting-started.md` — clarified the `withContext(Dispatchers.Default)` wrap is for wait-helper EDT rejection only.

## Test plan

- [x] `./gradlew check` green locally
- [x] CI green on Linux, Windows, macOS
- [x] mkdocs strict build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)