### PR TITLE
Add ScreenCaptureKit helper notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,85 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  recording-release:
+    runs-on: macos-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Import Developer ID certificate
+        env:
+          APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_SIGNING_KEYCHAIN_PASSWORD }}
+        run: |
+          test -n "$APPLE_DEVELOPER_ID_P12"
+          test -n "$APPLE_DEVELOPER_ID_P12_PASSWORD"
+          test -n "$KEYCHAIN_PASSWORD"
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
+
+          echo "$APPLE_DEVELOPER_ID_P12" | base64 --decode > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Build, sign, notarize, and package recording jar
+        env:
+          APPLE_DEVELOPER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
+          APPLE_NOTARY_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY }}
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_NOTARY_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER }}
+        run: |
+          test -n "$APPLE_NOTARY_API_KEY"
+          test -n "$APPLE_NOTARY_API_KEY_ID"
+          test -n "$APPLE_NOTARY_API_ISSUER"
+
+          API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
+          echo "$APPLE_NOTARY_API_KEY" | base64 --decode > "$API_KEY_PATH"
+
+          APPLE_NOTARY_API_KEY_PATH="$API_KEY_PATH" \
+            ./gradlew :recording:jar \
+              -PuniversalHelper \
+              -PnotarizeScreenCaptureKitHelper
+
+      - name: Upload recording jar to GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          JAR_PATH="$(find recording/build/libs -maxdepth 1 -type f -name 'recording-*.jar' ! -name '*sources*' | sort | tail -n 1)"
+          test -n "$JAR_PATH"
+          gh release view "$GITHUB_REF_NAME" || gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME"
+          gh release upload "$GITHUB_REF_NAME" "$JAR_PATH" --clobber

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,7 @@ jobs:
           APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
           APPLE_NOTARY_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER }}
         run: |
+          test -n "$APPLE_DEVELOPER_IDENTITY"
           test -n "$APPLE_NOTARY_API_KEY"
           test -n "$APPLE_NOTARY_API_KEY_ID"
           test -n "$APPLE_NOTARY_API_ISSUER"

