### PR TITLE
R4: Test and CI robustness

### DIFF
--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -95,6 +95,12 @@ jobs:
         shell: bash
 
       - name: Verify validation tests passed via JUnit XML
+        # Envelope-detection safety net (issue #72): the last 8 validation runs since
+        # 2026-05-11 16:05Z showed no protocol-flake marker. Kept in place as a dormant safety
+        # net — if #72 resurfaces we'll see the existing `::warning::` rather than silent
+        # missing-XML failures. R-future may garbage-collect this block if the dormancy
+        # persists across a broader sample.
+        #
         # Source-of-truth check that ignores Gradle's exit code but does NOT rubber-stamp every
         # failure. Two passes over the JUnit XMLs:
         #

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -477,7 +477,11 @@ private constructor(
         timeout: Duration = 5.seconds,
         pollInterval: Duration = 100.milliseconds,
     ): AutomatorNode {
+        // Argument validation runs before the EDT check so `waitForNode()` from the EDT still
+        // surfaces the bad-input error rather than the curated EDT error — bad arguments are
+        // the more actionable signal in that case.
         require(tag != null || text != null) { "Either tag or text must be specified" }
+        rejectEdtCaller("waitForNode")
         return waitUntil(timeout = timeout, pollInterval = pollInterval) {
             readOnEdt {
                 refreshWindows()

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
@@ -1,0 +1,445 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.AWTEvent
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+import java.awt.Toolkit
+import java.awt.datatransfer.DataFlavor
+import java.awt.datatransfer.StringSelection
+import java.awt.datatransfer.Transferable
+import java.awt.event.AWTEventListener
+import java.awt.event.KeyEvent
+import java.awt.event.MouseEvent
+import java.awt.event.MouseListener
+import java.awt.event.MouseMotionListener
+import java.awt.event.MouseWheelEvent
+import java.awt.event.MouseWheelListener
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.TimeUnit
+import javax.swing.JFrame
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Parity coverage for the synthetic AWT driver (R4). Each test asserts an **observable** AWT
+ * contract through a real `JFrame` + listener — never peeking at adapter internals. The synthetic
+ * driver runs alongside the real `java.awt.Robot` path in production, so when this suite drifts
+ * from what AWT actually emits, real-world behaviour drifts with it.
+ *
+ * Test scaffolding rules (per R4 plan guardrails):
+ * - `assumeFalse(GraphicsEnvironment.isHeadless())` on every test — synthetic dispatch needs a real
+ *   AWT display.
+ * - Frames are constructed and disposed on the EDT.
+ * - Event-queue drains use `SwingUtilities.invokeAndWait { }` rather than time-based sleeps.
+ * - `@Timeout` backstops every test so a regression doesn't pin the JVM via a non-daemon EDT.
+ */
+class SyntheticInputParityTest {
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `mouseWheel emits one MouseWheelEvent per call with scrollAmount 1 and signed wheelRotation`() {
+        assumeFalse(GraphicsEnvironment.isHeadless())
+        val target = WheelTargetPanel()
+        val frame = showFrameOnEdt(target)
+        try {
+            val (cx, cy) = frame.targetCenterOnScreen(target)
+            val driver = RobotDriver.synthetic(frame.frame)
+            runBlocking { driver.scrollWheel(cx, cy, 3) }
+            runBlocking { driver.scrollWheel(cx, cy, -2) }
+            drainEdt()
+
+            assertEquals(2, target.events.size, "expected one MouseWheelEvent per scrollWheel call")
+            val first = target.events[0]
+            assertEquals(
+                1,
+                first.scrollAmount,
+                "scrollAmount must always be 1 per the adapter contract",
+            )
+            assertEquals(
+                3,
+                first.wheelRotation,
+                "wheelRotation must be the signed wheelClicks input",
+            )
+            assertEquals(
+                MouseWheelEvent.WHEEL_UNIT_SCROLL,
+                first.scrollType,
+                "scrollType must be WHEEL_UNIT_SCROLL",
+            )
+            assertEquals(3, first.unitsToScroll, "unitsToScroll = scrollAmount * wheelRotation = 3")
+            val second = target.events[1]
+            assertEquals(
+                -2,
+                second.wheelRotation,
+                "negative wheelClicks must produce negative rotation",
+            )
+            assertEquals(-2, second.unitsToScroll, "unitsToScroll mirrors the signed input")
+        } finally {
+            disposeFrame(frame.frame)
+        }
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `double-click sequence reports clickCount=2 on the second pair`() {
+        assumeFalse(GraphicsEnvironment.isHeadless())
+        val target = MouseTargetPanel()
+        val frame = showFrameOnEdt(target)
+        try {
+            val (cx, cy) = frame.targetCenterOnScreen(target)
+            val driver = RobotDriver.synthetic(frame.frame)
+            runBlocking { driver.click(cx, cy) }
+            runBlocking { driver.click(cx, cy) }
+            drainEdt()
+
+            // We expect two press/release/click triples, with the second triple reporting
+            // clickCount=2. Filter out MOUSE_MOVED noise so the sequence assertion is precise.
+            val significant =
+                target.events.filter {
+                    it.id == MouseEvent.MOUSE_PRESSED ||
+                        it.id == MouseEvent.MOUSE_RELEASED ||
+                        it.id == MouseEvent.MOUSE_CLICKED
+                }
+            val counts = significant.map { it.id to it.clickCount }
+            assertEquals(
+                listOf(
+                    MouseEvent.MOUSE_PRESSED to 1,
+                    MouseEvent.MOUSE_RELEASED to 1,
+                    MouseEvent.MOUSE_CLICKED to 1,
+                    MouseEvent.MOUSE_PRESSED to 2,
+                    MouseEvent.MOUSE_RELEASED to 2,
+                    MouseEvent.MOUSE_CLICKED to 2,
+                ),
+                counts,
+                "expected click-count to advance to 2 on the second click pair, got $counts",
+            )
+        } finally {
+            disposeFrame(frame.frame)
+        }
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `swipe between distinct points emits no MOUSE_CLICKED`() {
+        assumeFalse(GraphicsEnvironment.isHeadless())
+        val target = MouseTargetPanel()
+        val frame = showFrameOnEdt(target)
+        try {
+            val origin = frame.targetTopLeftOnScreen(target)
+            val driver = RobotDriver.synthetic(frame.frame)
+            val startX = origin.x + 10
+            val startY = origin.y + 10
+            val endX = origin.x + target.width - 10
+            val endY = origin.y + target.height - 10
+            runBlocking { driver.swipe(startX, startY, endX, endY) }
+            drainEdt()
+
+            val clicks = target.events.filter { it.id == MouseEvent.MOUSE_CLICKED }
+            assertTrue(clicks.isEmpty(), "expected no MOUSE_CLICKED during a swipe, got $clicks")
+            // Sanity: press + at least one drag + release happened.
+            val pressed = target.events.count { it.id == MouseEvent.MOUSE_PRESSED }
+            val released = target.events.count { it.id == MouseEvent.MOUSE_RELEASED }
+            val dragged = target.events.count { it.id == MouseEvent.MOUSE_DRAGGED }
+            assertEquals(1, pressed, "expected exactly one MOUSE_PRESSED")
+            assertEquals(1, released, "expected exactly one MOUSE_RELEASED")
+            assertTrue(dragged > 0, "expected at least one MOUSE_DRAGGED, got $dragged")
+        } finally {
+            disposeFrame(frame.frame)
+        }
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `modifier mask appears on the held key and does not leak to the next key`() {
+        assumeFalse(GraphicsEnvironment.isHeadless())
+        val target = JPanel().apply { preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX) }
+        val frame = showFrameOnEdt(target)
+        // Use a global AWT event listener instead of relying on focus transfer to the JPanel:
+        // undecorated JFrames in tests are subject to window-manager focus quirks on macOS that
+        // make `requestFocusInWindow` unreliable. The synthetic adapter dispatches KeyEvents to
+        // the focus owner (or the root window if none), so a global listener catches both paths
+        // without depending on which target won focus.
+        val recorder = GlobalKeyEventRecorder().also { it.install() }
+        try {
+            val driver = RobotDriver.synthetic(frame.frame)
+            // SHIFT+A then plain B. Modifier should be set on 'A' KEY_PRESSED and absent on 'B'.
+            runBlocking {
+                driver.pressKey(KeyEvent.VK_A, modifiers = KeyEvent.SHIFT_DOWN_MASK)
+                driver.pressKey(KeyEvent.VK_B)
+            }
+            drainEdt()
+
+            val aPressed =
+                recorder.events.firstOrNull {
+                    it.id == KeyEvent.KEY_PRESSED && it.keyCode == KeyEvent.VK_A
+                }
+            val bPressed =
+                recorder.events.firstOrNull {
+                    it.id == KeyEvent.KEY_PRESSED && it.keyCode == KeyEvent.VK_B
+                }
+            assertNotNull(aPressed, "expected a KEY_PRESSED for 'A'")
+            assertNotNull(bPressed, "expected a KEY_PRESSED for 'B'")
+            assertTrue(
+                aPressed.modifiersEx and KeyEvent.SHIFT_DOWN_MASK != 0,
+                "expected SHIFT_DOWN_MASK on 'A' KEY_PRESSED, got modifiersEx=${aPressed.modifiersEx}",
+            )
+            assertEquals(
+                0,
+                bPressed.modifiersEx and KeyEvent.SHIFT_DOWN_MASK,
+                "expected no SHIFT_DOWN_MASK leak on 'B' KEY_PRESSED",
+            )
+        } finally {
+            recorder.uninstall()
+            disposeFrame(frame.frame)
+        }
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `typeText through the synthetic driver isolates and restores the fake clipboard`() {
+        assumeFalse(GraphicsEnvironment.isHeadless())
+        val target = JPanel().apply { preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX) }
+        val frame = showFrameOnEdt(target)
+        // See modifier test: a global AWT key listener avoids brittle focus-transfer assumptions
+        // for tests that only need to observe dispatched keystrokes.
+        val recorder = GlobalKeyEventRecorder().also { it.install() }
+        try {
+            val fakeClipboard = InMemoryClipboardAdapter(initial = "existing")
+            // Build a RobotDriver manually so we can plug in the fake clipboard instead of
+            // SystemClipboardAdapter. This is the canonical isolation strategy — no real
+            // system clipboard is touched. Same module, internal constructor visible.
+            val driver =
+                RobotDriver(
+                    robot = SyntheticRobotAdapter(frame.frame),
+                    clipboard = fakeClipboard,
+                    tccGuard = MacOsTccGuard.noop(),
+                )
+            runBlocking { driver.typeText("hello") }
+            drainEdt()
+
+            // Clipboard contents restored to the pre-typeText state.
+            val restored =
+                fakeClipboard.getContents()?.getTransferData(DataFlavor.stringFlavor) as? String
+            assertEquals("existing", restored, "expected clipboard contents to be restored")
+
+            // Observable paste keystroke: the VK_V KEY_PRESSED must carry the shortcut modifier
+            // mask. Asserting only "modifier was pressed somewhere" + "V was pressed somewhere"
+            // would pass even if the adapter degraded into "press modifier, release modifier,
+            // then press plain V" — exactly the regression this parity test exists to catch.
+            val expectedMask =
+                if (detectMacOs()) KeyEvent.META_DOWN_MASK else KeyEvent.CTRL_DOWN_MASK
+            val expectedModifierKey = if (detectMacOs()) KeyEvent.VK_META else KeyEvent.VK_CONTROL
+            val vPressed =
+                recorder.events.firstOrNull {
+                    it.id == KeyEvent.KEY_PRESSED && it.keyCode == KeyEvent.VK_V
+                }
+            assertNotNull(vPressed, "expected a KEY_PRESSED for VK_V")
+            assertTrue(
+                vPressed.modifiersEx and expectedMask != 0,
+                "expected VK_V KEY_PRESSED to carry the shortcut modifier mask " +
+                    "(expectedMask=$expectedMask), got modifiersEx=${vPressed.modifiersEx}",
+            )
+            // Sanity: the modifier was pressed earlier in the sequence (so the mask above did
+            // not sneak in from leftover state).
+            val modifierPressedIndex =
+                recorder.events.indexOfFirst {
+                    it.id == KeyEvent.KEY_PRESSED && it.keyCode == expectedModifierKey
+                }
+            val vPressedIndex = recorder.events.indexOf(vPressed)
+            assertTrue(
+                modifierPressedIndex in 0 until vPressedIndex,
+                "expected modifier (keyCode=$expectedModifierKey) KEY_PRESSED before VK_V; " +
+                    "modifierPressedIndex=$modifierPressedIndex vPressedIndex=$vPressedIndex",
+            )
+        } finally {
+            recorder.uninstall()
+            disposeFrame(frame.frame)
+        }
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `synthetic screenshot returns the requested dimensions and samples the rendered colour`() {
+        assumeFalse(GraphicsEnvironment.isHeadless())
+        val target = ColoredPanel(Color.RED)
+        val frame = showFrameOnEdt(target)
+        try {
+            val driver = RobotDriver.synthetic(frame.frame)
+            val origin = frame.targetTopLeftOnScreen(target)
+            // Capture a sub-region inside the panel — keeps the test robust against frame
+            // padding / WM decorations that could pollute pixels near the edges.
+            val captureRegion =
+                Rectangle(origin.x + 20, origin.y + 20, REGION_SIZE_PX, REGION_SIZE_PX)
+            val image = driver.screenshot(captureRegion)
+            assertEquals(REGION_SIZE_PX, image.width, "image width must match requested width")
+            assertEquals(REGION_SIZE_PX, image.height, "image height must match requested height")
+            // Sample a pixel inside the captured region. Synthetic capture paints the target via
+            // Component.paint(Graphics); we expect the painted red to come through.
+            val sampledRgb = image.getRGB(REGION_SIZE_PX / 2, REGION_SIZE_PX / 2)
+            val sampled = Color(sampledRgb)
+            assertEquals(
+                Color.RED.rgb and 0x00FFFFFF,
+                sampledRgb and 0x00FFFFFF,
+                "expected red pixel; got $sampled",
+            )
+        } finally {
+            disposeFrame(frame.frame)
+        }
+    }
+
+    // --- Fixtures ---------------------------------------------------------------------------
+
+    private fun showFrameOnEdt(target: JPanel): TestFrame {
+        var frame: JFrame? = null
+        SwingUtilities.invokeAndWait {
+            frame =
+                JFrame("SyntheticInputParityTest").apply {
+                    defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                    isUndecorated = true
+                    contentPane.layout = BorderLayout()
+                    contentPane.add(target, BorderLayout.CENTER)
+                    size = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
+                    setLocation(FRAME_OFFSET_PX, FRAME_OFFSET_PX)
+                    isVisible = true
+                }
+        }
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(SHOW_TIMEOUT_SECONDS)
+        while (System.nanoTime() < deadline && !target.isShowing) {
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        check(target.isShowing) { "Test JFrame did not become visible" }
+        return TestFrame(frame!!)
+    }
+
+    private fun drainEdt() {
+        // Drain twice: the first invokeAndWait flushes events already on the queue, the second
+        // catches anything those events themselves posted (synthetic dispatch routes through
+        // runOnEdt, and Compose-style listeners can repost).
+        repeat(2) { SwingUtilities.invokeAndWait {} }
+    }
+
+    private fun disposeFrame(frame: JFrame) {
+        // invokeLater (not invokeAndWait) so a wedged EDT — should never happen, but a
+        // regression could trip the @Timeout — doesn't deadlock the cleanup path. The frame
+        // is a daemon-thread JVM resource; it goes away with the JVM if dispose can't run now.
+        SwingUtilities.invokeLater {
+            frame.isVisible = false
+            frame.dispose()
+        }
+    }
+
+    private fun TestFrame.targetCenterOnScreen(target: JPanel): Pair<Int, Int> {
+        var center = 0 to 0
+        SwingUtilities.invokeAndWait {
+            val origin = target.locationOnScreen
+            center = (origin.x + target.width / 2) to (origin.y + target.height / 2)
+        }
+        return center
+    }
+
+    private fun TestFrame.targetTopLeftOnScreen(target: JPanel): java.awt.Point {
+        var origin = java.awt.Point()
+        SwingUtilities.invokeAndWait { origin = target.locationOnScreen }
+        return origin
+    }
+
+    private class TestFrame(val frame: JFrame)
+
+    private class WheelTargetPanel : JPanel(), MouseWheelListener {
+        val events: MutableList<MouseWheelEvent> = CopyOnWriteArrayList()
+
+        init {
+            preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
+            addMouseWheelListener(this)
+        }
+
+        override fun mouseWheelMoved(e: MouseWheelEvent) {
+            events.add(e)
+        }
+    }
+
+    private class MouseTargetPanel : JPanel(), MouseListener, MouseMotionListener {
+        val events: MutableList<MouseEvent> = CopyOnWriteArrayList()
+
+        init {
+            preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
+            addMouseListener(this)
+            addMouseMotionListener(this)
+        }
+
+        override fun mouseClicked(e: MouseEvent) {
+            events.add(e)
+        }
+
+        override fun mousePressed(e: MouseEvent) {
+            events.add(e)
+        }
+
+        override fun mouseReleased(e: MouseEvent) {
+            events.add(e)
+        }
+
+        override fun mouseEntered(e: MouseEvent) = Unit
+
+        override fun mouseExited(e: MouseEvent) = Unit
+
+        override fun mouseDragged(e: MouseEvent) {
+            events.add(e)
+        }
+
+        override fun mouseMoved(e: MouseEvent) = Unit
+    }
+
+    private class GlobalKeyEventRecorder {
+        val events: MutableList<KeyEvent> = CopyOnWriteArrayList()
+        private val listener = AWTEventListener { event ->
+            if (event is KeyEvent) events.add(event)
+        }
+
+        fun install() {
+            Toolkit.getDefaultToolkit().addAWTEventListener(listener, AWTEvent.KEY_EVENT_MASK)
+        }
+
+        fun uninstall() {
+            Toolkit.getDefaultToolkit().removeAWTEventListener(listener)
+        }
+    }
+
+    private class ColoredPanel(private val color: Color) : JPanel() {
+        init {
+            preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
+            background = color
+            isOpaque = true
+        }
+    }
+
+    private class InMemoryClipboardAdapter(initial: String? = null) : ClipboardAdapter {
+        private var current: Transferable? = initial?.let { StringSelection(it) }
+
+        override val supportsRead: Boolean = true
+
+        override fun getContents(): Transferable? = current
+
+        override fun setContents(contents: Transferable) {
+            current = contents
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_SECONDS: Long = 15L
+        const val SHOW_TIMEOUT_SECONDS: Long = 5L
+        const val POLL_INTERVAL_MS: Long = 25L
+        const val FRAME_SIZE_PX: Int = 200
+        const val FRAME_OFFSET_PX: Int = 100
+        const val REGION_SIZE_PX: Int = 60
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForIdleTest.kt
@@ -211,4 +211,23 @@ class WaitForIdleTest {
             )
         }
     }
+
+    @Test
+    fun `waitForIdle rejects EDT callers with a curated error`() {
+        val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+        val errorRef = java.util.concurrent.atomic.AtomicReference<Throwable?>()
+        javax.swing.SwingUtilities.invokeAndWait {
+            kotlinx.coroutines.runBlocking {
+                errorRef.set(runCatching { automator.waitForIdle() }.exceptionOrNull())
+            }
+        }
+        val error = errorRef.get()
+        assertTrue(error is IllegalStateException, "expected IllegalStateException, got $error")
+        assertTrue(
+            error.message?.contains(
+                "waitForIdle must not be called from the AWT event dispatch thread"
+            ) == true,
+            "expected curated EDT message, got: ${error.message}",
+        )
+    }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForNodeTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForNodeTest.kt
@@ -1,0 +1,71 @@
+package dev.sebastiano.spectre.core
+
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Unit-level tests for [ComposeAutomator.waitForNode]'s public-boundary contracts: argument
+ * validation and EDT rejection. The matching behaviour (tag-only, text-only, combined tag+text AND,
+ * timeout) is exercised end-to-end against a live Compose surface in the sample-desktop validation
+ * suite (`WaitForNodeMatchingValidationTest`); the contracts that don't need real Compose live
+ * here.
+ */
+class WaitForNodeTest {
+
+    @Test
+    fun `waitForNode requires tag or text`() = runBlocking {
+        val automator = headlessAutomator()
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                automator.waitForNode(tag = null, text = null)
+            }
+        assertEquals("Either tag or text must be specified", error.message)
+    }
+
+    @Test
+    fun `waitForNode reports the bad-argument error when called from the EDT with null inputs`() {
+        // Argument validation must run BEFORE the EDT check. An EDT caller passing
+        // (null, null) is doing two things wrong; surfacing the input error first keeps
+        // the diagnostic actionable instead of redirecting users to the EDT story.
+        val automator = headlessAutomator()
+        val errorRef = AtomicReference<Throwable?>()
+        SwingUtilities.invokeAndWait {
+            runBlocking { errorRef.set(runCatching { automator.waitForNode() }.exceptionOrNull()) }
+        }
+        val error = errorRef.get()
+        assertTrue(
+            error is IllegalArgumentException,
+            "expected IllegalArgumentException, got $error",
+        )
+        assertEquals("Either tag or text must be specified", error.message)
+    }
+
+    @Test
+    fun `waitForNode rejects EDT callers with valid arguments`() {
+        val automator = headlessAutomator()
+        val errorRef = AtomicReference<Throwable?>()
+        SwingUtilities.invokeAndWait {
+            runBlocking {
+                errorRef.set(
+                    runCatching { automator.waitForNode(tag = "irrelevant") }.exceptionOrNull()
+                )
+            }
+        }
+        val error = errorRef.get()
+        assertTrue(error is IllegalStateException, "expected IllegalStateException, got $error")
+        assertTrue(
+            error.message?.contains(
+                "waitForNode must not be called from the AWT event dispatch thread"
+            ) == true,
+            "expected curated EDT message, got: ${error.message}",
+        )
+    }
+
+    private fun headlessAutomator(): ComposeAutomator =
+        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
@@ -138,4 +138,23 @@ class WaitForVisualIdleTest {
             )
         }
     }
+
+    @Test
+    fun `waitForVisualIdle rejects EDT callers with a curated error`() {
+        val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+        val errorRef = java.util.concurrent.atomic.AtomicReference<Throwable?>()
+        javax.swing.SwingUtilities.invokeAndWait {
+            kotlinx.coroutines.runBlocking {
+                errorRef.set(runCatching { automator.waitForVisualIdle() }.exceptionOrNull())
+            }
+        }
+        val error = errorRef.get()
+        assertTrue(error is IllegalStateException, "expected IllegalStateException, got $error")
+        assertTrue(
+            error.message?.contains(
+                "waitForVisualIdle must not be called from the AWT event dispatch thread"
+            ) == true,
+            "expected curated EDT message, got: ${error.message}",
+        )
+    }
 }

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitForNodeMatchingValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitForNodeMatchingValidationTest.kt
@@ -1,0 +1,118 @@
+package dev.sebastiano.spectre.sample.validation
+
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Live-Compose coverage for
+ * [`ComposeAutomator.waitForNode`][dev.sebastiano.spectre.core.ComposeAutomator.waitForNode]
+ * matching modes and timeout behaviour (R4).
+ *
+ * The argument-validation and EDT-rejection contracts are exercised at the unit level in
+ * `WaitForNodeTest`. Those tests do not need a Compose surface; the matching modes do, because the
+ * matcher walks live semantics. Living in the validation suite means we run against the real EDT /
+ * Compose / SemanticsReader path that production users hit.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class WaitForNodeMatchingValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre R4 waitForNode matching validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `waitForNode resolves by tag only`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val node = waitForNode(tag = "incrementButton")
+            assertEquals("incrementButton", node.testTag, "tag-only match should return the button")
+        }
+    }
+
+    @Test
+    fun `waitForNode resolves by text only`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            // Read the button's current 'Count: N' text first so the assertion is robust against
+            // any counter state that survived a previous test in this PER_CLASS fixture.
+            val button = waitForTestTag("incrementButton")
+            val buttonText = button.text
+            assertNotNull(buttonText, "incrementButton must expose its 'Count: N' text")
+
+            val node = waitForNode(text = buttonText)
+            assertTrue(
+                node.texts.any { it == buttonText } || node.editableText == buttonText,
+                "text-only match should return a node carrying the requested text, got texts=${node.texts}",
+            )
+        }
+    }
+
+    @Test
+    fun `waitForNode combines tag and text with AND semantics`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val button = waitForTestTag("incrementButton")
+            val buttonText = button.text
+            assertNotNull(buttonText, "incrementButton must expose its 'Count: N' text")
+
+            // Positive case: both predicates match the same node.
+            val matched = waitForNode(tag = "incrementButton", text = buttonText)
+            assertEquals("incrementButton", matched.testTag)
+            assertTrue(
+                matched.texts.any { it == buttonText } || matched.editableText == buttonText,
+                "combined match should carry both the requested tag and text",
+            )
+
+            // Negative case: text exists on the button but not under the picker's testTag, so the
+            // combined match must time out — AND semantics, not OR.
+            val timeoutError =
+                runCatching {
+                        waitForNode(
+                            tag = "scenario.counter",
+                            text = buttonText,
+                            timeout = 250.milliseconds,
+                            pollInterval = 50.milliseconds,
+                        )
+                    }
+                    .exceptionOrNull()
+            assertNotNull(
+                timeoutError,
+                "expected timeout when tag+text refer to disjoint nodes (AND, not OR)",
+            )
+            Unit
+        }
+    }
+
+    @Test
+    fun `waitForNode throws when no node ever matches within the timeout`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val error =
+                runCatching {
+                        waitForNode(
+                            tag = "this.tag.definitely.does.not.exist",
+                            timeout = 250.milliseconds,
+                            pollInterval = 50.milliseconds,
+                        )
+                    }
+                    .exceptionOrNull()
+            assertNotNull(error, "expected waitForNode to throw on timeout")
+            Unit
+        }
+    }
+}

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -85,7 +85,7 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
 
     post("/click") {
         automator.refreshWindows()
-        val request = call.receive<ClickRequest>()
+        val request = receiveOrRespond400<ClickRequest>(call, "ClickRequest") ?: return@post
         // NodeKey.parse throws on malformed input — surface that as a client error (400)
         // rather than letting it bubble up as a generic 500.
         val key =
@@ -105,7 +105,7 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
     }
 
     post("/typeText") {
-        val request = call.receive<TypeTextRequest>()
+        val request = receiveOrRespond400<TypeTextRequest>(call, "TypeTextRequest") ?: return@post
         automator.typeText(request.text)
         call.respond(HttpStatusCode.NoContent)
     }
