### PR TITLE
Route synthetic keys to Compose's Skiko canvas under UIElement

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
@@ -294,13 +294,14 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
         // for any plain-Swing fixture (test or otherwise) that registers its own key listener.
         val windows = allWindows()
         val pointerTarget = hitTestComponent()
+        val composeFallbackTarget = findComposeKeyEventTarget(windows)
         val target =
             windows.asSequence().mapNotNull { it.focusOwner }.firstOrNull()
                 ?: pointerTarget?.findKeyListenerSelfOrDescendant()
                 ?: pointerTarget?.composeHostAncestorOrSelf()?.findKeyListenerDescendant()
                 ?: pointerTarget
-                ?: findComposeKeyEventTarget(windows)?.findKeyListenerSelfOrDescendant()
-                ?: findComposeKeyEventTarget(windows)
+                ?: composeFallbackTarget?.findKeyListenerSelfOrDescendant()
+                ?: composeFallbackTarget
                 ?: rootWindow
         val event =
             KeyEvent(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.core
 
 import java.awt.Component
 import java.awt.Container
+import java.awt.KeyboardFocusManager
 import java.awt.Point
 import java.awt.Rectangle
 import java.awt.Window
@@ -275,17 +276,30 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
     }
 
     private fun dispatchKey(type: Int, keyCode: Int, keyCharOverride: Char? = null) {
-        // Key events go to the focus owner of whichever window owns the keyboard. When macOS runs
-        // the JVM as an `apple.awt.UIElement`, AWT may never grant OS keyboard focus to any window
-        // even though the app's own focus model has a focused field. In that case, dispatch to
-        // the last pointer target first (matching click-then-type flows) and then to an embedded
-        // Compose host so Compose can route the event internally.
+        // Pick the AWT component that should receive the synthetic KeyEvent. The chain below is
+        // ordered from "AWT thinks it knows where focus is" down to "best-effort by structure".
+        //
+        // Why this is more involved than "dispatch to the focus owner": when macOS runs the JVM as
+        // an `apple.awt.UIElement`, AWT never grants OS keyboard focus to any window — every
+        // `Window.focusOwner` stays null even though Compose's own focus model has a focused
+        // composable. Without a fallback, real text input never reaches Compose at all.
+        //
+        // Compose Desktop registers its AWT `KeyListener` on
+        // `ComposeSceneMediator.contentComponent`
+        // — the inner Skiko canvas (an `org.jetbrains.skiko.SkiaLayer` or
+        // `androidx.compose.ui.scene.skia.SkiaSwingLayer`) inside `ComposeWindowPanel`, NOT on the
+        // panel itself. So dispatching to the panel produces visible focus side-effects but no
+        // text. We pick the deepest descendant of a Compose host that actually has a registered
+        // `KeyListener`, which lands on the Skiko canvas in real Compose hierarchies and works
+        // for any plain-Swing fixture (test or otherwise) that registers its own key listener.
         val windows = allWindows()
         val pointerTarget = hitTestComponent()
         val target =
             windows.asSequence().mapNotNull { it.focusOwner }.firstOrNull()
-                ?: pointerTarget?.composeHostAncestorOrSelf()
+                ?: pointerTarget?.findKeyListenerSelfOrDescendant()
+                ?: pointerTarget?.composeHostAncestorOrSelf()?.findKeyListenerDescendant()
                 ?: pointerTarget
+                ?: findComposeKeyEventTarget(windows)?.findKeyListenerSelfOrDescendant()
                 ?: findComposeKeyEventTarget(windows)
                 ?: rootWindow
         val event =
@@ -311,7 +325,15 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
                         )
                     else KeyEvent.CHAR_UNDEFINED,
             )
-        runOnEdt { target.dispatchEvent(event) }
+        // Bypass `KeyboardFocusManager` via `redispatchEvent`. `Component.dispatchEvent(KeyEvent)`
+        // would otherwise hand the event to KFM first, which redirects to the global focus owner —
+        // null under `apple.awt.UIElement=true`, causing the event to be silently dropped. The
+        // `redispatchEvent` entry point exists precisely for callers "using key events generated
+        // from non-keyboard sources": it sets `KeyEvent.focusManagerIsDispatching=true` so AWT
+        // skips the KFM redirect and delivers straight to the target's `processKeyEvent`.
+        runOnEdt {
+            KeyboardFocusManager.getCurrentKeyboardFocusManager().redispatchEvent(target, event)
+        }
     }
 
     private fun findWindowAt(screenX: Int, screenY: Int): Window? =
