### PR TITLE
Split recording native helper artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,10 @@ jobs:
         # the default `check` graph (which uses the host-arch `assembleWaylandHelper`) so
         # contributor builds without the cross toolchain still pass `check` cleanly. When
         # #84's publish pipeline lands, the release job will pass `-PallLinuxArches` so
-        # `processResources` bundles both arches into the published jar.
+        # `:recording-linux:processResources` bundles both arches into the published
+        # platform-helper jar.
         #
-        # `-PallLinuxArches` makes `processResources` depend on the cross-arch staging task
-        # and `verifyBundledRecordingHelpers` expect both arches in `build/resources/main`.
-        # The verify task parses each ELF header in-JVM (no `readelf` dependency) and
-        # asserts the e_machine field matches the expected arch — same assertion strength
-        # as the previous shell loop, now reusable from any host that wants to sanity-check
-        # a build.
-        run: ./gradlew :recording:assembleWaylandHelperAllArches :recording:verifyBundledRecordingHelpers -PallLinuxArches
+        # `-PallLinuxArches` makes `:recording-linux:processResources` depend on the
+        # cross-arch staging task and `verifyRecordingLinuxHelpers` expect both resource
+        # entries in the platform-helper jar.
+        run: ./gradlew :recording-linux:verifyRecordingLinuxHelpers -PallLinuxArches

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,14 +28,14 @@ name: Release
 #                            as a GitHub Actions artifact.
 #
 #   4. `publish`          — Linux runner. Depends on the gate and both helper jobs. Downloads
-#                            the artefacts, stages them into recording's resource
-#                            tree via `-PprebuiltMacHelperPath=...` and
+#                            the artefacts, stages them into the platform helper
+#                            resource jars via `-PprebuiltMacHelperPath=...` and
 #                            `-PprebuiltLinuxHelpersDir=...`, runs the publication-
 #                            shape verification, then `publish` against the Sonatype
 #                            Central Portal staging endpoint. Finally creates the
-#                            GitHub release (draft, with the cross-platform
-#                            recording jar attached) so the maintainer can sanity-
-#                            check Central + GitHub side-by-side before promoting.
+#                            GitHub release (draft, with the recording API jar plus
+#                            platform helper jars attached) so the maintainer can
+#                            sanity-check Central + GitHub side-by-side before promoting.
 #
 # Secrets used (all from repo settings):
 #   APPLE_DEVELOPER_ID_P12 / _PASSWORD                  → keychain import (mac-helper)
@@ -185,8 +185,8 @@ jobs:
           # `recording/build/generated/screenCaptureHelper/native/macos/spectre-screencapture`.
           # `-PnotarizeScreenCaptureKitHelper` wires the codesign + notarytool + verify
           # steps into the dependency chain. The publish job downloads the artefact and
-          # stages it via `-PprebuiltMacHelperPath` so the resulting recording jar is
-          # consumable on any macOS host without needing to redo the notarisation dance.
+          # stages it via `-PprebuiltMacHelperPath` so the resulting
+          # spectre-recording-macos jar is consumable without redoing notarisation.
           APPLE_NOTARY_API_KEY_PATH="$API_KEY_PATH" \
             ./gradlew :recording:assembleScreenCaptureKitHelperUniversal \
               -PuniversalHelper \
@@ -342,7 +342,7 @@ jobs:
       - name: Verify publication shape against mavenLocal
         # Belt-and-braces: publishes everything to mavenLocal first with the prebuilt
         # helpers staged, then asserts the artefact set (per-module jar + sources jar +
-        # javadoc jar + POM + module file, recording jar bundles all three helpers)
+        # javadoc jar + POM + module file; platform helper jars carry the native helpers)
         # before we sign and upload to Central. A failure here means the Central upload
         # would have published something incomplete — better to catch it before the
         # remote staging repo gets a partial deployment.
@@ -367,21 +367,26 @@ jobs:
             :core:publishToMavenCentral \
             :server:publishToMavenCentral \
             :recording:publishToMavenCentral \
+            :recording-macos:publishToMavenCentral \
+            :recording-linux:publishToMavenCentral \
             :testing:publishToMavenCentral \
             -PVERSION_NAME="$RELEASE_VERSION" \
             -PprebuiltMacHelperPath="$RUNNER_TEMP/mac-helper/spectre-screencapture" \
             -PprebuiltLinuxHelpersDir="$RUNNER_TEMP/linux-helpers"
 
-      - name: Stage published recording jar for GitHub release attachment
+      - name: Stage published recording jars for GitHub release attachment
         # mavenLocal already has the artefact from the earlier verify step. Pulling from
-        # there avoids the publish step needing a second jar build (the Central upload
-        # consumed the same jar).
+        # there avoids the publish step needing a second jar build.
         run: |
           set -euo pipefail
-          JAR_PATH="$HOME/.m2/repository/dev/sebastiano/spectre/spectre-recording/$RELEASE_VERSION/spectre-recording-$RELEASE_VERSION.jar"
-          test -f "$JAR_PATH"
-          cp "$JAR_PATH" "$RUNNER_TEMP/spectre-recording-$RELEASE_VERSION.jar"
-          echo "GH_RELEASE_JAR=$RUNNER_TEMP/spectre-recording-$RELEASE_VERSION.jar" >> "$GITHUB_ENV"
+          RELEASE_ASSETS="$RUNNER_TEMP/release-assets"
+          mkdir -p "$RELEASE_ASSETS"
+          for artifact in spectre-recording spectre-recording-macos spectre-recording-linux; do
+            jar="$HOME/.m2/repository/dev/sebastiano/spectre/$artifact/$RELEASE_VERSION/$artifact-$RELEASE_VERSION.jar"
+            test -f "$jar"
+            cp "$jar" "$RELEASE_ASSETS/"
+          done
+          echo "GH_RELEASE_ASSETS=$RELEASE_ASSETS/*.jar" >> "$GITHUB_ENV"
 
       - name: Create / update draft GitHub release
         env:
@@ -389,4 +394,4 @@ jobs:
         run: |
           gh release view "$GITHUB_REF_NAME" \
             || gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME"
