### PR TITLE
Harden release tag gate

### DIFF
--- a/.github/scripts/derive-release-version.sh
+++ b/.github/scripts/derive-release-version.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$#" -ne 1 ]]; then
+  echo "Usage: $0 <tag>" >&2
+  exit 2
+fi
+
+tag="$1"
+semver_core="(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)"
+semver_identifier="[0-9A-Za-z-]+"
+semver_suffix="(-${semver_identifier}([.]${semver_identifier})*)?([+]${semver_identifier}([.]${semver_identifier})*)?"
+
+if [[ ! "$tag" =~ ^v(${semver_core}${semver_suffix})$ ]]; then
+  echo "Release tags must match v<semver>, for example v0.2.0 or v0.2.0-rc.1." >&2
+  exit 1
+fi
+
+version="${tag#v}"
+echo "$version"

--- a/.github/scripts/test-derive-release-version.sh
+++ b/.github/scripts/test-derive-release-version.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+script="$script_dir/derive-release-version.sh"
+
+expect_version() {
+  local tag="$1"
+  local expected="$2"
+  local actual
+
+  actual="$(bash "$script" "$tag")"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "Expected $tag to produce $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+expect_rejection() {
+  local tag="$1"
+
+  if bash "$script" "$tag" >/tmp/spectre-release-version-test.out 2>/tmp/spectre-release-version-test.err; then
+    echo "Expected $tag to be rejected, but it succeeded" >&2
+    cat /tmp/spectre-release-version-test.out >&2
+    cat /tmp/spectre-release-version-test.err >&2
+    exit 1
+  fi
+}
+
+expect_version "v0.1.0" "0.1.0"
+expect_version "v1.2.3" "1.2.3"
+expect_version "v10.20.30-rc.1" "10.20.30-rc.1"
+
+expect_rejection "0.1.0"
+expect_rejection "v1"
+expect_rejection "v1.2"
+expect_rejection "v1.2.3.4"
+expect_rejection "v01.2.3"
+expect_rejection "v1.02.3"
+expect_rejection "v1.2.03"
+expect_rejection "v1.2.3-pre..1"
+expect_rejection "vnext"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,26 +2,32 @@ name: Release
 
 # Tag-driven publishing pipeline (#84).
 #
-# Trigger: pushing a tag matching `v*` (e.g. `v0.2.0`). The leading `v` is stripped
-# from `${GITHUB_REF_NAME}` and the result becomes the version everywhere — the
-# Gradle invocation is parameterised via `-PVERSION_NAME=...`, and `vanniktech-
-# maven-publish`'s POMs pick up the override automatically.
+# Trigger: pushing a tag matching `v*` (e.g. `v0.2.0`). The `release-gate`
+# job rejects anything that is not `v<semver>` before helper builds or publishing
+# can start. The leading `v` is stripped from `${GITHUB_REF_NAME}` and the result
+# becomes the version everywhere — the Gradle invocation is parameterised via
+# `-PVERSION_NAME=...`, and `vanniktech-maven-publish`'s POMs pick up the override
+# automatically.
 #
-# Three-stage fan-out:
+# Four-stage fan-out:
 #
-#   1. `mac-helper`       — macOS runner. Builds the universal arm64+x86_64
+#   1. `release-gate`     — Linux runner. Rejects non-SemVer `v*` tags, runs the
+#                            full Gradle `check`, and runs `mkdocs build --strict`
+#                            before any helper build or publish job starts.
+#
+#   2. `mac-helper`       — macOS runner. Builds the universal arm64+x86_64
 #                            `SpectreScreenCapture` Swift helper, codesigns it with
 #                            our Developer ID, and runs `notarytool submit --wait`.
 #                            Uploads the notarised binary as a GitHub Actions
 #                            artifact.
 #
-#   2. `linux-helpers`    — Linux runner. Cross-builds the Wayland Rust helper for
+#   3. `linux-helpers`    — Linux runner. Cross-builds the Wayland Rust helper for
 #                            both x86_64 and aarch64 using the same toolchain dance
 #                            `ci.yml` documents (dpkg multi-arch + per-arch libdbus
 #                            sysroot + cross-linker). Uploads the per-arch binaries
 #                            as a GitHub Actions artifact.
 #
-#   3. `publish`          — Linux runner. Depends on both helper jobs. Downloads
+#   4. `publish`          — Linux runner. Depends on the gate and both helper jobs. Downloads
 #                            the artefacts, stages them into recording's resource
 #                            tree via `-PprebuiltMacHelperPath=...` and
 #                            `-PprebuiltLinuxHelpersDir=...`, runs the publication-
@@ -58,9 +64,52 @@ permissions:
   contents: read
 
 jobs:
+  release-gate:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Set up Python for docs
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.x"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Install docs dependencies
+        run: pip install -r requirements-docs.txt
+
+      - name: Derive release version from SemVer tag
+        id: version
+        run: |
+          version="$(bash .github/scripts/derive-release-version.sh "$GITHUB_REF_NAME")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Run CI gate
+        run: ./gradlew check
+
+      - name: Build docs strictly
+        run: mkdocs build --strict
+
   mac-helper:
     name: Build + notarise macOS helper
     runs-on: macos-latest
+    needs:
+      - release-gate
 
     steps:
       - name: Check out repository
@@ -166,6 +215,8 @@ jobs:
   linux-helpers:
     name: Build cross-arch Linux helpers
     runs-on: ubuntu-latest