--- a/docs/NOTARIZATION.md
+++ b/docs/NOTARIZATION.md
@@ -1,0 +1,144 @@
+# Notarization
+
+Spectre ships the macOS ScreenCaptureKit recorder as a small Swift command-line helper inside
+the `recording` jar. Distribution builds must Developer ID sign and notarize that helper before
+the jar is published, otherwise macOS Gatekeeper can reject the extracted helper when a consumer
+starts `ScreenCaptureKitRecorder`.
+
+Local development builds do not need Apple credentials. The notarization path is opt-in and is
+only intended for release builds.
+
+## What gets notarized
+
+The release build creates a universal `arm64` + `x86_64` helper binary at:
+
+```text
+recording/build/generated/screenCaptureHelperUniversal/SpectreScreenCapture
+```
+
+Gradle then:
+
+1. Signs the helper with `codesign --options runtime --timestamp --force`.
+2. Archives the signed helper with `ditto -c -k --keepParent`.
+3. Submits the archive with `xcrun notarytool submit`.
+4. Waits for Apple to finish processing, bounded by a 30 minute timeout.
+5. Verifies the resulting Developer ID signature with `codesign --verify --strict --verbose=4`
+   before staging it into `native/macos/spectre-screencapture` in the jar resources.
+
+Apple's notary service can issue a ticket for a standalone binary inside the submitted archive,
+but `xcrun stapler` cannot currently staple tickets directly to bare command-line executables,
+and `spctl --assess --type execute` reports bare tools as valid code that is not an app.
+Spectre therefore notarizes the helper and verifies the Developer ID signature locally, but does
+not run `stapler` or use `spctl` as the Gradle gate for `SpectreScreenCapture`.
+
+## Local setup
+
+Install Xcode or the Xcode Command Line Tools so these commands are available:
+
+```bash
+codesign --version
+xcrun notarytool --version
+xcrun stapler --version
+```
+
+Create and install a Developer ID Application certificate through Apple Developer, then confirm
+Keychain can see it:
+
+```bash
+security find-identity -v -p codesigning
+```
+
+The identity should look like:
+
+```text
+Developer ID Application: Example Developer (TEAMID)
+```
+
+Store notarization credentials in Keychain once. Let `notarytool` prompt for the app-specific
+password:
+
+```bash
+xcrun notarytool store-credentials spectre-notary \
+  --apple-id "developer@example.com" \
+  --team-id "TEAMID"
+```
+
+Do not pass the app-specific password to Gradle or `notarytool` on the command line. macOS
+process listings include command arguments while a submission is running.
+
+## Local release smoke
+
+Add non-secret release properties to `~/.gradle/gradle.properties`:
+
+```properties
+compose.desktop.mac.signing.identity=Developer ID Application: Example Developer (TEAMID)
+compose.desktop.mac.notarization.keychainProfile=spectre-notary
+```
+
+Then run:
+
+```bash
+./gradlew :recording:jar -PuniversalHelper -PnotarizeScreenCaptureKitHelper
+```
+
+If Apple accepts the submission, the build verifies the helper's signature and packages the jar.
+If Apple keeps the submission in `In Progress` past the timeout, the Gradle task fails locally but
+the submission continues processing on Apple's side. Query it with:
+
+```bash
+xcrun notarytool info <submission-id> --keychain-profile spectre-notary
+```
+
+## CI release workflow
+
+The tag workflow at
+[`.github/workflows/release.yml`](https://github.com/rock3r/spectre/blob/main/.github/workflows/release.yml)
+builds the universal helper on `macos-latest`, imports the Developer ID certificate into a
+temporary keychain, signs and notarizes the helper, and uploads the recording jar to the GitHub
+release.
+
+Set these repository secrets:
+
+| Secret | Purpose |
+|---|---|
+| `APPLE_DEVELOPER_ID_P12` | Base64-encoded Developer ID Application `.p12`. |
+| `APPLE_DEVELOPER_ID_P12_PASSWORD` | Password for that `.p12` export. |
+| `APPLE_SIGNING_KEYCHAIN_PASSWORD` | Temporary CI keychain password. Use a long random value. |
+| `APPLE_DEVELOPER_IDENTITY` | Exact `codesign` identity, for example `Developer ID Application: Example Developer (TEAMID)`. |
+| `APPLE_NOTARY_API_KEY` | Base64-encoded App Store Connect API `.p8` key. |
+| `APPLE_NOTARY_API_KEY_ID` | App Store Connect API key ID. |
+| `APPLE_NOTARY_API_ISSUER` | App Store Connect API issuer UUID. |
+
+Use App Store Connect API key auth in CI so no app-specific password is passed as a process
+argument. The workflow writes the `.p8` key to `$RUNNER_TEMP` and passes only the file path,
+key id, and issuer to Gradle.
+
+## Rotation
+
+To rotate the Developer ID certificate:
+
+1. Create or renew a Developer ID Application certificate in Apple Developer.
+2. Export it from Keychain Access as a password-protected `.p12`.
+3. Base64-encode it with `base64 -i DeveloperID.p12 | pbcopy`.
+4. Update `APPLE_DEVELOPER_ID_P12`, `APPLE_DEVELOPER_ID_P12_PASSWORD`, and
+   `APPLE_DEVELOPER_IDENTITY` in the repository secrets.
+
+To rotate notarization credentials:
+
+1. Create a new App Store Connect API key with access to notarization.
+2. Base64-encode the `.p8` file.
+3. Update `APPLE_NOTARY_API_KEY`, `APPLE_NOTARY_API_KEY_ID`, and
+   `APPLE_NOTARY_API_ISSUER`.
+4. Push a test tag and verify the release workflow reaches the `codesign --verify` step.
+
+## Validation
+
+After a notarized release, validate on a fresh macOS user or machine:
+
+```bash
+codesign --verify --strict --verbose=2 spectre-screencapture
+```
+
+Then run a small `ScreenCaptureKitRecorder` scenario from the released jar. The expected user
+experience is a normal Screen Recording permission prompt if the host process is not already
+trusted, and no Gatekeeper rejection for the extracted helper.

--- a/docs/NOTARIZATION.md
+++ b/docs/NOTARIZATION.md
@@ -58,7 +58,7 @@ Store notarization credentials in Keychain once. Let `notarytool` prompt for the
 password:
 
 ```bash
-xcrun notarytool store-credentials spectre-notary \
+xcrun notarytool store-credentials <notary-profile> \
   --apple-id "developer@example.com" \
   --team-id "TEAMID"
 ```
@@ -72,7 +72,7 @@ Add non-secret release properties to `~/.gradle/gradle.properties`:
 
 ```properties
 compose.desktop.mac.signing.identity=Developer ID Application: Example Developer (TEAMID)
-compose.desktop.mac.notarization.keychainProfile=spectre-notary
+compose.desktop.mac.notarization.keychainProfile=<notary-profile>
 ```
 
 Then run:
@@ -86,7 +86,7 @@ If Apple keeps the submission in `In Progress` past the timeout, the Gradle task
 the submission continues processing on Apple's side. Query it with:
 
 ```bash
-xcrun notarytool info <submission-id> --keychain-profile spectre-notary
+xcrun notarytool info <submission-id> --keychain-profile <notary-profile>
 ```
 
 ## CI release workflow

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,3 +107,4 @@ nav:
       - Conventions: CONVENTIONS.md
       - Static analysis: STATIC-ANALYSIS.md
       - Recording limitations: RECORDING-LIMITATIONS.md
+      - Notarization: NOTARIZATION.md

--- a/recording/README.md
+++ b/recording/README.md
@@ -104,14 +104,14 @@ The distribution path is opt-in so local development does not require Apple cred
 
 ```bash
 APPLE_DEVELOPER_IDENTITY="Developer ID Application: Example, Inc. (TEAMID1234)" \
-APPLE_NOTARY_KEYCHAIN_PROFILE="spectre-notary" \
+APPLE_NOTARY_KEYCHAIN_PROFILE="<notary-profile>" \
 ./gradlew :recording:jar -PuniversalHelper -PnotarizeScreenCaptureKitHelper
 ```
 
 Create the keychain profile once with:
 
 ```bash
-xcrun notarytool store-credentials spectre-notary \
+xcrun notarytool store-credentials <notary-profile> \
   --apple-id "developer@example.com" \
   --team-id "TEAMID1234"
 ```
@@ -125,7 +125,7 @@ properties from `~/.gradle/gradle.properties`:
 
 ```properties
 compose.desktop.mac.signing.identity=Developer ID Application: Example Developer (TEAMID)
-compose.desktop.mac.notarization.keychainProfile=spectre-notary
+compose.desktop.mac.notarization.keychainProfile=<notary-profile>
 ```
 
 CI should use App Store Connect API key auth instead of an app-specific password. Set

--- a/recording/README.md
+++ b/recording/README.md
@@ -50,7 +50,7 @@ capture (ScreenCaptureKit) live side by side — pick by what you need.
 | Windows `gdigrab` recording | ⏸ v3 (#22) |
 | Linux `x11grab` / pipewire recording | ⏸ v4 (#27) |
 | Audio | ⏸ deferred — add when asked |
-| Notarization of the SCK helper | ⏸ deferred — local dev relies on Screen Recording grant inheriting from the host JVM |
+| Notarization of the SCK helper | ✅ release workflow signs and notarizes the universal helper |
 
 ## ScreenCaptureKit helper build
 
@@ -63,8 +63,8 @@ produce a structurally-correct jar that just doesn't contain the helper file (co
 
 **Distribution must be built on macOS.** A jar published from a Linux CI runner won't carry
 the helper, so any macOS consumer of that jar would fail with "helper binary not found" the
-first time `ScreenCaptureKitRecorder.start()` runs. A future macOS CI workflow will guard
-against this — see the v2 follow-ups doc.
+first time `ScreenCaptureKitRecorder.start()` runs. The release workflow builds on
+`macos-latest`, signs and notarizes the universal helper, then packages the recording jar.
 
 For local dev the default `:recording:assembleScreenCaptureKitHelper` builds host-arch only
 — faster iteration. The universal `arm64+x86_64` binary is opt-in via a project property:
@@ -95,8 +95,87 @@ deliberately avoids `swift build --arch arm64 --arch x86_64` (which delegates to
 and requires a full Xcode install). `lipo` ships with CLT.
 
 Universal builds roughly double the helper build time (two `swift build` invocations + the
-`lipo` step), which is why the default stays single-arch. The publish workflow (when we add
-one) sets `-PuniversalHelper` so distribution jars always contain the fat binary.
+`lipo` step), which is why the default stays single-arch. The release workflow sets
+`-PuniversalHelper` so distribution jars always contain the fat binary.
+
+## ScreenCaptureKit helper notarization
+
+The distribution path is opt-in so local development does not require Apple credentials:
+
+```bash
+APPLE_DEVELOPER_IDENTITY="Developer ID Application: Example, Inc. (TEAMID1234)" \
+APPLE_NOTARY_KEYCHAIN_PROFILE="spectre-notary" \
+./gradlew :recording:jar -PuniversalHelper -PnotarizeScreenCaptureKitHelper
+```
+
+Create the keychain profile once with:
+
+```bash
+xcrun notarytool store-credentials spectre-notary \
+  --apple-id "developer@example.com" \
+  --team-id "TEAMID1234"
+```
+
+Let `notarytool` prompt for the app-specific password. Do not pass the password on the
+command line: macOS process listings can expose command arguments while notarization is
+running.
+
+For local consistency with Compose Desktop apps, the same task also accepts these user Gradle
+properties from `~/.gradle/gradle.properties`:
+
+```properties
+compose.desktop.mac.signing.identity=Developer ID Application: Example Developer (TEAMID)
+compose.desktop.mac.notarization.keychainProfile=spectre-notary
+```
+
+CI should use App Store Connect API key auth instead of an app-specific password. Set
+`APPLE_NOTARY_API_KEY_PATH`, `APPLE_NOTARY_API_KEY_ID`, and `APPLE_NOTARY_API_ISSUER`; the
+release workflow writes the key file from a base64 secret before invoking Gradle.
+
+The Gradle pipeline:
+
+1. Builds the universal helper with the `arm64` + `x86_64` SwiftPM/lipo path described above.
+2. Signs the Mach-O with `codesign --options runtime --timestamp --force`.
+3. Archives the signed helper with `ditto -c -k --keepParent` because `notarytool submit`
+   expects an archive for this shape of software.
+4. Submits the archive with `xcrun notarytool submit --keychain-profile ... --wait --timeout
+   30m`.
+5. Runs `codesign --verify --strict --verbose=4` against the signed helper before staging it
+   into the jar resources.
+
+Apple's notary service creates tickets for standalone binaries inside the submitted archive,
+but Apple's stapler does not currently attach tickets directly to bare command-line
+executables. `spctl --assess --type execute` also reports a bare helper as valid code that is
+not an app. That is why Spectre notarizes and verifies the helper signature but does not run
+`xcrun stapler staple` or use `spctl` as the Gradle gate for `SpectreScreenCapture`.
+Gatekeeper can fetch the ticket online on first run; the jar-bundled helper is still
+Developer ID signed and notarized.
+
+### GitHub release secrets
+
+The tag workflow in
+[`../.github/workflows/release.yml`](https://github.com/rock3r/spectre/blob/main/.github/workflows/release.yml)
+expects these repository secrets:
+
+| Secret | Purpose |
+|---|---|
+| `APPLE_DEVELOPER_ID_P12` | Base64-encoded Developer ID Application `.p12`. |
+| `APPLE_DEVELOPER_ID_P12_PASSWORD` | Password for that `.p12` export. |
+| `APPLE_SIGNING_KEYCHAIN_PASSWORD` | Temporary CI keychain password. Generate a long random value. |
+| `APPLE_DEVELOPER_IDENTITY` | Exact `codesign` identity, for example `Developer ID Application: Example, Inc. (TEAMID1234)`. |
+| `APPLE_NOTARY_API_KEY` | Base64-encoded App Store Connect API `.p8` key. |
+| `APPLE_NOTARY_API_KEY_ID` | App Store Connect API key ID. |
+| `APPLE_NOTARY_API_ISSUER` | App Store Connect API issuer UUID. |
+
+To rotate the certificate:
+
+1. Create or renew a Developer ID Application certificate in the Apple Developer portal.
+2. Export it from Keychain Access as a password-protected `.p12`.
+3. Base64-encode it with `base64 -i DeveloperID.p12 | pbcopy`.
+4. Update `APPLE_DEVELOPER_ID_P12`, `APPLE_DEVELOPER_ID_P12_PASSWORD`, and
+   `APPLE_DEVELOPER_IDENTITY` in the repository secrets.
+5. Rotate the App Store Connect API key secrets if needed.
+6. Push a test tag and verify the `Release` workflow reaches the `codesign --verify` step.
 
 ### Manual end-to-end smoke
 After granting the host JVM Screen Recording permission, point a `ScreenCaptureKitRecorder`

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -388,7 +388,10 @@ sourceSets["main"].resources.srcDir(layout.buildDirectory.dir("generated/screenC
 //
 // Default invocation: `./gradlew :recording:jar` → host-arch (fast iteration).
 // Distribution invocation: `./gradlew :recording:jar -PuniversalHelper` → universal binary.
-val useUniversalHelper = providers.gradleProperty("universalHelper").isPresent
+// Notarization always implies the universal helper; signing/notarizing a host-arch helper would
+// be misleading for a distribution build.
+val useUniversalHelper =
+    providers.gradleProperty("universalHelper").isPresent || shouldNotarizeScreenCaptureKitHelper
 
 if (OperatingSystem.current().isMacOsX) {
     tasks.named("processResources") {

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.gradle.api.GradleException
 import org.gradle.internal.os.OperatingSystem
 
 /**
@@ -135,6 +136,8 @@ val perArchSwiftBuildTasks = universalArchitectures.map { arch ->
 // vals that goes with it (Gradle's configuration cache refuses to serialise that).
 val universalHelperBinary =
     layout.buildDirectory.file("generated/screenCaptureHelperUniversal/SpectreScreenCapture")
+val universalHelperNotaryArchive =
+    layout.buildDirectory.file("generated/screenCaptureHelperUniversal/SpectreScreenCapture.zip")
 
 // Precompute everything as plain String/File outside the task action bodies. Capturing
 // `swiftHelperSource` / `universalHelperBinary` (which are Gradle Layout types) inside an
@@ -147,6 +150,81 @@ val perArchOutputFiles = universalArchitectures.map { arch ->
 }
 val perArchOutputAbsolutePaths = perArchOutputFiles.map { it.asFile.absolutePath }
 val universalHelperAbsolutePath = universalHelperBinary.get().asFile.absolutePath
+val universalHelperNotaryArchiveAbsolutePath =
+    universalHelperNotaryArchive.get().asFile.absolutePath
+val shouldNotarizeScreenCaptureKitHelper =
+    providers.gradleProperty("notarizeScreenCaptureKitHelper").isPresent
+val notarizationTaskEnabled =
+    OperatingSystem.current().isMacOsX && shouldNotarizeScreenCaptureKitHelper
+val appleDeveloperIdIdentity =
+    providers
+        .gradleProperty("appleDeveloperIdIdentity")
+        .orElse(providers.gradleProperty("compose.desktop.mac.signing.identity"))
+        .orElse(providers.environmentVariable("APPLE_DEVELOPER_IDENTITY"))
+val appleNotaryKeychainProfile =
+    providers
+        .gradleProperty("appleNotaryKeychainProfile")
+        .orElse(providers.gradleProperty("compose.desktop.mac.notarization.keychainProfile"))
+        .orElse(providers.environmentVariable("APPLE_NOTARY_KEYCHAIN_PROFILE"))
+val appleNotaryApiKeyPath =
+    providers
+        .gradleProperty("appleNotaryApiKeyPath")
+        .orElse(providers.environmentVariable("APPLE_NOTARY_API_KEY_PATH"))
+val appleNotaryApiKeyId =
+    providers
+        .gradleProperty("appleNotaryApiKeyId")
+        .orElse(providers.environmentVariable("APPLE_NOTARY_API_KEY_ID"))
+val appleNotaryApiIssuer =
+    providers
+        .gradleProperty("appleNotaryApiIssuer")
+        .orElse(providers.environmentVariable("APPLE_NOTARY_API_ISSUER"))
+
+fun notarizationInput(provider: Provider<String>, displayName: String): String =
+    provider.orNull?.takeIf { it.isNotBlank() }
+        ?: when {
+            !notarizationTaskEnabled -> ""
+            else ->
+                throw GradleException(
+                    "$displayName is required when -PnotarizeScreenCaptureKitHelper is set. " +
+                        "Use Spectre's apple* Gradle properties, the matching APPLE_* " +
+                        "environment variables, or the Compose Desktop macOS signing and " +
+                        "notarization property names."
+                )
+        }
+
+val appleDeveloperIdIdentityValue =
+    notarizationInput(appleDeveloperIdIdentity, "APPLE_DEVELOPER_IDENTITY")
+val appleNotaryKeychainProfileValue = appleNotaryKeychainProfile.orNull?.takeIf { it.isNotBlank() }
+val appleNotaryApiKeyPathValue = appleNotaryApiKeyPath.orNull?.takeIf { it.isNotBlank() }
+val appleNotaryApiKeyIdValue = appleNotaryApiKeyId.orNull?.takeIf { it.isNotBlank() }
+val appleNotaryApiIssuerValue = appleNotaryApiIssuer.orNull?.takeIf { it.isNotBlank() }
+val hasAppleNotaryApiKey =
+    appleNotaryApiKeyPathValue != null &&
+        appleNotaryApiKeyIdValue != null &&
+        appleNotaryApiIssuerValue != null
+val appleNotaryAuthArguments: List<String> =
+    when {
+        appleNotaryKeychainProfileValue != null ->
+            listOf("--keychain-profile", appleNotaryKeychainProfileValue)
+        hasAppleNotaryApiKey ->
+            listOf(
+                "--key",
+                requireNotNull(appleNotaryApiKeyPathValue),
+                "--key-id",
+                requireNotNull(appleNotaryApiKeyIdValue),
+                "--issuer",
+                requireNotNull(appleNotaryApiIssuerValue),
+            )
+        !notarizationTaskEnabled -> emptyList()
+        else ->
+            throw GradleException(
+                "A safe Apple notarization credential source is required when " +
+                    "-PnotarizeScreenCaptureKitHelper is set. Configure " +
+                    "APPLE_NOTARY_KEYCHAIN_PROFILE for a local notarytool keychain profile, " +
+                    "or APPLE_NOTARY_API_KEY_PATH / APPLE_NOTARY_API_KEY_ID / " +
+                    "APPLE_NOTARY_API_ISSUER for App Store Connect API key auth."
+            )
+    }
 
 val lipoScreenCaptureKitHelper by
     tasks.registering(Exec::class) {
@@ -189,6 +267,73 @@ val verifyUniversalScreenCaptureKitHelper by
         inputs.file(universalHelperBinary)
     }
 
+val signScreenCaptureKitHelper by
+    tasks.registering(Exec::class) {
+        description = "Codesigns the universal ScreenCaptureKit helper for distribution."
+        group = "build"
+        enabled = notarizationTaskEnabled
+        dependsOn(lipoScreenCaptureKitHelper)
+        commandLine(
+            "codesign",
+            "--sign",
+            appleDeveloperIdIdentityValue,
+            "--options",
+            "runtime",
+            "--timestamp",
+            "--force",
+            universalHelperAbsolutePath,
+        )
+        inputs.file(universalHelperBinary)
+        outputs.file(universalHelperBinary)
+    }
+
+val zipScreenCaptureKitHelperForNotarization by
+    tasks.registering(Exec::class) {
+        description = "Archives the signed ScreenCaptureKit helper for Apple notarization."
+        group = "build"
+        enabled = notarizationTaskEnabled
+        dependsOn(signScreenCaptureKitHelper)
+        commandLine(
+            "ditto",
+            "-c",
+            "-k",
+            "--keepParent",
+            universalHelperAbsolutePath,
+            universalHelperNotaryArchiveAbsolutePath,
+        )
+        inputs.file(universalHelperBinary)
+        outputs.file(universalHelperNotaryArchive)
+    }
+
+val notarizeScreenCaptureKitHelper by
+    tasks.registering(Exec::class) {
+        description = "Submits the signed ScreenCaptureKit helper archive to Apple notarization."
+        group = "build"
+        enabled = notarizationTaskEnabled
+        dependsOn(zipScreenCaptureKitHelperForNotarization)
+        commandLine(
+            "xcrun",
+            "notarytool",
+            "submit",
+            universalHelperNotaryArchiveAbsolutePath,
+            *appleNotaryAuthArguments.toTypedArray(),
+            "--timeout",
+            "30m",
+            "--wait",
+        )
+        inputs.file(universalHelperNotaryArchive)
+    }
+
+val verifyNotarizedScreenCaptureKitHelper by
+    tasks.registering(Exec::class) {
+        description = "Verifies the signed and notarized ScreenCaptureKit helper's code signature."
+        group = "verification"
+        enabled = notarizationTaskEnabled
+        dependsOn(notarizeScreenCaptureKitHelper)
+        commandLine("codesign", "--verify", "--strict", "--verbose=4", universalHelperAbsolutePath)
+        inputs.file(universalHelperBinary)
+    }
+
 val assembleScreenCaptureKitHelper by
     tasks.registering(Copy::class) {
         description = "Stages the ScreenCaptureKit helper binary into the resources tree."
@@ -207,7 +352,10 @@ val assembleScreenCaptureKitHelperUniversal by
                 "processResources by passing -PuniversalHelper at invocation time."
         group = "build"
         onlyIf { OperatingSystem.current().isMacOsX }
-        dependsOn(verifyUniversalScreenCaptureKitHelper)
+        dependsOn(
+            if (shouldNotarizeScreenCaptureKitHelper) verifyNotarizedScreenCaptureKitHelper
+            else verifyUniversalScreenCaptureKitHelper
+        )
         from(universalHelperBinary) { rename { "spectre-screencapture" } }
         into(helperResourceDest.get().asFile.parentFile)
     }

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -272,7 +272,7 @@ val signScreenCaptureKitHelper by
         description = "Codesigns the universal ScreenCaptureKit helper for distribution."
         group = "build"
         enabled = notarizationTaskEnabled
-        dependsOn(lipoScreenCaptureKitHelper)
+        dependsOn(verifyUniversalScreenCaptureKitHelper)
         commandLine(
             "codesign",
             "--sign",


### PR DESCRIPTION
## Summary
- add Gradle tasks to sign, notarize, and verify the universal ScreenCaptureKit helper
- add a tag-driven release workflow for notarized recording jars
- document local/CI notarization setup and validation

## Validation
- ./gradlew :recording:jar -PuniversalHelper -PnotarizeScreenCaptureKitHelper -PappleNotaryKeychainProfile=<local-profile>
- env APPLE_NOTARY_KEYCHAIN_PROFILE=dummy ./gradlew :recording:jar -PnotarizeScreenCaptureKitHelper --dry-run
- /private/tmp/spectre-docs-venv/bin/python -m mkdocs build --strict
- ./gradlew check

Real local notarization was exercised successfully with a local keychain profile; submission ids are intentionally omitted from the PR body.