### PR TITLE
R6: Public KDoc and user docs parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ for the mental model.
 ## Modules
 
 - `core` — semantics tree, selectors, coordinate mapping, Robot-backed input.
-- `server` — embedded HTTP transport (Ktor) for cross-JVM access.
+- `server` — embedded HTTP transport (Ktor) for cross-JVM access. **Experimental**; see
+  [`docs/SECURITY.md`](docs/SECURITY.md) for the trust model.
 - `recording` — region capture via `ffmpeg`, plus window-targeted capture (ScreenCaptureKit on
   macOS, `gdigrab` on Windows). `AutoRecorder` picks per call. See
   [`docs/RECORDING-LIMITATIONS.md`](docs/RECORDING-LIMITATIONS.md).

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -10,12 +10,29 @@ import androidx.compose.ui.semantics.getOrNull
 import java.awt.Point
 import java.awt.Rectangle
 
+/**
+ * Stable identifier for a node in the semantics tree across refreshes.
+ *
+ * Three parts:
+ * - [surfaceId] — the surface this node belongs to (a window or popup root); may contain colons.
+ * - [ownerIndex] — index of the SemanticsOwner inside that surface (Compose can host multiple).
+ * - [nodeId] — the SemanticsNode id assigned by Compose, stable across recompositions as long as
+ *   the node is not re-keyed or removed.
+ *
+ * The string form is `surfaceId:ownerIndex:nodeId` — used on the HTTP transport's
+ * `ClickRequest.nodeKey` field and produced by [toString]. Parse with [parse]; parsing splits from
+ * the right so colons inside [surfaceId] are preserved.
+ */
 data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) {
 
     override fun toString(): String = "$surfaceId:$ownerIndex:$nodeId"
 
     companion object {
 
+        /**
+         * Parses a string of the form `surfaceId:ownerIndex:nodeId` into a [NodeKey]. Throws
+         * [IllegalArgumentException] on malformed input.
+         */
         fun parse(key: String): NodeKey {
             // Split from the right: last segment is nodeId, second-to-last is ownerIndex,
             // everything before is surfaceId (which may contain colons).
@@ -32,6 +49,20 @@ data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) 
     }
 }
 