@@ -128,3 +128,30 @@ internal fun BufferedImage.toScreenshotResponse(): ScreenshotResponse {
         height = height,
     )
 }
+
+/**
+ * Narrow decode-error mapping for `call.receive<T>()` (R4): Ktor's default response when
+ * kotlinx-serialization fails to decode a request body (invalid JSON, missing required field) is
+ * `400 Bad Request` with an empty body. That's a poor user experience — the client gets a 4xx but
+ * no clue what request shape was expected. Wrap each `receive<T>()` so the response carries the
+ * request type name plus the underlying decode message; the type name is what the negative-contract
+ * tests pin.
+ *
+ * Scope is intentionally narrow: only `BadRequestException` (which `ContentTransformation` raises
+ * on decode failures) is caught. Everything else propagates. Wrong Content-Type still surfaces as
+ * `415 Unsupported Media Type` via Ktor's content-negotiation precheck — Ktor doesn't even get to
+ * `receive<T>()` in that case.
+ */
+private suspend inline fun <reified T : Any> receiveOrRespond400(
+    call: io.ktor.server.application.ApplicationCall,
+    requestTypeName: String,
+): T? =
+    try {
+        call.receive<T>()
+    } catch (e: io.ktor.server.plugins.BadRequestException) {
+        call.respond(
+            HttpStatusCode.BadRequest,
+            "Could not decode $requestTypeName: ${e.message ?: e.javaClass.simpleName}",
+        )
+        null
+    }

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpNegativeContractTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpNegativeContractTest.kt
@@ -1,0 +1,202 @@
+package dev.sebastiano.spectre.server
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.server.dto.ScreenshotResponse
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.server.application.Application
+import io.ktor.server.application.install as serverInstall
+import io.ktor.server.cio.CIO
+import io.ktor.server.engine.EmbeddedServer
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation as ServerContentNegotiation
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get as serverGet
+import io.ktor.server.routing.post as serverPost
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+import java.util.Base64
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Negative-path coverage for the HTTP transport (R4):
+ *
+ * - **Server-side** (routes registered via [installSpectreRoutes]): malformed request bodies and
+ *   wrong content types map to actionable 4xx responses. The handlers wrap `call.receive` in narrow
+ *   try/catch blocks so the client gets a curated message naming the request type instead of Ktor's
+ *   default `BadRequest` empty-bodied response.
+ * - **Client-side** ([HttpComposeAutomator]): server 5xx on `click` surfaces as
+ *   `IllegalStateException` (existing `check {}` guard), and `screenshot` decoding a response with
+ *   non-image bytes surfaces as the existing `checkNotNull` failure. Other client methods
+ *   (`windows`, `allNodes`, `findByTestTag`, `typeText`) go directly into `body<T>()` on the
+ *   response — adding curated handling for them would expand the transport surface, which R4
+ *   explicitly declines (tracked as R-future, post-#96).
+ */
+class HttpNegativeContractTest {
+
+    private fun headlessAutomator(): ComposeAutomator =
+        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+
+    // --- Server-side decode failures -----------------------------------------------------
+
+    @Test
+    fun `POST click with empty body returns 415`() = testApplication {
+        // Empty body + `Content-Type: application/json` reaches Ktor's content-negotiation
+        // precheck before our `receiveOrRespond400` wrapper. The precheck rejects the
+        // zero-byte body with 415 because there's nothing for the JSON converter to read —
+        // we pin that here so a future Ktor upgrade that changed it to 400 would notice us.
+        application { installSpectreRoutes(headlessAutomator()) }
+        val response =
+            postRaw("/spectre/click", body = "", contentType = ContentType.Application.Json)
+        assertEquals(HttpStatusCode.UnsupportedMediaType, response.status)
+    }
+
+    @Test
+    fun `POST click with invalid JSON returns 400 with a useful message`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val response =
+            postRaw("/spectre/click", body = "not json", contentType = ContentType.Application.Json)
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertBodyMentions(response, "ClickRequest")
+    }
+
+    @Test
+    fun `POST click with missing nodeKey returns 400 with a useful message`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val response =
+            postRaw("/spectre/click", body = "{}", contentType = ContentType.Application.Json)
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertBodyMentions(response, "ClickRequest")
+    }
+
+    @Test
+    fun `POST click with wrong Content-Type returns 415`() = testApplication {
+        application { installSpectreRoutes(headlessAutomator()) }
+        val response =
+            postRaw("/spectre/click", body = "anything", contentType = ContentType.Text.Plain)
+        assertEquals(HttpStatusCode.UnsupportedMediaType, response.status)
+    }
+
+    @Test
+    fun `POST typeText with empty body returns 415`() = testApplication {
+        // Symmetry confirmation that the same Ktor content-negotiation precheck applies to
+        // /typeText — empty body with `application/json` is rejected as 415 before our
+        // `receiveOrRespond400` wrapper runs. Pinned for the same reason as the /click case.
+        application { installSpectreRoutes(headlessAutomator()) }
+        val response =
+            postRaw("/spectre/typeText", body = "", contentType = ContentType.Application.Json)
+        assertEquals(HttpStatusCode.UnsupportedMediaType, response.status)
+    }
+
+    @Test
+    fun `POST typeText with invalid JSON returns 400 with a useful message`() = testApplication {
+        // Symmetry confirmation that the `receiveOrRespond400` wrapper is wired on /typeText too,
+        // and that the curated body names the request type.
+        application { installSpectreRoutes(headlessAutomator()) }
+        val response =
+            postRaw(
+                "/spectre/typeText",
+                body = "not json",
+                contentType = ContentType.Application.Json,
+            )
+        assertEquals(HttpStatusCode.BadRequest, response.status)
+        assertBodyMentions(response, "TypeTextRequest")
+    }
+
+    // --- Client-side error surfacing -----------------------------------------------------
+    //
+    // HttpComposeAutomator owns its CIO HttpClient internally (no constructor seam to inject
+    // one), so client-side negative tests boot a real CIO server bound to port 0 — same
+    // pattern as HttpComposeAutomatorE2ETest.kt — and point the public `ComposeAutomator.http`
+    // factory at it.
+
+    @Test
+    fun `click against a 500 response surfaces an IllegalStateException`() {
+        val server = startEphemeralServer {
+            routing {
+                serverPost("/spectre/click") {
+                    call.respond(HttpStatusCode.InternalServerError, "synthetic server failure")
+                }
+            }
+        }
+        try {
+            val error =
+                ComposeAutomator.http(host = "127.0.0.1", port = server.port).use {
+                    assertFailsWith<IllegalStateException> { runBlocking { it.click("ignored") } }
+                }
+            assertTrue(
+                error.message?.contains("500") == true,
+                "expected status=500 to appear in the error, got: ${error.message}",
+            )
+        } finally {
+            server.server.stop(gracePeriodMillis = 0L, timeoutMillis = 0L)
+        }
+    }
+
+    @Test
+    fun `screenshot against a non-image response raises a clear decode error`() {
+        val server = startEphemeralServer {
+            serverInstall(ServerContentNegotiation) { json() }
+            routing {
+                serverGet("/spectre/screenshot") {
+                    call.respond(
+                        ScreenshotResponse(
+                            width = 0,
+                            height = 0,
+                            pngBase64 =
+                                Base64.getEncoder()
+                                    .encodeToString("definitely not a png".toByteArray()),
+                        )
+                    )
+                }
+            }
+        }
+        try {
+            val error =
+                ComposeAutomator.http(host = "127.0.0.1", port = server.port).use {
+                    assertFailsWith<IllegalStateException> { runBlocking { it.screenshot() } }
+                }
+            assertEquals("Server returned an image we could not decode", error.message)
+        } finally {
+            server.server.stop(gracePeriodMillis = 0L, timeoutMillis = 0L)
+        }
+    }
+
+    private fun startEphemeralServer(module: Application.() -> Unit): EphemeralServer {
+        val server = embeddedServer(CIO, port = 0, module = module).start(wait = false)
+        val port = runBlocking { server.engine.resolvedConnectors().first().port }
+        return EphemeralServer(server, port)
+    }
+
+    private data class EphemeralServer(val server: EmbeddedServer<*, *>, val port: Int)
+
+    private suspend fun ApplicationTestBuilder.postRaw(
+        path: String,
+        body: String,
+        contentType: ContentType,
+    ): HttpResponse =
+        client.post(path) {
+            this.contentType(contentType)
+            setBody(body)
+        }
+
+    private suspend fun assertBodyMentions(response: HttpResponse, needle: String) {
+        val text = response.bodyAsText()
+        assertTrue(
+            text.contains(needle, ignoreCase = true),
+            "expected response body to mention '$needle', got: $text",
+        )
+    }
+}


