### PR TITLE
Add spectre Claude skill for automating Compose Desktop UI tests

### DIFF
--- a/.agents/skills/spectre/SKILL.md
+++ b/.agents/skills/spectre/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spectre
-description: Use when writing, debugging, or reviewing tests that drive a live Compose Desktop UI with Spectre — the JVM/Kotlin library for automating real Compose Desktop windows (and IntelliJ/Jewel-hosted Compose) via the semantics tree plus java.awt.Robot or synthetic AWT input. Trigger on mentions of `ComposeAutomator`, `RobotDriver`, `AutomatorNode`, `findByTestTag`, `waitForNode`, `waitForIdle`, "Compose Desktop UI test", "automate a Compose window", screenshotting or recording a Compose Desktop window, or any task involving `dev.sebastiano.spectre.*` imports. Also use when the user is writing JUnit 4/5 tests against Compose Desktop, even if they don't say "Spectre" explicitly — if the test drives a real Compose window (not `runComposeUiTest`), this is the right tool.
+description: Use when writing, debugging, or reviewing tests that drive a real, on-screen Compose Desktop window with Spectre — the JVM/Kotlin library for automating live Compose Desktop UIs (and IntelliJ/Jewel-hosted Compose) via the semantics tree plus java.awt.Robot or synthetic AWT input. Trigger on mentions of `ComposeAutomator`, `RobotDriver`, `AutomatorNode`, `findByTestTag`, `waitForNode`, `waitForIdle`, "automate a Compose window", "live/real-window Compose Desktop UI test", screenshotting or recording a Compose Desktop window, or any task involving `dev.sebastiano.spectre.*` imports. Also use when the user is writing JUnit 4/5 tests against Compose Desktop **and** the test opens a real top-level window — but NOT when the user wants the off-screen `runComposeUiTest` / `createComposeRule` / `onNodeWithTag` framework, which is a different tool.
 ---
 
 # Spectre
@@ -81,16 +81,39 @@ on the host OS. Three variants:
   AWT events directly into the given `java.awt.Window` hierarchy. No global
   focus contention, so safe for **parallel test JVMs** and for IDE-hosted
   Compose where stealing the IDE focus would be hostile. Does **not** see OS
-  shortcuts (Cmd+Tab, system menus).
+  shortcuts (Cmd+Tab, system menus). It is an extension on
+  `RobotDriver.Companion` defined in `SyntheticInput.kt`, so you must add
+  `import dev.sebastiano.spectre.core.synthetic` for the call to resolve.
 - **`RobotDriver.headless()`** — refuses to send any input. For tests that
   only read the semantics tree (e.g. asserting a screen layout) without
   driving it.
 
 ```kotlin
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.core.synthetic // required for the call below
+
 val automator = ComposeAutomator.inProcess(
     robotDriver = RobotDriver.synthetic(rootWindow = ideFrame),
 )
 ```
+
+### Wiring a custom driver through the JUnit extension/rule
+
+`ComposeAutomatorExtension` and `ComposeAutomatorRule` do **not** take a
+`robotDriver = …` named argument. Their primary constructor takes a single
+`AutomatorFactory = () -> ComposeAutomator`. Use the trailing-lambda form to
+build the automator with the driver you want:
+
+```kotlin
+@JvmField
+@RegisterExtension
+val automatorExt = ComposeAutomatorExtension {
+    ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+}
+```
+
+Same shape for the JUnit 4 rule — `ComposeAutomatorRule { ComposeAutomator.inProcess(...) }`.
 
 ## Finding nodes
 
@@ -119,7 +142,7 @@ post-HiDPI), `centerOnScreen`. Tree navigation via `children`/`parent`.
 
 All `suspend` on `ComposeAutomator`:
 