+/**
+ * Snapshot of a Compose `SemanticsNode` plus enough live geometry to act on it.
+ *
+ * Spectre reads the semantics tree on the EDT (where it must) and constructs `AutomatorNode`s with
+ * **eagerly-snapshotted properties** ([testTag], [texts], [contentDescriptions], …) so callers can
+ * read those fields from any thread without touching the tree again. Geometry properties (bounds,
+ * hit-test rectangles) are computed lazily and may consult the underlying `SemanticsNode` if read
+ * after a recomposition — treat them as snapshots that may not match the node's current on-screen
+ * position after a subsequent refresh.
+ *
+ * Instances are produced by [ComposeAutomator.allNodes] / [ComposeAutomator.findByTestTag] and the
+ * other query entry points; consumers should not construct them directly. The [key] uniquely
+ * identifies the node across refreshes (see [NodeKey]).
+ */
 class AutomatorNode
 internal constructor(
     val key: NodeKey,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorTree.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorTree.kt
@@ -4,6 +4,14 @@ package dev.sebastiano.spectre.core
 
 import androidx.compose.ui.semantics.Role
 
+/**
+ * Read-only snapshot of every Spectre-visible Compose surface and the nodes in it.
+ *
+ * Produced by [ComposeAutomator.tree]; each [AutomatorWindow] in [windows] is a main window or
+ * popup root with a stable [AutomatorWindow.surfaceId]. Use this as the starting point when you
+ * need the full picture rather than a single match — most user-facing queries
+ * ([ComposeAutomator.findByTestTag], etc.) go through this snapshot too.
+ */
 class AutomatorTree internal constructor(private val windows: List<AutomatorWindow>) {
 
     fun windows(): List<AutomatorWindow> = windows
@@ -15,6 +23,15 @@ class AutomatorTree internal constructor(private val windows: List<AutomatorWind
     fun roots(): List<AutomatorNode> = windows.flatMap(AutomatorWindow::roots)
 }
 
+/**
+ * A single Compose surface — a main window or a popup root — within an [AutomatorTree] snapshot.
+ *
+ * Surfaces are stable across refreshes by [surfaceId]; [windowIndex] is the position inside the
+ * tree at the time the snapshot was taken and is not a long-lived identifier. Popups ([isPopup] ==
+ * `true`) come from the Compose popup layer and are listed alongside their hosting main window. The
+ * `findBy*` methods filter the surface's nodes using the same matchers as the top-level
+ * [ComposeAutomator] queries.
+ */
 class AutomatorWindow
 internal constructor(
     val windowIndex: Int,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -33,6 +33,13 @@ internal constructor(
 
     constructor(robot: Robot) : this(AwtRobotAdapter(robot))
 
+    /**
+     * Dispatches a single left-button click at the given screen coordinates: move, press, release.
+     *
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it
+     * (real `java.awt.Robot`), and dispatches inline otherwise (synthetic adapter). Throws
+     * [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
     suspend fun click(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
@@ -42,6 +49,14 @@ internal constructor(
         }
     }
 
+    /**
+     * Dispatches a double left-button click at the given screen coordinates: move, press, release,
+     * press, release. The second press inherits the OS double-click window from the first release,
+     * so Compose's `combinedClickable` and Swing's `MouseEvent.clickCount == 2` fire as expected.
+     *
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
     suspend fun doubleClick(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
@@ -53,6 +68,17 @@ internal constructor(
         }
     }
 
+    /**
+     * Dispatches a press-and-hold at the given screen coordinates: move, press, sleep for
+     * [holdFor], release. Useful for Compose's `Modifier.combinedClickable` long-press handler and
+     * for context-menu triggers.
+     *
+     * The release is wrapped in a `finally` so a cancellation during the hold still lifts the mouse
+     * button — otherwise subsequent clicks would be interpreted as drags.
+     *
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
     suspend fun longClick(
         screenX: Int,
         screenY: Int,
@@ -70,6 +96,20 @@ internal constructor(
         }
     }
 
+    /**
+     * Dispatches a press-drag-release from `(startX, startY)` to `(endX, endY)`, interpolating
+     * through [steps] intermediate points spread over [duration]. The pause between intermediate
+     * moves is computed so that the overall walltime tracks [duration]; [steps] controls
+     * smoothness, not speed.
+     *
+     * The button is released in a `finally`, so a cancellation mid-swipe still lifts the mouse
+     * button. No `MOUSE_CLICKED` event fires when start and end points differ — AWT treats
+     * press/move/release across distinct points as a drag, which is the contract Compose's
+     * `Modifier.draggable` and lazy-list scroll expect.
+     *
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
     suspend fun swipe(
         startX: Int,
         startY: Int,
@@ -98,6 +138,21 @@ internal constructor(
         }
     }
 
+    /**
+     * Pastes [text] into the focused field via the OS clipboard and a synthetic Ctrl/Cmd+V
+     * shortcut. This is the fast path — `Robot.keyPress`-per-character is significantly slower and
+     * stumbles on capitalisation / locale-specific layouts.
+     *
+     * The clipboard is **saved before** and **restored after** the paste, so caller-held clipboard
+     * content survives. On platforms where the clipboard supports read-back the call polls until
+     * the OS pasteboard surfaces the new value before dispatching the shortcut, and pumps the EDT a
+     * few times after the release so the focused field's paste handler reads the right value before
+     * the restore happens. Adapters that don't support clipboard read-back (synthetic test fakes)
+     * skip both settle waits.
+     *
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
     suspend fun typeText(text: String) {
         tccGuard.requireAccessibility()
         runOffEdt {
@@ -169,6 +224,18 @@ internal constructor(
         }
     }
 
+    /**
+     * Selects all content in the focused field, deletes it, then pastes [text]. Uses the same
+     * clipboard-backed paste as [typeText] for the second half; the first half is a Ctrl/Cmd+A
+     * followed by Backspace.
+     *
+     * Useful for overwriting a `TextField`'s current value without the caller having to compute
+     * cursor / selection state. Same caveats as [typeText] for clipboard preservation and EDT
+     * settle.
+     *
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
     suspend fun clearAndTypeText(text: String) {
         tccGuard.requireAccessibility()
         val selectAllModifier = shortcutModifierKeyCode(detectMacOs())
@@ -197,6 +264,15 @@ internal constructor(
         }
     }
 
+    /**
+     * Presses [keyCode] (a `java.awt.event.KeyEvent.VK_*` constant) with any AWT modifier-mask bits
+     * set in [modifiers] (`InputEvent.SHIFT_DOWN_MASK`, `CTRL_DOWN_MASK`, etc.). Modifier keys are
+     * pressed before the key, released after — the modifier mask appears on the `keyCode`
+     * KEY_PRESSED event and does not leak into subsequent calls.
+     *
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
     suspend fun pressKey(keyCode: Int, modifiers: Int = 0) {
         tccGuard.requireAccessibility()
         runOffEdt {
@@ -241,14 +317,16 @@ internal constructor(
      * The returned [BufferedImage] is owned by the caller and safe to read, mutate, or pass to
      * downstream pipelines.
      *
-     * ## Capture scope
+     * ## Trust boundary
      *
      * `region` is passed through to `java.awt.Robot.createScreenCapture` unchanged. It is **not**
      * constrained to the app under test: any rectangle the JVM can see — including other
      * applications, sensitive on-screen content, and unrelated windows — is fair game. With `region
      * = null` the capture covers the **entire virtual desktop**. Treat the returned pixels as
      * OS-visible content rather than as a slice of the test surface. A narrower per-window /
-     * per-node screenshot API is tracked under #96.
+     * per-node screenshot API is tracked under #96. See
+     * [the published security notes](https://spectre.sebastiano.dev/SECURITY/) for the full
+     * exposure model.
      */
     fun screenshot(region: Rectangle? = null): BufferedImage {
         tccGuard.requireScreenRecording()

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TextQuery.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TextQuery.kt
@@ -1,5 +1,13 @@
 package dev.sebastiano.spectre.core
 
+/**
+ * Predicate used by [ComposeAutomator.findByText] and the `findByText` family on [AutomatorWindow]
+ * to match against a node's text properties (`Text`, `EditableText`).
+ *
+ * Build via the factory methods on the companion: [exact] for case-sensitive (or case-insensitive
+ * via the flag) full-string equality, [substring] for `contains`-style partial matching. Regex /
+ * pattern matching is not supported.
+ */
 data class TextQuery(
     val value: String,
     val matchType: TextMatchType = TextMatchType.Exact,
@@ -24,7 +32,10 @@ data class TextQuery(
     }
 }
 
+/** How [TextQuery] compares its [TextQuery.value] against a candidate string. */
 enum class TextMatchType {
+    /** The candidate must equal `value` (subject to `ignoreCase`). */
     Exact,
+    /** The candidate must contain `value` as a substring (subject to `ignoreCase`). */
     Substring,
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/Tracer.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/Tracer.kt
@@ -5,12 +5,12 @@ import java.nio.file.Path
 /**
  * Records performance/profiling traces around an automator scenario.
  *
- * The v1 contract assumes the **app under test owns its own instrumentation** (typically via
+ * The contract assumes the **app under test owns its own instrumentation** (typically via
  * `androidx.tracing` 2.0, which automatically tags Compose's composition / layout / measure / draw
  * phases). The automator's job is to bracket the scenario: start a recording, drive the UI, stop
  * the recording, and flush it to disk so the developer can open it in Perfetto.
  *
- * `PerfettoTracer` is the v1 default — it uses `androidx.tracing-wire-desktop` to produce standard
+ * `PerfettoTracer` is the default — it uses `androidx.tracing-wire-desktop` to produce standard
  * Perfetto trace files (open them at [ui.perfetto.dev](https://ui.perfetto.dev)). Callers that want
  * a different recorder (an in-memory event collector for tests, a JFR adapter, etc.) can plug their
  * own `Tracer` into [ComposeAutomator.withTracing].

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -148,9 +148,7 @@ from a coroutine on `Dispatchers.Main` (Swing EDT), wrap them in
     those pauses to zero. The result is that `longClick` doesn't actually hold, `swipe`
     jumps to the end position instantly, and clipboard operations may race.
 
-    Stick with `runBlocking` for Spectre tests. A future `runSpectreTest` helper may
-    provide `runTest`-style structured concurrency while preserving real time for
-    Spectre's internal delays.
+    Stick with `runBlocking` for Spectre tests.
 
 ## Where to go next
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -81,7 +81,7 @@ pick whichever they're already using.
 | `core`      | `ComposeAutomator`, semantics tree reader, selectors, `RobotDriver` for input.    |
 | `testing`   | `ComposeAutomatorExtension` (JUnit 5), `ComposeAutomatorRule` (JUnit 4).         |
 | `recording` | Region and window-targeted screen capture (`AutoRecorder`, `FfmpegRecorder`, …). |
-| `server`    | Embedded HTTP transport (Ktor) and `HttpComposeAutomator` for cross-JVM access.   |
+| `server`    | Embedded HTTP transport (Ktor) and `HttpComposeAutomator` for cross-JVM access. **Experimental**; see [Security notes](../SECURITY.md). |
 
 Most projects only need `core` + `testing`. Add `recording` if you want video output for
 test runs, and `server` if your test process needs to reach a UI in a different JVM.

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -283,6 +283,6 @@ A few things to know about IDE-hosted Compose surfaces:
   — the in-tree IntelliJ plugin Spectre drives in CI, with the
   pooled-thread / EDT-marshalling pattern fully worked out.
 - [`ide-uitest.yml`](https://github.com/rock3r/spectre/blob/main/.github/workflows/ide-uitest.yml)
-  — the workflow that boots IntelliJ and runs the UI test on macOS and Windows.
+  — the workflow that boots IntelliJ and runs the UI test on macOS, Windows, and Linux.
 - [Spike gist](https://gist.github.com/rock3r/8e520bb3fe8fe5886367d5e22cefbab8) — the
   original design notes covering IDE-hosting more broadly.

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -25,6 +25,33 @@ You start a recording, you get a `RecordingHandle`, you stop the handle when you
 done. Implementations must spawn the underlying process eagerly so frames are landing
 in `output` by the time `start()` returns.
 
+## Recorder capability matrix
+
+Five concrete recorders ship today. `AutoRecorder` (next section) picks one of them per
+call based on platform and whether you pass a window; the matrix below is the per-recorder
+view for when you want to know what each backend can and cannot do.
+
+| Recorder | Capture shape | Follows window resize? | Captures occluding windows / popups? | Prerequisites | Platforms |
+| --- | --- | --- | --- | --- | --- |
+| `FfmpegRecorder` | Screen region (fixed `Rectangle`) | No — region fixed at `start()` | Yes — anything visible inside the region lands in the frame, including occluding apps and overlapping Compose `OnWindow` popups | `ffmpeg` on `PATH`; macOS Screen Recording TCC for the launching app | macOS · Windows · Linux Xorg |
+| `FfmpegWindowRecorder` | Named window (`gdigrab title=`) | Yes — `gdigrab` retracks the window across moves and resizes | No — only the window's pixels are captured. Compose `OnWindow` popups land in a separate OS window with a different title, so they are **not** captured. `OnSameCanvas` / `OnComponent` popups are part of the window surface and are captured | `ffmpeg` on `PATH`; visible window with a non-blank exact title | Windows |
+| `ScreenCaptureKitRecorder` | Named window (pid + title substring) | Yes — reads the window backing store directly, follows moves and resizes | No — same window-source semantics as `FfmpegWindowRecorder`. `OnWindow` popups not captured; `OnSameCanvas` / `OnComponent` captured | Bundled Swift helper (`spectre-screencapture`); macOS Screen Recording TCC for the launching app | macOS |
+| `WaylandPortalRecorder` | Monitor region (portal `SourceType.MONITOR`, cropped) | No — monitor-level source | Depends on the compositor. Validated on GNOME/Mutter to include the user's overlays but exclude apps occluding the recorded region | Bundled Rust helper (`spectre-wayland-helper`); `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`. First call pops the compositor's "share screen" dialog | Linux Wayland |
+| `WaylandPortalWindowRecorder` | Named window (portal `SourceType.WINDOW` + fixed crop) | **No.** The crop is computed once from `_GTK_FRAME_EXTENTS` at `start()` and stays at those pixel coordinates for the rest of the recording. If the user moves or resizes the window during the recording, the crop no longer aligns with the window's pixels (typically the recording shows blank / black for the unrendered area of the original rectangle) — see `WaylandPortalWindowRecorder`'s KDoc for the detailed rationale | No — only the picked window's pixels are in the stream. `OnWindow` popups not captured | Bundled Rust helper; `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`; `xprop` on `PATH`; compositor must publish `_GTK_FRAME_EXTENTS` (GNOME/Mutter verified; older Mutter / KDE / sway may not — the recorder throws rather than producing misaligned video) | Linux Wayland |
+
+A note on the Wayland window row: window-source isolation (no leakage from other apps) is
+what makes window-targeted Wayland capture different from ffmpeg-on-X11 region capture. The
+crop is fixed at `start()`, so the recording is robust against occluders but not against the
+user moving or resizing the window mid-recording.
+
+Embedded-host implications: `ComposePanel`s without a top-level OS window — including
+Jewel-hosted Compose inside an IntelliJ plugin tool window — have no exact window title for
+`FfmpegWindowRecorder` to bind to and no top-level window for the SCK helper to discover.
+`AutoRecorder` falls through to region capture (`FfmpegRecorder` on macOS / Windows / Linux
+Xorg; `WaylandPortalRecorder` on Linux Wayland) for those surfaces. Linux support is
+best-effort: portal capture is exercised against GNOME/Mutter on Ubuntu 22.04 and 24.04;
+KDE / sway / wlroots may behave differently and are not validated.
+
 ## `AutoRecorder` — pick a backend per call
 
 `AutoRecorder` is the entry point you should reach for first. It looks at what you pass

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,7 +57,7 @@ familiar — Spectre brings the same "find a node, do a thing, assert" loop to C
 - :material-video: **[Recording](guide/recording.md)** — Region and window-targeted capture
   across macOS, Windows, and Linux.
 - :material-server: **[Cross-JVM](guide/cross-jvm.md)** — Drive a UI hosted in another JVM
-  process via the embedded HTTP transport.
+  process via the embedded HTTP transport (experimental; see [Security notes](SECURITY.md)).
 
 </div>
 

--- a/recording/README.md
+++ b/recording/README.md
@@ -1,34 +1,51 @@
 # Recording
 
-Screen recording for Spectre scenarios. v1 region capture (ffmpeg) and v2 window-targeted
-capture (ScreenCaptureKit) live side by side — pick by what you need.
+Screen recording for Spectre scenarios. Region capture (ffmpeg) and window-targeted capture
+(ScreenCaptureKit on macOS, `gdigrab` on Windows, xdg-desktop-portal on Linux Wayland) live
+side by side — pick by what you need.
+
+The user-facing recorder capability matrix lives in
+[`docs/guide/recording.md`](../docs/guide/recording.md). This README is the in-tree
+implementer's view of the same module.
 
 ## Public surface
 
-### Region capture (v1)
+### Region capture
 - `Recorder` — interface; produces a `RecordingHandle` for an in-progress capture.
-- `FfmpegRecorder` — v1 default. Shells out to a system `ffmpeg` and captures the requested
-  region via the macOS avfoundation device. Resolves the binary via PATH (`resolveFfmpegPath()`)
-  by default; pass `ffmpegPath` to override (testing, non-PATH installs).
+- `FfmpegRecorder` — the region-capture default. Shells out to a system `ffmpeg` and captures
+  the requested region via `avfoundation` on macOS, `gdigrab` on Windows, and `x11grab` on
+  Linux Xorg. Throws on Linux Wayland — use `WaylandPortalRecorder` instead. Resolves the
+  binary via `PATH` (`resolveFfmpegPath()`) by default; pass `ffmpegPath` to override (testing,
+  non-`PATH` installs).
 
-### Window-targeted capture (v2, #18)
+### Window-targeted capture
 - `screencapturekit.ScreenCaptureKitRecorder` — forks a bundled Swift helper that drives
   `SCStream` + `AVAssetWriter` against a single window identified by `(pid, title-substring)`.
   Captures only that window's pixels even when partially occluded, and survives the host
   window moving across the screen. macOS only. Implements `WindowRecorder`.
-- `screencapturekit.WindowRecorder` — interface for window-targeted backends. SCK is the only
-  implementation today; future Windows / Linux backends would slot in here.
+- `screencapturekit.WindowRecorder` — interface for window-targeted backends. SCK is the
+  macOS implementation; `FfmpegWindowRecorder` covers Windows, and `WaylandPortalWindowRecorder`
+  covers Linux Wayland.
+- `FfmpegWindowRecorder` — `gdigrab title=` capture on Windows. Follows the window across
+  moves and resizes; requires a non-blank exact title.
+- `portal.WaylandPortalWindowRecorder` — Linux Wayland window-targeted capture via
+  `xdg-desktop-portal`'s `SourceType.WINDOW`. Captures only the picked window's pixels (no
+  leakage from occluding apps), but Spectre's crop is fixed at `start()` time — if the user
+  moves or resizes the window during the recording, the crop no longer aligns with the
+  window's pixels and the output is misaligned. Requires `xprop` and a compositor publishing
+  `_GTK_FRAME_EXTENTS` (validated on GNOME/Mutter).
 
   Decision rationale + alternatives considered are written up in the bridge strategy doc kept
   in `.plans/`.
 
-### Auto-routing (v2)
-- `AutoRecorder` — high-level wrapper that takes both a `WindowRecorder` and a `Recorder`
-  plus a `(window?, region, output, options)` per-call signature. Picks SCK when a window
-  is supplied on macOS, falls back to ffmpeg region capture otherwise. If the SCK helper
-  isn't bundled in the jar (e.g. built on Linux running on macOS) it degrades to ffmpeg
-  with a stderr warning. Operational SCK failures (TCC denied, window not found) propagate
-  unmodified — only `HelperNotBundledException` triggers the fallback.
+### Auto-routing
+- `AutoRecorder` — high-level wrapper that takes a `WindowRecorder`, a `Recorder`, and the
+  Linux portal recorders (when wired). Routing is Wayland-first (window-targeted portal,
+  region portal, or loud failure if no portal recorder is wired), then no-window region
+  capture, then macOS SCK with `HelperNotBundledException` → ffmpeg region fallback, then
+  Windows `gdigrab` title capture, then ffmpeg region as the final fallback. Operational
+  SCK failures (TCC denied, window not found) propagate unmodified — only
+  `HelperNotBundledException` triggers the fallback.
 
 ### Shared
 - `RecordingHandle` — `AutoCloseable`. Stop sends `q` on stdin (the documented clean-shutdown
@@ -37,18 +54,21 @@ capture (ScreenCaptureKit) live side by side — pick by what you need.
 - `RecordingOptions` — frame rate, cursor capture, codec.
 - `MacOsRecordingPermissions.diagnose()` — best-effort startup diagnostic for Screen Recording
   and Accessibility permissions. Full native detection (`CGPreflightScreenCaptureAccess`,
-  `AXIsProcessTrusted`) is still deferred — the v2 helper detects TCC denial by exit code,
-  which is the practical signal callers need.
+  `AXIsProcessTrusted`) is a future improvement — the SCK helper detects TCC denial by exit
+  code, which is the practical signal callers need.
 
 ## Capability matrix
 
 | Capability | Status |
 |---|---|
-| macOS region capture (avfoundation) | ✅ `FfmpegRecorder` |
+| macOS region capture (`avfoundation`) | ✅ `FfmpegRecorder` |
+| macOS window-targeted capture (ScreenCaptureKit) | ✅ `ScreenCaptureKitRecorder` |
 | Embedded `ComposePanel` (`windowHandle == 0L`) | ✅ region capture (window-targeted not applicable) |
-| ScreenCaptureKit window-targeted capture | ✅ `ScreenCaptureKitRecorder` |
-| Windows `gdigrab` recording | ⏸ v3 (#22) |
-| Linux `x11grab` / pipewire recording | ⏸ v4 (#27) |
+| Windows region capture (`gdigrab`) | ✅ `FfmpegRecorder` |
+| Windows window-targeted capture (`gdigrab title=`) | ✅ `FfmpegWindowRecorder` |
+| Linux Xorg region capture (`x11grab`) | ✅ `FfmpegRecorder` |
+| Linux Wayland region capture (xdg-desktop-portal) | ✅ `WaylandPortalRecorder` |
+| Linux Wayland window-targeted capture (xdg-desktop-portal `SourceType.WINDOW`) | ✅ `WaylandPortalWindowRecorder` (fixed crop at `start()` — moves and resizes during recording break alignment) |
 | Audio | ⏸ deferred — add when asked |
 | Notarization of the SCK helper | ✅ release workflow signs and notarizes the universal helper |
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -24,8 +24,13 @@ import java.util.concurrent.atomic.AtomicReference
  *   for the JVM process** (see [MacOsRecordingPermissions]).
  * - Windows: gdigrab device with input-side region selection (`-offset_x`/`-offset_y`/
  *   `-video_size`). No equivalent TCC permission gate, but gdigrab can't capture minimised windows.
- * - Linux / BSD: not yet implemented — [FfmpegBackend.detect] throws on those hosts. Tracked under
- *   v4.
+ * - Linux Xorg: x11grab device with input-side region selection. Works against real Xorg and
+ *   against XWayland-bridged X clients.
+ * - Linux Wayland: not handled by this recorder — Wayland's security model forbids cross-process
+ *   framebuffer reads. [FfmpegBackend.detect] throws on Wayland sessions; route through
+ *   `WaylandPortalRecorder` / `WaylandPortalWindowRecorder` instead (`AutoRecorder` does this
+ *   automatically).
+ * - BSD: not supported.
  *
  * The platform backend is picked at construction time via [FfmpegBackend.detect] and can be
  * overridden via the internal constructor for tests (so the produced argv is deterministic

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
@@ -14,10 +14,13 @@ import java.util.concurrent.TimeUnit
  *
  * Detecting these without JNI is awkward — the canonical native APIs
  * (`CGPreflightScreenCaptureAccess`, `AXIsProcessTrusted`) live in CoreGraphics /
- * ApplicationServices and aren't reachable from pure JVM. v1 ships the diagnostic surface as
- * documentation plus a probe-style heuristic via the `tccutil`/`osascript` CLIs where available;
- * full native detection is deferred to v2 once the ScreenCaptureKit work brings in JNI/Panama
- * bindings anyway.
+ * ApplicationServices and aren't reachable from pure JVM. Spectre currently ships the diagnostic
+ * surface as documentation plus a probe-style heuristic via the `tccutil` / `osascript` CLIs where
+ * available. Full native detection (calling into CoreGraphics / ApplicationServices via JNI or
+ * Panama) is a future improvement; in the meantime callers see the actual permission outcome at
+ * recording start because
+ * [ScreenCaptureKitRecorder][dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureKitRecorder]
+ * detects TCC denial via the helper's exit code.
  */
 object MacOsRecordingPermissions {
 
@@ -45,9 +48,9 @@ object MacOsRecordingPermissions {
 
     private fun probeScreenRecordingPermission(): PermissionStatus {
         // CGPreflightScreenCaptureAccess lives in CoreGraphics and isn't reachable from pure
-        // JVM. There's no AppleScript proxy for the Screen Recording TCC entry either, so for
-        // v1 we honestly report Unknown rather than pretending we know — full native detection
-        // is deferred to v2 alongside the ScreenCaptureKit JNI/Panama work.
+        // JVM. There's no AppleScript proxy for the Screen Recording TCC entry either, so we
+        // honestly report Unknown rather than pretending we know — callers see the actual
+        // outcome at recording start when the SCK helper exits with a TCC-denied code.
         return PermissionStatus.Unknown
     }
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/Recorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/Recorder.kt
@@ -6,9 +6,12 @@ import java.nio.file.Path
 /**
  * Captures a region of the screen to a video file.
  *
- * The v1 default is [FfmpegRecorder] which shells out to a system `ffmpeg` binary. Tests and
- * advanced consumers can swap in their own [Recorder] implementation (e.g. an in-memory frame
- * accumulator, or the future ScreenCaptureKit-backed window-targeted recorder tracked in v2).
+ * The default region-capture implementation is [FfmpegRecorder], which shells out to a system
+ * `ffmpeg` binary. Window-targeted capture lives behind separate
+ * [WindowRecorder][dev.sebastiano.spectre.recording.screencapturekit.WindowRecorder]
+ * implementations: `ScreenCaptureKitRecorder` on macOS, `FfmpegWindowRecorder` on Windows, and
+ * `WaylandPortalWindowRecorder` on Linux Wayland. Tests and advanced consumers can swap in their
+ * own [Recorder] implementation (e.g. an in-memory frame accumulator).
  */
 interface Recorder {
 

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
@@ -28,10 +28,9 @@ import javax.imageio.ImageIO
 /**
  * Cross-JVM client for a `ComposeAutomator` running behind [installSpectreRoutes].
  *
- * Created via the companion extension `ComposeAutomator.http(host, port)` (see
- * [HttpFactory.kt][http]). The v1 client surface mirrors the in-process automator's most-used
- * queries and actions; advanced features (idling resources, `withTracing`, `waitForVisualIdle`)
- * remain in-process only and are documented as such.
+ * Created via the companion extension [ComposeAutomator.http][http]. The client surface mirrors the
+ * in-process automator's most-used queries and actions; advanced features (idling resources,
+ * `withTracing`, `waitForVisualIdle`) remain in-process only and are documented as such.
  *
  * The instance owns its [HttpClient] and must be `close()`d to release pooled connections. Use `use
  * { ... }` from `kotlin.AutoCloseable` for scoped lifecycles.
@@ -44,15 +43,23 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
     // leak the engine on close, since Ktor only auto-closes engines it constructed itself.
     private val client: HttpClient = HttpClient(CIO) { install(ContentNegotiation) { json() } }
 
+    /** Fetches the current list of tracked windows from the remote automator. */
     suspend fun windows(): List<WindowSummaryDto> =
         client.get("$baseUrl/windows").body<WindowsResponse>().windows
 
+    /** Fetches every visible semantics node from every tracked surface on the remote automator. */
     suspend fun allNodes(): List<NodeSnapshotDto> =
         client.get("$baseUrl/nodes").body<NodesResponse>().nodes
 
+    /** Fetches semantics nodes carrying the given `testTag` from the remote automator. */
     suspend fun findByTestTag(tag: String): List<NodeSnapshotDto> =
         client.get("$baseUrl/nodes") { parameter("testTag", tag) }.body<NodesResponse>().nodes
 
+    /**
+     * Asks the remote automator to click the node addressed by [nodeKey] (the canonical string form
+     * of [dev.sebastiano.spectre.core.NodeKey] — `surfaceId:ownerIndex:nodeId`). Throws
+     * [IllegalStateException] on any non-2xx response.
+     */
     suspend fun click(nodeKey: String) {
         val response =
             client.post("$baseUrl/click") {
@@ -65,6 +72,11 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
         check(response.status.isSuccess()) { "click failed: ${response.status}" }
     }
 
+    /**
+     * Asks the remote automator to type [text] into whatever currently has focus, via the same
+     * clipboard-backed paste as the in-process driver. Throws [IllegalStateException] on any
+     * non-2xx response.
+     */
     suspend fun typeText(text: String) {
         val response =
             client.post("$baseUrl/typeText") {
@@ -75,6 +87,10 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
         check(response.status.isSuccess()) { "typeText failed: ${response.status}" }
     }
 
+    /**
+     * Fetches a screenshot from the remote automator and decodes it as a [BufferedImage]. Throws
+     * [IllegalStateException] if the decoded PNG bytes can't be parsed.
+     */
     suspend fun screenshot(): BufferedImage {
         val response = client.get("$baseUrl/screenshot").body<ScreenshotResponse>()
         val bytes = Base64.getDecoder().decode(response.pngBase64)

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -16,8 +16,20 @@ import org.junit.rules.ExternalResource
  * }
  * ```
  *
- * The [factory] defaults to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
- * or focused unit testing can supply their own factory.
+ * ## Lifecycle
+ *
+ * The [factory] is invoked in `before` (before each `@Test` method); the resulting automator is
+ * available via [automator] for the duration of the test and goes out of scope in `after`.
+ * Accessing [automator] outside a running test throws [IllegalStateException]. The default factory
+ * is `ComposeAutomator.inProcess()`; tests that need a stub for headless CI or focused unit testing
+ * can supply their own factory.
+ *
+ * Both [factory] invocation and automator interaction can touch the EDT; standard Spectre EDT rules
+ * apply (no EDT callers of suspend wait helpers; see
+ * [`waitForIdle` / `waitForNode` / `waitForVisualIdle`][ComposeAutomator]).
+ *
+ * Prefer [ComposeAutomatorExtension] when using JUnit 5 — JUnit 5's parameter-injection model is a
+ * better fit for parallel test execution.
  */
 class ComposeAutomatorRule(private val factory: AutomatorFactory) : ExternalResource() {
 


### PR DESCRIPTION
Implements bucket R6 of the release-hardening epic (#114). Makes the documented contract match the implementation and decisions that landed in R1–R5. **No code-behaviour changes. No new APIs. No new compatibility tooling — that's R7.**

## Summary

- **Recorder capability matrix** added to `docs/guide/recording.md`: one row per concrete recorder × backend / capture shape / follows window resize / captures occluding windows / prerequisites / platforms, plus embedded-host fall-through and Linux best-effort coverage notes. The Wayland window-recorder row matches the existing production KDoc in `WaylandPortalWindowRecorder.kt` — the crop is computed once at `start()`; moving or resizing the window during recording breaks alignment.

- **User-guide drift fixes.** `docs/guide/intellij.md` now correctly states `ide-uitest.yml` runs on macOS, Windows, and Linux (post-#82). `docs/guide/getting-started.md` lost the speculative `runSpectreTest` future-tense sentence (DOCS-STYLE rule 3 violation).

- **HTTP transport "experimental" markers** added in the three places they were still missing: the root README module list, the installation-guide module table, and the `docs/index.md` landing card. R5's trust-boundary work in KDoc + `docs/guide/cross-jvm.md` + `docs/SECURITY.md` is left intact.

- **`recording/README.md`** updated: dropped the "(v2, #18)" / "(v2)" section labels; replaced "⏸ v3" Windows + "⏸ v4" Linux rows in the capability matrix with `✅` rows naming `FfmpegWindowRecorder`, `WaylandPortalRecorder`, `WaylandPortalWindowRecorder`, plus `FfmpegRecorder`'s x11grab fallback on Linux Xorg. Added a pointer to the user-facing matrix.

- **KDoc cleanup (no behaviour change)**:
  - Dropped decorative milestone language (`v1` / `v2` / `v3` / `v4`, "the future ...") from `Recorder.kt`, `FfmpegRecorder.kt`, `MacOsRecordingPermissions.kt`, `Tracer.kt`, and `HttpComposeAutomator.kt`. Live tracker references (e.g. #96) kept; "future improvement" used where no live issue exists.
  - Fixed `HttpComposeAutomator`'s KDoc reference to the nonexistent `HttpFactory.kt`.
  - New KDoc on the seven bare `RobotDriver` suspend input methods (`click`, `doubleClick`, `longClick`, `swipe`, `typeText`, `clearAndTypeText`, `pressKey`). EDT-safety wording is honest about both backends: \"Safe to call from the EDT; `RobotDriver` moves work off the EDT when the backend requires it\" — the synthetic adapter sets `requiresOffEdt = false` and dispatches inline, so the universal \"runs on a worker\" claim would be wrong.
  - Renamed `RobotDriver.screenshot`'s "Capture scope" subsection to "Trust boundary" for symmetry with R5's HTTP KDocs.
  - Class-level docstrings on `NodeKey` (with the `surfaceId:ownerIndex:nodeId` format documented), `AutomatorNode`, `AutomatorTree`, `AutomatorWindow`, `TextQuery`, `TextMatchType`, per-method KDoc on `HttpComposeAutomator`, and a "Lifecycle" section on `ComposeAutomatorRule`.

## Out of scope by design (R7 or deferred)

- Stability / compatibility policy file (R7).
- Explicit API mode, Binary Compatibility Validator, Metalava (R7).
- Dokka rendering / KDoc CI plumbing.
- Maven publishing (R7).
- `core/README.md` scaffold (intentionally scaffold-only per repo policy).

## Note on the macOS universal-helper command

The masterplan flagged `docs/guide/recording.md`'s macOS universal-helper command as wrong. **Verified correct** against `recording/build.gradle.kts:374–388`: passing `-PuniversalHelper` flips `processResources` to depend on `assembleScreenCaptureKitHelperUniversal` rather than the host-arch task. No fix needed; recorded here so this debt doesn't get re-raised.

## Test plan

- [x] `./gradlew check` (detekt + ktfmt + JVM tests across all modules) green.
- [x] `mkdocs build --strict` green (no broken anchors, nav, or links).
- [ ] CI green on Linux + macOS + Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)