### PR TITLE
Add verifyBundledRecordingHelpers task and developer build matrix (R3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,19 +102,11 @@ jobs:
         # contributor builds without the cross toolchain still pass `check` cleanly. When
         # #84's publish pipeline lands, the release job will pass `-PallLinuxArches` so
         # `processResources` bundles both arches into the published jar.
-        run: |
-          ./gradlew :recording:assembleWaylandHelperAllArches
-          for arch in x86_64 aarch64; do
-            bin="recording/build/generated/waylandHelper/native/linux/$arch/spectre-wayland-helper"
-            if [ ! -f "$bin" ]; then
-              echo "::error::Missing per-arch helper binary: $bin"
-              exit 1
-            fi
-            machine=$(readelf -h "$bin" | awk -F: '/Machine:/{print $2}' | xargs)
-            case "$arch:$machine" in
-              "x86_64:Advanced Micro Devices X86-64") ;;
-              "aarch64:AArch64") ;;
-              *) echo "::error::$bin reports ELF machine '$machine' (expected $arch)"; exit 1 ;;
-            esac
-            echo "$bin → $machine ✓"
-          done
+        #
+        # `-PallLinuxArches` makes `processResources` depend on the cross-arch staging task
+        # and `verifyBundledRecordingHelpers` expect both arches in `build/resources/main`.
+        # The verify task parses each ELF header in-JVM (no `readelf` dependency) and
+        # asserts the e_machine field matches the expected arch — same assertion strength
+        # as the previous shell loop, now reusable from any host that wants to sanity-check
+        # a build.
+        run: ./gradlew :recording:assembleWaylandHelperAllArches :recording:verifyBundledRecordingHelpers -PallLinuxArches

--- a/recording/README.md
+++ b/recording/README.md
@@ -225,3 +225,67 @@ returns a human-readable summary you can dump at startup to surface this to deve
 
 The SCK helper is a child process, so it inherits the host JVM's TCC grant — no separate
 permission grant needed for it.
