### PR TITLE
build(recording): cross-arch bundle the Wayland helper for x86_64 + aarch64 (#86)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,16 +43,42 @@ jobs:
       - name: Enable arm64 dpkg multi-arch + install aarch64 cross-toolchain (issue #86)
         # `:recording:assembleWaylandHelperAllArches` cross-compiles the Wayland helper for
         # aarch64 from this x86_64 runner. Two prereqs:
-        #   - `gcc-aarch64-linux-gnu` provides the cross-linker the cargo target invokes
-        #     via CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER.
+        #   - `gcc-aarch64-linux-gnu` provides the cross-linker that cargo invokes via
+        #     CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER.
         #   - `libdbus-1-dev:arm64` provides the aarch64-arch sysroot libdbus + .pc files
-        #     pkg-config picks via PKG_CONFIG_PATH_aarch64. dpkg multi-arch must be enabled
-        #     before apt knows where to look for the foreign-arch package.
-        # Ubuntu 24.04 runners' default sources.list already includes ports.ubuntu.com
-        # mirrors for non-amd64 arches, so the `:arm64` install resolves without an extra
-        # sources.list edit. (Older Ubuntu releases would have needed a manual entry.)
+        #     pkg-config picks via PKG_CONFIG_PATH_aarch64_unknown_linux_gnu. dpkg
+        #     multi-arch must be enabled before apt resolves foreign-arch packages.
+        # Ubuntu 24.04 runners' default sources point at azure.archive.ubuntu.com which
+        # only ships amd64 binaries — so adding `arm64` to dpkg without redirecting arm64
+        # apt lookups to ports.ubuntu.com makes `apt-get update` 404 on every arm64 list.
+        # We restrict the default sources to amd64 (deb822 + legacy formats both, since
+        # the layout has shifted across Ubuntu releases) and add a ports.ubuntu.com source
+        # for arm64.
         run: |
+          set -euo pipefail
           sudo dpkg --add-architecture arm64
+          if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+            # deb822 format (ubuntu 24.04+): inject `Architectures: amd64` into each
+            # stanza that doesn't already declare one.
+            sudo sed -i '/^Architectures:/!{ /^Signed-By:/i\
+          Architectures: amd64
+          }' /etc/apt/sources.list.d/ubuntu.sources
+          fi
+          if [ -f /etc/apt/sources.list ]; then
+            # Legacy one-line format (older runners or .list.d additions): add the
+            # [arch=amd64] qualifier in front of every existing `deb ` line that doesn't
+            # already specify an arch.
+            sudo sed -i 's|^deb \([^[]\)|deb [arch=amd64] \1|' /etc/apt/sources.list
+          fi
+          codename=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          sudo tee /etc/apt/sources.list.d/ubuntu-arm64.sources >/dev/null <<EOF
+          Types: deb
+          URIs: http://ports.ubuntu.com/ubuntu-ports/
+          Suites: $codename $codename-updates $codename-backports $codename-security
+          Components: main universe restricted multiverse
+          Architectures: arm64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu libdbus-1-dev:arm64
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,12 +40,55 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev pkg-config
 
+      - name: Enable arm64 dpkg multi-arch + install aarch64 cross-toolchain (issue #86)
+        # `:recording:assembleWaylandHelperAllArches` cross-compiles the Wayland helper for
+        # aarch64 from this x86_64 runner. Two prereqs:
+        #   - `gcc-aarch64-linux-gnu` provides the cross-linker the cargo target invokes
+        #     via CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER.
+        #   - `libdbus-1-dev:arm64` provides the aarch64-arch sysroot libdbus + .pc files
+        #     pkg-config picks via PKG_CONFIG_PATH_aarch64. dpkg multi-arch must be enabled
+        #     before apt knows where to look for the foreign-arch package.
+        # Ubuntu 24.04 runners' default sources.list already includes ports.ubuntu.com
+        # mirrors for non-amd64 arches, so the `:arm64` install resolves without an extra
+        # sources.list edit. (Older Ubuntu releases would have needed a manual entry.)
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu libdbus-1-dev:arm64
+
       - name: Set up Rust (stable, MSRV-pinned to spectre-wayland-helper's rust-version)
         # `:recording:assembleWaylandHelper` runs `cargo build --release` from
         # recording/native/linux/. The crate's `rust-version = "1.75"` pin matches what
         # Ubuntu 22.04's jammy-backports apt provides on the dev VM; the action installs
-        # latest stable (≥ 1.75) on the runner.
+        # latest stable (≥ 1.75) on the runner. The aarch64 cross target is added below;
+        # the host-arch `x86_64-unknown-linux-gnu` is part of the default rustup install.
         uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-unknown-linux-gnu
 
       - name: Run checks
         run: ./gradlew check
+
+      - name: Verify cross-arch helper bundling (issue #86)
+        # Proves on every PR that `:recording:assembleWaylandHelperAllArches` can produce
+        # both x86_64 and aarch64 binaries from this x86_64 runner. Doesn't run as part of
+        # the default `check` graph (which uses the host-arch `assembleWaylandHelper`) so
+        # contributor builds without the cross toolchain still pass `check` cleanly. When
+        # #84's publish pipeline lands, the release job will pass `-PallLinuxArches` so
+        # `processResources` bundles both arches into the published jar.
+        run: |
+          ./gradlew :recording:assembleWaylandHelperAllArches
+          for arch in x86_64 aarch64; do
+            bin="recording/build/generated/waylandHelper/native/linux/$arch/spectre-wayland-helper"
+            if [ ! -f "$bin" ]; then
+              echo "::error::Missing per-arch helper binary: $bin"
+              exit 1
+            fi
+            machine=$(readelf -h "$bin" | awk -F: '/Machine:/{print $2}' | xargs)
+            case "$arch:$machine" in
+              "x86_64:Advanced Micro Devices X86-64") ;;
+              "aarch64:AArch64") ;;
+              *) echo "::error::$bin reports ELF machine '$machine' (expected $arch)"; exit 1 ;;
+            esac
+            echo "$bin → $machine ✓"
+          done

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -338,60 +338,58 @@ data class LinuxHelperTarget(
     val pkgConfigLibPath: String,
 )
 
-val linuxHelperTargets =
-    linuxHelperArchitectures.map { arch ->
-        when (arch) {
-            "x86_64" ->
-                LinuxHelperTarget(
-                    arch = "x86_64",
-                    triple = "x86_64-unknown-linux-gnu",
-                    crossLinker = "x86_64-linux-gnu-gcc",
-                    pkgConfigLibPath = "/usr/lib/x86_64-linux-gnu/pkgconfig",
-                )
-            "aarch64" ->
-                LinuxHelperTarget(
-                    arch = "aarch64",
-                    triple = "aarch64-unknown-linux-gnu",
-                    crossLinker = "aarch64-linux-gnu-gcc",
-                    pkgConfigLibPath = "/usr/lib/aarch64-linux-gnu/pkgconfig",
-                )
-            else -> error("Unsupported linux helper arch: $arch")
-        }
-    }
-
-val perArchCargoBuildTasks =
-    linuxHelperTargets.map { target ->
-        val taskName = "buildWaylandHelper${target.arch.replaceFirstChar { it.uppercase() }}"
-        val perArchOutput =
-            waylandHelperSource
-                .dir("target/${target.triple}/release")
-                .file("spectre-wayland-helper")
-        tasks.register<Exec>(taskName) {
-            description = "Cross-builds the Wayland helper for ${target.arch}."
-            group = "build"
-            onlyIf { OperatingSystem.current().isLinux }
-            workingDir = waylandHelperSource.asFile
-            commandLine("cargo", "build", "--release", "--target", target.triple)
-            // Cargo accepts the per-target linker as
-            // `CARGO_TARGET_<TRIPLE_UPPER_UNDERSCORED>_LINKER` without needing a
-            // .cargo/config.toml. The `_LINKER` form is undocumented for direct env-var
-            // use but stable since cargo 1.0 — see rust-lang/cargo issues #4135 and #6133.
-            environment(
-                "CARGO_TARGET_${target.triple.uppercase().replace("-", "_")}_LINKER",
-                target.crossLinker,
+val linuxHelperTargets = linuxHelperArchitectures.map { arch ->
+    when (arch) {
+        "x86_64" ->
+            LinuxHelperTarget(
+                arch = "x86_64",
+                triple = "x86_64-unknown-linux-gnu",
+                crossLinker = "x86_64-linux-gnu-gcc",
+                pkgConfigLibPath = "/usr/lib/x86_64-linux-gnu/pkgconfig",
             )
-            // pkg-config arch-suffix lookup: PKG_CONFIG_PATH_<arch> overrides
-            // PKG_CONFIG_PATH for the matching target arch (the suffix is the Rust target
-            // arch, which matches our `target.arch`). PKG_CONFIG_ALLOW_CROSS=1 disables
-            // pkg-config's safety guard against cross-arch link config — required by
-            // dbus-rs's build.rs.
-            environment("PKG_CONFIG_PATH_${target.arch}", target.pkgConfigLibPath)
-            environment("PKG_CONFIG_ALLOW_CROSS", "1")
-            inputs.dir(waylandHelperSource.dir("src"))
-            inputs.file(waylandHelperSource.file("Cargo.toml"))
-            outputs.file(perArchOutput)
-        }
+        "aarch64" ->
+            LinuxHelperTarget(
+                arch = "aarch64",
+                triple = "aarch64-unknown-linux-gnu",
+                crossLinker = "aarch64-linux-gnu-gcc",
+                pkgConfigLibPath = "/usr/lib/aarch64-linux-gnu/pkgconfig",
+            )
+        else -> error("Unsupported linux helper arch: $arch")
     }
+}
+
+val perArchCargoBuildTasks = linuxHelperTargets.map { target ->
+    val taskName = "buildWaylandHelper${target.arch.replaceFirstChar { it.uppercase() }}"
+    val perArchOutput =
+        waylandHelperSource.dir("target/${target.triple}/release").file("spectre-wayland-helper")
+    tasks.register<Exec>(taskName) {
+        description = "Cross-builds the Wayland helper for ${target.arch}."
+        group = "build"
+        onlyIf { OperatingSystem.current().isLinux }
+        workingDir = waylandHelperSource.asFile
+        commandLine("cargo", "build", "--release", "--target", target.triple)
+        // Cargo accepts the per-target linker as
+        // `CARGO_TARGET_<TRIPLE_UPPER_UNDERSCORED>_LINKER` without needing a
+        // .cargo/config.toml. The `_LINKER` form is undocumented for direct env-var
+        // use but stable since cargo 1.0 — see rust-lang/cargo issues #4135 and #6133.
+        environment(
+            "CARGO_TARGET_${target.triple.uppercase().replace("-", "_")}_LINKER",
+            target.crossLinker,
+        )
+        // pkg-config crate's per-target lookup uses the full Rust target triple as the
+        // suffix, with hyphens converted to underscores (e.g.
+        // PKG_CONFIG_PATH_aarch64_unknown_linux_gnu) — see pkg-config-rs's
+        // `targeted_env_var`. The arch-only suffix doesn't match any lookup pattern, so
+        // it would silently fall through to plain PKG_CONFIG_PATH and pull host-arch
+        // .pc files. PKG_CONFIG_ALLOW_CROSS=1 disables pkg-config's safety guard
+        // against cross-arch link config — required by dbus-rs's build.rs.
+        environment("PKG_CONFIG_PATH_${target.triple.replace("-", "_")}", target.pkgConfigLibPath)
+        environment("PKG_CONFIG_ALLOW_CROSS", "1")
+        inputs.dir(waylandHelperSource.dir("src"))
+        inputs.file(waylandHelperSource.file("Cargo.toml"))
+        outputs.file(perArchOutput)
+    }
+}
 
 // Per-arch staging copies — one Copy task per arch so the destination layout matches the
 // resource path `WaylandHelperBinaryExtractor` probes.
@@ -412,16 +410,15 @@ val perArchStageTasks =
         }
     }
 
-val assembleWaylandHelperAllArches by
-    tasks.registering {
-        description =
-            "Stages the Wayland helper binary for both x86_64 and aarch64 Linux. Opt-in for " +
-                "distribution builds (slower than host-arch). Wire into processResources by " +
-                "passing -PallLinuxArches at invocation time."
-        group = "build"
-        onlyIf { OperatingSystem.current().isLinux }
-        dependsOn(perArchStageTasks)
-    }
+val assembleWaylandHelperAllArches by tasks.registering {
+    description =
+        "Stages the Wayland helper binary for both x86_64 and aarch64 Linux. Opt-in for " +
+            "distribution builds (slower than host-arch). Wire into processResources by " +
+            "passing -PallLinuxArches at invocation time."
+    group = "build"
+    onlyIf { OperatingSystem.current().isLinux }
+    dependsOn(perArchStageTasks)
+}
 
 // Same pattern as the SCK helper: register the generated resource srcDir unconditionally so
 // jar layouts are host-agnostic, but only attach the build task to processResources on

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -267,9 +267,10 @@ if (OperatingSystem.current().isMacOsX) {
 //   3. `processResources` depends on the assemble task on Linux, so the JAR carries the
 //      helper transparently and `WaylandHelperBinaryExtractor` finds it via the classloader.
 //
-// Cross-compilation (arm64 / x86_64) is currently NOT wired up — the host-arch build is
-// what ships in the dev-loop jar. Distribution builds will need a per-arch matrix similar
-// to the macOS lipo path; tracked as a follow-up. For dev iteration without re-bundling,
+// Default `assembleWaylandHelper` builds the host-arch helper only — keeps contributor
+// builds fast and free of cross-compile toolchain prereqs. The opt-in
+// `assembleWaylandHelperAllArches` block below builds both x86_64 and aarch64 from any
+// Linux host for distribution. For dev iteration without re-bundling at all,
 // `WaylandHelperBinaryExtractor`'s `SPECTRE_WAYLAND_HELPER` env var override points the
 // recorder at `target/release/spectre-wayland-helper` directly.
 val waylandHelperSource = layout.projectDirectory.dir("native/linux")
@@ -299,14 +300,145 @@ val assembleWaylandHelper by
         into(waylandHelperResourceDest)
     }
 
+// --- Cross-arch bundling (release distribution) ---------------------------------------------
+//
+// Opt-in path producing helpers for both x86_64 and aarch64 Linux from any Linux host —
+// mirrors the macOS `assembleScreenCaptureKitHelperUniversal` shape (per-arch builds +
+// per-arch staging) but without a lipo step (Linux ELF has no fat-binary equivalent; we
+// keep the per-arch resource directories and let `WaylandHelperBinaryExtractor` pick at
+// runtime).
+//
+// Cross-compile mechanism: stock rustup target + system cross-linker + apt multi-arch
+// libdbus-1 sysroot. Picked over `cross` (would add a Docker-daemon prereq + a privileged
+// container to CI) and `cargo-zigbuild` (would need a hand-built libdbus sysroot since
+// `dbus-rs` links via pkg-config). The bare-metal recipe is:
+//   1. `rustup target add <triple>` for the non-host arch.
+//   2. apt: `gcc-<arch>-linux-gnu` (cross linker) + `libdbus-1-dev:<dpkg-arch>`. dpkg
+//      multi-arch must be enabled (`dpkg --add-architecture <arch> && apt update`) before
+//      installing foreign-arch packages — the CI step in `.github/workflows/ci.yml` does
+//      this.
+//   3. cargo invocation: `cargo build --release --target=<triple>` with env
+//      `CARGO_TARGET_<TRIPLE_UPPER>_LINKER=<arch>-linux-gnu-gcc` and
+//      `PKG_CONFIG_PATH_<arch>=/usr/lib/<arch>-linux-gnu/pkgconfig` +
+//      `PKG_CONFIG_ALLOW_CROSS=1` so `dbus-rs`'s build script picks the foreign-arch `.pc`
+//      files instead of the host's.
+//
+// Use `:recording:assembleWaylandHelperAllArches` to invoke the cross-arch staging
+// explicitly. Distribution invocation: `./gradlew :recording:jar -PallLinuxArches`. CI
+// release jobs (when #84 lands the publish pipeline) wire this in as the
+// `processResources` dependency to bundle both arches.
+val linuxHelperArchitectures = listOf("x86_64", "aarch64")
+
+// Architecture metadata kept together so the per-arch task wiring below stays one
+// straight loop rather than three when/lookups.
+data class LinuxHelperTarget(
+    val arch: String,
+    val triple: String,
+    val crossLinker: String,
+    val pkgConfigLibPath: String,
+)
+
+val linuxHelperTargets =
+    linuxHelperArchitectures.map { arch ->
+        when (arch) {
+            "x86_64" ->
+                LinuxHelperTarget(
+                    arch = "x86_64",
+                    triple = "x86_64-unknown-linux-gnu",
+                    crossLinker = "x86_64-linux-gnu-gcc",
+                    pkgConfigLibPath = "/usr/lib/x86_64-linux-gnu/pkgconfig",
+                )
+            "aarch64" ->
+                LinuxHelperTarget(
+                    arch = "aarch64",
+                    triple = "aarch64-unknown-linux-gnu",
+                    crossLinker = "aarch64-linux-gnu-gcc",
+                    pkgConfigLibPath = "/usr/lib/aarch64-linux-gnu/pkgconfig",
+                )
+            else -> error("Unsupported linux helper arch: $arch")
+        }
+    }
+
+val perArchCargoBuildTasks =
+    linuxHelperTargets.map { target ->
+        val taskName = "buildWaylandHelper${target.arch.replaceFirstChar { it.uppercase() }}"
+        val perArchOutput =
+            waylandHelperSource
+                .dir("target/${target.triple}/release")
+                .file("spectre-wayland-helper")
+        tasks.register<Exec>(taskName) {
+            description = "Cross-builds the Wayland helper for ${target.arch}."
+            group = "build"
+            onlyIf { OperatingSystem.current().isLinux }
+            workingDir = waylandHelperSource.asFile
+            commandLine("cargo", "build", "--release", "--target", target.triple)
+            // Cargo accepts the per-target linker as
+            // `CARGO_TARGET_<TRIPLE_UPPER_UNDERSCORED>_LINKER` without needing a
+            // .cargo/config.toml. The `_LINKER` form is undocumented for direct env-var
+            // use but stable since cargo 1.0 — see rust-lang/cargo issues #4135 and #6133.
+            environment(
+                "CARGO_TARGET_${target.triple.uppercase().replace("-", "_")}_LINKER",
+                target.crossLinker,
+            )
+            // pkg-config arch-suffix lookup: PKG_CONFIG_PATH_<arch> overrides
+            // PKG_CONFIG_PATH for the matching target arch (the suffix is the Rust target
+            // arch, which matches our `target.arch`). PKG_CONFIG_ALLOW_CROSS=1 disables
+            // pkg-config's safety guard against cross-arch link config — required by
+            // dbus-rs's build.rs.
+            environment("PKG_CONFIG_PATH_${target.arch}", target.pkgConfigLibPath)
+            environment("PKG_CONFIG_ALLOW_CROSS", "1")
+            inputs.dir(waylandHelperSource.dir("src"))
+            inputs.file(waylandHelperSource.file("Cargo.toml"))
+            outputs.file(perArchOutput)
+        }
+    }
+
+// Per-arch staging copies — one Copy task per arch so the destination layout matches the
+// resource path `WaylandHelperBinaryExtractor` probes.
+val perArchStageTasks =
+    linuxHelperTargets.zip(perArchCargoBuildTasks).map { (target, buildTask) ->
+        val taskName = "stageWaylandHelper${target.arch.replaceFirstChar { it.uppercase() }}"
+        val perArchOutput =
+            waylandHelperSource
+                .dir("target/${target.triple}/release")
+                .file("spectre-wayland-helper")
+        tasks.register<Copy>(taskName) {
+            description = "Stages the ${target.arch} Wayland helper into the resources tree."
+            group = "build"
+            onlyIf { OperatingSystem.current().isLinux }
+            dependsOn(buildTask)
+            from(perArchOutput) { rename { "spectre-wayland-helper" } }
+            into(layout.buildDirectory.dir("generated/waylandHelper/native/linux/${target.arch}"))
+        }
+    }
+
+val assembleWaylandHelperAllArches by
+    tasks.registering {
+        description =
+            "Stages the Wayland helper binary for both x86_64 and aarch64 Linux. Opt-in for " +
+                "distribution builds (slower than host-arch). Wire into processResources by " +
+                "passing -PallLinuxArches at invocation time."
+        group = "build"
+        onlyIf { OperatingSystem.current().isLinux }
+        dependsOn(perArchStageTasks)
+    }
+
 // Same pattern as the SCK helper: register the generated resource srcDir unconditionally so
 // jar layouts are host-agnostic, but only attach the build task to processResources on
 // Linux. macOS/Windows builds will have an empty `native/linux/` directory in the jar — fine,
 // the recorder gates on the resource being present and falls back per HelperNotBundledException.
 sourceSets["main"].resources.srcDir(layout.buildDirectory.dir("generated/waylandHelper"))
 
+// Switch `processResources` to either the host-arch staging (default, fast) or the
+// cross-arch staging (release). Single-staging-task wiring follows the macOS universal
+// helper precedent — see the comment block above the `useUniversalHelper` declaration for
+// why `mustRunAfter`-based ordering wouldn't work here.
+val useAllLinuxArches = providers.gradleProperty("allLinuxArches").isPresent
+
 if (OperatingSystem.current().isLinux) {
-    tasks.named("processResources") { dependsOn(assembleWaylandHelper) }
+    tasks.named("processResources") {
+        dependsOn(if (useAllLinuxArches) assembleWaylandHelperAllArches else assembleWaylandHelper)
+    }
 }
 
 // Manual smoke entry point — opens a JFrame, records it for ~3s via ScreenCaptureKitRecorder,


### PR DESCRIPTION
Closes #86.

## Summary

- Opt-in `:recording:assembleWaylandHelperAllArches` task builds the Rust helper for both x86_64 and aarch64 from any Linux host. Default `assembleWaylandHelper` stays host-arch only — contributor builds don't need cross toolchains.
- `processResources` flips to the cross-arch staging when `-PallLinuxArches` is passed (parallels macOS's `-PuniversalHelper`).
- Output layout per arch: `build/generated/waylandHelper/native/linux/<arch>/spectre-wayland-helper`. Matches what `WaylandHelperBinaryExtractor` already probes — no Kotlin / runtime changes needed.

## Cross-compile mechanism

Stock rustup target + system cross-linker + apt multi-arch libdbus-1 sysroot. The CI step does:

```yaml
sudo dpkg --add-architecture arm64
sudo apt-get install -y gcc-aarch64-linux-gnu libdbus-1-dev:arm64
rustup target add aarch64-unknown-linux-gnu
```

Picked over alternatives:
- **`cross`** — would add a Docker-daemon dependency + privileged container to CI. Heavier than necessary for one Rust crate with one C dep.
- **`cargo-zigbuild`** — would need a hand-built libdbus sysroot since dbus-rs links via `pkg-config`. Adds a manual sysroot maintenance burden.

The bare-metal recipe routes through cargo's `CARGO_TARGET_<TRIPLE>_LINKER`, `PKG_CONFIG_PATH_<arch>`, and `PKG_CONFIG_ALLOW_CROSS=1` env vars so `dbus-rs`'s `build.rs` picks the foreign-arch `.pc` files.

## CI

Adds a step after `./gradlew check` that runs `assembleWaylandHelperAllArches` and uses `readelf -h` to verify each per-arch binary's ELF machine field — catches a misconfigured cross-target that would silently drop a host-arch binary into the foreign-arch slot.

## Out of scope

- **#84 (Maven Central publish)** isn't started yet, so the issue's "lands in the published jar" criterion is the publish pipeline's job. This PR just makes the cross-arch binaries *bundlable*.
- **aarch64 hardware smoke** — issue checklist item 5 (smoke-test on a real ARM laptop / Pi 5 / Ampere VM). I don't have aarch64 hardware in this environment; CI's `readelf` check + the `qemu-aarch64-static` smoke I'll run on the spectre-vm cover the binary-runs side, but real-hardware portal handshake validation needs your eyes.

## Test plan

- [x] `./gradlew :recording:tasks --group=build` lists `buildWaylandHelperAarch64`, `buildWaylandHelperX86_64`, `stageWaylandHelper*`, `assembleWaylandHelperAllArches`. Configuration cache stores cleanly.
- [ ] CI green, including the new cross-arch bundle step + per-arch `readelf` check.
- [ ] spectre-vm smoke: cross-build aarch64 binary, `qemu-aarch64-static` confirms it loads and runs.
- [ ] Cursor Bugbot: pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)