### PR TITLE
Address downstream Spectre feedback

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -121,8 +121,8 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 }
 
 public final class dev/sebastiano/spectre/core/ComposeAutomator$Companion {
-	public final fun inProcess (Ldev/sebastiano/spectre/core/RobotDriver;)Ldev/sebastiano/spectre/core/ComposeAutomator;
-	public static synthetic fun inProcess$default (Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;Ldev/sebastiano/spectre/core/RobotDriver;ILjava/lang/Object;)Ldev/sebastiano/spectre/core/ComposeAutomator;
+	public final fun inProcess (Ldev/sebastiano/spectre/core/RobotDriver;Z)Ldev/sebastiano/spectre/core/ComposeAutomator;
+	public static synthetic fun inProcess$default (Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;Ldev/sebastiano/spectre/core/RobotDriver;ZILjava/lang/Object;)Ldev/sebastiano/spectre/core/ComposeAutomator;
 }
 
 public final class dev/sebastiano/spectre/core/HiDpiMapperKt {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -88,6 +88,7 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public final fun getWindows ()Ljava/util/List;
 	public final fun longClick-8Mi8wO0 (Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun longClick-8Mi8wO0$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun pasteText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun performSemanticsClick (Ldev/sebastiano/spectre/core/AutomatorNode;)V
 	public final fun pressEnter (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun pressKey (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -178,6 +179,7 @@ public final class dev/sebastiano/spectre/core/RobotDriver {
 	public final fun doubleClick (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun longClick-exY8QGI (IIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun longClick-exY8QGI$default (Ldev/sebastiano/spectre/core/RobotDriver;IIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun pasteText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun pressKey (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun pressKey$default (Ldev/sebastiano/spectre/core/RobotDriver;IILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun screenshot (Ljava/awt/Rectangle;)Ljava/awt/image/BufferedImage;
@@ -190,10 +192,7 @@ public final class dev/sebastiano/spectre/core/RobotDriver {
 
 public final class dev/sebastiano/spectre/core/RobotDriver$Companion {
 	public final fun headless ()Ldev/sebastiano/spectre/core/RobotDriver;
-}
-
-public final class dev/sebastiano/spectre/core/SyntheticInputKt {
-	public static final fun synthetic (Ldev/sebastiano/spectre/core/RobotDriver$Companion;Ljava/awt/Window;)Ldev/sebastiano/spectre/core/RobotDriver;
+	public final fun synthetic (Ljava/awt/Window;)Ldev/sebastiano/spectre/core/RobotDriver;
 }
 
 public final class dev/sebastiano/spectre/core/TextMatchType : java/lang/Enum {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -141,6 +141,10 @@ private constructor(
         robotDriver.typeText(text)
     }
 
+    public suspend fun pasteText(text: String) {
+        robotDriver.pasteText(text)
+    }
+
     public suspend fun clearAndTypeText(node: AutomatorNode, text: String) {
         click(node)
         robotDriver.clearAndTypeText(text)
@@ -515,7 +519,12 @@ private constructor(
     public companion object {
 
         public fun inProcess(robotDriver: RobotDriver = RobotDriver()): ComposeAutomator =
-            ComposeAutomator(WindowTracker(), SemanticsReader(), robotDriver)
+            ComposeAutomator(
+                windowTracker =
+                    if (robotDriver.isHeadless) WindowTracker.empty() else WindowTracker(),
+                semanticsReader = SemanticsReader(),
+                robotDriver = robotDriver,
+            )
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -518,10 +518,12 @@ private constructor(
 
     public companion object {
 
-        public fun inProcess(robotDriver: RobotDriver = RobotDriver()): ComposeAutomator =
+        public fun inProcess(
+            robotDriver: RobotDriver = RobotDriver(),
+            discoverWindows: Boolean = true,
+        ): ComposeAutomator =
             ComposeAutomator(
-                windowTracker =
-                    if (robotDriver.isHeadless) WindowTracker.empty() else WindowTracker(),
+                windowTracker = if (discoverWindows) WindowTracker() else WindowTracker.empty(),
                 semanticsReader = SemanticsReader(),
                 robotDriver = robotDriver,
             )

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -27,9 +27,6 @@ internal constructor(
     private val tccGuard: MacOsTccGuard = defaultTccGuardFor(robot),
 ) {
 
-    internal val isHeadless: Boolean
-        get() = robot === HeadlessThrowingRobotAdapter
-
     // Public surface: callers may instantiate without arguments (defaults to a fresh
     // AWT Robot + system clipboard) or hand in an existing Robot. The internal
     // adapter-injecting constructor is reserved for tests within this module.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -204,7 +204,7 @@ internal constructor(
                 robot.keyPress(KeyEvent.VK_V)
                 robot.keyRelease(KeyEvent.VK_V)
                 robot.keyRelease(modifier)
-                if (clipboard.supportsRead && robot.shouldDrainAfterClipboardPaste()) {
+                if (clipboard.supportsRead && robot.shouldDrainAfterClipboardPaste) {
                     // Drain queued AWT events (KEY_PRESSED/RELEASED + Compose's input
                     // pipeline) so the paste handler has a chance to read the clipboard before
                     // we restore it. Without this, the finally block can clobber the clipboard
@@ -451,7 +451,8 @@ internal interface RobotAdapter {
      * `true` when [RobotDriver.pasteText] should pump event queues before restoring the clipboard.
      * Keep the default `false` so pure fakes/headless adapters do not initialise the AWT toolkit.
      */
-    fun shouldDrainAfterClipboardPaste(): Boolean = false
+    val shouldDrainAfterClipboardPaste: Boolean
+        get() = false
 }
 
 internal interface ClipboardAdapter {
@@ -500,7 +501,8 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
 
     override fun waitForIdle() = robot.waitForIdle()
 
-    override fun shouldDrainAfterClipboardPaste(): Boolean = !SwingUtilities.isEventDispatchThread()
+    override val shouldDrainAfterClipboardPaste: Boolean
+        get() = !SwingUtilities.isEventDispatchThread()
 }
 
 private object HeadlessThrowingRobotAdapter : RobotAdapter {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -5,6 +5,7 @@ import java.awt.Point
 import java.awt.Rectangle
 import java.awt.Robot
 import java.awt.Toolkit
+import java.awt.Window
 import java.awt.datatransfer.DataFlavor
 import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
@@ -25,6 +26,9 @@ internal constructor(
     private val clipboard: ClipboardAdapter = SystemClipboardAdapter(),
     private val tccGuard: MacOsTccGuard = defaultTccGuardFor(robot),
 ) {
+
+    internal val isHeadless: Boolean
+        get() = robot === HeadlessThrowingRobotAdapter
 
     // Public surface: callers may instantiate without arguments (defaults to a fresh
     // AWT Robot + system clipboard) or hand in an existing Robot. The internal
@@ -139,9 +143,32 @@ internal constructor(
     }
 
     /**
+     * Types [text] into the focused field by dispatching key press/release pairs. This path avoids
+     * the system clipboard entirely, so it keeps working in environments where clipboard-backed
+     * paste is unavailable or stale. It is intentionally conservative: supported characters are
+     * ASCII letters, digits, space, newline, and common US-keyboard punctuation. Use [pasteText]
+     * when you need arbitrary Unicode text.
+     *
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
+    public suspend fun typeText(text: String) {
+        tccGuard.requireAccessibility()
+        runOffEdt {
+            for (char in text) {
+                val stroke = keyStrokeForChar(char)
+                for (modifier in stroke.modifiers) robot.keyPress(modifier)
+                robot.keyPress(stroke.keyCode)
+                robot.keyRelease(stroke.keyCode)
+                for (modifier in stroke.modifiers.asReversed()) robot.keyRelease(modifier)
+            }
+        }
+    }
+
+    /**
      * Pastes [text] into the focused field via the OS clipboard and a synthetic Ctrl/Cmd+V
-     * shortcut. This is the fast path — `Robot.keyPress`-per-character is significantly slower and
-     * stumbles on capitalisation / locale-specific layouts.
+     * shortcut. This is the fast path for large or Unicode strings, but it depends on the platform
+     * clipboard being visible to the UI toolkit.
      *
      * The clipboard is **saved before** and **restored after** the paste, so caller-held clipboard
      * content survives. On platforms where the clipboard supports read-back the call polls until
@@ -153,7 +180,7 @@ internal constructor(
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
-    public suspend fun typeText(text: String) {
+    public suspend fun pasteText(text: String) {
         tccGuard.requireAccessibility()
         runOffEdt {
             val previousContents = runCatching { clipboard.getContents() }.getOrNull()
@@ -180,7 +207,7 @@ internal constructor(
                 robot.keyPress(KeyEvent.VK_V)
                 robot.keyRelease(KeyEvent.VK_V)
                 robot.keyRelease(modifier)
-                if (clipboard.supportsRead && !SwingUtilities.isEventDispatchThread()) {
+                if (clipboard.supportsRead && robot.shouldDrainAfterClipboardPaste()) {
                     // Drain queued AWT events (KEY_PRESSED/RELEASED + Compose's input
                     // pipeline) so the paste handler has a chance to read the clipboard before
                     // we restore it. Without this, the finally block can clobber the clipboard
@@ -189,12 +216,9 @@ internal constructor(
                     // Compose's paste action runs on its own coroutine dispatcher which posts
                     // back to the EDT, so we pump a few times and also wait a short interval
                     // to let the OS-side paste read complete before we clobber the clipboard
-                    // contents. Skip the whole block when called on the EDT (the synthetic
-                    // adapter's runOffEdt short-circuit lets it stay on EDT), where
-                    // waitForIdle is a no-op and the post-paste settle would just add wall-
-                    // clock latency for nothing — same skip the pre-suspend code applied. Skip
-                    // for adapters that don't support clipboard read-back too — there's no real
-                    // paste handler to drain.
+                    // contents. The adapter owns the drain decision so pure unit-test fakes do
+                    // not accidentally initialise the macOS AWT toolkit just to answer
+                    // SwingUtilities.isEventDispatchThread().
                     repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }
                     delay(POST_PASTE_SETTLE_MS.milliseconds)
                     repeat(POST_PASTE_EDT_PUMPS) { robot.waitForIdle() }
@@ -225,13 +249,11 @@ internal constructor(
     }
 
     /**
-     * Selects all content in the focused field, deletes it, then pastes [text]. Uses the same
-     * clipboard-backed paste as [typeText] for the second half; the first half is a Ctrl/Cmd+A
-     * followed by Backspace.
+     * Selects all content in the focused field, deletes it, then types [text]. The first half is a
+     * Ctrl/Cmd+A followed by Backspace; the second half uses [typeText].
      *
      * Useful for overwriting a `TextField`'s current value without the caller having to compute
-     * cursor / selection state. Same caveats as [typeText] for clipboard preservation and EDT
-     * settle.
+     * cursor / selection state. Same caveats as [typeText] for supported characters apply.
      *
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
@@ -330,13 +352,20 @@ internal constructor(
      */
     public fun screenshot(region: Rectangle? = null): BufferedImage {
         tccGuard.requireScreenRecording()
-        val captureRegion = region ?: virtualDesktopBounds()
+        val captureRegion = region ?: robot.defaultScreenshotRegion()
         return robot.createScreenCapture(captureRegion)
     }
 
     private suspend fun runOffEdt(block: suspend () -> Unit) = runOffEdt(robot, block)
 
     public companion object {
+
+        /**
+         * Returns a [RobotDriver] that delivers synthetic AWT events directly to [rootWindow]'s AWT
+         * hierarchy instead of routing through `java.awt.Robot`'s OS-level input.
+         */
+        public fun synthetic(rootWindow: Window): RobotDriver =
+            RobotDriver(SyntheticRobotAdapter(rootWindow), SystemClipboardAdapter())
 
         /**
          * Returns a [RobotDriver] that throws [UnsupportedOperationException] on every input,
@@ -417,7 +446,15 @@ internal interface RobotAdapter {
 
     fun createScreenCapture(region: Rectangle): BufferedImage
 
+    fun defaultScreenshotRegion(): Rectangle = virtualDesktopBounds()
+
     fun waitForIdle()
+
+    /**
+     * `true` when [RobotDriver.pasteText] should pump event queues before restoring the clipboard.
+     * Keep the default `false` so pure fakes/headless adapters do not initialise the AWT toolkit.
+     */
+    fun shouldDrainAfterClipboardPaste(): Boolean = false
 }
 
 internal interface ClipboardAdapter {
@@ -465,6 +502,8 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
         robot.createScreenCapture(region)
 
     override fun waitForIdle() = robot.waitForIdle()
+
+    override fun shouldDrainAfterClipboardPaste(): Boolean = !SwingUtilities.isEventDispatchThread()
 }
 
 private object HeadlessThrowingRobotAdapter : RobotAdapter {
@@ -490,8 +529,10 @@ private object HeadlessThrowingRobotAdapter : RobotAdapter {
     override fun createScreenCapture(region: Rectangle): BufferedImage =
         throwHeadless("createScreenCapture")
 
+    override fun defaultScreenshotRegion(): Rectangle = throwHeadless("screenshot")
+
     // waitForIdle is purely a synchronisation barrier — it produces no observable side effect, so
-    // making it a no-op keeps internal pump loops (e.g. the post-paste drain in typeText) callable
+    // making it a no-op keeps internal pump loops (e.g. the post-paste drain in pasteText) callable
     // without triggering throws on a path where they'd be unreachable anyway.
     override fun waitForIdle() = Unit
 }
@@ -560,6 +601,71 @@ internal fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
     if (mask and InputEvent.META_DOWN_MASK != 0) add(KeyEvent.VK_META)
 }
 
+internal data class KeyStrokeSpec(val keyCode: Int, val modifiers: List<Int> = emptyList())
+
+internal fun keyStrokeForChar(char: Char): KeyStrokeSpec {
+    unmodifiedCharKeyCodes[char]?.let {
+        return KeyStrokeSpec(it)
+    }
+    shiftedCharKeyCodes[char]?.let {
+        return KeyStrokeSpec(it, listOf(KeyEvent.VK_SHIFT))
+    }
+    return when (char) {
+        in 'a'..'z' -> KeyStrokeSpec(KeyEvent.VK_A + (char - 'a'))
+        in 'A'..'Z' -> KeyStrokeSpec(KeyEvent.VK_A + (char - 'A'), listOf(KeyEvent.VK_SHIFT))
+        in '0'..'9' -> KeyStrokeSpec(KeyEvent.VK_0 + (char - '0'))
+        else -> unsupportedTypeTextChar(char)
+    }
+}
+
+private fun unsupportedTypeTextChar(char: Char): Nothing =
+    throw IllegalArgumentException(
+        "typeText supports ASCII key-event input only; use pasteText for unsupported " +
+            "character U+${char.code.toString(HEX_RADIX).uppercase().padStart(UNICODE_CODE_WIDTH, '0')}"
+    )
+
+private val unmodifiedCharKeyCodes: Map<Char, Int> =
+    mapOf(
+        ' ' to KeyEvent.VK_SPACE,
+        '\n' to KeyEvent.VK_ENTER,
+        '-' to KeyEvent.VK_MINUS,
+        '=' to KeyEvent.VK_EQUALS,
+        '[' to KeyEvent.VK_OPEN_BRACKET,
+        ']' to KeyEvent.VK_CLOSE_BRACKET,
+        '\\' to KeyEvent.VK_BACK_SLASH,
+        ';' to KeyEvent.VK_SEMICOLON,
+        '\'' to KeyEvent.VK_QUOTE,
+        ',' to KeyEvent.VK_COMMA,
+        '.' to KeyEvent.VK_PERIOD,
+        '/' to KeyEvent.VK_SLASH,
+        '`' to KeyEvent.VK_BACK_QUOTE,
+    )
+
+private val shiftedCharKeyCodes: Map<Char, Int> =
+    mapOf(
+        '!' to KeyEvent.VK_1,
+        '@' to KeyEvent.VK_2,
+        '#' to KeyEvent.VK_3,
+        '$' to KeyEvent.VK_4,
+        '%' to KeyEvent.VK_5,
+        '^' to KeyEvent.VK_6,
+        '&' to KeyEvent.VK_7,
+        '*' to KeyEvent.VK_8,
+        '(' to KeyEvent.VK_9,
+        ')' to KeyEvent.VK_0,
+        '_' to KeyEvent.VK_MINUS,
+        '+' to KeyEvent.VK_EQUALS,
+        '{' to KeyEvent.VK_OPEN_BRACKET,
+        '}' to KeyEvent.VK_CLOSE_BRACKET,
+        '|' to KeyEvent.VK_BACK_SLASH,
+        ':' to KeyEvent.VK_SEMICOLON,
+        '"' to KeyEvent.VK_QUOTE,
+        '<' to KeyEvent.VK_COMMA,
+        '>' to KeyEvent.VK_PERIOD,
+        '?' to KeyEvent.VK_SLASH,
+        '~' to KeyEvent.VK_BACK_QUOTE,
+    )
+
 internal fun swipePauseMillis(duration: Duration, steps: Int, autoDelayMs: Int): Long {
     require(steps > 0) { "steps must be positive" }
     val perStepBudgetMs = duration.inWholeMilliseconds / steps
@@ -615,6 +721,8 @@ private val DEFAULT_LONG_CLICK_DURATION: Duration = 500.milliseconds
 private const val CLIPBOARD_SETTLE_TIMEOUT_MS: Long = 1_000L
 private const val CLIPBOARD_SETTLE_POLL_MS: Long = 5L
 private const val NANOS_PER_MILLI: Long = 1_000_000L
+private const val HEX_RADIX: Int = 16
+private const val UNICODE_CODE_WIDTH: Int = 4
 
 // After dispatching Cmd+V we drain the EDT a few times to let Compose's paste-action coroutine
 // post back, then sleep briefly so the OS clipboard read completes, then drain again. The total

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SemanticsReader.kt
@@ -10,8 +10,9 @@ import androidx.compose.ui.semantics.SemanticsOwner
 
 internal class SemanticsReader {
 
-    fun readAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> = readOnEdt {
-        collectAllNodes(trackedWindows)
+    fun readAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> {
+        if (trackedWindows.isEmpty()) return emptyList()
+        return readOnEdt { collectAllNodes(trackedWindows) }
     }
 
     fun findByTestTag(tag: String, trackedWindows: List<TrackedWindow>): List<AutomatorNode> =
@@ -52,10 +53,13 @@ internal class SemanticsReader {
     private fun findMatching(
         trackedWindows: List<TrackedWindow>,
         matcher: LiveNodeMatcher,
-    ): List<AutomatorNode> = readOnEdt {
-        val entries = collectEntries(trackedWindows)
-        val nodes = projectEntriesToNodes(entries)
-        entries.filter { matcher.matches(it.node) }.mapNotNull { nodes[it.key] }
+    ): List<AutomatorNode> {
+        if (trackedWindows.isEmpty()) return emptyList()
+        return readOnEdt {
+            val entries = collectEntries(trackedWindows)
+            val nodes = projectEntriesToNodes(entries)
+            entries.filter { matcher.matches(it.node) }.mapNotNull { nodes[it.key] }
+        }
     }
 
     private fun collectAllNodes(trackedWindows: List<TrackedWindow>): List<AutomatorNode> {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
@@ -47,6 +47,9 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
     // (Codex P1 on PR #35).
     override val requiresOffEdt: Boolean = false
 
+    override val shouldDrainAfterClipboardPaste: Boolean
+        get() = !SwingUtilities.isEventDispatchThread()
+
     @Volatile private var lastX: Int = 0
     @Volatile private var lastY: Int = 0
     @Volatile private var pressedButtons: Int = 0

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
@@ -408,7 +408,7 @@ private val SHORTCUT_MODIFIER_MASK: Int =
         java.awt.event.InputEvent.CTRL_DOWN_MASK or
         java.awt.event.InputEvent.ALT_DOWN_MASK
 
-private fun keyCharFor(keyCode: Int, shift: Boolean = false): Char =
+internal fun keyCharFor(keyCode: Int, shift: Boolean = false): Char =
     when (keyCode) {
         KeyEvent.VK_ENTER -> '\n'
         KeyEvent.VK_SPACE -> ' '
@@ -421,17 +421,50 @@ private fun keyCharFor(keyCode: Int, shift: Boolean = false): Char =
             // listeners that consume KEY_TYPED character validators see the right input.
             if (shift) SHIFTED_DIGIT_CHARS[keyCode - KeyEvent.VK_0]
             else ('0' + (keyCode - KeyEvent.VK_0))
-        else -> KeyEvent.CHAR_UNDEFINED
+        else ->
+            if (shift) SHIFTED_PUNCTUATION_CHARS[keyCode] ?: KeyEvent.CHAR_UNDEFINED
+            else PUNCTUATION_CHARS[keyCode] ?: KeyEvent.CHAR_UNDEFINED
     }
 
 private val SHIFTED_DIGIT_CHARS: CharArray =
     charArrayOf(')', '!', '@', '#', '$', '%', '^', '&', '*', '(')
 
+private val PUNCTUATION_CHARS: Map<Int, Char> =
+    mapOf(
+        KeyEvent.VK_MINUS to '-',
+        KeyEvent.VK_EQUALS to '=',
+        KeyEvent.VK_OPEN_BRACKET to '[',
+        KeyEvent.VK_CLOSE_BRACKET to ']',
+        KeyEvent.VK_BACK_SLASH to '\\',
+        KeyEvent.VK_SEMICOLON to ';',
+        KeyEvent.VK_QUOTE to '\'',
+        KeyEvent.VK_COMMA to ',',
+        KeyEvent.VK_PERIOD to '.',
+        KeyEvent.VK_SLASH to '/',
+        KeyEvent.VK_BACK_QUOTE to '`',
+    )
+
+private val SHIFTED_PUNCTUATION_CHARS: Map<Int, Char> =
+    mapOf(
+        KeyEvent.VK_MINUS to '_',
+        KeyEvent.VK_EQUALS to '+',
+        KeyEvent.VK_OPEN_BRACKET to '{',
+        KeyEvent.VK_CLOSE_BRACKET to '}',
+        KeyEvent.VK_BACK_SLASH to '|',
+        KeyEvent.VK_SEMICOLON to ':',
+        KeyEvent.VK_QUOTE to '"',
+        KeyEvent.VK_COMMA to '<',
+        KeyEvent.VK_PERIOD to '>',
+        KeyEvent.VK_SLASH to '?',
+        KeyEvent.VK_BACK_QUOTE to '~',
+    )
+
 // Conservative subset of printable VK_ codes for KeyEvent's keyChar; matches what RobotDriver
-// typically dispatches via direct keyPress.
+// dispatches via direct keyPress for key-event text entry.
 private val PRINTABLE_KEY_CODES: Set<Int> = buildSet {
     addAll((KeyEvent.VK_A..KeyEvent.VK_Z))
     addAll((KeyEvent.VK_0..KeyEvent.VK_9))
+    addAll(PUNCTUATION_CHARS.keys)
     add(KeyEvent.VK_SPACE)
     add(KeyEvent.VK_ENTER)
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
@@ -31,12 +31,9 @@ import javax.swing.SwingUtilities
  * ([Window.getOwnedWindows]) on every dispatch, so popups and secondary windows added after
  * construction work without re-creating the driver.
  *
- * Clipboard access is left as the system clipboard — paste-based [RobotDriver.typeText] still works
- * with synthetic Cmd/Ctrl+V keystrokes.
+ * Clipboard access is left as the system clipboard — paste-based [RobotDriver.pasteText] still
+ * works with synthetic Cmd/Ctrl+V keystrokes.
  */
-public fun RobotDriver.Companion.synthetic(rootWindow: Window): RobotDriver =
-    RobotDriver(SyntheticRobotAdapter(rootWindow), SystemClipboardAdapter())
-
 internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdapter {
 
     // Synthetic events have no OS-level inter-event delay; we always dispatch immediately.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -9,21 +9,35 @@ import java.awt.Container
 import java.awt.Window
 
 @InternalSpectreApi
-public class WindowTracker {
+public class WindowTracker
+internal constructor(
+    private val allWindows: () -> Array<Window>,
+    private val requiresEdt: Boolean,
+) {
+
+    public constructor() : this(Window::getWindows, requiresEdt = true)
 
     @Volatile private var _trackedWindows: List<TrackedWindow> = emptyList()
 
     public val trackedWindows: List<TrackedWindow>
         get() = _trackedWindows
 
-    public fun refresh(): Unit = readOnEdt {
+    public fun refresh() {
+        if (requiresEdt) {
+            readOnEdt { refreshOnCurrentThread() }
+        } else {
+            refreshOnCurrentThread()
+        }
+    }
+
+    private fun refreshOnCurrentThread() {
         val pending = mutableListOf<TrackedWindow>()
         // Iterate every top-level window (`owner == null`) regardless of visibility — Swing's
         // `SharedOwnerFrame` is a hidden parent for `JDialog(null as Frame?, ...)`, so filtering
         // by `isShowing` here would drop the dialog along with it. Visibility is enforced per
         // candidate further down (a hidden parent only contributes through its visible
         // descendants).
-        val topLevelWindows = Window.getWindows().filter { it.owner == null }
+        val topLevelWindows = allWindows().filter { it.owner == null }
         for (window in topLevelWindows) {
             when {
                 window is ComposeWindow && window.isShowing -> trackComposeWindow(pending, window)
@@ -126,6 +140,10 @@ public class WindowTracker {
                 isPopup = true,
                 overlaySemanticsOwners = layer.semanticsOwnersAccessor,
             )
+    }
+
+    internal companion object {
+        fun empty(): WindowTracker = WindowTracker({ emptyArray() }, requiresEdt = false)
     }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -310,6 +310,7 @@ class ComposeAutomatorPublicSurfaceTest {
                 "swipe",
                 "scrollWheel",
                 "typeText",
+                "pasteText",
                 "clearAndTypeText",
                 "pressKey",
                 "pressEnter",

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/DocsGuidanceContractTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/DocsGuidanceContractTest.kt
@@ -1,0 +1,39 @@
+package dev.sebastiano.spectre.core
+
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class DocsGuidanceContractTest {
+
+    @Test
+    fun `docs pin downstream setup troubleshooting guidance`() {
+        val docs =
+            listOf(
+                    "docs/guide/getting-started.md",
+                    "docs/guide/junit.md",
+                    "docs/guide/troubleshooting.md",
+                    "docs/guide/selectors.md",
+                    "docs/guide/interactions.md",
+                    "skills/spectre/SKILL.md",
+                )
+                .joinToString(separator = "\n") { root.resolve(it).readText() }
+
+        assertContains(docs, "apple.awt.UIElement=true")
+        assertContains(docs, "pasteText")
+        assertContains(docs, "java.awt.headless")
+        assertContains(docs, "fun mySpec(): Unit = runBlocking")
+        assertContains(docs, "printTree()` returns an empty string")
+        assertContains(docs, "No Component provided")
+        assertContains(docs, "RobotDriver.synthetic(rootWindow =")
+    }
+
+    private fun assertContains(haystack: String, needle: String) {
+        assertTrue(haystack.contains(needle), "Expected docs/skill guidance to contain: $needle")
+    }
+
+    private companion object {
+        val root: Path = Path.of("..").toAbsolutePath().normalize()
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/LiveAwtAssumptions.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/LiveAwtAssumptions.kt
@@ -1,0 +1,18 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.GraphicsEnvironment
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+internal fun assumeLiveAwtAvailable() {
+    if (detectMacOs()) {
+        assumeTrue(
+            System.getProperty(LIVE_AWT_OPT_IN_PROPERTY).toBoolean(),
+            "Live AWT tests are opt-in on macOS because AppKit initialisation can hang in " +
+                "non-interactive workers; rerun with -D$LIVE_AWT_OPT_IN_PROPERTY=true to exercise them.",
+        )
+    }
+    assumeFalse(GraphicsEnvironment.isHeadless(), "Live AWT tests need a non-headless JVM")
+}
+
+private const val LIVE_AWT_OPT_IN_PROPERTY = "spectre.test.liveAwt"

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -433,7 +433,8 @@ private class RecordingRobotAdapter(
 
     override fun waitForIdle() = log("waitForIdle()")
 
-    override fun shouldDrainAfterClipboardPaste(): Boolean = drainAfterPaste
+    override val shouldDrainAfterClipboardPaste: Boolean
+        get() = drainAfterPaste
 }
 
 private class RecordingClipboardAdapter : ClipboardAdapter {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -86,6 +86,50 @@ class RobotDriverTest {
     }
 
     @Test
+    fun `keyStrokeForChar maps shifted and unshifted ASCII`() {
+        assertEquals(KeyStrokeSpec(KeyEvent.VK_A), keyStrokeForChar('a'))
+        assertEquals(KeyStrokeSpec(KeyEvent.VK_A, listOf(KeyEvent.VK_SHIFT)), keyStrokeForChar('A'))
+        assertEquals(KeyStrokeSpec(KeyEvent.VK_1), keyStrokeForChar('1'))
+        assertEquals(KeyStrokeSpec(KeyEvent.VK_1, listOf(KeyEvent.VK_SHIFT)), keyStrokeForChar('!'))
+        assertEquals(KeyStrokeSpec(KeyEvent.VK_SPACE), keyStrokeForChar(' '))
+    }
+
+    @Test
+    fun `typeText dispatches key events without touching the clipboard`() = runTest {
+        val robot = RecordingRobotAdapter()
+        val clipboard = RecordingClipboardAdapter()
+        val driver = RobotDriver(robot, clipboard)
+
+        driver.typeText("aA1!")
+
+        assertEquals(0, clipboard.setCalls)
+        assertEquals(
+            listOf(
+                "keyPress(${KeyEvent.VK_A})",
+                "keyRelease(${KeyEvent.VK_A})",
+                "keyPress(${KeyEvent.VK_SHIFT})",
+                "keyPress(${KeyEvent.VK_A})",
+                "keyRelease(${KeyEvent.VK_A})",
+                "keyRelease(${KeyEvent.VK_SHIFT})",
+                "keyPress(${KeyEvent.VK_1})",
+                "keyRelease(${KeyEvent.VK_1})",
+                "keyPress(${KeyEvent.VK_SHIFT})",
+                "keyPress(${KeyEvent.VK_1})",
+                "keyRelease(${KeyEvent.VK_1})",
+                "keyRelease(${KeyEvent.VK_SHIFT})",
+            ),
+            robot.events,
+        )
+    }
+
+    @Test
+    fun `typeText rejects unsupported non-ASCII characters`() = runTest {
+        val driver = RobotDriver(RecordingRobotAdapter(), RecordingClipboardAdapter())
+        val error = assertFailsWith<IllegalArgumentException> { driver.typeText("é") }
+        assertTrue(error.message?.contains("pasteText") == true)
+    }
+
+    @Test
     fun `interpolateSwipePoints includes both endpoints`() {
         val result =
             interpolateSwipePoints(startX = 10, startY = 20, endX = 40, endY = 50, steps = 3)
@@ -121,16 +165,16 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `typeText waits for the clipboard to reflect the new text before dispatching paste`() =
+    fun `pasteText waits for the clipboard to reflect the new text before dispatching paste`() =
         runTest {
             // Simulate a slow OS pasteboard: the first N reads after setContents still return the
-            // previous value. typeText must not press Cmd+V until the clipboard has settled,
+            // previous value. pasteText must not press Cmd+V until the clipboard has settled,
             // otherwise the paste handler reads stale contents.
             val clipboard = LatentClipboardAdapter(latencyReads = 3)
             clipboard.setContentsImmediate(StringSelection("previous"))
             val driver = RobotDriver(clipboard.robotAdapter, clipboard)
 
-            driver.typeText("spectre")
+            driver.pasteText("spectre")
 
             // The first key event must come AFTER the clipboard has the new value. Reconstruct by
             // looking at the recorded order: each call to clipboard.getContents() interleaves with
@@ -144,22 +188,22 @@ class RobotDriverTest {
                 }
             assertTrue(
                 readsBeforePaste >= 1,
-                "typeText must observe the new clipboard contents at least once before pressing " +
+                "pasteText must observe the new clipboard contents at least once before pressing " +
                     "Cmd+V (event log: ${clipboard.eventLog})",
             )
         }
 
     @Test
-    fun `typeText pumps the EDT after key release before restoring the clipboard`() = runTest {
+    fun `pasteText pumps the EDT after key release before restoring the clipboard`() = runTest {
         // The OS paste handler reads the clipboard asynchronously after Cmd+V is released, so
         // restoring the previous contents synchronously can clobber the value before the paste
         // lands. typeText must give the AWT event queue (and any post-press settle) a chance to
         // drain before restoring.
-        val clipboard = LatentClipboardAdapter()
+        val clipboard = LatentClipboardAdapter(drainAfterPaste = true)
         clipboard.setContentsImmediate(StringSelection("previous"))
         val driver = RobotDriver(clipboard.robotAdapter, clipboard)
 
-        driver.typeText("spectre")
+        driver.pasteText("spectre")
 
         // The order must be: setContents("spectre") → keyPress/keyRelease → waitForIdle
         // → setContents("previous"). If waitForIdle does not appear between the last keyRelease
@@ -178,7 +222,7 @@ class RobotDriverTest {
         check(restoreIdx > lastReleaseIdx) { "Expected restore after last keyRelease in $log" }
         assertTrue(
             waitIdx in (lastReleaseIdx + 1) until restoreIdx,
-            "typeText must call waitForIdle() between the final keyRelease and the clipboard " +
+            "pasteText must call waitForIdle() between the final keyRelease and the clipboard " +
                 "restore (log: $log)",
         )
     }
@@ -250,8 +294,8 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `typeText consults the accessibility guard before mutating the clipboard`() = runTest {
-        // typeText writes to and restores the clipboard, so a failed accessibility check
+    fun `pasteText consults the accessibility guard before mutating the clipboard`() = runTest {
+        // pasteText writes to and restores the clipboard, so a failed accessibility check
         // must short-circuit BEFORE the clipboard is touched. Otherwise a failing macOS run
         // would still pollute the user's clipboard.
         val guard = RecordingTccGuard(accessibilityThrows = true)
@@ -259,7 +303,7 @@ class RobotDriverTest {
         val robot = RecordingRobotAdapter()
         val driver = RobotDriver(robot, clipboard, guard)
 
-        assertFailsWith<IllegalStateException> { driver.typeText("hello") }
+        assertFailsWith<IllegalStateException> { driver.pasteText("hello") }
 
         assertEquals(0, clipboard.setCalls, "clipboard must not be mutated when guard blocks")
         assertEquals(emptyList(), robot.events)
@@ -287,6 +331,12 @@ class RobotDriverTest {
     fun `headless typeText throws UnsupportedOperationException`() = runTest {
         val driver = RobotDriver.headless()
         assertFailsWith<UnsupportedOperationException> { driver.typeText("hello") }
+    }
+
+    @Test
+    fun `headless pasteText throws UnsupportedOperationException`() = runTest {
+        val driver = RobotDriver.headless()
+        assertFailsWith<UnsupportedOperationException> { driver.pasteText("hello") }
     }
 
     @Test
@@ -348,6 +398,7 @@ private class RecordingTccGuard(
 private class RecordingRobotAdapter(
     override val autoDelayMs: Int = 0,
     private val sharedLog: MutableList<String>? = null,
+    private val drainAfterPaste: Boolean = false,
 ) : RobotAdapter {
     override val requiresOffEdt: Boolean = false
     val events = mutableListOf<String>()
@@ -381,6 +432,8 @@ private class RecordingRobotAdapter(
     }
 
     override fun waitForIdle() = log("waitForIdle()")
+
+    override fun shouldDrainAfterClipboardPaste(): Boolean = drainAfterPaste
 }
 
 private class RecordingClipboardAdapter : ClipboardAdapter {
@@ -403,9 +456,13 @@ private class RecordingClipboardAdapter : ClipboardAdapter {
  * one. Records every read and write into a shared event log alongside robot events so tests can
  * assert ordering between input dispatch and clipboard mutation.
  */
-private class LatentClipboardAdapter(private val latencyReads: Int = 0) : ClipboardAdapter {
+private class LatentClipboardAdapter(
+    private val latencyReads: Int = 0,
+    drainAfterPaste: Boolean = false,
+) : ClipboardAdapter {
     val eventLog: MutableList<String> = mutableListOf()
-    val robotAdapter: RecordingRobotAdapter = RecordingRobotAdapter(sharedLog = eventLog)
+    val robotAdapter: RecordingRobotAdapter =
+        RecordingRobotAdapter(sharedLog = eventLog, drainAfterPaste = drainAfterPaste)
 
     private var current: Transferable? = null
     private var pending: Transferable? = null

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
@@ -4,7 +4,6 @@ import java.awt.AWTEvent
 import java.awt.BorderLayout
 import java.awt.Color
 import java.awt.Dimension
-import java.awt.GraphicsEnvironment
 import java.awt.Rectangle
 import java.awt.Toolkit
 import java.awt.datatransfer.DataFlavor
@@ -27,7 +26,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.Timeout
 
 /**
@@ -37,8 +35,8 @@ import org.junit.jupiter.api.Timeout
  * from what AWT actually emits, real-world behaviour drifts with it.
  *
  * Test scaffolding rules (per R4 plan guardrails):
- * - `assumeFalse(GraphicsEnvironment.isHeadless())` on every test — synthetic dispatch needs a real
- *   AWT display.
+ * - `assumeLiveAwtAvailable()` on every test — synthetic dispatch needs a real AWT display, and
+ *   macOS AppKit initialisation is opt-in for default unit-test stability.
  * - Frames are constructed and disposed on the EDT.
  * - Event-queue drains use `SwingUtilities.invokeAndWait { }` rather than time-based sleeps.
  * - `@Timeout` backstops every test so a regression doesn't pin the JVM via a non-daemon EDT.
@@ -48,7 +46,7 @@ class SyntheticInputParityTest {
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `mouseWheel emits one MouseWheelEvent per call with scrollAmount 1 and signed wheelRotation`() {
-        assumeFalse(GraphicsEnvironment.isHeadless())
+        assumeLiveAwtAvailable()
         val target = WheelTargetPanel()
         val frame = showFrameOnEdt(target)
         try {
@@ -91,7 +89,7 @@ class SyntheticInputParityTest {
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `double-click sequence reports clickCount=2 on the second pair`() {
-        assumeFalse(GraphicsEnvironment.isHeadless())
+        assumeLiveAwtAvailable()
         val target = MouseTargetPanel()
         val frame = showFrameOnEdt(target)
         try {
@@ -130,7 +128,7 @@ class SyntheticInputParityTest {
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `swipe between distinct points emits no MOUSE_CLICKED`() {
-        assumeFalse(GraphicsEnvironment.isHeadless())
+        assumeLiveAwtAvailable()
         val target = MouseTargetPanel()
         val frame = showFrameOnEdt(target)
         try {
@@ -160,7 +158,7 @@ class SyntheticInputParityTest {
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `modifier mask appears on the held key and does not leak to the next key`() {
-        assumeFalse(GraphicsEnvironment.isHeadless())
+        assumeLiveAwtAvailable()
         val target = JPanel().apply { preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX) }
         val frame = showFrameOnEdt(target)
         // Use a global AWT event listener instead of relying on focus transfer to the JPanel:
@@ -205,8 +203,8 @@ class SyntheticInputParityTest {
 
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
-    fun `typeText through the synthetic driver isolates and restores the fake clipboard`() {
-        assumeFalse(GraphicsEnvironment.isHeadless())
+    fun `pasteText through the synthetic driver isolates and restores the fake clipboard`() {
+        assumeLiveAwtAvailable()
         val target = JPanel().apply { preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX) }
         val frame = showFrameOnEdt(target)
         // See modifier test: a global AWT key listener avoids brittle focus-transfer assumptions
@@ -223,10 +221,10 @@ class SyntheticInputParityTest {
                     clipboard = fakeClipboard,
                     tccGuard = MacOsTccGuard.noop(),
                 )
-            runBlocking { driver.typeText("hello") }
+            runBlocking { driver.pasteText("hello") }
             drainEdt()
 
-            // Clipboard contents restored to the pre-typeText state.
+            // Clipboard contents restored to the pre-pasteText state.
             val restored =
                 fakeClipboard.getContents()?.getTransferData(DataFlavor.stringFlavor) as? String
             assertEquals("existing", restored, "expected clipboard contents to be restored")
@@ -269,7 +267,7 @@ class SyntheticInputParityTest {
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `synthetic screenshot returns the requested dimensions and samples the rendered colour`() {
-        assumeFalse(GraphicsEnvironment.isHeadless())
+        assumeLiveAwtAvailable()
         val target = ColoredPanel(Color.RED)
         val frame = showFrameOnEdt(target)
         try {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputTest.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.core
 
 import java.awt.BorderLayout
 import java.awt.Dimension
+import java.awt.event.KeyEvent
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.util.concurrent.CountDownLatch
@@ -9,12 +10,27 @@ import java.util.concurrent.TimeUnit
 import javax.swing.JFrame
 import javax.swing.JPanel
 import javax.swing.SwingUtilities
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 
 class SyntheticInputTest {
+
+    @Test
+    fun `synthetic key char mapping covers RobotDriver typeText punctuation`() {
+        assertEquals('-', keyCharFor(KeyEvent.VK_MINUS))
+        assertEquals('_', keyCharFor(KeyEvent.VK_MINUS, shift = true))
+        assertEquals('=', keyCharFor(KeyEvent.VK_EQUALS))
+        assertEquals('+', keyCharFor(KeyEvent.VK_EQUALS, shift = true))
+        assertEquals('[', keyCharFor(KeyEvent.VK_OPEN_BRACKET))
+        assertEquals('{', keyCharFor(KeyEvent.VK_OPEN_BRACKET, shift = true))
+        assertEquals(';', keyCharFor(KeyEvent.VK_SEMICOLON))
+        assertEquals(':', keyCharFor(KeyEvent.VK_SEMICOLON, shift = true))
+        assertEquals('.', keyCharFor(KeyEvent.VK_PERIOD))
+        assertEquals('?', keyCharFor(KeyEvent.VK_SLASH, shift = true))
+    }
 
     /**
      * Regression test for the EDT deadlock between [RobotDriver]'s `runOffEdt` and the synthetic

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputTest.kt
@@ -2,7 +2,6 @@ package dev.sebastiano.spectre.core
 
 import java.awt.BorderLayout
 import java.awt.Dimension
-import java.awt.GraphicsEnvironment
 import java.awt.event.MouseAdapter
 import java.awt.event.MouseEvent
 import java.util.concurrent.CountDownLatch
@@ -12,7 +11,6 @@ import javax.swing.JPanel
 import javax.swing.SwingUtilities
 import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Timeout
 
@@ -45,7 +43,7 @@ class SyntheticInputTest {
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `click from EDT does not deadlock with synthetic adapter`() {
-        assumeFalse(GraphicsEnvironment.isHeadless())
+        assumeLiveAwtAvailable()
 
         val frame = createTestFrame()
         try {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import org.junit.jupiter.api.condition.EnabledIf
 
-@EnabledIf("isNotHeadless")
+@EnabledIf("liveAwtAvailable")
 class TrackedWindowTest {
 
     @Test
@@ -71,6 +71,9 @@ class TrackedWindowTest {
 
     companion object {
 
-        @JvmStatic fun isNotHeadless(): Boolean = !GraphicsEnvironment.isHeadless()
+        @JvmStatic
+        fun liveAwtAvailable(): Boolean =
+            !GraphicsEnvironment.isHeadless() &&
+                (!detectMacOs() || System.getProperty("spectre.test.liveAwt").toBoolean())
     }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForIdleTest.kt
@@ -214,6 +214,7 @@ class WaitForIdleTest {
 
     @Test
     fun `waitForIdle rejects EDT callers with a curated error`() {
+        assumeLiveAwtAvailable()
         val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
         val errorRef = java.util.concurrent.atomic.AtomicReference<Throwable?>()
         javax.swing.SwingUtilities.invokeAndWait {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForNodeTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForNodeTest.kt
@@ -32,6 +32,7 @@ class WaitForNodeTest {
         // Argument validation must run BEFORE the EDT check. An EDT caller passing
         // (null, null) is doing two things wrong; surfacing the input error first keeps
         // the diagnostic actionable instead of redirecting users to the EDT story.
+        assumeLiveAwtAvailable()
         val automator = headlessAutomator()
         val errorRef = AtomicReference<Throwable?>()
         SwingUtilities.invokeAndWait {
@@ -47,6 +48,7 @@ class WaitForNodeTest {
 
     @Test
     fun `waitForNode rejects EDT callers with valid arguments`() {
+        assumeLiveAwtAvailable()
         val automator = headlessAutomator()
         val errorRef = AtomicReference<Throwable?>()
         SwingUtilities.invokeAndWait {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
@@ -141,6 +141,7 @@ class WaitForVisualIdleTest {
 
     @Test
     fun `waitForVisualIdle rejects EDT callers with a curated error`() {
+        assumeLiveAwtAvailable()
         val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
         val errorRef = java.util.concurrent.atomic.AtomicReference<Throwable?>()
         javax.swing.SwingUtilities.invokeAndWait {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowTrackerTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowTrackerTest.kt
@@ -3,7 +3,6 @@ package dev.sebastiano.spectre.core
 import java.awt.Container
 import java.awt.GraphicsEnvironment
 import javax.swing.JFrame
-import javax.swing.JPanel
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -11,11 +10,11 @@ import org.junit.jupiter.api.condition.EnabledIf
 
 class WindowTrackerTest {
 
-    @EnabledIf("isNotHeadless")
+    @EnabledIf("liveAwtAvailable")
     @Test
     fun `findComposePanels returns empty for plain Swing container`() {
         val frame = JFrame()
-        val panel = JPanel()
+        val panel = Container()
         frame.contentPane.add(panel)
         val result = findComposePanels(frame.contentPane as Container)
         assertTrue(result.isEmpty())
@@ -24,16 +23,16 @@ class WindowTrackerTest {
 
     @Test
     fun `findComposePanels returns empty for empty container`() {
-        val panel = JPanel()
+        val panel = Container()
         val result = findComposePanels(panel)
         assertTrue(result.isEmpty())
     }
 
     @Test
     fun `findComposePanels searches nested containers`() {
-        val root = JPanel()
-        val child = JPanel()
-        val grandchild = JPanel()
+        val root = Container()
+        val child = Container()
+        val grandchild = Container()
         child.add(grandchild)
         root.add(child)
         val result = findComposePanels(root)
@@ -42,6 +41,9 @@ class WindowTrackerTest {
 
     companion object {
 
-        @JvmStatic fun isNotHeadless(): Boolean = !GraphicsEnvironment.isHeadless()
+        @JvmStatic
+        fun liveAwtAvailable(): Boolean =
+            !GraphicsEnvironment.isHeadless() &&
+                (!detectMacOs() || System.getProperty("spectre.test.liveAwt").toBoolean())
     }
 }

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -76,10 +76,10 @@ When in doubt, grep the source. `findOneByContentDescription` doesn't exist;
 
 ### Imports in samples
 
-Show the imports the sample actually needs, including extension-function imports. The
-`RobotDriver.synthetic(...)` and `Frame.asTitledWindow()` paths require explicit
-imports because they're companion/member extensions — leave those imports out and
-the sample doesn't compile.
+Show the imports the sample actually needs, including extension-function imports.
+`Frame.asTitledWindow()` is an extension and requires an explicit import.
+`RobotDriver.synthetic(...)` is a real companion function and needs only the
+`RobotDriver` import.
 
 ### Default arguments and named parameters
 
@@ -109,11 +109,12 @@ corresponding doc page is touched:
   node.
 - **`AutomatorIdlingResource.isIdleNow` and `diagnosticMessage()`.** Not `isIdle()`,
   not `name`. Identity-based register/unregister.
-- **`AutoRecorder` routes Wayland first.** Then `window == null`, then macOS SCK,
-  then Windows title-based, then ffmpeg region as fallback. Wayland never falls
-  through to `x11grab`.
+- **`AutoRecorder` has explicit capture modes.** `startWindow(...)` uses true
+  window-targeted backends and fails loudly if unavailable. `startRegion(...)` uses
+  region capture backends and fails loudly if unavailable. Do not document silent
+  fallback between the two modes.
 - **`TitledWindow` is an interface.** Production adapter is `Frame.asTitledWindow()`.
-  Tests provide minimal `TitledWindow` implementations.
+  Tests provide minimal `TitledWindow` implementations with title and bounds.
 - **`installSpectreRoutes` is engine-agnostic.** The `server` module deliberately
   doesn't bundle Netty/CIO/Jetty — consumers add the engine themselves.
 - **`HttpComposeAutomator.DEFAULT_PORT` is `9274`.** That's the *client* default;
@@ -125,9 +126,10 @@ corresponding doc page is touched:
   clipboard, and screenshot call raises `UnsupportedOperationException` so accidental
   real-I/O calls fail at the call site. `WindowTracker`/`SemanticsReader` are
   untouched, so semantics-tree reads still work.
-- **`typeText` is always clipboard-paste.** It writes the text, dispatches the
-  platform paste shortcut, drains, then restores the previous clipboard contents.
-  No per-key fallback.
+- **`typeText` is key-event typing; `pasteText` is clipboard-paste.** `typeText`
+  supports conservative ASCII key-event input without touching the clipboard. `pasteText`
+  writes the text, dispatches the platform paste shortcut, drains, then restores the
+  previous clipboard contents.
 - **Linux Wayland + `LinuxX11Grab` throws.** It does not silently produce black
   frames. The thrown message points users at `AutoRecorder`/`WaylandPortalRecorder`.
 

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -78,9 +78,9 @@ failure modes, and the section below
   `_GTK_FRAME_EXTENTS` (older Mutter, non-GTK CSD, server-side decorations like KDE
   Plasma's default), or the call to `WaylandPortalWindowRecorder.start` is given a
   `TitledWindow` with a null/blank title, the recorder throws `IllegalStateException`
-  rather than producing a silently-misaligned recording. The fallback is to use
-  `WaylandPortalRecorder` (region capture) — pass `window = null` to
-  `AutoRecorder.start` and the router selects it automatically.
+  rather than producing a silently-misaligned recording. The fallback is explicit
+  region capture: call `AutoRecorder.startRegion(...)`, or instantiate
+  `WaylandPortalRecorder` directly.
 
   Validated end-to-end on Ubuntu 22.04/GNOME 42/mutter, Ubuntu 24.04/GNOME 46/mutter, and
   Ubuntu 26.04/GNOME 50/mutter (real-pixel mp4 with the smoke runner, 2026-05-02 and
@@ -118,14 +118,14 @@ failure modes, and the section below
   not follow a window. Use `ScreenCaptureKitRecorder` (macOS) or `FfmpegWindowRecorder`
   (Windows) when you have a top-level window to target — the next section covers what
   the window-targeted backends do differently.
-- **Embedded `ComposePanel` surfaces without an adaptable top-level `Frame` fall
-  through to region capture.**
-  `AutoRecorder.start(window: TitledWindow?, region: Rectangle, …)` picks window-targeted
-  capture only when `window` is non-null and (on Windows) has a non-blank title. The
-  `Frame.asTitledWindow()` adapter exposes that title for any top-level `Frame`,
-  including `ComposeWindow` and `JFrame` hosts. A panel embedded inside an IntelliJ
-  tool window or a `SwingPanel` host inside Compose has no separate titled `Frame` to
-  adapt — callers pass `window = null` and get the region path. Practical
+- **Embedded `ComposePanel` surfaces without an adaptable top-level `Frame` need explicit
+  region capture.**
+  `AutoRecorder.startWindow(...)` uses window-targeted capture only and fails loudly when
+  no true window target is available. The `Frame.asTitledWindow()` adapter exposes the
+  title and bounds for any top-level `Frame`, including `ComposeWindow` and `JFrame`
+  hosts. A panel embedded inside an IntelliJ tool window or a `SwingPanel` host inside
+  Compose has no separate titled `Frame` to adapt — callers use
+  `AutoRecorder.startRegion(...)`. Practical
   consequences:
   - Anything that visually overlaps the panel — other windows, the menu bar, OS notifications, a
     floating popup that escapes the panel's bounds — appears in the recording.
@@ -139,7 +139,7 @@ failure modes, and the section below
 These limitations are specific to the region path; the window-targeted backends below
 solve them.
 
-- **Window movement isn't followed.** Move the host window after `start(...)` and the
+- **Window movement isn't followed.** Move the host window after `startRegion(...)` and the
   recording keeps capturing the original screen rectangle. Stop and restart to follow
   the new position.
 - **Popups that escape the captured region are clipped.** Compose Desktop's `OnWindow`

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -45,7 +45,7 @@ out of scope.
 | Capability | Surface | Default exposure |
 | --- | --- | --- |
 | Move mouse / press keys | `RobotDriver.click`, `swipe`, `pressKey`, `scrollWheel` | In-process; trusted-local HTTP via `/spectre/click` |
-| Modify clipboard | `RobotDriver.typeText` (save / set / paste / restore) | In-process; trusted-local HTTP via `/spectre/typeText` |
+| Modify clipboard | `RobotDriver.pasteText` (save / set / paste / restore) | In-process |
 | Capture pixels | `RobotDriver.screenshot(region)` — **captures any rectangle of the virtual desktop**, not just the app under test | In-process; trusted-local HTTP via `/spectre/screenshot` |
 | Record video | `AutoRecorder`, `FfmpegRecorder`, `ScreenCaptureKitRecorder`, `WaylandPortalRecorder` | In-process only |
 | Execute a helper binary | `HelperBinaryExtractor` (SCK), `WaylandHelperBinaryExtractor` | Local file system, JVM process |
@@ -100,7 +100,7 @@ expansion); items that are hygiene fixes get their own issues.
 - **Recording output-path validation.** Spectre passes the caller-supplied output path
   through to ffmpeg / the helpers without rejecting `/dev/`, `/proc/`, symlinks, or
   not-yet-existing parents. Standalone follow-up issue, separate from #96.
-- **`typeText` clipboard-restore robustness.** A failure during the post-paste restore is
+- **`pasteText` clipboard-restore robustness.** A failure during the post-paste restore is
   swallowed via `runCatching` (clipboard may be left holding the typed text). Standalone
   follow-up issue.
 - **Helper-extraction cleanup.** Extracted helper binaries are not `deleteOnExit`-registered.

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -71,7 +71,7 @@ The API is split into two layers:
   yourself if you want one.) These do a single read against the current semantics state
   and return what they see.
 - **Interactions** — `click`, `doubleClick`, `longClick`, `swipe`, `scrollWheel`,
-  `typeText`, `clearAndTypeText`, `pressKey`, `pressEnter`, `screenshot`. These dispatch
+  `typeText`, `pasteText`, `clearAndTypeText`, `pressKey`, `pressEnter`, `screenshot`. These dispatch
   input via `RobotDriver` (or capture pixels).
 
 The split matters because **queries do not auto-wait**. If you call `findOneByTestTag(...)`
@@ -128,8 +128,7 @@ real OS-level input. That's what end users actually do, so it's the most realist
 
 The trade-off is that real OS input fights for global focus. Two parallel test JVMs
 clicking at the same time will collide. For that case `RobotDriver.synthetic(rootWindow)`
-(a companion extension function in the `dev.sebastiano.spectre.core` package) dispatches
-AWT events directly into the target window's event queue:
+dispatches AWT events directly into the target window's event queue:
 
 - No real cursor moves, no keyboard focus stolen.
 - Tests in parallel processes can run without coordinating focus.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -57,7 +57,7 @@ description, or role — see [Finding nodes](selectors.md).
         val automatorExt = ComposeAutomatorExtension()
 
         @Test
-        fun `clicking increment bumps the counter`() = runBlocking {
+        fun `clicking increment bumps the counter`(): Unit = runBlocking {
             launchCounterApp() // your harness — opens the Compose window
 
             val automator = automatorExt.automator
@@ -94,7 +94,7 @@ description, or role — see [Finding nodes](selectors.md).
         val automatorRule = ComposeAutomatorRule()
 
         @Test
-        fun clickingIncrementBumpsTheCounter() = runBlocking {
+        fun clickingIncrementBumpsTheCounter(): Unit = runBlocking {
             launchCounterApp()
 
             val automator = automatorRule.automator
@@ -132,7 +132,7 @@ description, or role — see [Finding nodes](selectors.md).
   dispatches a real mouse click via `java.awt.Robot`, and only hops to `Dispatchers.IO`
   when the call originates on the AWT event dispatch thread.
 
-All interaction methods (`click`, `doubleClick`, `swipe`, `typeText`, …) and all wait
+All interaction methods (`click`, `doubleClick`, `swipe`, `typeText`, `pasteText`, …) and all wait
 helpers (`waitForNode`, `waitForIdle`, `waitForVisualIdle`) are `suspend`, so the test
 body runs inside `runBlocking { … }`. JUnit test methods don't run on the AWT event
 dispatch thread, so no extra `withContext` is needed here. If you ever call wait helpers
@@ -140,11 +140,18 @@ from a coroutine on `Dispatchers.Main` (Swing EDT), wrap them in
 `withContext(Dispatchers.Default)` — they reject EDT callers at runtime. See
 [Synchronization](synchronization.md).
 
+!!! warning "Force JUnit expression-body tests to return `Unit`"
+    In JUnit 5.14 and newer, `@Test` methods whose JVM return type is not `void` are
+    rejected during discovery. Kotlin expression-body tests infer their return type from
+    the last expression inside `runBlocking { ... }`; assertions such as `assertNotNull`
+    return the asserted value, not `Unit`. Write `fun mySpec(): Unit = runBlocking { ... }`
+    so the JVM signature stays `void` regardless of the last assertion.
+
 !!! warning "Use `runBlocking`, not `runTest`"
     `runTest` from `kotlinx-coroutines-test` controls time via a virtual scheduler and
     skips `delay()` calls, advancing the clock instantly. Spectre uses `delay` internally
     for timing-sensitive operations — `longClick` hold durations, `swipe` step pacing, and
-    clipboard-settle polling in `typeText` — so running under `runTest` silently collapses
+    clipboard-settle polling in `pasteText` — so running under `runTest` silently collapses
     those pauses to zero. The result is that `longClick` doesn't actually hold, `swipe`
     jumps to the end position instantly, and clipboard operations may race.
 

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -20,7 +20,6 @@ import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.wm.WindowManager
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.synthetic
 
 class RunSpectreAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
@@ -245,9 +244,9 @@ A few things to know about IDE-hosted Compose surfaces:
   three options:
 
     1. **Region-capture the tool window's screen bounds.** Compute the tool window
-       component's `boundsOnScreen` and pass it as the `region` argument with
-       `window = null`. `AutoRecorder` routes that through `ffmpeg` region capture
-       (or the Wayland portal on Linux Wayland). Works everywhere; the trade-off is
+       component's `boundsOnScreen` and pass it to `AutoRecorder.startRegion(...)`.
+       `AutoRecorder` routes that through `ffmpeg` region capture (or the Wayland
+       portal on Linux Wayland). Works everywhere; the trade-off is
        that anything overlapping the captured rectangle — the IDE's chrome,
        notifications, popups that escape the tool window's bounds — appears in the
        recording.

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -67,8 +67,11 @@ val input = automator.findOneByTestTag("MessageInput") ?: error("input missing")
 automator.click(input)
 automator.typeText("Hello, Spectre!")
 
-// click-clear-type in one go (uses clipboard paste under the hood for speed)
+// click-clear-type in one go (uses key events, not the clipboard)
 automator.clearAndTypeText(input, "replacement text")
+
+// clipboard paste for large or Unicode text
+automator.pasteText("こんにちは, Spectre!")
 
 // raw key events
 automator.pressKey(KeyEvent.VK_TAB)
@@ -82,13 +85,14 @@ automator.pressEnter()
 `InputEvent.SHIFT_DOWN_MASK`, …) — not a `KeyEvent` constant. The driver translates the
 mask into the right modifier-key presses around the main `keyCode`.
 
-`typeText` always works through the system clipboard: it stashes the previous clipboard
-contents, writes the requested text, dispatches the platform paste shortcut
-(<kbd>Cmd</kbd>+<kbd>V</kbd> on macOS, <kbd>Ctrl</kbd>+<kbd>V</kbd> elsewhere), waits for
-the paste handler to drain, then restores the previous clipboard contents. It does not
-fall back to per-key dispatch, so `typeText` works for any text the system clipboard can
-carry — non-ASCII included. See [Troubleshooting](troubleshooting.md) for the
-platform-specific quirks.
+`typeText` dispatches key press/release pairs and does not touch the clipboard. It is
+intentionally conservative: ASCII letters, digits, space, newline, and common
+US-keyboard punctuation. Use `pasteText` for large strings or arbitrary Unicode; it
+stashes the previous clipboard contents, writes the requested text, dispatches the
+platform paste shortcut (<kbd>Cmd</kbd>+<kbd>V</kbd> on macOS,
+<kbd>Ctrl</kbd>+<kbd>V</kbd> elsewhere), waits for the paste handler to drain, then
+restores the previous clipboard contents. See [Troubleshooting](troubleshooting.md) for
+macOS clipboard and `apple.awt.UIElement=true` caveats.
 
 ## Screenshots
 
@@ -165,8 +169,7 @@ public surface:
   `GraphicsDevice`).
 - **`RobotDriver.synthetic(rootWindow)`** — synthetic AWT events posted straight into the
   target window's event queue. No real cursor motion, no global focus, doesn't fight with
-  other processes. `synthetic` is a companion extension function in the
-  `dev.sebastiano.spectre.core` package, so it needs an explicit import.
+  other processes.
   `screenshot()` under a synthetic driver also bypasses the OS framebuffer — it renders
   the target window via `Component.paint(Graphics)` into a `BufferedImage` instead of
   calling `Robot.createScreenCapture`. Results are consistent for regression tests, but
@@ -185,8 +188,6 @@ Pass a non-default driver via the `inProcess` factory:
 ```kotlin
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.synthetic
-
 val automator = ComposeAutomator.inProcess(
     robotDriver = RobotDriver.synthetic(rootWindow = composeWindow),
 )

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -52,6 +52,12 @@ class MyTest {
     `automatorExt.automator` accessor returns the most recently created instance and is
     fine for sequential runs but races under parallel execution.
 
+!!! warning "Expression-body tests should declare `: Unit`"
+    JUnit 5.14 and newer reject `@Test` methods whose JVM return type is not `void`.
+    Kotlin expression-body tests infer the return type from the last expression in the
+    `runBlocking { ... }` body; some assertions, including `assertNotNull`, return the
+    asserted value. Prefer `fun mySpec(): Unit = runBlocking { ... }` for Spectre tests.
+
 ## JUnit 4: `ComposeAutomatorRule`
 
 ```kotlin
@@ -75,6 +81,78 @@ class MyTest {
 `@get:Rule` (note the `get:` prefix) targets the annotation at the property's generated
 getter, which is what JUnit 4 reflects on. Without the `get:` prefix Kotlin would put
 the annotation on the property itself and JUnit wouldn't see it.
+
+## Launching a Compose window from a test
+
+`application { Window(...) { ... } }` blocks until the app exits, so do not call it
+inline from `@BeforeAll`. Start the Compose application loop on a daemon thread, disable
+`exitProcessOnExit`, capture `exitApplication` for cleanup, and capture the
+`ComposeWindow` from inside the `Window` content scope:
+
+```kotlin
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.window.application
+import androidx.compose.ui.window.Window
+import androidx.compose.ui.awt.ComposeWindow
+import java.util.concurrent.atomic.AtomicReference
+
+internal class SpectreTestWindow(
+    private val title: String,
+    private val content: @Composable () -> Unit,
+) {
+    @Volatile private var exitFn: (() -> Unit)? = null
+    private val windowRef = AtomicReference<ComposeWindow?>()
+
+    fun start() {
+        Thread({
+            application(exitProcessOnExit = false) {
+                exitFn = ::exitApplication
+                Window(onCloseRequest = ::exitApplication, title = title) {
+                    windowRef.compareAndSet(null, window)
+                    content()
+                }
+            }
+        }, "$title-window").apply {
+            isDaemon = true
+            start()
+        }
+    }
+
+    fun stop() {
+        exitFn?.invoke()
+    }
+
+    fun awaitWindow(timeoutMs: Long = 30_000): ComposeWindow {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            windowRef.get()?.let { return it }
+            Thread.sleep(50)
+        }
+        error("ComposeWindow for '$title' was not captured within ${timeoutMs}ms")
+    }
+}
+```
+
+Use the returned `ComposeWindow` when constructing
+`RobotDriver.synthetic(rootWindow = window)` or when adapting the window for recording.
+
+## Test JVM requirements
+
+Spectre tests that drive a real Compose window need a non-headless JVM. If your default
+`Test` task sets `java.awt.headless=true`, move Spectre tests to a separate task and
+force that task to run with `java.awt.headless=false`:
+
+```kotlin
+val spectreTest by tasks.registering(Test::class) {
+    description = "Runs live Compose Desktop UI tests with Spectre."
+    group = "verification"
+    useJUnitPlatform()
+    systemProperty("java.awt.headless", "false")
+}
+```
+
+Use `RobotDriver.headless()` only for read-only semantics-tree tests. It throws on
+input, clipboard, and screenshot calls by design.
 
 ## Custom `AutomatorFactory`
 

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -66,9 +66,8 @@ import java.awt.Rectangle
 import java.nio.file.Path
 
 val recorder = AutoRecorder()
-val handle = recorder.start(
+val handle = recorder.startWindow(
     window = composeWindow.asTitledWindow(), // any java.awt.Frame works
-    region = Rectangle(100, 100, 800, 600),
     output = Path.of("build/recordings/my-test.mp4"),
     options = RecordingOptions(),
 )
@@ -82,6 +81,21 @@ try {
 
 `TitledWindow` is an interface. The production adapter is the `Frame.asTitledWindow()`
 extension shown above; tests typically wire a small in-memory implementation.
+
+Use `startRegion(...)` when you want an explicit screen rectangle instead of a
+window-targeted source:
+
+```kotlin
+val handle = recorder.startRegion(
+    region = Rectangle(100, 100, 800, 600),
+    output = Path.of("build/recordings/my-test.mp4"),
+    options = RecordingOptions(),
+)
+```
+
+The two paths do not silently fall back to each other. If `startWindow(...)` cannot use
+a true window-targeted backend on the current platform, it throws with remediation
+guidance; call `startRegion(...)` explicitly if region capture semantics are acceptable.
 
 The routing is platform-keyed. Read the row that matches your OS:
 
@@ -127,8 +141,7 @@ A few details worth knowing:
   package on minimal images. If `xprop` isn't available or the window's WM doesn't
   publish `_GTK_FRAME_EXTENTS` (older Mutter, non-GTK CSD, KDE / sway with server-side
   decorations), the recorder throws `IllegalStateException` rather than producing a
-  misaligned mp4. Fall back to `WaylandPortalRecorder` (region capture) — pass
-  `window = null` and the router selects it automatically. See
+  misaligned mp4. Use explicit region capture instead by calling `startRegion(...)`. See
   [Recording limitations](../RECORDING-LIMITATIONS.md#platform) for more.
 
 ## Lower-level backends
@@ -192,7 +205,7 @@ pitfalls, audio support) see [Recording limitations](../RECORDING-LIMITATIONS.md
 test fails before reaching the stop call, wrap the recording in `try`/`finally`:
 
 ```kotlin
-val handle = recorder.start(/* ... */)
+val handle = recorder.startWindow(/* ... */)
 try {
     // test body
 } finally {

--- a/docs/guide/selectors.md
+++ b/docs/guide/selectors.md
@@ -127,3 +127,7 @@ println(automator.printTree())
 You'll see every window, every node, and the test tags, text, and roles attached to them.
 This is usually the fastest way to find out whether the node simply isn't where you
 think it is, or hasn't been composed yet.
+
+If `printTree()` returns an empty string, the composition probably crashed before any
+node registered. Check the test JVM's stderr for exceptions from the EDT or composition
+thread; those exceptions do not always propagate to the test method.

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -23,7 +23,7 @@ needed:
 
 ```kotlin
 @Test
-fun mySpec() = runBlocking {
+fun mySpec(): Unit = runBlocking {
     launchApp()
     automator.waitForNode(tag = "Root")
     // ...your test body
@@ -34,6 +34,14 @@ If you call any wait helper from the EDT you'll get a clear `IllegalStateExcepti
 rather than a deadlock. The fix in that case is `withContext(Dispatchers.Default)`
 around the offending call — see
 [Troubleshooting](troubleshooting.md#i-called-a-wait-helper-from-the-edt).
+
+## JUnit expression-body return types
+
+When you write Spectre tests as `fun mySpec(): Unit = runBlocking { ... }`, the explicit
+`: Unit` matters. JUnit 5.14 and newer reject `@Test` methods whose JVM return type is
+not `void`, and Kotlin expression-body functions infer their return type from the last
+expression in the body. Some assertion helpers return the asserted value, not `Unit`, so
+omitting `: Unit` can make a test compile but disappear at discovery time.
 
 ## `waitForNode`
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -44,6 +44,9 @@ In order of likelihood:
    `waitForIdle()`/`waitForVisualIdle()` after the click or type.
 4. **The selector doesn't match.** Run `println(automator.printTree())` and check the
    actual test tags/text/role. Localised text is the usual culprit.
+5. **The tree is empty.** If `printTree()` returns `""`, the composition probably
+   crashed before any node registered. Check the test JVM's stderr for exceptions from
+   the EDT or composition thread; they do not always propagate to the test method.
 
 ## "Tests fight over OS focus when run in parallel"
 
@@ -55,7 +58,6 @@ Use synthetic input:
 ```kotlin
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.synthetic
 
 val automator = ComposeAutomator.inProcess(
     robotDriver = RobotDriver.synthetic(rootWindow = composeWindow),
@@ -67,12 +69,14 @@ global focus, no cursor motion. The trade-off is that some interactions (system-
 shortcuts, real OS drag-and-drop) won't behave the same way. See
 [Driving input](interactions.md#real-vs-synthetic-input).
 
-## "`typeText` didn't reach my field"
+## "`typeText` or `pasteText` didn't reach my field"
 
-`typeText` writes to the system clipboard, dispatches the platform paste shortcut
-(<kbd>Cmd</kbd>+<kbd>V</kbd> on macOS, <kbd>Ctrl</kbd>+<kbd>V</kbd> elsewhere), waits
-for the paste to land, and restores the previous clipboard contents. A few failure
-modes follow from that:
+`typeText` dispatches key press/release pairs and avoids the clipboard. It supports
+ASCII letters, digits, space, newline, and common US-keyboard punctuation. Use
+`pasteText` for arbitrary Unicode or large text: it writes to the system clipboard,
+dispatches the platform paste shortcut (<kbd>Cmd</kbd>+<kbd>V</kbd> on macOS,
+<kbd>Ctrl</kbd>+<kbd>V</kbd> elsewhere), waits for the paste to land, and restores the
+previous clipboard contents. A few failure modes follow from those contracts:
 
 - **Nothing has focus.** `typeText` types into whatever the focused component is. If
   your test never clicked into the field — or the click landed on something else,
@@ -82,15 +86,20 @@ modes follow from that:
 - **The field doesn't accept paste.** Some Compose components (and any read-only
   text field) ignore the system paste shortcut. Verify the field accepts pasted
   input outside the test before assuming Spectre is at fault.
+- **macOS `apple.awt.UIElement=true`.** UI-element/helper mode can break clipboard
+  paste even when you use `RobotDriver.synthetic(rootWindow = ...)`: the field may be
+  focused and the paste shortcut may be delivered, but Compose reads stale or empty
+  clipboard contents. Disable `apple.awt.UIElement=true` for the JVM hosting the test
+  window when you need `pasteText`, or use `typeText` for supported ASCII input.
 - **macOS pasteboard race.** macOS's `NSPasteboard` writes are asynchronous, so
   Spectre polls the clipboard until it reads back the requested text before
   dispatching <kbd>Cmd</kbd>+<kbd>V</kbd>. If your environment has a clipboard
   manager or another process actively rewriting the clipboard, the poll can time
   out and the paste lands stale. Disable clipboard managers in the test
   environment.
-- **`RobotDriver.headless()` throws on `typeText`.** It throws on every input,
-  clipboard, and screenshot call by design (see [Driving input](interactions.md#real-vs-synthetic-input)),
-  so `typeText` against a headless driver surfaces an `UnsupportedOperationException`
+- **`RobotDriver.headless()` throws on `typeText` and `pasteText`.** It throws on every
+  input, clipboard, and screenshot call by design (see [Driving input](interactions.md#real-vs-synthetic-input)),
+  so text entry against a headless driver surfaces an `UnsupportedOperationException`
   at the call site rather than silently dropping. Use `RobotDriver.synthetic(rootWindow)`
   or the default `RobotDriver()` for any real-input scenario.
 - **Compose's paste action runs on its own dispatcher.** After the keystroke,
@@ -101,7 +110,23 @@ modes follow from that:
 
 Use `pressKey(...)` for individual key events (modifier shortcuts, navigation keys,
 `<kbd>Tab</kbd>`, `<kbd>Esc</kbd>`) — those go through the AWT key map, not the
-clipboard, so none of the above applies.
+clipboard, so none of the paste-specific caveats apply.
+
+## "The JVM is headless"
+
+Spectre input and screenshots need AWT. If the JVM is launched with
+`-Djava.awt.headless=true`, real `RobotDriver()` cannot drive the window, and synthetic
+input still needs a real AWT window hierarchy to dispatch into. Move live Spectre tests
+to a non-headless test task (`systemProperty("java.awt.headless", "false")`). Use
+`RobotDriver.headless()` only for read-only semantics-tree checks.
+
+## "The test hangs behind a Swing Error dialog"
+
+A modal Swing dialog with text such as `Error: No Component provided` usually means the
+UI library threw an uncaught composition exception and JBR surfaced it as a blocking
+`JOptionPane`. Check stderr for the real exception and make sure required
+`CompositionLocal`s are provided. For Jewel standalone windows, use Jewel's window
+wrapper when your UI reads Jewel locals such as `LocalComponent`.
 
 ## "Captured screenshot pixels look slightly off"
 
@@ -175,10 +200,11 @@ See [Recording limitations](../RECORDING-LIMITATIONS.md) for the full Wayland st
   parent app — not just the JVM child. macOS only picks up the new entitlement on
   process start.
 - **The SCK helper isn't bundled.** If you built `recording` on a non-macOS host and
-  shipped the jar to macOS, the bundled Swift helper isn't present and `AutoRecorder`
-  will fall back to `ffmpeg` region capture with a warning on stderr. To fix, build on
-  macOS, or run `:recording:assembleScreenCaptureKitHelper` (optionally with
-  `-PuniversalHelper`).
+  shipped the jar to macOS, the bundled Swift helper isn't present and
+  `AutoRecorder.startWindow(...)` throws instead of silently switching capture modes. To
+  fix, build on macOS, or run `:recording:assembleScreenCaptureKitHelper` (optionally
+  with `-PuniversalHelper`). Use `startRegion(...)` explicitly if region capture is an
+  acceptable fallback for your test.
 - **Operational SCK errors propagate.** Permission denied, target window not found,
   helper crashed during init — these all throw `IllegalStateException` rather than
   silently falling back, so you see the real cause.

--- a/recording/api/recording.api
+++ b/recording/api/recording.api
@@ -6,8 +6,10 @@ public final class dev/sebastiano/spectre/recording/AutoRecorder {
 	public static final fun defaultIsWayland ()Z
 	public static final fun defaultIsWindows ()Z
 	public static final fun defaultWindowsWindowRecorder ()Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;
-	public final fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;J)Ldev/sebastiano/spectre/recording/RecordingHandle;
-	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;JILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public final fun startRegion (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun startRegion$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public final fun startWindow (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;J)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun startWindow$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;JILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public final class dev/sebastiano/spectre/recording/FfmpegRecorder : dev/sebastiano/spectre/recording/Recorder {
@@ -140,6 +142,7 @@ public abstract interface class dev/sebastiano/spectre/recording/screencaptureki
 }
 
 public abstract interface class dev/sebastiano/spectre/recording/screencapturekit/TitledWindow {
+	public abstract fun getBounds ()Ljava/awt/Rectangle;
 	public abstract fun getTitle ()Ljava/lang/String;
 	public abstract fun setTitle (Ljava/lang/String;)V
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -11,53 +11,18 @@ import dev.sebastiano.spectre.recording.screencapturekit.WindowRecorder
 import java.awt.Rectangle
 import java.lang.ProcessHandle
 import java.nio.file.Path
-import java.util.concurrent.atomic.AtomicBoolean
 
 /**
- * High-level recorder that picks between window-targeted capture and region-based ffmpeg capture
- * per call, so callers don't have to know which backend is appropriate.
+ * High-level recorder with explicit capture modes.
  *
- * Routing logic (in order):
- * 1. Linux Wayland session (detected via env / runtime-dir signals; see
- *    [FfmpegBackend.detectWaylandSession]) — handled BEFORE the window-null check below because
- *    `LinuxX11Grab` throws on Wayland and can't be a fallback. Sub-routing:
- *     - `window != null` AND [waylandPortalWindowRecorder] wired (#85) → window-targeted portal
- *       recorder. Uses `SourceType.WINDOW`: the dialog asks the user to pick a specific window and
- *       the granted PipeWire stream contains only that window's pixels (no leakage from occluding
- *       apps). The helper still crops to the JVM-supplied `region` (the window's bounds at start),
- *       so the mp4 dimensions match the window's pixel size.
- *     - Otherwise (`window == null`, OR no window-targeted recorder wired) AND
- *       [waylandPortalRecorder] wired → region-targeted portal recorder. Uses `SourceType.MONITOR`:
- *       the dialog asks the user to pick a monitor, and the helper crops the monitor stream to
- *       [region]. This is the embedded `ComposePanel` path and the backwards-compatible fallback
- *       for callers from before #85.
- *     - Neither portal recorder wired → falls through to ffmpeg, which fails fast on Wayland. Both
- *       portal paths pop a compositor permission dialog on first call within a session and reuse
- *       the grant via the portal's `restore_token` afterwards. See [WaylandPortalRecorder].
- * 2. `window == null` → ffmpeg region capture. Caller doesn't have a window in mind, or is
- *    capturing an embedded `ComposePanel` where there's no top-level window to target.
- * 3. macOS host with a window → SCK ([WindowRecorder]). If SCK fails because the helper isn't
- *    bundled (e.g. a jar built on Linux running on macOS), falls back to ffmpeg region capture with
- *    a stderr warning so the degradation is visible. **Only** [HelperNotBundledException] triggers
- *    fallback — operational SCK failures (Screen Recording permission denied, target window not
- *    found, helper crashed during init) propagate as `IllegalStateException` so the caller sees the
- *    real error rather than getting a silently-different recording.
- * 4. Non-macOS host with a window whose [TitledWindow.title] is non-blank, AND a non-null
- *    [windowsWindowRecorder] — uses [FfmpegWindowRecorder] (gdigrab `title=` capture). This is the
- *    Windows window-targeted path: window movement is followed automatically and occlusion doesn't
- *    matter. Jewel-in-IDE tool windows have no top-level title so they fall through to the region
- *    path (see step 5).
- * 5. Non-macOS host without an applicable [windowsWindowRecorder] OR with a blank/null title, on a
- *    non-Wayland host → ffmpeg region capture. The region path is the documented fallback when the
- *    target window title is missing, ambiguous, or points at a tool window with no top-level title.
- *    The underlying [FfmpegRecorder]'s [FfmpegBackend.detect] picks the platform device: gdigrab on
- *    Windows, x11grab on Linux Xorg. (Linux Wayland is handled by step 1 before falling through
- *    here, and `LinuxX11Grab` itself throws on Wayland — see `FfmpegBackend.checkNotWayland`.)
+ * [startWindow] uses true window-targeted backends only: ScreenCaptureKit on macOS, `gdigrab
+ * title=` on Windows, and the Wayland portal window-source path on Linux Wayland. If the requested
+ * window mode is unavailable, it throws with an actionable error instead of silently falling back
+ * to region capture.
  *
- * The router always needs both a window AND a region: the region is used as the fallback when the
- * window-targeted path isn't applicable. If you don't have a region (e.g. no clear bounds for a
- * missing window), instantiate [ScreenCaptureKitRecorder], [FfmpegWindowRecorder], or
- * [FfmpegRecorder] directly.
+ * [startRegion] uses region capture only: ffmpeg region capture on macOS, Windows, and Linux Xorg,
+ * and the Wayland portal monitor-source path on Linux Wayland. If the requested region mode is
+ * unavailable, it throws instead of switching capture semantics.
  */
 public class AutoRecorder
 internal constructor(
@@ -96,46 +61,20 @@ internal constructor(
         isWayland = ::defaultIsWayland,
     )
 
-    /**
-     * Latched to true the first time we emit the Wayland portal fallback warning, so repeated
-     * `start()` calls on the same AutoRecorder instance don't spam stderr.
-     */
-    private val waylandFallbackWarned = AtomicBoolean(false)
-
-    public fun start(
-        window: TitledWindow?,
-        region: Rectangle,
+    public fun startWindow(
+        window: TitledWindow,
         output: Path,
         options: RecordingOptions = RecordingOptions(),
         windowOwnerPid: Long = ProcessHandle.current().pid(),
     ): RecordingHandle {
-        // Linux Wayland routing has to happen BEFORE the window-null check below: a Wayland
-        // session can't fall through to FfmpegRecorder for either window-targeted OR region
-        // capture, because LinuxX11Grab throws on Wayland.
-        //
-        // Window-targeted (#85) takes precedence when both wired and the caller has a window
-        // in mind: SourceType.WINDOW makes the portal scope the granted stream to the picked
-        // window's pixels (no leakage from occluding apps the way MONITOR + region capture
-        // suffers from). Falls back to the region recorder when no window is supplied OR the
-        // window-targeted recorder isn't wired (e.g. older callers, helper construction
-        // failed). Both pass the same `region` to the helper; the difference is the
-        // SourceType the portal hands to the compositor.
-        if (isWayland() && window != null && waylandPortalWindowRecorder != null) {
-            return waylandPortalWindowRecorder.start(window, region, output, options)
-        }
-        if (isWayland() && waylandPortalRecorder != null) {
-            return waylandPortalRecorder.start(region, output, options)
-        }
         if (isWayland()) {
-            // Wayland session detected but no portal recorder could be constructed. The
-            // ffmpeg fallback below will fail loudly ("Wayland detected, x11grab unavailable")
-            // — but the underlying construction failure for the portal recorder is the more
-            // useful diagnostic, so surface it once via stderr before we let ffmpeg complete
-            // the routing.
-            maybeWarnWaylandFallback(window)
-        }
-        if (window == null) {
-            return ffmpegRecorder.start(region, output, options)
+            val recorder =
+                waylandPortalWindowRecorder
+                    ?: throw unavailable(
+                        "Wayland window capture",
+                        waylandPortalWindowRecorderFailure,
+                    )
+            return recorder.start(window, window.bounds, output, options)
         }
         if (isMacOs()) {
             return try {
@@ -146,56 +85,49 @@ internal constructor(
                     options = options,
                 )
             } catch (e: HelperNotBundledException) {
-                // The helper isn't in the jar. This is the cross-platform-jar case (built on
-                // Linux, run on macOS) — degrade to region capture rather than throwing, but
-                // surface a stderr warning so the silent downgrade is at least visible.
-                System.err.println(
-                    "AutoRecorder: SCK helper not bundled (${e.message}); falling back to " +
-                        "ffmpeg region capture."
-                )
-                ffmpegRecorder.start(region, output, options)
+                throw unavailable("macOS window capture", e)
             }
         }
-        // Non-mac path. Try title-based window capture if we have a Windows window recorder
-        // wired up AND a non-blank title to feed it; otherwise fall through to region.
-        val titledRecorder = windowsWindowRecorder
         val title = window.title
-        if (titledRecorder != null && isWindows() && !title.isNullOrBlank()) {
-            return titledRecorder.start(
-                window = window,
-                windowOwnerPid = windowOwnerPid,
-                output = output,
-                options = options,
-            )
+        val recorder = windowsWindowRecorder
+        if (isWindows()) {
+            require(!title.isNullOrBlank()) {
+                "AutoRecorder.startWindow requires a non-blank window title on Windows. " +
+                    "Use startRegion(...) explicitly if region capture is what you want."
+            }
+            return recorder?.start(window, windowOwnerPid, output, options)
+                ?: throw unavailable("Windows window capture", null)
+        }
+        throw unsupportedWindowCapture()
+    }
+
+    public fun startRegion(
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions = RecordingOptions(),
+    ): RecordingHandle {
+        if (isWayland()) {
+            val recorder =
+                waylandPortalRecorder
+                    ?: throw unavailable("Wayland region capture", waylandPortalRecorderFailure)
+            return recorder.start(region, output, options)
         }
         return ffmpegRecorder.start(region, output, options)
     }
 
-    /**
-     * Emit the Wayland portal fallback warning at most once per AutoRecorder instance. Picks the
-     * window-recorder failure when a [window] is supplied (that's the slot the router checked
-     * first), otherwise the region-recorder failure. Both being null means the caller explicitly
-     * passed `null` recorders without going through our defaults — we still emit the warning so the
-     * silent downgrade is visible, just with a less specific cause.
-     */
-    private fun maybeWarnWaylandFallback(window: TitledWindow?) {
-        if (!waylandFallbackWarned.compareAndSet(false, true)) return
-        val failure =
-            if (window != null) {
-                waylandPortalWindowRecorderFailure ?: waylandPortalRecorderFailure
-            } else {
-                waylandPortalRecorderFailure ?: waylandPortalWindowRecorderFailure
-            }
-        val cause =
-            failure?.message?.takeIf { it.isNotBlank() }
-                ?: failure?.javaClass?.simpleName
-                ?: "no construction failure recorded — recorder slot was passed as null"
-        System.err.println(
-            "AutoRecorder: Wayland portal recorder unavailable ($cause); falling back to " +
-                "ffmpeg region capture (which will fail on Wayland — install the portal helper " +
-                "prerequisites or supply a custom recorder)."
-        )
+    private fun unavailable(mode: String, cause: Throwable?): IllegalStateException {
+        val detail = cause?.message?.takeIf { it.isNotBlank() } ?: cause?.javaClass?.simpleName
+        val message =
+            if (detail == null) "$mode is unavailable." else "$mode is unavailable: $detail"
+        return IllegalStateException(message, cause)
     }
+
+    private fun unsupportedWindowCapture(): IllegalStateException =
+        IllegalStateException(
+            "AutoRecorder.startWindow is unsupported on this platform because no true " +
+                "window-targeted recorder is available. Use startRegion(...) explicitly for " +
+                "region capture."
+        )
 
     private companion object {
         @JvmStatic

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/TitledWindow.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/TitledWindow.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.recording.screencapturekit
 
 import java.awt.EventQueue
 import java.awt.Frame
+import java.awt.Rectangle
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -12,6 +13,8 @@ import java.util.concurrent.atomic.AtomicReference
  */
 public interface TitledWindow {
     public var title: String?
+
+    public val bounds: Rectangle
 }
 
 /**
@@ -32,6 +35,9 @@ public fun Frame.asTitledWindow(): TitledWindow =
             set(value) {
                 onEdt { this@asTitledWindow.title = value ?: "" }
             }
+
+        override val bounds: Rectangle
+            get() = onEdt { this@asTitledWindow.bounds }
     }
 
 /**

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
@@ -5,485 +5,246 @@ import dev.sebastiano.spectre.recording.screencapturekit.HelperNotBundledExcepti
 import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
 import dev.sebastiano.spectre.recording.screencapturekit.WindowRecorder
 import java.awt.Rectangle
-import java.io.ByteArrayOutputStream
-import java.io.PrintStream
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.deleteIfExists
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 class AutoRecorderTest {
 
     @Test
-    fun `null window always routes to ffmpeg regardless of OS or helper availability`() {
-        val sck = StubWindowRecorder(name = "sck")
-        val ffmpeg = StubFfmpegRecorder()
-        val recorder = autoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+    fun `startRegion routes to ffmpeg on non-Wayland hosts`() {
+        val ffmpeg = StubRegionRecorder()
+        val recorder = autoRecorder(ffmpegRecorder = ffmpeg, isMacOs = { true })
         val output = tempMov()
         try {
-            recorder.start(window = null, region = Rectangle(0, 0, 100, 100), output = output)
+            val region = Rectangle(0, 0, 100, 100)
 
-            assertTrue(ffmpeg.startCalled, "Should fall back to ffmpeg when no window provided")
-            assertEquals(0, sck.startCallCount)
+            recorder.startRegion(region = region, output = output)
+
+            assertEquals(region, ffmpeg.lastRegion)
         } finally {
             output.deleteIfExists()
         }
     }
 
     @Test
-    fun `non-mac non-Windows host with a window routes to ffmpeg region capture`() {
-        // Linux today; v4 follow-up may add a window-targeted X11/Wayland recorder. Until then
-        // any non-mac/non-Windows host must fall through to region capture even when a window
-        // is supplied.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val window = StubTitledWindow(title = "MyApp")
+    fun `startRegion routes to Wayland region portal on Wayland hosts`() {
+        val ffmpeg = StubRegionRecorder()
+        val portal = StubRegionRecorder()
         val recorder =
             autoRecorder(
-                sckRecorder = sck,
                 ffmpegRecorder = ffmpeg,
-                windowsWindowRecorder = null,
+                waylandPortalRecorder = portal,
                 isMacOs = { false },
-                isWindows = { false },
+                isWayland = { true },
             )
         val output = tempMov()
         try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
+            val region = Rectangle(0, 0, 100, 100)
 
-            assertTrue(ffmpeg.startCalled)
-            assertEquals(0, sck.startCallCount)
+            recorder.startRegion(region = region, output = output)
+
+            assertEquals(region, portal.lastRegion)
+            assertFalse(
+                ffmpeg.startCalled,
+                "Wayland region capture must not fall through to ffmpeg",
+            )
         } finally {
             output.deleteIfExists()
         }
     }
 
     @Test
-    fun `mac host with a window routes to SCK`() {
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.Succeeds)
-        val ffmpeg = StubFfmpegRecorder()
-        val window = StubTitledWindow(title = "MyApp")
-        val recorder = autoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
-        val output = tempMov()
-        try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertEquals(1, sck.startCallCount)
-            assertEquals(false, ffmpeg.startCalled, "Should not fall back when SCK succeeds")
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `helper-not-bundled triggers fallback to ffmpeg`() {
-        // The cross-platform-jar case: built on Linux, run on macOS — helper isn't in the
-        // jar, but the user has ffmpeg available. AutoRecorder should silently degrade to
-        // region capture rather than throwing.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.HelperNotBundled)
-        val ffmpeg = StubFfmpegRecorder()
-        val window = StubTitledWindow(title = "MyApp")
-        val recorder = autoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
-        val output = tempMov()
-        try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertEquals(1, sck.startCallCount, "SCK is attempted first")
-            assertTrue(ffmpeg.startCalled, "Falls back to ffmpeg when helper isn't bundled")
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `non-fallback SCK failures (TCC, window-not-found) propagate without falling back`() {
-        // If SCK is bundled but fails for a caller-actionable reason (no Screen Recording
-        // permission, window doesn't exist), the user should see that error — falling back
-        // would mask a real configuration mistake.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.RuntimeFailure)
-        val ffmpeg = StubFfmpegRecorder()
-        val window = StubTitledWindow(title = "MyApp")
-        val recorder = autoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
-        val output = tempMov()
-        try {
-            assertFailsWith<IllegalStateException> {
-                recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
-            }
-            assertEquals(1, sck.startCallCount)
-            assertEquals(false, ffmpeg.startCalled, "Real SCK failures must not silently fall back")
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `Wayland portal construction failure logs warning on the fallback path`() {
-        // Wayland session detected, both portal recorder slots null because their construction
-        // failed at AutoRecorder init time. The router falls through to ffmpeg (which will
-        // itself fail loudly on a real Wayland session), but before that we want one stderr
-        // line naming the underlying portal failure so the user knows what to fix.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val failure = IllegalStateException("dbus-launch not found on PATH")
+    fun `startRegion fails loudly when Wayland region portal is unavailable`() {
+        val failure = IllegalStateException("gst-launch not found")
         val recorder =
             autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
                 waylandPortalRecorder = null,
-                waylandPortalWindowRecorder = null,
                 waylandPortalRecorderFailure = failure,
+                isMacOs = { false },
+                isWayland = { true },
+            )
+        val output = tempMov()
+        try {
+            val error =
+                assertFailsWith<IllegalStateException> {
+                    recorder.startRegion(Rectangle(0, 0, 100, 100), output)
+                }
+
+            assertTrue(error.message.orEmpty().contains("Wayland region capture"))
+            assertSame(failure, error.cause)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startWindow routes to SCK on macOS`() {
+        val sck = StubWindowRecorder(name = "sck")
+        val ffmpeg = StubRegionRecorder()
+        val recorder = autoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val output = tempMov()
+        try {
+            val window = StubTitledWindow(title = "MyApp")
+
+            recorder.startWindow(window = window, output = output)
+
+            assertEquals(1, sck.startCallCount)
+            assertFalse(ffmpeg.startCalled, "Window capture must not silently fall back to region")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startWindow propagates missing SCK helper as loud window-capture failure`() {
+        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.HelperNotBundled)
+        val ffmpeg = StubRegionRecorder()
+        val recorder = autoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val output = tempMov()
+        try {
+            val error =
+                assertFailsWith<IllegalStateException> {
+                    recorder.startWindow(
+                        window = StubTitledWindow(title = "MyApp"),
+                        output = output,
+                    )
+                }
+
+            assertTrue(error.message.orEmpty().contains("macOS window capture"))
+            assertFalse(ffmpeg.startCalled, "Helper failure must not degrade to region capture")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startWindow routes to Windows title recorder on Windows`() {
+        val ffmpeg = StubRegionRecorder()
+        val windowRecorder = StubWindowRecorder(name = "ffmpegWindow")
+        val recorder =
+            autoRecorder(
+                ffmpegRecorder = ffmpeg,
+                windowsWindowRecorder = windowRecorder,
+                isMacOs = { false },
+                isWindows = { true },
+            )
+        val output = tempMov()
+        try {
+            recorder.startWindow(window = StubTitledWindow(title = "MyApp"), output = output)
+
+            assertEquals(1, windowRecorder.startCallCount)
+            assertFalse(ffmpeg.startCalled, "Window capture must not silently fall back to region")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startWindow rejects blank Windows titles instead of falling back to region`() {
+        val ffmpeg = StubRegionRecorder()
+        val windowRecorder = StubWindowRecorder(name = "ffmpegWindow")
+        val recorder =
+            autoRecorder(
+                ffmpegRecorder = ffmpeg,
+                windowsWindowRecorder = windowRecorder,
+                isMacOs = { false },
+                isWindows = { true },
+            )
+        val output = tempMov()
+        try {
+            val error =
+                assertFailsWith<IllegalArgumentException> {
+                    recorder.startWindow(window = StubTitledWindow(title = ""), output = output)
+                }
+
+            assertTrue(error.message.orEmpty().contains("non-blank window title"))
+            assertEquals(0, windowRecorder.startCallCount)
+            assertFalse(ffmpeg.startCalled)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startWindow routes to Wayland window portal with window bounds`() {
+        val ffmpeg = StubRegionRecorder()
+        val portalRegion = StubRegionRecorder()
+        val portalWindow = StubWaylandWindowSourceRecorder()
+        val recorder =
+            autoRecorder(
+                ffmpegRecorder = ffmpeg,
+                waylandPortalRecorder = portalRegion,
+                waylandPortalWindowRecorder = portalWindow,
+                isMacOs = { false },
+                isWayland = { true },
+            )
+        val output = tempMov()
+        try {
+            val bounds = Rectangle(5, 6, 100, 120)
+            val window = StubTitledWindow(title = "MyApp", bounds = bounds)
+
+            recorder.startWindow(window = window, output = output)
+
+            assertEquals(1, portalWindow.startCallCount)
+            assertSame(window, portalWindow.lastWindow)
+            assertEquals(bounds, portalWindow.lastRegion)
+            assertFalse(portalRegion.startCalled, "Window mode must not use region portal")
+            assertFalse(ffmpeg.startCalled)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startWindow fails loudly when Wayland window portal is unavailable`() {
+        val failure = IllegalStateException("xprop not found")
+        val recorder =
+            autoRecorder(
+                waylandPortalWindowRecorder = null,
                 waylandPortalWindowRecorderFailure = failure,
                 isMacOs = { false },
                 isWayland = { true },
             )
         val output = tempMov()
-        val originalErr = System.err
-        val captured = ByteArrayOutputStream()
-        System.setErr(PrintStream(captured))
         try {
-            recorder.start(window = null, region = Rectangle(0, 0, 100, 100), output = output)
-        } finally {
-            System.setErr(originalErr)
-            output.deleteIfExists()
-        }
-        val warning = captured.toString(Charsets.UTF_8)
-        assertTrue(
-            warning.contains("AutoRecorder", ignoreCase = true) &&
-                warning.contains("Wayland portal recorder unavailable", ignoreCase = true) &&
-                warning.contains("dbus-launch not found"),
-            "Expected Wayland fallback warning naming the underlying cause, got: $warning",
-        )
-    }
+            val error =
+                assertFailsWith<IllegalStateException> {
+                    recorder.startWindow(
+                        window = StubTitledWindow(title = "MyApp"),
+                        output = output,
+                    )
+                }
 
-    @Test
-    fun `Wayland portal fallback warning fires at most once per AutoRecorder instance`() {
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                waylandPortalRecorder = null,
-                waylandPortalWindowRecorder = null,
-                waylandPortalRecorderFailure = IllegalStateException("dbus-launch missing"),
-                waylandPortalWindowRecorderFailure = IllegalStateException("dbus-launch missing"),
-                isMacOs = { false },
-                isWayland = { true },
-            )
-        val outputs = listOf(tempMov(), tempMov())
-        val originalErr = System.err
-        val captured = ByteArrayOutputStream()
-        System.setErr(PrintStream(captured))
-        try {
-            outputs.forEach {
-                recorder.start(window = null, region = Rectangle(0, 0, 100, 100), output = it)
-            }
-        } finally {
-            System.setErr(originalErr)
-            outputs.forEach { it.deleteIfExists() }
-        }
-        val warning = captured.toString(Charsets.UTF_8)
-        val occurrences = warning.split("Wayland portal recorder unavailable").size - 1
-        assertEquals(
-            1,
-            occurrences,
-            "Expected the Wayland fallback warning to fire exactly once across repeated " +
-                "start() calls; saw $occurrences. Full stderr: $warning",
-        )
-    }
-
-    @Test
-    fun `helper-not-bundled fallback writes a warning to stderr so the degradation is visible`() {
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.HelperNotBundled)
-        val ffmpeg = StubFfmpegRecorder()
-        val window = StubTitledWindow(title = "MyApp")
-        val recorder = autoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
-        val output = tempMov()
-        val originalErr = System.err
-        val captured = ByteArrayOutputStream()
-        System.setErr(PrintStream(captured))
-        try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
-        } finally {
-            System.setErr(originalErr)
-            output.deleteIfExists()
-        }
-        val warning = captured.toString(Charsets.UTF_8)
-        assertTrue(
-            warning.contains("AutoRecorder", ignoreCase = true) ||
-                warning.contains("falling back", ignoreCase = true),
-            "Expected stderr fallback warning, got: $warning",
-        )
-    }
-
-    @Test
-    fun `Windows host with non-blank window title routes to FfmpegWindowRecorder`() {
-        // Issue #55: when the host is Windows and the caller supplies a TitledWindow whose
-        // title is usable for gdigrab `-i title=...`, AutoRecorder hands the window-targeted
-        // recorder rather than dropping back to region capture — same shape as SCK on macOS.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val winWindowRecorder =
-            StubWindowRecorder(name = "ffmpegWindow", behavior = StubBehavior.Succeeds)
-        val window = StubTitledWindow(title = "MyApp")
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                windowsWindowRecorder = winWindowRecorder,
-                isMacOs = { false },
-                isWindows = { true },
-            )
-        val output = tempMov()
-        try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertEquals(1, winWindowRecorder.startCallCount, "Windows window recorder should fire")
-            assertEquals(
-                false,
-                ffmpeg.startCalled,
-                "Region path must not fire when title is usable",
-            )
+            assertTrue(error.message.orEmpty().contains("Wayland window capture"))
+            assertSame(failure, error.cause)
         } finally {
             output.deleteIfExists()
         }
     }
 
     @Test
-    fun `Windows host with blank window title falls back to ffmpeg region capture`() {
-        // gdigrab's `title=` form rejects blank titles (Jewel-in-IDE tool windows etc.). The
-        // documented fallback is region capture; AutoRecorder must apply it before reaching
-        // FfmpegWindowRecorder so the require() in there never fires for routed callers.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val winWindowRecorder =
-            StubWindowRecorder(name = "ffmpegWindow", behavior = StubBehavior.ShouldNeverBeCalled)
-        val window = StubTitledWindow(title = "")
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                windowsWindowRecorder = winWindowRecorder,
-                isMacOs = { false },
-                isWindows = { true },
-            )
+    fun `startWindow fails loudly on unsupported window-capture platforms`() {
+        val ffmpeg = StubRegionRecorder()
+        val recorder = autoRecorder(ffmpegRecorder = ffmpeg, isMacOs = { false })
         val output = tempMov()
         try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
+            val error =
+                assertFailsWith<IllegalStateException> {
+                    recorder.startWindow(
+                        window = StubTitledWindow(title = "MyApp"),
+                        output = output,
+                    )
+                }
 
-            assertTrue(
-                ffmpeg.startCalled,
-                "Region path should be the documented blank-title fallback",
-            )
-            assertEquals(0, winWindowRecorder.startCallCount)
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `Windows host with null window title falls back to ffmpeg region capture`() {
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val winWindowRecorder =
-            StubWindowRecorder(name = "ffmpegWindow", behavior = StubBehavior.ShouldNeverBeCalled)
-        val window = StubTitledWindow(title = null)
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                windowsWindowRecorder = winWindowRecorder,
-                isMacOs = { false },
-                isWindows = { true },
-            )
-        val output = tempMov()
-        try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertTrue(ffmpeg.startCalled)
-            assertEquals(0, winWindowRecorder.startCallCount)
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `Windows host without a configured windowsWindowRecorder falls back to ffmpeg region`() {
-        // Defensive case: even if the AutoRecorder construction couldn't resolve a Windows
-        // window recorder (e.g. ffmpeg not on PATH at AutoRecorder() time), the router stays
-        // usable for the region path that doesn't depend on the absent recorder.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val window = StubTitledWindow(title = "MyApp")
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                windowsWindowRecorder = null,
-                isMacOs = { false },
-                isWindows = { true },
-            )
-        val output = tempMov()
-        try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertTrue(ffmpeg.startCalled)
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `Linux Wayland host with a configured waylandPortalRecorder routes there even with null window`() {
-        // The Wayland branch is unconditional on `window` because LinuxX11Grab can't be a
-        // fallback (it throws on Wayland). Both window=null and window=non-null land on the
-        // portal recorder; the SCK / Windows branches must NOT be reached.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val portal = StubFfmpegRecorder()
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                waylandPortalRecorder = portal,
-                isMacOs = { false },
-                isWindows = { false },
-                isWayland = { true },
-            )
-        val output = tempMov()
-        try {
-            // Null window — would have gone to ffmpeg without Wayland routing.
-            recorder.start(window = null, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertTrue(portal.startCalled, "Should route to Wayland portal recorder")
-            assertEquals(false, ffmpeg.startCalled)
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `Linux Wayland windowed call routes to window-targeted portal recorder when wired`() {
-        // #85: window-targeted Wayland with a window-targeted portal recorder wired up. Routes
-        // there with the same `region` (the window's bounds), giving us SourceType.WINDOW
-        // semantics — only the window's pixels in the stream — and a window-sized mp4 from
-        // the helper's existing crop. Region portal must NOT be hit; SCK / Windows must NOT be hit.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val portalRegion = StubFfmpegRecorder()
-        val portalWindow = StubWaylandWindowSourceRecorder()
-        val window = StubTitledWindow(title = "MyApp")
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                waylandPortalRecorder = portalRegion,
-                waylandPortalWindowRecorder = portalWindow,
-                isMacOs = { false },
-                isWindows = { false },
-                isWayland = { true },
-            )
-        val output = tempMov()
-        try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertEquals(
-                1,
-                portalWindow.startCallCount,
-                "Should route to Wayland window-targeted recorder",
-            )
-            assertEquals(window, portalWindow.lastWindow)
-            assertEquals(false, portalRegion.startCalled, "Region portal must not be hit")
-            assertEquals(0, sck.startCallCount)
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `Linux Wayland windowed call falls back to region portal when window recorder is not wired`() {
-        // Pre-#85 behaviour preserved: callers that constructed AutoRecorder before the
-        // window-targeted Wayland recorder existed (or whose helper failed to wire it) still
-        // get region capture rather than a hard failure. Region portal handles both null and
-        // non-null window because the dialog asks the user to pick the source.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val portalRegion = StubFfmpegRecorder()
-        val window = StubTitledWindow(title = "MyApp")
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                waylandPortalRecorder = portalRegion,
-                waylandPortalWindowRecorder = null,
-                isMacOs = { false },
-                isWindows = { false },
-                isWayland = { true },
-            )
-        val output = tempMov()
-        try {
-            recorder.start(window = window, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertTrue(portalRegion.startCalled, "Should fall back to region portal")
-            assertEquals(0, sck.startCallCount)
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `Linux Wayland null window stays on the region portal recorder`() {
-        // Null window means embedded ComposePanel / arbitrary region — the region path is
-        // the right one, even when a window-targeted recorder is wired.
-        val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.ShouldNeverBeCalled)
-        val ffmpeg = StubFfmpegRecorder()
-        val portalRegion = StubFfmpegRecorder()
-        val portalWindow = StubWaylandWindowSourceRecorder()
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                waylandPortalRecorder = portalRegion,
-                waylandPortalWindowRecorder = portalWindow,
-                isMacOs = { false },
-                isWindows = { false },
-                isWayland = { true },
-            )
-        val output = tempMov()
-        try {
-            recorder.start(window = null, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertTrue(portalRegion.startCalled, "Null window should land on region portal")
-            assertEquals(0, portalWindow.startCallCount)
-        } finally {
-            output.deleteIfExists()
-        }
-    }
-
-    @Test
-    fun `Linux Wayland host without a configured waylandPortalRecorder falls through to ffmpeg`() {
-        // Defensive case: AutoRecorder construction couldn't resolve a Wayland portal recorder
-        // (e.g. gst-launch-1.0 not installed), but the user still got an AutoRecorder back. The
-        // ffmpeg path will throw via LinuxX11Grab.checkNotWayland, but that's the right error
-        // to surface — better than the router silently degrading to a broken recording.
-        val sck = StubWindowRecorder(name = "sck")
-        val ffmpeg = StubFfmpegRecorder()
-        val recorder =
-            autoRecorder(
-                sckRecorder = sck,
-                ffmpegRecorder = ffmpeg,
-                waylandPortalRecorder = null,
-                isMacOs = { false },
-                isWindows = { false },
-                isWayland = { true },
-            )
-        val output = tempMov()
-        try {
-            recorder.start(window = null, region = Rectangle(0, 0, 100, 100), output = output)
-
-            assertTrue(ffmpeg.startCalled, "No portal recorder → ffmpeg fallback fires")
+            assertTrue(error.message.orEmpty().contains("unsupported"))
+            assertFalse(ffmpeg.startCalled, "Unsupported window mode must not fall back to region")
         } finally {
             output.deleteIfExists()
         }
@@ -492,14 +253,9 @@ class AutoRecorderTest {
     private fun tempMov(): Path = Files.createTempFile("spectre-auto-recorder-test-", ".mov")
 }
 
-// AutoRecorder's internal constructor takes the dispatch lambdas + the optional Windows / Wayland
-// recorders. Tests use this helper so the public default constructor (which detects the host OS
-// at runtime) doesn't leak through and make the suite host-dependent. The Wayland slot defaults
-// to null + isWayland=false so existing tests behave as before; tests that exercise the Wayland
-// routing pass them explicitly.
 private fun autoRecorder(
-    sckRecorder: WindowRecorder,
-    ffmpegRecorder: Recorder,
+    sckRecorder: WindowRecorder = StubWindowRecorder(name = "sck"),
+    ffmpegRecorder: Recorder = StubRegionRecorder(),
     windowsWindowRecorder: WindowRecorder? = null,
     waylandPortalRecorder: Recorder? = null,
     waylandPortalWindowRecorder: WaylandWindowSourceRecorder? = null,
@@ -555,8 +311,11 @@ private class StubWindowRecorder(
     }
 }
 
-private class StubFfmpegRecorder : Recorder {
+private class StubRegionRecorder : Recorder {
     var startCalled: Boolean = false
+        private set
+
+    var lastRegion: Rectangle? = null
         private set
 
     override fun start(
@@ -565,6 +324,7 @@ private class StubFfmpegRecorder : Recorder {
         options: RecordingOptions,
     ): RecordingHandle {
         startCalled = true
+        lastRegion = region
         return NoopHandle(output)
     }
 }
@@ -576,6 +336,9 @@ private class StubWaylandWindowSourceRecorder : WaylandWindowSourceRecorder {
     var lastWindow: TitledWindow? = null
         private set
 
+    var lastRegion: Rectangle? = null
+        private set
+
     override fun start(
         window: TitledWindow,
         region: Rectangle,
@@ -584,13 +347,15 @@ private class StubWaylandWindowSourceRecorder : WaylandWindowSourceRecorder {
     ): RecordingHandle {
         startCallCount += 1
         lastWindow = window
+        lastRegion = region
         return NoopHandle(output)
     }
 }
 
-private class StubTitledWindow(title: String? = "MyApp") : TitledWindow {
-    override var title: String? = title
-}
+private class StubTitledWindow(
+    override var title: String? = "MyApp",
+    override val bounds: Rectangle = Rectangle(0, 0, 100, 100),
+) : TitledWindow
 
 private class NoopHandle(override val output: Path) : RecordingHandle {
     override val isStopped: Boolean = false

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegWindowRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegWindowRecorderTest.kt
@@ -166,6 +166,7 @@ class FfmpegWindowRecorderTest {
 
 private class WindowFakeTitledWindow(title: String?) : TitledWindow {
     override var title: String? = title
+    override val bounds: java.awt.Rectangle = java.awt.Rectangle(0, 0, 100, 100)
 }
 
 private class WindowRecordingProcessFactory : FfmpegRecorder.ProcessFactory {

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorderTest.kt
@@ -140,7 +140,9 @@ private class StubRecorderCapture : Recorder {
     fun asWaylandPortalRecorder(): Recorder = this
 }
 
-private class StubTitledWindow(override var title: String?) : TitledWindow
+private class StubTitledWindow(override var title: String?) : TitledWindow {
+    override val bounds: Rectangle = Rectangle(0, 0, 100, 100)
+}
 
 private class NoopHandle(override val output: Path) : RecordingHandle {
     override val isStopped: Boolean = false

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/FakeTitledWindow.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/FakeTitledWindow.kt
@@ -1,8 +1,9 @@
 package dev.sebastiano.spectre.recording.screencapturekit
 
-/**
- * In-memory stand-in for a Compose `Window` / AWT `Frame` — only models the title getter/setter.
- */
+import java.awt.Rectangle
+
+/** In-memory stand-in for a Compose `Window` / AWT `Frame`. */
 internal class FakeTitledWindow(initialTitle: String?) : TitledWindow {
     override var title: String? = initialTitle
+    override val bounds: Rectangle = Rectangle(0, 0, 100, 100)
 }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitHelperContractTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitHelperContractTest.kt
@@ -182,6 +182,10 @@ class ScreenCaptureKitHelperContractTest {
 
     @Test
     fun `helper exits 3 when no window matches the discriminator`() {
+        assumeTrue(
+            System.getProperty("spectre.test.screenCaptureKitHelperDiscovery").toBoolean(),
+            "ScreenCaptureKit discovery can initialise AppKit/SCK and is opt-in on local workers",
+        )
         // pid 1 on macOS is launchd, which has no windows by definition. Even if it did, the
         // discriminator "spectre-contract-test-no-such-window-xyz" guarantees no match.
         val exit =
@@ -214,12 +218,14 @@ class ScreenCaptureKitHelperContractTest {
                 .redirectError(ProcessBuilder.Redirect.DISCARD)
                 .start()
         try {
-            check(process.waitFor(HELPER_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            if (!process.waitFor(HELPER_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
-                "Helper did not exit within ${HELPER_TIMEOUT_SECONDS}s for argv=$argv"
+                process.waitFor(HELPER_KILL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                error("Helper did not exit within ${HELPER_TIMEOUT_SECONDS}s for argv=$argv")
             }
         } catch (e: IOException) {
             process.destroyForcibly()
+            process.waitFor(HELPER_KILL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             throw e
         }
         return process.exitValue()
@@ -227,5 +233,6 @@ class ScreenCaptureKitHelperContractTest {
 
     private companion object {
         const val HELPER_TIMEOUT_SECONDS: Long = 5
+        const val HELPER_KILL_TIMEOUT_SECONDS: Long = 2
     }
 }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/TitledWindowAdapterTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/TitledWindowAdapterTest.kt
@@ -5,22 +5,22 @@ import java.awt.GraphicsEnvironment
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
  * Light tests for the public [Frame.asTitledWindow] adapter — the surface external callers use to
  * pass a `ComposeWindow` / `JFrame` / any `Frame` subclass into [ScreenCaptureKitRecorder.start].
  *
- * Constructing an AWT [Frame] hits `Window.<init>` which throws [java.awt.HeadlessException] on
- * machines without a display (headless CI). Each test gates on [GraphicsEnvironment.isHeadless] via
- * JUnit 5's [assumeFalse] — locally (where the recorder actually runs) the assertions execute; in
- * headless CI the tests are skipped rather than failing. The recorder itself is gated on macOS at
- * runtime, so headless CI never exercises it either way.
+ * Constructing an AWT [Frame] hits `Window.<init>`, which can throw on headless hosts and can hang
+ * while initialising AppKit on non-interactive macOS workers. Each test gates through
+ * [assumeLiveAwtAvailable] so the default unit suite skips instead of wedging; run with
+ * `-Dspectre.test.liveAwt=true` on macOS to exercise the adapter locally.
  */
 class TitledWindowAdapterTest {
 
     @Test
     fun `adapter reads through to the wrapped frame's title`() {
-        assumeFalse(GraphicsEnvironment.isHeadless(), "AWT Frame requires a graphical environment")
+        assumeLiveAwtAvailable()
 
         val frame = TestFrame(initialTitle = "MyApp")
         val adapter = frame.asTitledWindow()
@@ -30,7 +30,7 @@ class TitledWindowAdapterTest {
 
     @Test
     fun `adapter writes through to the wrapped frame's title`() {
-        assumeFalse(GraphicsEnvironment.isHeadless(), "AWT Frame requires a graphical environment")
+        assumeLiveAwtAvailable()
 
         val frame = TestFrame(initialTitle = "MyApp")
         val adapter = frame.asTitledWindow()
@@ -41,8 +41,18 @@ class TitledWindowAdapterTest {
     }
 
     @Test
+    fun `adapter reads through to the wrapped frame's bounds`() {
+        assumeLiveAwtAvailable()
+
+        val frame = TestFrame(initialTitle = "MyApp").apply { setBounds(10, 20, 300, 200) }
+        val adapter = frame.asTitledWindow()
+
+        assertEquals(frame.bounds, adapter.bounds)
+    }
+
+    @Test
     fun `adapter writes null as empty string mirroring AWT behaviour`() {
-        assumeFalse(GraphicsEnvironment.isHeadless(), "AWT Frame requires a graphical environment")
+        assumeLiveAwtAvailable()
 
         // AWT's Frame.setTitle(null) silently coerces to "" and treats getTitle() as "" thereafter.
         // The adapter preserves that behaviour rather than throwing or no-op'ing, so callers can
@@ -54,6 +64,17 @@ class TitledWindowAdapterTest {
 
         assertEquals("", frame.title)
     }
+}
+
+private fun assumeLiveAwtAvailable() {
+    if (System.getProperty("os.name").orEmpty().lowercase().contains("mac")) {
+        assumeTrue(
+            System.getProperty("spectre.test.liveAwt").toBoolean(),
+            "AWT Frame tests are opt-in on macOS because AppKit initialisation can hang in " +
+                "non-interactive workers",
+        )
+    }
+    assumeFalse(GraphicsEnvironment.isHeadless(), "AWT Frame requires a graphical environment")
 }
 
 /** A subclass of [Frame] that doesn't try to allocate a peer — safe for headless unit tests. */

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -84,7 +84,7 @@ tasks
 // directly so it doesn't need the window in the foreground.
 //
 // Trade-off: macOS restricts NSPasteboard access for UI-element processes, so the
-// clipboard-driven `typeText` validation can't run under this flag. That single test is gated
+// clipboard-driven paste validation can't run under this flag. That single test is gated
 // on `spectre.sample.fixture.uiElement` (which mirrors `apple.awt.UIElement` so JVM-level
 // invocations not going through this build script — IDE / CI — still gate correctly) and skips
 // itself when the flag is on; everything else runs as normal.
@@ -202,7 +202,7 @@ tasks.register<JavaExec>("runWindowsHiDpiDiagnostic") {
 }
 
 // Manual smoke for `RobotDriver` on Windows (#20). Drives a Compose window through real
-// java.awt.Robot input — counter clicks, clipboard typeText, clearAndTypeText, Ctrl+S
+// java.awt.Robot input — counter clicks, pasteText, clearAndTypeText, Ctrl+S
 // shortcut — and reports PASS/FAIL per scenario. Mirrors the diagnostic shape so future
 // platform smokes can land alongside.
 tasks.register<JavaExec>("runWindowsRobotSmoke") {

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
@@ -47,10 +47,8 @@ import kotlinx.coroutines.runBlocking
  *    not observed across multiple CI runs). The rig keeps the warmup unconditionally because
  *    removing it asymmetrically across platforms would obscure the Windows justification, and the
  *    cost is one extra click per smoke (~250ms).
- * 3. **Clipboard-paste path works through XWayland.** The `typeText` clipboard-poll budget
- *    (`CLIPBOARD_SETTLE_TIMEOUT_MS = 1_000L`) tuned for macOS NSPasteboard latency was never
- *    approached on X11 — observed settle is essentially synchronous. The path validates with
- *    XWayland transparently bridging clipboard ownership.
+ * 3. **Key-event text entry works through XWayland.** `typeText` sends key events rather than
+ *    touching the clipboard, and XWayland/Xvfb deliver the expected text to the focused field.
  *
  * What this *doesn't* exercise:
  * - Native Wayland input — gated above; not testable without a synthetic compositor that grants the

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
@@ -42,10 +42,9 @@ import kotlinx.coroutines.runBlocking
  *    the same scenario step, on both XWayland and Xvfb. (Reflects the X11 click-to-focus
  *    convention; differs from macOS, where the first click on an inactive app traditionally
  *    activates without delivering — to be verified separately when MacOsRobotUnfocusedSmoke runs.)
- * 4. **typeText-after-focus-click works through XSelection on XWayland.** No clipboard-settle
- *    pressure observed; the existing `CLIPBOARD_SETTLE_TIMEOUT_MS = 1_000L` budget tuned for macOS
- *    NSPasteboard latency is never approached on X11. Both XWayland and Xvfb produce the expected
- *    text after the focus-handoff click.
+ * 4. **typeText-after-focus-click works through XWayland.** `typeText` sends key events rather than
+ *    touching the clipboard. Both XWayland and Xvfb produce the expected text after the
+ *    focus-handoff click.
  *
  * Three Linux session modes validated (mirrors [LinuxRobotSmoke]'s focused-smoke findings):
  * - **XWayland** (Wayland session with `DISPLAY=:0` set): 4/4 PASS through XWayland's X11 bridge.

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
@@ -279,8 +279,8 @@ internal suspend fun scenarioPressKeySingleChar(
     state: SmokeState,
 ): ScenarioResult {
     // Baseline for the typeText scenario: if the BasicTextField is focused after a click and
-    // accepts direct keystrokes (no clipboard involved), the focus path works and any
-    // typeText failure isolates to the clipboard-paste path.
+    // accepts direct keystrokes, the focus path works and any typeText failure isolates to key
+    // dispatch rather than focus.
     val target = awtCenter(state, state.textFieldBounds)
     if (target == null) {
         return ScenarioResult("pressKey 'h' into BasicTextField", false, "no target rect available")
@@ -315,7 +315,7 @@ internal suspend fun scenarioTypeText(
     val actual = state.textValue.text
     // Exact equality: the field starts empty (typeText runs first in the scenario order
     // before any keystroke leaves state behind), so the only correct outcome is the typed
-    // string — substring match would mask paste-doubling or stray-keypress bugs.
+    // string — substring match would mask duplicate or stray-keypress bugs.
     val passed = actual == expected
     val detail = "text=\"$actual\" expected=\"$expected\" focusOwner=$focusOwnerBefore"
     return ScenarioResult("typeText into BasicTextField", passed = passed, detail = detail)

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotSmoke.kt
@@ -22,7 +22,7 @@ import kotlinx.coroutines.runBlocking
  * Issue #20 checklist coverage:
  * - mouseMove + mousePress against the spawned window (counter button)
  * - pressKey single character — focus baseline so a typeText failure isolates from focus issues
- * - clipboard-driven typeText into a Compose `BasicTextField`
+ * - key-event `typeText` into a Compose `BasicTextField`
  * - clearAndTypeText (Ctrl+A on Windows, Cmd+A on macOS — uses the platform-aware
  *   `shortcutModifierKeyCode`)
  * - pressKey with Ctrl+S — verifies the modifier-mask → keyCode path Spectre uses for shortcuts

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/WindowsRobotUnfocusedSmoke.kt
@@ -47,10 +47,9 @@ import kotlinx.coroutines.runBlocking
  *    first click is "free" — it counts as both a real interaction *and* a focus handoff. Spectre
  *    automation does NOT need to dispatch a separate activation click before driving an inactive
  *    Compose window.
- * 4. **`typeText` works after the focus-handoff click** — the existing clipboard-paste path
- *    (`clearAndTypeText("post-focus paste")`) lands the exact expected string in the text field.
- *    Once focus has moved, this is the same path as the focused smoke; no Windows- specific quirk
- *    in the unfocused-then-focused transition.
+ * 4. **`typeText` works after the focus-handoff click** — `clearAndTypeText("post-focus paste")`
+ *    lands the exact expected string in the text field. Once focus has moved, this is the same path
+ *    as the focused smoke; no Windows-specific quirk in the unfocused-then-focused transition.
  *
  * Net effect: Spectre callers can safely drive a Compose window that's not currently foreground.
  * Document for users running automation alongside other apps that the FIRST Robot mouse event acts

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
@@ -8,7 +8,6 @@ import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.InternalSpectreApi
 import dev.sebastiano.spectre.core.RobotDriver
 import dev.sebastiano.spectre.core.WindowTracker
-import dev.sebastiano.spectre.core.synthetic
 import java.awt.GraphicsEnvironment
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -123,9 +122,9 @@ class SampleAppFixture(
 /**
  * `true` when this JVM was booted as a macOS UI element (`apple.awt.UIElement=true`), in which case
  * AppKit suppresses the spawned window's focus-grab / Dock icon but also restricts NSPasteboard
- * access. Tests that rely on the clipboard (currently only `Issue8FidelityValidationTest.typeText`)
- * gate themselves on this so the focus-quiet workflow stays the default while the paste fidelity
- * test still runs when the property is explicitly off.
+ * access. Tests that rely on the clipboard (currently only the paste-text fidelity validation) gate
+ * themselves on this so the focus-quiet workflow stays the default while the paste fidelity test
+ * still runs when the property is explicitly off.
  *
  * We check `apple.awt.UIElement` directly (the actual AWT switch) in addition to the
  * `spectre.sample.fixture.uiElement` mirror flag the validation Gradle tasks set. Either being

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomatorE2ETest.kt
@@ -38,7 +38,11 @@ class HttpComposeAutomatorE2ETest {
 
     @BeforeTest
     fun startServer() {
-        val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+        val automator =
+            ComposeAutomator.inProcess(
+                robotDriver = RobotDriver.headless(),
+                discoverWindows = false,
+            )
         server =
             embeddedServer(CIO, port = 0) { installSpectreRoutes(automator) }.start(wait = false)
         port = runBlocking { server.engine.resolvedConnectors().first().port }

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpNegativeContractTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/HttpNegativeContractTest.kt
@@ -49,7 +49,7 @@ import kotlinx.coroutines.runBlocking
 class HttpNegativeContractTest {
 
     private fun headlessAutomator(): ComposeAutomator =
-        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless(), discoverWindows = false)
 
     // --- Server-side decode failures -----------------------------------------------------
 

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
@@ -39,7 +39,7 @@ import kotlin.test.assertTrue
 class SpectreServerRoundTripTest {
 
     private fun headlessAutomator(): ComposeAutomator =
-        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless(), discoverWindows = false)
 
     @Test
     fun `windows endpoint returns an empty list for an empty automator`() = testApplication {

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -45,7 +45,7 @@ class CounterTest {
     val automatorExt = ComposeAutomatorExtension()
 
     @Test
-    fun `clicking increment bumps the counter`() = runBlocking {
+    fun `clicking increment bumps the counter`(): Unit = runBlocking {
         launchCounterApp() // your harness — opens the Compose window
 
         val automator = automatorExt.automator
@@ -81,9 +81,7 @@ on the host OS. Three variants:
   AWT events directly into the given `java.awt.Window` hierarchy. No global
   focus contention, so safe for **parallel test JVMs** and for IDE-hosted
   Compose where stealing the IDE focus would be hostile. Does **not** see OS
-  shortcuts (Cmd+Tab, system menus). It is an extension on
-  `RobotDriver.Companion` defined in `SyntheticInput.kt`, so you must add
-  `import dev.sebastiano.spectre.core.synthetic` for the call to resolve.
+  shortcuts (Cmd+Tab, system menus).
 - **`RobotDriver.headless()`** — refuses to send any input. For tests that
   only read the semantics tree (e.g. asserting a screen layout) without
   driving it.
@@ -91,8 +89,6 @@ on the host OS. Three variants:
 ```kotlin
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.synthetic // required for the call below
-
 val automator = ComposeAutomator.inProcess(
     robotDriver = RobotDriver.synthetic(rootWindow = ideFrame),
 )
@@ -145,9 +141,12 @@ All `suspend` on `ComposeAutomator`:
 - `click(node)`, `doubleClick(node)`, `longClick(node, holdFor = 500.milliseconds)`
 - `swipe(from, to, steps, duration)` or `swipe(startX, startY, endX, endY, …)`
 - `scrollWheel(node, wheelClicks)`
-- `typeText("hello")` — pastes via the system clipboard (faster, handles
-  unicode). On macOS the clipboard write is async; Spectre polls until the
-  clipboard reads back the requested text. Disable clipboard managers in CI.
+- `typeText("hello")` — types supported ASCII text via key events without using
+  the clipboard. Use `pasteText` for large or Unicode strings.
+- `pasteText("hello")` — pastes via the system clipboard. On macOS the clipboard
+  write is async; Spectre polls until the clipboard reads back the requested text.
+  Disable clipboard managers in CI, and do not use `apple.awt.UIElement=true` for
+  JVMs that need clipboard-backed paste.
 - `clearAndTypeText(node, "new")` — Ctrl/Cmd+A, Backspace, then `typeText`.
 - `pressKey(KeyEvent.VK_ENTER, modifiers = 0)`, `pressEnter()`.
 - `performSemanticsClick(node)` — bypasses the OS entirely and invokes
@@ -200,8 +199,15 @@ older carve-out for `waitForNode` — that exception is gone in current code.
 
 `kotlinx-coroutines-test`'s `runTest` skips `delay()`. That collapses
 `longClick` hold durations, `swipe` pacing, and the macOS clipboard-settle
-poll inside `typeText` to zero, breaking them all. Use `runBlocking { ... }`
+poll inside `pasteText` to zero, breaking them all. Use `runBlocking { ... }`
 in the test body.
+
+### Rule 4b: force expression-body tests to return `Unit`
+
+Write `@Test fun mySpec(): Unit = runBlocking { ... }`. JUnit 5.14+ rejects
+non-void test methods during discovery, and Kotlin infers an expression-body
+function's return type from the last expression in the `runBlocking` body. Some
+assertions return the asserted value, not `Unit`.
 
 ### Custom idling resources
 
@@ -260,9 +266,10 @@ touches that area*; they are not needed for the common case.
 | Two parallel test JVMs steal focus from each other | Both use real `RobotDriver()` | Use `RobotDriver.synthetic(rootWindow)` |
 | Cmd+Tab or OS shortcuts don't work under synthetic driver | Synthetic events bypass HID | Use real `RobotDriver()` for those tests |
 | Screenshot is blurry / mid-animation | Captured before frame stabilised | `waitForVisualIdle()` first |
-| `typeText` times out on macOS in CI | Clipboard manager rewriting `NSPasteboard` | Disable clipboard utilities in CI |
+| `pasteText` silently does not land on macOS with `apple.awt.UIElement=true` | UI-element/helper mode breaks clipboard-backed paste, even with synthetic input | Disable `apple.awt.UIElement=true` for the JVM hosting the test window, or use `typeText` for supported ASCII |
+| `pasteText` times out on macOS in CI | Clipboard manager rewriting `NSPasteboard` | Disable clipboard utilities in CI |
 | Recording misses popups that escape the host window | Popups live in their own AWT window outside both the region rectangle *and* a window-targeted capture | Choose an explicit region (or full-desktop crop) wide enough to include where the popup opens, or document the limitation — neither region nor window targeting follows cross-window popups |
-| Window-targeted Wayland recording throws `IllegalStateException` | `xprop` missing or non-GNOME compositor | Fall back to region capture (`window = null`) |
+| Window-targeted Wayland recording throws `IllegalStateException` | `xprop` missing or non-GNOME compositor | Use `AutoRecorder.startRegion(...)` with an explicit rectangle |
 | Coordinates derived from `boundsInWindow` land off-target on HiDPI | `boundsInWindow` is dp; screen is pixels | Use `boundsOnScreen`/`centerOnScreen`, or apply density |
 
 ## What Spectre is NOT (don't pretend it is)
@@ -288,4 +295,5 @@ println(automator.printTree())
 
 Run it right before a failing selector. The output names every node Spectre
 can see, with tags/texts/bounds. 90% of "selector returned null" mysteries
-resolve here.
+resolve here. If it returns an empty string, the composition probably crashed
+before any node registered; check test stderr for EDT/composition exceptions.

--- a/skills/spectre/references/intellij.md
+++ b/skills/spectre/references/intellij.md
@@ -17,7 +17,6 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.wm.WindowManager
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-import dev.sebastiano.spectre.core.synthetic
 
 class RunSpectreAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {

--- a/skills/spectre/references/junit.md
+++ b/skills/spectre/references/junit.md
@@ -82,13 +82,9 @@ val automatorExt = ComposeAutomatorExtension {
 }
 ```
 
-Same shape for parallel-safe synthetic input (note the
-`import dev.sebastiano.spectre.core.synthetic` — `synthetic` is an extension
-on `RobotDriver.Companion`, not a member):
+Same shape for parallel-safe synthetic input:
 
 ```kotlin
-import dev.sebastiano.spectre.core.synthetic
-
 @JvmField
 @RegisterExtension
 val automatorExt = ComposeAutomatorExtension {

--- a/skills/spectre/references/recording.md
+++ b/skills/spectre/references/recording.md
@@ -6,20 +6,19 @@ is not supported.**
 
 ## Entry point — `AutoRecorder`
 
-`AutoRecorder` picks an appropriate platform backend:
+`AutoRecorder` exposes explicit window and region capture entry points:
 
-| Platform | Window target | Region target |
+| Platform | `startWindow` | `startRegion` |
 |---|---|---|
-| macOS | ScreenCaptureKit (native) | ScreenCaptureKit cropped |
+| macOS | ScreenCaptureKit (native) | ffmpeg region capture |
 | Windows | ffmpeg `gdigrab title=` | ffmpeg `gdigrab` |
-| Linux X11 / XWayland | (n/a — fall back to region) | ffmpeg `x11grab` |
-| Linux Wayland (GNOME/Mutter) | xdg-desktop-portal | xdg-desktop-portal |
+| Linux X11 / XWayland | unsupported | ffmpeg `x11grab` |
+| Linux Wayland (GNOME/Mutter) | xdg-desktop-portal window source | xdg-desktop-portal monitor source |
 
 ```kotlin
 val recorder = AutoRecorder()
-val handle = recorder.start(
-    window = composeWindow.asTitledWindow(),   // or null for region only
-    region = Rectangle(100, 100, 800, 600),
+val handle = recorder.startWindow(
+    window = composeWindow.asTitledWindow(),
     output = Path.of("build/recordings/my-test.mp4"),
     options = RecordingOptions(),
 )
@@ -37,7 +36,7 @@ the file is finalised even on failure.
 
 Two trade-offs, pick deliberately:
 
-- **Region (`window = null`)**: fixed screen `Rectangle`. Does **not** follow
+- **Region (`startRegion`)**: fixed screen `Rectangle`. Does **not** follow
   the window if it moves or resizes; pixels outside the rectangle (popups,
   dialogs that escape the bounds) are lost. Use when you control window
   placement and want a fixed crop.
@@ -45,8 +44,9 @@ Two trade-offs, pick deliberately:
   live in their own AWT window outside the target. Use for tests where the
   window may move but stays the focus.
 
-Embedded `ComposePanel` instances have no top-level window title, so window
-targeting silently falls back to region capture — pass an explicit region.
+Embedded `ComposePanel` instances have no top-level window title, so use
+`startRegion(...)` with an explicit rectangle. `startWindow(...)` fails loudly when a
+true window-targeted backend is unavailable.
 
 ## Linux Wayland caveats
 
@@ -57,8 +57,8 @@ Window-targeted Wayland recording throws `IllegalStateException` if:
 - The compositor doesn't publish `_GTK_FRAME_EXTENTS` (verified only on
   GNOME/Mutter; KDE, sway, wlroots are best-effort).
 
-If a test must run on those compositors, fall back to region capture with
-`window = null` and a fixed `Rectangle`.
+If a test must run on those compositors, use `startRegion(...)` with a fixed
+`Rectangle`.
 
 ## HiDPI and coordinates
 


### PR DESCRIPTION
## Summary
- split text entry into key-event `typeText` and clipboard-backed `pasteText`
- make `RobotDriver.synthetic(rootWindow)` a real companion API and harden headless/window discovery paths
- replace mixed `AutoRecorder.start(window, region, ...)` with explicit `startWindow` / `startRegion` APIs
- update docs and packaged skill guidance for JUnit `: Unit`, non-headless tests, macOS UIElement clipboard caveats, recording modes, and troubleshooting

## Validation
- `./gradlew check -Dorg.gradle.vfs.watch=false --no-daemon --no-configuration-cache`
- `uv run --with-requirements requirements-docs.txt mkdocs build --strict`