### PR TITLE
R7: Release compatibility tooling and policy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,13 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v5
 
+      - name: Validate public API against committed baselines
+        # R7 defensive depth: PR-time `check` already runs `checkKotlinAbi` via the Kotlin
+        # Gradle Plugin's built-in abiValidation extension, but a tag pushed from a
+        # feature branch that wasn't merged through PR review would otherwise skip the
+        # ABI check. Running it here catches that path.
+        run: ./gradlew checkKotlinAbi
+
       - name: Import Developer ID certificate
         env:
           APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -1,0 +1,261 @@
+public abstract interface class dev/sebastiano/spectre/core/AutomatorIdlingResource {
+	public fun diagnosticMessage ()Ljava/lang/String;
+	public abstract fun isIdleNow ()Z
+}
+
+public final class dev/sebastiano/spectre/core/AutomatorIdlingResource$DefaultImpls {
+	public static fun diagnosticMessage (Ldev/sebastiano/spectre/core/AutomatorIdlingResource;)Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/AutomatorNode {
+	public final fun bothBounds ()Ldev/sebastiano/spectre/core/BothBounds;
+	public final fun getBoundsInWindow ()Landroidx/compose/ui/geometry/Rect;
+	public final fun getBoundsOnScreen ()Ljava/awt/Rectangle;
+	public final fun getCenterOnScreen ()Ljava/awt/Point;
+	public final fun getChildren ()Ljava/util/List;
+	public final fun getContentDescription ()Ljava/lang/String;
+	public final fun getContentDescriptions ()Ljava/util/List;
+	public final fun getEditableText ()Ljava/lang/String;
+	public final fun getKey ()Ldev/sebastiano/spectre/core/NodeKey;
+	public final fun getParent ()Ldev/sebastiano/spectre/core/AutomatorNode;
+	public final fun getRole-RLKlGQI ()Landroidx/compose/ui/semantics/Role;
+	public final fun getSurfaceId ()Ljava/lang/String;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getTexts ()Ljava/util/List;
+	public final fun isDisabled ()Z
+	public final fun isFocused ()Z
+	public final fun isSelected ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/AutomatorTree {
+	public final fun allNodes ()Ljava/util/List;
+	public final fun roots ()Ljava/util/List;
+	public final fun window (I)Ldev/sebastiano/spectre/core/AutomatorWindow;
+	public final fun windows ()Ljava/util/List;
+}
+
+public final class dev/sebastiano/spectre/core/AutomatorWindow {
+	public final fun allNodes ()Ljava/util/List;
+	public final fun findByContentDescription (Ljava/lang/String;)Ljava/util/List;
+	public final fun findByRole-V4PA4sw (I)Ljava/util/List;
+	public final fun findByTestTag (Ljava/lang/String;)Ljava/util/List;
+	public final fun findByText (Ldev/sebastiano/spectre/core/TextQuery;)Ljava/util/List;
+	public final fun findByText (Ljava/lang/String;Z)Ljava/util/List;
+	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/core/AutomatorWindow;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun findOneByTestTag (Ljava/lang/String;)Ldev/sebastiano/spectre/core/AutomatorNode;
+	public final fun findOneByText (Ldev/sebastiano/spectre/core/TextQuery;)Ldev/sebastiano/spectre/core/AutomatorNode;
+	public final fun findOneByText (Ljava/lang/String;Z)Ldev/sebastiano/spectre/core/AutomatorNode;
+	public static synthetic fun findOneByText$default (Ldev/sebastiano/spectre/core/AutomatorWindow;Ljava/lang/String;ZILjava/lang/Object;)Ldev/sebastiano/spectre/core/AutomatorNode;
+	public final fun getSurfaceId ()Ljava/lang/String;
+	public final fun getWindowIndex ()I
+	public final fun isPopup ()Z
+	public final fun roots ()Ljava/util/List;
+}
+
+public final class dev/sebastiano/spectre/core/BothBounds {
+	public fun <init> (Landroidx/compose/ui/geometry/Rect;Ljava/awt/Rectangle;)V
+	public final fun component1 ()Landroidx/compose/ui/geometry/Rect;
+	public final fun component2 ()Ljava/awt/Rectangle;
+	public final fun copy (Landroidx/compose/ui/geometry/Rect;Ljava/awt/Rectangle;)Ldev/sebastiano/spectre/core/BothBounds;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/BothBounds;Landroidx/compose/ui/geometry/Rect;Ljava/awt/Rectangle;ILjava/lang/Object;)Ldev/sebastiano/spectre/core/BothBounds;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInWindow ()Landroidx/compose/ui/geometry/Rect;
+	public final fun getOnScreen ()Ljava/awt/Rectangle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/ComposeAutomator {
+	public static final field Companion Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;
+	public synthetic fun <init> (Ldev/sebastiano/spectre/core/WindowTracker;Ldev/sebastiano/spectre/core/SemanticsReader;Ldev/sebastiano/spectre/core/RobotDriver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun allNodes ()Ljava/util/List;
+	public final fun clearAndTypeText (Ldev/sebastiano/spectre/core/AutomatorNode;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun click (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun doubleClick (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun findByContentDescription (Ljava/lang/String;)Ljava/util/List;
+	public final fun findByRole-V4PA4sw (I)Ljava/util/List;
+	public final fun findByTestTag (Ljava/lang/String;)Ljava/util/List;
+	public final fun findByText (Ldev/sebastiano/spectre/core/TextQuery;)Ljava/util/List;
+	public final fun findByText (Ljava/lang/String;Z)Ljava/util/List;
+	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun findOneByTestTag (Ljava/lang/String;)Ldev/sebastiano/spectre/core/AutomatorNode;
+	public final fun findOneByText (Ldev/sebastiano/spectre/core/TextQuery;)Ldev/sebastiano/spectre/core/AutomatorNode;
+	public final fun findOneByText (Ljava/lang/String;Z)Ldev/sebastiano/spectre/core/AutomatorNode;
+	public static synthetic fun findOneByText$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;ZILjava/lang/Object;)Ldev/sebastiano/spectre/core/AutomatorNode;
+	public final fun focusWindow (Ldev/sebastiano/spectre/core/AutomatorNode;)V
+	public final fun getWindows ()Ljava/util/List;
+	public final fun longClick-8Mi8wO0 (Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun longClick-8Mi8wO0$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun performSemanticsClick (Ldev/sebastiano/spectre/core/AutomatorNode;)V
+	public final fun pressEnter (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun pressKey (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun pressKey$default (Ldev/sebastiano/spectre/core/ComposeAutomator;IILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun printTree ()Ljava/lang/String;
+	public final fun refreshWindows ()V
+	public final fun registerIdlingResource (Ldev/sebastiano/spectre/core/AutomatorIdlingResource;)V
+	public final fun screenshot (I)Ljava/awt/image/BufferedImage;
+	public final fun screenshot (Ldev/sebastiano/spectre/core/AutomatorNode;)Ljava/awt/image/BufferedImage;
+	public final fun screenshot (Ljava/awt/Rectangle;)Ljava/awt/image/BufferedImage;
+	public static synthetic fun screenshot$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/awt/Rectangle;ILjava/lang/Object;)Ljava/awt/image/BufferedImage;
+	public final fun scrollWheel (Ldev/sebastiano/spectre/core/AutomatorNode;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun surfaceIds ()Ljava/util/List;
+	public final fun swipe-x2RqbK4 (IIIIIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun swipe-x2RqbK4$default (Ldev/sebastiano/spectre/core/ComposeAutomator;IIIIIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun swipe-zkXUZaI (Ldev/sebastiano/spectre/core/AutomatorNode;Ldev/sebastiano/spectre/core/AutomatorNode;IJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun swipe-zkXUZaI$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ldev/sebastiano/spectre/core/AutomatorNode;Ldev/sebastiano/spectre/core/AutomatorNode;IJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun tree ()Ldev/sebastiano/spectre/core/AutomatorTree;
+	public final fun tree (I)Ldev/sebastiano/spectre/core/AutomatorWindow;
+	public final fun typeText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun unregisterIdlingResource (Ldev/sebastiano/spectre/core/AutomatorIdlingResource;)V
+	public final fun waitForIdle-2d-g_3Q (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun waitForIdle-2d-g_3Q$default (Ldev/sebastiano/spectre/core/ComposeAutomator;JJJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun waitForNode-ck1zr5g (Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun waitForNode-ck1zr5g$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun waitForVisualIdle-t_idYME (JIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun waitForVisualIdle-t_idYME$default (Ldev/sebastiano/spectre/core/ComposeAutomator;JIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun withTracing (Ljava/nio/file/Path;Ldev/sebastiano/spectre/core/Tracer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun withTracing$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/nio/file/Path;Ldev/sebastiano/spectre/core/Tracer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class dev/sebastiano/spectre/core/ComposeAutomator$Companion {
+	public final fun inProcess (Ldev/sebastiano/spectre/core/RobotDriver;)Ldev/sebastiano/spectre/core/ComposeAutomator;
+	public static synthetic fun inProcess$default (Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;Ldev/sebastiano/spectre/core/RobotDriver;ILjava/lang/Object;)Ldev/sebastiano/spectre/core/ComposeAutomator;
+}
+
+public final class dev/sebastiano/spectre/core/HiDpiMapperKt {
+	public static final fun composeBoundsToAwtCenter (FFFFFFII)Ljava/awt/Point;
+	public static final fun composeBoundsToAwtRectangle (FFFFFFII)Ljava/awt/Rectangle;
+}
+
+public final class dev/sebastiano/spectre/core/IdleTimeoutException : java/lang/RuntimeException {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public abstract interface annotation class dev/sebastiano/spectre/core/InternalSpectreApi : java/lang/annotation/Annotation {
+}
+
+public final class dev/sebastiano/spectre/core/NodeKey {
+	public static final field Companion Ldev/sebastiano/spectre/core/NodeKey$Companion;
+	public fun <init> (Ljava/lang/String;II)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;II)Ldev/sebastiano/spectre/core/NodeKey;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/NodeKey;Ljava/lang/String;IIILjava/lang/Object;)Ldev/sebastiano/spectre/core/NodeKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeId ()I
+	public final fun getOwnerIndex ()I
+	public final fun getSurfaceId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/NodeKey$Companion {
+	public final fun parse (Ljava/lang/String;)Ldev/sebastiano/spectre/core/NodeKey;
+}
+
+public final class dev/sebastiano/spectre/core/PerfettoTracer : dev/sebastiano/spectre/core/Tracer {
+	public static final field Companion Ldev/sebastiano/spectre/core/PerfettoTracer$Companion;
+	public static final field DEFAULT_SEQUENCE_ID I
+	public fun <init> ()V
+	public fun <init> (I)V
+	public synthetic fun <init> (IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun start (Ljava/nio/file/Path;)V
+	public fun stop ()V
+}
+
+public final class dev/sebastiano/spectre/core/PerfettoTracer$Companion {
+}
+
+public final class dev/sebastiano/spectre/core/RobotDriver {
+	public static final field Companion Ldev/sebastiano/spectre/core/RobotDriver$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/awt/Robot;)V
+	public final fun clearAndTypeText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun click (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun doubleClick (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun longClick-exY8QGI (IIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun longClick-exY8QGI$default (Ldev/sebastiano/spectre/core/RobotDriver;IIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun pressKey (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun pressKey$default (Ldev/sebastiano/spectre/core/RobotDriver;IILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun screenshot (Ljava/awt/Rectangle;)Ljava/awt/image/BufferedImage;
+	public static synthetic fun screenshot$default (Ldev/sebastiano/spectre/core/RobotDriver;Ljava/awt/Rectangle;ILjava/lang/Object;)Ljava/awt/image/BufferedImage;
+	public final fun scrollWheel (IIILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun swipe-x2RqbK4 (IIIIIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun swipe-x2RqbK4$default (Ldev/sebastiano/spectre/core/RobotDriver;IIIIIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun typeText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/sebastiano/spectre/core/RobotDriver$Companion {
+	public final fun headless ()Ldev/sebastiano/spectre/core/RobotDriver;
+}
+
+public final class dev/sebastiano/spectre/core/SyntheticInputKt {
+	public static final fun synthetic (Ldev/sebastiano/spectre/core/RobotDriver$Companion;Ljava/awt/Window;)Ldev/sebastiano/spectre/core/RobotDriver;
+}
+
+public final class dev/sebastiano/spectre/core/TextMatchType : java/lang/Enum {
+	public static final field Exact Ldev/sebastiano/spectre/core/TextMatchType;
+	public static final field Substring Ldev/sebastiano/spectre/core/TextMatchType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/core/TextMatchType;
+	public static fun values ()[Ldev/sebastiano/spectre/core/TextMatchType;
+}
+
+public final class dev/sebastiano/spectre/core/TextQuery {
+	public static final field Companion Ldev/sebastiano/spectre/core/TextQuery$Companion;
+	public fun <init> (Ljava/lang/String;Ldev/sebastiano/spectre/core/TextMatchType;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ldev/sebastiano/spectre/core/TextMatchType;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ldev/sebastiano/spectre/core/TextMatchType;
+	public final fun component3 ()Z
+	public final fun copy (Ljava/lang/String;Ldev/sebastiano/spectre/core/TextMatchType;Z)Ldev/sebastiano/spectre/core/TextQuery;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/TextQuery;Ljava/lang/String;Ldev/sebastiano/spectre/core/TextMatchType;ZILjava/lang/Object;)Ldev/sebastiano/spectre/core/TextQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIgnoreCase ()Z
+	public final fun getMatchType ()Ldev/sebastiano/spectre/core/TextMatchType;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun matches (Ljava/lang/String;)Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/TextQuery$Companion {
+	public final fun exact (Ljava/lang/String;Z)Ldev/sebastiano/spectre/core/TextQuery;
+	public static synthetic fun exact$default (Ldev/sebastiano/spectre/core/TextQuery$Companion;Ljava/lang/String;ZILjava/lang/Object;)Ldev/sebastiano/spectre/core/TextQuery;
+	public final fun substring (Ljava/lang/String;Z)Ldev/sebastiano/spectre/core/TextQuery;
+	public static synthetic fun substring$default (Ldev/sebastiano/spectre/core/TextQuery$Companion;Ljava/lang/String;ZILjava/lang/Object;)Ldev/sebastiano/spectre/core/TextQuery;
+}
+
+public abstract interface class dev/sebastiano/spectre/core/Tracer {
+	public abstract fun start (Ljava/nio/file/Path;)V
+	public abstract fun stop ()V
+}
+
+public final class dev/sebastiano/spectre/core/TrackedWindow {
+	public fun <init> (Ljava/lang/String;Ljava/awt/Window;Landroidx/compose/ui/awt/ComposePanel;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/awt/Window;
+	public final fun component3 ()Landroidx/compose/ui/awt/ComposePanel;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/awt/Window;Landroidx/compose/ui/awt/ComposePanel;ZLkotlin/jvm/functions/Function0;)Ldev/sebastiano/spectre/core/TrackedWindow;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/TrackedWindow;Ljava/lang/String;Ljava/awt/Window;Landroidx/compose/ui/awt/ComposePanel;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ldev/sebastiano/spectre/core/TrackedWindow;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComposeContentOrigin ()Ljava/awt/Point;
+	public final fun getComposePanel ()Landroidx/compose/ui/awt/ComposePanel;
+	public final fun getComposeSurfaceBoundsOnScreen ()Ljava/awt/Rectangle;
+	public final fun getSurfaceId ()Ljava/lang/String;
+	public final fun getWindow ()Ljava/awt/Window;
+	public fun hashCode ()I
+	public final fun isPopup ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/WindowTracker {
+	public fun <init> ()V
+	public final fun getTrackedWindows ()Ljava/util/List;
+	public final fun refresh ()V
+}
+

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,7 +4,13 @@ plugins {
     alias(libs.plugins.kotlinJvm)
 }
 
-kotlin { jvmToolchain(21) }
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation { enabled.set(true) }
+}
 
 dependencies {
     implementation(libs.compose.runtime)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorIdlingResource.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorIdlingResource.kt
@@ -11,9 +11,9 @@ package dev.sebastiano.spectre.core
  * `diagnosticMessage()` is included in [IdleTimeoutException] when a wait times out, so it should
  * describe the in-flight work in a way that helps a developer narrow down the cause.
  */
-interface AutomatorIdlingResource {
+public interface AutomatorIdlingResource {
 
-    val isIdleNow: Boolean
+    public val isIdleNow: Boolean
 
-    fun diagnosticMessage(): String? = null
+    public fun diagnosticMessage(): String? = null
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -23,17 +23,17 @@ import java.awt.Rectangle
  * `ClickRequest.nodeKey` field and produced by [toString]. Parse with [parse]; parsing splits from
  * the right so colons inside [surfaceId] are preserved.
  */
-data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) {
+public data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) {
 
     override fun toString(): String = "$surfaceId:$ownerIndex:$nodeId"
 
-    companion object {
+    public companion object {
 
         /**
          * Parses a string of the form `surfaceId:ownerIndex:nodeId` into a [NodeKey]. Throws
          * [IllegalArgumentException] on malformed input.
          */
-        fun parse(key: String): NodeKey {
+        public fun parse(key: String): NodeKey {
             // Split from the right: last segment is nodeId, second-to-last is ownerIndex,
             // everything before is surfaceId (which may contain colons).
             val lastColon = key.lastIndexOf(':')
@@ -63,40 +63,43 @@ data class NodeKey(val surfaceId: String, val ownerIndex: Int, val nodeId: Int) 
  * other query entry points; consumers should not construct them directly. The [key] uniquely
  * identifies the node across refreshes (see [NodeKey]).
  */
-class AutomatorNode
+public class AutomatorNode
 internal constructor(
-    val key: NodeKey,
+    public val key: NodeKey,
     internal val semanticsNode: SemanticsNode,
     internal val trackedWindow: TrackedWindow,
     private val relations: NodeRelations = EmptyNodeRelations,
 ) {
 
     /** Stable identifier of the tracked window/surface this node belongs to. */
-    val surfaceId: String = trackedWindow.surfaceId
+    public val surfaceId: String = trackedWindow.surfaceId
 
     // Eagerly snapshot all semantics properties at construction time (which runs on
     // the EDT inside readAllNodes) so callers can safely read them from any thread.
-    val testTag: String? = semanticsNode.config.getOrNull(SemanticsProperties.TestTag)
-    val texts: List<String> =
+    public val testTag: String? = semanticsNode.config.getOrNull(SemanticsProperties.TestTag)
+    public val texts: List<String> =
         semanticsNode.config.getOrNull(SemanticsProperties.Text)?.map { it.text }.orEmpty()
-    val text: String? = texts.firstOrNull()
-    val editableText: String? =
+    public val text: String? = texts.firstOrNull()
+    public val editableText: String? =
         semanticsNode.config.getOrNull(SemanticsProperties.EditableText)?.text
-    val contentDescriptions: List<String> =
+    public val contentDescriptions: List<String> =
         semanticsNode.config.getOrNull(SemanticsProperties.ContentDescription).orEmpty()
-    val contentDescription: String? = contentDescriptions.firstOrNull()
-    val role: Role? = semanticsNode.config.getOrNull(SemanticsProperties.Role)
-    val isDisabled: Boolean = semanticsNode.config.getOrNull(SemanticsProperties.Disabled) != null
-    val isFocused: Boolean = semanticsNode.config.getOrNull(SemanticsProperties.Focused) == true
-    val isSelected: Boolean = semanticsNode.config.getOrNull(SemanticsProperties.Selected) == true
+    public val contentDescription: String? = contentDescriptions.firstOrNull()
+    public val role: Role? = semanticsNode.config.getOrNull(SemanticsProperties.Role)
+    public val isDisabled: Boolean =
+        semanticsNode.config.getOrNull(SemanticsProperties.Disabled) != null
+    public val isFocused: Boolean =
+        semanticsNode.config.getOrNull(SemanticsProperties.Focused) == true
+    public val isSelected: Boolean =
+        semanticsNode.config.getOrNull(SemanticsProperties.Selected) == true
 
     // Geometry is always read live: layout can change between node lookup and action,
     // so a snapshot would let click/screenshot drift to stale coordinates after scrolling
     // or recomposition-driven repositioning.
-    val boundsInWindow: Rect
+    public val boundsInWindow: Rect
         get() = readOnEdt { semanticsNode.boundsInWindow }
 
-    val centerOnScreen: Point
+    public val centerOnScreen: Point
         get() = readOnEdt {
             val bounds = semanticsNode.boundsInWindow
             val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
@@ -113,7 +116,7 @@ internal constructor(
             )
         }
 
-    val boundsOnScreen: Rectangle
+    public val boundsOnScreen: Rectangle
         get() = readOnEdt {
             val bounds = semanticsNode.boundsInWindow
             val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
@@ -136,7 +139,7 @@ internal constructor(
      * same underlying layout state. Reading the two getters separately would issue two independent
      * EDT bounces, between which layout could shift.
      */
-    fun bothBounds(): BothBounds = readOnEdt {
+    public fun bothBounds(): BothBounds = readOnEdt {
         val bounds = semanticsNode.boundsInWindow
         val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
         val contentOrigin = trackedWindow.composeContentOrigin
@@ -156,10 +159,10 @@ internal constructor(
         )
     }
 
-    val parent: AutomatorNode?
+    public val parent: AutomatorNode?
         get() = relations.parentOf(key)
 
-    val children: List<AutomatorNode>
+    public val children: List<AutomatorNode>
         get() = relations.childrenOf(key)
 
     override fun toString(): String = buildString {
@@ -172,7 +175,7 @@ internal constructor(
 }
 
 /** Atomic snapshot of [AutomatorNode.boundsInWindow] and [AutomatorNode.boundsOnScreen]. */
-data class BothBounds(val inWindow: Rect, val onScreen: Rectangle)
+public data class BothBounds(val inWindow: Rect, val onScreen: Rectangle)
 
 internal interface NodeRelations {
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorTree.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorTree.kt
@@ -12,15 +12,15 @@ import androidx.compose.ui.semantics.Role
  * need the full picture rather than a single match — most user-facing queries
  * ([ComposeAutomator.findByTestTag], etc.) go through this snapshot too.
  */
-class AutomatorTree internal constructor(private val windows: List<AutomatorWindow>) {
+public class AutomatorTree internal constructor(private val windows: List<AutomatorWindow>) {
 
-    fun windows(): List<AutomatorWindow> = windows
+    public fun windows(): List<AutomatorWindow> = windows
 
-    fun window(windowIndex: Int): AutomatorWindow = windows[windowIndex]
+    public fun window(windowIndex: Int): AutomatorWindow = windows[windowIndex]
 
-    fun allNodes(): List<AutomatorNode> = windows.flatMap(AutomatorWindow::allNodes)
+    public fun allNodes(): List<AutomatorNode> = windows.flatMap(AutomatorWindow::allNodes)
 
-    fun roots(): List<AutomatorNode> = windows.flatMap(AutomatorWindow::roots)
+    public fun roots(): List<AutomatorNode> = windows.flatMap(AutomatorWindow::roots)
 }
 
 /**
@@ -32,29 +32,29 @@ class AutomatorTree internal constructor(private val windows: List<AutomatorWind
  * `findBy*` methods filter the surface's nodes using the same matchers as the top-level
  * [ComposeAutomator] queries.
  */
-class AutomatorWindow
+public class AutomatorWindow
 internal constructor(
-    val windowIndex: Int,
+    public val windowIndex: Int,
     internal val trackedWindow: TrackedWindow,
     private val nodes: List<AutomatorNode>,
 ) {
 
-    val surfaceId: String = trackedWindow.surfaceId
-    val isPopup: Boolean = trackedWindow.isPopup
+    public val surfaceId: String = trackedWindow.surfaceId
+    public val isPopup: Boolean = trackedWindow.isPopup
 
-    fun allNodes(): List<AutomatorNode> = nodes
+    public fun allNodes(): List<AutomatorNode> = nodes
 
-    fun roots(): List<AutomatorNode> = nodes.filter { it.parent == null }
+    public fun roots(): List<AutomatorNode> = nodes.filter { it.parent == null }
 
-    fun findByTestTag(tag: String): List<AutomatorNode> =
+    public fun findByTestTag(tag: String): List<AutomatorNode> =
         nodes.filter(NodeMatchers.hasTestTag(tag)::matches)
 
-    fun findOneByTestTag(tag: String): AutomatorNode? = findByTestTag(tag).firstOrNull()
+    public fun findOneByTestTag(tag: String): AutomatorNode? = findByTestTag(tag).firstOrNull()
 
-    fun findByText(query: TextQuery): List<AutomatorNode> =
+    public fun findByText(query: TextQuery): List<AutomatorNode> =
         nodes.filter(NodeMatchers.hasText(query)::matches)
 
-    fun findByText(text: String, exact: Boolean = true): List<AutomatorNode> =
+    public fun findByText(text: String, exact: Boolean = true): List<AutomatorNode> =
         findByText(
             if (exact) {
                 TextQuery.exact(text)
@@ -63,14 +63,14 @@ internal constructor(
             }
         )
 
-    fun findOneByText(query: TextQuery): AutomatorNode? = findByText(query).firstOrNull()
+    public fun findOneByText(query: TextQuery): AutomatorNode? = findByText(query).firstOrNull()
 
-    fun findOneByText(text: String, exact: Boolean = true): AutomatorNode? =
+    public fun findOneByText(text: String, exact: Boolean = true): AutomatorNode? =
         findByText(text, exact).firstOrNull()
 
-    fun findByContentDescription(description: String): List<AutomatorNode> =
+    public fun findByContentDescription(description: String): List<AutomatorNode> =
         nodes.filter(NodeMatchers.hasContentDescription(description)::matches)
 
-    fun findByRole(role: Role): List<AutomatorNode> =
+    public fun findByRole(role: Role): List<AutomatorNode> =
         nodes.filter(NodeMatchers.hasRole(role)::matches)
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -28,7 +28,7 @@ import kotlin.time.Duration.Companion.seconds
  * friction without a corresponding win for discoverability.
  */
 @Suppress("TooManyFunctions")
-class ComposeAutomator
+public class ComposeAutomator
 private constructor(
     private val windowTracker: WindowTracker,
     private val semanticsReader: SemanticsReader,
@@ -42,17 +42,17 @@ private constructor(
      * the rich type.
      */
     @InternalSpectreApi
-    val windows: List<TrackedWindow>
+    public val windows: List<TrackedWindow>
         get() = windowTracker.trackedWindows
 
     /** Stable surface IDs of every tracked window, in tracking order. */
-    fun surfaceIds(): List<String> = windowTracker.trackedWindows.map { it.surfaceId }
+    public fun surfaceIds(): List<String> = windowTracker.trackedWindows.map { it.surfaceId }
 
-    fun refreshWindows() {
+    public fun refreshWindows() {
         windowTracker.refresh()
     }
 
-    fun tree(): AutomatorTree {
+    public fun tree(): AutomatorTree {
         refreshWindows()
         val windowScopes = windows.mapIndexed { index, trackedWindow ->
             AutomatorWindow(
@@ -64,47 +64,48 @@ private constructor(
         return AutomatorTree(windowScopes)
     }
 
-    fun tree(windowIndex: Int): AutomatorWindow = tree().window(windowIndex)
+    public fun tree(windowIndex: Int): AutomatorWindow = tree().window(windowIndex)
 
-    fun allNodes(): List<AutomatorNode> = semanticsReader.readAllNodes(windows)
+    public fun allNodes(): List<AutomatorNode> = semanticsReader.readAllNodes(windows)
 
-    fun findByTestTag(tag: String): List<AutomatorNode> =
+    public fun findByTestTag(tag: String): List<AutomatorNode> =
         semanticsReader.findByTestTag(tag, windows)
 
-    fun findOneByTestTag(tag: String): AutomatorNode? = findByTestTag(tag).firstOrNull()
+    public fun findOneByTestTag(tag: String): AutomatorNode? = findByTestTag(tag).firstOrNull()
 
-    fun findByText(query: TextQuery): List<AutomatorNode> =
+    public fun findByText(query: TextQuery): List<AutomatorNode> =
         semanticsReader.findByText(query, windows)
 
-    fun findByText(text: String, exact: Boolean = true): List<AutomatorNode> =
+    public fun findByText(text: String, exact: Boolean = true): List<AutomatorNode> =
         semanticsReader.findByText(text, windows, exact)
 
-    fun findOneByText(query: TextQuery): AutomatorNode? = findByText(query).firstOrNull()
+    public fun findOneByText(query: TextQuery): AutomatorNode? = findByText(query).firstOrNull()
 
-    fun findOneByText(text: String, exact: Boolean = true): AutomatorNode? =
+    public fun findOneByText(text: String, exact: Boolean = true): AutomatorNode? =
         findByText(text, exact).firstOrNull()
 
-    fun findByContentDescription(description: String): List<AutomatorNode> =
+    public fun findByContentDescription(description: String): List<AutomatorNode> =
         semanticsReader.findByContentDescription(description, windows)
 
-    fun findByRole(role: Role): List<AutomatorNode> = semanticsReader.findByRole(role, windows)
+    public fun findByRole(role: Role): List<AutomatorNode> =
+        semanticsReader.findByRole(role, windows)
 
-    suspend fun click(node: AutomatorNode) {
+    public suspend fun click(node: AutomatorNode) {
         val center = node.centerOnScreen
         robotDriver.click(center.x, center.y)
     }
 
-    suspend fun doubleClick(node: AutomatorNode) {
+    public suspend fun doubleClick(node: AutomatorNode) {
         val center = node.centerOnScreen
         robotDriver.doubleClick(center.x, center.y)
     }
 
-    suspend fun longClick(node: AutomatorNode, holdFor: Duration = 500.milliseconds) {
+    public suspend fun longClick(node: AutomatorNode, holdFor: Duration = 500.milliseconds) {
         val center = node.centerOnScreen
         robotDriver.longClick(center.x, center.y, holdFor)
     }
 
-    suspend fun swipe(
+    public suspend fun swipe(
         startX: Int,
         startY: Int,
         endX: Int,
@@ -115,7 +116,7 @@ private constructor(
         robotDriver.swipe(startX, startY, endX, endY, steps, duration)
     }
 
-    suspend fun swipe(
+    public suspend fun swipe(
         from: AutomatorNode,
         to: AutomatorNode,
         steps: Int = 12,
@@ -131,25 +132,25 @@ private constructor(
      * lower in the list); negative scrolls up. Drives Compose's `Modifier.scrollable` /
      * `LazyColumn` on desktop, which respond to wheel events rather than touch-style drags.
      */
-    suspend fun scrollWheel(node: AutomatorNode, wheelClicks: Int) {
+    public suspend fun scrollWheel(node: AutomatorNode, wheelClicks: Int) {
         val center = node.centerOnScreen
         robotDriver.scrollWheel(center.x, center.y, wheelClicks)
     }
 
-    suspend fun typeText(text: String) {
+    public suspend fun typeText(text: String) {
         robotDriver.typeText(text)
     }
 
-    suspend fun clearAndTypeText(node: AutomatorNode, text: String) {
+    public suspend fun clearAndTypeText(node: AutomatorNode, text: String) {
         click(node)
         robotDriver.clearAndTypeText(text)
     }
 
-    suspend fun pressKey(keyCode: Int, modifiers: Int = 0) {
+    public suspend fun pressKey(keyCode: Int, modifiers: Int = 0) {
         robotDriver.pressKey(keyCode, modifiers)
     }
 
-    suspend fun pressEnter() {
+    public suspend fun pressEnter() {
         robotDriver.pressKey(KeyEvent.VK_ENTER)
     }
 
@@ -158,7 +159,7 @@ private constructor(
      * Robot-driven inputs on a non-focused window. The actual focus change is dispatched on the
      * EDT.
      */
-    fun focusWindow(node: AutomatorNode) {
+    public fun focusWindow(node: AutomatorNode) {
         val window = node.trackedWindow.window
         if (SwingUtilities.isEventDispatchThread()) {
             window.toFront()
@@ -181,7 +182,7 @@ private constructor(
      * Throws [IllegalStateException] if [node] has no `OnClick` semantics action attached, or if
      * the action's invocable body is null (a semantics property without a wired-up handler).
      */
-    fun performSemanticsClick(node: AutomatorNode) {
+    public fun performSemanticsClick(node: AutomatorNode) {
         val accessibilityAction =
             node.semanticsNode.config.getOrNull(SemanticsActions.OnClick)
                 ?: error(
@@ -206,21 +207,22 @@ private constructor(
      * KDoc for colour-space, focus-overlay, and per-platform TCC / Wayland gotchas before using the
      * result for pixel-level assertions.
      */
-    fun screenshot(region: Rectangle? = null): BufferedImage = robotDriver.screenshot(region)
+    public fun screenshot(region: Rectangle? = null): BufferedImage = robotDriver.screenshot(region)
 
     /**
      * Captures the on-screen bounds of [node] as an sRGB [BufferedImage]. Delegates to
      * [RobotDriver.screenshot] — see that method's KDoc before using the result for pixel-level
      * assertions.
      */
-    fun screenshot(node: AutomatorNode): BufferedImage = robotDriver.screenshot(node.boundsOnScreen)
+    public fun screenshot(node: AutomatorNode): BufferedImage =
+        robotDriver.screenshot(node.boundsOnScreen)
 
     /**
      * Captures the Compose surface bounds of the tracked window at [windowIndex] as an sRGB
      * [BufferedImage]. Refreshes the window list first. Delegates to [RobotDriver.screenshot] — see
      * that method's KDoc before using the result for pixel-level assertions.
      */
-    fun screenshot(windowIndex: Int): BufferedImage {
+    public fun screenshot(windowIndex: Int): BufferedImage {
         refreshWindows()
         val trackedWindow =
             windows.getOrNull(windowIndex)
@@ -233,11 +235,11 @@ private constructor(
     // wrapping every read/action is intentionally deferred — see the v1 issue tracker.
     private val idlingResources = CopyOnWriteArrayList<AutomatorIdlingResource>()
 
-    fun registerIdlingResource(resource: AutomatorIdlingResource) {
+    public fun registerIdlingResource(resource: AutomatorIdlingResource) {
         idlingResources.addIfAbsent(resource)
     }
 
-    fun unregisterIdlingResource(resource: AutomatorIdlingResource) {
+    public fun unregisterIdlingResource(resource: AutomatorIdlingResource) {
         idlingResources.remove(resource)
     }
 
@@ -253,13 +255,13 @@ private constructor(
      * still runs so the partial trace is flushed to disk; any exception thrown by `stop` is
      * attached as a suppressed exception so the original failure stays visible.
      */
-    suspend fun <T> withTracing(
+    public suspend fun <T> withTracing(
         output: Path,
         tracer: Tracer = PerfettoTracer(),
         block: suspend () -> T,
     ): T = withTracingInternal(output, tracer, block)
 
-    suspend fun waitForIdle(
+    public suspend fun waitForIdle(
         timeout: Duration = DEFAULT_WAIT_TIMEOUT,
         quietPeriod: Duration = DEFAULT_QUIET_PERIOD,
         pollInterval: Duration = DEFAULT_POLL_INTERVAL,
@@ -275,7 +277,7 @@ private constructor(
         )
     }
 
-    suspend fun waitForVisualIdle(
+    public suspend fun waitForVisualIdle(
         timeout: Duration = DEFAULT_WAIT_TIMEOUT,
         stableFrames: Int = DEFAULT_STABLE_FRAMES,
         pollInterval: Duration = DEFAULT_POLL_INTERVAL,
@@ -471,7 +473,7 @@ private constructor(
         }
     }
 
-    suspend fun waitForNode(
+    public suspend fun waitForNode(
         tag: String? = null,
         text: String? = null,
         timeout: Duration = 5.seconds,
@@ -493,7 +495,7 @@ private constructor(
         }
     }
 
-    fun printTree(): String {
+    public fun printTree(): String {
         return readOnEdt {
             buildString {
                 // tree() already refreshes windows before reading semantics nodes.
@@ -508,9 +510,9 @@ private constructor(
         }
     }
 
-    companion object {
+    public companion object {
 
-        fun inProcess(robotDriver: RobotDriver = RobotDriver()): ComposeAutomator =
+        public fun inProcess(robotDriver: RobotDriver = RobotDriver()): ComposeAutomator =
             ComposeAutomator(WindowTracker(), SemanticsReader(), robotDriver)
     }
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/HiDpiMapper.kt
@@ -28,7 +28,7 @@ internal fun composeToAwtY(composeY: Float, scaleY: Float, panelScreenY: Int): I
     (composeY / scaleY).toInt() + panelScreenY
 
 @InternalSpectreApi
-fun composeBoundsToAwtCenter(
+public fun composeBoundsToAwtCenter(
     left: Float,
     top: Float,
     right: Float,
@@ -46,7 +46,7 @@ fun composeBoundsToAwtCenter(
 }
 
 @InternalSpectreApi
-fun composeBoundsToAwtRectangle(
+public fun composeBoundsToAwtRectangle(
     left: Float,
     top: Float,
     right: Float,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InternalSpectreApi.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InternalSpectreApi.kt
@@ -32,4 +32,4 @@ package dev.sebastiano.spectre.core
     AnnotationTarget.CONSTRUCTOR,
     AnnotationTarget.TYPEALIAS,
 )
-annotation class InternalSpectreApi
+public annotation class InternalSpectreApi

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/PerfettoTracer.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/PerfettoTracer.kt
@@ -20,7 +20,7 @@ import java.nio.file.Path
  * recompositions, RPC calls, state updates, etc.) — this tracer just provides the recording
  * lifecycle that brackets the scenario.
  */
-class PerfettoTracer(private val sequenceId: Int = DEFAULT_SEQUENCE_ID) : Tracer {
+public class PerfettoTracer(private val sequenceId: Int = DEFAULT_SEQUENCE_ID) : Tracer {
 
     private var driver: TraceDriver? = null
 
@@ -42,8 +42,8 @@ class PerfettoTracer(private val sequenceId: Int = DEFAULT_SEQUENCE_ID) : Tracer
         }
     }
 
-    companion object {
+    public companion object {
 
-        const val DEFAULT_SEQUENCE_ID: Int = 1
+        public const val DEFAULT_SEQUENCE_ID: Int = 1
     }
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
-class RobotDriver
+public class RobotDriver
 internal constructor(
     private val robot: RobotAdapter = AwtRobotAdapter(),
     private val clipboard: ClipboardAdapter = SystemClipboardAdapter(),
@@ -29,9 +29,9 @@ internal constructor(
     // Public surface: callers may instantiate without arguments (defaults to a fresh
     // AWT Robot + system clipboard) or hand in an existing Robot. The internal
     // adapter-injecting constructor is reserved for tests within this module.
-    constructor() : this(AwtRobotAdapter(), SystemClipboardAdapter())
+    public constructor() : this(AwtRobotAdapter(), SystemClipboardAdapter())
 
-    constructor(robot: Robot) : this(AwtRobotAdapter(robot))
+    public constructor(robot: Robot) : this(AwtRobotAdapter(robot))
 
     /**
      * Dispatches a single left-button click at the given screen coordinates: move, press, release.
@@ -40,7 +40,7 @@ internal constructor(
      * (real `java.awt.Robot`), and dispatches inline otherwise (synthetic adapter). Throws
      * [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
-    suspend fun click(screenX: Int, screenY: Int) {
+    public suspend fun click(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
             robot.mouseMove(screenX, screenY)
@@ -57,7 +57,7 @@ internal constructor(
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
-    suspend fun doubleClick(screenX: Int, screenY: Int) {
+    public suspend fun doubleClick(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
             robot.mouseMove(screenX, screenY)
@@ -79,7 +79,7 @@ internal constructor(
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
-    suspend fun longClick(
+    public suspend fun longClick(
         screenX: Int,
         screenY: Int,
         holdFor: Duration = DEFAULT_LONG_CLICK_DURATION,
@@ -110,7 +110,7 @@ internal constructor(
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
-    suspend fun swipe(
+    public suspend fun swipe(
         startX: Int,
         startY: Int,
         endX: Int,
@@ -153,7 +153,7 @@ internal constructor(
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
-    suspend fun typeText(text: String) {
+    public suspend fun typeText(text: String) {
         tccGuard.requireAccessibility()
         runOffEdt {
             val previousContents = runCatching { clipboard.getContents() }.getOrNull()
@@ -236,7 +236,7 @@ internal constructor(
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
-    suspend fun clearAndTypeText(text: String) {
+    public suspend fun clearAndTypeText(text: String) {
         tccGuard.requireAccessibility()
         val selectAllModifier = shortcutModifierKeyCode(detectMacOs())
         runOffEdt {
@@ -256,7 +256,7 @@ internal constructor(
      * desk); negative scrolls up. Drives Compose's `Modifier.scrollable` and lazy-list scroll on
      * desktop, which respond to wheel events rather than touch-style drag gestures.
      */
-    suspend fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
+    public suspend fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
             robot.mouseMove(screenX, screenY)
@@ -273,7 +273,7 @@ internal constructor(
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
-    suspend fun pressKey(keyCode: Int, modifiers: Int = 0) {
+    public suspend fun pressKey(keyCode: Int, modifiers: Int = 0) {
         tccGuard.requireAccessibility()
         runOffEdt {
             val modifierKeys = modifierMaskToKeyCodes(modifiers)
@@ -328,7 +328,7 @@ internal constructor(
      * [the published security notes](https://spectre.sebastiano.dev/SECURITY/) for the full
      * exposure model.
      */
-    fun screenshot(region: Rectangle? = null): BufferedImage {
+    public fun screenshot(region: Rectangle? = null): BufferedImage {
         tccGuard.requireScreenRecording()
         val captureRegion = region ?: virtualDesktopBounds()
         return robot.createScreenCapture(captureRegion)
@@ -336,7 +336,7 @@ internal constructor(
 
     private suspend fun runOffEdt(block: suspend () -> Unit) = runOffEdt(robot, block)
 
-    companion object {
+    public companion object {
 
         /**
          * Returns a [RobotDriver] that throws [UnsupportedOperationException] on every input,
@@ -353,7 +353,7 @@ internal constructor(
          * [RobotDriver.Companion.synthetic] against a known root window for synthetic AWT events,
          * or invoke `SemanticsActions.OnClick` directly on the target node for click-only flows.
          */
-        fun headless(): RobotDriver =
+        public fun headless(): RobotDriver =
             RobotDriver(
                 HeadlessThrowingRobotAdapter,
                 HeadlessThrowingClipboardAdapter,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticInput.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticInput.kt
@@ -34,7 +34,7 @@ import javax.swing.SwingUtilities
  * Clipboard access is left as the system clipboard — paste-based [RobotDriver.typeText] still works
  * with synthetic Cmd/Ctrl+V keystrokes.
  */
-fun RobotDriver.Companion.synthetic(rootWindow: Window): RobotDriver =
+public fun RobotDriver.Companion.synthetic(rootWindow: Window): RobotDriver =
     RobotDriver(SyntheticRobotAdapter(rootWindow), SystemClipboardAdapter())
 
 internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdapter {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TextQuery.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TextQuery.kt
@@ -8,13 +8,13 @@ package dev.sebastiano.spectre.core
  * via the flag) full-string equality, [substring] for `contains`-style partial matching. Regex /
  * pattern matching is not supported.
  */
-data class TextQuery(
+public data class TextQuery(
     val value: String,
     val matchType: TextMatchType = TextMatchType.Exact,
     val ignoreCase: Boolean = false,
 ) {
 
-    fun matches(candidate: String?): Boolean {
+    public fun matches(candidate: String?): Boolean {
         if (candidate == null) return false
         return when (matchType) {
             TextMatchType.Exact -> candidate.equals(value, ignoreCase = ignoreCase)
@@ -22,18 +22,18 @@ data class TextQuery(
         }
     }
 
-    companion object {
+    public companion object {
 
-        fun exact(value: String, ignoreCase: Boolean = false): TextQuery =
+        public fun exact(value: String, ignoreCase: Boolean = false): TextQuery =
             TextQuery(value = value, matchType = TextMatchType.Exact, ignoreCase = ignoreCase)
 
-        fun substring(value: String, ignoreCase: Boolean = false): TextQuery =
+        public fun substring(value: String, ignoreCase: Boolean = false): TextQuery =
             TextQuery(value = value, matchType = TextMatchType.Substring, ignoreCase = ignoreCase)
     }
 }
 
 /** How [TextQuery] compares its [TextQuery.value] against a candidate string. */
-enum class TextMatchType {
+public enum class TextMatchType {
     /** The candidate must equal `value` (subject to `ignoreCase`). */
     Exact,
     /** The candidate must contain `value` as a substring (subject to `ignoreCase`). */

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/Tracer.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/Tracer.kt
@@ -15,7 +15,7 @@ import java.nio.file.Path
  * a different recorder (an in-memory event collector for tests, a JFR adapter, etc.) can plug their
  * own `Tracer` into [ComposeAutomator.withTracing].
  */
-interface Tracer {
+public interface Tracer {
 
     /**
      * Begin a recording, writing captured trace data into [output]. Implementations may interpret
@@ -23,10 +23,10 @@ interface Tracer {
      * writes one file per sequence). Implementations may throw if a recording is already in
      * progress.
      */
-    fun start(output: Path)
+    public fun start(output: Path)
 
     /** Stop the recording and flush any buffered events to disk. */
-    fun stop()
+    public fun stop()
 }
 
 /**

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
@@ -9,7 +9,7 @@ import java.awt.Window
 import javax.swing.JFrame
 
 @InternalSpectreApi
-data class TrackedWindow
+public data class TrackedWindow
 @OptIn(ExperimentalComposeUiApi::class)
 internal constructor(
     val surfaceId: String,
@@ -32,7 +32,7 @@ internal constructor(
      * `TrackedWindow` directly (notably `core`'s own unit tests).
      */
     @OptIn(ExperimentalComposeUiApi::class)
-    constructor(
+    public constructor(
         surfaceId: String,
         window: Window,
         composePanel: ComposePanel?,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
@@ -4,7 +4,7 @@ import kotlin.time.Duration
 import kotlinx.coroutines.delay
 
 /** Thrown when [ComposeAutomator.waitForIdle] cannot reach an idle state before the timeout. */
-class IdleTimeoutException(message: String) : RuntimeException(message)
+public class IdleTimeoutException(message: String) : RuntimeException(message)
 
 internal interface MonotonicClock {
     fun now(): Long

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -9,14 +9,14 @@ import java.awt.Container
 import java.awt.Window
 
 @InternalSpectreApi
-class WindowTracker {
+public class WindowTracker {
 
     @Volatile private var _trackedWindows: List<TrackedWindow> = emptyList()
 
-    val trackedWindows: List<TrackedWindow>
+    public val trackedWindows: List<TrackedWindow>
         get() = _trackedWindows
 
-    fun refresh() = readOnEdt {
+    public fun refresh(): Unit = readOnEdt {
         val pending = mutableListOf<TrackedWindow>()
         // Iterate every top-level window (`owner == null`) regardless of visibility — Swing's
         // `SharedOwnerFrame` is a hidden parent for `JDialog(null as Frame?, ...)`, so filtering

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -1,0 +1,144 @@
+# Stability policy
+
+Spectre is **pre-1.0**. This page documents what changes between releases, what doesn't, and
+how the project signals the difference at the source / compiler / binary level.
+
+The companion document on the trust model lives at [Security notes](SECURITY.md).
+
+## Versioning
+
+Spectre follows [Semantic Versioning](https://semver.org/):
+
+- **Major** (`X.0.0`) — breaking changes to the stable public API.
+- **Minor** (`0.X.0`) — additive changes to the stable public API; experimental APIs may change.
+- **Patch** (`0.0.X`) — bug fixes; experimental APIs may change.
+
+**Pre-1.0 caveats.** The project has not yet shipped 1.0. Minor versions may introduce breaking
+changes to the stable public API until 1.0; that's the whole point of the pre-1.0 window. Each
+release notes call those out explicitly.
+
+## API tiers
+
+Spectre distinguishes three tiers of public API. The distinction matters because experimental
+APIs are still *visible*: they appear in jar bytecode and in [Kotlin Binary Compatibility
+Validator](#binary-compatibility-validation) dumps. The tier controls what guarantees you get,
+not whether you can call the code.
+
+### Stable public API
+
+Public declarations **not** annotated with `@InternalSpectreApi` or any experimental opt-in
+annotation. Covered by binary-compatibility guarantees within a major version: a method
+signature won't change, a class won't disappear, a property won't change type. Source-level
+breaking changes (parameter renames with default values, etc.) are also treated as breaking
+within a major version, even though [BCV](#binary-compatibility-validation) doesn't catch
+every such case.
+
+The committed `api/<module>.api` baselines in each library module enumerate the stable
+public API for that module.
+
+### Experimental public API
+
+Public declarations annotated with `@ExperimentalSpectreHttpApi` (or any future per-area
+`@ExperimentalSpectre*Api` markers we add). These are **visible** to consumers and **appear in
+the API baselines**, but they are explicitly **not covered** by compatibility guarantees and
+may change or be removed in any release, including patch releases.
+
+Today the only experimental marker is `@ExperimentalSpectreHttpApi`, which covers the entire
+`server` module's public surface — the HTTP transport (`installSpectreRoutes`,
+`HttpComposeAutomator`, the `ComposeAutomator.http(...)` factory, and the DTOs). Authentication,
+TLS, narrower per-window capture, and other major reshapes are tracked under #96 and will land
+under this marker.
+
+Consumers opt in either at file level or call site:
+
+```kotlin
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
+import dev.sebastiano.spectre.server.ExperimentalSpectreHttpApi
+import dev.sebastiano.spectre.server.installSpectreRoutes
+```
+
+The annotation is `WARNING`-level, so callers that ignore the opt-in still compile — they just
+see a compiler warning per call site. The instability guarantees are the same either way.
+
+### Internal escape hatch
+
+Public declarations annotated with `@InternalSpectreApi`. **Not** part of the supported
+surface; `ERROR`-level opt-in (the compiler refuses without an explicit `@OptIn`). May change
+without notice and without a deprecation cycle.
+
+This marker exists because some in-repo collaborators (the HTTP transport, the recording
+module's helpers, in-repo fixtures) legitimately need to reach into core's internals. End-user
+code should not need this annotation — if you find yourself opting in, please file an issue
+describing the use case so we can shape a stable API for it.
+
+## Binary compatibility validation
+
+Spectre uses the Kotlin Gradle Plugin's built-in **`abiValidation`** extension to track public
+ABI per module. Each library module commits a baseline at `<module>/api/<module>.api` listing
+every public class, function, property, and field that consumers depend on. The baseline is
+a textual snapshot of the JVM-level public surface.
+
+Workflow:
+
+- **On every PR** — `./gradlew check` runs `checkKotlinAbi` automatically. A PR that changes
+  the public surface without updating the committed baselines fails CI.
+- **At release** — the release workflow re-runs `checkKotlinAbi` before building artefacts, as
+  defensive depth against tag-from-feature-branch shenanigans that would otherwise skip the
+  PR-time check.
+- **Regenerating the baselines** — when a public API change is intentional, run
+  `./gradlew updateKotlinAbi` locally, review the diff, and commit the updated `api/*.api`
+  files alongside the source change.
+
+### What's covered
+
+- Public JVM ABI of `core`, `testing`, `server`, `recording` — class shapes, method signatures,
+  property types, field visibility, inheritance.
+- Both stable and experimental APIs appear in baselines. The annotation level controls the
+  *guarantee*, not the *visibility*.
+
+### What's not covered
+
+- **Annotation usages on individual symbols.** The baseline records the shape of declarations,
+  not the annotations attached to them. Silently removing `@ExperimentalSpectreHttpApi` from a
+  marked declaration would not fail `checkKotlinAbi`, because removing an annotation doesn't
+  change the JVM symbol shape. The opt-in / experimental-marker layer is enforced at compile
+  time by the Kotlin compiler (via `@RequiresOptIn`), not by ABI validation. Source review
+  remains the gate for the marker layer; ABI validation is the gate for the symbol layer.
+- Source-level breakages that don't change JVM ABI (renaming a parameter that has a default
+  value, removing the default from a parameter, etc.).
+- Runtime artefacts: the HTTP transport's wire format, recording video output, helper
+  extracted-binary layout, semantics-tree refresh ordering, etc.
+- Sample apps (`sample-desktop`, `sample-intellij-plugin`) — not published, no baseline.
+
+## Platform support tiers
+
+Spectre is JVM-first and targets desktop OSes.
+
+| Platform | Tier | Notes |
+| --- | --- | --- |
+| **macOS** | Primary | Full support. AWT Robot input, ScreenCaptureKit recording (with bundled Swift helper), TCC permission diagnostics. |
+| **Windows** | Full | AWT Robot input + `gdigrab` region and window-targeted recording. |
+| **Linux Xorg** | Full | AWT Robot input + `x11grab` region recording. Validated against Xvfb in CI. |
+| **Linux Wayland** | Best-effort | Portal-mediated capture via `WaylandPortalRecorder` / `WaylandPortalWindowRecorder`. **Validated on GNOME/Mutter only**; KDE / sway / wlroots compositors may behave differently and are not exercised in CI. Real Robot input is unavailable on Wayland — use the synthetic adapter for tests. |
+| **BSD** | Unsupported | Not built or tested. |
+
+## AndroidX-style stability expectations
+
+Spectre adopts the cultural convention pioneered by [AndroidX](https://developer.android.com/jetpack/androidx):
+
+- Experimental APIs are explicit opt-in via a `@RequiresOptIn` annotation. The annotation
+  carries the rationale ("not yet stable", "may change", etc.) and the opt-in is per file or
+  per call site, not project-wide.
+- The compiler — not just docs — enforces the opt-in. Forgetting it is a warning (for
+  `@ExperimentalSpectreHttpApi`) or an error (for `@InternalSpectreApi`).
+- Stability promotions follow a deprecation cycle when feasible: when an experimental API
+  graduates to stable, the marker is removed in the release that promotes it; when an
+  experimental API is removed, it's done in a single release with the rationale documented.
+
+## Reporting incompatibilities
+
+If a change in a Spectre release breaks your build or runtime in a way that wasn't called out
+in the release notes, please open an issue at
+<https://github.com/rock3r/spectre/issues> with the diff (a `git log -p api/`-style snippet
+of the BCV baseline change is most useful) and what you observed.

--- a/docs/guide/cross-jvm.md
+++ b/docs/guide/cross-jvm.md
@@ -38,6 +38,9 @@ top of an in-process `ComposeAutomator`; the test JVM talks to it through
     See [Security notes](../SECURITY.md) for the full risk register and the
     accepted-risk list.
 
+    All entry points in this guide require `@OptIn(ExperimentalSpectreHttpApi::class)`
+    — see [Stability policy](../STABILITY.md) for the API tier definitions.
+
 ## Server side: mount the routes
 
 In the hosting JVM, build an in-process automator and install Spectre's routes on a
@@ -52,7 +55,10 @@ dependencies {
 ```
 
 ```kotlin
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
 import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.server.ExperimentalSpectreHttpApi
 import dev.sebastiano.spectre.server.installSpectreRoutes
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
@@ -96,7 +102,10 @@ In the test JVM, the canonical entry point is the `ComposeAutomator.http(...)`
 companion extension:
 
 ```kotlin
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
 import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.server.ExperimentalSpectreHttpApi
 import dev.sebastiano.spectre.server.http
 import kotlinx.coroutines.runBlocking
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,3 +109,4 @@ nav:
       - Recording limitations: RECORDING-LIMITATIONS.md
       - Notarization: NOTARIZATION.md
       - Security notes: SECURITY.md
+      - Stability policy: STABILITY.md

--- a/recording/api/recording.api
+++ b/recording/api/recording.api
@@ -1,0 +1,170 @@
+public final class dev/sebastiano/spectre/recording/AutoRecorder {
+	public fun <init> (Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/Recorder;Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/Recorder;Ldev/sebastiano/spectre/recording/portal/WaylandWindowSourceRecorder;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/Recorder;Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/Recorder;Ldev/sebastiano/spectre/recording/portal/WaylandWindowSourceRecorder;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public static final fun defaultIsLinux ()Z
+	public static final fun defaultIsMacOs ()Z
+	public static final fun defaultIsWayland ()Z
+	public static final fun defaultIsWindows ()Z
+	public static final fun defaultWindowsWindowRecorder ()Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;
+	public final fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;J)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;JILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public final class dev/sebastiano/spectre/recording/FfmpegRecorder : dev/sebastiano/spectre/recording/Recorder {
+	public static final field Companion Ldev/sebastiano/spectre/recording/FfmpegRecorder$Companion;
+	public fun <init> (Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/FfmpegRecorder$ProcessFactory;)V
+	public synthetic fun <init> (Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/FfmpegRecorder$ProcessFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun start (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public final class dev/sebastiano/spectre/recording/FfmpegRecorder$Companion {
+	public final fun resolveFfmpegPath ()Ljava/nio/file/Path;
+}
+
+public abstract interface class dev/sebastiano/spectre/recording/FfmpegRecorder$ProcessFactory {
+	public abstract fun start (Ljava/util/List;)Ljava/lang/Process;
+}
+
+public final class dev/sebastiano/spectre/recording/FfmpegWindowRecorder : dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder {
+	public fun <init> (Ljava/nio/file/Path;)V
+	public synthetic fun <init> (Ljava/nio/file/Path;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public final class dev/sebastiano/spectre/recording/MacOsRecordingPermissions {
+	public static final field INSTANCE Ldev/sebastiano/spectre/recording/MacOsRecordingPermissions;
+	public final fun diagnose ()Ldev/sebastiano/spectre/recording/PermissionDiagnostic;
+}
+
+public final class dev/sebastiano/spectre/recording/PermissionDiagnostic {
+	public fun <init> (Ljava/lang/String;Ldev/sebastiano/spectre/recording/PermissionStatus;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ldev/sebastiano/spectre/recording/PermissionStatus;
+	public final fun copy (Ljava/lang/String;Ldev/sebastiano/spectre/recording/PermissionStatus;)Ldev/sebastiano/spectre/recording/PermissionDiagnostic;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/recording/PermissionDiagnostic;Ljava/lang/String;Ldev/sebastiano/spectre/recording/PermissionStatus;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/PermissionDiagnostic;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getStatus ()Ldev/sebastiano/spectre/recording/PermissionStatus;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/recording/PermissionStatus : java/lang/Enum {
+	public static final field Denied Ldev/sebastiano/spectre/recording/PermissionStatus;
+	public static final field Granted Ldev/sebastiano/spectre/recording/PermissionStatus;
+	public static final field NotApplicable Ldev/sebastiano/spectre/recording/PermissionStatus;
+	public static final field Unknown Ldev/sebastiano/spectre/recording/PermissionStatus;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getLabel ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/recording/PermissionStatus;
+	public static fun values ()[Ldev/sebastiano/spectre/recording/PermissionStatus;
+}
+
+public abstract interface class dev/sebastiano/spectre/recording/Recorder {
+	public abstract fun start (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/Recorder;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public final class dev/sebastiano/spectre/recording/Recorder$DefaultImpls {
+	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/Recorder;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public abstract interface class dev/sebastiano/spectre/recording/RecordingHandle : java/lang/AutoCloseable {
+	public fun close ()V
+	public abstract fun getOutput ()Ljava/nio/file/Path;
+	public abstract fun isStopped ()Z
+	public abstract fun stop ()V
+}
+
+public final class dev/sebastiano/spectre/recording/RecordingHandle$DefaultImpls {
+	public static fun close (Ldev/sebastiano/spectre/recording/RecordingHandle;)V
+}
+
+public final class dev/sebastiano/spectre/recording/RecordingOptions {
+	public static final field Companion Ldev/sebastiano/spectre/recording/RecordingOptions$Companion;
+	public static final field DEFAULT_CODEC Ljava/lang/String;
+	public static final field DEFAULT_FRAME_RATE I
+	public static final field DEFAULT_SCREEN_INDEX I
+	public fun <init> ()V
+	public fun <init> (IZLjava/lang/String;I)V
+	public synthetic fun <init> (IZLjava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun copy (IZLjava/lang/String;I)Ldev/sebastiano/spectre/recording/RecordingOptions;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/recording/RecordingOptions;IZLjava/lang/String;IILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCaptureCursor ()Z
+	public final fun getCodec ()Ljava/lang/String;
+	public final fun getFrameRate ()I
+	public final fun getScreenIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/recording/RecordingOptions$Companion {
+}
+
+public final class dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder : dev/sebastiano/spectre/recording/Recorder {
+	public fun <init> ()V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor;Ldev/sebastiano/spectre/recording/portal/WaylandPortalRecorder$ProcessFactory;Ljava/util/List;JJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun start (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public final class dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorder : dev/sebastiano/spectre/recording/portal/WaylandWindowSourceRecorder {
+	public fun <init> ()V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/recording/Recorder;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public abstract interface class dev/sebastiano/spectre/recording/portal/WaylandWindowSourceRecorder {
+	public abstract fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/portal/WaylandWindowSourceRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public final class dev/sebastiano/spectre/recording/portal/WaylandWindowSourceRecorder$DefaultImpls {
+	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/portal/WaylandWindowSourceRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public final class dev/sebastiano/spectre/recording/screencapturekit/HelperNotBundledException : java/lang/IllegalStateException {
+}
+
+public final class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder : dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder {
+	public static final field DEFAULT_DISCOVERY_TIMEOUT_MS I
+	public static final field EXIT_HELPER_NOT_REAPED I
+	public static final field FORCE_KILL_DURING_START_SECONDS J
+	public static final field HELPER_EXIT_BAD_ARGS I
+	public static final field HELPER_EXIT_PIPELINE I
+	public static final field HELPER_EXIT_TCC_DENIED I
+	public static final field HELPER_EXIT_WINDOW_NOT_FOUND I
+	public static final field POLL_INTERVAL_MILLIS J
+	public static final field READER_DRAIN_MILLIS J
+	public static final field READY_MARKER Ljava/lang/String;
+	public static final field READY_WAIT_MILLIS J
+	public fun <init> ()V
+	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public abstract interface class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder$ProcessFactory {
+	public abstract fun start (Ljava/util/List;)Ljava/lang/Process;
+}
+
+public abstract interface class dev/sebastiano/spectre/recording/screencapturekit/TitledWindow {
+	public abstract fun getTitle ()Ljava/lang/String;
+	public abstract fun setTitle (Ljava/lang/String;)V
+}
+
+public final class dev/sebastiano/spectre/recording/screencapturekit/TitledWindowKt {
+	public static final fun asTitledWindow (Ljava/awt/Frame;)Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;
+}
+
+public abstract interface class dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder {
+	public abstract fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
+public final class dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder$DefaultImpls {
+	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -30,7 +30,13 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
 }
 
-kotlin { jvmToolchain(21) }
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation { enabled.set(true) }
+}
 
 dependencies {
     // recording is intentionally isolated per docs/ARCHITECTURE.md — it has its own native /

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -59,7 +59,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * missing window), instantiate [ScreenCaptureKitRecorder], [FfmpegWindowRecorder], or
  * [FfmpegRecorder] directly.
  */
-class AutoRecorder
+public class AutoRecorder
 internal constructor(
     private val sckRecorder: WindowRecorder,
     private val ffmpegRecorder: Recorder,
@@ -73,7 +73,7 @@ internal constructor(
     private val isWayland: () -> Boolean,
 ) {
 
-    constructor(
+    public constructor(
         sckRecorder: WindowRecorder = ScreenCaptureKitRecorder(),
         ffmpegRecorder: Recorder = FfmpegRecorder(),
         windowsWindowRecorder: WindowRecorder? = defaultWindowsWindowRecorder(),
@@ -102,7 +102,7 @@ internal constructor(
      */
     private val waylandFallbackWarned = AtomicBoolean(false)
 
-    fun start(
+    public fun start(
         window: TitledWindow?,
         region: Rectangle,
         output: Path,

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -43,7 +43,7 @@ import java.util.concurrent.atomic.AtomicReference
  * The [processFactory] seam exists so the lifecycle can be unit-tested without spawning a real
  * `ffmpeg` (a fake factory can return a `Process`-like stand-in driven by an in-memory pipe).
  */
-class FfmpegRecorder
+public class FfmpegRecorder
 internal constructor(
     private val ffmpegPath: Path,
     private val processFactory: ProcessFactory,
@@ -56,7 +56,7 @@ internal constructor(
     private val backendProvider: () -> FfmpegBackend,
 ) : Recorder {
 
-    constructor(
+    public constructor(
         ffmpegPath: Path = resolveFfmpegPath(),
         processFactory: ProcessFactory = SystemProcessFactory,
     ) : this(ffmpegPath, processFactory, FfmpegBackend::detect)
@@ -77,8 +77,8 @@ internal constructor(
     }
 
     /** Indirection over `ProcessBuilder.start()` so tests can drive the subprocess lifecycle. */
-    interface ProcessFactory {
-        fun start(argv: List<String>): Process
+    public interface ProcessFactory {
+        public fun start(argv: List<String>): Process
     }
 
     internal object SystemProcessFactory : ProcessFactory {
@@ -96,7 +96,7 @@ internal constructor(
                 .start()
     }
 
-    companion object {
+    public companion object {
 
         // Sentinel returned by resolveFfmpegPath() when no binary is found. Constructing an
         // FfmpegRecorder against this path lets the caller see the explicit failure message
@@ -121,7 +121,7 @@ internal constructor(
          * [FfmpegRecorder] with [PROBE_PATH] will get a clear error explaining the missing binary
          * at use time.
          */
-        fun resolveFfmpegPath(): Path = which("ffmpeg") ?: PROBE_PATH
+        public fun resolveFfmpegPath(): Path = which("ffmpeg") ?: PROBE_PATH
 
         private fun which(executable: String): Path? {
             val pathEnv = System.getenv("PATH") ?: return null

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegWindowRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegWindowRecorder.kt
@@ -34,13 +34,13 @@ import java.nio.file.Path
  * Construction mirrors [FfmpegRecorder]'s shape: an [ffmpegPath] resolved by default from `PATH`
  * via [FfmpegRecorder.resolveFfmpegPath], and a [processFactory] seam for tests.
  */
-class FfmpegWindowRecorder
+public class FfmpegWindowRecorder
 internal constructor(
     private val ffmpegPath: Path,
     private val processFactory: FfmpegRecorder.ProcessFactory,
 ) : WindowRecorder {
 
-    constructor(
+    public constructor(
         ffmpegPath: Path = FfmpegRecorder.resolveFfmpegPath()
     ) : this(ffmpegPath, FfmpegRecorder.SystemProcessFactory)
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
@@ -22,14 +22,14 @@ import java.util.concurrent.TimeUnit
  * [ScreenCaptureKitRecorder][dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureKitRecorder]
  * detects TCC denial via the helper's exit code.
  */
-object MacOsRecordingPermissions {
+public object MacOsRecordingPermissions {
 
     /**
      * Returns a human-readable diagnostic that downstream tooling can dump at startup. On non-macOS
      * platforms returns [PermissionStatus.NotApplicable]. On macOS, runs a best-effort probe via
      * `osascript` if available, otherwise returns [PermissionStatus.Unknown] with guidance text.
      */
-    fun diagnose(): PermissionDiagnostic {
+    public fun diagnose(): PermissionDiagnostic {
         if (!isMacOs()) return PermissionDiagnostic(NOT_MAC_MESSAGE, PermissionStatus.NotApplicable)
         val screen = probeScreenRecordingPermission()
         val accessibility = probeAccessibilityPermission()
@@ -135,7 +135,7 @@ object MacOsRecordingPermissions {
 }
 
 /** Coarse permission status we can detect without JNI. */
-enum class PermissionStatus(val label: String) {
+public enum class PermissionStatus(public val label: String) {
     Granted("granted"),
     Denied("denied"),
     Unknown("unknown (could not detect — see guidance)"),
@@ -143,4 +143,4 @@ enum class PermissionStatus(val label: String) {
 }
 
 /** Result of [MacOsRecordingPermissions.diagnose]. */
-data class PermissionDiagnostic(val message: String, val status: PermissionStatus)
+public data class PermissionDiagnostic(val message: String, val status: PermissionStatus)

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/Recorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/Recorder.kt
@@ -13,7 +13,7 @@ import java.nio.file.Path
  * `WaylandPortalWindowRecorder` on Linux Wayland. Tests and advanced consumers can swap in their
  * own [Recorder] implementation (e.g. an in-memory frame accumulator).
  */
-interface Recorder {
+public interface Recorder {
 
     /**
      * Begin recording [region] to [output]. Returns a [RecordingHandle] that the caller stops to
@@ -21,7 +21,7 @@ interface Recorder {
      * drive the UI immediately afterwards — by the time `start` returns, frames should be landing
      * in the output file.
      */
-    fun start(
+    public fun start(
         region: Rectangle,
         output: Path,
         options: RecordingOptions = RecordingOptions(),

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingHandle.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingHandle.kt
@@ -8,16 +8,16 @@ import java.nio.file.Path
  * Call [stop] (or use the recorder's [AutoCloseable] form) to flush the pending frames and finalise
  * the file at [output]. Stopping a handle that has already been stopped is a no-op.
  */
-interface RecordingHandle : AutoCloseable {
+public interface RecordingHandle : AutoCloseable {
 
     /** The destination file the recorder is writing to. */
-    val output: Path
+    public val output: Path
 
     /** True once [stop] has been called and the recorder has flushed/exited. */
-    val isStopped: Boolean
+    public val isStopped: Boolean
 
     /** Flush, terminate the underlying recording process/pipeline, and finalise [output]. */
-    fun stop()
+    public fun stop()
 
     override fun close() {
         stop()

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
@@ -5,7 +5,7 @@ package dev.sebastiano.spectre.recording
  * scenario-level test recordings: 30fps, cursor visible, hardware-accelerated H.264 on macOS where
  * available.
  */
-data class RecordingOptions(
+public data class RecordingOptions(
     val frameRate: Int = DEFAULT_FRAME_RATE,
     val captureCursor: Boolean = true,
     /**
@@ -32,10 +32,10 @@ data class RecordingOptions(
         require(screenIndex >= 0) { "screenIndex must be non-negative, was $screenIndex" }
     }
 
-    companion object {
+    public companion object {
 
-        const val DEFAULT_FRAME_RATE: Int = 30
-        const val DEFAULT_CODEC: String = "libx264"
-        const val DEFAULT_SCREEN_INDEX: Int = 0
+        public const val DEFAULT_FRAME_RATE: Int = 30
+        public const val DEFAULT_CODEC: String = "libx264"
+        public const val DEFAULT_SCREEN_INDEX: Int = 0
     }
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorder.kt
@@ -19,8 +19,8 @@ import java.util.concurrent.TimeUnit
  * itself via OS APIs and don't take a region). The production implementation is
  * [WaylandPortalWindowRecorder].
  */
-interface WaylandWindowSourceRecorder {
-    fun start(
+public interface WaylandWindowSourceRecorder {
+    public fun start(
         window: TitledWindow,
         region: Rectangle,
         output: Path,

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperNotBundledException.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperNotBundledException.kt
@@ -10,5 +10,5 @@ package dev.sebastiano.spectre.recording.screencapturekit
  * denied, window not found, helper crashed during init) stay as `IllegalStateException` and
  * propagate — those are caller-actionable and shouldn't be silently masked.
  */
-class HelperNotBundledException internal constructor(message: String) :
+public class HelperNotBundledException internal constructor(message: String) :
     IllegalStateException(message)

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -34,13 +34,13 @@ import java.util.concurrent.atomic.AtomicReference
  * macOS-only. On non-macOS hosts the helper isn't bundled; [start] fails early with a clear "helper
  * not found" error from [HelperBinaryExtractor].
  */
-class ScreenCaptureKitRecorder
+public class ScreenCaptureKitRecorder
 internal constructor(
     private val helperExtractor: HelperBinaryExtractor,
     private val processFactory: ProcessFactory,
 ) : WindowRecorder {
 
-    constructor() : this(HelperBinaryExtractor(), SystemProcessFactory)
+    public constructor() : this(HelperBinaryExtractor(), SystemProcessFactory)
 
     override fun start(
         window: TitledWindow,
@@ -186,8 +186,8 @@ internal constructor(
     }
 
     /** Indirection over `ProcessBuilder.start()` so tests can drive the subprocess lifecycle. */
-    interface ProcessFactory {
-        fun start(argv: List<String>): Process
+    public interface ProcessFactory {
+        public fun start(argv: List<String>): Process
     }
 
     internal object SystemProcessFactory : ProcessFactory {

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/TitledWindow.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/TitledWindow.kt
@@ -10,8 +10,8 @@ import java.util.concurrent.atomic.AtomicReference
  * `androidx.compose.ui.awt.ComposeWindow` (which extends `java.awt.Frame` and inherits `getTitle` /
  * `setTitle`) is the [asTitledWindow] adapter below.
  */
-interface TitledWindow {
-    var title: String?
+public interface TitledWindow {
+    public var title: String?
 }
 
 /**
@@ -25,7 +25,7 @@ interface TitledWindow {
  * Null titles set through this adapter are written as the empty string, mirroring AWT's own
  * behaviour for `Frame.setTitle(null)`.
  */
-fun Frame.asTitledWindow(): TitledWindow =
+public fun Frame.asTitledWindow(): TitledWindow =
     object : TitledWindow {
         override var title: String?
             get() = onEdt { this@asTitledWindow.title }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder.kt
@@ -19,8 +19,8 @@ import java.nio.file.Path
  * [WindowRecorder] and a [dev.sebastiano.spectre.recording.Recorder] and picks the right one per
  * call based on whether a window was supplied + the current host OS.
  */
-interface WindowRecorder {
-    fun start(
+public interface WindowRecorder {
+    public fun start(
         window: TitledWindow,
         windowOwnerPid: Long = ProcessHandle.current().pid(),
         output: Path,

--- a/server/api/server.api
+++ b/server/api/server.api
@@ -1,0 +1,281 @@
+public abstract interface annotation class dev/sebastiano/spectre/server/ExperimentalSpectreHttpApi : java/lang/annotation/Annotation {
+}
+
+public final class dev/sebastiano/spectre/server/HttpComposeAutomator : java/lang/AutoCloseable {
+	public static final field Companion Ldev/sebastiano/spectre/server/HttpComposeAutomator$Companion;
+	public static final field DEFAULT_PORT I
+	public final fun allNodes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun click (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close ()V
+	public final fun findByTestTag (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun screenshot (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun typeText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun windows (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/sebastiano/spectre/server/HttpComposeAutomator$Companion {
+}
+
+public final class dev/sebastiano/spectre/server/HttpComposeAutomatorKt {
+	public static final fun http (Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;Ljava/lang/String;ILjava/lang/String;)Ldev/sebastiano/spectre/server/HttpComposeAutomator;
+	public static synthetic fun http$default (Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/server/HttpComposeAutomator;
+}
+
+public final class dev/sebastiano/spectre/server/SpectreServerKt {
+	public static final fun installSpectreRoutes (Lio/ktor/server/application/Application;Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;)V
+	public static synthetic fun installSpectreRoutes$default (Lio/ktor/server/application/Application;Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;ILjava/lang/Object;)V
+}
+
+public final class dev/sebastiano/spectre/server/dto/ClickRequest {
+	public static final field Companion Ldev/sebastiano/spectre/server/dto/ClickRequest$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/sebastiano/spectre/server/dto/ClickRequest;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/server/dto/ClickRequest;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/server/dto/ClickRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodeKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/server/dto/ClickRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/server/dto/ClickRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/server/dto/ClickRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/server/dto/ClickRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/ClickRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/NodeSnapshotDto {
+	public static final field Companion Ldev/sebastiano/spectre/server/dto/NodeSnapshotDto$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZZLdev/sebastiano/spectre/server/dto/RectangleDto;Ldev/sebastiano/spectre/server/dto/RectangleDto;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZZLdev/sebastiano/spectre/server/dto/RectangleDto;Ldev/sebastiano/spectre/server/dto/RectangleDto;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ldev/sebastiano/spectre/server/dto/RectangleDto;
+	public final fun component11 ()Ldev/sebastiano/spectre/server/dto/RectangleDto;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZZLdev/sebastiano/spectre/server/dto/RectangleDto;Ldev/sebastiano/spectre/server/dto/RectangleDto;)Ldev/sebastiano/spectre/server/dto/NodeSnapshotDto;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/server/dto/NodeSnapshotDto;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ZZZLdev/sebastiano/spectre/server/dto/RectangleDto;Ldev/sebastiano/spectre/server/dto/RectangleDto;ILjava/lang/Object;)Ldev/sebastiano/spectre/server/dto/NodeSnapshotDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBoundsInWindow ()Ldev/sebastiano/spectre/server/dto/RectangleDto;
+	public final fun getBoundsOnScreen ()Ldev/sebastiano/spectre/server/dto/RectangleDto;
+	public final fun getContentDescriptions ()Ljava/util/List;
+	public final fun getEditableText ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTestTag ()Ljava/lang/String;
+	public final fun getTexts ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isDisabled ()Z
+	public final fun isFocused ()Z
+	public final fun isSelected ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/server/dto/NodeSnapshotDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/server/dto/NodeSnapshotDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/server/dto/NodeSnapshotDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/server/dto/NodeSnapshotDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/NodeSnapshotDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/NodesResponse {
+	public static final field Companion Ldev/sebastiano/spectre/server/dto/NodesResponse$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Ldev/sebastiano/spectre/server/dto/NodesResponse;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/server/dto/NodesResponse;Ljava/util/List;ILjava/lang/Object;)Ldev/sebastiano/spectre/server/dto/NodesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNodes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/server/dto/NodesResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/server/dto/NodesResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/server/dto/NodesResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/server/dto/NodesResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/NodesResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/RectangleDto {
+	public static final field Companion Ldev/sebastiano/spectre/server/dto/RectangleDto$Companion;
+	public fun <init> (DDDD)V
+	public final fun component1 ()D
+	public final fun component2 ()D
+	public final fun component3 ()D
+	public final fun component4 ()D
+	public final fun copy (DDDD)Ldev/sebastiano/spectre/server/dto/RectangleDto;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/server/dto/RectangleDto;DDDDILjava/lang/Object;)Ldev/sebastiano/spectre/server/dto/RectangleDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()D
+	public final fun getWidth ()D
+	public final fun getX ()D
+	public final fun getY ()D
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/server/dto/RectangleDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/server/dto/RectangleDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/server/dto/RectangleDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/server/dto/RectangleDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/RectangleDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/ScreenshotResponse {
+	public static final field Companion Ldev/sebastiano/spectre/server/dto/ScreenshotResponse$Companion;
+	public fun <init> (Ljava/lang/String;II)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;II)Ldev/sebastiano/spectre/server/dto/ScreenshotResponse;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/server/dto/ScreenshotResponse;Ljava/lang/String;IIILjava/lang/Object;)Ldev/sebastiano/spectre/server/dto/ScreenshotResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHeight ()I
+	public final fun getPngBase64 ()Ljava/lang/String;
+	public final fun getWidth ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/server/dto/ScreenshotResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/server/dto/ScreenshotResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/server/dto/ScreenshotResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/server/dto/ScreenshotResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/ScreenshotResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/TypeTextRequest {
+	public static final field Companion Ldev/sebastiano/spectre/server/dto/TypeTextRequest$Companion;
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/sebastiano/spectre/server/dto/TypeTextRequest;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/server/dto/TypeTextRequest;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/server/dto/TypeTextRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/server/dto/TypeTextRequest$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/server/dto/TypeTextRequest$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/server/dto/TypeTextRequest;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/server/dto/TypeTextRequest;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/TypeTextRequest$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/WindowSummaryDto {
+	public static final field Companion Ldev/sebastiano/spectre/server/dto/WindowSummaryDto$Companion;
+	public fun <init> (ILjava/lang/String;ZLdev/sebastiano/spectre/server/dto/RectangleDto;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Z
+	public final fun component4 ()Ldev/sebastiano/spectre/server/dto/RectangleDto;
+	public final fun copy (ILjava/lang/String;ZLdev/sebastiano/spectre/server/dto/RectangleDto;)Ldev/sebastiano/spectre/server/dto/WindowSummaryDto;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/server/dto/WindowSummaryDto;ILjava/lang/String;ZLdev/sebastiano/spectre/server/dto/RectangleDto;ILjava/lang/Object;)Ldev/sebastiano/spectre/server/dto/WindowSummaryDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComposeSurfaceBounds ()Ldev/sebastiano/spectre/server/dto/RectangleDto;
+	public final fun getIndex ()I
+	public final fun getSurfaceId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isPopup ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/server/dto/WindowSummaryDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/server/dto/WindowSummaryDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/server/dto/WindowSummaryDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/server/dto/WindowSummaryDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/WindowSummaryDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/WindowsResponse {
+	public static final field Companion Ldev/sebastiano/spectre/server/dto/WindowsResponse$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Ldev/sebastiano/spectre/server/dto/WindowsResponse;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/server/dto/WindowsResponse;Ljava/util/List;ILjava/lang/Object;)Ldev/sebastiano/spectre/server/dto/WindowsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getWindows ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/server/dto/WindowsResponse$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/server/dto/WindowsResponse$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/server/dto/WindowsResponse;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/server/dto/WindowsResponse;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/server/dto/WindowsResponse$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -5,7 +5,13 @@ plugins {
     alias(libs.plugins.ktfmt)
 }
 
-kotlin { jvmToolchain(21) }
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation { enabled.set(true) }
+}
 
 dependencies {
     api(projects.core)

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/ExperimentalSpectreHttpApi.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/ExperimentalSpectreHttpApi.kt
@@ -1,0 +1,45 @@
+package dev.sebastiano.spectre.server
+
+/**
+ * Marks a declaration as part of the **experimental HTTP transport** in Spectre's `server` module.
+ *
+ * The HTTP transport is intentionally pre-1.0 and is expected to change as authentication, TLS,
+ * narrower per-window capture APIs, and the design work tracked under #96 land. Declarations
+ * carrying this annotation are **public** but are explicitly **not covered** by Spectre's binary
+ * compatibility guarantees — they may change or be removed in any release, including patch
+ * releases.
+ *
+ * Opt in to use the experimental transport:
+ * ```
+ * @file:OptIn(ExperimentalSpectreHttpApi::class)
+ * ```
+ *
+ * Or, at a specific call site:
+ * ```
+ * @OptIn(ExperimentalSpectreHttpApi::class)
+ * fun mountTransport(app: Application) { app.installSpectreRoutes(automator) }
+ * ```
+ *
+ * See [the stability policy](https://spectre.sebastiano.dev/STABILITY/) for the full picture of
+ * stable / experimental / internal API tiers, and
+ * [the security notes](https://spectre.sebastiano.dev/SECURITY/) for the transport's trust
+ * boundaries.
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message =
+        "The Spectre HTTP transport is experimental and is not covered by the stability " +
+            "policy — its public API may change or be removed in any release. Opt in with " +
+            "@OptIn(ExperimentalSpectreHttpApi::class) to acknowledge.",
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.TYPEALIAS,
+)
+public annotation class ExperimentalSpectreHttpApi

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
 package dev.sebastiano.spectre.server
 
 import dev.sebastiano.spectre.core.ComposeAutomator
@@ -35,7 +37,9 @@ import javax.imageio.ImageIO
  * The instance owns its [HttpClient] and must be `close()`d to release pooled connections. Use `use
  * { ... }` from `kotlin.AutoCloseable` for scoped lifecycles.
  */
-class HttpComposeAutomator internal constructor(private val baseUrl: String) : AutoCloseable {
+@ExperimentalSpectreHttpApi
+public class HttpComposeAutomator internal constructor(private val baseUrl: String) :
+    AutoCloseable {
 
     // HttpClient(CIO) — the engine *factory* form — makes the client own the engine, so
     // close() shuts down both the client and the underlying CIO engine (its connection pool
@@ -44,15 +48,15 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
     private val client: HttpClient = HttpClient(CIO) { install(ContentNegotiation) { json() } }
 
     /** Fetches the current list of tracked windows from the remote automator. */
-    suspend fun windows(): List<WindowSummaryDto> =
+    public suspend fun windows(): List<WindowSummaryDto> =
         client.get("$baseUrl/windows").body<WindowsResponse>().windows
 
     /** Fetches every visible semantics node from every tracked surface on the remote automator. */
-    suspend fun allNodes(): List<NodeSnapshotDto> =
+    public suspend fun allNodes(): List<NodeSnapshotDto> =
         client.get("$baseUrl/nodes").body<NodesResponse>().nodes
 
     /** Fetches semantics nodes carrying the given `testTag` from the remote automator. */
-    suspend fun findByTestTag(tag: String): List<NodeSnapshotDto> =
+    public suspend fun findByTestTag(tag: String): List<NodeSnapshotDto> =
         client.get("$baseUrl/nodes") { parameter("testTag", tag) }.body<NodesResponse>().nodes
 
     /**
@@ -60,7 +64,7 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
      * of [dev.sebastiano.spectre.core.NodeKey] — `surfaceId:ownerIndex:nodeId`). Throws
      * [IllegalStateException] on any non-2xx response.
      */
-    suspend fun click(nodeKey: String) {
+    public suspend fun click(nodeKey: String) {
         val response =
             client.post("$baseUrl/click") {
                 contentType(ContentType.Application.Json)
@@ -77,7 +81,7 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
      * clipboard-backed paste as the in-process driver. Throws [IllegalStateException] on any
      * non-2xx response.
      */
-    suspend fun typeText(text: String) {
+    public suspend fun typeText(text: String) {
         val response =
             client.post("$baseUrl/typeText") {
                 contentType(ContentType.Application.Json)
@@ -91,7 +95,7 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
      * Fetches a screenshot from the remote automator and decodes it as a [BufferedImage]. Throws
      * [IllegalStateException] if the decoded PNG bytes can't be parsed.
      */
-    suspend fun screenshot(): BufferedImage {
+    public suspend fun screenshot(): BufferedImage {
         val response = client.get("$baseUrl/screenshot").body<ScreenshotResponse>()
         val bytes = Base64.getDecoder().decode(response.pngBase64)
         return checkNotNull(ImageIO.read(ByteArrayInputStream(bytes))) {
@@ -103,10 +107,10 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
         client.close()
     }
 
-    companion object {
+    public companion object {
 
         /** Default port suggested by the gist's HTTP example. */
-        const val DEFAULT_PORT: Int = 9274
+        public const val DEFAULT_PORT: Int = 9274
 
         internal fun create(host: String, port: Int, basePath: String): HttpComposeAutomator =
             HttpComposeAutomator(baseUrl = normaliseBaseUrl(host, port, basePath))
@@ -136,7 +140,8 @@ class HttpComposeAutomator internal constructor(private val baseUrl: String) : A
  * [the published security notes](https://spectre.sebastiano.dev/SECURITY/) for the full exposure
  * model.
  */
-fun ComposeAutomator.Companion.http(
+@ExperimentalSpectreHttpApi
+public fun ComposeAutomator.Companion.http(
     host: String = "localhost",
     port: Int = HttpComposeAutomator.DEFAULT_PORT,
     basePath: String = "/spectre",

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -1,4 +1,4 @@
-@file:OptIn(InternalSpectreApi::class)
+@file:OptIn(InternalSpectreApi::class, ExperimentalSpectreHttpApi::class)
 
 package dev.sebastiano.spectre.server
 
@@ -70,7 +70,11 @@ import javax.imageio.ImageIO
  *   converters into an already-installed plugin, and re-installing would throw a duplicate-plugin
  *   exception. Without JSON support the routes will fail at request time with a 415/500.
  */
-fun Application.installSpectreRoutes(automator: ComposeAutomator, basePath: String = "/spectre") {
+@ExperimentalSpectreHttpApi
+public fun Application.installSpectreRoutes(
+    automator: ComposeAutomator,
+    basePath: String = "/spectre",
+) {
     if (pluginOrNull(ContentNegotiation) == null) {
         install(ContentNegotiation) { json() }
     }

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Conversions.kt
@@ -1,10 +1,11 @@
-@file:OptIn(InternalSpectreApi::class)
+@file:OptIn(InternalSpectreApi::class, ExperimentalSpectreHttpApi::class)
 
 package dev.sebastiano.spectre.server.dto
 
 import dev.sebastiano.spectre.core.AutomatorNode
 import dev.sebastiano.spectre.core.InternalSpectreApi
 import dev.sebastiano.spectre.core.TrackedWindow
+import dev.sebastiano.spectre.server.ExperimentalSpectreHttpApi
 import java.awt.Rectangle
 
 internal fun TrackedWindow.toDto(index: Int): WindowSummaryDto =

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Dtos.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/dto/Dtos.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.server.dto
 
+import dev.sebastiano.spectre.server.ExperimentalSpectreHttpApi
 import kotlinx.serialization.Serializable
 
 /**
@@ -9,8 +10,9 @@ import kotlinx.serialization.Serializable
  * boundary). The `index` field matches the position in the in-process `windows` list, so HTTP
  * callers can address a specific window the same way in-process callers do.
  */
+@ExperimentalSpectreHttpApi
 @Serializable
-data class WindowSummaryDto(
+public data class WindowSummaryDto(
     val index: Int,
     val surfaceId: String,
     val isPopup: Boolean,
@@ -26,8 +28,9 @@ data class WindowSummaryDto(
  * the live `TrackedWindow`) are intentionally omitted — callers that need them have to use the
  * in-process automator.
  */
+@ExperimentalSpectreHttpApi
 @Serializable
-data class NodeSnapshotDto(
+public data class NodeSnapshotDto(
     val key: String,
     val testTag: String? = null,
     val texts: List<String> = emptyList(),
@@ -45,20 +48,27 @@ data class NodeSnapshotDto(
  * AWT rectangle in screen / window coordinates. Doubles are used for the in-window form to preserve
  * sub-pixel precision; the on-screen form is rounded into ints by callers when feeding Robot APIs.
  */
+@ExperimentalSpectreHttpApi
 @Serializable
-data class RectangleDto(val x: Double, val y: Double, val width: Double, val height: Double)
+public data class RectangleDto(val x: Double, val y: Double, val width: Double, val height: Double)
 
 /** Request body for `POST /click`. */
-@Serializable data class ClickRequest(val nodeKey: String)
+@ExperimentalSpectreHttpApi @Serializable public data class ClickRequest(val nodeKey: String)
 
 /** Request body for `POST /typeText`. */
-@Serializable data class TypeTextRequest(val text: String)
+@ExperimentalSpectreHttpApi @Serializable public data class TypeTextRequest(val text: String)
 
 /** Response body for `GET /screenshot` — the captured image as base64-encoded PNG bytes. */
-@Serializable data class ScreenshotResponse(val pngBase64: String, val width: Int, val height: Int)
+@ExperimentalSpectreHttpApi
+@Serializable
+public data class ScreenshotResponse(val pngBase64: String, val width: Int, val height: Int)
 
 /** Response body for `GET /nodes` and similar list endpoints. */
-@Serializable data class NodesResponse(val nodes: List<NodeSnapshotDto>)
+@ExperimentalSpectreHttpApi
+@Serializable
+public data class NodesResponse(val nodes: List<NodeSnapshotDto>)
 
 /** Response body for `GET /windows`. */
-@Serializable data class WindowsResponse(val windows: List<WindowSummaryDto>)
+@ExperimentalSpectreHttpApi
+@Serializable
+public data class WindowsResponse(val windows: List<WindowSummaryDto>)

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
 package dev.sebastiano.spectre.server
 
 import dev.sebastiano.spectre.core.ComposeAutomator

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
 package dev.sebastiano.spectre.server
 
 import kotlin.test.Test

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpNegativeContractTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpNegativeContractTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
 package dev.sebastiano.spectre.server
 
 import dev.sebastiano.spectre.core.ComposeAutomator

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/ScreenshotEnvelopeTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/ScreenshotEnvelopeTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
 package dev.sebastiano.spectre.server
 
 import java.awt.image.BufferedImage

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
 package dev.sebastiano.spectre.server
 
 import dev.sebastiano.spectre.core.ComposeAutomator

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/dto/DtoSerializationTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/dto/DtoSerializationTest.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ExperimentalSpectreHttpApi::class)
+
 package dev.sebastiano.spectre.server.dto
 
+import dev.sebastiano.spectre.server.ExperimentalSpectreHttpApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlinx.serialization.encodeToString

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -1,0 +1,18 @@
+public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/ParameterResolver {
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
+	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
+	public final fun getAutomator ()Ldev/sebastiano/spectre/core/ComposeAutomator;
+	public fun resolveParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Ljava/lang/Object;
+	public fun supportsParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Z
+}
+
+public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/junit/rules/ExternalResource {
+	public fun <init> ()V
+	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun after ()V
+	public fun before ()V
+	public final fun getAutomator ()Ldev/sebastiano/spectre/core/ComposeAutomator;
+}
+

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -4,7 +4,13 @@ plugins {
     alias(libs.plugins.kotlinJvm)
 }
 
-kotlin { jvmToolchain(21) }
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation { enabled.set(true) }
+}
 
 dependencies {
     api(projects.core)

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutomatorFactory.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutomatorFactory.kt
@@ -9,4 +9,4 @@ import dev.sebastiano.spectre.core.ComposeAutomator
  * display. Headless or unit-style tests that only need the test ergonomics (rule/extension
  * plumbing) without a real Robot/EDT can supply a custom factory that returns a stub or a fake.
  */
-typealias AutomatorFactory = () -> ComposeAutomator
+public typealias AutomatorFactory = () -> ComposeAutomator

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -39,17 +39,17 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * typical sequential `@RegisterExtension` flow; callers running tests in parallel should rely on
  * parameter injection instead.
  */
-class ComposeAutomatorExtension(private val factory: AutomatorFactory) :
+public class ComposeAutomatorExtension(private val factory: AutomatorFactory) :
     BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
     // Explicit no-arg secondary constructor so JUnit 5's @ExtendWith — which reflectively
     // calls the no-arg constructor — can instantiate the extension. Kotlin's default-parameter
     // primary constructor does not emit a true JVM no-arg overload without @JvmOverloads.
-    constructor() : this({ ComposeAutomator.inProcess() })
+    public constructor() : this({ ComposeAutomator.inProcess() })
 
     @Volatile private var lastInstance: ComposeAutomator? = null
 
-    val automator: ComposeAutomator
+    public val automator: ComposeAutomator
         get() =
             checkNotNull(lastInstance) {
                 "ComposeAutomatorExtension.automator accessed outside of a running test"
@@ -96,6 +96,12 @@ class ComposeAutomatorExtension(private val factory: AutomatorFactory) :
         // test invocations from clobbering each other.
         val NAMESPACE: ExtensionContext.Namespace =
             ExtensionContext.Namespace.create(ComposeAutomatorExtension::class.java)
-        const val STORE_KEY: String = "automator"
     }
 }
+
+// File-level private constant rather than `const val` inside the `private companion object`.
+// The Kotlin compiler emits `const val` members of any companion as JVM-level
+// `public static final` fields, which makes them visible in the ABI dump even though
+// the companion itself is `private`. A file-level `private const val` compiles to a private
+// static field on the file's facade class and stays out of the public ABI surface.
+private const val STORE_KEY: String = "automator"

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -31,16 +31,16 @@ import org.junit.rules.ExternalResource
  * Prefer [ComposeAutomatorExtension] when using JUnit 5 — JUnit 5's parameter-injection model is a
  * better fit for parallel test execution.
  */
-class ComposeAutomatorRule(private val factory: AutomatorFactory) : ExternalResource() {
+public class ComposeAutomatorRule(private val factory: AutomatorFactory) : ExternalResource() {
 
     // Explicit no-arg secondary constructor so JUnit 4 callers can write
     // `@get:Rule val r = ComposeAutomatorRule()` without relying on Kotlin's
     // default-parameter constructor synthesis (consistent with ComposeAutomatorExtension).
-    constructor() : this({ ComposeAutomator.inProcess() })
+    public constructor() : this({ ComposeAutomator.inProcess() })
 
     private var instance: ComposeAutomator? = null
 
-    val automator: ComposeAutomator
+    public val automator: ComposeAutomator
         get() =
             checkNotNull(instance) {
                 "ComposeAutomatorRule.automator accessed outside of a running test"


### PR DESCRIPTION
Implements bucket R7 of the release-hardening epic (#114), closing it. Locks the public API boundary before publishing. **No code behaviour changes. No new APIs. No Maven publishing or release automation.**

## Summary

- **`@ExperimentalSpectreHttpApi` marker** (`WARNING` level, AndroidX style) covers the entire `server` module's public surface — `installSpectreRoutes`, `ComposeAutomator.http`, `HttpComposeAutomator`, and the eight DTOs. `@file:OptIn(ExperimentalSpectreHttpApi::class)` added at every production, test, and docs consumer site the compiler flagged.

- **Explicit API mode (`Strict`)** enabled on `core`, `server`, `recording`, `testing`. Every previously Kotlin-default-public declaration now carries an explicit `public` modifier. **No internal-ization, no reshaping** — visibility intent is unchanged.

- **Kotlin Binary Compatibility Validation** wired via the Kotlin Gradle Plugin's **built-in** `abiValidation` extension on the four library modules — no standalone plugin, no pinned version. `checkKotlinAbi` runs automatically as part of `./gradlew check`. Initial baselines committed:
  - [`core/api/core.api`](core/api/core.api)
  - [`server/api/server.api`](server/api/server.api)
  - [`recording/api/recording.api`](recording/api/recording.api)
  - [`testing/api/testing.api`](testing/api/testing.api)

- **Zero exclusions**. No `ignoredProjects`, no `ignoredPackages`. kotlinx-serialization synthetic `$$serializer` classes appear in the `server` baseline as a normal artefact of `@Serializable` — not hidden.

- **`STORE_KEY` bytecode-leak fix**. `const val STORE_KEY` inside a `private companion object` in `ComposeAutomatorExtension` was compiled to a public static field on the bytecode side, surfacing in the testing ABI dump despite being source-private. Moved to a file-level `private const val` so the leak doesn't get fossilised in the first baseline. This is a fix to a source-private declaration that the Kotlin compiler accidentally exposed at the JVM level — **not** an API reshape.

- **Defensive depth at release** — `.github/workflows/release.yml` runs `./gradlew checkKotlinAbi` before the signed-jar build. PR-time `check` already gates the ABI; this catches the tag-from-feature-branch path.

- **New [`docs/STABILITY.md`](docs/STABILITY.md)** wired into the MkDocs Reference nav. Three-tier API model (stable / experimental / internal escape hatch), BCV workflow, platform-support tiers (mirrors R6's Linux-best-effort wording for Wayland), AndroidX-style stability conventions. Explicit on what ABI validation does **not** cover: per-symbol annotation usages — removing `@ExperimentalSpectreHttpApi` from a marked declaration is not caught by `checkKotlinAbi` because annotation removal doesn't change JVM symbol shape. The marker layer is enforced at compile time by `@RequiresOptIn`, gated by source review; the symbol layer is enforced by ABI validation. Complementary, not interchangeable.

## Tooling decision (recorded for the audit trail)

Used the Kotlin Gradle Plugin's **built-in** \`abiValidation\` extension (\`@OptIn(ExperimentalAbiValidation::class) kotlin { abiValidation { enabled.set(true) } }\`) rather than the standalone JetBrains BCV plugin. Reasons: same \`api/<module>.api\` baseline format, no version pin in \`libs.versions.toml\`, no plugin classpath addition. Tasks: \`checkKotlinAbi\` (auto-wired into \`check\`), \`updateKotlinAbi\`, \`internalDumpKotlinAbi\`. The \`@OptIn\` is for the DSL marker — the tooling itself is signaled as experimental by KGP.

## Out of scope (deferred)

Per the masterplan and plan v2:
- Metalava (BCV + explicit API are sufficient).
- Maven publishing (coordinates, signing, repository config).
- Release automation (release-please / semantic-release / version bumping).
- Umbrella \`@ExperimentalSpectreApi\` (only HTTP needs a marker today).
- API reshaping beyond the source-private \`STORE_KEY\` bytecode-leak fix.

## Test plan

- [x] \`./gradlew check\` (detekt + ktfmt + JVM tests + \`checkKotlinAbi\` across all modules) green.
- [x] \`mkdocs build --strict\` green.
- [ ] CI green on Linux + macOS + Windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)