### PR TITLE
Install dbus deps in release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,6 +99,14 @@ jobs:
           version="$(bash .github/scripts/derive-release-version.sh "$GITHUB_REF_NAME")"
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
+      - name: Install libdbus + pkg-config (for spectre-wayland-helper Rust build)
+        # `./gradlew check` builds the Linux Wayland helper on Linux runners. Keep the
+        # release gate aligned with CI so it can exercise the same graph before any
+        # helper build or publish job starts.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+
       - name: Run CI gate
         run: ./gradlew check
 


### PR DESCRIPTION
## Summary

- install libdbus-1-dev and pkg-config in the release-gate job before running Gradle check
- keep the release gate aligned with the normal CI setup for the Linux Wayland helper build

## Validation

- git diff --check
- bash .github/scripts/test-derive-release-version.sh

## Context

The first v0.1.0 release attempt stopped safely in release-gate before helper builds or Central publishing because the recording Wayland helper build could not find dbus-1.pc on the Ubuntu runner.