### PR TITLE
fix(sample-desktop): replace Thread.sleep with delay in suspend smoke helpers

### DIFF
--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/MacOsRobotUnfocusedSmoke.kt
@@ -99,7 +99,7 @@ private suspend fun runSmokeSuspend(): Int {
     waitForFrame(sutRef)
     waitForFrame(distractorRef)
     waitForLayout(state)
-    Thread.sleep(POST_LAYOUT_UNFOCUSED_WARMUP_MS)
+    delay(POST_LAYOUT_UNFOCUSED_WARMUP_MS.milliseconds)
 
     val driver = RobotDriver()
     // Reuse the focused smoke's TCC probe — the unfocused SUT can still receive Robot input

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
@@ -134,17 +134,17 @@ internal fun SmokeContent(state: SmokeState) {
 
 internal data class ScenarioResult(val label: String, val passed: Boolean, val detail: String)
 
-internal fun waitForFrame(ref: AtomicReference<JFrame>) {
+internal suspend fun waitForFrame(ref: AtomicReference<JFrame>) {
     val deadline = System.nanoTime() + WINDOW_OPEN_TIMEOUT_MS * 1_000_000L
     while (System.nanoTime() < deadline) {
         val frame = ref.get()
         if (frame != null && frame.isShowing) return
-        Thread.sleep(50)
+        delay(50.milliseconds)
     }
     error("frame never showed within ${WINDOW_OPEN_TIMEOUT_MS}ms")
 }
 
-internal fun waitForLayout(state: SmokeState) {
+internal suspend fun waitForLayout(state: SmokeState) {
     val deadline = System.nanoTime() + LAYOUT_TIMEOUT_MS * 1_000_000L
     while (System.nanoTime() < deadline) {
         val counter = state.counterBounds
@@ -158,7 +158,7 @@ internal fun waitForLayout(state: SmokeState) {
                 colorPatch.width > 0f &&
                 colorPatch.height > 0f
         if (ready) return
-        Thread.sleep(50)
+        delay(50.milliseconds)
     }
     error(
         "Compose targets never laid out within ${LAYOUT_TIMEOUT_MS}ms; " +


### PR DESCRIPTION
## Summary

- `waitForFrame` and `waitForLayout` in `RobotSmokeRig` are polling loops called exclusively from `suspend` smoke functions (`runSmokeSuspend`). Making them `suspend` and switching `Thread.sleep(50)` → `delay(50.milliseconds)` lets coroutine cancellation propagate through the wait and keeps the threading model consistent with the post-#93 codebase.
- `MacOsRobotUnfocusedSmoke` had one leftover `Thread.sleep(POST_LAYOUT_UNFOCUSED_WARMUP_MS)` that the #107 fixup sweep missed. All other smoke variants (Linux, Windows, focused and unfocused) already use `delay` for the equivalent warmup pause.

Out of scope (intentional `Thread.sleep` on non-coroutine threads):
- `WindowsHiDpiDiagnostic.waitForFrameDisposed` — diagnostic utility, non-suspend, non-coroutine
- `SampleAppFixture.start` — test fixture, non-suspend, polling before any coroutine scope exists
- `RunSpectreAction.pollOnEdt` — explicitly on a pooled background thread, not in a coroutine
- `RunSpectreUiTest.waitForSpectreLog` — log-file polling, non-coroutine integration test

## Test plan

- [x] `./gradlew check` passes in the worktree
- [ ] macOS unfocused smoke runs cleanly (verifies the one-line fix didn't break warmup timing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)