### PR TITLE
Document Spectre CI setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ with IntelliJ 2026.1). Any JDK 21+ works for the non-IDE modules. CI runs on Tem
   on Linux under `xvfb-run` (real Xorg, no compositor in the loop), gated on the same
   `sample-desktop/**` filter shape.
 
+For consumer projects, see [Running on CI](docs/guide/ci.md) for the required test-JVM flags:
+`java.awt.headless=false` for AWT, `skiko.renderApi=SOFTWARE_COMPAT` on GPU-less Linux runners,
+and the macOS `apple.awt.UIElement=true` trade-offs for synthetic typing vs. clipboard paste.
+
 ## Reference docs
 
 The user guide and these reference pages are also published as a single browseable site

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -1,0 +1,105 @@
+# Running on CI
+
+Spectre can run live Compose Desktop tests on CI as long as the test JVM is a real desktop JVM.
+GitHub Actions Linux runners are validated on Ubuntu 24.04 under `xvfb` for both scripted-RPC
+tests and real-backend Compose Desktop tests.
+
+## Test JVM flags
+
+Set these on the Gradle `Test` task that hosts Spectre, not only on the runner process:
+
+```kotlin
+tasks.withType<Test>().configureEach {
+    systemProperty("java.awt.headless", "false")
+    if (System.getProperty("os.name").lowercase().contains("linux")) {
+        systemProperty("skiko.renderApi", "SOFTWARE_COMPAT")
+    }
+}
+```
+
+`-Djava.awt.headless=false` is required because Spectre needs the AWT toolkit. `xvfb` gives
+Linux a display server, but it cannot help if the JVM has already decided to run headless and
+ignore `DISPLAY`.
+
+`-Dskiko.renderApi=SOFTWARE_COMPAT` is required on GPU-less Linux runners. Without it, Skiko's
+default OpenGL path can throw `RenderException: Cannot create Linux GL context`. The semantics
+tree may still compose, so selectors such as `findByTestTag` can pass, but typed input can
+silently no-op because the Skia surface is not fully wired. Software rendering is the reliable
+path when the runner has no GPU.
+
+## macOS helper JVMs
+
+On macOS, add `-Dapple.awt.UIElement=true` when you want the Spectre test JVM to stay out of the
+Dock:
+
+```kotlin
+tasks.withType<Test>().configureEach {
+    if (System.getProperty("os.name").lowercase().contains("mac")) {
+        systemProperty("apple.awt.UIElement", "true")
+    }
+}
+```
+
+This is safe with `RobotDriver.synthetic(rootWindow = ...)` and per-character `typeText(...)`.
+Synthetic typing posts key events into the window hierarchy and does not require the app to be
+the foreground Dock application. Clipboard-backed `pasteText(...)` still needs
+`apple.awt.UIElement=false`, because that path goes through macOS clipboard services.
+
+## Recording tests
+
+Keep recording tests tagged separately from normal UI tests. Linux CI can validate Xorg / `xvfb`
+region recording and non-recording Spectre flows, but it cannot validate macOS
+ScreenCaptureKit capture. The base `spectre-recording` artifact also does not carry the macOS
+ScreenCaptureKit helper; macOS recording tests need the `spectre-recording-macos` runtime
+artifact or a locally built helper artifact on the test classpath.
+
+For example:
+
+```kotlin
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform {
+        excludeTags("recording")
+    }
+}
+
+val macRecordingTest by tasks.registering(Test::class) {
+    useJUnitPlatform {
+        includeTags("recording")
+    }
+    onlyIf { System.getProperty("os.name").lowercase().contains("mac") }
+    systemProperty("java.awt.headless", "false")
+}
+```
+
+## GitHub Actions example
+
+Install `xvfb` on Linux, then run the Gradle task through `xvfb-run`. Keep the JVM flags in
+Gradle so local runs and CI use the same test process configuration.
+
+```yaml
+jobs:
+  spectre-ui-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+      - name: Run Spectre UI tests
+        run: xvfb-run --auto-servernum ./gradlew spectreTest
+```
+
+```kotlin
+val spectreTest by tasks.registering(Test::class) {
+    description = "Runs live Compose Desktop UI tests with Spectre."
+    group = "verification"
+    useJUnitPlatform()
+    systemProperty("java.awt.headless", "false")
+    if (System.getProperty("os.name").lowercase().contains("linux")) {
+        systemProperty("skiko.renderApi", "SOFTWARE_COMPAT")
+    }
+}
+```

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -12,10 +12,11 @@ The guide walks through using Spectre end-to-end:
 6. **[Synchronization](synchronization.md)** — wait helpers and the EDT rule.
 7. **[JUnit integration](junit.md)** — `ComposeAutomatorExtension` (JUnit 5) and
    `ComposeAutomatorRule` (JUnit 4).
