### PR TITLE
Document synthetic UIElement key dispatch behavior

### DIFF
--- a/.agents/skills/jewel-swing-interop/SKILL.md
+++ b/.agents/skills/jewel-swing-interop/SKILL.md
@@ -37,6 +37,18 @@ Always consider all of these when investigating popup semantics, hit-testing, or
 2. Swing-hosted `ComposePanel` layers
 3. real owned windows such as `JDialog` / `JBPopup`
 
+## Synthetic Key Dispatch Guidance
+
+- Compose Desktop key listeners usually live on the inner Skiko canvas (`SkiaLayer` /
+  `SkiaSwingLayer`), not on the outer `ComposePanel` / `ComposeWindowPanel` wrapper.
+- When debugging synthetic typing in Jewel or Swing-hosted Compose, do not assume
+  `Window.focusOwner` is available. macOS `apple.awt.UIElement=true` helper JVMs can
+  keep every AWT window unfocused while Compose's internal focus model still has a
+  focused `TextField`.
+- Spectre's synthetic driver should therefore target the key-listening descendant under
+  the pointer target or Compose host and use `KeyboardFocusManager.redispatchEvent`, not
+  plain `Component.dispatchEvent`, for key events generated outside the OS keyboard path.
+
 ## Coordinate And Interop Guidance
 
 - Be careful when moving between Compose coordinates and AWT screen coordinates.

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -130,6 +130,11 @@ corresponding doc page is touched:
   supports conservative ASCII key-event input without touching the clipboard. `pasteText`
   writes the text, dispatches the platform paste shortcut, drains, then restores the
   previous clipboard contents.
+- **Synthetic typing and macOS UIElement mode.** Current `RobotDriver.synthetic(rootWindow)`
+  routes key events to Compose Desktop's key-listening AWT host when AWT has no
+  `Window.focusOwner`, so `typeText` works in `apple.awt.UIElement=true` helper JVMs.
+  Keep documenting `pasteText` and OS recording as separate macOS-service paths that
+  UIElement mode can still break.
 - **Linux Wayland + `LinuxX11Grab` throws.** It does not silently produce black
   frames. The thrown message points users at `AutoRecorder`/`WaylandPortalRecorder`.
 

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -113,8 +113,11 @@ and `RobotDriver.headless()`. Two IDE-specific notes on top of that page:
 - **`synthetic` is the usual default.** When the JVM running the automator is also
   the JVM hosting the UI, real OS input would dispatch events back to the IDE
   you're inside, fight with whatever else has focus on the host machine, and move
-  the user's cursor visibly. Synthetic AWT events skip all of that. The
-  IntelliJ-specific recipe for the `rootWindow` argument is
+  the user's cursor visibly. Synthetic AWT events skip all of that. On macOS this
+  also works for helper/test JVMs launched with `apple.awt.UIElement=true`: AWT may
+  never report a `Window.focusOwner`, but Spectre routes key events to the
+  key-listening Compose Desktop host so focused text fields still receive
+  `typeText`. The IntelliJ-specific recipe for the `rootWindow` argument is
   `WindowManager.getInstance().getFrame(project)` — that's the `Window` shown in
   the action sample above.
 - **`RobotDriver()` is still valid** when you specifically need to exercise

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -168,8 +168,14 @@ public surface:
   `java.awt.Robot` you've already constructed (e.g., one targeted at a non-default
   `GraphicsDevice`).
 - **`RobotDriver.synthetic(rootWindow)`** — synthetic AWT events posted straight into the
-  target window's event queue. No real cursor motion, no global focus, doesn't fight with
-  other processes.
+  target window's AWT hierarchy. No real cursor motion, no global focus, doesn't fight
+  with other processes. Mouse and wheel events hit-test against `rootWindow`, its owned
+  windows, and other visible top-level windows. Key events go to the current AWT focus
+  owner when one exists; when AWT has no focus owner (for example, a macOS helper JVM
+  launched with `apple.awt.UIElement=true`), Spectre falls back to the key-listening AWT
+  descendant under the last pointer target or Compose host. That lets Compose Desktop's
+  internal focus model route `typeText` into focused `TextField`s even when the host
+  window is not the OS-foreground app.
   `screenshot()` under a synthetic driver also bypasses the OS framebuffer — it renders
   the target window via `Component.paint(Graphics)` into a `BufferedImage` instead of
   calling `Robot.createScreenCapture`. Results are consistent for regression tests, but
