### PR TITLE
Align docs with current Spectre behavior

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,12 +1,8 @@
 # Core
 
-Planned home for the in-process automation surface:
+In-process automation surface for live Compose Desktop UIs.
 
-- window tracking
-- semantics tree reading
-- coordinate mapping
-- Robot-backed interactions
-- shared data model
-
-This module is intentionally scaffold-only right now.
-
+This module contains the public `ComposeAutomator` API, semantics tree snapshots,
+window tracking, HiDPI-aware coordinate mapping, Robot-backed and synthetic input, wait
+helpers, screenshots, tracing hooks, and the shared node/window data model used by the
+other modules.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,8 +93,8 @@ Current backends:
   Window movement is followed automatically; occlusion doesn't matter.
 - `screencapturekit.ScreenCaptureKitRecorder` — macOS-only window-targeted capture via a
   bundled Swift helper (`recording/native/macos/`). The helper is built by Gradle on
-  macOS and staged into the module's `src/main/resources/native/macos/` so the JAR
-  carries it.
+  macOS, staged under `recording/build/generated/screenCaptureHelper/...`, and wired
+  into the module's generated resources so the JAR carries it.
 - `portal.WaylandPortalRecorder` — Linux Wayland capture via `xdg-desktop-portal`'s
   ScreenCast interface, driven by a bundled Rust helper
   (`recording/native/linux/spectre-wayland-helper`) that hands the PipeWire FD to
@@ -151,4 +151,3 @@ These should remain true as the codebase grows:
 4. Platform-specific integrations should be isolated behind small interfaces at module boundaries.
 5. Research-only shortcuts are acceptable in the sample app, but reusable behaviour must be moved
    into the proper module before it is treated as part of the product surface.
-

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -28,6 +28,7 @@ These rules apply to new and modified code:
 | Native/OS capture integration | `recording/` |
 | Test-only helpers and fixtures | `testing/` |
 | Manual validation harness UI | `sample-desktop/` |
+| IntelliJ/Jewel validation plugin | `sample-intellij-plugin/` |
 | Long-lived implementation guidance | `docs/` |
 | Local agent workflow help | `.agents/skills/` |
 

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -11,9 +11,9 @@ a video file, and each has its own limitations:
   equivalent — `avfoundation` on macOS, `gdigrab` on Windows, `x11grab` on Linux Xorg,
   or the Wayland compositor's PipeWire stream on Linux Wayland). Whatever is showing
   on screen inside that rectangle goes into the file, regardless of which window is
-  there. Region capture is the only path available for embedded surfaces (a
-  `ComposePanel` inside an IntelliJ tool window, a `JFrame`, etc.) because there's no
-  top-level OS window to target.
+  there. Region capture is the only path available when the Compose surface has no
+  adaptable top-level OS window, such as a `ComposePanel` inside an IntelliJ tool
+  window.
 - **Window-targeted capture** — captures a specific OS window's pixels directly, not
   the screen rectangle the window happens to occupy. The source is the window's own
   backing store (`ScreenCaptureKit` on macOS) or the OS-level `gdigrab title=` capture
@@ -118,13 +118,15 @@ failure modes, and the section below
   not follow a window. Use `ScreenCaptureKitRecorder` (macOS) or `FfmpegWindowRecorder`
   (Windows) when you have a top-level window to target — the next section covers what
   the window-targeted backends do differently.
-- **Embedded `ComposePanel` surfaces always fall through to region capture.**
+- **Embedded `ComposePanel` surfaces without an adaptable top-level `Frame` fall
+  through to region capture.**
   `AutoRecorder.start(window: TitledWindow?, region: Rectangle, …)` picks window-targeted
   capture only when `window` is non-null and (on Windows) has a non-blank title. The
-  `Frame.asTitledWindow()` adapter exposes that title for top-level `ComposeWindow`s, but
-  a panel embedded inside an IntelliJ tool window, a `JFrame`, a `JDialog`, or a
-  `SwingPanel` host inside Compose has no top-level `Frame` to adapt — callers pass
-  `window = null` and get the region path. Practical consequences:
+  `Frame.asTitledWindow()` adapter exposes that title for any top-level `Frame`,
+  including `ComposeWindow` and `JFrame` hosts. A panel embedded inside an IntelliJ
+  tool window or a `SwingPanel` host inside Compose has no separate titled `Frame` to
+  adapt — callers pass `window = null` and get the region path. Practical
+  consequences:
   - Anything that visually overlaps the panel — other windows, the menu bar, OS notifications, a
     floating popup that escapes the panel's bounds — appears in the recording.
   - The captured region is the panel's screen-space bounds at start. If the host window moves or

--- a/docs/STATIC-ANALYSIS.md
+++ b/docs/STATIC-ANALYSIS.md
@@ -27,7 +27,8 @@ Notes:
 - `ktfmtCheck` verifies formatting.
 - `ktfmtFormat` rewrites Kotlin and Gradle Kotlin DSL files to the chosen style.
 - `detekt` checks Kotlin source for structural/style issues.