+    needs:
+      - release-gate
 
     steps:
       - name: Check out repository
@@ -239,11 +290,14 @@ jobs:
     name: Publish to Maven Central + GitHub release
     runs-on: ubuntu-latest
     needs:
+      - release-gate
       - mac-helper
       - linux-helpers
     # `contents: write` needed for `gh release create / upload`; nothing else opted up.
     permissions:
       contents: write
+    env:
+      RELEASE_VERSION: ${{ needs.release-gate.outputs.version }}
 
     steps:
       - name: Check out repository
@@ -276,17 +330,6 @@ jobs:
         with:
           name: linux-helpers
           path: ${{ runner.temp }}/linux-helpers
-
-      - name: Derive release version from tag
-        # `v0.2.0` -> `0.2.0`. Stripping the leading `v` keeps tag conventions (which use
-        # the prefix) separate from Maven coordinates (which don't).
-        run: |
-          set -euo pipefail
-          tag="${GITHUB_REF_NAME}"
-          version="${tag#v}"
-          test -n "$version"
-          test "$version" != "$tag"  # Refuse to publish if the tag doesn't start with `v`.
-          echo "RELEASE_VERSION=$version" >> "$GITHUB_ENV"
 
       - name: Verify publication shape against mavenLocal
         # Belt-and-braces: publishes everything to mavenLocal first with the prebuilt

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -10,25 +10,31 @@ the plugin — they're deliverables, not libraries.
 ## Tag-driven release flow
 
 The pipeline is owned by [`.github/workflows/release.yml`][release-yml] and
-triggers on tags matching `v*` (e.g. `v0.2.0`). The leading `v` is stripped to
-form the published version, so `v0.2.0` publishes coordinates
+triggers on tags matching `v*`, but the first job rejects anything that is not a
+SemVer-shaped release tag: `v<major>.<minor>.<patch>` with optional SemVer
+pre-release/build metadata (for example `v0.2.0` or `v0.2.0-rc.1`). The leading
+`v` is stripped to form the published version, so `v0.2.0` publishes coordinates
 `dev.sebastiano.spectre:spectre-core:0.2.0` (and equivalent for the other three
 modules).
 
 [release-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/release.yml
 
-Three jobs run on tag push:
+Four jobs run on tag push:
 
-1. **`mac-helper`** (macOS runner) — builds the arm64+x86_64 universal
+1. **`release-gate`** (Linux runner) — validates the tag shape, runs
+   `./gradlew check`, installs the docs dependencies, and runs
+   `mkdocs build --strict`. Nothing else starts until this gate passes.
+2. **`mac-helper`** (macOS runner, depends on `release-gate`) — builds the
+   arm64+x86_64 universal
    `SpectreScreenCapture` Swift helper, codesigns it with the Developer ID, runs
    `notarytool submit --wait`, and uploads the notarised binary as a GitHub
    Actions artefact.
-2. **`linux-helpers`** (Linux runner) — cross-builds the
+3. **`linux-helpers`** (Linux runner, depends on `release-gate`) — cross-builds the
    `spectre-wayland-helper` Rust binary for `x86_64` and `aarch64` (same
    toolchain dance documented in [`ci.yml`][ci-yml]: dpkg multi-arch +
    per-arch libdbus sysroot + cross-linker). Uploads the per-arch binaries as a
    GitHub Actions artefact.
-3. **`publish`** (Linux runner, depends on both) — downloads the helper
+4. **`publish`** (Linux runner, depends on the gate and both helper jobs) — downloads the helper
    artefacts, runs `:verifyMavenLocalPublication` to assert the publication
    shape, then runs `publishToMavenCentral` against the
    [Sonatype Central Portal][central-portal]. Finally creates a draft GitHub
@@ -39,9 +45,21 @@ Three jobs run on tag push:
 
 Both the Central Portal deployment and the GitHub release stay in **manual-
 promotion** mode (`automaticRelease=false` in `build.gradle.kts`, `--draft` on
-`gh release create`) until the first few tagged releases prove the pipeline.
-Promote from the Central Portal UI and via `gh release edit --draft=false` once
-you've sanity-checked the artefacts side-by-side.
+`gh release create`) until the first few tagged releases prove the pipeline. Do
+not promote either surface until the release workflow is green and you've
+sanity-checked the artefacts side-by-side.
+
+Manual promotion checklist:
+
+- Confirm the tag points at the intended, already-reviewed `main` SHA.
+- Inspect the Central Portal staging deployment for all four modules, including
+  POM metadata, sources jars, javadoc jars, and Gradle module metadata.
+- Download the draft GitHub release's `spectre-recording-<version>.jar` and
+  confirm it contains `native/macos/spectre-screencapture`,
+  `native/linux/x86_64/spectre-wayland-helper`, and
+  `native/linux/aarch64/spectre-wayland-helper`.
+- Promote the Central staging deployment from the Central Portal UI.
+- Undraft the GitHub release with `gh release edit <tag> --draft=false`.
 
 ## Required secrets
 


### PR DESCRIPTION
## Summary
- add a release tag parser that accepts only SemVer-shaped v-prefixed tags
- gate release helper builds and publishing behind tag validation, ./gradlew check, and mkdocs build --strict
- document the release gate and manual promotion checklist

## Verification
- bash .github/scripts/test-derive-release-version.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release.yml parsed"'
- ./gradlew check
- /private/tmp/spectre-docs-venv-141/bin/mkdocs build --strict

Closes #141