### PR TITLE
R5: Pre-publishing security review — easy fixes + trust-boundary docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,12 +1,25 @@
-# Security Policy
+# Security policy
 
-## Supported Versions
+Spectre is pre-1.0. The HTTP transport in the `server` module is **experimental** and
+**unauthenticated**, and is intended for trusted local / test environments only.
+
+The full trust-boundary documentation, capability inventory, and accepted-risk list live on
+the published docs site: <https://spectre.sebastiano.dev/SECURITY/>. Please read that page
+before relying on Spectre's HTTP transport or screenshot / recording capabilities outside the
+intended trusted-local model.
+
+## Supported versions
 
 | Version | Supported          |
 | ------- | ------------------ |
 | 0.x     | :white_check_mark: |
 
-## Reporting a Vulnerability
+## Reporting a vulnerability
 
-We are not running a bug bounty programme. Please report vulnerabilities using
-GitHub issues or spectre@sebastiano.dev — we'll try to get them fixed asap.
+We do not run a bug bounty programme.
+
+- **Current channel:** email **spectre@sebastiano.dev**.
+- **Future:** GitHub's private vulnerability reporting flow may also be used once it is
+  enabled on this repository.
+
+Please do not file public GitHub issues for security reports.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -240,6 +240,15 @@ internal constructor(
      *
      * The returned [BufferedImage] is owned by the caller and safe to read, mutate, or pass to
      * downstream pipelines.
+     *
+     * ## Capture scope
+     *
+     * `region` is passed through to `java.awt.Robot.createScreenCapture` unchanged. It is **not**
+     * constrained to the app under test: any rectangle the JVM can see — including other
+     * applications, sensitive on-screen content, and unrelated windows — is fair game. With `region
+     * = null` the capture covers the **entire virtual desktop**. Treat the returned pixels as
+     * OS-visible content rather than as a slice of the test surface. A narrower per-window /
+     * per-node screenshot API is tracked under #96.
      */
     fun screenshot(region: Rectangle? = null): BufferedImage {
         tccGuard.requireScreenRecording()

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,0 +1,132 @@
+# Security notes
+
+Spectre is a JVM-first library for **automating live Compose Desktop UIs in trusted local /
+test environments**. It drives real OS input, captures screenshots, and records screen content
+by design. This page documents the trust boundaries Spectre relies on, the security-sensitive
+capabilities it exposes, and the risks that are explicitly accepted for the pre-1.0 release.
+
+Spectre is **pre-1.0**. The HTTP transport in the `server` module is **experimental** and is
+expected to change.
+
+## Reporting a vulnerability
+
+Please email security reports to **spectre@sebastiano.dev**. Do not open a public GitHub
+issue for security reports.
+
+GitHub's private vulnerability reporting flow may also be used once it is enabled on this
+repository.
+
+## Trust boundaries
+
+Spectre assumes the following trust model. Capabilities outside these boundaries are
+out of scope.
+
+1. **Test code is trusted.** A malicious test process can already run arbitrary JVM code.
+   Spectre does not try to constrain what its callers can do; it only tries not to expose
+   capabilities to unintended callers.
+2. **The local OS is trusted.** Real `RobotDriver`, screenshots, and recording act with the
+   privileges of the JVM process and the OS permissions granted to it (macOS TCC, Wayland
+   portal, X server access, etc.).
+3. **The HTTP transport assumes a trusted-local peer.** Routes registered by
+   `installSpectreRoutes` expose click, keystroke, and screenshot capture to anyone who can
+   reach the bound port. Bind to `127.0.0.1`. Anything network-reachable broadens the threat
+   model beyond what this release covers.
+4. **Bundled native helpers are trusted artifacts.** Spectre extracts and executes Swift
+   (`spectre-screencapture`) and Rust (`spectre-wayland-helper`) helpers from the published jar
+   resources. The extraction path is process-private; the helpers are launched with `argv`
+   lists (never shell strings). Developer-only override env vars exist for local iteration
+   and are explicitly documented as such — see the
+   [`SPECTRE_WAYLAND_HELPER` note](#developer-only-override-env-vars) below.
+5. **External binaries (ffmpeg, xprop, osascript) come from the host PATH.** Spectre does not
+   pin versions and treats them as prerequisites of the host environment.
+
+## Capabilities and their exposure
+
+| Capability | Surface | Default exposure |
+| --- | --- | --- |
+| Move mouse / press keys | `RobotDriver.click`, `swipe`, `pressKey`, `scrollWheel` | In-process; trusted-local HTTP via `/spectre/click` |
+| Modify clipboard | `RobotDriver.typeText` (save / set / paste / restore) | In-process; trusted-local HTTP via `/spectre/typeText` |
+| Capture pixels | `RobotDriver.screenshot(region)` — **captures any rectangle of the virtual desktop**, not just the app under test | In-process; trusted-local HTTP via `/spectre/screenshot` |
+| Record video | `AutoRecorder`, `FfmpegRecorder`, `ScreenCaptureKitRecorder`, `WaylandPortalRecorder` | In-process only |
+| Execute a helper binary | `HelperBinaryExtractor` (SCK), `WaylandHelperBinaryExtractor` | Local file system, JVM process |
+| Expose any of the above over HTTP | `installSpectreRoutes` mounts the windows / nodes / click / typeText / screenshot routes | **Unauthenticated, plaintext** — host application chooses bind address |
+
+The HTTP exposure column is the most important one to internalise: there are **no auth
+tokens, no TLS, and no origin checks** on any route. The transport is intentionally a
+testing affordance for the same machine, not a remote-control protocol.
+
+## What R5 changed
+
+The pre-publishing security review (R5) made the following changes; everything else listed
+under [Accepted risks](#accepted-risks-deferred-follow-ups) was deferred for a future,
+separately reviewed pass.
+
+- **Trust-boundary documentation** added on the user-facing cross-JVM guide, on
+  `installSpectreRoutes`, on `ComposeAutomator.http(...)`, on `RobotDriver.screenshot`, and on
+  the `SPECTRE_WAYLAND_HELPER` developer override.
+- **Pinned loopback bind in the cross-JVM example.** The published worked example now passes
+  `host = "127.0.0.1"` explicitly to `embeddedServer(...)`. Earlier guidance omitted the host
+  argument; the explicit pin is engine-independent and removes any reliance on whichever
+  default a given Ktor engine happens to apply.
+- **Stopped echoing attacker-controlled content in HTTP error bodies.**
+    - The server's decode-error mapping (`receiveOrRespond400`) responds with just the
+      curated request type name (`Could not decode ClickRequest`) instead of interpolating
+      the underlying `BadRequestException` message.
+    - The `/click` malformed-key 400 response no longer interpolates the caller-supplied
+      key string into the body.
+    - The `/click` no-matching-node 404 response no longer echoes the caller-supplied
+      `nodeKey`.
+    - The HTTP client (`HttpComposeAutomator.click` / `typeText`) no longer interpolates
+      `response.bodyAsText()` into the thrown `IllegalStateException` — peer body content
+      cannot reflect into logs / test output through these exception messages.
+- **New tests** in `HttpNegativeContractTest` pin all four no-echo behaviours so a future
+  regression is caught at `./gradlew check`.
+
+## Accepted risks / deferred follow-ups
+
+These risks are accepted for the pre-1.0 release and tracked for later. Each entry names
+the right venue: items requiring a security-design pass go to #96 (HTTP transport
+expansion); items that are hygiene fixes get their own issues.
+
+- **HTTP transport authentication / authorization.** No tokens, no headers, no principal
+  checks. Tracked under #96.
+- **TLS support on the HTTP client.** `HttpComposeAutomator` speaks plaintext only.
+  Tracked under #96.
+- **CORS / Origin policy on the HTTP routes.** No protection against a local browser
+  reaching the loopback server. Tracked under #96.
+- **Narrower screenshot API.** `RobotDriver.screenshot(region)` captures any rectangle on
+  the display, including unrelated windows. A per-window / per-node API for remote callers
+  is tracked under #96.
+- **Recording output-path validation.** Spectre passes the caller-supplied output path
+  through to ffmpeg / the helpers without rejecting `/dev/`, `/proc/`, symlinks, or
+  not-yet-existing parents. Standalone follow-up issue, separate from #96.
+- **`typeText` clipboard-restore robustness.** A failure during the post-paste restore is
+  swallowed via `runCatching` (clipboard may be left holding the typed text). Standalone
+  follow-up issue.
+- **Helper-extraction cleanup.** Extracted helper binaries are not `deleteOnExit`-registered.
+  This is hygiene, not security (the extraction path is process-private and writable only by
+  the user), but a tidy-up follow-up is worth tracking.
+- **Supply-chain audit of Gradle plugins and external binaries** (ffmpeg, GStreamer,
+  xdg-desktop-portal, OS APIs). Out of scope per the masterplan.
+
+## Developer-only override env vars
+
+The `SPECTRE_WAYLAND_HELPER` environment variable lets a developer point the recorder at a
+locally-built helper binary without rebundling. It is **honored unconditionally** — there is
+no signature check, hash check, or path constraint. Never set it in an environment that
+ingests untrusted input. The bundled helper is the only supported configuration for non-dev
+use.
+
+## Out of scope for this review
+
+The R5 review explicitly did not cover:
+
+- Making the HTTP transport safe for arbitrary untrusted networks.
+- Designing authentication / authorization for a production remote-control service.
+- Sandboxing untrusted test code.
+- Full supply-chain audit of third-party dependencies.
+- True Wayland window-targeted / window-following capture beyond what the portal helper
+  exposes.
+
+If a follow-up review uncovers an issue in any of the above areas, please use the reporting
+flow at the top of this page.

--- a/docs/guide/cross-jvm.md
+++ b/docs/guide/cross-jvm.md
@@ -21,6 +21,23 @@ top of an in-process `ComposeAutomator`; the test JVM talks to it through
     (`waitForVisualIdle`) are in-process only. If you need them, run the test JVM in
     the same process as the UI.
 
+!!! warning "Trust boundary"
+    The HTTP transport is **experimental** and intended for **trusted local / test
+    environments only**.
+
+    - Every route is **unauthenticated**. Anything that can reach the bound port
+      can click, type, and capture screenshots.
+    - Communication is **plaintext HTTP**. There is no TLS support.
+    - `click` and `typeText` drive **real OS input**; `screenshot` captures
+      whatever pixels the host JVM can see, including content from other windows.
+    - **Bind to `127.0.0.1`.** Do not expose this server on a network-reachable
+      interface. The examples below pin the loopback bind explicitly.
+    - Authentication, authorization, and TLS are tracked for a separately
+      reviewed future design (#96).
+
+    See [Security notes](../SECURITY.md) for the full risk register and the
+    accepted-risk list.
+
 ## Server side: mount the routes
 
 In the hosting JVM, build an in-process automator and install Spectre's routes on a
@@ -42,7 +59,10 @@ import io.ktor.server.netty.Netty
 
 val automator = ComposeAutomator.inProcess()
 
-embeddedServer(Netty, port = 9274) {
+// `host = "127.0.0.1"` is intentional: the HTTP transport is unauthenticated, so the
+// server must not be reachable from outside the local machine. See the "Trust boundary"
+// warning above.
+embeddedServer(Netty, host = "127.0.0.1", port = 9274) {
     installSpectreRoutes(automator)
 }.start(wait = false)
 ```
@@ -80,7 +100,8 @@ import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.server.http
 import kotlinx.coroutines.runBlocking
 
-ComposeAutomator.http(host = "localhost", port = 9274).use { remote ->
+// Connect to the loopback server mounted above.
+ComposeAutomator.http(host = "127.0.0.1", port = 9274).use { remote ->
     runBlocking {
         val nodes = remote.findByTestTag("Submit")
         if (nodes.isNotEmpty()) {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,3 +108,4 @@ nav:
       - Static analysis: STATIC-ANALYSIS.md
       - Recording limitations: RECORDING-LIMITATIONS.md
       - Notarization: NOTARIZATION.md
+      - Security notes: SECURITY.md

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
@@ -39,6 +39,13 @@ internal class WaylandHelperBinaryExtractor(
         // Dev-override path. The env var lets a developer point the recorder at their
         // `cargo build`'s output directly without re-bundling. Verifies the path is
         // executable before returning so a stale path surfaces a clear error.
+        //
+        // Trust boundary (R5): `SPECTRE_WAYLAND_HELPER` is a **developer-only escape hatch**.
+        // It routes the entire portal-recording pipeline through whatever binary the env var
+        // names, with no signature, hash, or path check. Never set it in an environment that
+        // ingests untrusted input (CI runners taking input from arbitrary forks, production
+        // recording pipelines, etc.). The bundled helper is the only supported configuration
+        // for non-dev use.
         envLookup(OVERRIDE_ENV)
             ?.takeIf { it.isNotBlank() }
             ?.let { override ->

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
@@ -16,7 +16,6 @@ import io.ktor.client.request.get
 import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
 import io.ktor.http.isSuccess
@@ -60,9 +59,10 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
                 contentType(ContentType.Application.Json)
                 setBody(ClickRequest(nodeKey = nodeKey))
             }
-        check(response.status.isSuccess()) {
-            "click failed: ${response.status} ${response.bodyAsText()}"
-        }
+        // R5/F5d: keep the status code in the message, but do NOT interpolate
+        // `response.bodyAsText()` — a malicious or unexpected peer can reflect arbitrary
+        // body content into logs/test output through this exception message.
+        check(response.status.isSuccess()) { "click failed: ${response.status}" }
     }
 
     suspend fun typeText(text: String) {
@@ -71,9 +71,8 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
                 contentType(ContentType.Application.Json)
                 setBody(TypeTextRequest(text = text))
             }
-        check(response.status.isSuccess()) {
-            "typeText failed: ${response.status} ${response.bodyAsText()}"
-        }
+        // R5/F5d: see `click` above — peer body deliberately not echoed.
+        check(response.status.isSuccess()) { "typeText failed: ${response.status}" }
     }
 
     suspend fun screenshot(): BufferedImage {
@@ -111,6 +110,15 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
  * Companion extension matching the gist's intended public surface `ComposeAutomator.http(host,
  * port)`. Returns an [HttpComposeAutomator] connected to the remote process; the caller is
  * responsible for closing it.
+ *
+ * ## Trust boundary
+ *
+ * This client speaks **plaintext HTTP** to an **unauthenticated peer**. The caller is responsible
+ * for ensuring `host` points at a trusted endpoint — typically `127.0.0.1` for a server bound on
+ * the same machine. Authentication, authorization, and TLS are tracked for a separately reviewed
+ * future design (#96). See [installSpectreRoutes] and
+ * [the published security notes](https://spectre.sebastiano.dev/SECURITY/) for the full exposure
+ * model.
  */
 fun ComposeAutomator.Companion.http(
     host: String = "localhost",

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -39,6 +39,24 @@ import javax.imageio.ImageIO
  * require live JVM objects (Tracer, IdlingResource) or stateful long-poll semantics that are out of
  * scope for the v1 transport.
  *
+ * ## Trust boundary
+ *
+ * The HTTP transport is **experimental** and intended for trusted local / test environments only:
+ *
+ * - **Unauthenticated.** Every route is open to any caller that can reach the bound port. There are
+ *   no tokens, headers, or origin checks.
+ * - **Plaintext.** Communication is HTTP, not HTTPS. There is no TLS support.
+ * - **Privileged side effects.** `click` and `typeText` drive real OS input; `screenshot` captures
+ *   pixels visible to the host JVM. Anything that can reach this server can do all of the above.
+ * - **Binding is the host application's responsibility.** This function does not start a server —
+ *   pick an engine and bind to `127.0.0.1`. Do not expose the routes to a network interface.
+ * - **Authentication, authorization, and TLS** are tracked for a separately reviewed future design
+ *   (#96).
+ *
+ * See [the cross-JVM guide](https://spectre.sebastiano.dev/guide/cross-jvm/) and
+ * [the security notes](https://spectre.sebastiano.dev/SECURITY/) for the published exposure model
+ * and risk register.
+ *
  * ## ContentNegotiation contract
  *
  * The Spectre routes exchange JSON DTOs, so a JSON-capable [ContentNegotiation] plugin must be
@@ -87,17 +105,21 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
         automator.refreshWindows()
         val request = receiveOrRespond400<ClickRequest>(call, "ClickRequest") ?: return@post
         // NodeKey.parse throws on malformed input — surface that as a client error (400)
-        // rather than letting it bubble up as a generic 500.
+        // rather than letting it bubble up as a generic 500. The body must NOT echo the
+        // attacker-supplied key (R5/F5b): `NodeKey.parse` raises `Invalid NodeKey: $key`
+        // and pre-R5 we interpolated that message verbatim.
         val key =
             try {
                 NodeKey.parse(request.nodeKey)
-            } catch (e: IllegalArgumentException) {
-                call.respond(HttpStatusCode.BadRequest, "Malformed node key: ${e.message}")
+            } catch (_: IllegalArgumentException) {
+                call.respond(HttpStatusCode.BadRequest, "Malformed node key")
                 return@post
             }
         val node = automator.allNodes().firstOrNull { it.key == key }
         if (node == null) {
-            call.respond(HttpStatusCode.NotFound, "No node with key ${request.nodeKey}")
+            // R5/F5c: do NOT echo `request.nodeKey` here — caller-controlled content must
+            // not be reflected in the response body.
+            call.respond(HttpStatusCode.NotFound, "No matching node")
             return@post
         }
         automator.click(node)
@@ -134,13 +156,17 @@ internal fun BufferedImage.toScreenshotResponse(): ScreenshotResponse {
  * kotlinx-serialization fails to decode a request body (invalid JSON, missing required field) is
  * `400 Bad Request` with an empty body. That's a poor user experience — the client gets a 4xx but
  * no clue what request shape was expected. Wrap each `receive<T>()` so the response carries the
- * request type name plus the underlying decode message; the type name is what the negative-contract
- * tests pin.
+ * request type name; the type name is what the negative-contract tests pin.
  *
  * Scope is intentionally narrow: only `BadRequestException` (which `ContentTransformation` raises
  * on decode failures) is caught. Everything else propagates. Wrong Content-Type still surfaces as
  * `415 Unsupported Media Type` via Ktor's content-negotiation precheck — Ktor doesn't even get to
  * `receive<T>()` in that case.
+ *
+ * R5/F5a: the response body deliberately omits the underlying exception message. Decode exceptions
+ * from kotlinx-serialization can quote fragments of the request body, which would reflect
+ * attacker-controlled content back to the caller. The curated request-type name alone is enough for
+ * diagnostics; serializer prose belongs in server-side logs, not on the wire.
  */
 private suspend inline fun <reified T : Any> receiveOrRespond400(
     call: io.ktor.server.application.ApplicationCall,
@@ -148,10 +174,7 @@ private suspend inline fun <reified T : Any> receiveOrRespond400(
 ): T? =
     try {
         call.receive<T>()
-    } catch (e: io.ktor.server.plugins.BadRequestException) {
-        call.respond(
-            HttpStatusCode.BadRequest,
-            "Could not decode $requestTypeName: ${e.message ?: e.javaClass.simpleName}",
-        )
+    } catch (_: io.ktor.server.plugins.BadRequestException) {
+        call.respond(HttpStatusCode.BadRequest, "Could not decode $requestTypeName")
         null
     }

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
@@ -77,9 +77,13 @@ class HttpComposeAutomatorE2ETest {
                 assertFailsWith<IllegalStateException> { remote.click(nodeKey = "nonexistent:0:1") }
             val message = checkNotNull(ex.message)
             assertTrue(message.contains("404"), "Expected 404 in error message, got: $message")
+            // R5/F5d: client `check {}` no longer interpolates `response.bodyAsText()`, so the
+            // node key must not appear in the exception message even when the server's 404
+            // body somehow surfaced it. The no-echo contract is pinned by
+            // `HttpNegativeContractTest`; here we just confirm the absence on the round-trip.
             assertTrue(
-                message.contains("nonexistent:0:1"),
-                "Expected node key in error message, got: $message",
+                !message.contains("nonexistent:0:1"),
+                "Expected node key NOT to appear in error message, got: $message",
             )
         }
     }

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpNegativeContractTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpNegativeContractTest.kt
@@ -65,12 +65,58 @@ class HttpNegativeContractTest {
 
     @Test
     fun `POST click with invalid JSON returns 400 with a useful message`() = testApplication {
+        // The body is deliberately an attacker-shaped payload: if the server ever regresses to
+        // echoing the underlying decoder message back to the caller (as it did pre-R5), this
+        // assertion fails. The test pins the no-echo behaviour without depending on Ktor's
+        // exact serializer prose — only the curated type name is part of the contract.
         application { installSpectreRoutes(headlessAutomator()) }
         val response =
-            postRaw("/spectre/click", body = "not json", contentType = ContentType.Application.Json)
+            postRaw(
+                "/spectre/click",
+                body = "<script>alert(1)</script>",
+                contentType = ContentType.Application.Json,
+            )
         assertEquals(HttpStatusCode.BadRequest, response.status)
         assertBodyMentions(response, "ClickRequest")
+        assertBodyDoesNotContain(response, "<script>")
     }
+
+    @Test
+    fun `POST click with a malformed node key returns 400 without echoing the key`() =
+        testApplication {
+            // Reaches `SpectreServer.kt`'s malformed-key 400 branch, not the schema-decode 400
+            // branch: the JSON parses cleanly, so `receiveOrRespond400` succeeds, and only then
+            // does `NodeKey.parse` throw `IllegalArgumentException("Invalid NodeKey: $key")`.
+            // Pre-R5 that exception message was interpolated into the response body, echoing the
+            // attacker key. Pin that no-echo behaviour here.
+            application { installSpectreRoutes(headlessAutomator()) }
+            val response =
+                postRaw(
+                    "/spectre/click",
+                    body = "{\"nodeKey\": \"<script>alert(1)</script>\"}",
+                    contentType = ContentType.Application.Json,
+                )
+            assertEquals(HttpStatusCode.BadRequest, response.status)
+            assertBodyDoesNotContain(response, "<script>")
+        }
+
+    @Test
+    fun `POST click with a well-formed but unknown node key returns 404 without echoing the key`() =
+        testApplication {
+            // Reaches the 404 no-matching-node branch (not the malformed-key 400 branch): the
+            // key parses as surfaceId=`<script>alert(1)</script>`, ownerIndex=0, nodeId=1, so
+            // `NodeKey.parse` succeeds and the handler falls through to "no node with this key".
+            // Pre-R5 that branch interpolated `request.nodeKey` into the response body.
+            application { installSpectreRoutes(headlessAutomator()) }
+            val response =
+                postRaw(
+                    "/spectre/click",
+                    body = "{\"nodeKey\": \"<script>alert(1)</script>:0:1\"}",
+                    contentType = ContentType.Application.Json,
+                )
+            assertEquals(HttpStatusCode.NotFound, response.status)
+            assertBodyDoesNotContain(response, "<script>")
+        }
 
     @Test
     fun `POST click with missing nodeKey returns 400 with a useful message`() = testApplication {
@@ -123,11 +169,15 @@ class HttpNegativeContractTest {
     // factory at it.
 
     @Test
-    fun `click against a 500 response surfaces an IllegalStateException`() {
+    fun `click against a 500 response surfaces an IllegalStateException without echoing body`() {
+        // The peer reply body is an attacker-shaped payload. Pre-R5 the client's `check {}`
+        // lambda interpolated `response.bodyAsText()` into the thrown message, reflecting
+        // arbitrary peer content into logs / test output. The fix retains the status code in
+        // the message but drops the body. Pin both halves: status present, body absent.
         val server = startEphemeralServer {
             routing {
                 serverPost("/spectre/click") {
-                    call.respond(HttpStatusCode.InternalServerError, "synthetic server failure")
+                    call.respond(HttpStatusCode.InternalServerError, "<script>alert(1)</script>")
                 }
             }
         }
@@ -139,6 +189,41 @@ class HttpNegativeContractTest {
             assertTrue(
                 error.message?.contains("500") == true,
                 "expected status=500 to appear in the error, got: ${error.message}",
+            )
+            assertTrue(
+                error.message?.contains("<script>") != true,
+                "expected peer body NOT to be echoed in the error, got: ${error.message}",
+            )
+        } finally {
+            server.server.stop(gracePeriodMillis = 0L, timeoutMillis = 0L)
+        }
+    }
+
+    @Test
+    fun `typeText against a 500 response surfaces an IllegalStateException without echoing body`() {
+        // Symmetry test for `HttpComposeAutomator.typeText`. Same `check {}` pattern as click,
+        // same body-echo concern, same fix shape.
+        val server = startEphemeralServer {
+            routing {
+                serverPost("/spectre/typeText") {
+                    call.respond(HttpStatusCode.InternalServerError, "<script>alert(1)</script>")
+                }
+            }
+        }
+        try {
+            val error =
+                ComposeAutomator.http(host = "127.0.0.1", port = server.port).use {
+                    assertFailsWith<IllegalStateException> {
+                        runBlocking { it.typeText("ignored") }
+                    }
+                }
+            assertTrue(
+                error.message?.contains("500") == true,
+                "expected status=500 to appear in the error, got: ${error.message}",
+            )
+            assertTrue(
+                error.message?.contains("<script>") != true,
+                "expected peer body NOT to be echoed in the error, got: ${error.message}",
             )
         } finally {
             server.server.stop(gracePeriodMillis = 0L, timeoutMillis = 0L)
@@ -197,6 +282,14 @@ class HttpNegativeContractTest {
         assertTrue(
             text.contains(needle, ignoreCase = true),
             "expected response body to mention '$needle', got: $text",
+        )
+    }
+
+    private suspend fun assertBodyDoesNotContain(response: HttpResponse, needle: String) {
+        val text = response.bodyAsText()
+        assertTrue(
+            !text.contains(needle, ignoreCase = true),
+            "expected response body NOT to contain '$needle', got: $text",
         )
     }
 }

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
@@ -81,7 +81,10 @@ class SpectreServerRoundTripTest {
             }
 
         assertEquals(HttpStatusCode.NotFound, response.status)
-        assertTrue(response.bodyAsText().contains("nonexistent:0:1"))
+        // R5/F5c: the 404 body deliberately does NOT echo the caller-supplied node key. The
+        // no-echo contract is pinned in `HttpNegativeContractTest`; here we just confirm the
+        // status code and the absence of the key in the round-trip path.
+        assertTrue(!response.bodyAsText().contains("nonexistent:0:1"))
     }
 
     @Test


### PR DESCRIPTION
Implements bucket R5 of the release-hardening epic (#114). Applies the pre-publishing security review methodology in `.plans/security-review-scope.md`: fixes the easy HTTP error-echo risks now, documents the rest on a new published security notes page, and defers redesign-shaped work to #96 follow-ups.

## Summary

- **HTTP error messages stop echoing attacker-controlled content.**
  - Server: `receiveOrRespond400`, `/click` malformed-key 400, `/click` no-match 404 each respond with fixed strings — no `e.message` / `NodeKey.parse` echo / caller-key reflection.
  - Client: `HttpComposeAutomator.click` / `typeText` drop `response.bodyAsText()` from their `check {}` exception messages; status code retained. Unused `bodyAsText` import removed.
  - `HttpNegativeContractTest` pins all four no-echo behaviours with branch-correct payloads (e.g. `<script>...:0:1` for the 404 branch, plain `<script>...` for the malformed-key 400). Two pre-existing tests in `SpectreServerRoundTripTest` / `HttpComposeAutomatorE2ETest` that asserted the old echo contract flipped to the new no-echo polarity.

- **Trust-boundary documentation.** New KDoc sections on `installSpectreRoutes`, `ComposeAutomator.http`, `RobotDriver.screenshot`, and the `SPECTRE_WAYLAND_HELPER` developer override. New "Trust boundary" admonition at the top of the cross-JVM user guide. The cross-JVM worked example now pins `host = \"127.0.0.1\"` explicitly on both `embeddedServer(...)` and `ComposeAutomator.http(...)` rather than relying on the chosen engine's implicit default.

- **New `docs/SECURITY.md` site page** wired into the MkDocs Reference nav: trust boundaries, capability/exposure table, "What R5 changed", and an accepted-risks list of follow-ups deferred to #96 (auth, TLS, CORS, narrower screenshot API) and standalone issues (recording output-path validation, clipboard-restore robustness, helper-extraction cleanup).

- **Root `SECURITY.md` rewritten as a pointer** to the published page. Reporting channel: email `spectre@sebastiano.dev` (pre-existing) as the active channel, with GitHub private vulnerability reporting noted as a future option once enabled on the repository.

## Out of scope (deferred)

Listed in full on `docs/SECURITY.md`. Highlights: HTTP authentication/authorization/TLS (#96), CORS/Origin policy (#96), narrower per-window screenshot API for remote callers (#96), recording output-path validation, `typeText` clipboard-restore robustness, helper-extraction cleanup, supply-chain audit.

## Note on the reporting channel

Repository setting **Private vulnerability reporting is currently disabled** (verified via \`gh api /repos/rock3r/spectre/private-vulnerability-reporting\`). To avoid pointing the published security page at a disabled channel, both `SECURITY.md` files use the existing `spectre@sebastiano.dev` email as the active channel and note GHSA as a future option once enabled. Flipping the toggle in repo Settings → Code security and analysis is enough to re-elevate GHSA in a follow-up PR.

## Test plan

- [x] \`./gradlew check\` (detekt + ktfmt + JVM tests across all modules) green.
- [x] \`mkdocs build --strict\` green (no broken anchors, no nav misses).
- [ ] CI green on Linux + macOS + Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)