### PR TITLE
Publish the Wayland portal recorders and warn on AutoRecorder fallback (R2)

### DIFF
--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -11,6 +11,7 @@ import dev.sebastiano.spectre.recording.screencapturekit.WindowRecorder
 import java.awt.Rectangle
 import java.lang.ProcessHandle
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * High-level recorder that picks between window-targeted capture and region-based ffmpeg capture
@@ -65,6 +66,8 @@ internal constructor(
     private val windowsWindowRecorder: WindowRecorder?,
     private val waylandPortalRecorder: Recorder?,
     private val waylandPortalWindowRecorder: WaylandWindowSourceRecorder?,
+    private val waylandPortalRecorderFailure: Throwable?,
+    private val waylandPortalWindowRecorderFailure: Throwable?,
     private val isMacOs: () -> Boolean,
     private val isWindows: () -> Boolean,
     private val isWayland: () -> Boolean,
@@ -74,19 +77,30 @@ internal constructor(
         sckRecorder: WindowRecorder = ScreenCaptureKitRecorder(),
         ffmpegRecorder: Recorder = FfmpegRecorder(),
         windowsWindowRecorder: WindowRecorder? = defaultWindowsWindowRecorder(),
-        waylandPortalRecorder: Recorder? = defaultWaylandPortalRecorder(),
-        waylandPortalWindowRecorder: WaylandWindowSourceRecorder? =
-            defaultWaylandPortalWindowRecorder(),
+        waylandPortalRecorder: Recorder? = defaultPortals.region,
+        waylandPortalWindowRecorder: WaylandWindowSourceRecorder? = defaultPortals.window,
     ) : this(
-        sckRecorder,
-        ffmpegRecorder,
-        windowsWindowRecorder,
-        waylandPortalRecorder,
-        waylandPortalWindowRecorder,
-        ::defaultIsMacOs,
-        ::defaultIsWindows,
-        ::defaultIsWayland,
+        sckRecorder = sckRecorder,
+        ffmpegRecorder = ffmpegRecorder,
+        windowsWindowRecorder = windowsWindowRecorder,
+        waylandPortalRecorder = waylandPortalRecorder,
+        waylandPortalWindowRecorder = waylandPortalWindowRecorder,
+        // A user who passed a non-null recorder owns its construction; we only surface our own
+        // resolution failure for slots the caller left as null (i.e. accepted the default).
+        waylandPortalRecorderFailure =
+            if (waylandPortalRecorder == null) defaultPortals.regionFailure else null,
+        waylandPortalWindowRecorderFailure =
+            if (waylandPortalWindowRecorder == null) defaultPortals.windowFailure else null,
+        isMacOs = ::defaultIsMacOs,
+        isWindows = ::defaultIsWindows,
+        isWayland = ::defaultIsWayland,
     )
+
+    /**
+     * Latched to true the first time we emit the Wayland portal fallback warning, so repeated
+     * `start()` calls on the same AutoRecorder instance don't spam stderr.
+     */
+    private val waylandFallbackWarned = AtomicBoolean(false)
 
     fun start(
         window: TitledWindow?,
@@ -111,6 +125,14 @@ internal constructor(
         }
         if (isWayland() && waylandPortalRecorder != null) {
             return waylandPortalRecorder.start(region, output, options)
+        }
+        if (isWayland()) {
+            // Wayland session detected but no portal recorder could be constructed. The
+            // ffmpeg fallback below will fail loudly ("Wayland detected, x11grab unavailable")
+            // — but the underlying construction failure for the portal recorder is the more
+            // useful diagnostic, so surface it once via stderr before we let ffmpeg complete
+            // the routing.
+            maybeWarnWaylandFallback(window)
         }
         if (window == null) {
             return ffmpegRecorder.start(region, output, options)
@@ -147,6 +169,32 @@ internal constructor(
             )
         }
         return ffmpegRecorder.start(region, output, options)
+    }
+
+    /**
+     * Emit the Wayland portal fallback warning at most once per AutoRecorder instance. Picks the
+     * window-recorder failure when a [window] is supplied (that's the slot the router checked
+     * first), otherwise the region-recorder failure. Both being null means the caller explicitly
+     * passed `null` recorders without going through our defaults — we still emit the warning so the
+     * silent downgrade is visible, just with a less specific cause.
+     */
+    private fun maybeWarnWaylandFallback(window: TitledWindow?) {
+        if (!waylandFallbackWarned.compareAndSet(false, true)) return
+        val failure =
+            if (window != null) {
+                waylandPortalWindowRecorderFailure ?: waylandPortalRecorderFailure
+            } else {
+                waylandPortalRecorderFailure ?: waylandPortalWindowRecorderFailure
+            }
+        val cause =
+            failure?.message?.takeIf { it.isNotBlank() }
+                ?: failure?.javaClass?.simpleName
+                ?: "no construction failure recorded — recorder slot was passed as null"
+        System.err.println(
+            "AutoRecorder: Wayland portal recorder unavailable ($cause); falling back to " +
+                "ffmpeg region capture (which will fail on Wayland — install the portal helper " +
+                "prerequisites or supply a custom recorder)."
+        )
     }
 
     private companion object {
@@ -190,45 +238,61 @@ internal constructor(
         }
 
         /**
-         * Constructs a [WaylandPortalRecorder] only when the host is Linux. dbus-java + gst-launch
-         * are no-ops on macOS / Windows (the gst-launch binary doesn't exist there, the D-Bus
-         * session bus isn't running) — gating on `isLinux` keeps cross-host distribution jars from
-         * triggering construction-time failures. The recorder is null on non-Linux even if the
-         * AutoRecorder is constructed; the router never asks for it on those hosts.
+         * Lazily resolves both portal recorders once per JVM (the first time the public no-arg
+         * `AutoRecorder` constructor's defaults fire). Captures any construction failure so the
+         * router can surface it via the fallback warning instead of silently dropping it.
          *
-         * Failures resolving the gst-launch path or constructing the recorder are swallowed for the
-         * same reasons as [defaultWindowsWindowRecorder]: a Linux host without GStreamer installed
-         * should still be able to instantiate AutoRecorder for non-Wayland or non-recording flows.
-         * If the user actually triggers Wayland recording on such a host, the construction-time
-         * error from `WaylandPortalRecorder.init` would surface at start() time as a clear
-         * "gst-launch-1.0 not found, install gstreamer1.0-tools".
+         * Tests bypass this entirely by going through the internal constructor.
          */
-        @JvmStatic
-        @Suppress("TooGenericExceptionCaught")
-        fun defaultWaylandPortalRecorder(): Recorder? {
-            if (!defaultIsLinux()) return null
-            return try {
-                WaylandPortalRecorder()
-            } catch (_: Throwable) {
-                null
-            }
+        val defaultPortals: WaylandPortalRecorders by lazy {
+            WaylandPortalRecorders.resolveDefaults(::defaultIsLinux)
         }
+    }
+}
+
+/**
+ * Internal routing state for the Wayland portal recorders + the construction failures (if any) that
+ * produced their null slots. Stays out of the public API so `AutoRecorder`'s public constructor
+ * doesn't have to take `Throwable` parameters.
+ */
+internal data class WaylandPortalRecorders(
+    val region: Recorder?,
+    val window: WaylandWindowSourceRecorder?,
+    val regionFailure: Throwable?,
+    val windowFailure: Throwable?,
+) {
+
+    companion object {
 
         /**
-         * Constructs a [WaylandPortalWindowRecorder] only when the host is Linux. Same gating as
-         * [defaultWaylandPortalRecorder] — the helper binary, GStreamer, and the portal D-Bus
-         * service are all Linux-only. Failures resolving dependencies are swallowed for the same
-         * reasons.
+         * Constructs the default portal recorders on Linux; returns all-null on other hosts.
+         *
+         * dbus-java + gst-launch are no-ops on macOS / Windows (the gst-launch binary doesn't exist
+         * there, the D-Bus session bus isn't running) — gating on `isLinux` keeps cross-host
+         * distribution jars from triggering construction-time failures. On Linux, failures
+         * resolving the gst-launch path or constructing either recorder are captured rather than
+         * dropped, so a Linux host without GStreamer installed can still instantiate AutoRecorder
+         * for non-Wayland flows but a user who triggers Wayland recording sees the diagnostic via
+         * the stderr fallback warning.
          */
-        @JvmStatic
         @Suppress("TooGenericExceptionCaught")
-        fun defaultWaylandPortalWindowRecorder(): WaylandWindowSourceRecorder? {
-            if (!defaultIsLinux()) return null
-            return try {
-                WaylandPortalWindowRecorder()
-            } catch (_: Throwable) {
-                null
+        fun resolveDefaults(isLinux: () -> Boolean): WaylandPortalRecorders {
+            if (!isLinux()) return WaylandPortalRecorders(null, null, null, null)
+            var region: Recorder? = null
+            var regionFailure: Throwable? = null
+            try {
+                region = WaylandPortalRecorder()
+            } catch (t: Throwable) {
+                regionFailure = t
             }
+            var window: WaylandWindowSourceRecorder? = null
+            var windowFailure: Throwable? = null
+            try {
+                window = WaylandPortalWindowRecorder()
+            } catch (t: Throwable) {
+                windowFailure = t
+            }
+            return WaylandPortalRecorders(region, window, regionFailure, windowFailure)
         }
     }
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
@@ -322,16 +322,18 @@ internal const val DEFAULT_PROCESS_EXIT_TIMEOUT_MS: Long = 5_000
  * [readerThread] unbounded (the kill propagates EOF on the helper's stdout, so the reader
  * terminates promptly). Throws [IllegalStateException] if the process is still alive after the
  * forced-reap window — that should never happen with SIGKILL but is surfaced rather than silently
- * leaked.
+ * leaked. The error message uses [phase] (e.g. `"during a failed start"`, `"during stop"`) so
+ * callers from different lifecycle stages produce accurate diagnostics.
  *
- * Shared by every `start()` failure path so the contract is consistent: when a partial start
- * throws, the helper process is reaped and the reader thread is gone before the exception
- * propagates.
+ * Shared by every `start()` and `stop()` failure path so the contract is consistent: when the
+ * caller is about to throw, the helper process is reaped and the reader thread is gone before the
+ * exception propagates.
  */
 internal fun killAndReapOrThrow(
     process: Process,
     readerThread: Thread,
     pendingFailure: Throwable? = null,
+    phase: String = "during a failed start",
 ) {
     process.destroyForcibly()
     if (!process.waitFor(FORCED_REAP_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
@@ -343,7 +345,7 @@ internal fun killAndReapOrThrow(
         val cleanupFailure =
             IllegalStateException(
                 "spectre-wayland-helper did not exit within ${FORCED_REAP_TIMEOUT_MS}ms after " +
-                    "SIGKILL during a failed start. Helper process may be leaked."
+                    "SIGKILL $phase. Helper process may be leaked."
             )
         if (pendingFailure != null) cleanupFailure.addSuppressed(pendingFailure)
         throw cleanupFailure
@@ -423,17 +425,19 @@ private class GstRecordingHandle(
                     "spectre-wayland-helper did not emit Stopped within ${shutdownGraceMillis}ms " +
                         "of stop(). Output at $output may be truncated or empty."
                 )
-            killAndReapOrThrow(process, readerThread, stopTimeoutFailure)
+            killAndReapOrThrow(process, readerThread, stopTimeoutFailure, phase = "during stop")
             throw stopTimeoutFailure
         }
         errorRef.get()?.let { err ->
             // Error event during recording: drain reader, then surface. The helper exits on
             // its own after an Error event, so the process should already be terminating.
-            waitForGracefulExitOrReap(process, readerThread)
-            throw IllegalStateException(
-                "spectre-wayland-helper reported an error during recording: kind=${err.kind} " +
-                    "message=${err.message}"
-            )
+            val errorFailure =
+                IllegalStateException(
+                    "spectre-wayland-helper reported an error during recording: " +
+                        "kind=${err.kind} message=${err.message}"
+                )
+            waitForGracefulExitOrReap(process, readerThread, errorFailure)
+            throw errorFailure
         }
         // Stopped event received cleanly. Wait for the helper to exit, then join the reader
         // unbounded (EOF on stdout follows process exit).
@@ -443,7 +447,7 @@ private class GstRecordingHandle(
                     "spectre-wayland-helper did not exit within ${processExitTimeoutMillis}ms " +
                         "after Stopped event. Output at $output may be in an undefined state."
                 )
-            killAndReapOrThrow(process, readerThread, exitTimeoutFailure)
+            killAndReapOrThrow(process, readerThread, exitTimeoutFailure, phase = "during stop")
             throw exitTimeoutFailure
         }
         readerThread.join()
@@ -457,9 +461,13 @@ private class GstRecordingHandle(
         }
     }
 
-    private fun waitForGracefulExitOrReap(process: Process, readerThread: Thread) {
+    private fun waitForGracefulExitOrReap(
+        process: Process,
+        readerThread: Thread,
+        pendingFailure: Throwable?,
+    ) {
         if (!process.waitFor(processExitTimeoutMillis, TimeUnit.MILLISECONDS)) {
-            killAndReapOrThrow(process, readerThread)
+            killAndReapOrThrow(process, readerThread, pendingFailure, phase = "during stop")
         } else {
             readerThread.join()
         }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
@@ -49,13 +49,40 @@ import kotlinx.serialization.json.Json
  * natively, and Rust's `Command` makes FD inheritance trivial. The helper is ~600 LOC, ships as a
  * per-arch binary in the recording module's jar resources, and uses a tiny stdin/stdout JSON
  * protocol.
+ *
+ * ## Strict direct-use contract
+ *
+ * Instantiating `WaylandPortalRecorder` directly assumes the bundled helper binary is present and
+ * the host's xdg-desktop-portal is reachable. Failures from either are surfaced as
+ * [IllegalStateException] with precise context — there is **no** silent no-op or automatic fallback
+ * to another recorder. If you want a "just record" experience that degrades to ffmpeg region
+ * capture when the portal isn't available, use [dev.sebastiano.spectre.recording.AutoRecorder]
+ * instead; it owns the fallback-with-warning policy.
  */
-internal class WaylandPortalRecorder(
-    private val helperExtractor: WaylandHelperBinaryExtractor = WaylandHelperBinaryExtractor(),
-    private val processFactory: ProcessFactory = SystemProcessFactory,
-    private val sourceTypes: List<SourceType> = listOf(SourceType.MONITOR),
-    private val startedTimeout: Long = DEFAULT_STARTED_TIMEOUT_MS,
+public class WaylandPortalRecorder
+private constructor(
+    private val helperExtractor: WaylandHelperBinaryExtractor,
+    private val processFactory: ProcessFactory,
+    private val sourceTypes: List<SourceType>,
+    private val startedTimeout: Long,
+    private val shutdownGraceMillis: Long,
+    private val processExitTimeoutMillis: Long,
 ) : Recorder {
+
+    /**
+     * Default user-facing constructor. Uses the bundled helper binary, the JVM's
+     * `ProcessBuilder`-based process factory, `SourceType.MONITOR` (region capture), a 90s
+     * portal-handshake timeout, a 30s stop-graceful-window, and a 5s post-Stopped exit window.
+     */
+    public constructor() :
+        this(
+            helperExtractor = WaylandHelperBinaryExtractor(),
+            processFactory = SystemProcessFactory,
+            sourceTypes = listOf(SourceType.MONITOR),
+            startedTimeout = DEFAULT_STARTED_TIMEOUT_MS,
+            shutdownGraceMillis = DEFAULT_SHUTDOWN_GRACE_MS,
+            processExitTimeoutMillis = DEFAULT_PROCESS_EXIT_TIMEOUT_MS,
+        )
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -109,35 +136,46 @@ internal class WaylandPortalRecorder(
                 ),
             )
         } catch (e: IOException) {
-            process.destroyForcibly()
-            throw IllegalStateException(
-                "Failed to send Start command to spectre-wayland-helper (it died on launch?). " +
-                    "Helper path: $helperPath",
-                e,
-            )
+            val launchFailure =
+                IllegalStateException(
+                    "Failed to send Start command to spectre-wayland-helper (it died on launch?). " +
+                        "Helper path: $helperPath",
+                    e,
+                )
+            killAndReapOrThrow(process, readerThread, launchFailure)
+            throw launchFailure
         }
 
         if (!startedLatch.await(startedTimeout, TimeUnit.MILLISECONDS)) {
-            process.destroyForcibly()
-            throw IllegalStateException(
-                "spectre-wayland-helper did not emit a Started or Error event within " +
-                    "${startedTimeout}ms. Likely portal-handshake stall (user dialog hidden, " +
-                    "compositor unresponsive, D-Bus session bus not reachable from helper)."
-            )
+            val timeoutFailure =
+                IllegalStateException(
+                    "spectre-wayland-helper did not emit a Started or Error event within " +
+                        "${startedTimeout}ms. Likely portal-handshake stall (user dialog hidden, " +
+                        "compositor unresponsive, D-Bus session bus not reachable from helper)."
+                )
+            killAndReapOrThrow(process, readerThread, timeoutFailure)
+            throw timeoutFailure
         }
         errorEvent.get()?.let { err ->
-            process.destroyForcibly()
-            throw IllegalStateException(
-                "spectre-wayland-helper reported an error before recording could start: " +
-                    "kind=${err.kind} message=${err.message}"
-            )
+            val helperErrorFailure =
+                IllegalStateException(
+                    "spectre-wayland-helper reported an error before recording could start: " +
+                        "kind=${err.kind} message=${err.message}"
+                )
+            killAndReapOrThrow(process, readerThread, helperErrorFailure)
+            throw helperErrorFailure
         }
         val startedEvent =
             started.get()
-                ?: error(
-                    "Started latch fired but neither Started nor Error event captured — " +
-                        "synchronisation bug in WaylandPortalRecorder."
-                )
+                ?: run {
+                    val syncFailure =
+                        IllegalStateException(
+                            "Started latch fired but neither Started nor Error event captured — " +
+                                "synchronisation bug in WaylandPortalRecorder."
+                        )
+                    killAndReapOrThrow(process, readerThread, syncFailure)
+                    throw syncFailure
+                }
         return GstRecordingHandle(
             process = process,
             output = output,
@@ -147,6 +185,8 @@ internal class WaylandPortalRecorder(
             errorRef = errorEvent,
             stoppedLatch = stoppedLatch,
             readerThread = readerThread,
+            shutdownGraceMillis = shutdownGraceMillis,
+            processExitTimeoutMillis = processExitTimeoutMillis,
         )
     }
 
@@ -223,7 +263,7 @@ internal class WaylandPortalRecorder(
     }
 
     /** Indirection over `ProcessBuilder.start()` so tests can drive the subprocess lifecycle. */
-    interface ProcessFactory {
+    internal interface ProcessFactory {
         fun start(helperPath: Path): Process
     }
 
@@ -239,16 +279,79 @@ internal class WaylandPortalRecorder(
                 .start()
     }
 
-    private companion object {
-        const val DEFAULT_STARTED_TIMEOUT_MS: Long = 90_000
+    internal companion object {
 
-        // Cap on how much of a malformed JSON line we echo back into the Error event message.
-        // Long enough to be useful for debugging (typical helper event lines are ~150 chars),
-        // short enough that a runaway helper writing megabytes of garbage doesn't blow the
-        // event channel.
-        const val MALFORMED_LINE_PREVIEW_LENGTH: Int = 200
+        /**
+         * In-module factory for tests and [WaylandPortalWindowRecorder]'s delegate path. Annotated
+         * `@JvmSynthetic` so Java consumers don't see it — the JVM-public `WaylandPortalRecorder`
+         * class is supposed to expose only its no-arg constructor. Reflection-based access still
+         * works for genuinely needs-the-internals callers but stays absent from IDE autocomplete
+         * and javap's default view.
+         */
+        @JvmSynthetic
+        internal fun createForInternalUse(
+            helperExtractor: WaylandHelperBinaryExtractor = WaylandHelperBinaryExtractor(),
+            processFactory: ProcessFactory = SystemProcessFactory,
+            sourceTypes: List<SourceType> = listOf(SourceType.MONITOR),
+            startedTimeout: Long = DEFAULT_STARTED_TIMEOUT_MS,
+            shutdownGraceMillis: Long = DEFAULT_SHUTDOWN_GRACE_MS,
+            processExitTimeoutMillis: Long = DEFAULT_PROCESS_EXIT_TIMEOUT_MS,
+        ): WaylandPortalRecorder =
+            WaylandPortalRecorder(
+                helperExtractor,
+                processFactory,
+                sourceTypes,
+                startedTimeout,
+                shutdownGraceMillis,
+                processExitTimeoutMillis,
+            )
     }
 }
+
+// File-level private so the constant stays out of WaylandPortalRecorder's public JVM surface.
+// `private companion object const val` is JVM-public on the outer class; file-level `private`
+// compiles to a private static final on the synthetic Kt facade.
+private const val MALFORMED_LINE_PREVIEW_LENGTH: Int = 200
+
+internal const val DEFAULT_STARTED_TIMEOUT_MS: Long = 90_000
+internal const val DEFAULT_SHUTDOWN_GRACE_MS: Long = 30_000
+internal const val DEFAULT_PROCESS_EXIT_TIMEOUT_MS: Long = 5_000
+
+/**
+ * Force-kills [process] and waits up to [FORCED_REAP_TIMEOUT_MS] for the OS to reap it, then joins
+ * [readerThread] unbounded (the kill propagates EOF on the helper's stdout, so the reader
+ * terminates promptly). Throws [IllegalStateException] if the process is still alive after the
+ * forced-reap window — that should never happen with SIGKILL but is surfaced rather than silently
+ * leaked.
+ *
+ * Shared by every `start()` failure path so the contract is consistent: when a partial start
+ * throws, the helper process is reaped and the reader thread is gone before the exception
+ * propagates.
+ */
+internal fun killAndReapOrThrow(
+    process: Process,
+    readerThread: Thread,
+    pendingFailure: Throwable? = null,
+) {
+    process.destroyForcibly()
+    if (!process.waitFor(FORCED_REAP_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+        // Don't join the reader on this path — without a confirmed reap the helper could keep
+        // stdout open and the join would block indefinitely. The leak is logged via the
+        // exception below; this is a "should never happen with SIGKILL" diagnostic. If the
+        // caller is mid-failure-handling, the pending failure is attached as suppressed so the
+        // original cause stays visible.
+        val cleanupFailure =
+            IllegalStateException(
+                "spectre-wayland-helper did not exit within ${FORCED_REAP_TIMEOUT_MS}ms after " +
+                    "SIGKILL during a failed start. Helper process may be leaked."
+            )
+        if (pendingFailure != null) cleanupFailure.addSuppressed(pendingFailure)
+        throw cleanupFailure
+    }
+    readerThread.join()
+}
+
+internal const val FORCED_REAP_TIMEOUT_MS: Long = 2_000
 
 /**
  * Recording handle for the helper-process pair. `stop()` writes a Stop command, blocks until the
@@ -266,6 +369,8 @@ private class GstRecordingHandle(
     private val errorRef: AtomicReference<Event.Error?>,
     private val stoppedLatch: CountDownLatch,
     private val readerThread: Thread,
+    private val shutdownGraceMillis: Long,
+    private val processExitTimeoutMillis: Long,
 ) : RecordingHandle {
 
     private val stopInitiated = AtomicBoolean(false)
@@ -308,27 +413,40 @@ private class GstRecordingHandle(
         } catch (_: IOException) {
             // Helper may have already exited; the latch wait below confirms.
         }
-        if (!stoppedLatch.await(SHUTDOWN_GRACE_SECONDS, TimeUnit.SECONDS)) {
-            process.destroyForcibly()
-            throw IllegalStateException(
-                "spectre-wayland-helper did not emit Stopped within ${SHUTDOWN_GRACE_SECONDS}s " +
-                    "of stop(). Output at $output may be truncated or empty."
-            )
+        if (!stoppedLatch.await(shutdownGraceMillis, TimeUnit.MILLISECONDS)) {
+            // Helper ignored the Stop command. Force-kill, wait for the OS to reap, then join
+            // the reader (the kill propagates EOF on stdout so the join is guaranteed to
+            // return). Only after termination is confirmed do we throw — otherwise we'd leak
+            // the reader thread.
+            val stopTimeoutFailure =
+                IllegalStateException(
+                    "spectre-wayland-helper did not emit Stopped within ${shutdownGraceMillis}ms " +
+                        "of stop(). Output at $output may be truncated or empty."
+                )
+            killAndReapOrThrow(process, readerThread, stopTimeoutFailure)
+            throw stopTimeoutFailure
         }
         errorRef.get()?.let { err ->
+            // Error event during recording: drain reader, then surface. The helper exits on
+            // its own after an Error event, so the process should already be terminating.
+            waitForGracefulExitOrReap(process, readerThread)
             throw IllegalStateException(
                 "spectre-wayland-helper reported an error during recording: kind=${err.kind} " +
                     "message=${err.message}"
             )
         }
-        readerThread.join(READER_JOIN_TIMEOUT_MS)
-        if (!process.waitFor(PROCESS_EXIT_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            process.destroyForcibly()
-            throw IllegalStateException(
-                "spectre-wayland-helper did not exit within ${PROCESS_EXIT_TIMEOUT_SECONDS}s " +
-                    "after Stopped event. Output at $output may be in an undefined state."
-            )
+        // Stopped event received cleanly. Wait for the helper to exit, then join the reader
+        // unbounded (EOF on stdout follows process exit).
+        if (!process.waitFor(processExitTimeoutMillis, TimeUnit.MILLISECONDS)) {
+            val exitTimeoutFailure =
+                IllegalStateException(
+                    "spectre-wayland-helper did not exit within ${processExitTimeoutMillis}ms " +
+                        "after Stopped event. Output at $output may be in an undefined state."
+                )
+            killAndReapOrThrow(process, readerThread, exitTimeoutFailure)
+            throw exitTimeoutFailure
         }
+        readerThread.join()
         val exit = process.exitValue()
         if (exit != 0) {
             throw IllegalStateException(
@@ -339,9 +457,11 @@ private class GstRecordingHandle(
         }
     }
 
-    private companion object {
-        const val SHUTDOWN_GRACE_SECONDS: Long = 30
-        const val PROCESS_EXIT_TIMEOUT_SECONDS: Long = 5
-        const val READER_JOIN_TIMEOUT_MS: Long = 1_000
+    private fun waitForGracefulExitOrReap(process: Process, readerThread: Thread) {
+        if (!process.waitFor(processExitTimeoutMillis, TimeUnit.MILLISECONDS)) {
+            killAndReapOrThrow(process, readerThread)
+        } else {
+            readerThread.join()
+        }
     }
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorder.kt
@@ -73,11 +73,36 @@ interface WaylandWindowSourceRecorder {
  * window for the compositor to scope a window-source stream to.
  * [dev.sebastiano.spectre.recording.AutoRecorder] routes those automatically.
  */
-internal class WaylandPortalWindowRecorder(
-    private val delegate: dev.sebastiano.spectre.recording.Recorder =
-        WaylandPortalRecorder(sourceTypes = listOf(SourceType.WINDOW)),
-    private val frameExtentsLookup: (String) -> Insets? = ::queryGtkFrameExtentsViaXprop,
+public class WaylandPortalWindowRecorder
+private constructor(
+    private val delegate: dev.sebastiano.spectre.recording.Recorder,
+    private val frameExtentsLookup: (String) -> Insets?,
 ) : WaylandWindowSourceRecorder {
+
+    /**
+     * Default user-facing constructor. Wraps a [WaylandPortalRecorder] configured for
+     * `SourceType.WINDOW` and the system `xprop` lookup for GTK frame extents.
+     */
+    public constructor() :
+        this(
+            delegate =
+                WaylandPortalRecorder.createForInternalUse(sourceTypes = listOf(SourceType.WINDOW)),
+            frameExtentsLookup = ::queryGtkFrameExtentsViaXprop,
+        )
+
+    internal companion object {
+
+        /**
+         * In-module factory for tests. See [WaylandPortalRecorder.createForInternalUse] for the
+         * rationale on the `@JvmSynthetic` annotation.
+         */
+        @JvmSynthetic
+        internal fun createForInternalUse(
+            delegate: dev.sebastiano.spectre.recording.Recorder =
+                WaylandPortalRecorder.createForInternalUse(sourceTypes = listOf(SourceType.WINDOW)),
+            frameExtentsLookup: (String) -> Insets? = ::queryGtkFrameExtentsViaXprop,
+        ): WaylandPortalWindowRecorder = WaylandPortalWindowRecorder(delegate, frameExtentsLookup)
+    }
 
     /**
      * Start the window-targeted recording. The caller passes [window] and the [region] containing

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
@@ -119,6 +119,82 @@ class AutoRecorderTest {
     }
 
     @Test
+    fun `Wayland portal construction failure logs warning on the fallback path`() {
+        // Wayland session detected, both portal recorder slots null because their construction
+        // failed at AutoRecorder init time. The router falls through to ffmpeg (which will
+        // itself fail loudly on a real Wayland session), but before that we want one stderr
+        // line naming the underlying portal failure so the user knows what to fix.
+        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
+        val ffmpeg = StubFfmpegRecorder()
+        val failure = IllegalStateException("dbus-launch not found on PATH")
+        val recorder =
+            autoRecorder(
+                sckRecorder = sck,
+                ffmpegRecorder = ffmpeg,
+                waylandPortalRecorder = null,
+                waylandPortalWindowRecorder = null,
+                waylandPortalRecorderFailure = failure,
+                waylandPortalWindowRecorderFailure = failure,
+                isMacOs = { false },
+                isWayland = { true },
+            )
+        val output = tempMov()
+        val originalErr = System.err
+        val captured = ByteArrayOutputStream()
+        System.setErr(PrintStream(captured))
+        try {
+            recorder.start(window = null, region = Rectangle(0, 0, 100, 100), output = output)
+        } finally {
+            System.setErr(originalErr)
+            output.deleteIfExists()
+        }
+        val warning = captured.toString(Charsets.UTF_8)
+        assertTrue(
+            warning.contains("AutoRecorder", ignoreCase = true) &&
+                warning.contains("Wayland portal recorder unavailable", ignoreCase = true) &&
+                warning.contains("dbus-launch not found"),
+            "Expected Wayland fallback warning naming the underlying cause, got: $warning",
+        )
+    }
+
+    @Test
+    fun `Wayland portal fallback warning fires at most once per AutoRecorder instance`() {
+        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
+        val ffmpeg = StubFfmpegRecorder()
+        val recorder =
+            autoRecorder(
+                sckRecorder = sck,
+                ffmpegRecorder = ffmpeg,
+                waylandPortalRecorder = null,
+                waylandPortalWindowRecorder = null,
+                waylandPortalRecorderFailure = IllegalStateException("dbus-launch missing"),
+                waylandPortalWindowRecorderFailure = IllegalStateException("dbus-launch missing"),
+                isMacOs = { false },
+                isWayland = { true },
+            )
+        val outputs = listOf(tempMov(), tempMov())
+        val originalErr = System.err
+        val captured = ByteArrayOutputStream()
+        System.setErr(PrintStream(captured))
+        try {
+            outputs.forEach {
+                recorder.start(window = null, region = Rectangle(0, 0, 100, 100), output = it)
+            }
+        } finally {
+            System.setErr(originalErr)
+            outputs.forEach { it.deleteIfExists() }
+        }
+        val warning = captured.toString(Charsets.UTF_8)
+        val occurrences = warning.split("Wayland portal recorder unavailable").size - 1
+        assertEquals(
+            1,
+            occurrences,
+            "Expected the Wayland fallback warning to fire exactly once across repeated " +
+                "start() calls; saw $occurrences. Full stderr: $warning",
+        )
+    }
+
+    @Test
     fun `helper-not-bundled fallback writes a warning to stderr so the degradation is visible`() {
         val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.HelperNotBundled)
         val ffmpeg = StubFfmpegRecorder()
@@ -427,6 +503,8 @@ private fun autoRecorder(
     windowsWindowRecorder: WindowRecorder? = null,
     waylandPortalRecorder: Recorder? = null,
     waylandPortalWindowRecorder: WaylandWindowSourceRecorder? = null,
+    waylandPortalRecorderFailure: Throwable? = null,
+    waylandPortalWindowRecorderFailure: Throwable? = null,
     isMacOs: () -> Boolean,
     isWindows: () -> Boolean = { false },
     isWayland: () -> Boolean = { false },
@@ -437,6 +515,8 @@ private fun autoRecorder(
         windowsWindowRecorder,
         waylandPortalRecorder,
         waylandPortalWindowRecorder,
+        waylandPortalRecorderFailure,
+        waylandPortalWindowRecorderFailure,
         isMacOs,
         isWindows,
         isWayland,

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorderLifecycleTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorderLifecycleTest.kt
@@ -1,0 +1,402 @@
+package dev.sebastiano.spectre.recording.portal
+
+import dev.sebastiano.spectre.recording.RecordingOptions
+import java.awt.Rectangle
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Fake-process lifecycle coverage for [WaylandPortalRecorder]. The recorder talks to the helper
+ * over stdin/stdout via newline-delimited JSON; this test stands up a [FakeHelperProcess] that lets
+ * the test write events and observe the recorder's stop/force-kill behaviour without ever exec'ing
+ * the real Rust helper binary.
+ *
+ * Every test that exercises a failed-start path asserts both `destroyForcibly()` and `waitFor`
+ * actually ran — the recorder's contract is that a failed start reaps the helper before propagating
+ * the exception, not just that it called `destroyForcibly()`.
+ */
+class WaylandPortalRecorderLifecycleTest {
+
+    private val tempOutputs = mutableListOf<Path>()
+    private val helperTempDir: Path = Files.createTempDirectory("spectre-r2-helper")
+
+    @AfterTest
+    fun cleanup() {
+        tempOutputs.forEach { it.deleteIfExists() }
+        helperTempDir.toFile().deleteRecursively()
+    }
+
+    @Test
+    fun `start happy path returns a handle when helper emits Started`() {
+        val fake = FakeHelperProcess()
+        val recorder = recorder(fake)
+        val handle = fake.runStartConcurrently { recorder.start(REGION, output(), OPTIONS) }
+
+        // Recorder waited for Started; on receipt, returned a usable handle. The reader thread
+        // is still running, the process is still alive.
+        assertTrue(handle.output.toString().isNotBlank())
+        assertEquals(false, fake.destroyForciblyCalled.get())
+        assertEquals(true, fake.isAlive())
+        // Stop the recording so the test doesn't leave a thread/process running.
+        fake.runStopConcurrently { handle.stop() }
+    }
+
+    @Test
+    fun `start fails clearly when helper emits Error before Started`() {
+        val fake = FakeHelperProcess()
+        val recorder = recorder(fake)
+        val error =
+            assertFailsWith<IllegalStateException> {
+                fake.runStartWithError { recorder.start(REGION, output(), OPTIONS) }
+            }
+        assertTrue(
+            error.message!!.contains("reported an error before recording could start"),
+            "wrong error message: ${error.message}",
+        )
+        assertReapedAfterFailedStart(fake)
+    }
+
+    @Test
+    fun `start fails when helper closes stdout before Started`() {
+        val fake = FakeHelperProcess()
+        val recorder = recorder(fake)
+        val error =
+            assertFailsWith<IllegalStateException> {
+                fake.runStartWithEofBeforeStarted { recorder.start(REGION, output(), OPTIONS) }
+            }
+        assertTrue(
+            error.message!!.contains("reported an error before recording could start"),
+            "wrong error message: ${error.message}",
+        )
+        assertReapedAfterFailedStart(fake)
+    }
+
+    @Test
+    fun `start fails when helper writes nothing within startedTimeout`() {
+        val fake = FakeHelperProcess()
+        // 50ms timeout — the fake helper writes nothing, so the recorder must time out.
+        val recorder = recorder(fake, startedTimeout = 50L)
+        val error =
+            assertFailsWith<IllegalStateException> { recorder.start(REGION, output(), OPTIONS) }
+        assertTrue(
+            error.message!!.contains("did not emit a Started or Error event within 50ms"),
+            "wrong error message: ${error.message}",
+        )
+        assertReapedAfterFailedStart(fake)
+    }
+
+    @Test
+    fun `stop happy path waits for Stopped and validates exit code`() {
+        val fake = FakeHelperProcess()
+        val recorder = recorder(fake)
+        val handle = fake.runStartConcurrently { recorder.start(REGION, output(), OPTIONS) }
+        fake.runStopConcurrently { handle.stop() }
+        assertEquals(true, handle.isStopped)
+        assertEquals(false, fake.destroyForciblyCalled.get(), "graceful stop must not force-kill")
+        assertEquals(false, fake.isAlive())
+    }
+
+    @Test
+    fun `stop force-kills and reaps when helper ignores the Stop command`() {
+        val fake = FakeHelperProcess()
+        // 0s grace so the test doesn't wait the production 30s. Inject via the internal seam
+        // — production callers can't reach this constant.
+        val recorder = recorder(fake, shutdownGraceMillis = 0L)
+        val handle = fake.runStartConcurrently { recorder.start(REGION, output(), OPTIONS) }
+
+        // Don't call completeStop() — the fake helper stays alive and silent. Recorder must
+        // hit the grace timeout, force-kill, reap, and throw a clear error.
+        val error = assertFailsWith<IllegalStateException> { handle.stop() }
+        assertTrue(
+            error.message!!.contains("did not emit Stopped within"),
+            "wrong error message: ${error.message}",
+        )
+        assertEquals(true, fake.destroyForciblyCalled.get(), "stop timeout must force-kill")
+        assertEquals(false, fake.isAlive(), "process must be reaped before stop() returns")
+    }
+
+    @Test
+    fun `stop is idempotent`() {
+        val fake = FakeHelperProcess()
+        val recorder = recorder(fake)
+        val handle = fake.runStartConcurrently { recorder.start(REGION, output(), OPTIONS) }
+        fake.runStopConcurrently { handle.stop() }
+        // Second stop is a no-op; should not re-touch the (already exited) fake process.
+        handle.stop()
+        assertEquals(true, handle.isStopped)
+    }
+
+    private fun output(): Path = Files.createTempFile("spectre-r2", ".mp4").also(tempOutputs::add)
+
+    private fun recorder(
+        fake: FakeHelperProcess,
+        startedTimeout: Long = 5_000L,
+        shutdownGraceMillis: Long = 5_000L,
+        processExitTimeoutMillis: Long = 5_000L,
+    ): WaylandPortalRecorder =
+        WaylandPortalRecorder.createForInternalUse(
+            helperExtractor = fakeHelperBinaryExtractor(helperTempDir),
+            processFactory = FakeProcessFactory(fake),
+            sourceTypes = listOf(SourceType.MONITOR),
+            startedTimeout = startedTimeout,
+            shutdownGraceMillis = shutdownGraceMillis,
+            processExitTimeoutMillis = processExitTimeoutMillis,
+        )
+
+    private fun assertReapedAfterFailedStart(fake: FakeHelperProcess) {
+        assertEquals(
+            true,
+            fake.destroyForciblyCalled.get(),
+            "failed start must call destroyForcibly()",
+        )
+        assertEquals(true, fake.waitForCalled.get(), "failed start must waitFor after force-kill")
+        assertEquals(false, fake.isAlive(), "failed start must reap the process before throwing")
+    }
+
+    private companion object {
+        val REGION: Rectangle = Rectangle(0, 0, 100, 100)
+        val OPTIONS: RecordingOptions = RecordingOptions()
+    }
+}
+
+/**
+ * Builds a real [WaylandHelperBinaryExtractor] whose classpath lookup returns an empty
+ * `InputStream`. `extract()` then copies that empty stream to a temp file, marks it executable, and
+ * returns the path — enough to satisfy the recorder, without needing the actual Rust helper binary
+ * on the classpath.
+ */
+private fun fakeHelperBinaryExtractor(tempDir: Path): WaylandHelperBinaryExtractor =
+    WaylandHelperBinaryExtractor(
+        envLookup = { null },
+        resourceLocator = { ByteArrayInputStream(ByteArray(0)) },
+        targetDirProvider = { tempDir },
+        archProvider = { "x86_64" },
+    )
+
+private class FakeProcessFactory(private val process: FakeHelperProcess) :
+    WaylandPortalRecorder.ProcessFactory {
+    override fun start(helperPath: Path): Process = process
+}
+
+/**
+ * A [Process] stand-in that the test drives directly: events go through [emit]; stop is observed
+ * via [waitForStopCommand]; reaping is exposed via [destroyForciblyCalled] / [waitForCalled].
+ *
+ * Writes Started/Stopped/Error JSON to its stdout pipe via [emit] so the recorder's reader thread
+ * parses real protocol events.
+ */
+private class FakeHelperProcess : Process() {
+
+    /**
+     * Stdout buffer that the recorder's reader thread reads from. Backed by a blocking queue of
+     * bytes (one per chunk) and an EOF sentinel — this avoids `PipedOutputStream`'s requirement
+     * that the writer thread stay alive, which would crash the reader the moment a short-lived
+     * emitter daemon thread exited.
+     */
+    private val stdoutQueue = LinkedBlockingQueue<ByteArray>()
+    private val helperStdout: InputStream =
+        object : InputStream() {
+            private var current: ByteArray? = null
+            private var offset: Int = 0
+
+            override fun read(): Int {
+                while (true) {
+                    val c = current
+                    if (c != null && offset < c.size) {
+                        return c[offset++].toInt() and 0xff
+                    }
+                    val next = stdoutQueue.take()
+                    if (next.isEmpty()) return -1 // EOF sentinel
+                    current = next
+                    offset = 0
+                }
+            }
+
+            override fun read(buf: ByteArray, off: Int, len: Int): Int {
+                // Critical override: java.io.InputStream's default vectored read blocks the
+                // BufferedReader's fill() in a per-byte loop until it has `len` bytes or EOF.
+                // With our LinkedBlockingQueue cadence, that means BufferedReader keeps
+                // calling our read() past the end of the current chunk, hangs on take(), and
+                // never returns the partial line it has buffered — so the recorder's
+                // startedLatch never fires. Drain only what's immediately available after the
+                // first byte: the caller (StreamDecoder) gets the newline-terminated chunk
+                // and readLine() can return.
+                if (len == 0) return 0
+                val first = read()
+                if (first == -1) return -1
+                buf[off] = first.toByte()
+                var i = 1
+                val cached = current
+                if (cached != null) {
+                    val drain = minOf(len - i, cached.size - offset)
+                    if (drain > 0) {
+                        System.arraycopy(cached, offset, buf, off + i, drain)
+                        offset += drain
+                        i += drain
+                    }
+                }
+                return i
+            }
+        }
+    private val helperStdin = ByteArrayOutputStream()
+    private val helperStderr = ByteArrayInputStream(ByteArray(0))
+    private val terminated = AtomicBoolean(false)
+    private val terminationLatch = CountDownLatch(1)
+    private val stopCommandLatch = CountDownLatch(1)
+
+    val destroyForciblyCalled = AtomicBoolean(false)
+    val waitForCalled = AtomicBoolean(false)
+
+    override fun getOutputStream(): OutputStream =
+        object : OutputStream() {
+            override fun write(b: Int) {
+                helperStdin.write(b)
+            }
+
+            override fun write(b: ByteArray, off: Int, len: Int) {
+                helperStdin.write(b, off, len)
+            }
+
+            override fun close() {
+                // The recorder closes stdin after writing its Stop command. The helper
+                // protocol explicitly treats stdin EOF as a Stop signal (belt-and-braces for
+                // buffered writes), so this is the right cue regardless of whether the
+                // bulk-write happened to deliver the JSON line in one chunk or many.
+                stopCommandLatch.countDown()
+            }
+        }
+
+    override fun getInputStream(): InputStream = helperStdout
+
+    override fun getErrorStream(): InputStream = helperStderr
+
+    override fun waitFor(): Int {
+        waitForCalled.set(true)
+        terminationLatch.await()
+        return EXIT_OK
+    }
+
+    override fun waitFor(timeout: Long, unit: TimeUnit): Boolean {
+        waitForCalled.set(true)
+        return terminationLatch.await(timeout, unit)
+    }
+
+    override fun exitValue(): Int {
+        if (!terminated.get()) throw IllegalThreadStateException("fake helper still alive")
+        return EXIT_OK
+    }
+
+    override fun isAlive(): Boolean = !terminated.get()
+
+    override fun destroy() {
+        markTerminated()
+    }
+
+    override fun destroyForcibly(): Process {
+        destroyForciblyCalled.set(true)
+        markTerminated()
+        return this
+    }
+
+    private fun markTerminated() {
+        if (terminated.compareAndSet(false, true)) {
+            terminationLatch.countDown()
+            // Push EOF sentinel so the recorder's reader thread sees EOF and exits the loop.
+            stdoutQueue.add(ByteArray(0))
+        }
+    }
+
+    /**
+     * Run [block] (the recorder's `start(...)`) on the calling thread while another thread emits a
+     * `Started` event so `start()` can return. Returns the resulting handle.
+     */
+    fun <T> runStartConcurrently(block: () -> T): T {
+        val emitter =
+            Thread({
+                Thread.sleep(EVENT_EMIT_DELAY_MS)
+                emit(STARTED_EVENT)
+            })
+        emitter.isDaemon = true
+        emitter.start()
+        return block()
+    }
+
+    /** Emits an Error event so the recorder's start fails. */
+    fun <T> runStartWithError(block: () -> T): T {
+        val emitter =
+            Thread({
+                Thread.sleep(EVENT_EMIT_DELAY_MS)
+                emit(ERROR_EVENT)
+            })
+        emitter.isDaemon = true
+        emitter.start()
+        return block()
+    }
+
+    /**
+     * Closes stdout without emitting Started — recorder synthesises an EOF-before-Started error.
+     */
+    fun <T> runStartWithEofBeforeStarted(block: () -> T): T {
+        val emitter =
+            Thread({
+                Thread.sleep(EVENT_EMIT_DELAY_MS)
+                // Push EOF without marking the process terminated yet — the recorder's
+                // failed-start path is what's expected to reap it.
+                stdoutQueue.add(ByteArray(0))
+            })
+        emitter.isDaemon = true
+        emitter.start()
+        return block()
+    }
+
+    /**
+     * Runs [block] (the caller's `handle.stop()`) on the calling thread while a daemon thread waits
+     * for the recorder's Stop command, then emits a Stopped event and marks the fake process
+     * terminated. The two have to overlap because `handle.stop()` blocks on the stoppedLatch until
+     * our emit fires; calling `completeStop()` *before* `handle.stop()` deadlocks waiting for a
+     * Stop command the recorder hasn't sent yet.
+     */
+    fun <T> runStopConcurrently(block: () -> T): T {
+        val stopper =
+            Thread({
+                if (stopCommandLatch.await(STOP_WAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    emit(STOPPED_EVENT)
+                    markTerminated()
+                }
+            })
+        stopper.isDaemon = true
+        stopper.start()
+        return block().also { stopper.join() }
+    }
+
+    private fun emit(line: String) {
+        stdoutQueue.add((line + "\n").toByteArray(StandardCharsets.UTF_8))
+    }
+
+    private companion object {
+        const val EVENT_EMIT_DELAY_MS: Long = 25
+        const val STOP_WAIT_TIMEOUT_MS: Long = 5_000
+        const val EXIT_OK: Int = 0
+        const val STARTED_EVENT: String =
+            "{\"event\":\"started\",\"node_id\":42,\"stream_size\":[100,100]," +
+                "\"stream_position\":[0,0],\"gst_pid\":1}"
+        const val ERROR_EVENT: String =
+            "{\"event\":\"error\",\"kind\":\"PortalRejected\",\"message\":\"user dismissed\"}"
+        const val STOPPED_EVENT: String = "{\"event\":\"stopped\",\"output_size_bytes\":1024}"
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorderTest.kt
@@ -23,7 +23,7 @@ class WaylandPortalWindowRecorderTest {
         // window-aligned mp4. Verify the recorder forwards the stream-relative crop.
         val captured = StubRecorderCapture()
         val recorder =
-            WaylandPortalWindowRecorder(
+            WaylandPortalWindowRecorder.createForInternalUse(
                 delegate = captured.asWaylandPortalRecorder(),
                 frameExtentsLookup = {
                     Insets(/* top= */ 25, /* left= */ 25, /* bottom= */ 25, /* right= */ 25)
@@ -51,7 +51,7 @@ class WaylandPortalWindowRecorderTest {
         // instead so the failure mode is visible.
         val captured = StubRecorderCapture()
         val recorder =
-            WaylandPortalWindowRecorder(
+            WaylandPortalWindowRecorder.createForInternalUse(
                 delegate = captured.asWaylandPortalRecorder(),
                 frameExtentsLookup = { null },
             )
@@ -88,7 +88,7 @@ class WaylandPortalWindowRecorderTest {
         // region path (WaylandPortalRecorder), which AutoRecorder routes for null windows.
         val captured = StubRecorderCapture()
         val recorder =
-            WaylandPortalWindowRecorder(
+            WaylandPortalWindowRecorder.createForInternalUse(
                 delegate = captured.asWaylandPortalRecorder(),
                 frameExtentsLookup = { error("should not be called") },
             )


### PR DESCRIPTION
## Summary

Second implementation bucket of the release hardening epic (#114). Makes the Wayland portal recorders publicly constructible, surfaces the underlying construction failure when `AutoRecorder` falls back through the Wayland path, and brings `WaylandPortalRecorder`'s process lifecycle to parity with the other recorder backends.

- **Public surface:** `WaylandPortalRecorder` and `WaylandPortalWindowRecorder` are now `public class` with a single public no-arg constructor each. The multi-arg seam constructor is `private`; in-module callers go through `@JvmSynthetic internal fun createForInternalUse(...)`. The helper extractor, process factory, source types, JSON protocol types, and xprop lookup all stay internal.
- **Strict direct-use contract documented:** KDoc on `WaylandPortalRecorder` makes explicit that direct instantiation fails with precise `IllegalStateException` on missing helper / portal — never a silent no-op. `AutoRecorder` owns the fallback policy.
- **Wayland fallback warning:** New internal `WaylandPortalRecorders` holder captures both portal recorders + any construction failures. `AutoRecorder` emits a single stderr line naming the underlying failure when Wayland is detected but the portal slots are unwired, then falls through to ffmpeg. Warn-once per instance via `AtomicBoolean`.
- **Lifecycle parity:** new `killAndReapOrThrow(process, reader, pendingFailure?)` helper. Every failed start and force-kill path now does `destroyForcibly()` → bounded `waitFor` → unbounded `readerThread.join()`. If reap fails, the resulting exception attaches the caller's pending failure via `addSuppressed` so the original cause stays visible.

## Tests

- New `WaylandPortalRecorderLifecycleTest`: 7 fake-process cases (start happy / Error / EOF / timeout, stop happy / force-kill+reap, idempotent stop). Every failure path asserts `destroyForcibly()` **and** `waitFor`-based reap, not just `destroyForcibly()`.
- `AutoRecorderTest` gains two cases: stderr warning fires with the underlying cause; warn-once across repeated `start()` calls.
- `WaylandPortalWindowRecorderTest` migrated to the new internal factory.

No user-facing docs touched — the recorder capability matrix and KDoc polish remain R6 territory.

## Test plan

- [ ] CI: `./gradlew check` passes (detekt + ktfmt + tests)
- [ ] CI: Linux runner exercises the recording module tests
- [ ] Local: javap -public confirms the seam constructors are now synthetic accessors with `DefaultConstructorMarker`, and `MALFORMED_LINE_PREVIEW_LENGTH` no longer appears on the public surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)