@@ -193,7 +199,10 @@ val automator = ComposeAutomator.inProcess(
 )
 ```
 
-Synthetic input is the right choice when you're running tests in parallel JVMs, or when
-the test machine also runs unrelated UI work. Stick to real input for end-to-end smokes
+Synthetic input is the right choice when you're running tests in parallel JVMs, when the
+test machine also runs unrelated UI work, or when a macOS test helper runs with
+`apple.awt.UIElement=true` to avoid a Dock icon. Stick to real input for end-to-end smokes
 where the realism of the input matters (e.g., validating that a system shortcut reaches
-the app).
+the app). `apple.awt.UIElement=true` is **not** a blanket substitute for a foreground app:
+clipboard-backed `pasteText` and OS capture/recording still depend on macOS services
+outside Spectre's synthetic key path.

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -154,6 +154,14 @@ val spectreTest by tasks.registering(Test::class) {
 Use `RobotDriver.headless()` only for read-only semantics-tree tests. It throws on
 input, clipboard, and screenshot calls by design.
 
+On macOS, a dedicated Spectre test task may also set
+`systemProperty("apple.awt.UIElement", "true")` to keep helper JVMs out of the Dock and
+avoid foreground-app fights. Pair that with `RobotDriver.synthetic(rootWindow = window)`
+for typing-driven Compose Desktop tests: Spectre can deliver key events through
+Compose's AWT key listener even when macOS never grants the window an AWT focus owner.
+Do not rely on UI-element mode for clipboard-backed `pasteText` or OS screen recording;
+those still go through macOS services outside the synthetic key-event path.
+
 ## Custom `AutomatorFactory`
 
 Both wrappers default to `ComposeAutomator.inProcess()`. Pass your own factory when you

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -187,6 +187,11 @@ run again". See
 [Troubleshooting](troubleshooting.md#macos-recording-errors-out-or-produces-no-file)
 for failure modes when permission is missing or attached to the wrong binary.
 
+`apple.awt.UIElement=true` helper/test JVMs are useful with `RobotDriver.synthetic(...)`
+for focus-safe typing, but recording still goes through macOS capture services and
+spawned helper processes. Prefer a normal foreground-capable parent process for
+recording tests, especially while establishing Screen Recording TCC grants.
+
 ### Other platforms
 
 - **Windows** — `ffmpeg` on `PATH`. `gdigrab` ships with `ffmpeg`.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -78,16 +78,22 @@ dispatches the platform paste shortcut (<kbd>Cmd</kbd>+<kbd>V</kbd> on macOS,
 <kbd>Ctrl</kbd>+<kbd>V</kbd> elsewhere), waits for the paste to land, and restores the
 previous clipboard contents. A few failure modes follow from those contracts:
 
-- **Nothing has focus.** `typeText` types into whatever the focused component is. If
-  your test never clicked into the field — or the click landed on something else,
-  e.g. a parent that absorbed it — the paste either no-ops or lands in the wrong
-  place. Use `clearAndTypeText(node, …)` (which clicks first) or precede the call
-  with an explicit `automator.click(field)`.
+- **Nothing has focus.** `typeText` types into whatever the focused component is. With
+  the real `RobotDriver()` that means the OS/AWT focus owner. With
+  `RobotDriver.synthetic(rootWindow)`, Spectre can also route key events through the
+  key-listening Compose Desktop host when AWT has no focus owner (for example,
+  `apple.awt.UIElement=true` helper JVMs), but Compose still needs an internally
+  focused text field. If your test never clicked into the field — or the click landed
+  on something else, e.g., a parent that absorbed it — the input either no-ops or lands
+  in the wrong place. Use `clearAndTypeText(node, …)` (which clicks first) or precede
+  the call with an explicit `automator.click(field)`.
 - **The field doesn't accept paste.** Some Compose components (and any read-only
   text field) ignore the system paste shortcut. Verify the field accepts pasted
   input outside the test before assuming Spectre is at fault.
-- **macOS `apple.awt.UIElement=true`.** UI-element/helper mode can break clipboard
-  paste even when you use `RobotDriver.synthetic(rootWindow = ...)`: the field may be
+- **macOS `apple.awt.UIElement=true`.** UI-element/helper mode is supported for
+  `RobotDriver.synthetic(rootWindow = ...)` per-character `typeText`: Spectre bypasses
+  the missing AWT focus owner and targets the key-listening Compose host under the
+  root window. It can still break clipboard-backed `pasteText`: the field may be
   focused and the paste shortcut may be delivered, but Compose reads stale or empty
   clipboard contents. Disable `apple.awt.UIElement=true` for the JVM hosting the test
   window when you need `pasteText`, or use `typeText` for supported ASCII input.

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -80,8 +80,13 @@ on the host OS. Three variants:
 - **`RobotDriver.synthetic(rootWindow = someTopLevelWindow)`** — dispatches
   AWT events directly into the given `java.awt.Window` hierarchy. No global
   focus contention, so safe for **parallel test JVMs** and for IDE-hosted
-  Compose where stealing the IDE focus would be hostile. Does **not** see OS
-  shortcuts (Cmd+Tab, system menus).
+  Compose where stealing the IDE focus would be hostile. For key events,
+  Spectre uses the current AWT focus owner when available and otherwise falls
+  back to the key-listening AWT descendant under the last pointer target or
+  Compose host; this is what makes Compose Desktop `TextField` typing work in
+  macOS helper JVMs launched with `apple.awt.UIElement=true`, where AWT never
+  grants a `Window.focusOwner`. Does **not** see OS shortcuts (Cmd+Tab, system
+  menus).
 - **`RobotDriver.headless()`** — refuses to send any input. For tests that
   only read the semantics tree (e.g. asserting a screen layout) without
   driving it.
@@ -146,7 +151,9 @@ All `suspend` on `ComposeAutomator`:
 - `pasteText("hello")` — pastes via the system clipboard. On macOS the clipboard
   write is async; Spectre polls until the clipboard reads back the requested text.
   Disable clipboard managers in CI, and do not use `apple.awt.UIElement=true` for
-  JVMs that need clipboard-backed paste.
+  JVMs that need clipboard-backed paste. `typeText` is the preferred UIElement-safe
+  path for supported ASCII because it uses per-character key events and does not
+  touch the clipboard.
 - `clearAndTypeText(node, "new")` — Ctrl/Cmd+A, Backspace, then `typeText`.
 - `pressKey(KeyEvent.VK_ENTER, modifiers = 0)`, `pressEnter()`.
 - `performSemanticsClick(node)` — bypasses the OS entirely and invokes
@@ -266,6 +273,7 @@ touches that area*; they are not needed for the common case.
 | Two parallel test JVMs steal focus from each other | Both use real `RobotDriver()` | Use `RobotDriver.synthetic(rootWindow)` |
 | Cmd+Tab or OS shortcuts don't work under synthetic driver | Synthetic events bypass HID | Use real `RobotDriver()` for those tests |
 | Screenshot is blurry / mid-animation | Captured before frame stabilised | `waitForVisualIdle()` first |
+| `typeText` silently does not land on macOS with `apple.awt.UIElement=true` | Usually stale Spectre or wrong `rootWindow`; current synthetic input should target the Compose key-listening host even without AWT focus | Verify the test uses a Spectre build with the UIElement synthetic-key fallback, click/focus the field first, and pass the top-level host window to `RobotDriver.synthetic(rootWindow)` |
 | `pasteText` silently does not land on macOS with `apple.awt.UIElement=true` | UI-element/helper mode breaks clipboard-backed paste, even with synthetic input | Disable `apple.awt.UIElement=true` for the JVM hosting the test window, or use `typeText` for supported ASCII |
 | `pasteText` times out on macOS in CI | Clipboard manager rewriting `NSPasteboard` | Disable clipboard utilities in CI |
 | Recording misses popups that escape the host window | Popups live in their own AWT window outside both the region rectangle *and* a window-targeted capture | Choose an explicit region (or full-desktop crop) wide enough to include where the popup opens, or document the limitation — neither region nor window targeting follows cross-window popups |

--- a/skills/spectre/references/intellij.md
+++ b/skills/spectre/references/intellij.md
@@ -10,7 +10,10 @@ ways.
 The real `RobotDriver()` would steal focus from the IDE and could
 mis-target windows when the developer alt-tabs away. Use
 `RobotDriver.synthetic(rootWindow = ideFrame)` so AWT events are dispatched
-directly into the IDE's window hierarchy:
+directly into the IDE's window hierarchy. On macOS this also works when the
+helper/test JVM is launched with `apple.awt.UIElement=true`: AWT may never
+report a `Window.focusOwner`, but Spectre targets the key-listening Compose
+host under `ideFrame` so focused `TextField`s still receive `typeText`.
 
 ```kotlin
 import com.intellij.openapi.application.ApplicationManager


### PR DESCRIPTION
## Summary

- document the synthetic key-dispatch behavior added for macOS `apple.awt.UIElement=true` helper JVMs
- clarify that synthetic `typeText` can route through Compose's key-listening AWT host when AWT has no `Window.focusOwner`
- keep `pasteText` and recording documented as separate macOS-service paths that UIElement mode can still break
- update the Spectre skill and Jewel/Swing interop skill with the same constraints

## Verification

- `mkdocs build --strict` using a temporary docs venv
- local docs link check
- `git diff --check`