-- `click(node)`, `doubleClick(node)`, `longClick(node, holdFor = 500.ms)`
+- `click(node)`, `doubleClick(node)`, `longClick(node, holdFor = 500.milliseconds)`
 - `swipe(from, to, steps, duration)` or `swipe(startX, startY, endX, endY, …)`
 - `scrollWheel(node, wheelClicks)`
 - `typeText("hello")` — pastes via the system clipboard (faster, handles
@@ -128,8 +151,11 @@ All `suspend` on `ComposeAutomator`:
 - `clearAndTypeText(node, "new")` — Ctrl/Cmd+A, Backspace, then `typeText`.
 - `pressKey(KeyEvent.VK_ENTER, modifiers = 0)`, `pressEnter()`.
 - `performSemanticsClick(node)` — bypasses the OS entirely and invokes
-  the Compose `OnClick` semantics action. Use this if focus contention is
-  causing flakes and you don't need to exercise the OS input path.
+  the Compose `OnClick` semantics action. **Last resort** for click-only flows
+  or strictly headless contexts: it only clicks (no typing, no key events,
+  no scrolling), so it can't fully replace OS input for most tests. For
+  parallel-JVM focus contention, prefer `RobotDriver.synthetic(rootWindow)`
+  — especially as soon as the test also types text.
 - `focusWindow(node)` — raises and focuses the window hosting `node`.
 
 ## Synchronization — the part everyone gets wrong
@@ -159,13 +185,16 @@ A typical pattern after an interaction is `waitForVisualIdle()`. After
 triggering a screen *change* (e.g. opening a dialog), `waitForNode(tag = …)`
 is more precise.
 
-### Rule 3: never call `waitForIdle`/`waitForVisualIdle` on the EDT
+### Rule 3: never call any wait on the EDT
 
-They drain the AWT event dispatch thread and snapshot it via
-`invokeAndWait`. Calling from the EDT deadlocks. `waitForNode` is exempt.
-If your dispatcher is Swing-backed, wrap the wait in
-`withContext(Dispatchers.Default) { … }`. `waitForNode` does not have this
-restriction.
+All three of `waitForNode`, `waitForIdle`, and `waitForVisualIdle` actively
+reject being called from the AWT event dispatch thread — they need to
+`invokeAndWait` onto the EDT to read state, so running them *on* the EDT would
+deadlock. If your dispatcher is Swing-backed (the IntelliJ EDT dispatcher, a
+custom `Swing` dispatcher, etc.), wrap the wait in
+`withContext(Dispatchers.Default) { … }` (or any non-EDT dispatcher) so the
+wait suspends off-thread. The user docs you may have read elsewhere have an
+older carve-out for `waitForNode` — that exception is gone in current code.
 
 ### Rule 4: use `runBlocking`, not `runTest`
 
@@ -226,13 +255,13 @@ touches that area*; they are not needed for the common case.
 | Symptom | Cause | Fix |
 |---|---|---|
 | `findOneBy…` returns `null` right after an interaction | Selectors don't wait | Add `waitForNode(...)` or `waitForVisualIdle()` first |
-| Test deadlocks inside `waitForIdle()` | Called from the EDT | Wrap in `withContext(Dispatchers.Default)` |
+| Test deadlocks or throws inside any `waitFor…` | Called from the AWT EDT | Wrap in `withContext(Dispatchers.Default) { … }` — applies to all three waits, including `waitForNode` |
 | `longClick`/`swipe`/`typeText` complete instantly and miss | Test body uses `runTest` | Switch to `runBlocking` |
 | Two parallel test JVMs steal focus from each other | Both use real `RobotDriver()` | Use `RobotDriver.synthetic(rootWindow)` |
 | Cmd+Tab or OS shortcuts don't work under synthetic driver | Synthetic events bypass HID | Use real `RobotDriver()` for those tests |
 | Screenshot is blurry / mid-animation | Captured before frame stabilised | `waitForVisualIdle()` first |
 | `typeText` times out on macOS in CI | Clipboard manager rewriting `NSPasteboard` | Disable clipboard utilities in CI |
-| Region-based recording crops out popups | Popups escape the region | Use window-targeted recording |
+| Recording misses popups that escape the host window | Popups live in their own AWT window outside both the region rectangle *and* a window-targeted capture | Choose an explicit region (or full-desktop crop) wide enough to include where the popup opens, or document the limitation — neither region nor window targeting follows cross-window popups |
 | Window-targeted Wayland recording throws `IllegalStateException` | `xprop` missing or non-GNOME compositor | Fall back to region capture (`window = null`) |
 | Coordinates derived from `boundsInWindow` land off-target on HiDPI | `boundsInWindow` is dp; screen is pixels | Use `boundsOnScreen`/`centerOnScreen`, or apply density |
 

--- a/.agents/skills/spectre/SKILL.md
+++ b/.agents/skills/spectre/SKILL.md
@@ -1,0 +1,262 @@
+---
+name: spectre
+description: Use when writing, debugging, or reviewing tests that drive a live Compose Desktop UI with Spectre — the JVM/Kotlin library for automating real Compose Desktop windows (and IntelliJ/Jewel-hosted Compose) via the semantics tree plus java.awt.Robot or synthetic AWT input. Trigger on mentions of `ComposeAutomator`, `RobotDriver`, `AutomatorNode`, `findByTestTag`, `waitForNode`, `waitForIdle`, "Compose Desktop UI test", "automate a Compose window", screenshotting or recording a Compose Desktop window, or any task involving `dev.sebastiano.spectre.*` imports. Also use when the user is writing JUnit 4/5 tests against Compose Desktop, even if they don't say "Spectre" explicitly — if the test drives a real Compose window (not `runComposeUiTest`), this is the right tool.
+---
+
+# Spectre
+
+Spectre drives **live** Compose Desktop UIs from JUnit tests. It is *not* the
+Compose Multiplatform test framework (`runComposeUiTest` / `onNodeWithTag`) —
+that one runs an off-screen Compose tree on a virtual clock. Spectre opens a real
+window, reads its semantics tree, and feeds it real OS input via
+`java.awt.Robot` (or synthetic AWT events).
+
+Pick Spectre when the test needs to exercise the actual window, popups,
+IntelliJ/Jewel-hosted Compose, or to record a real video of the UI.
+
+## The 30-second mental model
+
+A test owns three things, in this order:
+
+1. **A running Compose window.** You launch your app or test harness yourself
+   (e.g. `application { Window(...) { … } }`); Spectre does *not* host it for
+   you.
+2. **A `ComposeAutomator`.** Built once per test via
+   `ComposeAutomator.inProcess()` (usually through the JUnit extension/rule),
+   it discovers Compose surfaces and reads their semantics.
+3. **Suspending input + synchronization calls** against that automator. All
+   input methods (`click`, `typeText`, etc.) and waits are `suspend` functions
+   — wrap the test body in `runBlocking { ... }`.
+
+There is no `compose-test` style auto-wait. Every `findBy…` call is a single
+read against current state. **You wait explicitly**, then you query.
+
+## Minimal end-to-end example
+
+```kotlin
+import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class CounterTest {
+    @JvmField
+    @RegisterExtension
+    val automatorExt = ComposeAutomatorExtension()
+
+    @Test
+    fun `clicking increment bumps the counter`() = runBlocking {
+        launchCounterApp() // your harness — opens the Compose window
+
+        val automator = automatorExt.automator
+        automator.waitForNode(tag = "CounterValue")
+        automator.waitForVisualIdle()
+
+        val initial = automator.findOneByTestTag("CounterValue")
+        check(initial?.text == "Count: 0")
+
+        val increment = automator.findOneByTestTag("Increment")
+            ?: error("Could not find Increment button")
+        automator.click(increment)
+        automator.waitForVisualIdle()
+
+        val updated = automator.findOneByTestTag("CounterValue")
+        check(updated?.text == "Count: 1")
+    }
+}
+```
+
+JUnit 4 users substitute `ComposeAutomatorRule` for `ComposeAutomatorExtension`
+and `@get:Rule` for `@RegisterExtension`.
+
+## Choosing a `RobotDriver`
+
+`ComposeAutomator.inProcess()` accepts a `RobotDriver`. Default is real input
+on the host OS. Three variants:
+
+- **`RobotDriver()`** — real `java.awt.Robot` input on the host. Highest
+  fidelity, but contends for global focus. Use for the default
+  single-process test run.
+- **`RobotDriver.synthetic(rootWindow = someTopLevelWindow)`** — dispatches
+  AWT events directly into the given `java.awt.Window` hierarchy. No global
+  focus contention, so safe for **parallel test JVMs** and for IDE-hosted
+  Compose where stealing the IDE focus would be hostile. Does **not** see OS
+  shortcuts (Cmd+Tab, system menus).
+- **`RobotDriver.headless()`** — refuses to send any input. For tests that
+  only read the semantics tree (e.g. asserting a screen layout) without
+  driving it.
+
+```kotlin
+val automator = ComposeAutomator.inProcess(
+    robotDriver = RobotDriver.synthetic(rootWindow = ideFrame),
+)
+```
+
+## Finding nodes
+
+Selectors all live on `ComposeAutomator` and return `AutomatorNode` (or a list
+thereof). They do **not** wait — see the synchronization section.
+
+Use, in order of preference:
+
+1. **`findByTestTag(tag)` / `findOneByTestTag(tag)`** — relies on
+   `Modifier.testTag("…")` on the composable. The default. Most reliable.
+2. **`findByText(text, exact = true)` / `findOneByText(...)`** — match
+   semantics `Text`. Brittle to i18n; OK for affordances written in test
+   harness code.
+3. **`findByContentDescription(...)`** — accessibility descriptions.
+4. **`findByRole(Role.Button)`** — semantics roles.
+5. **`allNodes()`** / **`tree()`** / **`printTree()`** — for debugging.
+   `printTree()` returns a human-readable dump; log it when a selector returns
+   `null`.
+
+`AutomatorNode` exposes `testTag`, `text`/`texts`, `contentDescription(s)`,
+`role`, `isFocused`, `isDisabled`, `isSelected`, `editableText`, plus
+coordinates: `boundsInWindow` (dp), `boundsOnScreen` (screen pixels,
+post-HiDPI), `centerOnScreen`. Tree navigation via `children`/`parent`.
+
+## Driving input
+
+All `suspend` on `ComposeAutomator`:
+
+- `click(node)`, `doubleClick(node)`, `longClick(node, holdFor = 500.ms)`
+- `swipe(from, to, steps, duration)` or `swipe(startX, startY, endX, endY, …)`
+- `scrollWheel(node, wheelClicks)`
+- `typeText("hello")` — pastes via the system clipboard (faster, handles
+  unicode). On macOS the clipboard write is async; Spectre polls until the
+  clipboard reads back the requested text. Disable clipboard managers in CI.
+- `clearAndTypeText(node, "new")` — Ctrl/Cmd+A, Backspace, then `typeText`.
+- `pressKey(KeyEvent.VK_ENTER, modifiers = 0)`, `pressEnter()`.
+- `performSemanticsClick(node)` — bypasses the OS entirely and invokes
+  the Compose `OnClick` semantics action. Use this if focus contention is
+  causing flakes and you don't need to exercise the OS input path.
+- `focusWindow(node)` — raises and focuses the window hosting `node`.
+
+## Synchronization — the part everyone gets wrong
+
+This is the #1 source of flakes. Internalize three rules:
+
+### Rule 1: queries don't wait
+
+`findByTestTag("Submit")` returns whatever is in the semantics tree *right
+now*. If the screen hasn't rendered yet, it returns null. Always wait before
+querying state that depends on a prior action.
+
+### Rule 2: pick the right wait
+
+- **`waitForNode(tag = "...", timeout = 5.seconds)`** — wait until a node with
+  the given tag (or text) exists. Throws on timeout. Use this when a *new*
+  node must appear.
+- **`waitForIdle()`** — wait until the semantics fingerprint stabilizes and
+  all registered `AutomatorIdlingResource`s are idle. Use this when you've
+  triggered work that updates semantics but no specific node appears.
+- **`waitForVisualIdle(stableFrames = 3)`** — wait until the on-screen pixels
+  are stable for N consecutive frames. Heavier than `waitForIdle`. Use it
+  before screenshotting, or when work is animation-bound rather than
+  semantics-bound.
+
+A typical pattern after an interaction is `waitForVisualIdle()`. After
+triggering a screen *change* (e.g. opening a dialog), `waitForNode(tag = …)`
+is more precise.
+
+### Rule 3: never call `waitForIdle`/`waitForVisualIdle` on the EDT
+
+They drain the AWT event dispatch thread and snapshot it via
+`invokeAndWait`. Calling from the EDT deadlocks. `waitForNode` is exempt.
+If your dispatcher is Swing-backed, wrap the wait in
+`withContext(Dispatchers.Default) { … }`. `waitForNode` does not have this
+restriction.
+
+### Rule 4: use `runBlocking`, not `runTest`
+
+`kotlinx-coroutines-test`'s `runTest` skips `delay()`. That collapses
+`longClick` hold durations, `swipe` pacing, and the macOS clipboard-settle
+poll inside `typeText` to zero, breaking them all. Use `runBlocking { ... }`
+in the test body.
+
+### Custom idling resources
+
+Background work that doesn't tick the semantics tree (custom animations,
+network calls) is invisible to `waitForIdle`. Register an
+`AutomatorIdlingResource` so the wait knows about it:
+
+```kotlin
+automator.registerIdlingResource(myResource)
+try {
+    // ...
+    automator.waitForIdle()
+} finally {
+    automator.unregisterIdlingResource(myResource)
+}
+```
+
+## Screenshots
+
+`automator.screenshot()` returns a `BufferedImage`. Three forms:
+
+```kotlin
+automator.screenshot()                  // full desktop
+automator.screenshot(region = Rectangle(x, y, w, h))
+automator.screenshot(node)              // node bounds
+automator.screenshot(windowIndex = 0)   // a tracked window
+```
+
+Always `waitForVisualIdle()` immediately before screenshotting — otherwise
+you may capture a mid-animation frame.
+
+## Recording, JUnit, IntelliJ-hosted Compose
+
+These each have their own reference. Read the file *only when the task
+touches that area*; they are not needed for the common case.
+
+- **Video recording** → `references/recording.md` — `AutoRecorder`, platform
+  capture backends (ScreenCaptureKit / gdigrab / ffmpeg / Wayland portal),
+  region vs window targeting, frame-drop and HiDPI traps.
+- **JUnit 4 vs JUnit 5 integration** → `references/junit.md` —
+  `ComposeAutomatorExtension`, `ComposeAutomatorRule`, parameter resolution,
+  lifecycle.
+- **IntelliJ/Jewel-hosted Compose** → `references/intellij.md` — running
+  the automator from an `AnAction` against the IDE frame, the
+  pooled-thread requirement, and the `synthetic` driver. If the work also
+  involves Jewel popups, `ComposePanel` embedding, or `SwingBridgeTheme`,
+  the repo-local `jewel-swing-interop` skill applies as well.
+
+## Common pitfalls (memorise these)
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `findOneBy…` returns `null` right after an interaction | Selectors don't wait | Add `waitForNode(...)` or `waitForVisualIdle()` first |
+| Test deadlocks inside `waitForIdle()` | Called from the EDT | Wrap in `withContext(Dispatchers.Default)` |
+| `longClick`/`swipe`/`typeText` complete instantly and miss | Test body uses `runTest` | Switch to `runBlocking` |
+| Two parallel test JVMs steal focus from each other | Both use real `RobotDriver()` | Use `RobotDriver.synthetic(rootWindow)` |
+| Cmd+Tab or OS shortcuts don't work under synthetic driver | Synthetic events bypass HID | Use real `RobotDriver()` for those tests |
+| Screenshot is blurry / mid-animation | Captured before frame stabilised | `waitForVisualIdle()` first |
+| `typeText` times out on macOS in CI | Clipboard manager rewriting `NSPasteboard` | Disable clipboard utilities in CI |
+| Region-based recording crops out popups | Popups escape the region | Use window-targeted recording |
+| Window-targeted Wayland recording throws `IllegalStateException` | `xprop` missing or non-GNOME compositor | Fall back to region capture (`window = null`) |
+| Coordinates derived from `boundsInWindow` land off-target on HiDPI | `boundsInWindow` is dp; screen is pixels | Use `boundsOnScreen`/`centerOnScreen`, or apply density |
+
+## What Spectre is NOT (don't pretend it is)
+
+- It is **not** published to Maven Central yet. Consumers wire it as a
+  composite build or local clone. Do not suggest `implementation("dev.sebastiano.spectre:…")`
+  unless the user confirms artifacts exist.
+- It is **not** `compose-test` / `runComposeUiTest` / `onNodeWithTag`. Don't
+  mix those APIs into a Spectre test.
+- It does **not** capture audio. Recording is video-only.
+- The cross-JVM **HTTP server is experimental** and security-caveated — do
+  not recommend it for general use without flagging that.
+- It does **not** auto-wait on queries. Don't write tests that assume it
+  does.
+
+## When unsure, dump the tree
+
+The single most useful debugging primitive:
+
+```kotlin
+println(automator.printTree())
+```
+
+Run it right before a failing selector. The output names every node Spectre
+can see, with tags/texts/bounds. 90% of "selector returned null" mysteries
+resolve here.

