### PR TITLE
[codex] Update release readiness docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ useful when tests run in parallel and can't fight over OS focus) — and records
 against IDE-hosted Compose surfaces (IntelliJ, Jewel) and standalone desktop apps alike.
 
 > [!IMPORTANT]
-> **Heads up: this repo is currently a lot of vibe slop.** Large parts were written with
-> heavy AI pair-programming and haven't yet had a proper human review pass end-to-end.
-> I'll be going through it manually to read, audit, and tighten things up. Until then,
-> treat design and implementation choices as "looks plausible, not yet hand-audited" and
-> expect follow-up commits to rework bits once I've actually read them.
+> Spectre is pre-1.0. Stable APIs are covered by the compatibility policy in
+> [`docs/STABILITY.md`](docs/STABILITY.md); experimental APIs, especially the HTTP transport,
+> may change between releases. Read [`docs/SECURITY.md`](docs/SECURITY.md) before enabling
+> cross-JVM control or recording in environments that handle untrusted input.
 
 macOS, Windows, Linux Xorg, and Linux Wayland. The Wayland path goes through a small
 out-of-process Rust helper (`recording/native/linux/`) that owns the xdg-desktop-portal
@@ -34,6 +33,10 @@ architecture as the macOS Swift helper.
 ## Documentation
 
 User guide and API documentation: **<https://spectre.sebastiano.dev>**.