-          gh release upload "$GITHUB_REF_NAME" "$GH_RELEASE_JAR" --clobber
+          gh release upload "$GITHUB_REF_NAME" $GH_RELEASE_ASSETS --clobber

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,10 +148,9 @@ subprojects {
 //   3. Asserts each module has main jar + sources jar + javadoc jar + POM + module file.
 //   4. Asserts each POM has <name>, <description>, <url>, <licenses>, <scm>, <developers>
 //      populated — Central rejects POMs missing any of these.
-//   5. For `:recording`, asserts the main jar's `native/...` entries match the expected
-//      helper layout per the same -PprebuiltMacHelperPath / -PstubMacHelperForTesting /
-//      -PprebuiltLinuxHelpersDir / host-platform switches `verifyBundledRecordingHelpers`
-//      uses.
+//   5. Asserts no sources jar contains generated `native/...` helper binaries.
+//   6. Asserts `:recording` stays API/common-only while `:recording-macos` and
+//      `:recording-linux` carry the expected platform helper resources.
 //
 // Local invocation:
 //   ./gradlew verifyMavenLocalPublication \
@@ -164,7 +163,8 @@ subprojects {
 //       -PprebuiltLinuxHelpersDir=<dir>
 //
 // Verification only — it does not republish or mutate state. Safe to run repeatedly.
-val publishedLibraryProjects = listOf(":core", ":server", ":recording", ":testing")
+val publishedLibraryProjects =
+    listOf(":core", ":server", ":recording", ":recording-macos", ":recording-linux", ":testing")
 
 // Configure-time inputs captured into vals so the action body is configuration-cache safe
 // (no closure capture of Project references). The closure-based task is preferred over a
@@ -185,46 +185,51 @@ val mavenLocalRepoRoot: String = "${System.getProperty("user.home")}/.m2/reposit
 // Recording jar entries we expect to find — keep in sync with
 // `VerifyBundledRecordingHelpers`'s expectations so a contradiction between the two surfaces
 // as a duplicate failure rather than one silently passing.
-val expectedRecordingHelperEntries: List<String> = buildList {
-    val macOsExpected =
-        providers.gradleProperty("prebuiltMacHelperPath").isPresent ||
-            providers.gradleProperty("stubMacHelperForTesting").isPresent ||
-            org.gradle.internal.os.OperatingSystem.current().isMacOsX
-    if (macOsExpected) {
-        add("native/macos/spectre-screencapture")
-    }
-    val currentOs = org.gradle.internal.os.OperatingSystem.current()
-    val crossArchLinux =
-        providers.gradleProperty("prebuiltLinuxHelpersDir").isPresent ||
-            (currentOs.isLinux && providers.gradleProperty("allLinuxArches").isPresent)
-    when {
-        crossArchLinux -> {
-            add("native/linux/x86_64/spectre-wayland-helper")
-            add("native/linux/aarch64/spectre-wayland-helper")
+val expectedRecordingHelperEntriesByProject: Map<String, List<String>> =
+    mutableMapOf<String, List<String>>().apply {
+        val macOsExpected =
+            providers.gradleProperty("prebuiltMacHelperPath").isPresent ||
+                providers.gradleProperty("stubMacHelperForTesting").isPresent ||
+                org.gradle.internal.os.OperatingSystem.current().isMacOsX
+        if (macOsExpected) {
+            put(":recording-macos", listOf("native/macos/spectre-screencapture"))
         }
-        currentOs.isLinux -> {
-            val hostArch =
-                when (System.getProperty("os.arch").orEmpty().lowercase()) {
-                    "amd64",
-                    "x86_64",
-                    "x64" -> "x86_64"
-                    "aarch64",
-                    "arm64" -> "aarch64"
-                    else -> ""
+        val currentOs = org.gradle.internal.os.OperatingSystem.current()
+        val crossArchLinux =
+            providers.gradleProperty("prebuiltLinuxHelpersDir").isPresent ||
+                (currentOs.isLinux && providers.gradleProperty("allLinuxArches").isPresent)
+        when {
+            crossArchLinux -> {
+                put(
+                    ":recording-linux",
+                    listOf(
+                        "native/linux/x86_64/spectre-wayland-helper",
+                        "native/linux/aarch64/spectre-wayland-helper",
+                    ),
+                )
+            }
+            currentOs.isLinux -> {
+                val hostArch =
+                    when (System.getProperty("os.arch").orEmpty().lowercase()) {
+                        "amd64",
+                        "x86_64",
+                        "x64" -> "x86_64"
+                        "aarch64",
+                        "arm64" -> "aarch64"
+                        else -> ""
+                    }
+                if (hostArch.isNotEmpty()) {
+                    put(":recording-linux", listOf("native/linux/$hostArch/spectre-wayland-helper"))
                 }
-            if (hostArch.isNotEmpty()) {
-                add("native/linux/$hostArch/spectre-wayland-helper")
             }
         }
     }
-}
 
 val verifyMavenLocalPublication by tasks.registering {
     description =
-        "Publishes :core, :server, :recording, :testing to mavenLocal and asserts each " +
+        "Publishes Spectre library modules to mavenLocal and asserts each " +
             "module's artefact set (jar + sources + javadoc + POM + module) satisfies " +
-            "Sonatype Central's gating, plus the recording jar bundles the expected " +
-            "native helpers."
+            "Sonatype Central's gating, with platform helpers isolated in their runtime jars."
     group = "verification"
 
     dependsOn(publishedLibraryProjects.map { "$it:publishToMavenLocal" })
@@ -238,7 +243,7 @@ val verifyMavenLocalPublication by tasks.registering {
     val version = publishVersion
     val artifactIds = publishArtifactIds
     val repoRoot = file(mavenLocalRepoRoot)
-    val expectedHelpers = expectedRecordingHelperEntries
+    val expectedHelpersByProject = expectedRecordingHelperEntriesByProject
 
     doLast {
         val errors = mutableListOf<String>()
@@ -324,20 +329,37 @@ val verifyMavenLocalPublication by tasks.registering {
                         "$moduleName: POM has no <developers><developer><id> in " + pomFile.name
                 }
             }
-            if (moduleName == ":recording" && expectedHelpers.isNotEmpty()) {
-                val jar = moduleDir.resolve("$baseName.jar")
-                if (jar.isFile) {
-                    val entriesInJar = mutableSetOf<String>()
-                    ZipFile(jar).use { zip ->
-                        val entries = zip.entries()
-                        while (entries.hasMoreElements()) {
-                            entriesInJar += entries.nextElement().name
-                        }
+            for (jarSuffix in listOf(".jar", "-sources.jar")) {
+                val jar = moduleDir.resolve("$baseName$jarSuffix")
+                if (!jar.isFile) continue
+                val entriesInJar = mutableSetOf<String>()
+                ZipFile(jar).use { zip ->
+                    val entries = zip.entries()
+                    while (entries.hasMoreElements()) {
+                        entriesInJar += entries.nextElement().name
                     }
-                    for (path in expectedHelpers) {
+                }
+                if (jarSuffix == "-sources.jar") {
+                    val nativeSources = entriesInJar.filter { it.startsWith("native/") }
+                    if (nativeSources.isNotEmpty()) {
+                        errors +=
+                            "$moduleName: sources jar (${jar.name}) must not contain native " +
+                                "helper resources: ${nativeSources.sorted().joinToString()}"
+                    }
+                }
+                if (jarSuffix == ".jar" && moduleName == ":recording") {
+                    val nativeEntries = entriesInJar.filter { it.startsWith("native/") }
+                    if (nativeEntries.isNotEmpty()) {
+                        errors +=
+                            ":recording: API jar (${jar.name}) must not contain native helper " +
+                                "resources: ${nativeEntries.sorted().joinToString()}"
+                    }
+                }
+                if (jarSuffix == ".jar") {
+                    for (path in expectedHelpersByProject[moduleName].orEmpty()) {
                         if (path !in entriesInJar) {
                             errors +=
-                                ":recording: published jar (${jar.name}) is missing " +
+                                "$moduleName: published jar (${jar.name}) is missing " +
                                     "expected helper entry `$path`"
                         }
                     }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,9 @@
 spectre
 ├── core/                    — shared automation model and desktop automation primitives
 ├── server/                  — optional transport layer for cross-JVM access
-├── recording/               — screenshot / recording integrations and native capture boundaries
+├── recording/               — screenshot / recording API and common JVM implementation
+├── recording-macos/         — runtime-only macOS ScreenCaptureKit helper artifact
+├── recording-linux/         — runtime-only Linux Wayland helper artifact
 ├── testing/                 — test fixtures and JUnit-facing helpers built on top of public APIs
 ├── sample-desktop/          — small manual-test harness app for spike validation
 └── sample-intellij-plugin/  — sample IntelliJ plugin embedding Spectre in a Jewel tool window
@@ -20,7 +22,9 @@ sample-intellij-plugin   ├──> core
 server                   │
 testing                 ─┘
 
-recording                (isolated desktop/native integration module)
+recording                (isolated desktop/native integration API)
+recording-macos    ─┐
+recording-linux     ┴──> recording (runtime helper artifacts)
 ```
 
 Guidelines:
@@ -31,7 +35,7 @@ Guidelines:
 - `testing` should exercise public seams and reusable fixtures, not reach through private internals
   without a strong reason.
 - `recording` should isolate OS- and native-library-specific behaviour from the core query/input
-  APIs.
+  APIs. Runtime helper binaries live in platform helper artifacts, not the API jar.
 
 ## Spike Constraints
 
@@ -78,10 +82,22 @@ Keep server concerns out of the core data model unless they are genuinely transp
 Expected long-term responsibilities:
 
 - screen/region capture orchestration
-- macOS-specific window capture helpers
+- platform recorder selection and helper extraction
 - recorder lifecycle and output plumbing
 
 Keep native capture boundaries narrow and test the pure pieces separately from OS integration.
+The published `spectre-recording` jar is API/common-only; it must not contain generated
+`native/...` helper resources.
+
+### `recording-macos` and `recording-linux`
+
+Expected long-term responsibilities:
+
+- publish runtime-only helper resources for the recording API
+- keep native binary payloads out of `spectre-recording` and its sources jar
+- mirror the runtime resource paths the extractors probe:
+  `native/macos/spectre-screencapture` and
+  `native/linux/<arch>/spectre-wayland-helper`
 
 Current backends:
 
@@ -92,13 +108,13 @@ Current backends:
 - `FfmpegWindowRecorder` — Windows-only window-targeted capture via `gdigrab title=`.
   Window movement is followed automatically; occlusion doesn't matter.
 - `screencapturekit.ScreenCaptureKitRecorder` — macOS-only window-targeted capture via a
-  bundled Swift helper (`recording/native/macos/`). The helper is built by Gradle on
-  macOS, staged under `recording/build/generated/screenCaptureHelper/...`, and wired
-  into the module's generated resources so the JAR carries it.
+  Swift helper (`recording/native/macos/`). The helper is built by Gradle on macOS,
+  staged under `recording/build/generated/screenCaptureHelper/...`, and packaged by
+  `:recording-macos`.
 - `portal.WaylandPortalRecorder` — Linux Wayland capture via `xdg-desktop-portal`'s
-  ScreenCast interface, driven by a bundled Rust helper
-  (`recording/native/linux/spectre-wayland-helper`) that hands the PipeWire FD to
-  `gst-launch-1.0`.
+  ScreenCast interface, driven by a Rust helper
+  (`recording/native/linux/spectre-wayland-helper`) packaged by `:recording-linux`.
+  The helper hands the PipeWire FD to `gst-launch-1.0`.
 - `AutoRecorder` — high-level router that picks per call from `TitledWindow?` + region +
   OS detection: Wayland portal first, then `window == null` → ffmpeg region, then macOS
   SCK, then Windows title-based capture, then ffmpeg region as fallback.

--- a/docs/NOTARIZATION.md
+++ b/docs/NOTARIZATION.md
@@ -23,7 +23,8 @@ Gradle then:
 3. Submits the archive with `xcrun notarytool submit`.
 4. Waits for Apple to finish processing, bounded by a 30 minute timeout.
 5. Verifies the resulting Developer ID signature with `codesign --verify --strict --verbose=4`
-   before staging it into `native/macos/spectre-screencapture` in the jar resources.
+   before staging it into `native/macos/spectre-screencapture` in the
+   `spectre-recording-macos` jar resources.
 
 Apple's notary service can issue a ticket for a standalone binary inside the submitted archive,
 but `xcrun stapler` cannot currently staple tickets directly to bare command-line executables,
@@ -94,8 +95,8 @@ xcrun notarytool info <submission-id> --keychain-profile <notary-profile>
 The tag workflow at
 [`.github/workflows/release.yml`](https://github.com/rock3r/spectre/blob/main/.github/workflows/release.yml)
 builds the universal helper on `macos-latest`, imports the Developer ID certificate into a
-temporary keychain, signs and notarizes the helper, and uploads the recording jar to the GitHub
-release.
+temporary keychain, signs and notarizes the helper, and uploads the recording jars to the
+GitHub release.
 
 Set these repository secrets:
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,7 +1,8 @@
 # Publishing
 
-Spectre's library modules (`:core`, `:server`, `:recording`, `:testing`) publish
-to Sonatype Central via the [`com.vanniktech.maven.publish`][vanniktech] plugin.
+Spectre's library modules (`:core`, `:server`, `:recording`, `:recording-macos`,
+`:recording-linux`, `:testing`) publish to Sonatype Central via the
+[`com.vanniktech.maven.publish`][vanniktech] plugin.
 The sample modules (`:sample-desktop`, `:sample-intellij-plugin`) never apply
 the plugin — they're deliverables, not libraries.
 
@@ -14,8 +15,8 @@ triggers on tags matching `v*`, but the first job rejects anything that is not a
 SemVer-shaped release tag: `v<major>.<minor>.<patch>` with optional SemVer
 pre-release/build metadata (for example `v0.2.0` or `v0.2.0-rc.1`). The leading
 `v` is stripped to form the published version, so `v0.2.0` publishes coordinates
-`dev.sebastiano.spectre:spectre-core:0.2.0` (and equivalent for the other three
-modules).
+`dev.sebastiano.spectre:spectre-core:0.2.0` and the matching version for every
+published library module.
 
 [release-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/release.yml
 
@@ -38,7 +39,7 @@ Four jobs run on tag push:
    artefacts, runs `:verifyMavenLocalPublication` to assert the publication
    shape, then runs `publishToMavenCentral` against the
    [Sonatype Central Portal][central-portal]. Finally creates a draft GitHub
-   release with the cross-platform recording jar attached.
+   release with the recording API jar and platform helper jars attached.
 
 [ci-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/ci.yml
 [central-portal]: https://central.sonatype.com/
@@ -52,11 +53,13 @@ sanity-checked the artefacts side-by-side.
 Manual promotion checklist:
 
 - Confirm the tag points at the intended, already-reviewed `main` SHA.
-- Inspect the Central Portal staging deployment for all four modules, including
+- Inspect the Central Portal staging deployment for all six modules, including
   POM metadata, sources jars, javadoc jars, and Gradle module metadata.
-- Download the draft GitHub release's `spectre-recording-<version>.jar` and
-  confirm it contains `native/macos/spectre-screencapture`,
-  `native/linux/x86_64/spectre-wayland-helper`, and
+- Confirm `spectre-recording-<version>.jar` contains no `native/...` entries.
+- Confirm `spectre-recording-macos-<version>.jar` contains
+  `native/macos/spectre-screencapture`.
+- Confirm `spectre-recording-linux-<version>.jar` contains
+  `native/linux/x86_64/spectre-wayland-helper` and
   `native/linux/aarch64/spectre-wayland-helper`.
 - Promote the Central staging deployment from the Central Portal UI.
 - Undraft the GitHub release with `gh release edit <tag> --draft=false`.
@@ -94,7 +97,7 @@ signing convention only fires when `ORG_GRADLE_PROJECT_signingInMemoryKey` is
 set. The `:verifyMavenLocalPublication` task drives the full shape check:
 
 ```shell
-# Publish all four modules + verify shape. Stub mac helper because Linux can't
+# Publish all library modules + verify shape. Stub mac helper because Linux can't
 # build the real one; cross-arch Linux helpers come from the real Rust build.
 ./gradlew verifyMavenLocalPublication \
     -PstubMacHelperForTesting \
@@ -110,12 +113,13 @@ It asserts that each module ends up with:
   (`<name>`, `<description>`, `<url>`, `<licenses>`, `<scm>`, `<developers>`)
 - `<artifactId>-<version>.module` (Gradle Module Metadata)
 
-For `:recording` it additionally asserts the main jar contains the expected
-native helpers at:
+It additionally asserts:
 
-- `native/macos/spectre-screencapture` (universal SCK helper)
-- `native/linux/x86_64/spectre-wayland-helper`
-- `native/linux/aarch64/spectre-wayland-helper`
+- every sources jar is free of generated `native/...` helper resources
+- `:recording` is API/common-only and contains no `native/...` resources
+- `:recording-macos` contains `native/macos/spectre-screencapture`
+- `:recording-linux` contains `native/linux/x86_64/spectre-wayland-helper` and
+  `native/linux/aarch64/spectre-wayland-helper` when built with release helper inputs
 
 If you have a real notarised mac helper on disk (e.g. downloaded from a
 previous release-CI run), point at it instead of the stub:
@@ -136,6 +140,8 @@ The `prebuiltLinuxHelpersDir` directory must contain
 | `:core` | `dev.sebastiano.spectre:spectre-core:<version>` |
 | `:server` | `dev.sebastiano.spectre:spectre-server:<version>` |
 | `:recording` | `dev.sebastiano.spectre:spectre-recording:<version>` |
+| `:recording-macos` | `dev.sebastiano.spectre:spectre-recording-macos:<version>` |
+| `:recording-linux` | `dev.sebastiano.spectre:spectre-recording-linux:<version>` |
 | `:testing` | `dev.sebastiano.spectre:spectre-testing:<version>` |
 
 The shared metadata (group, license, SCM, developer) lives in

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -49,7 +49,7 @@ failure modes, and the section below
   the README.
 - **Linux Wayland sessions** — `gst-launch-1.0` driven through the
   `xdg-desktop-portal` ScreenCast interface, with the PipeWire FD passed to the encoder by a
-  small Rust helper binary (`spectre-wayland-helper`, sources at
+  small Rust helper binary from `spectre-recording-linux` (`spectre-wayland-helper`, sources at
   `recording/native/linux/`). Two JVM-side recorders share the helper:
   `WaylandPortalRecorder` (region-targeted, portal `SourceType.MONITOR` — user picks a
   monitor, helper crops to the requested rectangle) and `WaylandPortalWindowRecorder`
@@ -62,9 +62,8 @@ failure modes, and the section below
   Why the helper: a pure-JVM attempt hit a dbus-java UnixFD-unmarshalling bug that wasn't
   fixable trivially, and Rust's `std::process` makes FD inheritance into `gst-launch` a
   one-liner where the JVM's `ProcessBuilder` doesn't expose the necessary
-  `fcntl(F_SETFD, ...)` knob. The helper-as-subprocess shape also matches the macOS SCK
-  helper (`recording/native/macos/`) — same pattern, same bundling, same recorder-skeleton
-  on the JVM side.
+  `fcntl(F_SETFD, ...)` knob. The helper-as-subprocess shape also matches the
+  `spectre-recording-macos` SCK helper (`recording/native/macos/`) on the JVM side.
 
   **Window-targeted Wayland needs `xprop` on `PATH`.** Mutter renders window-source-type
   streams with the WM-imposed invisible-shadow extents around the visible window —

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -114,8 +114,8 @@ expansion); items that are hygiene fixes get their own issues.
 The `SPECTRE_WAYLAND_HELPER` environment variable lets a developer point the recorder at a
 locally-built helper binary without rebundling. It is **honored unconditionally** — there is
 no signature check, hash check, or path constraint. Never set it in an environment that
-ingests untrusted input. The bundled helper is the only supported configuration for non-dev
-use.
+ingests untrusted input. The published platform helper artifacts are the only supported
+configuration for non-dev use.
 
 ## Out of scope for this review
 

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -125,7 +125,7 @@ Spectre is JVM-first and targets desktop OSes.
 
 | Platform | Tier | Notes |
 | --- | --- | --- |
-| **macOS** | Primary | Full support. AWT Robot input, ScreenCaptureKit recording (with bundled Swift helper), TCC permission diagnostics. |
+| **macOS** | Primary | Full support. AWT Robot input, ScreenCaptureKit recording (with `spectre-recording-macos` helper), TCC permission diagnostics. |
 | **Windows** | Full | AWT Robot input + `gdigrab` region and window-targeted recording. |
 | **Linux Xorg** | Full | AWT Robot input + `x11grab` region recording. Validated against Xvfb in CI. |
 | **Linux Wayland** | Best-effort | Portal-mediated capture via `WaylandPortalRecorder` / `WaylandPortalWindowRecorder`. **Validated on GNOME/Mutter only**; KDE / sway / wlroots compositors may behave differently and are not exercised in CI. Real Robot input is unavailable on Wayland — use the synthetic adapter for tests. |

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,12 +1,14 @@
 # Installation
 
-Spectre publishes four library modules to Maven Central:
+Spectre publishes these library modules to Maven Central:
 
 | Module | Maven coordinate |
 | ------ | ---------------- |
 | `core` | `dev.sebastiano.spectre:spectre-core:<version>` |
 | `testing` | `dev.sebastiano.spectre:spectre-testing:<version>` |
 | `recording` | `dev.sebastiano.spectre:spectre-recording:<version>` |
+| `recording-macos` | `dev.sebastiano.spectre:spectre-recording-macos:<version>` |
+| `recording-linux` | `dev.sebastiano.spectre:spectre-recording-linux:<version>` |
 | `server` | `dev.sebastiano.spectre:spectre-server:<version>` |
 
 !!! note "Before a release tag is published"
@@ -34,9 +36,16 @@ dependencies {
 
     // Optional, depending on what you need:
     testImplementation("dev.sebastiano.spectre:spectre-recording:<version>")
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-macos:<version>") // macOS SCK helper
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-linux:<version>") // Linux Wayland helper
     testImplementation("dev.sebastiano.spectre:spectre-server:<version>")
 }
 ```
+
+`spectre-recording` contains the public recording API and common JVM implementation.
+The macOS and Linux helper artifacts are runtime-only resources: add the one(s) your
+tests can run on with `testRuntimeOnly(...)`, or with `runtimeOnly(...)` for production
+application code.
 
 If you depend on `server`, you also need to add a Ktor server engine yourself — Spectre
 intentionally doesn't bundle one. See [Cross-JVM access](cross-jvm.md) for the choice.
@@ -82,6 +91,10 @@ includeBuild("../spectre") {
             .using(project(":testing"))
         substitute(module("dev.sebastiano.spectre:spectre-recording"))
             .using(project(":recording"))
+        substitute(module("dev.sebastiano.spectre:spectre-recording-macos"))
+            .using(project(":recording-macos"))
+        substitute(module("dev.sebastiano.spectre:spectre-recording-linux"))
+            .using(project(":recording-linux"))
         substitute(module("dev.sebastiano.spectre:spectre-server"))
             .using(project(":server"))
     }
@@ -98,6 +111,8 @@ dependencies {
 
     // Optional, depending on what you need:
     testImplementation("dev.sebastiano.spectre:spectre-recording")
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-macos")
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-linux")
     testImplementation("dev.sebastiano.spectre:spectre-server")
 }
 ```
@@ -119,11 +134,14 @@ Maven Local:
 | ----------- | -------------------------------------------------------------------------------- |
 | `core`      | `ComposeAutomator`, semantics tree reader, selectors, `RobotDriver` for input.    |
 | `testing`   | `ComposeAutomatorExtension` (JUnit 5), `ComposeAutomatorRule` (JUnit 4).         |
-| `recording` | Region and window-targeted screen capture (`AutoRecorder`, `FfmpegRecorder`, …). |
+| `recording` | Region and window-targeted screen capture API (`AutoRecorder`, `FfmpegRecorder`, …). |
+| `recording-macos` | Runtime-only macOS ScreenCaptureKit helper resources for `recording`. |
+| `recording-linux` | Runtime-only Linux Wayland helper resources for `recording`. |
 | `server`    | Embedded HTTP transport (Ktor) and `HttpComposeAutomator` for cross-JVM access. **Experimental**; see [Security notes](../SECURITY.md). |
 
 Most projects only need `core` + `testing`. Add `recording` if you want video output for
-test runs, and `server` if your test process needs to reach a UI in a different JVM.
+test runs, add the platform helper artifact(s) for the OSes you run recording tests on, and
+add `server` if your test process needs to reach a UI in a different JVM.
 
 ## Next
 

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -6,8 +6,10 @@ right one per call.
 
 !!! note "External dependencies"
     The recording backends shell out to platform tools — `ffmpeg` everywhere, plus a
-    bundled Swift helper on macOS and a small Rust helper on Linux Wayland. See
-    [Recording limitations](../RECORDING-LIMITATIONS.md) for the per-platform notes.
+    Swift helper on macOS and a small Rust helper on Linux Wayland. Add
+    `spectre-recording-macos` and/or `spectre-recording-linux` as runtime-only
+    dependencies for those helpers. See [Recording limitations](../RECORDING-LIMITATIONS.md)
+    for the per-platform notes.
 
 ## The `Recorder` interface
 
@@ -36,9 +38,9 @@ view for when you want to know what each backend can and cannot do.
 | --- | --- | --- | --- | --- | --- |
 | `FfmpegRecorder` | Screen region (fixed `Rectangle`) | No — region fixed at `start()` | Yes — anything visible inside the region lands in the frame, including occluding apps and overlapping Compose `OnWindow` popups | `ffmpeg` on `PATH`; macOS Screen Recording TCC for the launching app | macOS · Windows · Linux Xorg |
 | `FfmpegWindowRecorder` | Named window (`gdigrab title=`) | Yes — `gdigrab` retracks the window across moves and resizes | No — only the window's pixels are captured. Compose `OnWindow` popups land in a separate OS window with a different title, so they are **not** captured. `OnSameCanvas` / `OnComponent` popups are part of the window surface and are captured | `ffmpeg` on `PATH`; visible window with a non-blank exact title | Windows |
-| `ScreenCaptureKitRecorder` | Named window (pid + title substring) | Yes — reads the window backing store directly, follows moves and resizes | No — same window-source semantics as `FfmpegWindowRecorder`. `OnWindow` popups not captured; `OnSameCanvas` / `OnComponent` captured | Bundled Swift helper (`spectre-screencapture`); macOS Screen Recording TCC for the launching app | macOS |
-| `WaylandPortalRecorder` | Monitor region (portal `SourceType.MONITOR`, cropped) | No — monitor-level source | Depends on the compositor. Validated on GNOME/Mutter to include the user's overlays but exclude apps occluding the recorded region | Bundled Rust helper (`spectre-wayland-helper`); `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`. First call pops the compositor's "share screen" dialog | Linux Wayland |
-| `WaylandPortalWindowRecorder` | Named window (portal `SourceType.WINDOW` + fixed crop) | **No.** The crop is computed once from `_GTK_FRAME_EXTENTS` at `start()` and stays at those pixel coordinates for the rest of the recording. If the user moves or resizes the window during the recording, the crop no longer aligns with the window's pixels (typically the recording shows blank / black for the unrendered area of the original rectangle) — see `WaylandPortalWindowRecorder`'s KDoc for the detailed rationale | No — only the picked window's pixels are in the stream. `OnWindow` popups not captured | Bundled Rust helper; `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`; `xprop` on `PATH`; compositor must publish `_GTK_FRAME_EXTENTS` (GNOME/Mutter verified; older Mutter / KDE / sway may not — the recorder throws rather than producing misaligned video) | Linux Wayland |
+| `ScreenCaptureKitRecorder` | Named window (pid + title substring) | Yes — reads the window backing store directly, follows moves and resizes | No — same window-source semantics as `FfmpegWindowRecorder`. `OnWindow` popups not captured; `OnSameCanvas` / `OnComponent` captured | `spectre-recording-macos` runtime helper (`spectre-screencapture`); macOS Screen Recording TCC for the launching app | macOS |
+| `WaylandPortalRecorder` | Monitor region (portal `SourceType.MONITOR`, cropped) | No — monitor-level source | Depends on the compositor. Validated on GNOME/Mutter to include the user's overlays but exclude apps occluding the recorded region | `spectre-recording-linux` runtime helper (`spectre-wayland-helper`); `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`. First call pops the compositor's "share screen" dialog | Linux Wayland |
+| `WaylandPortalWindowRecorder` | Named window (portal `SourceType.WINDOW` + fixed crop) | **No.** The crop is computed once from `_GTK_FRAME_EXTENTS` at `start()` and stays at those pixel coordinates for the rest of the recording. If the user moves or resizes the window during the recording, the crop no longer aligns with the window's pixels (typically the recording shows blank / black for the unrendered area of the original rectangle) — see `WaylandPortalWindowRecorder`'s KDoc for the detailed rationale | No — only the picked window's pixels are in the stream. `OnWindow` popups not captured | `spectre-recording-linux` runtime helper; `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`; `xprop` on `PATH`; compositor must publish `_GTK_FRAME_EXTENTS` (GNOME/Mutter verified; older Mutter / KDE / sway may not — the recorder throws rather than producing misaligned video) | Linux Wayland |
 
 A note on the Wayland window row: window-source isolation (no leakage from other apps) is
 what makes window-targeted Wayland capture different from ffmpeg-on-X11 region capture. The
@@ -101,7 +103,7 @@ The routing is platform-keyed. Read the row that matches your OS:
 
 | Platform                | `window`                          | Backend chosen                                                       |
 | ----------------------- | --------------------------------- | -------------------------------------------------------------------- |
-| **macOS**               | non-null                          | `ScreenCaptureKitRecorder` (bundled Swift helper).                   |
+| **macOS**               | non-null                          | `ScreenCaptureKitRecorder` (`spectre-recording-macos` helper).       |
 | **macOS**               | `null`                            | `FfmpegRecorder` region capture (`avfoundation`).                    |
 | **Windows**             | non-null with a non-blank title   | `FfmpegWindowRecorder` (`gdigrab title=`).                           |
 | **Windows**             | `null`, or non-null with no title | `FfmpegRecorder` region capture (`gdigrab`).                         |
@@ -111,8 +113,8 @@ The routing is platform-keyed. Read the row that matches your OS:
 
 A few details worth knowing:
 
-- **macOS SCK helper fallback.** If the Swift helper isn't bundled in the running
-  JAR (e.g., you built on Linux but ran on macOS), the macOS + window path falls
+- **macOS SCK helper fallback.** If the Swift helper isn't present on the runtime
+  classpath, the macOS + window path falls
   back to `FfmpegRecorder` region capture with a warning on stderr. Operational
   SCK failures — permission denied, target window not found, helper crashed during
   init — propagate as exceptions rather than falling back silently, so you see
@@ -129,7 +131,7 @@ A few details worth knowing:
   monitor stream to the requested rectangle. The first call pops the compositor's
   "share your screen" dialog; subsequent calls in the same JVM run reuse the grant.
 - **Linux Wayland helper.** Both portal recorders run the same small Rust binary
-  (`spectre-wayland-helper`) bundled in the `recording` artifact. It drives
+  (`spectre-wayland-helper`) from the `spectre-recording-linux` runtime artifact. It drives
   `xdg-desktop-portal`'s ScreenCast interface and hands a PipeWire FD to
   `gst-launch-1.0`.
 - **Window-targeted Wayland needs `xprop`.** `WaylandPortalWindowRecorder` queries the
@@ -152,8 +154,8 @@ If you know exactly which backend you want, instantiate it directly and skip the
 | ----------------------------- | ------------------------------------------------------------------------- |
 | `FfmpegRecorder`              | Region capture on macOS, Windows, and Linux Xorg. (Throws on Wayland — use `WaylandPortalRecorder` there.) Default for "no window in mind". |
 | `FfmpegWindowRecorder`        | Windows-only window-targeted capture via `gdigrab title=`.                |
-| `ScreenCaptureKitRecorder`    | macOS-only window-targeted capture via the bundled Swift helper.          |
-| `WaylandPortalRecorder`       | Linux Wayland region capture via `xdg-desktop-portal` (`SourceType.MONITOR`) and a bundled Rust helper. |
+| `ScreenCaptureKitRecorder`    | macOS-only window-targeted capture via the `spectre-recording-macos` Swift helper. |
+| `WaylandPortalRecorder`       | Linux Wayland region capture via `xdg-desktop-portal` (`SourceType.MONITOR`) and the `spectre-recording-linux` Rust helper. |
 | `WaylandPortalWindowRecorder` | Linux Wayland window-targeted capture via `xdg-desktop-portal` (`SourceType.WINDOW`). Window-sized output containing only the picked window's pixels. |
 
 ## Per-OS prerequisites
@@ -163,9 +165,9 @@ macOS has the most involved setup; the others are short. macOS first:
 ### macOS
 
 - `ffmpeg` on `PATH`.
-- The Swift ScreenCaptureKit helper is bundled inside `recording`'s artifact.
-  Universal-binary opt-in is available via
-  `./gradlew :recording:assembleScreenCaptureKitHelper -PuniversalHelper`.
+- Add `dev.sebastiano.spectre:spectre-recording-macos:<version>` as a runtime-only
+  dependency. Its jar carries the notarized universal ScreenCaptureKit helper at
+  `native/macos/spectre-screencapture`.
 - **Screen Recording TCC permission**, granted under System Settings → Privacy &
   Security → Screen Recording.
 
@@ -197,7 +199,9 @@ recording tests, especially while establishing Screen Recording TCC grants.
 - **Windows** — `ffmpeg` on `PATH`. `gdigrab` ships with `ffmpeg`.
 - **Linux Xorg** — `ffmpeg` with the `x11grab` input enabled (default in distro builds).
 - **Linux Wayland** — `gst-launch-1.0` plus the GStreamer plugins for H.264/Matroska.
-  The Rust helper is bundled inside `recording`'s artifact. Recording requires a
+  Add `dev.sebastiano.spectre:spectre-recording-linux:<version>` as a runtime-only
+  dependency. Its jar carries the Rust helper under `native/linux/<arch>/`.
+  Recording requires a
   Wayland compositor that exposes `org.freedesktop.portal.ScreenCast`; tested against
   GNOME/mutter on Ubuntu 22.04 and 24.04.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -178,8 +178,9 @@ uniform black). The error message points you at the fix:
 > `WaylandPortalRecorder` directly.
 
 If you're driving `FfmpegRecorder` directly on Linux, switch to `AutoRecorder` — it
-detects the session type and routes through the portal-based recorder when the bundled
-helper is wired up. If you'd rather force an Xorg session, verify with:
+detects the session type and routes through the portal-based recorder when the
+`spectre-recording-linux` helper artifact is on the runtime classpath. If you'd rather
+force an Xorg session, verify with:
 
 ```shell
 echo "$XDG_SESSION_TYPE"               # should be "x11"
@@ -205,12 +206,11 @@ See [Recording limitations](../RECORDING-LIMITATIONS.md) for the full Wayland st
 - **TCC doesn't refresh live.** After granting, fully quit and relaunch the
   parent app — not just the JVM child. macOS only picks up the new entitlement on
   process start.
-- **The SCK helper isn't bundled.** If you built `recording` on a non-macOS host and
-  shipped the jar to macOS, the bundled Swift helper isn't present and
-  `AutoRecorder.startWindow(...)` throws instead of silently switching capture modes. To
-  fix, build on macOS, or run `:recording:assembleScreenCaptureKitHelper` (optionally
-  with `-PuniversalHelper`). Use `startRegion(...)` explicitly if region capture is an
-  acceptable fallback for your test.
+- **The SCK helper artifact is missing.** If `spectre-recording-macos` is not on the
+  runtime classpath, the Swift helper is not present and `AutoRecorder.startWindow(...)`
+  throws instead of silently switching capture modes. Add the helper artifact as
+  `runtimeOnly(...)` or `testRuntimeOnly(...)`. Use `startRegion(...)` explicitly if region
+  capture is an acceptable fallback for your test.
 - **Operational SCK errors propagate.** Permission denied, target window not found,
   helper crashed during init — these all throw `IllegalStateException` rather than
   silently falling back, so you see the real cause.

--- a/recording-linux/build.gradle.kts
+++ b/recording-linux/build.gradle.kts
@@ -1,0 +1,93 @@
+import java.util.zip.ZipFile
+import org.gradle.api.GradleException
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.language.jvm.tasks.ProcessResources
+import org.gradle.nativeplatform.OperatingSystemFamily
+
+plugins {
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.ktfmt)
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.mavenPublish)
+}
+
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+}
+
+dependencies {
+    runtimeOnly(projects.recording)
+
+    detektPlugins(libs.compose.rules.detekt)
+
+    testImplementation(libs.kotlin.testJunit5)
+}
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }
+
+val linuxFamily = objects.named<OperatingSystemFamily>(OperatingSystemFamily.LINUX)
+
+configurations
+    .matching { it.name == "apiElements" || it.name == "runtimeElements" }
+    .configureEach {
+        attributes.attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, linuxFamily)
+    }
+
+val recordingProject = project(":recording")
+val prebuiltLinuxHelpersDir = providers.gradleProperty("prebuiltLinuxHelpersDir")
+val useAllLinuxArches = providers.gradleProperty("allLinuxArches").isPresent
+val shouldVerifyLinuxHelpers =
+    prebuiltLinuxHelpersDir.isPresent || OperatingSystem.current().isLinux
+val expectedLinuxHelperPaths =
+    if (prebuiltLinuxHelpersDir.isPresent || useAllLinuxArches) {
+        listOf(
+            "native/linux/x86_64/spectre-wayland-helper",
+            "native/linux/aarch64/spectre-wayland-helper",
+        )
+    } else {
+        val arch =
+            when (System.getProperty("os.arch").orEmpty().lowercase()) {
+                "amd64",
+                "x86_64",
+                "x64" -> "x86_64"
+                "aarch64",
+                "arm64" -> "aarch64"
+                else -> System.getProperty("os.arch").orEmpty().lowercase()
+            }
+        listOf("native/linux/$arch/spectre-wayland-helper")
+    }
+
+tasks.named<ProcessResources>("processResources") {
+    from(recordingProject.layout.buildDirectory.dir("generated/waylandHelper"))
+    when {
+        prebuiltLinuxHelpersDir.isPresent ->
+            dependsOn(recordingProject.tasks.named("stagePrebuiltLinuxHelpers"))
+        OperatingSystem.current().isLinux && useAllLinuxArches ->
+            dependsOn(recordingProject.tasks.named("assembleWaylandHelperAllArches"))
+        OperatingSystem.current().isLinux ->
+            dependsOn(recordingProject.tasks.named("assembleWaylandHelper"))
+    }
+}
+
+tasks.register("verifyRecordingLinuxHelpers") {
+    group = "verification"
+    description = "Verifies the Linux helper resources are packaged in spectre-recording-linux."
+    enabled = shouldVerifyLinuxHelpers
+    dependsOn(tasks.named("jar"))
+
+    val jarFile = tasks.named<Jar>("jar").flatMap { it.archiveFile }
+    val expectedHelpers = expectedLinuxHelperPaths
+    doLast {
+        val jar = jarFile.get().asFile
+        val entries = ZipFile(jar).use { zip -> zip.entries().asSequence().map { it.name }.toSet() }
+        val missing = expectedHelpers.filter { it !in entries }
+        if (missing.isNotEmpty()) {
+            throw GradleException(
+                "spectre-recording-linux jar is missing helper resources: " + missing.joinToString()
+            )
+        }
+    }
+}
+
+tasks.named("check") { dependsOn("verifyRecordingLinuxHelpers") }

--- a/recording-linux/gradle.properties
+++ b/recording-linux/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=spectre-recording-linux
+POM_NAME=Spectre Recording Linux Helpers
+# See :core's gradle.properties for the Latin-1 / ASCII safety note.
+POM_DESCRIPTION=Runtime-only Linux helper resources for Spectre Recording. Add as runtimeOnly or testRuntimeOnly alongside spectre-recording when running Wayland portal recording on Linux.

--- a/recording-macos/build.gradle.kts
+++ b/recording-macos/build.gradle.kts
@@ -1,0 +1,81 @@
+import java.util.zip.ZipFile
+import org.gradle.api.GradleException
+import org.gradle.internal.os.OperatingSystem
+import org.gradle.language.jvm.tasks.ProcessResources
+import org.gradle.nativeplatform.OperatingSystemFamily
+
+plugins {
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.ktfmt)
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.mavenPublish)
+}
+
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+}
+
+dependencies {
+    runtimeOnly(projects.recording)
+
+    detektPlugins(libs.compose.rules.detekt)
+
+    testImplementation(libs.kotlin.testJunit5)
+}
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }
+
+val macosFamily = objects.named<OperatingSystemFamily>(OperatingSystemFamily.MACOS)
+
+configurations
+    .matching { it.name == "apiElements" || it.name == "runtimeElements" }
+    .configureEach {
+        attributes.attribute(OperatingSystemFamily.OPERATING_SYSTEM_ATTRIBUTE, macosFamily)
+    }
+
+val recordingProject = project(":recording")
+val prebuiltMacHelperPath = providers.gradleProperty("prebuiltMacHelperPath")
+val useStubMacHelperForTesting = providers.gradleProperty("stubMacHelperForTesting").isPresent
+val shouldNotarizeScreenCaptureKitHelper =
+    providers.gradleProperty("notarizeScreenCaptureKitHelper").isPresent
+val useUniversalHelper =
+    providers.gradleProperty("universalHelper").isPresent || shouldNotarizeScreenCaptureKitHelper
+val shouldVerifyMacosHelper =
+    useStubMacHelperForTesting ||
+        prebuiltMacHelperPath.isPresent ||
+        OperatingSystem.current().isMacOsX
+
+tasks.named<ProcessResources>("processResources") {
+    from(recordingProject.layout.buildDirectory.dir("generated/screenCaptureHelper"))
+    when {
+        useStubMacHelperForTesting -> dependsOn(recordingProject.tasks.named("stageStubMacHelper"))
+        prebuiltMacHelperPath.isPresent ->
+            dependsOn(recordingProject.tasks.named("stagePrebuiltMacHelper"))
+        OperatingSystem.current().isMacOsX && useUniversalHelper ->
+            dependsOn(recordingProject.tasks.named("assembleScreenCaptureKitHelperUniversal"))
+        OperatingSystem.current().isMacOsX ->
+            dependsOn(recordingProject.tasks.named("assembleScreenCaptureKitHelper"))
+    }
+}
+
+tasks.register("verifyRecordingMacosHelpers") {
+    group = "verification"
+    description = "Verifies the macOS helper resource is packaged in spectre-recording-macos."
+    enabled = shouldVerifyMacosHelper
+    dependsOn(tasks.named("jar"))
+
+    val jarFile = tasks.named<Jar>("jar").flatMap { it.archiveFile }
+    doLast {
+        val jar = jarFile.get().asFile
+        val containsHelper =
+            ZipFile(jar).use { zip -> zip.getEntry("native/macos/spectre-screencapture") != null }
+        if (!containsHelper) {
+            throw GradleException(
+                "spectre-recording-macos jar is missing native/macos/spectre-screencapture"
+            )
+        }
+    }
+}
+
+tasks.named("check") { dependsOn("verifyRecordingMacosHelpers") }

--- a/recording-macos/gradle.properties
+++ b/recording-macos/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=spectre-recording-macos
+POM_NAME=Spectre Recording macOS Helpers
+# See :core's gradle.properties for the Latin-1 / ASCII safety note.
+POM_DESCRIPTION=Runtime-only macOS helper resources for Spectre Recording. Add as runtimeOnly or testRuntimeOnly alongside spectre-recording when running ScreenCaptureKit-based recording on macOS.

--- a/recording/README.md
+++ b/recording/README.md
@@ -284,26 +284,30 @@ needs is missing.
 
 ### Verifying bundled helpers
 
-`./gradlew :recording:check` runs `verifyBundledRecordingHelpers`, which inspects the
-recording jar's staged resources and asserts the helpers that *should* be there given
-the current host + project-property combination actually are, and that each one matches
-its expected arch (lipo for the macOS helper, JVM-side ELF header parse for the Linux
-helper). The task is verification-only — it never triggers a universal or cross-arch
-build that wasn't already requested.
+`./gradlew :recording-macos:check` and `./gradlew :recording-linux:check` verify the
+platform helper jars, not the API-only `:recording` jar. Each helper module packages the
+generated resources staged by `:recording`'s native build tasks:
+
+- `:recording-macos` expects `native/macos/spectre-screencapture` when a mac helper can
+  be produced or provided.
+- `:recording-linux` expects `native/linux/<arch>/spectre-wayland-helper` on Linux.
 
 When `-PallLinuxArches` is set the task expects both `x86_64` and `aarch64` Wayland
 helpers. CI invokes it as
 
-    ./gradlew :recording:assembleWaylandHelperAllArches :recording:verifyBundledRecordingHelpers -PallLinuxArches
+    ./gradlew :recording-linux:verifyRecordingLinuxHelpers -PallLinuxArches
 
 to lock in both-arch coverage explicitly.
 
 ### Release packaging
 
-The tag-driven release workflow builds the recording JAR on macOS with
-`-PuniversalHelper -PnotarizeScreenCaptureKitHelper`, so
-`native/macos/spectre-screencapture` carries a signed and notarized universal binary. It
-then uploads that JAR to the GitHub release for the pushed tag.
+The tag-driven release workflow builds and notarizes the macOS helper on a macOS runner,
+builds both Linux helper architectures on a Linux runner, then publishes three recording
+artifacts:
+
+- `spectre-recording` — API/common JVM implementation only.
+- `spectre-recording-macos` — signed and notarized universal ScreenCaptureKit helper.
+- `spectre-recording-linux` — x86_64 and aarch64 Wayland helpers.
 
 Local builds still produce a host-shaped subset of helpers unless you opt into the
 distribution-oriented flags above.

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -1,12 +1,7 @@
-import java.io.ByteArrayOutputStream
 import java.io.File
-import java.io.RandomAccessFile
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
-import javax.inject.Inject
 import org.gradle.api.GradleException
 import org.gradle.internal.os.OperatingSystem
-import org.gradle.process.ExecOperations
+import org.gradle.language.jvm.tasks.ProcessResources
 
 /**
  * Maps the host's `os.arch` system property to the Rust target-triple architecture name we ship the
@@ -32,11 +27,9 @@ plugins {
     // kotlinx.serialization for the Wayland helper's JSON wire protocol (#77 stage 3).
     alias(libs.plugins.kotlinSerialization)
     // See `:core`'s build script for the rationale on the shared publish convention. Per-module
-    // POM scalars live in this module's own `gradle.properties`. The recording jar published
-    // from the release pipeline bundles the macOS universal SCK helper (built+notarised on a
-    // mac runner) + the Linux x86_64 / aarch64 Wayland helpers (built on a Linux runner) —
-    // see `.github/workflows/release.yml` and the helper-staging tasks below for how the
-    // helpers flow into a single cross-platform recording jar.
+    // POM scalars live in this module's own `gradle.properties`. This module publishes the
+    // JVM recording API and common implementation only; `:recording-macos` and
+    // `:recording-linux` publish the runtime helper resources as separate artifacts.
     alias(libs.plugins.mavenPublish)
 }
 
@@ -381,19 +374,6 @@ val assembleScreenCaptureKitHelperUniversal by
         into(helperResourceDest.get().asFile.parentFile)
     }
 
-// The generated helper directory is wired into resources unconditionally — even on non-macOS
-// hosts. If we gated the srcDir registration on macOS too, a Linux CI build would produce a jar
-// with no `native/macos/` entries at all, so a downstream macOS consumer would later hit
-// `HelperBinaryExtractor`'s "binary not found" error. Wiring the srcDir always means the jar
-// structure is host-agnostic — the helper file just isn't there if the host can't build it.
-//
-// The actual `assembleScreenCaptureKitHelper` task only runs on macOS (its `onlyIf`), so it's
-// only attached to `processResources` when we're on a host that can produce the binary.
-//
-// For shipping a distribution jar, build on macOS — the README documents this. A future macOS
-// CI workflow (#18 follow-up) will guard against accidentally publishing a Linux-built jar.
-sourceSets["main"].resources.srcDir(layout.buildDirectory.dir("generated/screenCaptureHelper"))
-
 // Whether `processResources` (and therefore `jar` / distribution) bundles the host-arch helper
 // or the universal one is controlled by a project property. Two reasons for this design over
 // `mustRunAfter`-based ordering:
@@ -423,23 +403,28 @@ val prebuiltMacHelperPath = providers.gradleProperty("prebuiltMacHelperPath")
 val prebuiltLinuxHelpersDir = providers.gradleProperty("prebuiltLinuxHelpersDir")
 val useStubMacHelperForTesting = providers.gradleProperty("stubMacHelperForTesting").isPresent
 
-// `-PprebuiltMacHelperPath` / `-PstubMacHelperForTesting` are mutually exclusive with the
-// host-platform mac build path: when a pre-built (or stub) helper is staged, the host build
-// would only overwrite the same destination and produce a jar inconsistent with the artefact
-// promised by the release CI. The host build is silenced when either prebuilt path is set.
-if (
-    OperatingSystem.current().isMacOsX &&
-        !prebuiltMacHelperPath.isPresent &&
-        !useStubMacHelperForTesting
-) {
-    tasks.named("processResources") {
+tasks.named<ProcessResources>("processTestResources") {
+    from(layout.buildDirectory.dir("generated/screenCaptureHelper"))
+    from(layout.buildDirectory.dir("generated/waylandHelper"))
+    if (prebuiltMacHelperPath.isPresent || useStubMacHelperForTesting) {
+        dependsOn(if (useStubMacHelperForTesting) stageStubMacHelper else stagePrebuiltMacHelper)
+    } else if (OperatingSystem.current().isMacOsX) {
         dependsOn(
             if (useUniversalHelper) assembleScreenCaptureKitHelperUniversal
             else assembleScreenCaptureKitHelper
         )
     }
+    if (prebuiltLinuxHelpersDir.isPresent) {
+        dependsOn(stagePrebuiltLinuxHelpers)
+    } else if (OperatingSystem.current().isLinux) {
+        dependsOn(if (useAllLinuxArches) assembleWaylandHelperAllArches else assembleWaylandHelper)
+    }
 }
 
+// `-PprebuiltMacHelperPath` / `-PstubMacHelperForTesting` are mutually exclusive with the
+// host-platform mac build path: when a pre-built (or stub) helper is staged, the host build
+// would only overwrite the same destination and produce a jar inconsistent with the artefact
+// promised by the release CI. The host build is silenced when either prebuilt path is set.
 // --- Wayland Rust helper binary (issue #80) -------------------------------------------------
 //
 // `WaylandPortalRecorder` ships a small Rust CLI (`recording/native/linux/`) that drives the
@@ -609,12 +594,6 @@ val assembleWaylandHelperAllArches by tasks.registering {
     dependsOn(perArchStageTasks)
 }
 
-// Same pattern as the SCK helper: register the generated resource srcDir unconditionally so
-// jar layouts are host-agnostic, but only attach the build task to processResources on
-// Linux. macOS/Windows builds will have an empty `native/linux/` directory in the jar — fine,
-// the recorder gates on the resource being present and falls back per HelperNotBundledException.
-sourceSets["main"].resources.srcDir(layout.buildDirectory.dir("generated/waylandHelper"))
-
 // Switch `processResources` to either the host-arch staging (default, fast) or the
 // cross-arch staging (release). Single-staging-task wiring follows the macOS universal
 // helper precedent — see the comment block above the `useUniversalHelper` declaration for
@@ -625,12 +604,6 @@ val useAllLinuxArches = providers.gradleProperty("allLinuxArches").isPresent
 // per-arch wayland binaries, the host-arch cargo build must not also wire itself in — both
 // would target `build/generated/waylandHelper/native/linux/<arch>/...` and the host build's
 // freshly compiled x86_64 binary would overwrite the prebuilt one shipped by the release CI.
-if (OperatingSystem.current().isLinux && !prebuiltLinuxHelpersDir.isPresent) {
-    tasks.named("processResources") {
-        dependsOn(if (useAllLinuxArches) assembleWaylandHelperAllArches else assembleWaylandHelper)
-    }
-}
-
 // --- Pre-built native helpers for the release pipeline (#84) --------------------------------
 //
 // The release CI fans out: a macOS runner builds + signs + notarises the universal SCK
@@ -748,41 +721,6 @@ val stagePrebuiltLinuxHelpers by
         include("x86_64/spectre-wayland-helper", "aarch64/spectre-wayland-helper")
     }
 
-// Pre-built staging tasks become processResources dependencies wherever they're requested,
-// independent of host OS. The combinations the release CI uses:
-//   - publish job on Linux: -PprebuiltMacHelperPath -PprebuiltLinuxHelpersDir
-//     → stagePrebuiltMacHelper + stagePrebuiltLinuxHelpers (both)
-//   - smoke on Linux (this branch's verification): -PstubMacHelperForTesting -PallLinuxArches
-//     → stageStubMacHelper + assembleWaylandHelperAllArches
-// On the regular per-host paths configured above, neither task fires and the existing
-// per-host wiring runs as before.
-if (prebuiltMacHelperPath.isPresent || useStubMacHelperForTesting) {
-    tasks.named("processResources") {
-        if (useStubMacHelperForTesting) {
-            dependsOn(stageStubMacHelper)
-        } else {
-            dependsOn(stagePrebuiltMacHelper)
-        }
-    }
-}
-
-if (prebuiltLinuxHelpersDir.isPresent) {
-    tasks.named("processResources") { dependsOn(stagePrebuiltLinuxHelpers) }
-}
-
-// The sourcesJar registered by `com.vanniktech.maven.publish` bundles
-// `sourceSets["main"].allSource`, which transitively reads the generated resource srcDirs
-// (`build/generated/screenCaptureHelper`, `build/generated/waylandHelper`) the helper-
-// staging tasks write into. Gradle 9 surfaces an implicit-dependency check on that read.
-// Hooking sourcesJar onto `processResources` (which already depends on whichever staging
-// task is currently active per the host / property selection) keeps the dependency graph
-// honest without manually enumerating every variant.
-pluginManager.withPlugin("com.vanniktech.maven.publish") {
-    tasks
-        .matching { it.name == "sourcesJar" }
-        .configureEach { dependsOn(tasks.named("processResources")) }
-}
-
 // Manual smoke entry point — opens a JFrame, records it for ~3s via ScreenCaptureKitRecorder,
 // prints the resulting file path + size. Lives in the test source set because the helper class
 // it drives is `internal` and we don't want to publish it.
@@ -870,303 +808,3 @@ tasks.register<JavaExec>("runWaylandPortalWindowSmoke") {
     standardOutput = System.out
     errorOutput = System.err
 }
-
-// --- Bundled helper artifact verification (R3) -----------------------------------------------
-//
-// `verifyBundledRecordingHelpers` is the single entry point that asserts the recording jar
-// being built actually contains the helpers it claims to. The task's expectations are computed
-// from the host OS + project properties at configuration time:
-//
-//   - macOS host, default                : expect host-arch SCK helper, `lipo -verify_arch
-// <host-arch>`.
-//   - macOS host + `-PuniversalHelper`   : expect universal SCK helper, `lipo -verify_arch arm64
-// x86_64`.
-//   - Linux host, default                : expect host-arch Wayland helper, JVM-side ELF parse.
-//   - Linux host + `-PallLinuxArches`    : expect both x86_64 + aarch64 Wayland helpers, JVM-side
-// ELF
-//                                          parse for each.
-//   - Other hosts (Windows etc.)         : no expectations, task is a no-op success.
-//
-// Verification only — the task depends on `processResources` and inspects whatever was already
-// staged. It deliberately does NOT depend on `lipoScreenCaptureKitHelper` /
-// `assembleScreenCaptureKitHelperUniversal` / `assembleWaylandHelperAllArches` directly, so
-// running `./gradlew check` on macOS without `-PuniversalHelper` does not trigger a universal
-// build. The same project-property switches that drive `processResources` (above) drive the
-// task's expectations in parallel.
-//
-// The Linux ELF parse is JVM-side (no `readelf` dependency, works on every dev host where this
-// task might run for sanity-checking). The macOS check shells out to `lipo` because lipo only
-// runs on macOS anyway, and the existing `verifyUniversalScreenCaptureKitHelper` pattern
-// proves it. ELF magic + `e_machine` is the entirety of the parse — see the constants in
-// `VerifyBundledRecordingHelpers` for the per-arch machine fields.
-
-/**
- * Reports which helper artifacts should be in the recording jar and verifies each. Expectations are
- * configured at task-registration time from the host OS + project properties; the action itself
- * just walks the list and fails fast on the first missing or wrong-arch helper.
- */
-abstract class VerifyBundledRecordingHelpers
-@Inject
-constructor(private val execOperations: ExecOperations) : DefaultTask() {
-
-    /**
-     * Directory `processResources` writes into. Helper paths are resolved relative to this.
-     * `@Internal` rather than `@InputDirectory`: on hosts that produce no helpers (Windows;
-     * macOS/Linux with no other resources triggering processResources to create the dir),
-     * `build/resources/main` may not exist at all, and Gradle's `@InputDirectory` validation fails
-     * at task-graph time before the action runs (even with `@Optional`, because the value *is* set
-     * — we only fail to set it on hosts where no expectations exist). The task is pure verification
-     * with no incremental-build benefit anyway, so dropping input tracking is fine — the action
-     * below handles "expectations but no directory" as a real failure mode.
-     */
-    @get:Internal abstract val resourcesDir: DirectoryProperty
-
-    /**
-     * macOS architectures expected in `native/macos/spectre-screencapture`. Empty list means "no
-     * macOS expectation" (e.g. running on Linux/Windows). One arch = host-arch build; two arches =
-     * universal build (the order matters only for the error message — `lipo -verify_arch` requires
-     * all listed arches to be present).
-     */
-    @get:Input abstract val expectedMacOsArchs: ListProperty<String>
-
-    /**
-     * Linux architectures expected in `native/linux/<arch>/spectre-wayland-helper`. Empty means "no
-     * Linux expectation". `["x86_64"]` or `["aarch64"]` = host-arch; `["x86_64", "aarch64"]` =
-     * `-PallLinuxArches`.
-     */
-    @get:Input abstract val expectedLinuxArches: ListProperty<String>
-
-    @TaskAction
-    fun verify() {
-        val macOsArchs = expectedMacOsArchs.get()
-        val linuxArches = expectedLinuxArches.get()
-        if (macOsArchs.isEmpty() && linuxArches.isEmpty()) {
-            logger.lifecycle(
-                "verifyBundledRecordingHelpers: no helpers expected on this host — nothing to verify."
-            )
-            return
-        }
-        val resources = resourcesDir.orNull?.asFile
-        if (resources == null || !resources.isDirectory) {
-            throw GradleException(
-                "Recording helper verification failed: expected resources directory does not " +
-                    "exist (${resourcesDir.orNull?.asFile}). processResources must have run with " +
-                    "the helper staging tasks for this host wired in."
-            )
-        }
-        val errors = mutableListOf<String>()
-        if (macOsArchs.isNotEmpty()) {
-            verifyMacOsHelper(macOsArchs)?.let(errors::add)
-        }
-        for (arch in linuxArches) {
-            verifyLinuxHelper(arch)?.let(errors::add)
-        }
-        if (errors.isNotEmpty()) {
-            throw GradleException(
-                "Recording helper verification failed:\n" + errors.joinToString("\n") { "  - $it" }
-            )
-        }
-    }
-
-    private fun verifyMacOsHelper(expectedArchs: List<String>): String? {
-        val helperPath = "native/macos/spectre-screencapture"
-        val file = resourcesDir.file(helperPath).get().asFile
-        if (!file.isFile) {
-            return "Expected macOS helper missing at $helperPath (resolved to ${file.absolutePath})"
-        }
-        // On macOS, prefer `lipo -verify_arch` — same logic as the existing universal-helper
-        // verification, and it's the most authoritative answer because lipo parses the full
-        // Mach-O structure rather than just the fat header. On other hosts the JVM-side
-        // Mach-O fat-header parse handles the "is it a fat binary covering these archs"
-        // question without needing the macOS toolchain. The fallback is what makes the
-        // publish job's verification work on a Linux runner using a pre-built notarised
-        // mac helper artefact.
-        return if (OperatingSystem.current().isMacOsX) {
-            verifyMacOsHelperWithLipo(file, expectedArchs)
-        } else {
-            verifyMacOsHelperWithJvmParse(file, expectedArchs)
-        }
-    }
-
-    private fun verifyMacOsHelperWithLipo(file: File, expectedArchs: List<String>): String? {
-        val stdout = ByteArrayOutputStream()
-        val stderr = ByteArrayOutputStream()
-        val result = execOperations.exec {
-            commandLine(
-                buildList {
-                    add("lipo")
-                    add(file.absolutePath)
-                    add("-verify_arch")
-                    addAll(expectedArchs)
-                }
-            )
-            standardOutput = stdout
-            errorOutput = stderr
-            isIgnoreExitValue = true
-        }
-        if (result.exitValue != 0) {
-            return "lipo -verify_arch ${expectedArchs.joinToString(" ")} failed for " +
-                "${file.absolutePath}: exit=${result.exitValue} stdout=${stdout.toString().trim()} " +
-                "stderr=${stderr.toString().trim()}"
-        }
-        return null
-    }
-
-    private fun verifyMacOsHelperWithJvmParse(file: File, expectedArchs: List<String>): String? {
-        val headerBytes = ByteArray(FAT_HEADER_MAX_BYTES)
-        val readBytes =
-            RandomAccessFile(file, "r").use { raf ->
-                val toRead = minOf(raf.length().toInt(), headerBytes.size)
-                if (toRead < FAT_HEADER_MIN_BYTES) {
-                    return "File too short to be a Mach-O fat binary (${file.absolutePath})"
-                }
-                raf.readFully(headerBytes, 0, toRead)
-                toRead
-            }
-        val buffer = ByteBuffer.wrap(headerBytes, 0, readBytes).order(ByteOrder.BIG_ENDIAN)
-        val magic = buffer.int
-        if (magic != FAT_MAGIC.toInt()) {
-            return "Expected Mach-O fat magic 0xCAFEBABE but got 0x${magic.toString(16)} at " +
-                file.absolutePath
-        }
-        val nFatArch = buffer.int
-        if (nFatArch < 0 || nFatArch > FAT_ARCH_MAX) {
-            return "Implausible nfat_arch=$nFatArch in ${file.absolutePath}"
-        }
-        if (readBytes < FAT_HEADER_FIXED_BYTES + nFatArch * FAT_ARCH_ENTRY_BYTES) {
-            return "Truncated fat header in ${file.absolutePath}"
-        }
-        val presentArchs = mutableSetOf<String>()
-        repeat(nFatArch) {
-            val cpuType = buffer.int
-            buffer.int // cpuSubType — we don't filter on it
-            buffer.int // offset
-            buffer.int // size
-            buffer.int // align
-            MACHO_ARCH_BY_CPU_TYPE[cpuType]?.let(presentArchs::add)
-        }
-        val missing = expectedArchs.toSet() - presentArchs
-        if (missing.isNotEmpty()) {
-            return "Mach-O fat binary at ${file.absolutePath} missing arch(s): " +
-                "${missing.joinToString(", ")} (saw ${presentArchs.joinToString(", ")})"
-        }
-        return null
-    }
-
-    private fun verifyLinuxHelper(expectedArch: String): String? {
-        val relative = "native/linux/$expectedArch/spectre-wayland-helper"
-        val file = resourcesDir.file(relative).get().asFile
-        if (!file.isFile) {
-            return "Expected Linux helper missing at $relative (resolved to ${file.absolutePath})"
-        }
-        val expectedMachine =
-            ELF_MACHINE_BY_ARCH[expectedArch]
-                ?: return "Unknown expected Linux arch '$expectedArch' for $relative"
-        val header = ByteArray(ELF_HEADER_PREFIX_BYTES)
-        RandomAccessFile(file, "r").use { raf ->
-            if (raf.length() < ELF_HEADER_PREFIX_BYTES) {
-                return "File too short to be ELF ($file)"
-            }
-            raf.readFully(header)
-        }
-        if (
-            header[0].toInt() and 0xff != 0x7F ||
-                header[1] != 'E'.code.toByte() ||
-                header[2] != 'L'.code.toByte() ||
-                header[3] != 'F'.code.toByte()
-        ) {
-            return "Not an ELF file (bad magic) at ${file.absolutePath}"
-        }
-        // ELF spec: e_machine is a 2-byte little-endian field at offset 18.
-        val machine =
-            (header[ELF_E_MACHINE_OFFSET].toInt() and 0xff) or
-                ((header[ELF_E_MACHINE_OFFSET + 1].toInt() and 0xff) shl 8)
-        if (machine != expectedMachine) {
-            return "Expected e_machine=0x${expectedMachine.toString(16)} ($expectedArch) " +
-                "but ELF reports 0x${machine.toString(16)} at ${file.absolutePath}"
-        }
-        return null
-    }
-
-    companion object {
-        private const val ELF_HEADER_PREFIX_BYTES: Int = 20
-        private const val ELF_E_MACHINE_OFFSET: Int = 18
-        // e_machine constants from the ELF spec. Stable for the lifetime of the ABI.
-        private const val EM_X86_64: Int = 0x3E
-        private const val EM_AARCH64: Int = 0xB7
-        private val ELF_MACHINE_BY_ARCH: Map<String, Int> =
-            mapOf("x86_64" to EM_X86_64, "aarch64" to EM_AARCH64)
-
-        // Mach-O fat-binary header parse. Used by the non-macOS verification path so a Linux
-        // publish runner can sanity-check a pre-built notarised mac helper artefact. The fat
-        // header is BE regardless of host endianness — see <mach-o/fat.h> in Apple's SDK.
-        // Fields per fat_arch: cputype (4) + cpusubtype (4) + offset (4) + size (4) + align
-        // (4) = 20 bytes.
-        private const val FAT_MAGIC: Long = 0xCAFEBABE
-        private const val FAT_HEADER_FIXED_BYTES: Int = 8 // magic + nfat_arch
-        private const val FAT_ARCH_ENTRY_BYTES: Int = 20
-        private const val FAT_ARCH_MAX: Int = 32 // generous; real binaries have 2..3
-        private const val FAT_HEADER_MIN_BYTES: Int = FAT_HEADER_FIXED_BYTES + FAT_ARCH_ENTRY_BYTES
-        private const val FAT_HEADER_MAX_BYTES: Int =
-            FAT_HEADER_FIXED_BYTES + FAT_ARCH_MAX * FAT_ARCH_ENTRY_BYTES
-        // Mach-O cpu_type constants. The `0x01000000` bit is `CPU_ARCH_ABI64`; the lower
-        // byte distinguishes architectures within ABI64.
-        //   arm64 / arm64e: cpu_type = CPU_ARCH_ABI64 | CPU_TYPE_ARM (12)  = 0x0100000C
-        //   x86_64        : cpu_type = CPU_ARCH_ABI64 | CPU_TYPE_X86 (7)   = 0x01000007
-        private const val CPU_TYPE_ARM64: Int = 0x0100000C
-        private const val CPU_TYPE_X86_64: Int = 0x01000007
-        private val MACHO_ARCH_BY_CPU_TYPE: Map<Int, String> =
-            mapOf(CPU_TYPE_ARM64 to "arm64", CPU_TYPE_X86_64 to "x86_64")
-    }
-}
-
-val verifyBundledRecordingHelpers by
-    tasks.registering(VerifyBundledRecordingHelpers::class) {
-        description =
-            "Verifies the recording jar contains the native helpers it should, per host OS and " +
-                "project-property selection (-PuniversalHelper, -PallLinuxArches, " +
-                "-PprebuiltMacHelperPath, -PprebuiltLinuxHelpersDir, -PstubMacHelperForTesting). " +
-                "Inspection only — does not trigger universal SCK or all-arches Wayland builds."
-        group = "verification"
-        // Read whatever processResources staged. Depending on the project flags, that's either
-        // host-arch or the wider distribution build — the expectations below stay in sync.
-        dependsOn(tasks.named("processResources"))
-        resourcesDir.set(layout.buildDirectory.dir("resources/main"))
-
-        val os = OperatingSystem.current()
-        // macOS expectations. Three sources can stage a mac helper:
-        //   1. Host build on macOS (`assembleScreenCaptureKitHelper[Universal]`).
-        //   2. Pre-built notarised helper from the release pipeline
-        //      (`-PprebuiltMacHelperPath`) — assumed universal (arm64 + x86_64).
-        //   3. Stub Mach-O fat binary for publication-shape smoke
-        //      (`-PstubMacHelperForTesting`) — always covers arm64 + x86_64.
-        // The host-arch path uses `lipo -verify_arch <host-arch>`; lipo handles thin binaries
-        // fine.
-        val macOsArchs: List<String> =
-            when {
-                prebuiltMacHelperPath.isPresent || useStubMacHelperForTesting ->
-                    universalArchitectures
-                !os.isMacOsX -> emptyList()
-                useUniversalHelper -> universalArchitectures
-                else ->
-                    listOf(
-                        if (System.getProperty("os.arch").lowercase() == "aarch64") "arm64"
-                        else "x86_64"
-                    )
-            }
-        expectedMacOsArchs.set(macOsArchs)
-
-        // Linux expectations. `useAllLinuxArches` is true when `-PallLinuxArches` is set, and
-        // a pre-built Linux helpers directory always carries both arches (the release CI
-        // builds both before uploading).
-        val linuxArches: List<String> =
-            when {
-                prebuiltLinuxHelpersDir.isPresent -> linuxHelperArchitectures
-                !os.isLinux -> emptyList()
-                useAllLinuxArches -> linuxHelperArchitectures
-                else -> listOf(linuxRustHostArch())
-            }
-        expectedLinuxArches.set(linuxArches)
-    }
-
-tasks.named("check") { dependsOn(verifyBundledRecordingHelpers) }

--- a/recording/gradle.properties
+++ b/recording/gradle.properties
@@ -1,4 +1,4 @@
 POM_ARTIFACT_ID=spectre-recording
 POM_NAME=Spectre Recording
 # See :core's gradle.properties for the Latin-1 / ASCII safety note.
-POM_DESCRIPTION=Screen and window-targeted recording for Compose Desktop UIs. macOS via a bundled ScreenCaptureKit Swift helper, Windows via gdigrab through ffmpeg, Linux Xorg via x11grab, Linux Wayland via a bundled Rust helper that drives xdg-desktop-portal and PipeWire. Published jar bundles the macOS universal helper and Linux x86_64 / aarch64 helpers.
+POM_DESCRIPTION=Screen and window-targeted recording API and common JVM implementation for Compose Desktop UIs. macOS ScreenCaptureKit and Linux Wayland helper binaries are published as separate runtime-only helper artifacts.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -84,6 +84,10 @@ include(":server")
 
 include(":recording")
 
+include(":recording-macos")
+
+include(":recording-linux")
+
 include(":testing")
 
 include(":sample-desktop")


### PR DESCRIPTION
## Summary
- split recording native helpers into runtime-only macOS and Linux artifacts
- keep spectre-recording API/common-only and verify no native resources leak into sources jars
- update release workflow and docs for six published components

## Verification
- ./gradlew check
- ./gradlew verifyMavenLocalPublication -PstubMacHelperForTesting -PallLinuxArches
- /private/tmp/spectre-docs-venv/bin/mkdocs build --strict