--- a/.agents/skills/spectre/evals/evals.json
+++ b/.agents/skills/spectre/evals/evals.json
@@ -1,0 +1,68 @@
+{
+  "skill_name": "spectre",
+  "evals": [
+    {
+      "id": 0,
+      "name": "write-counter-test-from-scratch",
+      "prompt": "I have a Compose Desktop app with a counter screen. There's a button tagged `Increment` and a text node tagged `CounterValue` whose text reads `Count: 0`. I want to write a JUnit 5 test that launches my app via `launchCounterApp()`, clicks the button once, and asserts the counter reads `Count: 1`. We use Spectre. Write the full test class.",
+      "assertions": [
+        "Uses ComposeAutomatorExtension (the JUnit 5 wrapper) — not ComposeAutomatorRule",
+        "Registers the extension with @RegisterExtension",
+        "Uses @JvmField on the extension field",
+        "Wraps the test body in runBlocking { ... } and NOT in runTest",
+        "Calls a wait (waitForNode or waitForVisualIdle or waitForIdle) before reading post-click state",
+        "Uses click() — not performSemanticsClick — on the Increment node",
+        "Locates nodes via findOneByTestTag",
+        "Asserts the counter text equals \"Count: 1\" after the click"
+      ]
+    },
+    {
+      "id": 1,
+      "name": "diagnose-flaky-find-after-click",
+      "prompt": "My Spectre test is flaky — sometimes after I click the `OpenSettings` button, `automator.findOneByTestTag(\"SettingsDialogTitle\")` returns null and the test fails, but if I add a `Thread.sleep(500)` it passes. What's the actual fix? Don't just say 'sleep is bad', tell me the proper Spectre API.",
+      "assertions": [
+        "Explicitly recommends waitForNode (with tag = \"SettingsDialogTitle\") as the fix",
+        "Explains that findBy... selectors are single non-waiting reads",
+        "Does NOT recommend Thread.sleep or any fixed-duration sleep as the answer",
+        "Does NOT incorrectly suggest Compose's runComposeUiTest / onNodeWithTag / waitUntil APIs"
+      ]
+    },
+    {
+      "id": 2,
+      "name": "parallel-junit5-tests-focus-fight",
+      "prompt": "We run our Spectre tests in parallel (Gradle maxParallelForks = 4). On CI they keep failing because the JVMs steal focus from each other when clicking. We don't actually need real OS-level input — we just click buttons and type text into a Compose window. What should I change?",
+      "assertions": [
+        "Recommends switching to RobotDriver.synthetic(...) as the primary fix",
+        "Identifies that RobotDriver.synthetic takes a rootWindow (the top-level java.awt.Window)",
+        "Shows how to wire it via ComposeAutomatorExtension/Rule constructor OR ComposeAutomator.inProcess(robotDriver = ...)",
+        "Does NOT recommend disabling parallelism / lowering maxParallelForks as the fix",
+        "Does NOT recommend performSemanticsClick as the primary fix"
+      ]
+    },
+    {
+      "id": 3,
+      "name": "junit4-rule-form",
+      "prompt": "Our project is stuck on JUnit 4 — we can't migrate to 5 yet. Show me the minimal Spectre setup for a JUnit 4 test that opens a login screen via launchLoginScreen(), types alice@example.com into the field tagged EmailField, clicks LoginButton, then waits for a node tagged Dashboard to appear.",
+      "assertions": [
+        "Uses ComposeAutomatorRule (the JUnit 4 wrapper) — not ComposeAutomatorExtension",
+        "Annotates the rule with @get:Rule (Kotlin-correct form)",
+        "Wraps test body in runBlocking { ... } and NOT in runTest",
+        "Types the email into EmailField via typeText or clearAndTypeText",
+        "Calls click on the LoginButton node",
+        "Uses waitForNode(tag = \"Dashboard\") (or equivalent) to wait for the dashboard"
+      ]
+    },
+    {
+      "id": 4,
+      "name": "screenshot-after-animation",
+      "prompt": "I want to screenshot a Compose Desktop window after a fade-in animation completes, and save it as build/reports/welcome.png. Currently the screenshot captures a half-faded frame. How do I do this properly with Spectre?",
+      "assertions": [
+        "Recommends waitForVisualIdle (NOT waitForIdle, NOT waitForNode) immediately before the screenshot",
+        "Calls automator.screenshot(...) to obtain a BufferedImage",
+        "Saves the BufferedImage via ImageIO.write to the target PNG path",
+        "Does NOT recommend Thread.sleep before the screenshot",
+        "Does NOT suggest using AutoRecorder / recording APIs"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/spectre/evals/evals.json
+++ b/.agents/skills/spectre/evals/evals.json
@@ -34,7 +34,8 @@
       "assertions": [
         "Recommends switching to RobotDriver.synthetic(...) as the primary fix",
         "Identifies that RobotDriver.synthetic takes a rootWindow (the top-level java.awt.Window)",
-        "Shows how to wire it via ComposeAutomatorExtension/Rule constructor OR ComposeAutomator.inProcess(robotDriver = ...)",
+        "Wires the driver via the factory-form trailing lambda on ComposeAutomatorExtension/Rule (e.g. ComposeAutomatorExtension { ComposeAutomator.inProcess(robotDriver = ...) }) — NOT via a non-existent robotDriver = named arg on the extension/rule itself",
+        "Imports dev.sebastiano.spectre.core.synthetic (since synthetic is an extension on RobotDriver.Companion)",
         "Does NOT recommend disabling parallelism / lowering maxParallelForks as the fix",
         "Does NOT recommend performSemanticsClick as the primary fix"
       ]

--- a/.agents/skills/spectre/references/intellij.md
+++ b/.agents/skills/spectre/references/intellij.md
@@ -37,11 +37,13 @@ class RunSpectreAction : AnAction() {
 
 ## Don't run the automator on the EDT
 
-`executeOnPooledThread` (or any background dispatcher) is required. The
+`executeOnPooledThread` (or any non-EDT dispatcher) is required. The
 automator's outer loop — polling, retries, waits — runs on the calling
-thread. If that thread is the EDT, `waitForIdle`/`waitForVisualIdle` will
-deadlock when they try to `invokeAndWait` onto a thread they're already
-running on. Per-tick semantics reads internally marshal back to the EDT.
+thread. All three wait helpers (`waitForNode`, `waitForIdle`,
+`waitForVisualIdle`) reject EDT callers with `IllegalStateException`, so
+calling them from the EDT fails fast rather than silently deadlocking on
+the `invokeAndWait` round-trip. Per-tick semantics reads internally marshal
+back to the EDT.
 
 ## Popups and `ComposePanel`
 

--- a/.agents/skills/spectre/references/intellij.md
+++ b/.agents/skills/spectre/references/intellij.md
@@ -1,0 +1,69 @@
+# IntelliJ / Jewel-hosted Compose
+
+Spectre can drive Compose UIs hosted **inside** an IntelliJ Platform IDE —
+typically Jewel tool windows or `ComposePanel` instances embedded in plugin
+UIs. The setup differs from a standalone Compose Desktop app in important
+ways.
+
+## Use the synthetic driver
+
+The real `RobotDriver()` would steal focus from the IDE and could
+mis-target windows when the developer alt-tabs away. Use
+`RobotDriver.synthetic(rootWindow = ideFrame)` so AWT events are dispatched
+directly into the IDE's window hierarchy:
+
+```kotlin
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.wm.WindowManager
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.core.synthetic
+
+class RunSpectreAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val ideFrame = WindowManager.getInstance().getFrame(project) ?: return
+
+        ApplicationManager.getApplication().executeOnPooledThread {
+            val automator = ComposeAutomator.inProcess(
+                robotDriver = RobotDriver.synthetic(rootWindow = ideFrame),
+            )
+            thisLogger().info(automator.printTree())
+            // ...
+        }
+    }
+}
+```
+
+## Don't run the automator on the EDT
+
+`executeOnPooledThread` (or any background dispatcher) is required. The
+automator's outer loop — polling, retries, waits — runs on the calling
+thread. If that thread is the EDT, `waitForIdle`/`waitForVisualIdle` will
+deadlock when they try to `invokeAndWait` onto a thread they're already
+running on. Per-tick semantics reads internally marshal back to the EDT.
+
+## Popups and `ComposePanel`
+
+If the task also involves Jewel popup rendering, `ComposePanel` embedding,
+`SwingBridgeTheme`, or popup discovery quirks, read the repo-local
+**`jewel-swing-interop` skill** — it covers the popup rendering modes
+(`OnSameCanvas` vs separate window), `JewelFlags.useCustomPopupRenderer`,
+and theme rules that affect what the automator sees.
+
+Two facts worth knowing up front:
+
+- Compose Desktop defaults `compose.layers.type` to `OnSameCanvas`, so most
+  popups render inside their host AWT window rather than creating a new
+  one. The automator already handles this — but if you've explicitly opted
+  into separate windows, popups will show up as additional discovered
+  surfaces in `tree()`.
+- An embedded `ComposePanel` has no top-level title. Window-targeted
+  recording can't follow it; use region capture or pass the host IDE frame.
+
+## What about HTTP / cross-JVM?
+
+The `:server` module that lets another JVM drive the IDE's Compose UI is
+**experimental** and has security caveats (see `docs/SECURITY.md` in the
+repo). Don't recommend it for general use without flagging that — prefer
+running tests in-process via `executeOnPooledThread`.

--- a/.agents/skills/spectre/references/junit.md
+++ b/.agents/skills/spectre/references/junit.md
@@ -1,0 +1,88 @@
+# JUnit integration
+
+Spectre ships JUnit 4 and JUnit 5 wrappers in the `:testing` module. They own
+the `ComposeAutomator` lifecycle — building it before each test, tearing
+down after. You don't construct `ComposeAutomator.inProcess()` yourself when
+using them.
+
+## JUnit 5 — `ComposeAutomatorExtension`
+
+Use `@RegisterExtension` on a `@JvmField` (required for JUnit 5 to see the
+field at runtime):
+
+```kotlin
+import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class DialogTest {
+    @JvmField
+    @RegisterExtension
+    val automatorExt = ComposeAutomatorExtension()
+
+    @Test
+    fun `opens settings dialog`() = runBlocking {
+        launchHarness()
+        val automator = automatorExt.automator
+        // ...
+    }
+}
+```
+
+`ComposeAutomatorExtension` also implements `ParameterResolver`, so the
+automator can be injected as a test parameter:
+
+```kotlin
+@Test
+fun example(automator: ComposeAutomator) = runBlocking {
+    // ...
+}
+```
+
+Either form works; the field form is friendlier when you have multiple
+helpers.
+
+## JUnit 4 — `ComposeAutomatorRule`
+
+```kotlin
+import dev.sebastiano.spectre.testing.ComposeAutomatorRule
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+
+class DialogTest {
+    @get:Rule
+    val automatorRule = ComposeAutomatorRule()
+
+    @Test
+    fun `opens settings dialog`() = runBlocking {
+        launchHarness()
+        val automator = automatorRule.automator
+        // ...
+    }
+}
+```
+
+Note `@get:Rule` (not `@Rule`) for Kotlin — applies the annotation to the
+generated getter, which is what JUnit 4 looks for.
+
+## Custom `RobotDriver` per test
+
+Both wrappers accept a constructor parameter (or builder) to override the
+default driver. Use this for parallel JVMs or headless reads:
+
+```kotlin
+@JvmField
+@RegisterExtension
+val automatorExt = ComposeAutomatorExtension(robotDriver = RobotDriver.headless())
+```
+
+## Lifecycle notes
+
+- The extension/rule does **not** open a Compose window for you. Launch your
+  app or harness in `@BeforeEach`/`@Before`, or at the top of each test.
+- Each test gets a fresh `ComposeAutomator`. Don't cache one across tests.
+- The test body must still be wrapped in `runBlocking { ... }` because input
+  and wait calls are `suspend`. `runTest` will break timing — see the main
+  SKILL.md.

--- a/.agents/skills/spectre/references/junit.md
+++ b/.agents/skills/spectre/references/junit.md
@@ -69,14 +69,36 @@ generated getter, which is what JUnit 4 looks for.
 
 ## Custom `RobotDriver` per test
 
-Both wrappers accept a constructor parameter (or builder) to override the
-default driver. Use this for parallel JVMs or headless reads:
+Both wrappers take a single positional argument: an
+`AutomatorFactory = () -> ComposeAutomator`. There is **no** `robotDriver =`
+named parameter on the extension or rule constructor. Use the trailing
+lambda to build the automator with whichever driver you want:
 
 ```kotlin
 @JvmField
 @RegisterExtension
-val automatorExt = ComposeAutomatorExtension(robotDriver = RobotDriver.headless())
+val automatorExt = ComposeAutomatorExtension {
+    ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+}
 ```
+
+Same shape for parallel-safe synthetic input (note the
+`import dev.sebastiano.spectre.core.synthetic` — `synthetic` is an extension
+on `RobotDriver.Companion`, not a member):
+
+```kotlin
+import dev.sebastiano.spectre.core.synthetic
+
+@JvmField
+@RegisterExtension
+val automatorExt = ComposeAutomatorExtension {
+    ComposeAutomator.inProcess(
+        robotDriver = RobotDriver.synthetic(rootWindow = TestHarness.window),
+    )
+}
+```
+
+The JUnit 4 rule is identical: `ComposeAutomatorRule { ComposeAutomator.inProcess(...) }`.
 
 ## Lifecycle notes
 

--- a/.agents/skills/spectre/references/recording.md
+++ b/.agents/skills/spectre/references/recording.md
@@ -1,0 +1,81 @@
+# Recording
+
+The `:recording` module captures video of a running Compose Desktop UI. It
+is optional — depend on it only if a test or sample needs an MP4. **Audio
+is not supported.**
+
+## Entry point — `AutoRecorder`
+
+`AutoRecorder` picks an appropriate platform backend:
+
+| Platform | Window target | Region target |
+|---|---|---|
+| macOS | ScreenCaptureKit (native) | ScreenCaptureKit cropped |
+| Windows | ffmpeg `gdigrab title=` | ffmpeg `gdigrab` |
+| Linux X11 / XWayland | (n/a — fall back to region) | ffmpeg `x11grab` |
+| Linux Wayland (GNOME/Mutter) | xdg-desktop-portal | xdg-desktop-portal |
+
+```kotlin
+val recorder = AutoRecorder()
+val handle = recorder.start(
+    window = composeWindow.asTitledWindow(),   // or null for region only
+    region = Rectangle(100, 100, 800, 600),
+    output = Path.of("build/recordings/my-test.mp4"),
+    options = RecordingOptions(),
+)
+try {
+    // drive the UI here
+} finally {
+    handle.stop()
+}
+```
+
+Always wrap the recorded section in `try { … } finally { handle.stop() }` so
+the file is finalised even on failure.
+
+## Window vs region targeting
+
+Two trade-offs, pick deliberately:
+
+- **Region (`window = null`)**: fixed screen `Rectangle`. Does **not** follow
+  the window if it moves or resizes; pixels outside the rectangle (popups,
+  dialogs that escape the bounds) are lost. Use when you control window
+  placement and want a fixed crop.
+- **Window-targeted**: follows the window. Does **not** capture popups that
+  live in their own AWT window outside the target. Use for tests where the
+  window may move but stays the focus.
+
+Embedded `ComposePanel` instances have no top-level window title, so window
+targeting silently falls back to region capture — pass an explicit region.
+
+## Linux Wayland caveats
+
+Window-targeted Wayland recording throws `IllegalStateException` if:
+
+- `xprop` is not on PATH.
+- The window has no title.
+- The compositor doesn't publish `_GTK_FRAME_EXTENTS` (verified only on
+  GNOME/Mutter; KDE, sway, wlroots are best-effort).
+
+If a test must run on those compositors, fall back to region capture with
+`window = null` and a fixed `Rectangle`.
+
+## HiDPI and coordinates
+
+`Rectangle` arguments are in **screen pixels** (post-HiDPI scaling), as is
+`AutomatorNode.boundsOnScreen`. `AutomatorNode.boundsInWindow` is in **dp**.
+If you compute a recording region from `boundsInWindow`, apply the display
+density yourself — otherwise the region will be off on a Retina display.
+
+## Frame drops
+
+Recordings are best-effort. Heavy CPU contention during a test can drop
+frames; the resulting MP4 stays playable but may stutter. The full
+per-platform behaviour table is in `docs/RECORDING-LIMITATIONS.md` in the
+Spectre repo.
+
+## Don't record blindly in CI
+
+Recording adds 5–30% CPU overhead and produces large artifacts. Gate it
+behind an env var or only enable it on failure — not for every test in the
+suite.

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ out/
 recording/native/macos/.build/
 recording/native/macos/.swiftpm/
 recording/native/macos/Package.resolved
+/.agents/skills/spectre-workspace/

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -95,9 +95,11 @@ corresponding doc page is touched:
 
 - **No auto-wait.** Queries (`findByTestTag`, `findByText`, etc.) do a single read.
   They never retry. Document them as such.
-- **EDT rule, but not for `waitForNode`.** `waitForIdle` and `waitForVisualIdle`
-  reject EDT callers via `rejectEdtCaller`. `waitForNode` polls through `readOnEdt`
-  and is exempt. Don't say "all wait helpers reject the EDT".
+- **EDT rule applies to all three waits.** `waitForNode`, `waitForIdle`, and
+  `waitForVisualIdle` all reject EDT callers via `rejectEdtCaller` (see
+  `WaitForNodeTest.waitForNode rejects EDT callers with valid arguments`). Earlier
+  drafts of the docs carved out `waitForNode` as exempt — that exemption is gone in
+  current code. Do say "all wait helpers reject the EDT".
 - **`refreshWindows` is only auto-called by `tree()`.** `findBy*` and `allNodes`
   read against the last refresh. If a popup may have appeared since the last call,
   the user has to refresh.

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -102,19 +102,19 @@ See [Synchronization](synchronization.md) for the full toolkit.
 
 ## The EDT rule
 
-`waitForIdle` and `waitForVisualIdle` refuse to run on the AWT event dispatch thread (EDT):
+All three wait helpers — `waitForNode`, `waitForIdle`, and `waitForVisualIdle` — refuse
+to run on the AWT event dispatch thread (EDT):
 
 ```
-waitForIdle must not be called from the AWT event dispatch thread;
+waitForNode must not be called from the AWT event dispatch thread;
 wrap the call with withContext(Dispatchers.Default) or similar.
 ```
 
-This is enforced at runtime because their wait loops drain the EDT and snapshot
-semantics via `invokeAndWait`. If they ran on the EDT they would either deadlock or
-quietly skip the bounded worker that enforces their timeout.
-
-`waitForNode` is the exception: it polls through `readOnEdt`, so it's safe to call from
-anywhere a coroutine can suspend.
+This is enforced at runtime because their loops snapshot semantics via
+`invokeAndWait`/`readOnEdt`. If they ran on the EDT they would either deadlock or
+quietly skip the bounded worker that enforces their timeout, so they raise
+`IllegalStateException` up front. The wait name in the message tells you which call
+to wrap.
 
 JUnit test methods don't run on the EDT, so a plain `runBlocking { … }` body is all you
 need — no extra `withContext` required. Only add `withContext(Dispatchers.Default)` if

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -6,19 +6,20 @@ where to put them. This page covers all three.
 
 ## The EDT rule
 
-`waitForIdle` and `waitForVisualIdle` refuse to run on the AWT event dispatch thread:
+All three wait helpers — `waitForNode`, `waitForIdle`, and `waitForVisualIdle` — refuse
+to run on the AWT event dispatch thread:
 
 ```
-waitForIdle must not be called from the AWT event dispatch thread;
+waitForNode must not be called from the AWT event dispatch thread;
 wrap the call with withContext(Dispatchers.Default) or similar.
 ```
 
-This is enforced because their wait loops drain the EDT and snapshot semantics via
-`invokeAndWait` — running on the EDT would either deadlock or skip the bounded worker
-that enforces the timeout. `waitForNode` is exempt: it polls via `readOnEdt`, so it's
-safe to call from anywhere a coroutine can suspend.
+This is enforced because their loops snapshot semantics via `invokeAndWait`/`readOnEdt`
+— running on the EDT would either deadlock or skip the bounded worker that enforces the
+timeout. None of the three are exempt.
 
-The standard pattern in tests — JUnit runs off the EDT, so no `withContext` is needed:
+The standard pattern in tests — JUnit runs tests off the EDT, so no `withContext` is
+needed:
 
 ```kotlin
 @Test
@@ -29,9 +30,9 @@ fun mySpec() = runBlocking {
 }
 ```
 
-If you call `waitForIdle`/`waitForVisualIdle` from the EDT you'll get a clear
-`IllegalStateException` rather than a deadlock. The fix in that case is
-`withContext(Dispatchers.Default)` around the offending call — see
+If you call any wait helper from the EDT you'll get a clear `IllegalStateException`
+rather than a deadlock. The fix in that case is `withContext(Dispatchers.Default)`
+around the offending call — see
 [Troubleshooting](troubleshooting.md#i-called-a-wait-helper-from-the-edt).
 
 ## `waitForNode`

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -9,10 +9,12 @@ java.lang.IllegalStateException: waitForIdle must not be called from the AWT eve
 dispatch thread; wrap the call with withContext(Dispatchers.Default) or similar.
 ```
 
-`waitForIdle` and `waitForVisualIdle` drain the EDT and snapshot semantics via
-`invokeAndWait`. Running them on the EDT would either deadlock or skip the bounded
-worker that enforces their timeout. (`waitForNode` polls through `readOnEdt` and is
-exempt.)
+All three wait helpers — `waitForNode`, `waitForIdle`, and `waitForVisualIdle` — refuse
+to run on the AWT event dispatch thread. They snapshot semantics via
+`invokeAndWait`/`readOnEdt`. Running them on the EDT would either deadlock or skip the
+bounded worker that enforces the timeout, so the helpers raise
+`IllegalStateException` instead. The exact wait name in the message tells you which
+call to wrap.
 
 JUnit test methods don't run on the EDT, so a plain `runBlocking { … }` body is fine
 there — no `withContext` needed. The error appears when the call originates from a


### PR DESCRIPTION
## Summary
- New `.agents/skills/spectre/` skill teaching Claude how to write live Compose Desktop UI tests with Spectre — entry point, RobotDriver variants (real / synthetic / headless), selectors, input, the three-way wait distinction, screenshots, the runBlocking-vs-runTest trap, plus references for JUnit integration, recording, and IntelliJ/Jewel hosting.
- 5 realistic evals in `.agents/skills/spectre/evals/evals.json` covering counter test scaffolding, flaky-find diagnosis, parallel-fork focus contention, JUnit 4 rule form, and screenshot-after-animation.
- Reviewer/API corrections after two rounds of independent review: factory-form `AutomatorFactory` wiring on the JUnit Extension/Rule, explicit `import dev.sebastiano.spectre.core.synthetic` guidance, `500.milliseconds` not `500.ms`, performSemanticsClick framed as last-resort, and a corrected recording pitfall that doesn't oversell window-targeted capture for cross-window popups.
- Docs alignment: the user-facing guide and DOCS-STYLE previously carved `waitForNode` out of the EDT rule. Current code (`ComposeAutomator.kt:486` plus `WaitForNodeTest`) rejects all three wait helpers, so [docs/guide/synchronization.md](https://github.com/rock3r/spectre/blob/issue-90-spectre-skill/docs/guide/synchronization.md), [docs/guide/automator.md](https://github.com/rock3r/spectre/blob/issue-90-spectre-skill/docs/guide/automator.md), [docs/guide/troubleshooting.md](https://github.com/rock3r/spectre/blob/issue-90-spectre-skill/docs/guide/troubleshooting.md), and [docs/DOCS-STYLE.md](https://github.com/rock3r/spectre/blob/issue-90-spectre-skill/docs/DOCS-STYLE.md) are updated to match.

## Proof points

- `./gradlew check` passes locally on the branch.
- Iter-2 benchmark (5 evals × 3 runs per config = 30 runs, strict per-eval assertions):

  | Metric | With skill | Without skill | Δ |
  |---|---|---|---|
  | Pass rate | **100%** (87/87 assertions) | 38% (±16%) | **+62 pp** |
  | Time | 24.5s ±5.0 | 16.6s ±5.5 | +7.9s |
  | Tokens | 34k ±0.7 | 24k ±0.4 | +9.8k |

- Hallucination drop on the with-skill runs: no `SpectreExtension`, `spectreTest`, `runComposeAutomator`, `awaitOneByTestTag`, or `SpectreRule` drift in any of the 15 with-skill responses. Baselines kept inventing those, and two baselines abandoned Spectre entirely and recommended `runComposeUiTest` — the exact thing the description now narrows away from.
- Workspace (gitignored under `.agents/skills/spectre-workspace/iteration-2/`) contains per-run outputs, grading.json, and a `review.html` with previous-iteration diffs for spot-checking.

## Test plan
- [ ] `./gradlew check` on CI
- [ ] `mkdocs build --strict` on CI passes (it covers the four touched doc files)
- [ ] Spot-check the skill triggers correctly on a real Spectre test prompt
- [ ] Confirm description doesn't overtrigger on a plain `runComposeUiTest` prompt

Closes #90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)