### PR DESCRIPTION
Implements bucket R4 of the release-hardening epic (#114).

## Summary

- **EDT guards on the wait APIs.** `waitForNode` now rejects EDT callers, with argument validation running first so `waitForNode()` from the EDT surfaces the bad-input error instead of the EDT error. Unit-level EDT-rejection tests added for `waitForNode`, `waitForIdle`, `waitForVisualIdle`.
- **`waitForNode` matching coverage.** New `WaitForNodeMatchingValidationTest` in the sample-desktop validation suite exercises tag-only, text-only, combined tag+text **AND** semantics (with a negative case proving it's AND, not OR), and timeout.
- **HTTP transport negative contract.** New `HttpNegativeContractTest`:
  - Server-side decode failures on `/click` and `/typeText`: empty body → `415`, invalid JSON / missing field → `400` with a body naming `ClickRequest` / `TypeTextRequest`, wrong `Content-Type` → `415`.
  - Client-side surfacing: server `500` on `/click` becomes `IllegalStateException` with the status in the message; non-image bytes on `/screenshot` decode to the existing curated `IllegalStateException`.
  - Server gains a narrow `receiveOrRespond400<T>` helper that catches only `BadRequestException`; wrong Content-Type still surfaces as `415` via Ktor's content-negotiation precheck.
- **Synthetic input parity tests.** New `SyntheticInputParityTest` asserts the synthetic AWT driver matches real-AWT contracts via observable `JFrame` listeners: one `MouseWheelEvent` per call with signed `wheelRotation`, double-click `clickCount` progression, swipe emits no `MOUSE_CLICKED`, modifier mask appears on the held key and does not leak, paste-keystroke isolation through a fake clipboard with the `VK_V` `KEY_PRESSED` carrying the shortcut modifier mask, and screenshot dimensions + sampled pixel.
- **Windows validation #72 dormancy comment.** Measurement-based note above the envelope-detection step in `validation-windows.yml`, documenting that the last 8 runs were clean since 2026-05-11 16:05Z; safety net retained.

## Test plan

- [x] `./gradlew check` (detekt + ktfmt + JVM tests across all modules) passes.
- [x] `./gradlew :sample-desktop:validationTest --tests dev.sebastiano.spectre.sample.validation.WaitForNodeMatchingValidationTest` passes locally on a real macOS display (4/4 tests). `validationTest` is **not** part of `check` — run this opt-in command before merging if a maintainer wants the live coverage re-verified.
- [ ] CI green on Linux + macOS + Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)