### PR TITLE
Use real framebuffer capture for synthetic screenshots

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/MacOsTccGuard.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/MacOsTccGuard.kt
@@ -123,16 +123,18 @@ internal fun osascriptAccessibilityProbe(): TccStatus {
 
 /**
  * Probes Screen Recording TCC by capturing a small region near the screen origin (which on macOS
- * overlaps the menu bar, virtually never fully black) via the supplied [robot] adapter. If every
- * pixel has zero RGB the capture pipeline is silently returning a black image, which on macOS means
- * the wrapping process lacks Screen Recording TCC.
+ * overlaps the menu bar, virtually never fully black) via the supplied [screenCapture] adapter. If
+ * every pixel has zero RGB the capture pipeline is silently returning a black image, which on macOS
+ * means the wrapping process lacks Screen Recording TCC.
  *
  * False-positive risk: a user whose screen is genuinely all-black across the entire 32×32 origin
  * region. In practice the macOS menu bar always provides UI variation here.
  */
-internal fun robotScreenRecordingProbe(robot: RobotAdapter): TccStatus {
+internal fun robotScreenRecordingProbe(screenCapture: ScreenCaptureAdapter): TccStatus {
     val image =
-        runCatching { robot.createScreenCapture(Rectangle(0, 0, PROBE_SIZE_PX, PROBE_SIZE_PX)) }
+        runCatching {
+                screenCapture.createScreenCapture(Rectangle(0, 0, PROBE_SIZE_PX, PROBE_SIZE_PX))
+            }
             .getOrElse {
                 return TccStatus.Unknown
             }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -24,7 +24,8 @@ public class RobotDriver
 internal constructor(
     private val robot: RobotAdapter = AwtRobotAdapter(),
     private val clipboard: ClipboardAdapter = SystemClipboardAdapter(),
-    private val tccGuard: MacOsTccGuard = defaultTccGuardFor(robot),
+    private val tccGuard: MacOsTccGuard = defaultTccGuardFor(robot, robot),
+    private val screenCapture: ScreenCaptureAdapter = robot,
 ) {
 
     // Public surface: callers may instantiate without arguments (defaults to a fresh
@@ -336,6 +337,13 @@ internal constructor(
      * The returned [BufferedImage] is owned by the caller and safe to read, mutate, or pass to
      * downstream pipelines.
      *
+     * ## Visibility
+     *
+     * Screenshots are region-based OS framebuffer captures. Window and node helpers crop to their
+     * current screen bounds, so the target window should be visible and frontmost before capture.
+     * Occluding windows or off-screen portions affect the returned pixels until Spectre grows
+     * native window-capture backends.
+     *
      * ## Trust boundary
      *
      * `region` is passed through to `java.awt.Robot.createScreenCapture` unchanged. It is **not**
@@ -349,8 +357,8 @@ internal constructor(
      */
     public fun screenshot(region: Rectangle? = null): BufferedImage {
         tccGuard.requireScreenRecording()
-        val captureRegion = region ?: robot.defaultScreenshotRegion()
-        return robot.createScreenCapture(captureRegion)
+        val captureRegion = region ?: screenCapture.defaultScreenshotRegion()
+        return screenCapture.createScreenCapture(captureRegion)
     }
 
     private suspend fun runOffEdt(block: suspend () -> Unit) = runOffEdt(robot, block)
@@ -359,10 +367,20 @@ internal constructor(
 
         /**
          * Returns a [RobotDriver] that delivers synthetic AWT events directly to [rootWindow]'s AWT
-         * hierarchy instead of routing through `java.awt.Robot`'s OS-level input.
+         * hierarchy instead of routing through `java.awt.Robot`'s OS-level input. Screenshots still
+         * use `java.awt.Robot.createScreenCapture` so Compose/Skiko pixels come from the OS
+         * framebuffer rather than Swing repainting the host component.
          */
         public fun synthetic(rootWindow: Window): RobotDriver =
-            RobotDriver(SyntheticRobotAdapter(rootWindow), SystemClipboardAdapter())
+            SyntheticRobotAdapter(rootWindow).let { syntheticInput ->
+                val realCapture = AwtRobotAdapter()
+                RobotDriver(
+                    robot = syntheticInput,
+                    clipboard = SystemClipboardAdapter(),
+                    tccGuard = defaultTccGuardFor(syntheticInput, realCapture),
+                    screenCapture = realCapture,
+                )
+            }
 
         /**
          * Returns a [RobotDriver] that throws [UnsupportedOperationException] on every input,
@@ -381,30 +399,46 @@ internal constructor(
          */
         public fun headless(): RobotDriver =
             RobotDriver(
-                HeadlessThrowingRobotAdapter,
-                HeadlessThrowingClipboardAdapter,
+                robot = HeadlessThrowingRobotAdapter,
+                clipboard = HeadlessThrowingClipboardAdapter,
                 MacOsTccGuard.noop(),
+                screenCapture = HeadlessThrowingScreenCaptureAdapter,
             )
     }
 }
 
 /**
- * Builds the default [MacOsTccGuard] for a given adapter. Returns a real probe-backed guard only
- * when the adapter delegates to a real `java.awt.Robot` AND we're running on macOS — every other
- * combination (synthetic adapter, headless-throwing adapter, non-macOS host) gets the noop guard so
- * the probe never touches an OS that isn't being driven by Robot.
+ * Builds the default [MacOsTccGuard] for the input and capture adapters. On macOS, each probe is
+ * real only when the corresponding adapter reaches through `java.awt.Robot`; synthetic input can
+ * therefore skip Accessibility while still checking Screen Recording for real framebuffer capture.
  */
-internal fun defaultTccGuardFor(adapter: RobotAdapter): MacOsTccGuard =
-    if (adapter.gatesMacOsTcc && detectMacOs()) {
+internal fun defaultTccGuardFor(
+    input: RobotAdapter,
+    screenCapture: ScreenCaptureAdapter,
+): MacOsTccGuard =
+    if (
+        detectMacOs() &&
+            (input.gatesMacOsAccessibilityTcc || screenCapture.gatesMacOsScreenRecordingTcc)
+    ) {
         MacOsTccGuard(
-            accessibilityProbe = ::osascriptAccessibilityProbe,
-            screenRecordingProbe = { robotScreenRecordingProbe(adapter) },
+            accessibilityProbe =
+                if (input.gatesMacOsAccessibilityTcc) {
+                    ::osascriptAccessibilityProbe
+                } else {
+                    { TccStatus.Granted }
+                },
+            screenRecordingProbe =
+                if (screenCapture.gatesMacOsScreenRecordingTcc) {
+                    { robotScreenRecordingProbe(screenCapture) }
+                } else {
+                    { TccStatus.Granted }
+                },
         )
     } else {
         MacOsTccGuard.noop()
     }
 
-internal interface RobotAdapter {
+internal interface RobotAdapter : ScreenCaptureAdapter {
 
     val autoDelayMs: Int
 
@@ -420,13 +454,7 @@ internal interface RobotAdapter {
      */
     val requiresOffEdt: Boolean
 
-    /**
-     * `true` when this adapter delegates input/capture to the real OS `java.awt.Robot`, and
-     * therefore needs to be gated on macOS TCC entitlements (Accessibility for input, Screen
-     * Recording for capture). The synthetic and headless-throwing adapters bypass `Robot` entirely,
-     * so they declare `false` and skip the guard regardless of platform.
-     */
-    val gatesMacOsTcc: Boolean
+    val gatesMacOsAccessibilityTcc: Boolean
         get() = false
 
     fun mouseMove(x: Int, y: Int)
@@ -441,11 +469,10 @@ internal interface RobotAdapter {
 
     fun mouseWheel(wheelClicks: Int)
 
-    fun createScreenCapture(region: Rectangle): BufferedImage
-
-    fun defaultScreenshotRegion(): Rectangle = virtualDesktopBounds()
-
     fun waitForIdle()
+
+    override fun createScreenCapture(region: Rectangle): BufferedImage =
+        throw UnsupportedOperationException("This robot adapter does not support screen capture")
 
     /**
      * `true` when [RobotDriver.pasteText] should pump event queues before restoring the clipboard.
@@ -453,6 +480,16 @@ internal interface RobotAdapter {
      */
     val shouldDrainAfterClipboardPaste: Boolean
         get() = false
+}
+
+internal interface ScreenCaptureAdapter {
+
+    val gatesMacOsScreenRecordingTcc: Boolean
+        get() = false
+
+    fun createScreenCapture(region: Rectangle): BufferedImage
+
+    fun defaultScreenshotRegion(): Rectangle = virtualDesktopBounds()
 }
 
 internal interface ClipboardAdapter {
@@ -471,7 +508,8 @@ internal interface ClipboardAdapter {
     fun setContents(contents: Transferable)
 }
 
-private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : RobotAdapter {
+private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) :
+    RobotAdapter, ScreenCaptureAdapter {
 
     override val autoDelayMs: Int
         get() = robot.autoDelay
@@ -482,7 +520,9 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) : Rob
 
     // The only adapter that actually drives the OS through Robot, so the only one that ever
     // hits macOS TCC. Synthetic and headless-throwing adapters inherit the default `false`.
-    override val gatesMacOsTcc: Boolean = true
+    override val gatesMacOsAccessibilityTcc: Boolean = true
+
+    override val gatesMacOsScreenRecordingTcc: Boolean = true
 
     override fun mouseMove(x: Int, y: Int) = robot.mouseMove(x, y)
 
@@ -525,15 +565,18 @@ private object HeadlessThrowingRobotAdapter : RobotAdapter {
 
     override fun mouseWheel(wheelClicks: Int): Unit = throwHeadless("mouseWheel")
 
-    override fun createScreenCapture(region: Rectangle): BufferedImage =
-        throwHeadless("createScreenCapture")
-
-    override fun defaultScreenshotRegion(): Rectangle = throwHeadless("screenshot")
-
     // waitForIdle is purely a synchronisation barrier — it produces no observable side effect, so
     // making it a no-op keeps internal pump loops (e.g. the post-paste drain in pasteText) callable
     // without triggering throws on a path where they'd be unreachable anyway.
     override fun waitForIdle() = Unit
+}
+
+private object HeadlessThrowingScreenCaptureAdapter : ScreenCaptureAdapter {
+
+    override fun createScreenCapture(region: Rectangle): BufferedImage =
+        throwHeadless("createScreenCapture")
+
+    override fun defaultScreenshotRegion(): Rectangle = throwHeadless("screenshot")
 }
 
 private object HeadlessThrowingClipboardAdapter : ClipboardAdapter {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
@@ -4,13 +4,11 @@ import java.awt.Component
 import java.awt.Container
 import java.awt.KeyboardFocusManager
 import java.awt.Point
-import java.awt.Rectangle
 import java.awt.Window
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.awt.event.MouseEvent
 import java.awt.event.MouseWheelEvent
-import java.awt.image.BufferedImage
 import javax.swing.SwingUtilities
 
 /**
@@ -20,8 +18,7 @@ import javax.swing.SwingUtilities
  * Useful for **Spectre's own validation** and for any test environment where:
  * - the host machine's mouse and keyboard must remain free for the developer
  * - tests run in parallel without contending for OS focus
- * - the recorder doesn't need to capture real screen pixels (synthetic screenshots paint the target
- *   component into a [BufferedImage] via `Component.paint(Graphics)`)
+ * - real mouse/keyboard focus must stay out of the test process
  *
  * The trade-off is that synthetic events bypass the OS HID layer:
  * - Compose's input pipeline (Skiko's AWT listeners) reads them identically to real Robot events,
@@ -42,11 +39,10 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
     // The wait loop in ComposeAutomator handles synchronisation via waitForIdle / fingerprints.
     override val autoDelayMs: Int = 0
 
-    // The synthetic adapter's `dispatchMouse` / `dispatchKey` / `createScreenCapture` already
-    // marshal to the EDT via `runOnEdt` when needed. RobotDriver's worker-thread hop is therefore
-    // both unnecessary and harmful here: an EDT caller would block on `Thread.join()` while the
-    // worker thread blocked on `SwingUtilities.invokeAndWait`, deadlocking the whole pipeline
-    // (Codex P1 on PR #35).
+    // The synthetic adapter's `dispatchMouse` / `dispatchKey` already marshal to the EDT via
+    // `runOnEdt` when needed. RobotDriver's worker-thread hop is therefore both unnecessary and
+    // harmful here: an EDT caller would block on `Thread.join()` while the worker thread blocked on
+    // `SwingUtilities.invokeAndWait`, deadlocking the whole pipeline (Codex P1 on PR #35).
     override val requiresOffEdt: Boolean = false
 
     override val shouldDrainAfterClipboardPaste: Boolean
@@ -197,32 +193,6 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
         dispatchKey(type = KeyEvent.KEY_RELEASED, keyCode = keyCode)
         val modifierBit = modifierMaskFor(keyCode)
         if (modifierBit != 0) heldKeyModifiers = heldKeyModifiers and modifierBit.inv()
-    }
-
-    /**
-     * "Screen capture" without touching the OS — the target component paints itself into a
-     * BufferedImage via Swing's `paint(Graphics)`. ComposePanel renders correctly through this path
-     * because Skiko's AWT integration honours the standard paint contract.
-     */
-    override fun createScreenCapture(region: Rectangle): BufferedImage {
-        val image =
-            BufferedImage(
-                region.width.coerceAtLeast(1),
-                region.height.coerceAtLeast(1),
-                BufferedImage.TYPE_INT_ARGB,
-            )
-        val target = findWindowAt(region.x, region.y) ?: rootWindow
-        runOnEdt {
-            val g = image.createGraphics()
-            try {
-                val origin = target.locationOnScreen
-                g.translate(origin.x - region.x, origin.y - region.y)
-                target.paint(g)
-            } finally {
-                g.dispose()
-            }
-        }
-        return image
     }
 
     override fun waitForIdle() {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -274,23 +274,27 @@ class RobotDriverTest {
     fun `screenshot consults the screen-recording guard before capturing`() {
         val guard = RecordingTccGuard()
         val robot = RecordingRobotAdapter()
-        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
+        val capture = RecordingScreenCaptureAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard, capture)
 
         driver.screenshot(Rectangle(0, 0, 4, 4))
 
         assertEquals(0, guard.accessibilityCalls)
         assertEquals(1, guard.screenRecordingCalls)
+        assertEquals(1, capture.captureCalls)
+        assertEquals(0, robot.captureCalls)
     }
 
     @Test
     fun `screenshot that fails the screen-recording check does not capture`() {
         val guard = RecordingTccGuard(screenRecordingThrows = true)
         val robot = RecordingRobotAdapter()
-        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
+        val capture = RecordingScreenCaptureAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard, capture)
 
         assertFailsWith<IllegalStateException> { driver.screenshot(Rectangle(0, 0, 4, 4)) }
 
-        assertEquals(0, robot.captureCalls)
+        assertEquals(0, capture.captureCalls)
     }
 
     @Test
@@ -435,6 +439,20 @@ private class RecordingRobotAdapter(
 
     override val shouldDrainAfterClipboardPaste: Boolean
         get() = drainAfterPaste
+}
+
+private class RecordingScreenCaptureAdapter : ScreenCaptureAdapter {
+    var captureCalls: Int = 0
+        private set
+
+    override fun createScreenCapture(region: Rectangle): BufferedImage {
+        captureCalls++
+        return BufferedImage(
+            region.width.coerceAtLeast(1),
+            region.height.coerceAtLeast(1),
+            BufferedImage.TYPE_INT_ARGB,
+        )
+    }
 }
 
 private class RecordingClipboardAdapter : ClipboardAdapter {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
@@ -364,7 +364,7 @@ class SyntheticInputParityTest {
 
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
-    fun `synthetic screenshot returns the requested dimensions and samples the rendered colour`() {
+    fun `synthetic screenshot uses framebuffer capture for the requested dimensions`() {
         assumeLiveAwtAvailable()
         val target = ColoredPanel(Color.RED)
         val frame = showFrameOnEdt(target)
@@ -378,8 +378,8 @@ class SyntheticInputParityTest {
             val image = driver.screenshot(captureRegion)
             assertEquals(REGION_SIZE_PX, image.width, "image width must match requested width")
             assertEquals(REGION_SIZE_PX, image.height, "image height must match requested height")
-            // Sample a pixel inside the captured region. Synthetic capture paints the target via
-            // Component.paint(Graphics); we expect the painted red to come through.
+            // Sample a pixel inside the captured region. Synthetic input still uses real
+            // framebuffer capture for screenshots, so the visible red panel should come through.
             val sampledRgb = image.getRGB(REGION_SIZE_PX / 2, REGION_SIZE_PX / 2)
             val sampled = Color(sampledRgb)
             assertEquals(

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -119,6 +119,16 @@ val region = automator.screenshot(Rectangle(0, 0, 800, 600))
 
 Returns a `BufferedImage` you can save, hash, or compare against a baseline.
 
+!!! warning "Screenshots are screen-region captures"
+    Spectre screenshots currently capture OS framebuffer pixels for a rectangle and
+    crop to the requested window, node, or region. Before capturing a window or node,
+    make sure the target window is visible and brought to the front. If another app
+    overlaps the rectangle, those overlapping pixels can appear in the image; if the
+    target is partially off-screen, Spectre can only capture the visible screen area.
+    Native window-capture backends that avoid this screen-and-crop limitation are
+    tracked in
+    [issue #147](https://github.com/rock3r/spectre/issues/147).
+
 !!! note "Captures are normalised to sRGB"
     The returned `BufferedImage` is always sRGB (`TYPE_INT_ARGB` with an sRGB
     `ColorModel`), regardless of the source display's colour profile. Capturing on a
@@ -176,10 +186,11 @@ public surface:
   descendant under the last pointer target or Compose host. That lets Compose Desktop's
   internal focus model route `typeText` into focused `TextField`s even when the host
   window is not the OS-foreground app.
-  `screenshot()` under a synthetic driver also bypasses the OS framebuffer — it renders
-  the target window via `Component.paint(Graphics)` into a `BufferedImage` instead of
-  calling `Robot.createScreenCapture`. Results are consistent for regression tests, but
-  will differ from what the user sees on wide-gamut displays, and skip TCC probing entirely.
+  `screenshot()` under a synthetic driver still uses the OS framebuffer via
+  `Robot.createScreenCapture`, so screenshots show the pixels the display compositor
+  currently exposes rather than a Swing repaint of the Compose host. On macOS this
+  still requires Screen Recording permission, but synthetic input itself does not need
+  Accessibility permission.
 - **`RobotDriver.headless()`** — for read-only flows in headless CI where real OS I/O is
   unavailable. Every input, clipboard, and screenshot call throws
   `UnsupportedOperationException` so an accidental `automator.click(...)` /

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -139,6 +139,15 @@ wrapper when your UI reads Jewel locals such as `LocalComponent`.
 
 ## "Captured screenshot pixels look slightly off"
 
+First check whether the capture saw the target window itself. Spectre screenshots are
+currently screen-region captures: the requested window or node bounds are converted to
+a rectangle on the desktop, then the OS framebuffer is captured for that rectangle.
+Bring the target window to the front before capture. If another window overlaps it,
+or if the target is partly off-screen, the returned image reflects those visible
+screen pixels rather than an isolated window backing store. Native window-capture
+backends are tracked in
+[issue #147](https://github.com/rock3r/spectre/issues/147).
+
 **Rule of thumb: when you're validating colours from a `screenshot()`, always think
 about the node's interaction state first.** If the node is currently focused,
 hovered, or pressed, the captured pixels include whatever indication overlay the

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue14PerfValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/Issue14PerfValidationTest.kt
@@ -113,7 +113,7 @@ class Issue14PerfValidationTest {
             navigateToScenario("scenario.counter")
             val button = waitForTestTag("incrementButton")
 
-            // Cold call — first screenshot pays Skiko init costs on the synthetic paint path.
+            // Cold call — first screenshot may pay Robot / framebuffer capture setup costs.
             val coldSource = TimeSource.Monotonic.markNow()
             screenshot(button)
             val coldMs = coldSource.elapsedNow().inWholeMilliseconds


### PR DESCRIPTION
## Summary

- split screenshot capture from synthetic input dispatch
- make `RobotDriver.synthetic(...)` use real `java.awt.Robot.createScreenCapture` for screenshots
- keep macOS Accessibility probing tied to real input while Screen Recording probing follows real capture
- document that current screenshots are screen-region captures and require visible/frontmost target windows until native window capture backends land

## Verification

- `./gradlew :core:test`
- `./gradlew :sample-desktop:compileValidationKotlin`
- `./gradlew ktfmtCheckMain ktfmtCheckTest`
- `./gradlew check`
- `git diff --check`

Docs build note: `python3 -m mkdocs build --strict` could not run locally because `mkdocs` is not installed in this Python environment.
