### PR TITLE
Narrow the core public API and centralize selector matching (R1)

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.core
 
 import androidx.compose.ui.geometry.Rect
@@ -33,10 +35,13 @@ data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) 
 class AutomatorNode
 internal constructor(
     val key: NodeKey,
-    val semanticsNode: SemanticsNode,
-    val trackedWindow: TrackedWindow,
+    internal val semanticsNode: SemanticsNode,
+    internal val trackedWindow: TrackedWindow,
     private val relations: NodeRelations = EmptyNodeRelations,
 ) {
+
+    /** Stable identifier of the tracked window/surface this node belongs to. */
+    val surfaceId: String = trackedWindow.surfaceId
 
     // Eagerly snapshot all semantics properties at construction time (which runs on
     // the EDT inside readAllNodes) so callers can safely read them from any thread.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorTree.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorTree.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.core
 
 import androidx.compose.ui.semantics.Role
@@ -16,7 +18,7 @@ class AutomatorTree internal constructor(private val windows: List<AutomatorWind
 class AutomatorWindow
 internal constructor(
     val windowIndex: Int,
-    val trackedWindow: TrackedWindow,
+    internal val trackedWindow: TrackedWindow,
     private val nodes: List<AutomatorNode>,
 ) {
 
@@ -27,13 +29,13 @@ internal constructor(
 
     fun roots(): List<AutomatorNode> = nodes.filter { it.parent == null }
 
-    fun findByTestTag(tag: String): List<AutomatorNode> = nodes.filter { it.testTag == tag }
+    fun findByTestTag(tag: String): List<AutomatorNode> =
+        nodes.filter(NodeMatchers.hasTestTag(tag)::matches)
 
     fun findOneByTestTag(tag: String): AutomatorNode? = findByTestTag(tag).firstOrNull()
 
-    fun findByText(query: TextQuery): List<AutomatorNode> = nodes.filter { node ->
-        node.texts.any(query::matches) || query.matches(node.editableText)
-    }
+    fun findByText(query: TextQuery): List<AutomatorNode> =
+        nodes.filter(NodeMatchers.hasText(query)::matches)
 
     fun findByText(text: String, exact: Boolean = true): List<AutomatorNode> =
         findByText(
@@ -49,9 +51,9 @@ internal constructor(
     fun findOneByText(text: String, exact: Boolean = true): AutomatorNode? =
         findByText(text, exact).firstOrNull()
 
-    fun findByContentDescription(description: String): List<AutomatorNode> = nodes.filter { node ->
-        node.contentDescriptions.any { it == description }
-    }
+    fun findByContentDescription(description: String): List<AutomatorNode> =
+        nodes.filter(NodeMatchers.hasContentDescription(description)::matches)
 
-    fun findByRole(role: Role): List<AutomatorNode> = nodes.filter { it.role == role }
+    fun findByRole(role: Role): List<AutomatorNode> =
+        nodes.filter(NodeMatchers.hasRole(role)::matches)
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -1,6 +1,10 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.core
 
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsActions
+import androidx.compose.ui.semantics.getOrNull
 import java.awt.Rectangle
 import java.awt.event.KeyEvent
 import java.awt.image.BufferedImage
@@ -15,13 +19,34 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-sealed class ComposeAutomatorQueries {
+/**
+ * Single user-facing entry point for driving live Compose Desktop UIs: tracked-window discovery,
+ * node lookup, input dispatch, screenshot capture, and synchronisation. The R1 design choice is
+ * intentionally to keep this surface in one place — splitting it into extension-function files
+ * would force private wait/fingerprint helpers to widen to `internal` and would force every caller
+ * to add explicit per-symbol imports for `click` / `findByTestTag` / `screenshot` / etc., which is
+ * friction without a corresponding win for discoverability.
+ */
+@Suppress("TooManyFunctions")
+class ComposeAutomator
+private constructor(
+    private val windowTracker: WindowTracker,
+    private val semanticsReader: SemanticsReader,
+    private val robotDriver: RobotDriver,
+) {
 
-    protected abstract val windowTracker: WindowTracker
-    protected abstract val semanticsReader: SemanticsReader
-
+    /**
+     * Snapshot of the currently tracked windows. Returns the live `TrackedWindow` collaborator
+     * type, which is part of Spectre's internal escape hatch — typical users should call
+     * [surfaceIds] instead. The HTTP transport in `:server` is the one in-repo consumer that needs
+     * the rich type.
+     */
+    @InternalSpectreApi
     val windows: List<TrackedWindow>
         get() = windowTracker.trackedWindows
+
+    /** Stable surface IDs of every tracked window, in tracking order. */
+    fun surfaceIds(): List<String> = windowTracker.trackedWindows.map { it.surfaceId }
 
     fun refreshWindows() {
         windowTracker.refresh()
@@ -63,11 +88,6 @@ sealed class ComposeAutomatorQueries {
         semanticsReader.findByContentDescription(description, windows)
 
     fun findByRole(role: Role): List<AutomatorNode> = semanticsReader.findByRole(role, windows)
-}
-
-sealed class ComposeAutomatorInteractions : ComposeAutomatorQueries() {
-
-    protected abstract val robotDriver: RobotDriver
 
     suspend fun click(node: AutomatorNode) {
         val center = node.centerOnScreen
@@ -134,6 +154,53 @@ sealed class ComposeAutomatorInteractions : ComposeAutomatorQueries() {
     }
 
     /**
+     * Raises and requests focus on the AWT window that hosts [node]. Useful before a sequence of
+     * Robot-driven inputs on a non-focused window. The actual focus change is dispatched on the
+     * EDT.
+     */
+    fun focusWindow(node: AutomatorNode) {
+        val window = node.trackedWindow.window
+        if (SwingUtilities.isEventDispatchThread()) {
+            window.toFront()
+            window.requestFocus()
+        } else {
+            SwingUtilities.invokeAndWait {
+                window.toFront()
+                window.requestFocus()
+            }
+        }
+    }
+
+    /**
+     * Invokes the Compose `OnClick` semantics action on [node] directly. This bypasses the OS input
+     * stack — no AWT Robot event is generated, no real cursor moves, and no platform focus/raise
+     * side effects fire. It is **not** equivalent to a real user click; use [click] (which routes
+     * through [RobotDriver]) when verifying input plumbing. The intended use cases are headless
+     * contexts and IntelliJ tool-window flows where the OS input stack is unavailable.
+     *
+     * Throws [IllegalStateException] if [node] has no `OnClick` semantics action attached, or if
+     * the action's invocable body is null (a semantics property without a wired-up handler).
+     */
+    fun performSemanticsClick(node: AutomatorNode) {
+        val accessibilityAction =
+            node.semanticsNode.config.getOrNull(SemanticsActions.OnClick)
+                ?: error(
+                    "Node ${node.key} has no OnClick semantics action; cannot performSemanticsClick"
+                )
+        val action =
+            accessibilityAction.action
+                ?: error(
+                    "Node ${node.key} declares OnClick but its action is null; " +
+                        "cannot performSemanticsClick"
+                )
+        if (SwingUtilities.isEventDispatchThread()) {
+            action.invoke()
+        } else {
+            SwingUtilities.invokeAndWait { action.invoke() }
+        }
+    }
+
+    /**
      * Captures the given screen [region] (or the entire virtual desktop, if `null`) and returns
      * sRGB pixels as a [BufferedImage]. Delegates to [RobotDriver.screenshot] — see that method's
      * KDoc for colour-space, focus-overlay, and per-platform TCC / Wayland gotchas before using the
@@ -160,14 +227,6 @@ sealed class ComposeAutomatorInteractions : ComposeAutomatorQueries() {
                 ?: error("No tracked window at index $windowIndex (have ${windows.size})")
         return robotDriver.screenshot(trackedWindow.composeSurfaceBoundsOnScreen)
     }
-}
-
-class ComposeAutomator
-private constructor(
-    override val windowTracker: WindowTracker,
-    override val semanticsReader: SemanticsReader,
-    override val robotDriver: RobotDriver,
-) : ComposeAutomatorInteractions() {
 
     // V1 contract: queries and actions do not auto-wait. Callers must invoke waitForIdle() /
     // waitForVisualIdle() / waitForNode() explicitly when synchronisation matters. Auto-wait
@@ -447,11 +506,8 @@ private constructor(
 
     companion object {
 
-        fun inProcess(
-            windowTracker: WindowTracker = WindowTracker(),
-            semanticsReader: SemanticsReader = SemanticsReader(),
-            robotDriver: RobotDriver = RobotDriver(),
-        ): ComposeAutomator = ComposeAutomator(windowTracker, semanticsReader, robotDriver)
+        fun inProcess(robotDriver: RobotDriver = RobotDriver()): ComposeAutomator =
+            ComposeAutomator(WindowTracker(), SemanticsReader(), robotDriver)
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
@@ -21,12 +21,13 @@ import kotlin.math.floor
  * `panelScreenX` simply carries any negative offset through. Empirical scenarios are pinned in
  * `WindowsHiDpiScenariosTest`.
  */
-fun composeToAwtX(composeX: Float, scaleX: Float, panelScreenX: Int): Int =
+internal fun composeToAwtX(composeX: Float, scaleX: Float, panelScreenX: Int): Int =
     (composeX / scaleX).toInt() + panelScreenX
 
-fun composeToAwtY(composeY: Float, scaleY: Float, panelScreenY: Int): Int =
+internal fun composeToAwtY(composeY: Float, scaleY: Float, panelScreenY: Int): Int =
     (composeY / scaleY).toInt() + panelScreenY
 
+@InternalSpectreApi
 fun composeBoundsToAwtCenter(
     left: Float,
     top: Float,
@@ -44,6 +45,7 @@ fun composeBoundsToAwtCenter(
     return Point((awtLeft + awtRight) / 2, (awtTop + awtBottom) / 2)
 }
 
+@InternalSpectreApi
 fun composeBoundsToAwtRectangle(
     left: Float,
     top: Float,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InternalSpectreApi.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InternalSpectreApi.kt
@@ -1,0 +1,35 @@
+package dev.sebastiano.spectre.core
+
+/**
+ * Marks a declaration as an internal escape hatch — reachable from Kotlin/JVM but not part of
+ * Spectre's published user-facing API and not covered by the stability policy. Intended for in-repo
+ * fixtures and the experimental HTTP transport that legitimately need access to collaborators users
+ * should never reach into.
+ *
+ * Using a marked declaration requires opt-in:
+ * ```
+ * @OptIn(InternalSpectreApi::class)
+ * fun myFixture() { … }
+ * ```
+ *
+ * Anything annotated with `@InternalSpectreApi` may change or disappear between Spectre releases
+ * without notice. Prefer the public API when one exists.
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.ERROR,
+    message =
+        "This declaration is part of Spectre's internal escape hatch and is not covered by the " +
+            "stability policy. Use a public Spectre API where possible; opt in with " +
+            "@OptIn(InternalSpectreApi::class) only if you know why you need this.",
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.TYPEALIAS,
+)
+annotation class InternalSpectreApi

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/NodeMatcher.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/NodeMatcher.kt
@@ -14,6 +14,10 @@ import androidx.compose.ui.semantics.getOrNull
  * an [AutomatorNode] (with eagerly-snapshotted properties) before matching, so it must match
  * against [AutomatorNode]; the live path matches against [SemanticsNode] directly to avoid an extra
  * allocation per traversal.
+ *
+ * A logical `and` combinator is intentionally not provided yet — the bucket that needs combined
+ * tag+text matching (R4) will introduce one alongside its first caller, to avoid shipping unused
+ * matcher surface ahead of demand.
  */
 internal fun interface SnapshotNodeMatcher {
     fun matches(node: AutomatorNode): Boolean
@@ -22,16 +26,6 @@ internal fun interface SnapshotNodeMatcher {
 internal fun interface LiveNodeMatcher {
     fun matches(node: SemanticsNode): Boolean
 }
-
-internal infix fun SnapshotNodeMatcher.and(other: SnapshotNodeMatcher): SnapshotNodeMatcher =
-    SnapshotNodeMatcher { node ->
-        this@and.matches(node) && other.matches(node)
-    }
-
-internal infix fun LiveNodeMatcher.and(other: LiveNodeMatcher): LiveNodeMatcher =
-    LiveNodeMatcher { node ->
-        this@and.matches(node) && other.matches(node)
-    }
 
 internal object NodeMatchers {
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/NodeMatcher.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/NodeMatcher.kt
@@ -1,0 +1,70 @@
+package dev.sebastiano.spectre.core
+
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsNode
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.semantics.getOrNull
+
+/**
+ * Internal predicate used by both the live ([SemanticsReader]) and snapshot ([AutomatorWindow])
+ * lookup paths. Kept internal: the public selector surface stays the high-level `findByTestTag` /
+ * `findByText` / `findByContentDescription` / `findByRole` functions on [ComposeAutomator].
+ *
+ * The two variants exist because the snapshot path has already projected each [SemanticsNode] into
+ * an [AutomatorNode] (with eagerly-snapshotted properties) before matching, so it must match
+ * against [AutomatorNode]; the live path matches against [SemanticsNode] directly to avoid an extra
+ * allocation per traversal.
+ */
+internal fun interface SnapshotNodeMatcher {
+    fun matches(node: AutomatorNode): Boolean
+}
+
+internal fun interface LiveNodeMatcher {
+    fun matches(node: SemanticsNode): Boolean
+}
+
+internal infix fun SnapshotNodeMatcher.and(other: SnapshotNodeMatcher): SnapshotNodeMatcher =
+    SnapshotNodeMatcher { node ->
+        this@and.matches(node) && other.matches(node)
+    }
+
+internal infix fun LiveNodeMatcher.and(other: LiveNodeMatcher): LiveNodeMatcher =
+    LiveNodeMatcher { node ->
+        this@and.matches(node) && other.matches(node)
+    }
+
+internal object NodeMatchers {
+
+    fun hasTestTag(tag: String): SnapshotNodeMatcher = SnapshotNodeMatcher { it.testTag == tag }
+
+    fun hasText(query: TextQuery): SnapshotNodeMatcher = SnapshotNodeMatcher { node ->
+        node.texts.any(query::matches) || query.matches(node.editableText)
+    }
+
+    fun hasContentDescription(description: String): SnapshotNodeMatcher =
+        SnapshotNodeMatcher { node ->
+            node.contentDescriptions.any { it == description }
+        }
+
+    fun hasRole(role: Role): SnapshotNodeMatcher = SnapshotNodeMatcher { it.role == role }
+
+    fun liveHasTestTag(tag: String): LiveNodeMatcher = LiveNodeMatcher { node ->
+        node.config.getOrNull(SemanticsProperties.TestTag) == tag
+    }
+
+    fun liveHasText(query: TextQuery): LiveNodeMatcher = LiveNodeMatcher { node ->
+        val texts = node.config.getOrNull(SemanticsProperties.Text)?.map { it.text }.orEmpty()
+        val editable = node.config.getOrNull(SemanticsProperties.EditableText)?.text
+        texts.any(query::matches) || query.matches(editable)
+    }
+
+    fun liveHasContentDescription(description: String): LiveNodeMatcher = LiveNodeMatcher { node ->
+        node.config.getOrNull(SemanticsProperties.ContentDescription).orEmpty().any {
+            it == description
+        }
+    }
+
+    fun liveHasRole(role: Role): LiveNodeMatcher = LiveNodeMatcher { node ->
+        node.config.getOrNull(SemanticsProperties.Role) == role
+    }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -463,10 +463,10 @@ private suspend fun runOffEdt(robot: RobotAdapter, block: suspend () -> Unit) {
     withContext(Dispatchers.IO) { block() }
 }
 
-fun shortcutModifierKeyCode(isMacOs: Boolean): Int =
+internal fun shortcutModifierKeyCode(isMacOs: Boolean): Int =
     if (isMacOs) KeyEvent.VK_META else KeyEvent.VK_CONTROL
 
-fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
+internal fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
     if (mask and InputEvent.CTRL_DOWN_MASK != 0) add(KeyEvent.VK_CONTROL)
     if (mask and InputEvent.SHIFT_DOWN_MASK != 0) add(KeyEvent.VK_SHIFT)
     if (mask and InputEvent.ALT_DOWN_MASK != 0) add(KeyEvent.VK_ALT)
@@ -479,7 +479,7 @@ internal fun swipePauseMillis(duration: Duration, steps: Int, autoDelayMs: Int):
     return (perStepBudgetMs - autoDelayMs).coerceAtLeast(0)
 }
 
-fun interpolateSwipePoints(
+internal fun interpolateSwipePoints(
     startX: Int,
     startY: Int,
     endX: Int,
@@ -495,7 +495,7 @@ fun interpolateSwipePoints(
     }
 }
 
-fun detectMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
+internal fun detectMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
 
 private fun virtualDesktopBounds(): Rectangle {
     // GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices throws HeadlessException

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.core
 
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -6,23 +8,17 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
 
-class SemanticsReader {
+internal class SemanticsReader {
 
     fun readAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> = readOnEdt {
         collectAllNodes(trackedWindows)
     }
 
     fun findByTestTag(tag: String, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
-        readOnEdt {
-            collectAllNodes(trackedWindows).filter { it.testTag == tag }
-        }
+        findMatching(trackedWindows, NodeMatchers.liveHasTestTag(tag))
 
     fun findByText(query: TextQuery, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
-        readOnEdt {
-            collectAllNodes(trackedWindows).filter { node ->
-                node.texts.any(query::matches) || query.matches(node.editableText)
-            }
-        }
+        findMatching(trackedWindows, NodeMatchers.liveHasText(query))
 
     fun findByText(
         text: String,
@@ -42,19 +38,34 @@ class SemanticsReader {
     fun findByContentDescription(
         description: String,
         trackedWindows: List<TrackedWindow>,
-    ): List<AutomatorNode> = readOnEdt {
-        collectAllNodes(trackedWindows).filter { node ->
-            node.contentDescriptions.any { it == description }
-        }
-    }
+    ): List<AutomatorNode> =
+        findMatching(trackedWindows, NodeMatchers.liveHasContentDescription(description))
 
     fun findByRole(role: Role, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
-        readOnEdt {
-            collectAllNodes(trackedWindows).filter { it.role == role }
-        }
+        findMatching(trackedWindows, NodeMatchers.liveHasRole(role))
+
+    /**
+     * Walks the live semantics tree on the EDT, marking entries that satisfy [matcher] against the
+     * raw [SemanticsNode]. Every traversed entry is still projected into an [AutomatorNode] so
+     * parent/child relations remain valid for matched nodes; only matched ones are returned.
+     */
+    private fun findMatching(
+        trackedWindows: List<TrackedWindow>,
+        matcher: LiveNodeMatcher,
+    ): List<AutomatorNode> = readOnEdt {
+        val entries = collectEntries(trackedWindows)
+        val nodes = projectEntriesToNodes(entries)
+        entries.filter { matcher.matches(it.node) }.mapNotNull { nodes[it.key] }
+    }
+
+    private fun collectAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> {
+        val entries = collectEntries(trackedWindows)
+        val nodes = projectEntriesToNodes(entries)
+        return entries.mapNotNull { nodes[it.key] }
+    }
 
     @OptIn(ExperimentalComposeUiApi::class)
-    private fun collectAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> {
+    private fun collectEntries(trackedWindows: List<TrackedWindow>): List<NodeEntry> {
         val entries = mutableListOf<NodeEntry>()
         for (trackedWindow in trackedWindows) {
             val owners = getOwnersForWindow(trackedWindow)
@@ -68,7 +79,10 @@ class SemanticsReader {
                 )
             }
         }
+        return entries
+    }
 
+    private fun projectEntriesToNodes(entries: List<NodeEntry>): Map<NodeKey, AutomatorNode> {
         val parentKeyByNodeKey = entries.associate { it.key to it.parentKey }
         val nodeKeysByParentKey =
             entries.groupBy(keySelector = NodeEntry::parentKey, valueTransform = NodeEntry::key)
@@ -81,7 +95,6 @@ class SemanticsReader {
                 override fun childrenOf(key: NodeKey): List<AutomatorNode> =
                     nodeKeysByParentKey[key].orEmpty().mapNotNull(nodesByKey::get)
             }
-
         for (entry in entries) {
             nodesByKey[entry.key] =
                 AutomatorNode(
@@ -91,8 +104,7 @@ class SemanticsReader {
                     relations = relations,
                 )
         }
-
-        return entries.mapNotNull { entry -> nodesByKey[entry.key] }
+        return nodesByKey
     }
 
     @OptIn(ExperimentalComposeUiApi::class)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
@@ -8,6 +8,7 @@ import java.awt.Rectangle
 import java.awt.Window
 import javax.swing.JFrame
 
+@InternalSpectreApi
 data class TrackedWindow
 @OptIn(ExperimentalComposeUiApi::class)
 internal constructor(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
@@ -6,7 +6,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 
-suspend fun <T : Any> waitUntil(
+internal suspend fun <T : Any> waitUntil(
     timeout: Duration = 5.seconds,
     pollInterval: Duration = 100.milliseconds,
     predicate: () -> T?,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.core
 
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -6,6 +8,7 @@ import androidx.compose.ui.awt.ComposeWindow
 import java.awt.Container
 import java.awt.Window
 
+@InternalSpectreApi
 class WindowTracker {
 
     @Volatile private var _trackedWindows: List<TrackedWindow> = emptyList()
@@ -126,7 +129,7 @@ class WindowTracker {
     }
 }
 
-fun findComposePanels(container: Container): List<ComposePanel> {
+internal fun findComposePanels(container: Container): List<ComposePanel> {
     val result = mutableListOf<ComposePanel>()
     findComposePanelsRecursive(container, result)
     return result

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -1,0 +1,353 @@
+package dev.sebastiano.spectre.core
+
+import java.lang.reflect.Modifier
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Locks the intended public surface of the `core` module. The test partitions every JVM-public
+ * declaration **that the test knows about** into three buckets — published user API,
+ * `@InternalSpectreApi` escape hatch, and "must not be JVM-public" — at three granularities. The
+ * type-level allowlist is maintained explicitly (`DECLARED_TYPES`); a future top-level class not
+ * added there will not be caught by this test until R7's full BCV pass is wired in.
+ *
+ * 1. **Declared types** in `dev.sebastiano.spectre.core` (classes, interfaces, annotations).
+ * 2. **Public methods on user-facing declared classes** (so drift on `ComposeAutomator.windows` vs
+ *    `ComposeAutomator.surfaceIds` etc. is caught explicitly).
+ * 3. **File-level top-level functions** in named Kotlin facade classes that ship publicly-named
+ *    helpers (`HiDpiMapperKt`).
+ *
+ * Drives the boundary R7 (Kotlin Binary Compatibility Validator) will eventually freeze. Add new
+ * intentional public API by editing the relevant allowlist below in the same commit as the new
+ * declaration.
+ */
+class ComposeAutomatorPublicSurfaceTest {
+
+    @Test
+    fun `published user-facing types match the allowlist`() {
+        val actual =
+            declaredTypeEntries().filter { it.bucket == Bucket.Published }.map { it.name }.toSet()
+        assertEquals(
+            PUBLISHED_TYPES.toSortedSet(),
+            actual.toSortedSet(),
+            "Published user-facing types drifted from the allowlist. Update PUBLISHED_TYPES in " +
+                "the same commit as the deliberate API change.",
+        )
+    }
+
+    @Test
+    fun `escape-hatch types match the allowlist`() {
+        val actual =
+            declaredTypeEntries().filter { it.bucket == Bucket.EscapeHatch }.map { it.name }.toSet()
+        assertEquals(
+            ESCAPE_HATCH_TYPES.toSortedSet(),
+            actual.toSortedSet(),
+            "Escape-hatch type surface drifted. Widening or narrowing @InternalSpectreApi is a " +
+                "stability-policy decision — update ESCAPE_HATCH_TYPES intentionally.",
+        )
+    }
+
+    @Test
+    fun `no unintended JVM-public type exists in the core package`() {
+        val unknown =
+            declaredTypeEntries().filter {
+                it.bucket == Bucket.JvmPublic &&
+                    it.name !in PUBLISHED_TYPES &&
+                    it.name !in ESCAPE_HATCH_TYPES
+            }
+        assertTrue(
+            unknown.isEmpty(),
+            "Found JVM-public types in dev.sebastiano.spectre.core that are not on either " +
+                "type allowlist: ${unknown.map { it.name }}. Either add a deliberate allowlist " +
+                "entry or change the declaration's visibility.",
+        )
+    }
+
+    @Test
+    fun `ComposeAutomator user methods match the allowlist`() {
+        val actual = userVisibleMethodNames(ComposeAutomator::class.java)
+        assertEquals(
+            COMPOSE_AUTOMATOR_PUBLISHED_METHODS.toSortedSet(),
+            actual.toSortedSet(),
+            "ComposeAutomator's user-visible method surface drifted. Add intentional new methods " +
+                "to COMPOSE_AUTOMATOR_PUBLISHED_METHODS, route experimental ones through " +
+                "@InternalSpectreApi (escape hatch), or change visibility to internal.",
+        )
+    }
+
+    @Test
+    fun `ComposeAutomator escape-hatch members match the allowlist`() {
+        val escapeHatch = internallyAnnotatedNames(ComposeAutomator::class.java)
+        assertEquals(
+            COMPOSE_AUTOMATOR_ESCAPE_HATCH_MEMBERS.toSortedSet(),
+            escapeHatch.toSortedSet(),
+            "ComposeAutomator's @InternalSpectreApi members drifted. " +
+                "Update COMPOSE_AUTOMATOR_ESCAPE_HATCH_MEMBERS intentionally.",
+        )
+    }
+
+    @Test
+    fun `HiDpiMapper escape-hatch top-level functions match the allowlist`() {
+        val clazz = Class.forName("dev.sebastiano.spectre.core.HiDpiMapperKt")
+        val escapeHatch = internallyAnnotatedNames(clazz)
+        assertEquals(
+            HIDPI_ESCAPE_HATCH_FUNCTIONS.toSortedSet(),
+            escapeHatch.toSortedSet(),
+            "HiDpiMapper escape-hatch top-level functions drifted. " +
+                "Update HIDPI_ESCAPE_HATCH_FUNCTIONS intentionally.",
+        )
+    }
+
+    @Test
+    fun `ComposeAutomator companion factory surface matches the allowlist`() {
+        val companion = ComposeAutomator.Companion::class.java
+        val factoryNames = userVisibleMethodNames(companion)
+        assertEquals(
+            COMPOSE_AUTOMATOR_FACTORY_METHODS.toSortedSet(),
+            factoryNames.toSortedSet(),
+            "ComposeAutomator companion factory surface drifted. " +
+                "Update COMPOSE_AUTOMATOR_FACTORY_METHODS intentionally — the factory shape is " +
+                "exactly what R1 changed (windowTracker/semanticsReader removed from inProcess).",
+        )
+    }
+
+    @Test
+    fun `ComposeAutomator inProcess does not accept removed collaborators`() {
+        val companion = ComposeAutomator.Companion::class.java
+        val forbiddenTypeNames =
+            setOf(
+                "dev.sebastiano.spectre.core.WindowTracker",
+                "dev.sebastiano.spectre.core.SemanticsReader",
+            )
+        val violators =
+            companion.declaredMethods
+                .filter {
+                    Modifier.isPublic(it.modifiers) &&
+                        !it.isSynthetic &&
+                        !it.isBridge &&
+                        stripValueClassMangling(it.name) == "inProcess"
+                }
+                .flatMap { method ->
+                    method.parameterTypes
+                        .filter { it.name in forbiddenTypeNames }
+                        .map { param -> "${method.name}(${param.name})" }
+                }
+        assertTrue(
+            violators.isEmpty(),
+            "Found inProcess overload(s) still accepting removed collaborator types: $violators. " +
+                "R1 intentionally removed windowTracker / semanticsReader from the public " +
+                "factory surface; restoring either to a public overload undoes that boundary.",
+        )
+    }
+
+    @Test
+    fun `HiDpiMapper has no unannounced public top-level functions`() {
+        val clazz = Class.forName("dev.sebastiano.spectre.core.HiDpiMapperKt")
+        // Kotlin does not mangle `internal` top-level function names on the JVM (mangling only
+        // applies to internal members of classes). So `composeToAwtX` / `composeToAwtY` appear
+        // as JVM-public even though they are Kotlin-`internal`. We track those explicitly here
+        // so the test still catches genuine drift: any new helper that is neither in the
+        // escape-hatch list nor in the documented "internal but JVM-public" list fails.
+        val unannounced =
+            clazz.declaredMethods.filter { method ->
+                Modifier.isPublic(method.modifiers) &&
+                    !method.isSynthetic &&
+                    !method.name.endsWith("\$annotations") &&
+                    !method.name.contains('$') &&
+                    method.name !in HIDPI_ESCAPE_HATCH_FUNCTIONS &&
+                    method.name !in HIDPI_KOTLIN_INTERNAL_FUNCTIONS
+            }
+        assertTrue(
+            unannounced.isEmpty(),
+            "Found user-callable top-level functions in HiDpiMapperKt that are neither " +
+                "@InternalSpectreApi nor allowlisted: ${unannounced.map { it.name }}. Demote to " +
+                "`internal` or mark @InternalSpectreApi.",
+        )
+    }
+
+    /**
+     * Strips Kotlin's value-class mangling suffix (`-XxxXxxXx`) from a method name. When a function
+     * takes a value-class parameter (`kotlin.time.Duration`, `androidx.compose.ui.semantics.Role`),
+     * Kotlin emits a JVM method named `original-<hash>`. The hash is unstable across compilations
+     * so the allowlist tracks the original name.
+     */
+    private fun stripValueClassMangling(name: String): String {
+        val dash = name.indexOf('-')
+        return if (dash > 0) name.substring(0, dash) else name
+    }
+
+    private fun internallyAnnotatedNames(clazz: Class<*>): Set<String> {
+        // @InternalSpectreApi on a property lands on the `getX$annotations` synthetic the Kotlin
+        // compiler emits. Map back to the underlying property name (`getX`) so the allowlist
+        // tracks the actual reachable member.
+        return clazz.declaredMethods
+            .filter { it.isAnnotationPresent(InternalSpectreApi::class.java) }
+            .map { method ->
+                val stripped = stripValueClassMangling(method.name)
+                stripped.removeSuffix("\$annotations")
+            }
+            .toSet()
+    }
+
+    private enum class Bucket {
+        Published,
+        EscapeHatch,
+        JvmPublic,
+    }
+
+    private data class TypeEntry(val name: String, val bucket: Bucket)
+
+    private fun declaredTypeEntries(): List<TypeEntry> = DECLARED_TYPES.mapNotNull { name ->
+        val clazz = runCatching { Class.forName(name) }.getOrNull() ?: return@mapNotNull null
+        if (!Modifier.isPublic(clazz.modifiers)) return@mapNotNull null
+        val isInternal = clazz.isAnnotationPresent(InternalSpectreApi::class.java)
+        val bucket =
+            when {
+                isInternal -> Bucket.EscapeHatch
+                name in PUBLISHED_TYPES -> Bucket.Published
+                else -> Bucket.JvmPublic
+            }
+        TypeEntry(name, bucket)
+    }
+
+    /**
+     * Names of methods on [clazz] that are reachable from user code without `@OptIn`. Filters out:
+     * - Synthetic methods, bridges, and Kotlin's getter/setter `getXxx$annotations` helpers.
+     * - Methods name-mangled with `$` (Kotlin's marker for `internal` visibility on the JVM).
+     * - Methods annotated `@InternalSpectreApi` (those live on a separate allowlist).
+     * - `Object` overrides (`equals`, `hashCode`, `toString`) — universally present.
+     * - Companion accessors (`Companion`).
+     */
+    private fun userVisibleMethodNames(clazz: Class<*>): Set<String> {
+        // The `getXxx$annotations` synthetic carries property-level annotations including
+        // @InternalSpectreApi. We must consult the synthetic to know which property getters
+        // are escape-hatch, and exclude the synthetic itself from the user-visible set.
+        val escapeHatchGetters = internallyAnnotatedNames(clazz)
+        return clazz.declaredMethods
+            .filter { method ->
+                Modifier.isPublic(method.modifiers) &&
+                    !method.isSynthetic &&
+                    !method.isBridge &&
+                    !method.name.endsWith("\$annotations") &&
+                    !method.name.contains('$') &&
+                    method.name !in OBJECT_METHODS &&
+                    method.name != "getCompanion"
+            }
+            .map { method -> stripValueClassMangling(method.name) }
+            .filter { name -> name !in escapeHatchGetters }
+            // Many methods exist in multiple overloads (e.g. `findByText`, `screenshot`,
+            // `swipe`). Collapse to names — the allowlist tracks names, not signatures.
+            .toSet()
+    }
+
+    private companion object {
+
+        // Every type the test knows about. Adding a new top-level type means updating this
+        // list in the same commit; the allowlists below decide which bucket it falls in.
+        val DECLARED_TYPES: List<String> =
+            listOf(
+                "dev.sebastiano.spectre.core.AutomatorIdlingResource",
+                "dev.sebastiano.spectre.core.AutomatorNode",
+                "dev.sebastiano.spectre.core.AutomatorTree",
+                "dev.sebastiano.spectre.core.AutomatorWindow",
+                "dev.sebastiano.spectre.core.BothBounds",
+                "dev.sebastiano.spectre.core.ComposeAutomator",
+                "dev.sebastiano.spectre.core.IdleTimeoutException",
+                "dev.sebastiano.spectre.core.InternalSpectreApi",
+                "dev.sebastiano.spectre.core.NodeKey",
+                "dev.sebastiano.spectre.core.PerfettoTracer",
+                "dev.sebastiano.spectre.core.RobotDriver",
+                "dev.sebastiano.spectre.core.TextMatchType",
+                "dev.sebastiano.spectre.core.TextQuery",
+                "dev.sebastiano.spectre.core.TrackedWindow",
+                "dev.sebastiano.spectre.core.Tracer",
+                "dev.sebastiano.spectre.core.WindowTracker",
+            )
+
+        // The intended user-facing types. Update only on a deliberate API addition.
+        val PUBLISHED_TYPES: Set<String> =
+            setOf(
+                "dev.sebastiano.spectre.core.AutomatorIdlingResource",
+                "dev.sebastiano.spectre.core.AutomatorNode",
+                "dev.sebastiano.spectre.core.AutomatorTree",
+                "dev.sebastiano.spectre.core.AutomatorWindow",
+                "dev.sebastiano.spectre.core.BothBounds",
+                "dev.sebastiano.spectre.core.ComposeAutomator",
+                "dev.sebastiano.spectre.core.IdleTimeoutException",
+                "dev.sebastiano.spectre.core.InternalSpectreApi",
+                "dev.sebastiano.spectre.core.NodeKey",
+                "dev.sebastiano.spectre.core.PerfettoTracer",
+                "dev.sebastiano.spectre.core.RobotDriver",
+                "dev.sebastiano.spectre.core.TextMatchType",
+                "dev.sebastiano.spectre.core.TextQuery",
+                "dev.sebastiano.spectre.core.Tracer",
+            )
+
+        // Reachable from Kotlin/JVM, but not part of the stability policy.
+        val ESCAPE_HATCH_TYPES: Set<String> =
+            setOf(
+                "dev.sebastiano.spectre.core.TrackedWindow",
+                "dev.sebastiano.spectre.core.WindowTracker",
+            )
+
+        // The intended user-callable methods on ComposeAutomator (by name; overloads collapse).
+        val COMPOSE_AUTOMATOR_PUBLISHED_METHODS: Set<String> =
+            setOf(
+                "surfaceIds",
+                "refreshWindows",
+                "tree",
+                "allNodes",
+                "findByTestTag",
+                "findOneByTestTag",
+                "findByText",
+                "findOneByText",
+                "findByContentDescription",
+                "findByRole",
+                "click",
+                "doubleClick",
+                "longClick",
+                "swipe",
+                "scrollWheel",
+                "typeText",
+                "clearAndTypeText",
+                "pressKey",
+                "pressEnter",
+                "focusWindow",
+                "performSemanticsClick",
+                "screenshot",
+                "registerIdlingResource",
+                "unregisterIdlingResource",
+                "withTracing",
+                "waitForIdle",
+                "waitForVisualIdle",
+                "waitForNode",
+                "printTree",
+            )
+
+        // Members on ComposeAutomator that ship under @InternalSpectreApi — currently just the
+        // `windows: List<TrackedWindow>` accessor for the experimental server transport.
+        // Property getters are emitted as `getWindows`.
+        val COMPOSE_AUTOMATOR_ESCAPE_HATCH_MEMBERS: Set<String> = setOf("getWindows")
+
+        // Public factory methods on ComposeAutomator.Companion. R1 narrowed `inProcess(...)`
+        // to a single `robotDriver` parameter; restoring `windowTracker` / `semanticsReader`
+        // here would undo the API boundary. Update this set in the same commit as any
+        // intentional factory addition.
+        val COMPOSE_AUTOMATOR_FACTORY_METHODS: Set<String> = setOf("inProcess")
+
+        // Top-level functions in HiDpiMapper that intentionally stay reachable under
+        // @InternalSpectreApi for the Windows HiDPI diagnostic harness.
+        val HIDPI_ESCAPE_HATCH_FUNCTIONS: Set<String> =
+            setOf("composeBoundsToAwtCenter", "composeBoundsToAwtRectangle")
+
+        // Kotlin-`internal` top-level functions still appear as JVM-public because top-level
+        // internal function names are NOT mangled by the Kotlin compiler (mangling only applies
+        // to internal *members* of classes). Documented here so the surface test treats them as
+        // "known not user-facing despite JVM bytecode visibility". R7's BCV pass will refine
+        // this once it lands.
+        val HIDPI_KOTLIN_INTERNAL_FUNCTIONS: Set<String> = setOf("composeToAwtX", "composeToAwtY")
+
+        val OBJECT_METHODS: Set<String> = setOf("equals", "hashCode", "toString")
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/HiDpiMapperTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/HiDpiMapperTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.core
 
 import java.awt.Point

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.core
 
 import java.awt.GraphicsEnvironment

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowsHiDpiScenariosTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowsHiDpiScenariosTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.core
 
 import java.awt.Point

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -6,14 +6,10 @@ the deliberate design choices that affect how you write tests.
 
 ## What an automator owns
 
-Every `ComposeAutomator` wraps three collaborators:
-
-- **`WindowTracker`** — keeps a list of the running Compose surfaces (top-level windows
-  and popup roots) the automator can see.
-- **`SemanticsReader`** — reads Compose's semantics tree out of those surfaces and
-  produces `AutomatorNode`s.
-- **`RobotDriver`** — dispatches mouse, keyboard, and clipboard input, and captures
-  screenshots.
+A `ComposeAutomator` discovers the running Compose surfaces (top-level windows and
+popup roots), reads their semantics tree as `AutomatorNode`s, and dispatches input
+via a `RobotDriver`. The window discovery and semantics reading happen internally —
+the only collaborator users inject is the `RobotDriver`.
 
 Build one with the default in-process configuration:
 
@@ -30,13 +26,12 @@ val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
 
 `headless()` throws `UnsupportedOperationException` on every input, clipboard, and
 screenshot call — an accidental `automator.click(...)` / `typeText(...)` /
-`screenshot(...)` surfaces at the call site instead of silently dropping. It does
-**not** fake out the live `WindowTracker`/`SemanticsReader`, so semantics-tree
-queries still work against whatever Compose surfaces are actually on screen. Reach
-for it for read-only flows; pair it with `SemanticsActions.OnClick` (see
-[Driving input](interactions.md#real-vs-synthetic-input)) when you need to fire
-clicks without going through the OS. For unit-style tests that need full isolation,
-inject test-specific `WindowTracker` and `SemanticsReader` instances too.
+`screenshot(...)` surfaces at the call site instead of silently dropping. The
+semantics-tree queries still work against whatever Compose surfaces are actually on
+screen. When you need to fire a click without going through the OS input stack (e.g.
+in IntelliJ-hosted Compose, where Robot input is blocked), call
+`automator.performSemanticsClick(node)` instead of `click(node)` — see
+[Driving input](interactions.md#real-vs-synthetic-input).
 
 ## Surfaces and the semantics tree
 

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -135,21 +135,13 @@ the EDT. This is what Compose's own test rule does internally. It's useful when:
   layout dependency.
 
 ```kotlin
-import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.semantics.getOrNull
-import com.intellij.openapi.application.ApplicationManager
-
-private fun triggerOnClick(node: AutomatorNode) {
-    val onClick = node.semanticsNode.config.getOrNull(SemanticsActions.OnClick)
-    onClick?.action?.invoke()
-}
-
-// caller (must run on EDT):
-ApplicationManager.getApplication().invokeAndWait {
-    val toggle = automator.findOneByTestTag("popup.toggleButton") ?: return@invokeAndWait
-    triggerOnClick(toggle)
-}
+val toggle = automator.findOneByTestTag("popup.toggleButton") ?: return
+automator.performSemanticsClick(toggle)
 ```
+
+`performSemanticsClick` marshals onto the EDT itself and invokes the Compose
+`OnClick` semantics action directly. It throws `IllegalStateException` if the node
+has no `OnClick` attached.
 
 The trade-off: only nodes that expose an `OnClick` action (most `Modifier.clickable`
 content does) can be driven this way, and you bypass any composable that reacts to
@@ -279,8 +271,8 @@ A few things to know about IDE-hosted Compose surfaces:
 
     See [Recording](recording.md) for the full routing logic.
 - **Popups inside the IDE** are still tracked. Compose creates separate roots for them,
-  and the `WindowTracker` enumerates each one — your selectors find nodes regardless of
-  whether they live in the main tool window or a dropdown.
+  and Spectre's window tracking enumerates each one — your selectors find nodes regardless
+  of whether they live in the main tool window or a dropdown.
 - **The IDE owns its own EDT**. Spectre's `waitForIdle` and `waitForVisualIdle` still
   refuse to run on it, so any code path triggered from a UI handler needs to bounce
   off to a pooled background thread before calling them.

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -175,9 +175,9 @@ public surface:
   unavailable. Every input, clipboard, and screenshot call throws
   `UnsupportedOperationException` so an accidental `automator.click(...)` /
   `typeText(...)` / `screenshot(...)` surfaces at the call site instead of silently
-  dropping. `WindowTracker` and `SemanticsReader` are untouched, so semantics-tree
-  reads still work — pair this with `SemanticsActions.OnClick` if you need to fire
-  clicks without going through the OS. See
+  dropping. Semantics-tree reads still work — pair this with
+  `ComposeAutomator.performSemanticsClick(node)` if you need to fire clicks without
+  going through the OS. See
   [The automator](automator.md#what-an-automator-owns) for the full picture.
 
 Pass a non-default driver via the `inProcess` factory:

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/Main.kt
@@ -31,7 +31,7 @@ private suspend fun runAutomatorDemo() {
     automator.refreshWindows()
 
     println("=== Spectre Automator Demo ===")
-    println("Tracked windows: ${automator.windows.size}")
+    println("Tracked windows: ${automator.surfaceIds().size}")
     println()
     print(automator.printTree())
     println()
@@ -41,10 +41,7 @@ private suspend fun runAutomatorDemo() {
 
     val button = automator.findOneByTestTag("incrementButton")
     if (button != null) {
-        javax.swing.SwingUtilities.invokeAndWait {
-            button.trackedWindow.window.toFront()
-            button.trackedWindow.window.requestFocus()
-        }
+        automator.focusWindow(button)
         delay(BETWEEN_ACTION_DELAY_MS)
 
         println("Clicking button $CLICK_REPETITIONS times...")

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
@@ -32,9 +32,6 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.composeBoundsToAwtCenter
-import dev.sebastiano.spectre.core.detectMacOs
-import dev.sebastiano.spectre.core.shortcutModifierKeyCode
 import java.awt.Rectangle
 import java.awt.Window
 import java.util.concurrent.atomic.AtomicReference
@@ -213,17 +210,19 @@ internal fun awtCenter(state: SmokeState, rect: Rect): java.awt.Point? {
         } catch (_: java.awt.IllegalComponentStateException) {
             return null
         }
-    return composeBoundsToAwtCenter(
-        left = rect.left,
-        top = rect.top,
-        right = rect.right,
-        bottom = rect.bottom,
-        scaleX = xform.scaleX.toFloat(),
-        scaleY = xform.scaleY.toFloat(),
-        panelScreenX = panelLoc.x,
-        panelScreenY = panelLoc.y,
-    )
+    val scaleX = xform.scaleX.toFloat()
+    val scaleY = xform.scaleY.toFloat()
+    val awtLeft = (rect.left / scaleX).toInt() + panelLoc.x
+    val awtTop = (rect.top / scaleY).toInt() + panelLoc.y
+    val awtRight = (rect.right / scaleX).toInt() + panelLoc.x
+    val awtBottom = (rect.bottom / scaleY).toInt() + panelLoc.y
+    return java.awt.Point((awtLeft + awtRight) / 2, (awtTop + awtBottom) / 2)
 }
+
+private fun isMacOs(): Boolean = System.getProperty("os.name").lowercase().contains("mac")
+
+private fun shortcutModifierKeyCode(isMac: Boolean): Int =
+    if (isMac) java.awt.event.KeyEvent.VK_META else java.awt.event.KeyEvent.VK_CONTROL
 
 internal suspend fun warmupRobot(driver: RobotDriver, state: SmokeState) {
     // Click on the counter button, fire-and-forget. counterBounds is non-zero by here
@@ -356,19 +355,20 @@ internal suspend fun scenarioShortcut(driver: RobotDriver, state: SmokeState): S
     // and Cmd+S on macOS — `shortcutModifierKeyCode` is what RobotDriver itself uses for
     // typeText/clearAndTypeText, so the smoke proves the same modifier-mask → keyCode path
     // Spectre callers use for shortcut keystrokes.
+    val mac = isMacOs()
     val modifierMask =
-        if (detectMacOs()) java.awt.event.InputEvent.META_DOWN_MASK
+        if (mac) java.awt.event.InputEvent.META_DOWN_MASK
         else java.awt.event.InputEvent.CTRL_DOWN_MASK
     driver.pressKey(java.awt.event.KeyEvent.VK_S, modifierMask)
     delay(POST_CLICK_SETTLE_MS.milliseconds)
     val after = state.shortcutFiredCount
-    val modifierLabel = if (detectMacOs()) "Cmd+S" else "Ctrl+S"
+    val modifierLabel = if (mac) "Cmd+S" else "Ctrl+S"
     return ScenarioResult(
         "$modifierLabel shortcut via pressKey",
         passed = after == before + 1,
         detail =
             "shortcutFiredCount $before → $after (modifier keyCode=" +
-                "${shortcutModifierKeyCode(detectMacOs())})",
+                "${shortcutModifierKeyCode(mac)})",
     )
 }
 

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsHiDpiDiagnostic.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsHiDpiDiagnostic.kt
@@ -1,4 +1,5 @@
 @file:JvmName("WindowsHiDpiDiagnostic")
+@file:OptIn(InternalSpectreApi::class)
 
 package dev.sebastiano.spectre.sample
 
@@ -24,6 +25,7 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
+import dev.sebastiano.spectre.core.InternalSpectreApi
 import dev.sebastiano.spectre.core.composeBoundsToAwtCenter
 import dev.sebastiano.spectre.core.composeBoundsToAwtRectangle
 import java.awt.BorderLayout

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue7CompletionValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue7CompletionValidationTest.kt
@@ -57,13 +57,14 @@ class Issue7CompletionValidationTest {
     fun `JDialog hosting ComposePanel exposes its tree to the automator`() = runBlocking {
         with(fixture.automator) {
             navigateToScenario("scenario.jdialog")
-            val initialWindows = windows.size
+            val initialWindows = surfaceIds().size
             click(waitForTestTag("jdialog.toggleButton"))
             // The JDialog enters the AWT hierarchy a frame or two after the Swing call returns,
             // and the Compose semantics owner inside its embedded ComposePanel attaches
             // asynchronously. Wait until both the window count grew AND the body resolves.
             eventually(description = "jdialog window registered + body discoverable") {
-                if (windows.size > initialWindows && findOneByTestTag("jdialog.body") != null) Unit
+                if (surfaceIds().size > initialWindows && findOneByTestTag("jdialog.body") != null)
+                    Unit
                 else null
             }
             val body = waitForTestTag("jdialog.body")

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/MultiWindowAndPopupValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/MultiWindowAndPopupValidationTest.kt
@@ -73,25 +73,26 @@ class MultiWindowAndPopupValidationTest {
         with(fixture.automator) {
             navigateToScenario("scenario.multiwindow")
             // Capture the main window's surfaceIds BEFORE opening the secondary — the order
-            // returned by `windows` (built from `Window.getWindows()`) is not contractually
-            // guaranteed, so taking `windows.first()` after the open could pick the secondary.
-            val mainSurfaceIds = windows.map { it.surfaceId }.toSet()
-            val initialCount = windows.size
+            // returned by `surfaceIds()` (built from `Window.getWindows()`) is not contractually
+            // guaranteed, so taking `surfaceIds().first()` after the open could pick the
+            // secondary.
+            val mainSurfaceIds = surfaceIds().toSet()
+            val initialCount = surfaceIds().size
             click(waitForTestTag("multiwindow.toggleButton"))
-            eventually(description = "windows.size > $initialCount") {
-                if (windows.size > initialCount) Unit else null
+            eventually(description = "surfaceIds size > $initialCount") {
+                if (surfaceIds().size > initialCount) Unit else null
             }
             // Find a node specific to the secondary window — proves we can introspect it.
             val secondaryText = waitForTestTag("multiwindow.secondary.text")
             assertNotNull(secondaryText)
             assertTrue(
-                secondaryText.trackedWindow.surfaceId !in mainSurfaceIds,
-                "Secondary window's surfaceId should be new, was ${secondaryText.trackedWindow.surfaceId} (mains: $mainSurfaceIds)",
+                secondaryText.surfaceId !in mainSurfaceIds,
+                "Secondary window's surfaceId should be new, was ${secondaryText.surfaceId} (mains: $mainSurfaceIds)",
             )
             // Tear down: dismiss the secondary window and wait for the count to drop.
             click(waitForTestTag("multiwindow.secondary.dismissButton"))
-            eventually(description = "windows.size back to $initialCount") {
-                if (windows.size == initialCount) Unit else null
+            eventually(description = "surfaceIds size back to $initialCount") {
+                if (surfaceIds().size == initialCount) Unit else null
             }
         }
     }

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/NewInteractionsValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/NewInteractionsValidationTest.kt
@@ -1,0 +1,104 @@
+package dev.sebastiano.spectre.sample.validation
+
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+
+/**
+ * Validates the three public APIs introduced by R1 to replace what used to leak through
+ * [dev.sebastiano.spectre.core.AutomatorNode]'s `semanticsNode` / `trackedWindow`:
+ *
+ * - `AutomatorNode.surfaceId`: stable identifier without reaching into the tracked window.
+ * - `ComposeAutomator.focusWindow(node)`: raises/focuses the AWT window hosting the node.
+ * - `ComposeAutomator.performSemanticsClick(node)`: invokes the Compose `OnClick` action without
+ *   going through the OS input stack, for headless contexts where Robot input is unavailable.
+ *
+ * These tests use the live sample fixture so the assertions exercise the real EDT/Compose machinery
+ * the production code paths run through.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class NewInteractionsValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre R1 new-interactions validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    @Order(1)
+    fun `surfaceId on a node matches its window's surfaceId`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val button = waitForTestTag("incrementButton")
+            val mainSurfaces = surfaceIds()
+            assertTrue(
+                button.surfaceId in mainSurfaces,
+                "node.surfaceId=${button.surfaceId} should appear in surfaceIds()=$mainSurfaces",
+            )
+        }
+    }
+
+    @Test
+    @Order(2)
+    fun `performSemanticsClick increments the counter without OS input`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val button = waitForTestTag("incrementButton")
+            // Capture the count before; the button's text is "Count: N".
+            val initialText = button.text
+            assertNotNull(initialText, "incrementButton must expose its 'Count: N' text")
+            performSemanticsClick(button)
+            eventually(description = "counter text to advance after performSemanticsClick") {
+                val refreshed = findOneByTestTag("incrementButton") ?: return@eventually null
+                if (refreshed.text != initialText) refreshed else null
+            }
+        }
+    }
+
+    @Test
+    @Order(3)
+    fun `performSemanticsClick fails clearly when node has no OnClick action`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            // The echoText node only appears after typing; pick a static node that has no
+            // OnClick — the scenario.title heading is a Text composable with no click action.
+            val title = waitForTestTag("scenario.title")
+            val error = runCatching { performSemanticsClick(title) }.exceptionOrNull()
+            assertNotNull(error, "expected performSemanticsClick(title) to throw")
+            assertTrue(
+                error.message?.contains("OnClick") == true,
+                "expected error to mention OnClick, was: ${error.message}",
+            )
+        }
+    }
+
+    @Test
+    @Order(4)
+    fun `focusWindow brings the sample window forward without throwing`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val button = waitForTestTag("incrementButton")
+            // Smoke: focusWindow should complete without throwing. We cannot reliably assert
+            // OS-level window focus state in CI (window managers vary), so the assertion is
+            // limited to the contract — the call returns and the node is still discoverable
+            // afterwards.
+            focusWindow(button)
+            assertNotNull(findOneByTestTag("incrementButton"))
+        }
+    }
+}

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/NodeMatcherParityValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/NodeMatcherParityValidationTest.kt
@@ -1,0 +1,96 @@
+package dev.sebastiano.spectre.sample.validation
+
+import dev.sebastiano.spectre.core.NodeKey
+import dev.sebastiano.spectre.core.TextQuery
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Proves the R1 centralized-matcher contract end to end: the live path (`SemanticsReader`, which
+ * filters with `LiveNodeMatcher` while walking the Compose tree on the EDT) and the snapshot path
+ * (`AutomatorWindow`, which filters with `SnapshotNodeMatcher` over an already projected
+ * `AutomatorNode` collection) return equal node sets for the same fixture. If the two ever diverge
+ * — selector semantics drift, one path collects fewer or different nodes — this test fails before
+ * the bug reaches users.
+ *
+ * Lives in the validation suite because the matchers operate on real Compose `SemanticsNode`s and
+ * `AutomatorNode`s; constructing either without a live Compose surface is not feasible.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class NodeMatcherParityValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre R1 matcher parity")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `live and snapshot paths agree on findByTestTag results`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            // Make sure the counter is on screen before we capture both sides.
+            waitForTestTag("incrementButton")
+            refreshWindows()
+
+            val liveKeys = findByTestTag("incrementButton").map { it.key }.toSet()
+            val snapshotKeys =
+                tree()
+                    .windows()
+                    .flatMap { it.findByTestTag("incrementButton") }
+                    .map { it.key }
+                    .toSet()
+
+            assertEquals(liveKeys, snapshotKeys, "live vs snapshot diverged for findByTestTag")
+            assertTrue(liveKeys.isNotEmpty(), "expected at least one match for 'incrementButton'")
+        }
+    }
+
+    @Test
+    fun `live and snapshot paths agree on findByText with exact query`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val button = waitForTestTag("incrementButton")
+            val targetText = button.text ?: error("incrementButton must expose its 'Count: N' text")
+            refreshWindows()
+
+            val query = TextQuery.exact(targetText)
+            val liveKeys = findByText(query).map(::nodeKey).toSet()
+            val snapshotKeys =
+                tree().windows().flatMap { it.findByText(query) }.map(::nodeKey).toSet()
+
+            assertEquals(liveKeys, snapshotKeys, "live vs snapshot diverged for findByText(exact)")
+            assertTrue(liveKeys.isNotEmpty(), "expected at least one match for '$targetText'")
+        }
+    }
+
+    @Test
+    fun `live and snapshot paths return empty for an unknown selector`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            waitForTestTag("incrementButton")
+            refreshWindows()
+
+            val unknown = "this.tag.definitely.does.not.exist"
+            val liveKeys = findByTestTag(unknown).map { it.key }.toSet()
+            val snapshotKeys =
+                tree().windows().flatMap { it.findByTestTag(unknown) }.map { it.key }.toSet()
+
+            assertEquals(emptySet(), liveKeys)
+            assertEquals(emptySet(), snapshotKeys)
+        }
+    }
+
+    private fun nodeKey(node: dev.sebastiano.spectre.core.AutomatorNode): NodeKey = node.key
+}

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
@@ -1,10 +1,12 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.sample.validation
 
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.InternalSpectreApi
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.SemanticsReader
 import dev.sebastiano.spectre.core.WindowTracker
 import dev.sebastiano.spectre.core.synthetic
 import java.awt.GraphicsEnvironment
@@ -91,11 +93,7 @@ class SampleAppFixture(
                 }
             if (tracked != null) {
                 _automator =
-                    ComposeAutomator.inProcess(
-                        windowTracker = WindowTracker(),
-                        semanticsReader = SemanticsReader(),
-                        robotDriver = RobotDriver.synthetic(tracked.window),
-                    )
+                    ComposeAutomator.inProcess(robotDriver = RobotDriver.synthetic(tracked.window))
                 _automator.refreshWindows()
                 return
             }

--- a/sample-intellij-plugin/src/main/kotlin/dev/sebastiano/spectre/intellij/RunSpectreAction.kt
+++ b/sample-intellij-plugin/src/main/kotlin/dev/sebastiano/spectre/intellij/RunSpectreAction.kt
@@ -1,7 +1,5 @@
 package dev.sebastiano.spectre.intellij
 
-import androidx.compose.ui.semantics.SemanticsActions
-import androidx.compose.ui.semantics.getOrNull
 import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -12,8 +10,6 @@ import com.intellij.openapi.wm.ToolWindowManager
 import dev.sebastiano.spectre.core.AutomatorNode
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.SemanticsReader
-import dev.sebastiano.spectre.core.WindowTracker
 
 /**
  * Manual validation entry point for #13: opens the "Spectre Sample" tool window and runs the
@@ -65,12 +61,7 @@ class RunSpectreAction : AnAction() {
     }
 
     private fun driveAutomator() {
-        val automator =
-            ComposeAutomator.inProcess(
-                windowTracker = WindowTracker(),
-                semanticsReader = SemanticsReader(),
-                robotDriver = RobotDriver.headless(),
-            )
+        val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
         val log = thisLogger()
 
         // 1. Wait for the Jewel `ComposePanel` to attach its semantics owner. Compose
@@ -80,7 +71,8 @@ class RunSpectreAction : AnAction() {
         //    access is marshalled back to EDT.
         val panelReady = pollOnEdt {
             automator.refreshWindows()
-            automator.windows.isNotEmpty() && automator.findOneByTestTag("ide.counter.text") != null
+            automator.surfaceIds().isNotEmpty() &&
+                automator.findOneByTestTag("ide.counter.text") != null
         }
         if (!panelReady) {
             log.warn(
@@ -92,7 +84,7 @@ class RunSpectreAction : AnAction() {
         }
 
         // 2. Dump the initial tree (popup closed).
-        log.info("[Spectre] tracked windows (initial): ${automator.windows.map { it.surfaceId }}")
+        log.info("[Spectre] tracked windows (initial): ${automator.surfaceIds()}")
         runOnEdt { dumpTaggedNodes(automator, "[Spectre] (initial)") }
 
         // 3. Open the popup so the Jewel-hosted popup discovery path actually runs. Without
@@ -105,7 +97,7 @@ class RunSpectreAction : AnAction() {
             log.warn("[Spectre] popup toggle node not discoverable — popup discovery skipped")
             return
         }
-        runOnEdt { triggerOnClick(toggle) }
+        runOnEdt { automator.performSemanticsClick(toggle) }
 
         val popupReady = pollOnEdt {
             automator.refreshWindows()
@@ -119,9 +111,7 @@ class RunSpectreAction : AnAction() {
             return
         }
 
-        log.info(
-            "[Spectre] tracked windows (with popup): ${automator.windows.map { it.surfaceId }}"
-        )
+        log.info("[Spectre] tracked windows (with popup): ${automator.surfaceIds()}")
         runOnEdt { dumpTaggedNodes(automator, "[Spectre] (with popup)") }
     }
 
@@ -131,18 +121,6 @@ class RunSpectreAction : AnAction() {
             node.testTag ?: continue
             log.info("$prefix ${formatNode(node)}")
         }
-    }
-
-    /**
-     * Invokes the Compose `OnClick` semantics action on [node] from the EDT — equivalent to a
-     * synthetic click for the purpose of toggling state, without going through the OS input stack.
-     * The `RobotDriver.headless()` we use here throws on real input, so we drive the semantics tree
-     * directly. This is the same pattern Compose's own `composeTestRule.onNode` uses internally.
-     * Caller is responsible for ensuring this runs on the EDT.
-     */
-    private fun triggerOnClick(node: AutomatorNode) {
-        val onClick = node.semanticsNode.config.getOrNull(SemanticsActions.OnClick)
-        onClick?.action?.invoke()
     }
 
     /**
@@ -188,7 +166,7 @@ class RunSpectreAction : AnAction() {
         append(node.testTag)
         node.text?.let { append(" text=\"$it\"") }
         node.editableText?.let { append(" editableText=\"$it\"") }
-        append(" surface=").append(node.trackedWindow.surfaceId)
+        append(" surface=").append(node.surfaceId)
     }
 
     private companion object {

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -1,6 +1,9 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.server
 
 import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.InternalSpectreApi
 import dev.sebastiano.spectre.core.NodeKey
 import dev.sebastiano.spectre.server.dto.ClickRequest
 import dev.sebastiano.spectre.server.dto.NodesResponse

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
@@ -1,6 +1,9 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.server.dto
 
 import dev.sebastiano.spectre.core.AutomatorNode
+import dev.sebastiano.spectre.core.InternalSpectreApi
 import dev.sebastiano.spectre.core.TrackedWindow
 import java.awt.Rectangle
 

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
@@ -2,8 +2,6 @@ package dev.sebastiano.spectre.server
 
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.SemanticsReader
-import dev.sebastiano.spectre.core.WindowTracker
 import io.ktor.server.cio.CIO
 import io.ktor.server.engine.EmbeddedServer
 import io.ktor.server.engine.embeddedServer
@@ -38,12 +36,7 @@ class HttpComposeAutomatorE2ETest {
 
     @BeforeTest
     fun startServer() {
-        val automator =
-            ComposeAutomator.inProcess(
-                windowTracker = WindowTracker(),
-                semanticsReader = SemanticsReader(),
-                robotDriver = RobotDriver.headless(),
-            )
+        val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
         server =
             embeddedServer(CIO, port = 0) { installSpectreRoutes(automator) }.start(wait = false)
         port = runBlocking { server.engine.resolvedConnectors().first().port }

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
@@ -2,8 +2,6 @@ package dev.sebastiano.spectre.server
 
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.SemanticsReader
-import dev.sebastiano.spectre.core.WindowTracker
 import dev.sebastiano.spectre.server.dto.ClickRequest
 import dev.sebastiano.spectre.server.dto.NodesResponse
 import dev.sebastiano.spectre.server.dto.WindowsResponse
@@ -39,11 +37,7 @@ import kotlin.test.assertTrue
 class SpectreServerRoundTripTest {
 
     private fun headlessAutomator(): ComposeAutomator =
-        ComposeAutomator.inProcess(
-            windowTracker = WindowTracker(),
-            semanticsReader = SemanticsReader(),
-            robotDriver = RobotDriver.headless(),
-        )
+        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
 
     @Test
     fun `windows endpoint returns an empty list for an empty automator`() = testApplication {

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRuleTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRuleTest.kt
@@ -2,8 +2,6 @@ package dev.sebastiano.spectre.testing
 
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.SemanticsReader
-import dev.sebastiano.spectre.core.WindowTracker
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
@@ -54,8 +52,4 @@ class ComposeAutomatorRuleTest {
 }
 
 internal fun newHeadlessAutomator(): ComposeAutomator =
-    ComposeAutomator.inProcess(
-        windowTracker = WindowTracker(),
-        semanticsReader = SemanticsReader(),
-        robotDriver = RobotDriver.headless(),
-    )
+    ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())


### PR DESCRIPTION
## Summary

First implementation bucket of the release hardening epic (#114). Narrows the `:core` user-facing API and centralizes selector matching; downstream R6 (KDoc/docs) and R7 (BCV) follow this surface settling.

- Collapses public `ComposeAutomatorQueries` / `ComposeAutomatorInteractions` sealed hierarchy into a single concrete `ComposeAutomator`.
- Introduces `@InternalSpectreApi` opt-in marker for the small escape hatch (`WindowTracker`, `TrackedWindow`, `ComposeAutomator.windows`, `composeBoundsToAwtCenter` / `composeBoundsToAwtRectangle`) that in-repo fixtures and the experimental server transport legitimately need.
- Replaces leaks through `AutomatorNode` with public APIs: `surfaceId`, `ComposeAutomator.focusWindow(node)`, `ComposeAutomator.performSemanticsClick(node)`. The last bypasses Robot input and is documented as such.
- Adds `ComposeAutomator.surfaceIds()` as the no-opt-in replacement for common diagnostic uses of `windows`.
- Centralizes selector predicates in an internal `NodeMatcher` (`LiveNodeMatcher` for `SemanticsReader`, `SnapshotNodeMatcher` for `AutomatorWindow`). Selector behavior unchanged.
- Migrates every in-repo caller off the demoted symbols. Minimal docs edits stop the user guide from teaching the demoted collaborators; broader rewrites deferred to R6.

## Tests

- `ComposeAutomatorPublicSurfaceTest` locks the surface at three granularities (declared types, `ComposeAutomator` user-visible methods, escape-hatch members, the companion factory, and `HiDpiMapperKt` file-level fns). Handles Kotlin value-class name mangling and the `$annotations` synthetic.
- `NodeMatcherParityValidationTest` proves the live and snapshot lookup paths return equal node keys against real Compose fixtures.
- `NewInteractionsValidationTest` exercises the three new public APIs (`surfaceId`, `focusWindow`, `performSemanticsClick` happy + error paths) against the sample app.

## Test plan

- [ ] CI: `./gradlew check` passes (detekt + ktfmt + tests)
- [ ] CI: validation suite passes on macOS (real-AWT tests)
- [ ] Manual: `:sample-intellij-plugin:runIde` → Tools → Run Spectre Against the Sample Tool Window still drives the IDE-hosted ComposePanel
- [ ] Manual: `:sample-desktop:run` demo flow still finds and clicks the increment button

🤖 Generated with [Claude Code](https://claude.com/claude-code)