-8. **[Recording](recording.md)** — region and window-targeted screen capture.
-9. **[Cross-JVM access](cross-jvm.md)** — driving a UI hosted in another JVM.
-10. **[IntelliJ-hosted Compose](intellij.md)** — Jewel-on-IntelliJ tool windows.
-11. **[Troubleshooting](troubleshooting.md)** — platform-specific gotchas.
+8. **[Running on CI](ci.md)** — JVM flags, `xvfb`, macOS helper JVMs, and recording tags.
+9. **[Recording](recording.md)** — region and window-targeted screen capture.
+10. **[Cross-JVM access](cross-jvm.md)** — driving a UI hosted in another JVM.
+11. **[IntelliJ-hosted Compose](intellij.md)** — Jewel-on-IntelliJ tool windows.
+12. **[Troubleshooting](troubleshooting.md)** — platform-specific gotchas.
 
 If you're new to Spectre, start with [Installation](installation.md) and
 [Getting started](getting-started.md), then read [The automator](automator.md) before

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -201,8 +201,9 @@ val automator = ComposeAutomator.inProcess(
 
 Synthetic input is the right choice when you're running tests in parallel JVMs, when the
 test machine also runs unrelated UI work, or when a macOS test helper runs with
-`apple.awt.UIElement=true` to avoid a Dock icon. Stick to real input for end-to-end smokes
-where the realism of the input matters (e.g., validating that a system shortcut reaches
-the app). `apple.awt.UIElement=true` is **not** a blanket substitute for a foreground app:
-clipboard-backed `pasteText` and OS capture/recording still depend on macOS services
-outside Spectre's synthetic key path.
+`apple.awt.UIElement=true` to avoid a Dock icon. That macOS mode is safe for
+per-character `typeText` with `RobotDriver.synthetic(rootWindow = ...)`, but
+clipboard-backed `pasteText` still requires a foreground-capable app
+(`apple.awt.UIElement=false`). Stick to real input for end-to-end smokes where the realism
+of the input matters (e.g., validating that a system shortcut reaches the app). See
+[Running on CI](ci.md#macos-helper-jvms) for the macOS CI trade-off.

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -140,7 +140,8 @@ Use the returned `ComposeWindow` when constructing
 
 Spectre tests that drive a real Compose window need a non-headless JVM. If your default
 `Test` task sets `java.awt.headless=true`, move Spectre tests to a separate task and
-force that task to run with `java.awt.headless=false`:
+force that task to run with `java.awt.headless=false`. On GPU-less Linux CI, also force
+Skiko software rendering:
 
 ```kotlin
 val spectreTest by tasks.registering(Test::class) {
@@ -148,19 +149,24 @@ val spectreTest by tasks.registering(Test::class) {
     group = "verification"
     useJUnitPlatform()
     systemProperty("java.awt.headless", "false")
+    if (System.getProperty("os.name").lowercase().contains("linux")) {
+        systemProperty("skiko.renderApi", "SOFTWARE_COMPAT")
+    }
 }
 ```
 
 Use `RobotDriver.headless()` only for read-only semantics-tree tests. It throws on
-input, clipboard, and screenshot calls by design.
+input, clipboard, and screenshot calls by design. See [Running on CI](ci.md) for the
+full Linux `xvfb` and test-JVM flag recipe.
 
 On macOS, a dedicated Spectre test task may also set
 `systemProperty("apple.awt.UIElement", "true")` to keep helper JVMs out of the Dock and
 avoid foreground-app fights. Pair that with `RobotDriver.synthetic(rootWindow = window)`
 for typing-driven Compose Desktop tests: Spectre can deliver key events through
 Compose's AWT key listener even when macOS never grants the window an AWT focus owner.
-Do not rely on UI-element mode for clipboard-backed `pasteText` or OS screen recording;
-those still go through macOS services outside the synthetic key-event path.
+Do not rely on UI-element mode for clipboard-backed `pasteText`; that path still goes
+through macOS clipboard services outside the synthetic key-event path. Run recording tests
+as a separate, foreground-capable task while establishing Screen Recording TCC grants.
 
 ## Custom `AutomatorFactory`
 

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -167,7 +167,8 @@ macOS has the most involved setup; the others are short. macOS first:
 - `ffmpeg` on `PATH`.
 - Add `dev.sebastiano.spectre:spectre-recording-macos:<version>` as a runtime-only
   dependency. Its jar carries the notarized universal ScreenCaptureKit helper at
-  `native/macos/spectre-screencapture`.
+  `native/macos/spectre-screencapture`; the base `spectre-recording` artifact does not
+  bundle this helper.
 - **Screen Recording TCC permission**, granted under System Settings → Privacy &
   Security → Screen Recording.
 
@@ -190,9 +191,11 @@ run again". See
 for failure modes when permission is missing or attached to the wrong binary.
 
 `apple.awt.UIElement=true` helper/test JVMs are useful with `RobotDriver.synthetic(...)`
-for focus-safe typing, but recording still goes through macOS capture services and
-spawned helper processes. Prefer a normal foreground-capable parent process for
-recording tests, especially while establishing Screen Recording TCC grants.
+for focus-safe per-character `typeText`, but clipboard-backed `pasteText` and recording
+still go through macOS services outside Spectre's synthetic key path. Prefer a normal
+foreground-capable parent process for recording tests, especially while establishing Screen
+Recording TCC grants. See [Running on CI](ci.md#macos-helper-jvms) for the CI-side
+trade-offs.
 
 ### Other platforms
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -123,8 +123,11 @@ clipboard, so none of the paste-specific caveats apply.
 Spectre input and screenshots need AWT. If the JVM is launched with
 `-Djava.awt.headless=true`, real `RobotDriver()` cannot drive the window, and synthetic
 input still needs a real AWT window hierarchy to dispatch into. Move live Spectre tests
-to a non-headless test task (`systemProperty("java.awt.headless", "false")`). Use
-`RobotDriver.headless()` only for read-only semantics-tree checks.
+to a non-headless test task (`systemProperty("java.awt.headless", "false")`). On Linux CI
+under `xvfb`, also set `systemProperty("skiko.renderApi", "SOFTWARE_COMPAT")` on the
+same `Test` task so Skiko does not try to create a GPU-backed OpenGL context. Use
+`RobotDriver.headless()` only for read-only semantics-tree checks. See
+[Running on CI](ci.md) for a complete workflow example.
 
 ## "The test hangs behind a Swing Error dialog"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -54,6 +54,8 @@ familiar — Spectre brings the same "find a node, do a thing, assert" loop to C
   `findByContentDescription`, `findByRole`, and the `printTree()` debugger.
 - :material-clock-fast: **[Synchronization](guide/synchronization.md)**
   — `waitForIdle`, `waitForVisualIdle`, `waitForNode`, and the EDT rule.
+- :material-monitor-dashboard: **[Running on CI](guide/ci.md)** — `xvfb`, required test-JVM
+  flags, macOS helper mode, and recording test tags.
 - :material-video: **[Recording](guide/recording.md)** — Region and window-targeted capture
   across macOS, Windows, and Linux.
 - :material-server: **[Cross-JVM](guide/cross-jvm.md)** — Drive a UI hosted in another JVM

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
       - Driving input: guide/interactions.md
       - Synchronization: guide/synchronization.md
       - JUnit integration: guide/junit.md
+      - Running on CI: guide/ci.md
       - Recording: guide/recording.md
       - Cross-JVM access: guide/cross-jvm.md
       - IntelliJ-hosted Compose: guide/intellij.md


### PR DESCRIPTION
## Summary
- add a Running on CI guide covering required test JVM flags, xvfb, macOS UIElement mode, and recording tags
- link the new guide from the README and docs navigation
- align existing JUnit, input, recording, and troubleshooting notes with the CI guidance

## Verification
- mkdocs build --strict
- git diff --check