### PR TITLE
Fix synthetic typing when AWT has no focus owner

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.core
 
 import java.awt.Component
+import java.awt.Container
 import java.awt.Point
 import java.awt.Rectangle
 import java.awt.Window
@@ -274,13 +275,22 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
     }
 
     private fun dispatchKey(type: Int, keyCode: Int, keyCharOverride: Char? = null) {
-        // Key events go to the focus owner of whichever window owns the keyboard. Fall back to
-        // the root window if no focus owner is present (no field focused yet).
-        val focusOwner =
-            allWindows().asSequence().mapNotNull { it.focusOwner }.firstOrNull() ?: rootWindow
+        // Key events go to the focus owner of whichever window owns the keyboard. When macOS runs
+        // the JVM as an `apple.awt.UIElement`, AWT may never grant OS keyboard focus to any window
+        // even though the app's own focus model has a focused field. In that case, dispatch to
+        // the last pointer target first (matching click-then-type flows) and then to an embedded
+        // Compose host so Compose can route the event internally.
+        val windows = allWindows()
+        val pointerTarget = hitTestComponent()
+        val target =
+            windows.asSequence().mapNotNull { it.focusOwner }.firstOrNull()
+                ?: pointerTarget?.composeHostAncestorOrSelf()
+                ?: pointerTarget
+                ?: findComposeKeyEventTarget(windows)
+                ?: rootWindow
         val event =
             KeyEvent(
-                focusOwner,
+                target,
                 type,
                 System.currentTimeMillis(),
                 heldKeyModifiers,
@@ -301,7 +311,7 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
                         )
                     else KeyEvent.CHAR_UNDEFINED,
             )
-        runOnEdt { focusOwner.dispatchEvent(event) }
+        runOnEdt { target.dispatchEvent(event) }
     }
 
     private fun findWindowAt(screenX: Int, screenY: Int): Window? =
@@ -381,6 +391,27 @@ private fun collectWindowTree(window: Window, into: MutableCollection<Window>) {
     }
 }
 
+private fun findComposeKeyEventTarget(windows: List<Window>): Component? =
+    windows.asReversed().firstNotNullOfOrNull { window -> findComposeHostIn(window) }
+
+private fun findComposeHostIn(component: Component): Component? {
+    if (component.isComposeHostComponent()) return component
+    if (component !is Container) return null
+    return component.components.firstNotNullOfOrNull(::findComposeHostIn)
+}
+
+private fun Component.composeHostAncestorOrSelf(): Component? {
+    var current: Component? = this
+    while (current != null) {
+        if (current.isComposeHostComponent()) return current
+        current = current.parent
+    }
+    return null
+}
+
+private fun Component.isComposeHostComponent(): Boolean =
+    javaClass.name == COMPOSE_PANEL_CLASS_NAME || javaClass.name == COMPOSE_WINDOW_PANEL_CLASS_NAME
+
 private fun findDeepestComponentAt(root: Component, screenX: Int, screenY: Int): Component? {
     val origin = runCatching { root.locationOnScreen }.getOrNull() ?: return null
     val localPoint = Point(screenX - origin.x, screenY - origin.y)
@@ -397,6 +428,9 @@ private fun buttonNumber(buttonMask: Int): Int =
     }
 
 private const val NO_BUTTON: Int = MouseEvent.NOBUTTON
+private const val COMPOSE_PANEL_CLASS_NAME: String = "androidx.compose.ui.awt.ComposePanel"
+private const val COMPOSE_WINDOW_PANEL_CLASS_NAME: String =
+    "androidx.compose.ui.awt.ComposeWindowPanel"
 
 // Conservative double-click window — matches the typical OS default. Two press/release pairs
 // at the same coordinates within this window count as a double-click, so doubleClick() emits

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
@@ -11,6 +11,7 @@ import java.awt.datatransfer.StringSelection
 import java.awt.datatransfer.Transferable
 import java.awt.event.AWTEventListener
 import java.awt.event.KeyEvent
+import java.awt.event.KeyListener
 import java.awt.event.MouseEvent
 import java.awt.event.MouseListener
 import java.awt.event.MouseMotionListener
@@ -203,6 +204,42 @@ class SyntheticInputParityTest {
 
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `key events fall back to the last pointer target when AWT has no focus owner`() {
+        assumeLiveAwtAvailable()
+        val events: MutableList<KeyEvent> = CopyOnWriteArrayList()
+        val target =
+            JPanel().apply {
+                preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
+                addKeyListener(KeyEventRecorder(events))
+            }
+        val frame = showNonFocusableFrameOnEdt(target)
+        try {
+            assertTrue(
+                frame.frame.focusOwner == null,
+                "test fixture must model UIElement-style AWT with no focus owner",
+            )
+            val (cx, cy) = frame.targetCenterOnScreen(target)
+            val driver = RobotDriver.synthetic(frame.frame)
+            runBlocking {
+                driver.click(cx, cy)
+                driver.pressKey(KeyEvent.VK_A)
+            }
+            drainEdt()
+
+            val pressed = events.firstOrNull {
+                it.id == KeyEvent.KEY_PRESSED && it.keyCode == KeyEvent.VK_A
+            }
+            assertNotNull(
+                pressed,
+                "expected KEY_PRESSED to route to the last pointer target when no AWT focus owner exists",
+            )
+        } finally {
+            disposeFrame(frame.frame)
+        }
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `pasteText through the synthetic driver isolates and restores the fake clipboard`() {
         assumeLiveAwtAvailable()
         val target = JPanel().apply { preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX) }
@@ -296,13 +333,17 @@ class SyntheticInputParityTest {
 
     // --- Fixtures ---------------------------------------------------------------------------
 
-    private fun showFrameOnEdt(target: JPanel): TestFrame {
+    private fun showNonFocusableFrameOnEdt(target: JPanel): TestFrame =
+        showFrameOnEdt(target) { focusableWindowState = false }
+
+    private fun showFrameOnEdt(target: JPanel, configure: JFrame.() -> Unit = {}): TestFrame {
         var frame: JFrame? = null
         SwingUtilities.invokeAndWait {
             frame =
                 JFrame("SyntheticInputParityTest").apply {
                     defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
                     isUndecorated = true
+                    configure()
                     contentPane.layout = BorderLayout()
                     contentPane.add(target, BorderLayout.CENTER)
                     size = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
@@ -395,6 +436,20 @@ class SyntheticInputParityTest {
         }
 
         override fun mouseMoved(e: MouseEvent) = Unit
+    }
+
+    private class KeyEventRecorder(private val events: MutableList<KeyEvent>) : KeyListener {
+        override fun keyTyped(e: KeyEvent) {
+            events.add(e)
+        }
+
+        override fun keyPressed(e: KeyEvent) {
+            events.add(e)
+        }
+
+        override fun keyReleased(e: KeyEvent) {
+            events.add(e)
+        }
     }
 
     private class GlobalKeyEventRecorder {


### PR DESCRIPTION
## Summary
- fall back from missing AWT focus owner to the last pointer target / enclosing Compose host for synthetic key events
- discover embedded ComposePanel / ComposeWindowPanel hosts without adding a public API dependency
- add regression coverage for click-then-type key routing when no AWT focus owner exists

## Validation
- ✅ ./gradlew :core:check
- ⚠️ ./gradlew check attempted locally; blocked in :recording:buildScreenCaptureKitHelper by SwiftPM sandbox-exec: sandbox_apply: Operation not permitted