+
+Install released versions from Maven Central, or consume the current checkout as a
+Gradle composite build while working ahead of a release:
+[Installation](https://spectre.sebastiano.dev/guide/installation/).
 
 Start at [Getting started](https://spectre.sebastiano.dev/guide/getting-started/) for the
 shape of a Spectre test, or [The automator](https://spectre.sebastiano.dev/guide/automator/)

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,12 +1,18 @@
 # Installation
 
-!!! warning "No published artifacts yet"
-    Spectre is currently `0.1.0-SNAPSHOT` and isn't published to Maven Central or any
-    other public repository. The Gradle build also doesn't apply `maven-publish`, so
-    `./gradlew publishToMavenLocal` is not a working path either. Until a tagged
-    release lands, the supported way to consume Spectre is as a Gradle composite build
-    (`includeBuild`) — see below. Once releases start, this page will be updated with
-    artifact coordinates.
+Spectre publishes four library modules to Maven Central:
+
+| Module | Maven coordinate |
+| ------ | ---------------- |
+| `core` | `dev.sebastiano.spectre:spectre-core:<version>` |
+| `testing` | `dev.sebastiano.spectre:spectre-testing:<version>` |
+| `recording` | `dev.sebastiano.spectre:spectre-recording:<version>` |
+| `server` | `dev.sebastiano.spectre:spectre-server:<version>` |
+
+!!! note "Before a release tag is published"
+    The `main` branch declares `0.1.0-SNAPSHOT`. Until a tagged release has been published
+    to Maven Central, consume the checkout as a Gradle composite build (`includeBuild`) or
+    publish locally with `./gradlew publishToMavenLocal`.
 
 ## Requirements
 
@@ -17,38 +23,20 @@
 - **Platform-specific recording dependencies** if you plan to use the recording module
   — see [Recording](recording.md) for the per-OS prerequisites.
 
-## Consume as a composite build
+## Consume from Maven Central
 
-Clone Spectre next to the project that wants to use it:
-
-```shell
-git clone https://github.com/rock3r/spectre.git
-```
-
-In the consuming project's `settings.gradle.kts`, include Spectre's checkout as a
-composite build:
-
-```kotlin
-includeBuild("../spectre")
-```
-
-In the consuming project's `build.gradle.kts`, depend on the modules you need by
-project coordinates — Gradle resolves them against the included build:
+Add the modules you need to the consuming project's `build.gradle.kts`:
 
 ```kotlin
 dependencies {
-    testImplementation("dev.sebastiano.spectre:core")
-    testImplementation("dev.sebastiano.spectre:testing")
+    testImplementation("dev.sebastiano.spectre:spectre-core:<version>")
+    testImplementation("dev.sebastiano.spectre:spectre-testing:<version>")
 
-    // optional, depending on what you need:
-    testImplementation("dev.sebastiano.spectre:recording")
-    testImplementation("dev.sebastiano.spectre:server")
+    // Optional, depending on what you need:
+    testImplementation("dev.sebastiano.spectre:spectre-recording:<version>")
+    testImplementation("dev.sebastiano.spectre:spectre-server:<version>")
 }
 ```
-
-Versions are intentionally omitted: `includeBuild` substitutes the project dependency
-into the consumer's classpath using whatever version the included build declares, so
-the `0.1.0-SNAPSHOT` declared by Spectre's root Gradle build is implicit.
 
 If you depend on `server`, you also need to add a Ktor server engine yourself — Spectre
 intentionally doesn't bundle one. See [Cross-JVM access](cross-jvm.md) for the choice.
@@ -73,6 +61,57 @@ You also need the JUnit version that matches the wrapper you'll use:
 
 The `testing` module declares both JUnit dependencies as `compileOnly`, so consumers
 pick whichever they're already using.
+
+## Consume the current checkout
+
+Clone Spectre next to the project that wants to use it:
+
+```shell
+git clone https://github.com/rock3r/spectre.git
+```
+
+In the consuming project's `settings.gradle.kts`, include Spectre's checkout as a
+composite build and map the published module coordinates to the included projects:
+
+```kotlin
+includeBuild("../spectre") {
+    dependencySubstitution {
+        substitute(module("dev.sebastiano.spectre:spectre-core"))
+            .using(project(":core"))
+        substitute(module("dev.sebastiano.spectre:spectre-testing"))
+            .using(project(":testing"))
+        substitute(module("dev.sebastiano.spectre:spectre-recording"))
+            .using(project(":recording"))
+        substitute(module("dev.sebastiano.spectre:spectre-server"))
+            .using(project(":server"))
+    }
+}
+```
+
+In the consuming project's `build.gradle.kts`, use the same coordinates as the Maven
+Central path — Gradle resolves them against the included build:
+
+```kotlin
+dependencies {
+    testImplementation("dev.sebastiano.spectre:spectre-core")
+    testImplementation("dev.sebastiano.spectre:spectre-testing")
+
+    // Optional, depending on what you need:
+    testImplementation("dev.sebastiano.spectre:spectre-recording")
+    testImplementation("dev.sebastiano.spectre:spectre-server")
+}
+```
+
+Versions are intentionally omitted: `includeBuild` substitutes the project dependency
+into the consumer's classpath using whatever version the included build declares, so
+the `0.1.0-SNAPSHOT` declared by Spectre's root Gradle build is implicit.
+
+For local Maven-style testing without a composite build, publish the current checkout to
+Maven Local:
+
+```shell
+./gradlew publishToMavenLocal
+```
 
 ## Modules at a glance
 

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -201,4 +201,4 @@ forces both onto the test classpath.
 
 If you see a `NoClassDefFoundError` for a JUnit class when the rule or extension runs,
 add the corresponding `testImplementation` dependency to your project — see
-[Installation](installation.md#consume-as-a-composite-build).
+[Installation](installation.md#consume-the-current-checkout).

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,11 @@ hierarchy, and records what happens on screen — against IDE-hosted Compose sur
 If you've used UI Automator on Android or Espresso for that matter, the shape will feel
 familiar — Spectre brings the same "find a node, do a thing, assert" loop to Compose Desktop.
 
-!!! warning "Pre-release"
-    Spectre is in bootstrap. There are no published Maven artifacts yet, the public API is
-    still settling, and parts of the codebase are explicitly flagged as not yet hand-audited
-    in the [README](https://github.com/rock3r/spectre#readme). Treat anything here as a
-    moving target until a tagged release lands.
+!!! warning "Pre-1.0"
+    Spectre is pre-1.0. Stable APIs are covered by the project's compatibility policy;
+    experimental APIs, especially the HTTP transport, may change between releases. See
+    [Stability policy](STABILITY.md) and [Security notes](SECURITY.md) before depending on
+    cross-JVM control or recording in environments that handle untrusted input.
 
 ## Why Spectre
 


### PR DESCRIPTION
## Summary

- replace stale pre-release warnings with pre-1.0 stability and security guidance
- document Maven Central coordinates plus current-checkout and Maven Local consumption paths
- fix the JUnit guide link to the renamed installation section

## Validation

- git diff --check
- mkdocs build --strict
- ./gradlew check

## Notes

Issue #141 now tracks the remaining first-release operational gate: release secrets, SemVer tag validation, and final release checks.