+
+## Build matrix: which helpers each host can produce
+
+Spectre's recording module ships two native helpers — the macOS ScreenCaptureKit helper
+(Swift, requires `swiftc` + macOS frameworks) and the Linux Wayland helper (Rust, requires
+`cargo` + `libdbus-1-dev`). Neither toolchain works cross-host, so a single build host
+can only produce a subset of helpers. The recording jar's layout is host-agnostic — the
+non-producible directories are simply empty or absent depending on Gradle's jar-packing
+behavior — and the recorder gates on resource presence at runtime, throwing
+`HelperNotBundledException` with a clear message when the helper its current backend
+needs is missing.
+
+| Host                | Default `./gradlew :recording:build`                                 | `-PuniversalHelper`               | `-PallLinuxArches`                                      |
+| ------------------- | -------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------- |
+| macOS (arm64)       | host-arch SCK (`native/macos/spectre-screencapture` thin arm64)      | universal SCK (arm64 + x86_64)    | no-op (host can't build Wayland helper)                 |
+| macOS (x86_64)      | host-arch SCK (thin x86_64)                                          | universal SCK (arm64 + x86_64)    | no-op (same)                                            |
+| Linux x86_64        | host-arch Wayland (`native/linux/x86_64/spectre-wayland-helper`)     | no-op (host can't build SCK)      | x86_64 + aarch64 Wayland helpers                        |
+| Linux aarch64       | host-arch Wayland (`native/linux/aarch64/spectre-wayland-helper`)    | no-op (same)                      | x86_64 + aarch64 Wayland helpers                        |
+| Windows             | (no helpers produced)                                                | no-op                             | no-op                                                   |
+
+### Project-property reference
+
+- `-PuniversalHelper` — on macOS hosts, build the SCK helper as a universal arm64+x86_64
+  binary via `lipo -create`. Off by default to keep contributor builds fast; on for
+  distribution.
+- `-PnotarizeScreenCaptureKitHelper` — implies `-PuniversalHelper`. Codesigns the
+  universal helper, archives it, and submits it to Apple notarization via
+  `xcrun notarytool`. Only used by the release workflow; needs Developer ID + notary
+  credentials in env vars.
+- `-PallLinuxArches` — on Linux hosts, cross-compile both `x86_64` and `aarch64` Wayland
+  helpers from a single host. Requires the Rust `rustup target add` for the foreign
+  arch and the matching cross-linker (`gcc-aarch64-linux-gnu` / `gcc-x86_64-linux-gnu`)
+  plus the foreign-arch `libdbus-1-dev` sysroot. The CI workflow at
+  `.github/workflows/ci.yml` installs all of these on the Linux runner.
+
+### Verifying bundled helpers
+
+`./gradlew :recording:check` runs `verifyBundledRecordingHelpers`, which inspects the
+recording jar's staged resources and asserts the helpers that *should* be there given
+the current host + project-property combination actually are, and that each one matches
+its expected arch (lipo for the macOS helper, JVM-side ELF header parse for the Linux
+helper). The task is verification-only — it never triggers a universal or cross-arch
+build that wasn't already requested.
+
+When `-PallLinuxArches` is set the task expects both `x86_64` and `aarch64` Wayland
+helpers. CI invokes it as
+
+    ./gradlew :recording:assembleWaylandHelperAllArches :recording:verifyBundledRecordingHelpers -PallLinuxArches
+
+to lock in both-arch coverage explicitly.
+
+### Publishing intent (not yet implemented — gated on #84)
+
+The eventual publish flow merges artifacts from two release runners:
+
+- A macOS runner builds the SCK helper with `-PuniversalHelper -PnotarizeScreenCaptureKitHelper`
+  so `native/macos/spectre-screencapture` carries a notarized universal binary.
+- A Linux runner builds the Wayland helpers with `-PallLinuxArches` so
+  `native/linux/<arch>/spectre-wayland-helper` carries both supported architectures.
+
+The merged jar then has the full helper set regardless of which platform a downstream
+consumer runs Spectre on. Until #84's publish pipeline lands, building locally produces
+a host-shaped subset of helpers — useful for development, not yet a distribution
+artifact.

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -1,5 +1,9 @@
+import java.io.ByteArrayOutputStream
+import java.io.RandomAccessFile
+import javax.inject.Inject
 import org.gradle.api.GradleException
 import org.gradle.internal.os.OperatingSystem
+import org.gradle.process.ExecOperations
 
 /**
  * Maps the host's `os.arch` system property to the Rust target-triple architecture name we ship the
@@ -676,3 +680,194 @@ tasks.register<JavaExec>("runWaylandPortalWindowSmoke") {
     standardOutput = System.out
     errorOutput = System.err
 }
+
+// --- Bundled helper artifact verification (R3) -----------------------------------------------
+//
+// `verifyBundledRecordingHelpers` is the single entry point that asserts the recording jar
+// being built actually contains the helpers it claims to. The task's expectations are computed
+// from the host OS + project properties at configuration time:
+//
+//   - macOS host, default                : expect host-arch SCK helper, `lipo -verify_arch
+// <host-arch>`.
+//   - macOS host + `-PuniversalHelper`   : expect universal SCK helper, `lipo -verify_arch arm64
+// x86_64`.
+//   - Linux host, default                : expect host-arch Wayland helper, JVM-side ELF parse.
+//   - Linux host + `-PallLinuxArches`    : expect both x86_64 + aarch64 Wayland helpers, JVM-side
+// ELF
+//                                          parse for each.
+//   - Other hosts (Windows etc.)         : no expectations, task is a no-op success.
+//
+// Verification only — the task depends on `processResources` and inspects whatever was already
+// staged. It deliberately does NOT depend on `lipoScreenCaptureKitHelper` /
+// `assembleScreenCaptureKitHelperUniversal` / `assembleWaylandHelperAllArches` directly, so
+// running `./gradlew check` on macOS without `-PuniversalHelper` does not trigger a universal
+// build. The same project-property switches that drive `processResources` (above) drive the
+// task's expectations in parallel.
+//
+// The Linux ELF parse is JVM-side (no `readelf` dependency, works on every dev host where this
+// task might run for sanity-checking). The macOS check shells out to `lipo` because lipo only
+// runs on macOS anyway, and the existing `verifyUniversalScreenCaptureKitHelper` pattern
+// proves it. ELF magic + `e_machine` is the entirety of the parse — see the constants in
+// `VerifyBundledRecordingHelpers` for the per-arch machine fields.
+
+/**
+ * Reports which helper artifacts should be in the recording jar and verifies each. Expectations are
+ * configured at task-registration time from the host OS + project properties; the action itself
+ * just walks the list and fails fast on the first missing or wrong-arch helper.
+ */
+abstract class VerifyBundledRecordingHelpers
+@Inject
+constructor(private val execOperations: ExecOperations) : DefaultTask() {
+
+    /** Directory `processResources` writes into. Helper paths are resolved relative to this. */
+    @get:InputDirectory abstract val resourcesDir: DirectoryProperty
+
+    /**
+     * macOS architectures expected in `native/macos/spectre-screencapture`. Empty list means "no
+     * macOS expectation" (e.g. running on Linux/Windows). One arch = host-arch build; two arches =
+     * universal build (the order matters only for the error message — `lipo -verify_arch` requires
+     * all listed arches to be present).
+     */
+    @get:Input abstract val expectedMacOsArchs: ListProperty<String>
+
+    /**
+     * Linux architectures expected in `native/linux/<arch>/spectre-wayland-helper`. Empty means "no
+     * Linux expectation". `["x86_64"]` or `["aarch64"]` = host-arch; `["x86_64", "aarch64"]` =
+     * `-PallLinuxArches`.
+     */
+    @get:Input abstract val expectedLinuxArches: ListProperty<String>
+
+    @TaskAction
+    fun verify() {
+        val errors = mutableListOf<String>()
+        val macOsArchs = expectedMacOsArchs.get()
+        if (macOsArchs.isNotEmpty()) {
+            verifyMacOsHelper(macOsArchs)?.let(errors::add)
+        }
+        for (arch in expectedLinuxArches.get()) {
+            verifyLinuxHelper(arch)?.let(errors::add)
+        }
+        if (errors.isNotEmpty()) {
+            throw GradleException(
+                "Recording helper verification failed:\n" + errors.joinToString("\n") { "  - $it" }
+            )
+        }
+    }
+
+    private fun verifyMacOsHelper(expectedArchs: List<String>): String? {
+        val helperPath = "native/macos/spectre-screencapture"
+        val file = resourcesDir.file(helperPath).get().asFile
+        if (!file.isFile) {
+            return "Expected macOS helper missing at $helperPath (resolved to ${file.absolutePath})"
+        }
+        // `lipo -verify_arch <arch>...` exits 0 only if EVERY listed arch is present in the
+        // binary. Works for both thin (single-arch) and fat (universal) binaries. The macOS
+        // universal helper task already uses this — see verifyUniversalScreenCaptureKitHelper.
+        val stdout = ByteArrayOutputStream()
+        val stderr = ByteArrayOutputStream()
+        val result = execOperations.exec {
+            commandLine(
+                buildList {
+                    add("lipo")
+                    add(file.absolutePath)
+                    add("-verify_arch")
+                    addAll(expectedArchs)
+                }
+            )
+            standardOutput = stdout
+            errorOutput = stderr
+            isIgnoreExitValue = true
+        }
+        if (result.exitValue != 0) {
+            return "lipo -verify_arch ${expectedArchs.joinToString(" ")} failed for " +
+                "${file.absolutePath}: exit=${result.exitValue} stdout=${stdout.toString().trim()} " +
+                "stderr=${stderr.toString().trim()}"
+        }
+        return null
+    }
+
+    private fun verifyLinuxHelper(expectedArch: String): String? {
+        val relative = "native/linux/$expectedArch/spectre-wayland-helper"
+        val file = resourcesDir.file(relative).get().asFile
+        if (!file.isFile) {
+            return "Expected Linux helper missing at $relative (resolved to ${file.absolutePath})"
+        }
+        val expectedMachine =
+            ELF_MACHINE_BY_ARCH[expectedArch]
+                ?: return "Unknown expected Linux arch '$expectedArch' for $relative"
+        val header = ByteArray(ELF_HEADER_PREFIX_BYTES)
+        RandomAccessFile(file, "r").use { raf ->
+            if (raf.length() < ELF_HEADER_PREFIX_BYTES) {
+                return "File too short to be ELF ($file)"
+            }
+            raf.readFully(header)
+        }
+        if (
+            header[0].toInt() and 0xff != 0x7F ||
+                header[1] != 'E'.code.toByte() ||
+                header[2] != 'L'.code.toByte() ||
+                header[3] != 'F'.code.toByte()
+        ) {
+            return "Not an ELF file (bad magic) at ${file.absolutePath}"
+        }
+        // ELF spec: e_machine is a 2-byte little-endian field at offset 18.
+        val machine =
+            (header[ELF_E_MACHINE_OFFSET].toInt() and 0xff) or
+                ((header[ELF_E_MACHINE_OFFSET + 1].toInt() and 0xff) shl 8)
+        if (machine != expectedMachine) {
+            return "Expected e_machine=0x${expectedMachine.toString(16)} ($expectedArch) " +
+                "but ELF reports 0x${machine.toString(16)} at ${file.absolutePath}"
+        }
+        return null
+    }
+
+    companion object {
+        private const val ELF_HEADER_PREFIX_BYTES: Int = 20
+        private const val ELF_E_MACHINE_OFFSET: Int = 18
+        // e_machine constants from the ELF spec. Stable for the lifetime of the ABI.
+        private const val EM_X86_64: Int = 0x3E
+        private const val EM_AARCH64: Int = 0xB7
+        private val ELF_MACHINE_BY_ARCH: Map<String, Int> =
+            mapOf("x86_64" to EM_X86_64, "aarch64" to EM_AARCH64)
+    }
+}
+
+val verifyBundledRecordingHelpers by
+    tasks.registering(VerifyBundledRecordingHelpers::class) {
+        description =
+            "Verifies the recording jar contains the native helpers it should, per host OS and " +
+                "project-property selection (-PuniversalHelper, -PallLinuxArches). Inspection " +
+                "only — does not trigger universal SCK or all-arches Wayland builds."
+        group = "verification"
+        // Read whatever processResources staged. Depending on the project flags, that's either
+        // host-arch or the wider distribution build — the expectations below stay in sync.
+        dependsOn(tasks.named("processResources"))
+        resourcesDir.set(layout.buildDirectory.dir("resources/main"))
+
+        val os = OperatingSystem.current()
+        // macOS expectations. `useUniversalHelper` (declared above) is true when
+        // `-PuniversalHelper` or `-PnotarizeScreenCaptureKitHelper` is set. The host-arch case
+        // uses `lipo -verify_arch <host-arch>`; lipo handles thin binaries fine.
+        val macOsArchs: List<String> =
+            when {
+                !os.isMacOsX -> emptyList()
+                useUniversalHelper -> universalArchitectures
+                else ->
+                    listOf(
+                        if (System.getProperty("os.arch").lowercase() == "aarch64") "arm64"
+                        else "x86_64"
+                    )
+            }
+        expectedMacOsArchs.set(macOsArchs)
+
+        // Linux expectations. `useAllLinuxArches` is true when `-PallLinuxArches` is set.
+        val linuxArches: List<String> =
+            when {
+                !os.isLinux -> emptyList()
+                useAllLinuxArches -> linuxHelperArchitectures
+                else -> listOf(linuxRustHostArch())
+            }
+        expectedLinuxArches.set(linuxArches)
+    }
+
+tasks.named("check") { dependsOn(verifyBundledRecordingHelpers) }

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -719,8 +719,14 @@ abstract class VerifyBundledRecordingHelpers
 @Inject
 constructor(private val execOperations: ExecOperations) : DefaultTask() {
 
-    /** Directory `processResources` writes into. Helper paths are resolved relative to this. */
-    @get:InputDirectory abstract val resourcesDir: DirectoryProperty
+    /**
+     * Directory `processResources` writes into. Helper paths are resolved relative to this.
+     * `@Optional` because hosts that produce no helpers (Windows; macOS/Linux with
+     * `processResources` skipped because no inputs landed) may not create the directory at all. The
+     * action below treats an absent directory as a fail iff there are real expectations, and a
+     * clean no-op when expectations are empty.
+     */
+    @get:Optional @get:InputDirectory abstract val resourcesDir: DirectoryProperty
 
     /**
      * macOS architectures expected in `native/macos/spectre-screencapture`. Empty list means "no
@@ -739,12 +745,27 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
 
     @TaskAction
     fun verify() {
-        val errors = mutableListOf<String>()
         val macOsArchs = expectedMacOsArchs.get()
+        val linuxArches = expectedLinuxArches.get()
+        if (macOsArchs.isEmpty() && linuxArches.isEmpty()) {
+            logger.lifecycle(
+                "verifyBundledRecordingHelpers: no helpers expected on this host — nothing to verify."
+            )
+            return
+        }
+        val resources = resourcesDir.orNull?.asFile
+        if (resources == null || !resources.isDirectory) {
+            throw GradleException(
+                "Recording helper verification failed: expected resources directory does not " +
+                    "exist (${resourcesDir.orNull?.asFile}). processResources must have run with " +
+                    "the helper staging tasks for this host wired in."
+            )
+        }
+        val errors = mutableListOf<String>()
         if (macOsArchs.isNotEmpty()) {
             verifyMacOsHelper(macOsArchs)?.let(errors::add)
         }
-        for (arch in expectedLinuxArches.get()) {
+        for (arch in linuxArches) {
             verifyLinuxHelper(arch)?.let(errors::add)
         }
         if (errors.isNotEmpty()) {

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -721,12 +721,15 @@ constructor(private val execOperations: ExecOperations) : DefaultTask() {
 
     /**
      * Directory `processResources` writes into. Helper paths are resolved relative to this.
-     * `@Optional` because hosts that produce no helpers (Windows; macOS/Linux with
-     * `processResources` skipped because no inputs landed) may not create the directory at all. The
-     * action below treats an absent directory as a fail iff there are real expectations, and a
-     * clean no-op when expectations are empty.
+     * `@Internal` rather than `@InputDirectory`: on hosts that produce no helpers (Windows;
+     * macOS/Linux with no other resources triggering processResources to create the dir),
+     * `build/resources/main` may not exist at all, and Gradle's `@InputDirectory` validation fails
+     * at task-graph time before the action runs (even with `@Optional`, because the value *is* set
+     * — we only fail to set it on hosts where no expectations exist). The task is pure verification
+     * with no incremental-build benefit anyway, so dropping input tracking is fine — the action
+     * below handles "expectations but no directory" as a real failure mode.
      */
-    @get:Optional @get:InputDirectory abstract val resourcesDir: DirectoryProperty
+    @get:Internal abstract val resourcesDir: DirectoryProperty
 
     /**
      * macOS architectures expected in `native/macos/spectre-screencapture`. Empty list means "no


### PR DESCRIPTION
## Summary

Third bucket of the release hardening epic (#114). #109 already landed the cross-arch Wayland helper build; R3 fills the remaining gap from the masterplan: reusable artifact inspection that works on every host, plus developer-facing build-matrix documentation.

- **New `:recording:verifyBundledRecordingHelpers` task** — inspects the recording jar's staged resources against an expected-helpers rule computed from host OS + project properties (`-PuniversalHelper`, `-PallLinuxArches`). Depends on `processResources` only; never pulls universal SCK or all-arches Wayland builds into the graph by itself. ELF parsing is JVM-side (20-byte `RandomAccessFile` read, ELF magic + `e_machine` field) so no `readelf` dependency on the dev host. macOS check stays on `lipo -verify_arch` because lipo only runs on macOS anyway and the existing universal-helper task uses the same pattern.
- **Wired into `:recording:check`** so the verification runs on every contributor build, not just CI.
- **CI workflow updated** — the inline `readelf` shell loop in `ci.yml` is replaced with `./gradlew :recording:assembleWaylandHelperAllArches :recording:verifyBundledRecordingHelpers -PallLinuxArches`, preserving #109's both-arch coverage explicitly and giving the same assertion strength.
- **`recording/README.md`** gains a "Build matrix: which helpers each host can produce" section documenting per-host capability, the `-P` flag reference, and the intended publishing model (release CI on macOS for SCK universal+notarized, release CI on Linux for Wayland both-arches, merged at publish time). Publishing is framed as future work gated on #84.

## Expected-helpers rule

| Host | Property | Expected | Check |
|---|---|---|---|
| macOS (arm64) | (none) | thin arm64 SCK | `lipo -verify_arch arm64` |
| macOS (x86_64) | (none) | thin x86_64 SCK | `lipo -verify_arch x86_64` |
| macOS | `-PuniversalHelper` or `-PnotarizeScreenCaptureKitHelper` | universal SCK | `lipo -verify_arch arm64 x86_64` |
| Linux x86_64 | (none) | host Wayland helper | JVM ELF parse → `EM_X86_64` (0x3E) |
| Linux aarch64 | (none) | host Wayland helper | JVM ELF parse → `EM_AARCH64` (0xB7) |
| Linux | `-PallLinuxArches` | both arches | per-arch JVM ELF parse |
| Windows / other | any | (none) | no-op success |

## Test plan

- [ ] CI: `./gradlew check` passes (detekt + ktfmt + tests + the new verify task on macOS+Linux)
- [ ] CI: Linux runner runs `assembleWaylandHelperAllArches + verifyBundledRecordingHelpers -PallLinuxArches`, ELF check is in JVM
- [ ] Local: `./gradlew :recording:check` on macOS does NOT trigger a universal SCK build
- [ ] Local: deleting a staged helper and re-running `:recording:verifyBundledRecordingHelpers --rerun-tasks` fails with a precise missing-path message (manual smoke — task itself just re-stages because `processResources` is on the graph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)