-- Compose modules also run the upstream Compose Rules checks through Detekt.
+- Modules load the upstream Compose Rules checks through Detekt so Compose-bearing
+  sources are covered wherever they live.
 - `build` is the broader all-up build path and should also stay green before pushing.
 
 ## Style Choices

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -129,8 +129,8 @@ description, or role — see [Finding nodes](selectors.md).
 - `findOneByTestTag(...)` does a single semantics-tree read — no waiting. If the result
   isn't what you expect, your UI probably wasn't idle yet.
 - `automator.click(node)` is `suspend` — it resolves the node's centre on screen,
-  marshals the blocking AWT work onto `Dispatchers.IO` internally, and dispatches a
-  real mouse click via `java.awt.Robot`.
+  dispatches a real mouse click via `java.awt.Robot`, and only hops to `Dispatchers.IO`
+  when the call originates on the AWT event dispatch thread.
 
 All interaction methods (`click`, `doubleClick`, `swipe`, `typeText`, …) and all wait
 helpers (`waitForNode`, `waitForIdle`, `waitForVisualIdle`) are `suspend`, so the test

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -48,7 +48,7 @@ dependencies {
 
 Versions are intentionally omitted: `includeBuild` substitutes the project dependency
 into the consumer's classpath using whatever version the included build declares, so
-the `0.1.0-SNAPSHOT` you see in `gradle.properties` is implicit.
+the `0.1.0-SNAPSHOT` declared by Spectre's root Gradle build is implicit.
 
 If you depend on `server`, you also need to add a Ktor server engine yourself — Spectre
 intentionally doesn't bundle one. See [Cross-JVM access](cross-jvm.md) for the choice.

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -100,7 +100,7 @@ production plugin distribution's Tools menu. Hide it on two axes:
     Set the registry key via **Help → Find Action → Registry…** in any IDE, or pass
     `-Dmy.plugin.spectre.enabled=true` on the JVM command line for headless / CI
     runs (which is also the natural shape if you're combining this with
-    [`-DspectreAutorun=true`](#auto-trigger-on-startup) for non-interactive smokes).
+    [`-Dspectre.autorun=true`](#auto-trigger-on-startup) for non-interactive smokes).
 
 The combination keeps the action discoverable to the right audience (developers,
 QA, CI) and invisible to the rest of the world.

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -5,11 +5,11 @@ mouse, keyboard, and clipboard input to whatever surface the target node lives i
 
 All interaction methods (`click`, `doubleClick`, `longClick`, `swipe`, `scrollWheel`,
 `typeText`, `clearAndTypeText`, `pressKey`, `pressEnter`) are `suspend` — call them
-from a coroutine. They marshal blocking AWT/Robot work onto `Dispatchers.IO`
-internally, so a caller on `Dispatchers.Main` (the AWT EDT) yields cleanly while real
-input is dispatched. Internal sleeps use `delay` rather than `Thread.sleep`, so a
-cancelled coroutine cancels mid-`longClick` / mid-`swipe` rather than parking the
-worker thread until the hold completes.
+from a coroutine. Real `java.awt.Robot` work runs inline when the caller is already
+off the AWT event dispatch thread, and hops to `Dispatchers.IO` only when needed to
+keep EDT callers from blocking the UI. Internal sleeps use `delay` rather than
+`Thread.sleep`, so a cancelled coroutine cancels mid-`longClick` / mid-`swipe` rather
+than parking the worker thread until the hold completes.
 
 `screenshot` stays sync — it's a single framebuffer read, no blocking I/O to bury
 behind a coroutine boundary.

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -22,8 +22,9 @@ interface Recorder {
 ```
 
 You start a recording, you get a `RecordingHandle`, you stop the handle when you're
-done. Implementations must spawn the underlying process eagerly so frames are landing
-in `output` by the time `start()` returns.
+done. Implementations spawn the underlying process eagerly and fail fast when startup
+is clearly broken, but ffmpeg-backed recorders do not prove that the first frame has
+already landed in `output` before `start()` returns.
 
 ## Recorder capability matrix
 

--- a/recording/README.md
+++ b/recording/README.md
@@ -76,9 +76,10 @@ implementer's view of the same module.
 
 `recording/native/macos/` is a SwiftPM project that produces the `spectre-screencapture`
 helper binary. The `assembleScreenCaptureKitHelper` Gradle task runs `swift build -c release`
-and stages the binary into `src/main/resources/native/macos/`, so the JAR carries it
-transparently. The Swift `swift build` step only runs on macOS hosts — non-macOS hosts
-produce a structurally-correct jar that just doesn't contain the helper file (consumers see
+and stages the binary under `build/generated/screenCaptureHelper/native/macos/`, then
+wires that generated directory into the JAR resources transparently. The Swift `swift
+build` step only runs on macOS hosts — non-macOS hosts produce a structurally-correct jar
+that just doesn't contain the helper file (consumers see
 `HelperBinaryExtractor`'s "binary not found" message at runtime if they try to use SCK).
 
 **Distribution must be built on macOS.** A jar published from a Linux CI runner won't carry
@@ -108,7 +109,8 @@ which binary ends up bundled. The universal task pipeline:
    `recording/build/generated/screenCaptureHelperUniversal/SpectreScreenCapture`.
 3. Verifies the result via `lipo -verify_arch arm64 x86_64` — exits non-zero (fails the
    build) if any expected arch isn't present, so a thin binary can never sneak through.
-4. Stages the universal binary into `src/main/resources/native/macos/spectre-screencapture`.
+4. Stages the universal binary into generated resources at
+   `native/macos/spectre-screencapture`.
 
 **Both paths only need the macOS Command Line Tools.** The `--triple` + `lipo` recipe
 deliberately avoids `swift build --arch arm64 --arch x86_64` (which delegates to `xcbuild`
@@ -296,16 +298,12 @@ helpers. CI invokes it as
 
 to lock in both-arch coverage explicitly.
 
-### Publishing intent (not yet implemented — gated on #84)
+### Release packaging
 
-The eventual publish flow merges artifacts from two release runners:
+The tag-driven release workflow builds the recording JAR on macOS with
+`-PuniversalHelper -PnotarizeScreenCaptureKitHelper`, so
+`native/macos/spectre-screencapture` carries a signed and notarized universal binary. It
+then uploads that JAR to the GitHub release for the pushed tag.
 
-- A macOS runner builds the SCK helper with `-PuniversalHelper -PnotarizeScreenCaptureKitHelper`
-  so `native/macos/spectre-screencapture` carries a notarized universal binary.
-- A Linux runner builds the Wayland helpers with `-PallLinuxArches` so
-  `native/linux/<arch>/spectre-wayland-helper` carries both supported architectures.
-
-The merged jar then has the full helper set regardless of which platform a downstream
-consumer runs Spectre on. Until #84's publish pipeline lands, building locally produces
-a host-shaped subset of helpers — useful for development, not yet a distribution
-artifact.
+Local builds still produce a host-shaped subset of helpers unless you opt into the
+distribution-oriented flags above.

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -67,8 +67,9 @@ tasks.withType<Test>().configureEach { useJUnitPlatform() }
 //   1. `swift build -c release` produces a host-arch binary at
 //      `recording/native/macos/.build/release/SpectreScreenCapture`.
 //   2. `assembleScreenCaptureKitHelper` copies it into
-//      `src/main/resources/native/macos/spectre-screencapture` so the resource path is stable
-//      regardless of where SwiftPM lays out its output across versions.
+//      `build/generated/screenCaptureHelper/native/macos/spectre-screencapture` and wires that
+//      directory as generated resources, so the resource path is stable regardless of where
+//      SwiftPM lays out its output across versions.
 //   3. `processResources` depends on the assemble task (only on macOS), so the JAR carries
 //      the helper transparently and `ScreenCaptureKitRecorder.extractHelper()` finds it via
 //      the classloader.

--- a/recording/native/macos/Package.swift
+++ b/recording/native/macos/Package.swift
@@ -3,9 +3,9 @@ import PackageDescription
 
 // Out-of-process helper that Spectre forks per recording. The JVM side
 // (`ScreenCaptureKitRecorder`) extracts the built executable from
-// `recording/src/main/resources/native/macos/`, hands it window-discovery
-// arguments + an output path on stdin/argv, and stops it by writing `q\n`
-// to stdin (mirrors the existing `FfmpegRecorder` shutdown contract).
+// the recording JAR's `native/macos/` resources, hands it window-discovery
+// arguments + an output path on stdin/argv, and stops it by writing `q\n` to
+// stdin (mirrors the existing `FfmpegRecorder` shutdown contract).
 //
 // macOS 13 is the floor: ScreenCaptureKit shipped in 12.3, but the
 // `SCStreamConfiguration.queueDepth` / `SCStreamOutput` async surface we

--- a/testing/README.md
+++ b/testing/README.md
@@ -28,4 +28,6 @@ Contract tests pin the wire-level guarantees that cross module boundaries:
   string form the HTTP transport's `ClickRequest.nodeKey` and the recording module's
   `TitleDiscriminator` both depend on.
 
-More contract tests will land here as cross-module surfaces grow.
+Server DTO and HTTP transport contracts live with the `server` module, while recording
+backend contracts live with `recording`. Add new cross-module contract tests to the module
+that owns the public boundary they pin.


### PR DESCRIPTION
## Summary
- align user guide wording with current RobotDriver dispatch, recording startup, IntelliJ autorun, and included-build version behavior
- refresh maintainer docs and module READMEs for current core/server/recording/static-analysis state
- update stale ScreenCaptureKit helper resource-path comments and release packaging wording

## Test plan
- [x] .venv/bin/python -m mkdocs build --strict
- [x] ./gradlew check