@@ -411,6 +433,30 @@ private fun Component.composeHostAncestorOrSelf(): Component? {
 
 private fun Component.isComposeHostComponent(): Boolean =
     javaClass.name == COMPOSE_PANEL_CLASS_NAME || javaClass.name == COMPOSE_WINDOW_PANEL_CLASS_NAME
+
+/**
+ * Returns this component if it has any registered AWT [java.awt.event.KeyListener]s, otherwise the
+ * first such descendant in a depth-first walk, or `null` if none is found.
+ *
+ * Used to find the Skiko canvas under a `ComposeWindowPanel` (`ComposeSceneMediator` registers its
+ * key listener on `contentComponent`, not on the outer panel). Walking by structural class name is
+ * fragile across Compose versions; checking for a registered key listener is the behavioural
+ * property we actually care about and keeps plain-Swing fixtures working too.
+ */
+private fun Component.findKeyListenerSelfOrDescendant(): Component? {
+    if (keyListeners.isNotEmpty()) return this
+    return findKeyListenerDescendant()
+}
+
+private fun Component.findKeyListenerDescendant(): Component? {
+    if (this !is Container) return null
+    for (child in components) {
+        if (child.keyListeners.isNotEmpty()) return child
+        val nested = child.findKeyListenerDescendant()
+        if (nested != null) return nested
+    }
+    return null
+}
 
 private fun findDeepestComponentAt(root: Component, screenX: Int, screenY: Int): Component? {
     val origin = runCatching { root.locationOnScreen }.getOrNull() ?: return null

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
@@ -240,6 +240,67 @@ class SyntheticInputParityTest {
 
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `key events descend from pointer target into a key-listening descendant`() {
+        // Models the real Compose Desktop topology where the pointer target is a wrapper that
+        // doesn't own the AWT KeyListener (e.g. `ComposeWindowPanel`) but a descendant does
+        // (the inner Skiko canvas, where `ComposeSceneMediator` registers its key listener).
+        //
+        // To force the pointer hit-test to return the wrapper rather than `inner`, the inner
+        // component is placed in a corner so the center of the wrapper is NOT covered by it.
+        // The adapter must walk down from the wrapper to find the key-listening descendant for
+        // text input to land where Compose actually consumes it.
+        assumeLiveAwtAvailable()
+        val innerEvents: MutableList<KeyEvent> = CopyOnWriteArrayList()
+        val inner =
+            JPanel().apply {
+                isOpaque = true
+                background = Color.BLUE
+                // Sit in the top-left corner, leaving the wrapper's center uncovered so the
+                // synthetic pointer hit-test resolves to the wrapper, not `inner`.
+                setBounds(0, 0, FRAME_SIZE_PX / 4, FRAME_SIZE_PX / 4)
+                addKeyListener(KeyEventRecorder(innerEvents))
+            }
+        val wrapper =
+            JPanel(null).apply {
+                preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
+                add(inner)
+            }
+        val frame = showNonFocusableFrameOnEdt(wrapper)
+        try {
+            assertTrue(
+                frame.frame.focusOwner == null,
+                "test fixture must model UIElement-style AWT with no focus owner",
+            )
+            // Click the center of the wrapper, which is NOT inside `inner`'s bounds: this is the
+            // scenario where the pointer target is the wrapper and the adapter has to descend.
+            val (cx, cy) = frame.targetCenterOnScreen(wrapper)
+            val driver = RobotDriver.synthetic(frame.frame)
+            runBlocking {
+                driver.click(cx, cy)
+                driver.pressKey(KeyEvent.VK_B)
+            }
+            drainEdt()
+
+            val pressed = innerEvents.firstOrNull {
+                it.id == KeyEvent.KEY_PRESSED && it.keyCode == KeyEvent.VK_B
+            }
+            assertNotNull(
+                pressed,
+                "expected KEY_PRESSED to descend from the wrapper pointer target into the " +
+                    "key-listening inner component; innerEvents=$innerEvents",
+            )
+            assertEquals(
+                inner,
+                pressed.source,
+                "expected the KeyEvent source to be the inner component, not the wrapper",
+            )
+        } finally {
+            disposeFrame(frame.frame)
+        }
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `pasteText through the synthetic driver isolates and restores the fake clipboard`() {
         assumeLiveAwtAvailable()
         val target = JPanel().apply { preferredSize = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX) }


### PR DESCRIPTION
## Summary

- route synthetic key fallback to the component that actually owns AWT key listeners (the inner Skiko canvas under Compose hosts)
- use `KeyboardFocusManager.redispatchEvent` so synthetic key events bypass KFM's global-focus-owner redirect under `apple.awt.UIElement=true`
- add live-AWT parity coverage for wrapper → key-listening-descendant dispatch

## Verification

- `./gradlew --no-watch-fs --no-daemon :core:check :server:check :testing:check`
- `/tmp/run-spectre-live-awt-tests.sh` from a normal Terminal:
  - `SyntheticInputParityTest.key events fall back to the last pointer target when AWT has no focus owner`
  - `SyntheticInputParityTest.key events descend from pointer target into a key-listening descendant`

Note: full `check` in the agent sandbox is blocked by the native Swift ScreenCaptureKit helper build (`sandbox-exec: sandbox_apply: Operation not permitted`), unrelated to these `:core` changes.
