### PR TITLE
Add RecompositionMonitor for counting Compose recompositions

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -174,7 +174,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -148,7 +148,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -195,6 +195,12 @@ public final class dev/sebastiano/spectre/core/RobotDriver$Companion {
 	public final fun synthetic (Ljava/awt/Window;)Ldev/sebastiano/spectre/core/RobotDriver;
 }
 
+public final class dev/sebastiano/spectre/core/SurfaceIdAssigner {
+	public static final field HASH_MULTIPLIER I
+	public fun <init> ()V
+	public final fun assign (Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+}
+
 public final class dev/sebastiano/spectre/core/TextMatchType : java/lang/Enum {
 	public static final field Exact Ldev/sebastiano/spectre/core/TextMatchType;
 	public static final field Substring Ldev/sebastiano/spectre/core/TextMatchType;
@@ -239,8 +245,8 @@ public final class dev/sebastiano/spectre/core/TrackedWindow {
 	public final fun component2 ()Ljava/awt/Window;
 	public final fun component3 ()Landroidx/compose/ui/awt/ComposePanel;
 	public final fun component4 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/awt/Window;Landroidx/compose/ui/awt/ComposePanel;ZLkotlin/jvm/functions/Function0;)Ldev/sebastiano/spectre/core/TrackedWindow;
-	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/TrackedWindow;Ljava/lang/String;Ljava/awt/Window;Landroidx/compose/ui/awt/ComposePanel;ZLkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ldev/sebastiano/spectre/core/TrackedWindow;
+	public final fun copy (Ljava/lang/String;Ljava/awt/Window;Landroidx/compose/ui/awt/ComposePanel;Z)Ldev/sebastiano/spectre/core/TrackedWindow;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/TrackedWindow;Ljava/lang/String;Ljava/awt/Window;Landroidx/compose/ui/awt/ComposePanel;ZILjava/lang/Object;)Ldev/sebastiano/spectre/core/TrackedWindow;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getComposeContentOrigin ()Ljava/awt/Point;
 	public final fun getComposePanel ()Landroidx/compose/ui/awt/ComposePanel;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -272,7 +272,6 @@ public abstract interface annotation class dev/sebastiano/spectre/core/perf/Expe
 public final class dev/sebastiano/spectre/core/perf/RecomposerInspector {
 	public static final field INSTANCE Ldev/sebastiano/spectre/core/perf/RecomposerInspector;
 	public final fun findRecomposer (Ldev/sebastiano/spectre/core/TrackedWindow;)Landroidx/compose/runtime/Recomposer;
-	public final fun findRecomposerInHostChain (Ljava/lang/Object;)Landroidx/compose/runtime/Recomposer;
 }
 
 public final class dev/sebastiano/spectre/core/perf/RecompositionMonitor : java/lang/AutoCloseable {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -260,7 +260,7 @@ public final class dev/sebastiano/spectre/core/TrackedWindow {
 
 public final class dev/sebastiano/spectre/core/WindowTracker {
 	public fun <init> ()V
-	public final fun getTrackedWindows ()Ljava/util/List;
+	public final fun getTrackedWindows ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun refresh ()V
 }
 

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -88,6 +88,8 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public final fun getWindows ()Ljava/util/List;
 	public final fun longClick-8Mi8wO0 (Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun longClick-8Mi8wO0$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun monitorRecompositions-LRDsOJo (J)Ldev/sebastiano/spectre/core/perf/RecompositionMonitor;
+	public static synthetic fun monitorRecompositions-LRDsOJo$default (Ldev/sebastiano/spectre/core/ComposeAutomator;JILjava/lang/Object;)Ldev/sebastiano/spectre/core/perf/RecompositionMonitor;
 	public final fun pasteText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun performSemanticsClick (Ldev/sebastiano/spectre/core/AutomatorNode;)V
 	public final fun pressEnter (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -262,5 +264,71 @@ public final class dev/sebastiano/spectre/core/WindowTracker {
 	public fun <init> ()V
 	public final fun getTrackedWindows ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun refresh ()V
+}
+
+public abstract interface annotation class dev/sebastiano/spectre/core/perf/ExperimentalSpectreApi : java/lang/annotation/Annotation {
+}
+
+public final class dev/sebastiano/spectre/core/perf/RecomposerInspector {
+	public static final field INSTANCE Ldev/sebastiano/spectre/core/perf/RecomposerInspector;
+	public final fun findRecomposer (Ldev/sebastiano/spectre/core/TrackedWindow;)Landroidx/compose/runtime/Recomposer;
+	public final fun findRecomposerInHostChain (Ljava/lang/Object;)Landroidx/compose/runtime/Recomposer;
+}
+
+public final class dev/sebastiano/spectre/core/perf/RecompositionMonitor : java/lang/AutoCloseable {
+	public static final field Companion Ldev/sebastiano/spectre/core/perf/RecompositionMonitor$Companion;
+	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLkotlin/time/TimeSource$WithComparableMarks;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun awaitCompositionIdle-2d-g_3Q (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun awaitCompositionIdle-2d-g_3Q$default (Ldev/sebastiano/spectre/core/perf/RecompositionMonitor;JJJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun awaitRateBelow-vLdBGDU (DJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun awaitRateBelow-vLdBGDU$default (Ldev/sebastiano/spectre/core/perf/RecompositionMonitor;DJJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun close ()V
+	public final fun getActiveSurfaces ()I
+	public final fun getRatePerSecond ()D
+	public final fun getTotal ()J
+	public final fun perSurface ()Ljava/util/List;
+	public final fun reset ()V
+	public final fun snapshot ()Ldev/sebastiano/spectre/core/perf/RecompositionSnapshot;
+}
+
+public final class dev/sebastiano/spectre/core/perf/RecompositionMonitor$Companion {
+	public final fun getDEFAULT_AWAIT_TIMEOUT-UwyO8pc ()J
+	public final fun getDEFAULT_POLL_INTERVAL-UwyO8pc ()J
+	public final fun getDEFAULT_QUIET_PERIOD-UwyO8pc ()J
+	public final fun getDEFAULT_WINDOW-UwyO8pc ()J
+}
+
+public final class dev/sebastiano/spectre/core/perf/RecompositionSnapshot {
+	public synthetic fun <init> (JDIJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()D
+	public final fun component3 ()I
+	public final fun component4-UwyO8pc ()J
+	public final fun copy-Wn2Vu4Y (JDIJ)Ldev/sebastiano/spectre/core/perf/RecompositionSnapshot;
+	public static synthetic fun copy-Wn2Vu4Y$default (Ldev/sebastiano/spectre/core/perf/RecompositionSnapshot;JDIJILjava/lang/Object;)Ldev/sebastiano/spectre/core/perf/RecompositionSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActiveSurfaces ()I
+	public final fun getRatePerSecond ()D
+	public final fun getTotal ()J
+	public final fun getWindowDuration-UwyO8pc ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/perf/SurfaceRecompositions {
+	public fun <init> (Ljava/lang/String;JD)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()D
+	public final fun copy (Ljava/lang/String;JD)Ldev/sebastiano/spectre/core/perf/SurfaceRecompositions;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/perf/SurfaceRecompositions;Ljava/lang/String;JDILjava/lang/Object;)Ldev/sebastiano/spectre/core/perf/SurfaceRecompositions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRatePerSecond ()D
+	public final fun getSurfaceId ()Ljava/lang/String;
+	public final fun getTotal ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -43,10 +43,10 @@ private constructor(
      */
     @InternalSpectreApi
     public val windows: List<TrackedWindow>
-        get() = windowTracker.trackedWindows
+        get() = windowTracker.trackedWindows.value
 
     /** Stable surface IDs of every tracked window, in tracking order. */
-    public fun surfaceIds(): List<String> = windowTracker.trackedWindows.map { it.surfaceId }
+    public fun surfaceIds(): List<String> = windowTracker.trackedWindows.value.map { it.surfaceId }
 
     public fun refreshWindows() {
         windowTracker.refresh()

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -5,6 +5,8 @@ package dev.sebastiano.spectre.core
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.getOrNull
+import dev.sebastiano.spectre.core.perf.ExperimentalSpectreApi
+import dev.sebastiano.spectre.core.perf.RecompositionMonitor
 import java.awt.Rectangle
 import java.awt.event.KeyEvent
 import java.awt.image.BufferedImage
@@ -266,6 +268,26 @@ private constructor(
         tracer: Tracer = PerfettoTracer(),
         block: suspend () -> T,
     ): T = withTracingInternal(output, tracer, block)
+
+    /**
+     * Starts a [dev.sebastiano.spectre.core.perf.RecompositionMonitor] that observes recomposition
+     * counts across every Compose surface this automator currently tracks, plus any surfaces that
+     * appear later. The monitor piggybacks on the existing `WindowTracker` flow — call
+     * `refreshWindows()` or any query helper to drive discovery, and the monitor reconciles its
+     * Compose tooling observers automatically.
+     *
+     * The caller owns the returned monitor's lifecycle: [RecompositionMonitor.close] cancels its
+     * internal scope and disposes every CompositionObserver handle. Failing to close it leaks the
+     * subscription against the tracker.
+     */
+    @ExperimentalSpectreApi
+    public fun monitorRecompositions(
+        windowDuration: Duration = RecompositionMonitor.DEFAULT_WINDOW
+    ): RecompositionMonitor {
+        val monitor = RecompositionMonitor(windowDuration)
+        monitor.subscribeTo(windowTracker)
+        return monitor
+    }
 
     public suspend fun waitForIdle(
         timeout: Duration = DEFAULT_WAIT_TIMEOUT,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -272,9 +272,14 @@ private constructor(
     /**
      * Starts a [dev.sebastiano.spectre.core.perf.RecompositionMonitor] that observes recomposition
      * counts across every Compose surface this automator currently tracks, plus any surfaces that
-     * appear later. The monitor piggybacks on the existing `WindowTracker` flow — call
-     * `refreshWindows()` or any query helper to drive discovery, and the monitor reconciles its
-     * Compose tooling observers automatically.
+     * appear later. The monitor piggybacks on the existing `WindowTracker` flow — every
+     * [refreshWindows] call (and `tree()`, which refreshes internally) emits the new surface set,
+     * and the monitor reconciles its CompositionObserver attachments automatically.
+     *
+     * Note: query helpers like [findByTestTag] / [findByText] read the *current* tracked-windows
+     * snapshot without driving a refresh, so they do not by themselves discover newly opened
+     * windows. Call [refreshWindows] (or [tree], or [waitForIdle], all of which refresh) after
+     * opening a new window if you need the monitor to attach to it before continuing.
      *
      * The caller owns the returned monitor's lifecycle: [RecompositionMonitor.close] cancels its
      * internal scope and disposes every CompositionObserver handle. Failing to close it leaks the

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SurfaceIdAssigner.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SurfaceIdAssigner.kt
@@ -1,5 +1,7 @@
 package dev.sebastiano.spectre.core
 
+import java.lang.ref.WeakReference
+
 /**
  * Assigns stable, human-readable surface ids of the form `"$prefix:$index"`.
  *
@@ -11,6 +13,11 @@ package dev.sebastiano.spectre.core
  *
  * Indices grow monotonically per prefix; a surface that goes away does not have its index recycled,
  * so the same numeric suffix never refers to two different surfaces within the assigner's lifetime.
+ *
+ * Identity parts are held via [WeakReference] so a closed window or disposed panel is not retained
+ * by this cache. On every [assign] call we prune entries whose any non-null part has been
+ * garbage-collected — keeps the cache footprint bounded in long-running sessions that churn
+ * through many transient popups.
  */
 @InternalSpectreApi
 public class SurfaceIdAssigner {
@@ -19,7 +26,9 @@ public class SurfaceIdAssigner {
     private val cache = mutableMapOf<CompositeIdentity, String>()
 
     public fun assign(prefix: String, vararg identity: Any?): String {
-        val key = CompositeIdentity(prefix, identity)
+        pruneCollected()
+        val parts = Array<IdentityRef?>(identity.size) { i -> identity[i]?.let(::IdentityRef) }
+        val key = CompositeIdentity(prefix, parts)
         cache[key]?.let {
             return it
         }
@@ -30,14 +39,54 @@ public class SurfaceIdAssigner {
         return id
     }
 
-    private class CompositeIdentity(val prefix: String, private val parts: Array<out Any?>) {
+    private fun pruneCollected() {
+        // O(cache size) per call but cache size is bounded by the number of surfaces ever seen
+        // within an automator lifetime — typically tens, rarely hundreds. Avoiding the prune
+        // would mean either a separately scheduled cleanup task (more moving parts) or letting
+        // the cache grow unbounded across long sessions.
+        cache.keys.removeAll { it.anyCollected() }
+    }
+
+    /**
+     * Reference-equality wrapper around an identity part. Holds the referent weakly so this cache
+     * never keeps a window/panel alive past its real lifetime, while a stable [identityHashCode]
+     * captured at construction keeps hashes consistent across cache lookups even before the
+     * referent is collected.
+     */
+    private class IdentityRef(referent: Any) {
+        private val ref = WeakReference(referent)
+        private val identityHashCode = System.identityHashCode(referent)
+
+        fun referent(): Any? = ref.get()
+
+        fun isCollected(): Boolean = ref.get() == null
+
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is IdentityRef) return false
+            val thisReferent = ref.get() ?: return false
+            val otherReferent = other.ref.get() ?: return false
+            return thisReferent === otherReferent
+        }
+
+        override fun hashCode(): Int = identityHashCode
+    }
+
+    private class CompositeIdentity(val prefix: String, private val parts: Array<out IdentityRef?>) {
+
+        fun anyCollected(): Boolean = parts.any { it != null && it.isCollected() }
+
         override fun equals(other: Any?): Boolean {
             if (this === other) return true
             if (other !is CompositeIdentity) return false
             if (prefix != other.prefix) return false
             if (parts.size != other.parts.size) return false
             for (i in parts.indices) {
-                if (parts[i] !== other.parts[i]) return false
+                val left = parts[i]
+                val right = other.parts[i]
+                if (left == null && right == null) continue
+                if (left == null || right == null) return false
+                if (left != right) return false
             }
             return true
         }
@@ -45,9 +94,7 @@ public class SurfaceIdAssigner {
         override fun hashCode(): Int {
             var hash = prefix.hashCode()
             for (part in parts) {
-                hash =
-                    HASH_MULTIPLIER * hash +
-                        (if (part == null) 0 else System.identityHashCode(part))
+                hash = HASH_MULTIPLIER * hash + (part?.hashCode() ?: 0)
             }
             return hash
         }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SurfaceIdAssigner.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SurfaceIdAssigner.kt
@@ -1,0 +1,59 @@
+package dev.sebastiano.spectre.core
+
+/**
+ * Assigns stable, human-readable surface ids of the form `"$prefix:$index"`.
+ *
+ * Identity is compared **by reference** across all [identity] parts so that two objects which
+ * happen to be `equals` (e.g. two `String` instances with the same content) still get distinct ids
+ * — what matters for a surface is the underlying object handle, not its value. Composite identities
+ * (e.g. `(window, composePanel)`) are supported via the vararg: every part must be the same
+ * reference for a cache hit.
+ *
+ * Indices grow monotonically per prefix; a surface that goes away does not have its index recycled,
+ * so the same numeric suffix never refers to two different surfaces within the assigner's lifetime.
+ */
+@InternalSpectreApi
+public class SurfaceIdAssigner {
+
+    private val nextIndex = mutableMapOf<String, Int>()
+    private val cache = mutableMapOf<CompositeIdentity, String>()
+
+    public fun assign(prefix: String, vararg identity: Any?): String {
+        val key = CompositeIdentity(prefix, identity)
+        cache[key]?.let {
+            return it
+        }
+        val index = nextIndex.getOrDefault(prefix, 0)
+        nextIndex[prefix] = index + 1
+        val id = "$prefix:$index"
+        cache[key] = id
+        return id
+    }
+
+    private class CompositeIdentity(val prefix: String, private val parts: Array<out Any?>) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is CompositeIdentity) return false
+            if (prefix != other.prefix) return false
+            if (parts.size != other.parts.size) return false
+            for (i in parts.indices) {
+                if (parts[i] !== other.parts[i]) return false
+            }
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var hash = prefix.hashCode()
+            for (part in parts) {
+                hash =
+                    HASH_MULTIPLIER * hash +
+                        (if (part == null) 0 else System.identityHashCode(part))
+            }
+            return hash
+        }
+    }
+
+    private companion object {
+        const val HASH_MULTIPLIER = 31
+    }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SurfaceIdAssigner.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SurfaceIdAssigner.kt
@@ -16,8 +16,8 @@ import java.lang.ref.WeakReference
  *
  * Identity parts are held via [WeakReference] so a closed window or disposed panel is not retained
  * by this cache. On every [assign] call we prune entries whose any non-null part has been
- * garbage-collected — keeps the cache footprint bounded in long-running sessions that churn
- * through many transient popups.
+ * garbage-collected — keeps the cache footprint bounded in long-running sessions that churn through
+ * many transient popups.
  */
 @InternalSpectreApi
 public class SurfaceIdAssigner {
@@ -57,8 +57,6 @@ public class SurfaceIdAssigner {
         private val ref = WeakReference(referent)
         private val identityHashCode = System.identityHashCode(referent)
 
-        fun referent(): Any? = ref.get()
-
         fun isCollected(): Boolean = ref.get() == null
 
         override fun equals(other: Any?): Boolean {
@@ -72,7 +70,10 @@ public class SurfaceIdAssigner {
         override fun hashCode(): Int = identityHashCode
     }
 
-    private class CompositeIdentity(val prefix: String, private val parts: Array<out IdentityRef?>) {
+    private class CompositeIdentity(
+        val prefix: String,
+        private val parts: Array<out IdentityRef?>,
+    ) {
 
         fun anyCollected(): Boolean = parts.any { it != null && it.isCollected() }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
@@ -9,35 +9,28 @@ import java.awt.Window
 import javax.swing.JFrame
 
 @InternalSpectreApi
-public data class TrackedWindow
-@OptIn(ExperimentalComposeUiApi::class)
-internal constructor(
+public data class TrackedWindow(
     val surfaceId: String,
     val window: Window,
     val composePanel: ComposePanel?,
     val isPopup: Boolean,
-    /**
-     * Reflective override that lets `WindowTracker` plug in a non-`ComposePanel` semantics source
-     * for Compose Desktop's `OnWindow` popup layers (`compose.layers.type=WINDOW`). Compose hosts
-     * those popups inside an internal `WindowComposeSceneLayer` whose mediator isn't reachable
-     * through any public API; `OverlayLayerInspector` resolves them by reflection and
-     * `SemanticsReader` dispatches to this accessor. `null` for every other tracked window — the
-     * existing `composePanel` / `ComposeWindow` paths handle those.
-     */
-    internal val overlaySemanticsOwners: (() -> Collection<SemanticsOwner>)? = null,
 ) {
 
     /**
-     * Stable public constructor preserved for source compatibility with anything that builds a
-     * `TrackedWindow` directly (notably `core`'s own unit tests).
+     * Reflective overlay accessor used for Compose Desktop's `OnWindow` popup layers
+     * (`compose.layers.type=WINDOW`). Compose hosts those popups inside an internal
+     * `WindowComposeSceneLayer` whose mediator isn't reachable through any public API;
+     * `OverlayLayerInspector` resolves them by reflection and `SemanticsReader` dispatches to this
+     * accessor when present. `null` for every other tracked window — the existing `composePanel` /
+     * `ComposeWindow` paths handle those.
+     *
+     * Held outside the primary constructor so [equals]/[hashCode] (generated from primary-ctor
+     * parameters only) ignore the lambda; otherwise lambda reference equality would make every
+     * rediscovery look like a fresh window and break `StateFlow.distinctUntilChanged` semantics on
+     * `WindowTracker.trackedWindows`.
      */
     @OptIn(ExperimentalComposeUiApi::class)
-    public constructor(
-        surfaceId: String,
-        window: Window,
-        composePanel: ComposePanel?,
-        isPopup: Boolean,
-    ) : this(surfaceId, window, composePanel, isPopup, overlaySemanticsOwners = null)
+    internal var overlaySemanticsOwners: (() -> Collection<SemanticsOwner>)? = null
 
     /**
      * The screen location of the Compose content origin.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -17,6 +17,8 @@ internal constructor(
 
     public constructor() : this(Window::getWindows, requiresEdt = true)
 
+    private val surfaceIdAssigner = SurfaceIdAssigner()
+
     @Volatile private var _trackedWindows: List<TrackedWindow> = emptyList()
 
     public val trackedWindows: List<TrackedWindow>
@@ -118,9 +120,11 @@ internal constructor(
         prefix: String,
         isPopup: Boolean,
     ) {
+        // Identity for a "normal" surface is (Window, ComposePanel?). Two refreshes that find the
+        // same JFrame and the same embedded ComposePanel resolve to the same surfaceId.
         pending +=
             TrackedWindow(
-                surfaceId = "$prefix:${pending.size}",
+                surfaceId = surfaceIdAssigner.assign(prefix, window, panel),
                 window = window,
                 composePanel = panel,
                 isPopup = isPopup,
@@ -132,14 +136,18 @@ internal constructor(
         pending: MutableList<TrackedWindow>,
         layer: OverlayLayerEntry,
     ) {
-        pending +=
+        // Overlay-layer identity is the internal JDialog (`layer.window`) — that's the stable
+        // handle that survives across rediscovery passes, even though the lambda that reads its
+        // semantics is freshly built each call.
+        val tracked =
             TrackedWindow(
-                surfaceId = "overlay:${pending.size}",
+                surfaceId = surfaceIdAssigner.assign("overlay", layer.window),
                 window = layer.window,
                 composePanel = null,
                 isPopup = true,
-                overlaySemanticsOwners = layer.semanticsOwnersAccessor,
             )
+        tracked.overlaySemanticsOwners = layer.semanticsOwnersAccessor
+        pending += tracked
     }
 
     internal companion object {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -7,6 +7,9 @@ import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.awt.ComposeWindow
 import java.awt.Container
 import java.awt.Window
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 @InternalSpectreApi
 public class WindowTracker
@@ -19,10 +22,15 @@ internal constructor(
 
     private val surfaceIdAssigner = SurfaceIdAssigner()
 
-    @Volatile private var _trackedWindows: List<TrackedWindow> = emptyList()
+    private val _trackedWindows = MutableStateFlow<List<TrackedWindow>>(emptyList())
 
-    public val trackedWindows: List<TrackedWindow>
-        get() = _trackedWindows
+    /**
+     * Live view of the currently tracked surfaces. Backed by a [StateFlow] so that subscribers
+     * (e.g. `RecompositionMonitor`) can reconcile against window-set changes without polling.
+     * Synchronous callers read [StateFlow.value]; the flow follows the standard
+     * distinctUntilChanged contract, so two refreshes that produce equal lists emit only once.
+     */
+    public val trackedWindows: StateFlow<List<TrackedWindow>> = _trackedWindows.asStateFlow()
 
     public fun refresh() {
         if (requiresEdt) {
@@ -49,7 +57,7 @@ internal constructor(
                 else -> trackOwnedPopups(pending, window)
             }
         }
-        _trackedWindows = pending.toList()
+        _trackedWindows.value = pending.toList()
     }
 
     @OptIn(ExperimentalComposeUiApi::class)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/ExperimentalSpectreApi.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/ExperimentalSpectreApi.kt
@@ -1,0 +1,31 @@
+package dev.sebastiano.spectre.core.perf
+
+/**
+ * Marks a user-facing Spectre API as experimental: it is intentionally exposed for users to try,
+ * but its shape may change without a deprecation cycle between Spectre releases. Distinct from
+ * `@InternalSpectreApi`, which marks declarations that are only intended for in-repo escape
+ * hatches.
+ *
+ * Using an experimental declaration requires explicit opt-in:
+ * ```
+ * @OptIn(ExperimentalSpectreApi::class)
+ * fun myTest() { … }
+ * ```
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.BINARY)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message =
+        "This Spectre API is experimental and may change between releases. " +
+            "Opt in with @OptIn(ExperimentalSpectreApi::class) to use it.",
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.TYPEALIAS,
+)
+public annotation class ExperimentalSpectreApi

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspector.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspector.kt
@@ -1,0 +1,124 @@
+package dev.sebastiano.spectre.core.perf
+
+import androidx.compose.runtime.Recomposer
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.awt.ComposeWindow
+import dev.sebastiano.spectre.core.InternalSpectreApi
+import dev.sebastiano.spectre.core.TrackedWindow
+import java.awt.Window
+
+/**
+ * Resolves the [Recomposer] that drives a Compose Desktop surface.
+ *
+ * The traversal mirrors `OverlayLayerInspector`: walk the private CMP host chain by field name, so
+ * a renamed internal field degrades gracefully (returns `null`) instead of crashing the rest of the
+ * automator. The chain is:
+ * ```
+ * ComposeWindow.composePanel  (ComposeWindowPanel)
+ *   ._composeContainer         (ComposeContainer)
+ *   .mediator                  (ComposeSceneMediator)
+ *   .scene                     (ComposeScene / BaseComposeScene — backing field of `by lazy`,
+ *                                 fall back to the synthetic `getScene` accessor)
+ *   .recomposer                (ComposeSceneRecomposer)
+ *   .recomposer                (Recomposer)
+ * ```
+ *
+ * `ComposePanel` enters the same chain at `_composeContainer`, so the inspector accepts either a
+ * `ComposeWindow` or a `ComposePanel` as the starting host. Overlay-popup recomposers are not
+ * resolved by this MVP; they live behind a separate chain inside `WindowComposeSceneLayer` and will
+ * be wired in a follow-up.
+ */
+@InternalSpectreApi
+public object RecomposerInspector {
+
+    private const val COMPOSE_PANEL_FIELD = "composePanel"
+    private const val COMPOSE_CONTAINER_FIELD = "_composeContainer"
+    private const val MEDIATOR_FIELD = "mediator"
+    private const val SCENE_FIELD = "scene"
+    private const val SCENE_GETTER = "getScene"
+    private const val SCENE_RECOMPOSER_FIELD = "recomposer"
+    private const val SCENE_RECOMPOSER_INNER_FIELD = "recomposer"
+
+    /**
+     * Returns the [Recomposer] for [trackedWindow]'s main surface, or `null` for surfaces this MVP
+     * does not yet resolve (overlay popups) or hosts that don't match the expected internal shape.
+     */
+    @OptIn(ExperimentalComposeUiApi::class)
+    public fun findRecomposer(trackedWindow: TrackedWindow): Recomposer? {
+        // Overlay popups currently report through `overlaySemanticsOwners`; their recomposers live
+        // on the layer's own mediator, which we don't yet traverse. Returning null is the explicit
+        // "not yet supported" signal — RecompositionMonitor skips those surfaces.
+        if (trackedWindow.overlaySemanticsOwners != null) return null
+
+        // Prefer the embedded ComposePanel when present (covers both ComposeWindow's internal panel
+        // and stand-alone embedded panels). Fall back to the window itself for ComposeWindow.
+        val composePanel: ComposePanel? = trackedWindow.composePanel
+        if (composePanel != null) {
+            return findRecomposerInHostChainBelowComposeContainer(composePanel)
+        }
+        val window: Window = trackedWindow.window
+        if (window is ComposeWindow) {
+            return findRecomposerInHostChain(window)
+        }
+        return null
+    }
+
+    /**
+     * Walks the full chain starting from a host that owns a `composePanel` field (i.e. a
+     * `ComposeWindow`). Public for unit-testing against a fake hierarchy that mirrors the field
+     * names used by Compose Multiplatform Desktop.
+     */
+    public fun findRecomposerInHostChain(host: Any?): Recomposer? {
+        if (host == null) return null
+        val composePanel = readField(host, COMPOSE_PANEL_FIELD) ?: return null
+        return findRecomposerInHostChainBelowComposeContainer(composePanel)
+    }
+
+    private fun findRecomposerInHostChainBelowComposeContainer(panelHost: Any): Recomposer? {
+        val composeContainer = readField(panelHost, COMPOSE_CONTAINER_FIELD) ?: return null
+        val mediator = readField(composeContainer, MEDIATOR_FIELD) ?: return null
+        // `scene` is a `by lazy` property: the backing field is named `scene$delegate` (a Lazy
+        // wrapper), so a direct `getDeclaredField("scene")` returns null on real CMP. The
+        // synthetic getter `getScene()` triggers initialisation and returns the live scene; in
+        // fake hierarchies that use a plain `val`, the field read succeeds first and we never
+        // hit the getter path.
+        val scene = readField(mediator, SCENE_FIELD) ?: invokeGetter(mediator, SCENE_GETTER)
+        if (scene == null) return null
+        val sceneRecomposer = readField(scene, SCENE_RECOMPOSER_FIELD) ?: return null
+        val recomposer = readField(sceneRecomposer, SCENE_RECOMPOSER_INNER_FIELD) ?: return null
+        return recomposer as? Recomposer
+    }
+
+    private fun invokeGetter(target: Any, methodName: String): Any? {
+        var cls: Class<*>? = target.javaClass
+        while (cls != null) {
+            try {
+                val method = cls.getDeclaredMethod(methodName)
+                method.isAccessible = true
+                return method.invoke(target)
+            } catch (_: NoSuchMethodException) {
+                cls = cls.superclass
+            } catch (_: ReflectiveOperationException) {
+                return null
+            }
+        }
+        return null
+    }
+
+    private fun readField(target: Any, fieldName: String): Any? {
+        var cls: Class<*>? = target.javaClass
+        while (cls != null) {
+            try {
+                val field = cls.getDeclaredField(fieldName)
+                field.isAccessible = true
+                return field.get(target)
+            } catch (_: NoSuchFieldException) {
+                cls = cls.superclass
+            } catch (_: ReflectiveOperationException) {
+                return null
+            }
+        }
+        return null
+    }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspector.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspector.kt
@@ -66,10 +66,11 @@ public object RecomposerInspector {
 
     /**
      * Walks the full chain starting from a host that owns a `composePanel` field (i.e. a
-     * `ComposeWindow`). Public for unit-testing against a fake hierarchy that mirrors the field
-     * names used by Compose Multiplatform Desktop.
+     * `ComposeWindow`). Internal so unit tests in the same module can drive it against a fake
+     * hierarchy without widening the JVM-public surface — production callers go through
+     * [findRecomposer], which encodes which host to start the walk from.
      */
-    public fun findRecomposerInHostChain(host: Any?): Recomposer? {
+    internal fun findRecomposerInHostChain(host: Any?): Recomposer? {
         if (host == null) return null
         val composePanel = readField(host, COMPOSE_PANEL_FIELD) ?: return null
         return findRecomposerInHostChainBelowComposeContainer(composePanel)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitor.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitor.kt
@@ -1,0 +1,372 @@
+@file:OptIn(ExperimentalComposeRuntimeApi::class, InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core.perf
+
+import androidx.compose.runtime.ExperimentalComposeRuntimeApi
+import androidx.compose.runtime.RecomposeScope
+import androidx.compose.runtime.Recomposer
+import androidx.compose.runtime.tooling.CompositionObserver
+import androidx.compose.runtime.tooling.CompositionObserverHandle
+import androidx.compose.runtime.tooling.CompositionRegistrationObserver
+import androidx.compose.runtime.tooling.ObservableComposition
+import androidx.compose.runtime.tooling.observe
+import dev.sebastiano.spectre.core.InternalSpectreApi
+import dev.sebastiano.spectre.core.TrackedWindow
+import dev.sebastiano.spectre.core.WindowTracker
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.ComparableTimeMark
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.DurationUnit
+import kotlin.time.TimeSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Counts Compose recompositions across a set of attached [Recomposer]s. Exposes a monotonic
+ * lifetime [total] and a sliding-window [ratePerSecond] for cheap "is the UI thrashing?" checks
+ * during automation. Per-surface counters live under stable surface ids assigned by
+ * `WindowTracker`.
+ *
+ * The monitor owns a [SupervisorJob]-backed [CoroutineScope]; [close] cancels the scope, disposes
+ * every [CompositionObserverHandle], and is idempotent. Multiple [Recomposer]s can be attached
+ * concurrently — the monitor sums their per-pass events.
+ *
+ * Counting alone is cheap: the installed [CompositionObserver] only implements
+ * [CompositionObserver.onBeginComposition] (one atomic increment per recomposition pass) and leaves
+ * the per-scope hooks as no-ops, so the per-recomposition overhead is essentially a single counter
+ * bump plus a ring-buffer append.
+ */
+@ExperimentalSpectreApi
+public class RecompositionMonitor
+internal constructor(
+    private val windowDuration: Duration = DEFAULT_WINDOW,
+    private val timeSource: TimeSource.WithComparableMarks = TimeSource.Monotonic,
+) : AutoCloseable {
+
+    /** Default user-facing constructor with the wall-clock time source. */
+    public constructor(
+        windowDuration: Duration = DEFAULT_WINDOW
+    ) : this(windowDuration, TimeSource.Monotonic)
+
+    private val ownedJob = SupervisorJob()
+
+    /** Test-visible accessor for the owned scope so unit tests can assert cancellation. */
+    internal val scopeForTests: CoroutineScope = CoroutineScope(ownedJob + Dispatchers.Default)
+
+    private val surfaces = ConcurrentHashMap<String, SurfaceTracker>()
+
+    /**
+     * Per-Recomposer registration: each entry holds the top-level registration handle plus the
+     * per-composition observer handles we installed via [ObservableComposition.setObserver]. We
+     * dispose them in reverse on detach/close so Compose can release its observer state cleanly.
+     * The [Recomposer] reference is retained so [awaitCompositionIdle] can query
+     * [Recomposer.hasPendingWork] without re-resolving it via reflection on every poll.
+     */
+    private val attachments = ConcurrentHashMap<String, Attachment>()
+
+    @Volatile private var closed: Boolean = false
+
+    /** Lifetime recomposition count across every attached surface. */
+    public val total: Long
+        get() = surfaces.values.sumOf { it.total }
+
+    /** Sum of per-surface sliding-window rates, in recompositions per second. */
+    public val ratePerSecond: Double
+        get() = surfaces.values.sumOf { it.ratePerSecond() }
+
+    /** Number of distinct surfaces this monitor has observed at least once. */
+    public val activeSurfaces: Int
+        get() = surfaces.size
+
+    public fun snapshot(): RecompositionSnapshot =
+        RecompositionSnapshot(
+            total = total,
+            ratePerSecond = ratePerSecond,
+            activeSurfaces = activeSurfaces,
+            windowDuration = windowDuration,
+        )
+
+    /** Per-surface breakdown. Order is not specified; sort by `surfaceId` if you need stability. */
+    public fun perSurface(): List<SurfaceRecompositions> =
+        surfaces.entries.map { (id, tracker) ->
+            SurfaceRecompositions(
+                surfaceId = id,
+                total = tracker.total,
+                ratePerSecond = tracker.ratePerSecond(),
+            )
+        }
+
+    /** Zeros counters and clears rate windows; surface registrations remain. */
+    public fun reset() {
+        surfaces.values.forEach { it.reset() }
+    }
+
+    /**
+     * Installs the per-pass observer on every [androidx.compose.runtime.Composition] registered
+     * with [recomposer], recording each `onBeginComposition` under [surfaceId]. Subsequent
+     * compositions joining the same Recomposer attach automatically; departing compositions stop
+     * counting.
+     *
+     * Calling [attach] twice with the same [surfaceId] disposes the previous registration before
+     * installing the new one — useful when reconciling against a [WindowTracker] flow where the
+     * same surfaceId may flip recomposer instances across host restarts.
+     */
+    internal fun attach(surfaceId: String, recomposer: Recomposer) {
+        check(!closed) { "RecompositionMonitor is closed" }
+        detach(surfaceId)
+        val tracker =
+            surfaces.computeIfAbsent(surfaceId) { SurfaceTracker(windowDuration, timeSource) }
+        val perCompositionHandles = ConcurrentHashMap.newKeySet<CompositionObserverHandle>()
+        val compositionObserver = SurfaceCompositionObserver(tracker)
+        val registrationHandle =
+            recomposer.observe(
+                object : CompositionRegistrationObserver {
+                    override fun onCompositionRegistered(composition: ObservableComposition) {
+                        val handle = composition.setObserver(compositionObserver)
+                        perCompositionHandles += handle
+                    }
+
+                    override fun onCompositionUnregistered(composition: ObservableComposition) {
+                        // Composition-side handles are disposed implicitly by Compose when the
+                        // composition is unregistered; no explicit dispose call needed here.
+                    }
+                }
+            )
+        attachments[surfaceId] = Attachment(recomposer, registrationHandle, perCompositionHandles)
+    }
+
+    /**
+     * Subscribes the monitor to [windowTracker]'s flow of tracked surfaces and reconciles
+     * attachments on every change: surfaces that appear are resolved to a [Recomposer] via
+     * [RecomposerInspector] and attached; surfaces that disappear are detached. Surfaces whose
+     * recomposer cannot be resolved (overlay popups in this MVP) are skipped silently —
+     * `RecomposerInspector.findRecomposer` returns `null` and the monitor leaves them off the
+     * per-surface map.
+     */
+    internal fun subscribeTo(windowTracker: WindowTracker) {
+        windowTracker.trackedWindows
+            .map { it.toSet() }
+            .scan<Set<TrackedWindow>, Pair<Set<TrackedWindow>, Set<TrackedWindow>>>(
+                emptySet<TrackedWindow>() to emptySet()
+            ) { (_, prev), curr ->
+                prev to curr
+            }
+            .drop(1)
+            .onEach { (prev, curr) ->
+                val departed = prev - curr
+                val arrived = curr - prev
+                departed.forEach { detach(it.surfaceId) }
+                arrived.forEach { tracked ->
+                    val recomposer = RecomposerInspector.findRecomposer(tracked)
+                    if (recomposer != null) attach(tracked.surfaceId, recomposer)
+                }
+            }
+            .launchIn(scopeForTests)
+    }
+
+    /**
+     * Suspends until every attached [Recomposer] reports no pending work AND no per-pass counter
+     * has ticked for [quietPeriod]. Returns `true` on success; `false` if [timeout] elapses first —
+     * recomposition idleness is the cheapest of Spectre's three idleness signals (it bypasses the
+     * semantics fingerprint and screenshot paths), so prefer it when you only need to assert
+     * Compose has stopped thinking.
+     *
+     * Note: composition-idle ≠ visual-idle. A `graphicsLayer { translationX = animatedValue }`
+     * animation can change pixels every frame without triggering recomposition; conversely, a
+     * recomposition that produces identical pixels still counts as not-idle. See [awaitRateBelow]
+     * for a threshold-based variant.
+     */
+    public suspend fun awaitCompositionIdle(
+        quietPeriod: Duration = DEFAULT_QUIET_PERIOD,
+        timeout: Duration = DEFAULT_AWAIT_TIMEOUT,
+        pollInterval: Duration = DEFAULT_POLL_INTERVAL,
+    ): Boolean {
+        val result =
+            withTimeoutOrNull(timeout) {
+                var lastTotal = total
+                var lastChange = timeSource.markNow()
+                while (true) {
+                    val now = timeSource.markNow()
+                    val currentTotal = total
+                    if (currentTotal != lastTotal) {
+                        lastTotal = currentTotal
+                        lastChange = now
+                    }
+                    val anyPending = attachments.values.any { it.recomposer.hasPendingWork }
+                    if (!anyPending && now - lastChange >= quietPeriod) {
+                        return@withTimeoutOrNull true
+                    }
+                    delay(pollInterval)
+                }
+                @Suppress("UNREACHABLE_CODE") true
+            }
+        return result ?: false
+    }
+
+    /**
+     * Suspends until [ratePerSecond] is strictly below [threshold] across all attached surfaces, or
+     * [timeout] elapses. Useful for assertions like "after this interaction, no surface should be
+     * recomposing more than N times per second."
+     */
+    public suspend fun awaitRateBelow(
+        threshold: Double,
+        timeout: Duration = DEFAULT_AWAIT_TIMEOUT,
+        pollInterval: Duration = DEFAULT_POLL_INTERVAL,
+    ): Boolean {
+        val result =
+            withTimeoutOrNull(timeout) {
+                while (ratePerSecond >= threshold) {
+                    delay(pollInterval)
+                }
+                true
+            }
+        return result ?: false
+    }
+
+    /**
+     * Disposes the per-Recomposer registration for [surfaceId]. The accumulated counters remain
+     * accessible via [perSurface] and [total] — detaching is about stopping new events, not
+     * forgetting old ones. Use [reset] to zero counters explicitly.
+     */
+    internal fun detach(surfaceId: String) {
+        attachments.remove(surfaceId)?.dispose()
+    }
+
+    /**
+     * Test seam: records a recomposition for [surfaceId] as if `onBeginComposition` fired on the
+     * attached observer. Production code uses the real [CompositionObserver] installed by [attach];
+     * unit tests use this hook to drive deterministic counter / rate scenarios without standing up
+     * a live Recomposer.
+     */
+    internal fun recordRecomposition(surfaceId: String) {
+        val tracker =
+            surfaces.computeIfAbsent(surfaceId) { SurfaceTracker(windowDuration, timeSource) }
+        tracker.record()
+    }
+
+    override fun close() {
+        if (closed) return
+        closed = true
+        attachments.keys.toList().forEach { detach(it) }
+        scopeForTests.cancel()
+    }
+
+    private class Attachment(
+        val recomposer: Recomposer,
+        private val registrationHandle: CompositionObserverHandle,
+        private val perCompositionHandles: MutableSet<CompositionObserverHandle>,
+    ) {
+        fun dispose() {
+            // Dispose the Recomposer-level registration first so no new compositions arrive while
+            // we tear down per-composition handles.
+            registrationHandle.dispose()
+            perCompositionHandles.forEach { it.dispose() }
+            perCompositionHandles.clear()
+        }
+    }
+
+    private class SurfaceCompositionObserver(private val tracker: SurfaceTracker) :
+        CompositionObserver {
+
+        override fun onBeginComposition(composition: ObservableComposition) {
+            tracker.record()
+        }
+
+        // Per-scope hooks are deliberately no-ops: counting recomposition passes only requires
+        // begin, and the per-scope callbacks are the expensive ones we explicitly opt out of.
+        // (We also skip `onEndComposition` because the begin event already increments the counter;
+        // measuring "in-progress" composition duration is out of scope for this MVP.)
+        override fun onScopeEnter(scope: RecomposeScope): Unit = Unit
+
+        override fun onReadInScope(scope: RecomposeScope, value: Any): Unit = Unit
+
+        override fun onScopeExit(scope: RecomposeScope): Unit = Unit
+
+        override fun onEndComposition(composition: ObservableComposition): Unit = Unit
+
+        override fun onScopeInvalidated(scope: RecomposeScope, value: Any?): Unit = Unit
+
+        override fun onScopeDisposed(scope: RecomposeScope): Unit = Unit
+    }
+
+    public companion object {
+        public val DEFAULT_WINDOW: Duration = 1.seconds
+        public val DEFAULT_AWAIT_TIMEOUT: Duration = 5.seconds
+        public val DEFAULT_QUIET_PERIOD: Duration = 50.milliseconds
+        public val DEFAULT_POLL_INTERVAL: Duration = 16.milliseconds
+    }
+}
+
+/** Immutable point-in-time snapshot returned by [RecompositionMonitor.snapshot]. */
+@ExperimentalSpectreApi
+public data class RecompositionSnapshot(
+    val total: Long,
+    val ratePerSecond: Double,
+    val activeSurfaces: Int,
+    val windowDuration: Duration,
+)
+
+/** Per-surface row returned by [RecompositionMonitor.perSurface]. */
+@ExperimentalSpectreApi
+public data class SurfaceRecompositions(
+    val surfaceId: String,
+    val total: Long,
+    val ratePerSecond: Double,
+)
+
+/**
+ * Per-surface counter + sliding-window ring buffer. Thread-safe: every method synchronises on the
+ * tracker so concurrent recompositions across Compose's internal dispatchers can't tear state.
+ */
+private class SurfaceTracker(
+    private val windowDuration: Duration,
+    private val timeSource: TimeSource.WithComparableMarks,
+) {
+    private val lock = Any()
+    @Volatile private var totalCount: Long = 0L
+    private val recentMarks = ArrayDeque<ComparableTimeMark>()
+
+    val total: Long
+        get() = totalCount
+
+    fun record() {
+        synchronized(lock) {
+            totalCount++
+            val now = timeSource.markNow()
+            recentMarks.addLast(now)
+            pruneOld(now)
+        }
+    }
+
+    fun ratePerSecond(): Double =
+        synchronized(lock) {
+            val now = timeSource.markNow()
+            pruneOld(now)
+            val seconds = windowDuration.toDouble(DurationUnit.SECONDS)
+            if (seconds <= 0.0) 0.0 else recentMarks.size / seconds
+        }
+
+    fun reset() {
+        synchronized(lock) {
+            totalCount = 0L
+            recentMarks.clear()
+        }
+    }
+
+    private fun pruneOld(now: ComparableTimeMark) {
+        while (recentMarks.isNotEmpty() && now - recentMarks.first() > windowDuration) {
+            recentMarks.removeFirst()
+        }
+    }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitor.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitor.kt
@@ -246,11 +246,11 @@ internal constructor(
     }
 
     /**
-     * Disposes the per-Recomposer registration for [surfaceId] and clears that surface's rate
-     * ring buffer so its `ratePerSecond` immediately reads as `0`. Lifetime `total` is preserved
-     * — detaching stops new events from counting toward the rate, not from being remembered.
-     * Without this clear, a closed popup would keep [awaitRateBelow] failing until the sliding
-     * window naturally expires.
+     * Disposes the per-Recomposer registration for [surfaceId] and clears that surface's rate ring
+     * buffer so its `ratePerSecond` immediately reads as `0`. Lifetime `total` is preserved —
+     * detaching stops new events from counting toward the rate, not from being remembered. Without
+     * this clear, a closed popup would keep [awaitRateBelow] failing until the sliding window
+     * naturally expires.
      */
     internal fun detach(surfaceId: String) {
         attachments.remove(surfaceId)?.dispose()

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitor.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitor.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.tooling.observe
 import dev.sebastiano.spectre.core.InternalSpectreApi
 import dev.sebastiano.spectre.core.TrackedWindow
 import dev.sebastiano.spectre.core.WindowTracker
+import dev.sebastiano.spectre.core.readOnEdt
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.ComparableTimeMark
 import kotlin.time.Duration
@@ -127,19 +128,25 @@ internal constructor(
         detach(surfaceId)
         val tracker =
             surfaces.computeIfAbsent(surfaceId) { SurfaceTracker(windowDuration, timeSource) }
-        val perCompositionHandles = ConcurrentHashMap.newKeySet<CompositionObserverHandle>()
+        // Key per-Composition handles by Composition reference so onCompositionUnregistered can
+        // dispose precisely the matching handle instead of waiting for full detach to drain them
+        // — long-lived sessions that churn through compositions would otherwise leak handles.
+        val perCompositionHandles =
+            ConcurrentHashMap<ObservableComposition, CompositionObserverHandle>()
         val compositionObserver = SurfaceCompositionObserver(tracker)
         val registrationHandle =
             recomposer.observe(
                 object : CompositionRegistrationObserver {
                     override fun onCompositionRegistered(composition: ObservableComposition) {
                         val handle = composition.setObserver(compositionObserver)
-                        perCompositionHandles += handle
+                        val previous = perCompositionHandles.put(composition, handle)
+                        // Defensive: Compose's contract says register fires once per composition,
+                        // but if a host re-registers the same instance we don't want to leak.
+                        previous?.dispose()
                     }
 
                     override fun onCompositionUnregistered(composition: ObservableComposition) {
-                        // Composition-side handles are disposed implicitly by Compose when the
-                        // composition is unregistered; no explicit dispose call needed here.
+                        perCompositionHandles.remove(composition)?.dispose()
                     }
                 }
             )
@@ -167,8 +174,12 @@ internal constructor(
                 val departed = prev - curr
                 val arrived = curr - prev
                 departed.forEach { detach(it.surfaceId) }
+                // Recomposer discovery reflects through Compose Desktop internals and may invoke
+                // `getScene()` (a `by lazy` accessor that touches scene state). The collector
+                // runs on Dispatchers.Default but live UI access in Spectre is EDT-marshalled —
+                // hop onto the EDT for the resolve+attach so reflection sees consistent state.
                 arrived.forEach { tracked ->
-                    val recomposer = RecomposerInspector.findRecomposer(tracked)
+                    val recomposer = readOnEdt { RecomposerInspector.findRecomposer(tracked) }
                     if (recomposer != null) attach(tracked.surfaceId, recomposer)
                 }
             }
@@ -235,12 +246,15 @@ internal constructor(
     }
 
     /**
-     * Disposes the per-Recomposer registration for [surfaceId]. The accumulated counters remain
-     * accessible via [perSurface] and [total] — detaching is about stopping new events, not
-     * forgetting old ones. Use [reset] to zero counters explicitly.
+     * Disposes the per-Recomposer registration for [surfaceId] and clears that surface's rate
+     * ring buffer so its `ratePerSecond` immediately reads as `0`. Lifetime `total` is preserved
+     * — detaching stops new events from counting toward the rate, not from being remembered.
+     * Without this clear, a closed popup would keep [awaitRateBelow] failing until the sliding
+     * window naturally expires.
      */
     internal fun detach(surfaceId: String) {
         attachments.remove(surfaceId)?.dispose()
+        surfaces[surfaceId]?.clearRateWindow()
     }
 
     /**
@@ -265,13 +279,15 @@ internal constructor(
     private class Attachment(
         val recomposer: Recomposer,
         private val registrationHandle: CompositionObserverHandle,
-        private val perCompositionHandles: MutableSet<CompositionObserverHandle>,
+        private val perCompositionHandles:
+            ConcurrentHashMap<ObservableComposition, CompositionObserverHandle>,
     ) {
         fun dispose() {
             // Dispose the Recomposer-level registration first so no new compositions arrive while
-            // we tear down per-composition handles.
+            // we tear down per-composition handles. Any handles still in the map at this point
+            // belong to compositions that hadn't yet unregistered themselves.
             registrationHandle.dispose()
-            perCompositionHandles.forEach { it.dispose() }
+            perCompositionHandles.values.forEach { it.dispose() }
             perCompositionHandles.clear()
         }
     }
@@ -362,6 +378,11 @@ private class SurfaceTracker(
             totalCount = 0L
             recentMarks.clear()
         }
+    }
+
+    /** Clears the rate ring buffer without touching [total]. Called on detach. */
+    fun clearRateWindow() {
+        synchronized(lock) { recentMarks.clear() }
     }
 
     private fun pruneOld(now: ComparableTimeMark) {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -324,6 +324,7 @@ class ComposeAutomatorPublicSurfaceTest {
                 "waitForVisualIdle",
                 "waitForNode",
                 "printTree",
+                "monitorRecompositions",
             )
 
         // Members on ComposeAutomator that ship under @InternalSpectreApi — currently just the

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -258,14 +258,22 @@ class ComposeAutomatorPublicSurfaceTest {
                 "dev.sebastiano.spectre.core.NodeKey",
                 "dev.sebastiano.spectre.core.PerfettoTracer",
                 "dev.sebastiano.spectre.core.RobotDriver",
+                "dev.sebastiano.spectre.core.SurfaceIdAssigner",
                 "dev.sebastiano.spectre.core.TextMatchType",
                 "dev.sebastiano.spectre.core.TextQuery",
                 "dev.sebastiano.spectre.core.TrackedWindow",
                 "dev.sebastiano.spectre.core.Tracer",
                 "dev.sebastiano.spectre.core.WindowTracker",
+                "dev.sebastiano.spectre.core.perf.ExperimentalSpectreApi",
+                "dev.sebastiano.spectre.core.perf.RecomposerInspector",
+                "dev.sebastiano.spectre.core.perf.RecompositionMonitor",
+                "dev.sebastiano.spectre.core.perf.RecompositionSnapshot",
+                "dev.sebastiano.spectre.core.perf.SurfaceRecompositions",
             )
 
-        // The intended user-facing types. Update only on a deliberate API addition.
+        // The intended user-facing types. Update only on a deliberate API addition. Types
+        // annotated `@ExperimentalSpectreApi` (e.g. the recomposition-monitor surface) live here
+        // because they are intentionally callable by users — opt-in is a warning, not an error.
         val PUBLISHED_TYPES: Set<String> =
             setOf(
                 "dev.sebastiano.spectre.core.AutomatorIdlingResource",
@@ -282,13 +290,19 @@ class ComposeAutomatorPublicSurfaceTest {
                 "dev.sebastiano.spectre.core.TextMatchType",
                 "dev.sebastiano.spectre.core.TextQuery",
                 "dev.sebastiano.spectre.core.Tracer",
+                "dev.sebastiano.spectre.core.perf.ExperimentalSpectreApi",
+                "dev.sebastiano.spectre.core.perf.RecompositionMonitor",
+                "dev.sebastiano.spectre.core.perf.RecompositionSnapshot",
+                "dev.sebastiano.spectre.core.perf.SurfaceRecompositions",
             )
 
         // Reachable from Kotlin/JVM, but not part of the stability policy.
         val ESCAPE_HATCH_TYPES: Set<String> =
             setOf(
+                "dev.sebastiano.spectre.core.SurfaceIdAssigner",
                 "dev.sebastiano.spectre.core.TrackedWindow",
                 "dev.sebastiano.spectre.core.WindowTracker",
+                "dev.sebastiano.spectre.core.perf.RecomposerInspector",
             )
 
         // The intended user-callable methods on ComposeAutomator (by name; overloads collapse).

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SurfaceIdAssignerTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SurfaceIdAssignerTest.kt
@@ -1,0 +1,101 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+class SurfaceIdAssignerTest {
+
+    @Test
+    fun `same identity returns same id across calls`() {
+        val assigner = SurfaceIdAssigner()
+        val identity = Any()
+        val first = assigner.assign("window", identity)
+        val second = assigner.assign("window", identity)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `different identities get distinct sequential ids per prefix`() {
+        val assigner = SurfaceIdAssigner()
+        val a = assigner.assign("window", Any())
+        val b = assigner.assign("window", Any())
+        val c = assigner.assign("window", Any())
+        assertEquals("window:0", a)
+        assertEquals("window:1", b)
+        assertEquals("window:2", c)
+    }
+
+    @Test
+    fun `each prefix has its own index sequence`() {
+        val assigner = SurfaceIdAssigner()
+        val window0 = assigner.assign("window", Any())
+        val popup0 = assigner.assign("popup", Any())
+        val overlay0 = assigner.assign("overlay", Any())
+        assertEquals("window:0", window0)
+        assertEquals("popup:0", popup0)
+        assertEquals("overlay:0", overlay0)
+    }
+
+    @Test
+    fun `closed identity does not recycle its index when a new identity arrives later`() {
+        val assigner = SurfaceIdAssigner()
+        val a = Any()
+        val b = Any()
+        val idA = assigner.assign("popup", a)
+        val idB = assigner.assign("popup", b)
+        assertEquals("popup:0", idA)
+        assertEquals("popup:1", idB)
+        // "a" goes away. The assigner does not know about disposal (no need to — identity will
+        // simply never be asked again), so the next fresh identity must get index 2, not 0.
+        val c = Any()
+        val idC = assigner.assign("popup", c)
+        assertEquals("popup:2", idC)
+        assertNotEquals(idA, idC)
+    }
+
+    @Test
+    fun `identity equality is reference-based`() {
+        // Two distinct objects that share the same equals/hashCode (Strings, in this case) must
+        // still get distinct ids — surface identity is the underlying object, not its value.
+        val assigner = SurfaceIdAssigner()
+        val left = String(charArrayOf('x'))
+        val right = String(charArrayOf('x'))
+        assertEquals(left, right)
+        val idLeft = assigner.assign("window", left)
+        val idRight = assigner.assign("window", right)
+        assertNotEquals(idLeft, idRight)
+    }
+
+    @Test
+    fun `composite identity caches across calls with same references`() {
+        val assigner = SurfaceIdAssigner()
+        val window = Any()
+        val panel = Any()
+        val first = assigner.assign("window", window, panel)
+        val second = assigner.assign("window", window, panel)
+        assertEquals(first, second)
+    }
+
+    @Test
+    fun `composite identity differs when any part differs`() {
+        val assigner = SurfaceIdAssigner()
+        val window = Any()
+        val panelA = Any()
+        val panelB = Any()
+        val idA = assigner.assign("window", window, panelA)
+        val idB = assigner.assign("window", window, panelB)
+        assertNotEquals(idA, idB)
+    }
+
+    @Test
+    fun `null parts are stable across calls`() {
+        val assigner = SurfaceIdAssigner()
+        val window = Any()
+        val first = assigner.assign("window", window, null)
+        val second = assigner.assign("window", window, null)
+        assertEquals(first, second)
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowStructureTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/TrackedWindowStructureTest.kt
@@ -1,0 +1,36 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Structural assertions on [TrackedWindow]. These run in any environment (no AWT initialisation
+ * required), unlike the equality tests in [TrackedWindowTest] which depend on live `JFrame`
+ * instances and are gated by `liveAwtAvailable` guards.
+ */
+class TrackedWindowStructureTest {
+
+    @Test
+    fun `TrackedWindow constructors contain no function-typed parameters`() {
+        // Function-typed parameters (e.g. a semantics-owners accessor lambda) break data class
+        // equality because Kotlin generates equals/hashCode over every primary-constructor
+        // parameter and lambdas use reference equality. That would cause StateFlow's
+        // distinctUntilChanged to re-emit on every WindowTracker refresh for any session that
+        // hosts an overlay popup, since rediscovery produces a fresh lambda each time. Keep
+        // TrackedWindow a pure description; any per-surface accessors live elsewhere.
+        val offenders =
+            TrackedWindow::class.java.declaredConstructors.flatMap { ctor ->
+                ctor.parameterTypes
+                    .withIndex()
+                    .filter { (_, type) -> kotlin.Function::class.java.isAssignableFrom(type) }
+                    .map { (index, type) -> "constructor ${ctor.name}#param$index: ${type.name}" }
+            }
+        assertTrue(
+            offenders.isEmpty(),
+            "TrackedWindow constructors must not declare function-typed parameters, " +
+                "but found: $offenders",
+        )
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowTrackerStateFlowTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowTrackerStateFlowTest.kt
@@ -1,0 +1,57 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Verifies that [WindowTracker.trackedWindows] is exposed as a [StateFlow] and follows
+ * `StateFlow`'s distinctUntilChanged contract — successive refreshes that produce equal lists emit
+ * only the initial value, so downstream subscribers (e.g. `RecompositionMonitor`) can reconcile on
+ * change events without false positives.
+ *
+ * No live AWT required: [WindowTracker.empty] runs entirely synchronously and always produces an
+ * empty list, which is the simplest distinct-emission scenario.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class WindowTrackerStateFlowTest {
+
+    @Test
+    fun `trackedWindows is exposed as a StateFlow with an initial empty value`() = runTest {
+        val tracker = WindowTracker.empty()
+        val flow: StateFlow<List<TrackedWindow>> = tracker.trackedWindows
+        assertEquals(emptyList(), flow.value)
+        assertEquals(emptyList(), flow.first())
+    }
+
+    @Test
+    fun `repeated refresh with no actual change emits only the initial value`() = runTest {
+        val tracker = WindowTracker.empty()
+        val emissions = mutableListOf<List<TrackedWindow>>()
+        val collector =
+            launch(UnconfinedTestDispatcher(testScheduler)) {
+                tracker.trackedWindows.take(2).toList(emissions)
+            }
+        runCurrent()
+        tracker.refresh()
+        tracker.refresh()
+        tracker.refresh()
+        runCurrent()
+        collector.cancel()
+        assertEquals(
+            listOf(emptyList<TrackedWindow>()),
+            emissions,
+            "Expected only the initial empty emission, got $emissions",
+        )
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspectorTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspectorTest.kt
@@ -1,0 +1,114 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core.perf
+
+import androidx.compose.runtime.Recomposer
+import dev.sebastiano.spectre.core.InternalSpectreApi
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+/**
+ * Unit-tests [RecomposerInspector] against a fake host-object hierarchy that mirrors the field
+ * names used by Compose Multiplatform Desktop:
+ * ```
+ * host → composePanel → _composeContainer → mediator → scene → recomposer → recomposer (Recomposer)
+ * ```
+ *
+ * The intermediate types are irrelevant to the reflection — only field names matter — so the fakes
+ * are plain objects with the expected `val` shape. Live CMP wiring is exercised in sample-desktop
+ * integration tests.
+ */
+class RecomposerInspectorTest {
+
+    @Test
+    fun `walks the host chain and returns the inner Recomposer`() {
+        val recomposer = Recomposer(EmptyCoroutineContext)
+        val host = FakeComposeWindow(recomposer)
+
+        val found = RecomposerInspector.findRecomposerInHostChain(host)
+
+        assertSame(recomposer, found)
+    }
+
+    @Test
+    fun `returns null when host has no composePanel field`() {
+        val found = RecomposerInspector.findRecomposerInHostChain(Any())
+        assertNull(found)
+    }
+
+    @Test
+    fun `returns null when any intermediate field is missing`() {
+        // Host stops at composePanel — no _composeContainer field beneath.
+        val brokenHost = FakeHostWithDeadEnd()
+        val found = RecomposerInspector.findRecomposerInHostChain(brokenHost)
+        assertNull(found)
+    }
+
+    @Test
+    fun `returns null for null host`() {
+        val found = RecomposerInspector.findRecomposerInHostChain(null)
+        assertNull(found)
+    }
+
+    @Test
+    fun `returns null when terminal field is not a Recomposer`() {
+        // Terminal slot holds a String, not a Recomposer — inspector must not blindly cast.
+        val host = FakeComposeWindowWithWrongTerminal()
+        val found = RecomposerInspector.findRecomposerInHostChain(host)
+        assertNull(found)
+    }
+}
+
+private class FakeComposeWindow(recomposer: Recomposer) {
+    @JvmField val composePanel = FakeComposePanel(recomposer)
+}
+
+private class FakeComposePanel(recomposer: Recomposer) {
+    // Field name must match Compose's private property exactly — the inspector reads by field
+    // name, and any rename here would silently stop reflecting the real CMP shape.
+    @Suppress("VariableNaming") @JvmField val _composeContainer = FakeComposeContainer(recomposer)
+}
+
+private class FakeComposeContainer(recomposer: Recomposer) {
+    @JvmField val mediator = FakeMediator(recomposer)
+}
+
+private class FakeMediator(recomposer: Recomposer) {
+    @JvmField val scene = FakeScene(recomposer)
+}
+
+private class FakeScene(recomposer: Recomposer) {
+    @JvmField val recomposer = FakeSceneRecomposer(recomposer)
+}
+
+private class FakeSceneRecomposer(@JvmField val recomposer: Recomposer)
+
+private class FakeHostWithDeadEnd {
+    @JvmField val composePanel: Any = Any()
+}
+
+private class FakeComposeWindowWithWrongTerminal {
+    @JvmField val composePanel = FakeComposePanelWithWrongTerminal()
+}
+
+private class FakeComposePanelWithWrongTerminal {
+    @Suppress("VariableNaming") @JvmField val _composeContainer = FakeContainerWithWrongTerminal()
+}
+
+private class FakeContainerWithWrongTerminal {
+    @JvmField val mediator = FakeMediatorWithWrongTerminal()
+}
+
+private class FakeMediatorWithWrongTerminal {
+    @JvmField val scene = FakeSceneWithWrongTerminal()
+}
+
+private class FakeSceneWithWrongTerminal {
+    @JvmField val recomposer = FakeSceneRecomposerWithWrongTerminal()
+}
+
+private class FakeSceneRecomposerWithWrongTerminal {
+    @JvmField val recomposer = "not a Recomposer"
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspectorTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspectorTest.kt
@@ -17,8 +17,10 @@ import kotlin.test.assertSame
  * ```
  *
  * The intermediate types are irrelevant to the reflection — only field names matter — so the fakes
- * are plain objects with the expected `val` shape. Live CMP wiring is exercised in sample-desktop
- * integration tests.
+ * are plain objects with the expected `val` shape. **Live CMP wiring against a real
+ * `ComposeWindow` is not yet covered by automated tests** (planned follow-up under `sample-desktop`);
+ * the reflective chain here is verified structurally and any field-rename regression in real CMP
+ * will surface as `findRecomposer` returning `null` rather than crashing.
  */
 class RecomposerInspectorTest {
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspectorTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspectorTest.kt
@@ -17,10 +17,10 @@ import kotlin.test.assertSame
  * ```
  *
  * The intermediate types are irrelevant to the reflection — only field names matter — so the fakes
- * are plain objects with the expected `val` shape. **Live CMP wiring against a real
- * `ComposeWindow` is not yet covered by automated tests** (planned follow-up under `sample-desktop`);
- * the reflective chain here is verified structurally and any field-rename regression in real CMP
- * will surface as `findRecomposer` returning `null` rather than crashing.
+ * are plain objects with the expected `val` shape. **Live CMP wiring against a real `ComposeWindow`
+ * is not yet covered by automated tests** (planned follow-up under `sample-desktop`); the
+ * reflective chain here is verified structurally and any field-rename regression in real CMP will
+ * surface as `findRecomposer` returning `null` rather than crashing.
  */
 class RecomposerInspectorTest {
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitorTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitorTest.kt
@@ -1,0 +1,143 @@
+@file:OptIn(ExperimentalSpectreApi::class)
+
+package dev.sebastiano.spectre.core.perf
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Unit tests for [RecompositionMonitor]'s counter math via the internal `recordRecomposition` seam.
+ * Live `Recomposer` wire-up is exercised by sample-desktop integration tests.
+ */
+class RecompositionMonitorTest {
+
+    @Test
+    fun `total counts every recordRecomposition call across surfaces`() {
+        val monitor = RecompositionMonitor(windowDuration = 1.seconds)
+        monitor.recordRecomposition("window:0")
+        monitor.recordRecomposition("window:0")
+        monitor.recordRecomposition("popup:0")
+        assertEquals(3, monitor.total)
+        monitor.close()
+    }
+
+    @Test
+    fun `ratePerSecond reflects only entries inside the window`() {
+        val timeSource = TestTimeSource()
+        val monitor = RecompositionMonitor(windowDuration = 1.seconds, timeSource = timeSource)
+        repeat(5) { monitor.recordRecomposition("window:0") }
+        assertEquals(5.0, monitor.ratePerSecond)
+        timeSource += 2.seconds
+        assertEquals(0.0, monitor.ratePerSecond)
+        monitor.close()
+    }
+
+    @Test
+    fun `ratePerSecond uses windowDuration as the denominator`() {
+        val timeSource = TestTimeSource()
+        val monitor =
+            RecompositionMonitor(windowDuration = 500.milliseconds, timeSource = timeSource)
+        repeat(10) { monitor.recordRecomposition("window:0") }
+        // 10 recompositions in a 500ms window → 20/s rate.
+        assertEquals(20.0, monitor.ratePerSecond)
+        monitor.close()
+    }
+
+    @Test
+    fun `perSurface lists each surface separately with its own counters`() {
+        val monitor = RecompositionMonitor(windowDuration = 1.seconds)
+        monitor.recordRecomposition("window:0")
+        monitor.recordRecomposition("window:0")
+        monitor.recordRecomposition("popup:0")
+        val byId = monitor.perSurface().associateBy { it.surfaceId }
+        assertEquals(2L, byId.getValue("window:0").total)
+        assertEquals(1L, byId.getValue("popup:0").total)
+        monitor.close()
+    }
+
+    @Test
+    fun `activeSurfaces tracks the distinct surface count`() {
+        val monitor = RecompositionMonitor(windowDuration = 1.seconds)
+        assertEquals(0, monitor.activeSurfaces)
+        monitor.recordRecomposition("window:0")
+        monitor.recordRecomposition("window:0")
+        assertEquals(1, monitor.activeSurfaces)
+        monitor.recordRecomposition("popup:0")
+        assertEquals(2, monitor.activeSurfaces)
+        monitor.close()
+    }
+
+    @Test
+    fun `reset zeroes counters but preserves surface registrations`() {
+        val monitor = RecompositionMonitor(windowDuration = 1.seconds)
+        monitor.recordRecomposition("window:0")
+        monitor.recordRecomposition("popup:0")
+        monitor.reset()
+        assertEquals(0, monitor.total)
+        assertEquals(0.0, monitor.ratePerSecond)
+        // Surfaces remain registered so subsequent observations land in the same buckets.
+        assertEquals(2, monitor.activeSurfaces)
+        monitor.close()
+    }
+
+    @Test
+    fun `snapshot captures a coherent view at one moment`() {
+        val timeSource = TestTimeSource()
+        val monitor = RecompositionMonitor(windowDuration = 1.seconds, timeSource = timeSource)
+        repeat(3) { monitor.recordRecomposition("window:0") }
+        val snapshot = monitor.snapshot()
+        assertEquals(3, snapshot.total)
+        assertEquals(3.0, snapshot.ratePerSecond)
+        assertEquals(1, snapshot.activeSurfaces)
+        assertEquals(1.seconds, snapshot.windowDuration)
+        monitor.close()
+    }
+
+    @Test
+    fun `close cancels the owned scope and is idempotent`() {
+        val monitor = RecompositionMonitor(windowDuration = 1.seconds)
+        val scope = monitor.scopeForTests
+        assertTrue(scope.isActive)
+        monitor.close()
+        assertFalse(scope.isActive)
+        // Calling close again must be a safe no-op.
+        monitor.close()
+    }
+
+    @Test
+    fun `awaitRateBelow returns true immediately when no surfaces have been recorded`() =
+        runBlocking {
+            // Real time, not runTest's virtual time — the monitor's loop uses
+            // TimeSource.Monotonic for elapsed-time accounting and `delay` for pacing; mixing
+            // those with a virtual scheduler makes the quiet-period check fire on virtual time
+            // while the elapsed-time check still uses wall clock, producing false timeouts.
+            val monitor = RecompositionMonitor(windowDuration = 1.seconds)
+            val under = monitor.awaitRateBelow(threshold = 1.0, timeout = 100.milliseconds)
+            assertTrue(under)
+            monitor.close()
+        }
+
+    @Test
+    fun `awaitCompositionIdle returns true when there are no attached recomposers`() = runBlocking {
+        // With nothing attached, "any pending work" is vacuously false and the quiet period
+        // begins counting from t=0 — the wait must return true within timeout. runBlocking
+        // (not runTest) so the wall-clock TimeSource the monitor uses internally lines up
+        // with the coroutine `delay`s.
+        val monitor = RecompositionMonitor(windowDuration = 1.seconds)
+        val idle =
+            monitor.awaitCompositionIdle(
+                quietPeriod = 10.milliseconds,
+                timeout = 500.milliseconds,
+                pollInterval = 5.milliseconds,
+            )
+        assertTrue(idle)
+        monitor.close()
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitorTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitorTest.kt
@@ -14,7 +14,9 @@ import kotlinx.coroutines.runBlocking
 
 /**
  * Unit tests for [RecompositionMonitor]'s counter math via the internal `recordRecomposition` seam.
- * Live `Recomposer` wire-up is exercised by sample-desktop integration tests.
+ * **Live `Recomposer` wire-up is not yet covered by automated tests** — a `sample-desktop`
+ * integration that drives an actual ComposeWindow recomposing and asserts the monitor counts is
+ * planned as a follow-up.
  */
 class RecompositionMonitorTest {
 
@@ -97,6 +99,22 @@ class RecompositionMonitorTest {
         assertEquals(3.0, snapshot.ratePerSecond)
         assertEquals(1, snapshot.activeSurfaces)
         assertEquals(1.seconds, snapshot.windowDuration)
+        monitor.close()
+    }
+
+    @Test
+    fun `detach clears the rate window for that surface without resetting total`() {
+        val monitor = RecompositionMonitor(windowDuration = 1.seconds)
+        monitor.recordRecomposition("window:0")
+        monitor.recordRecomposition("window:0")
+        monitor.recordRecomposition("window:0")
+        assertEquals(3.0, monitor.ratePerSecond)
+        // detach is the internal hook the StateFlow reconciler uses when a surface disappears.
+        // It must immediately zero the rate so awaitRateBelow doesn't keep failing against the
+        // ghost of a closed popup, while leaving the lifetime total intact for perSurface().
+        monitor.detach("window:0")
+        assertEquals(0.0, monitor.ratePerSecond)
+        assertEquals(3L, monitor.total)
         monitor.close()
     }
 

--- a/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/MultiWindowScenario.kt
+++ b/sample-desktop/src/main/kotlin/dev/sebastiano/spectre/sample/scenarios/MultiWindowScenario.kt
@@ -10,6 +10,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -30,7 +31,14 @@ import androidx.compose.ui.window.rememberWindowState
  *   CMP exposes it as a popup-class window when launched from inside a parent composition)
  *
  * Tags: `multiwindow.toggleButton`, `multiwindow.secondary.text`,
- * `multiwindow.secondary.dismissButton`.
+ * `multiwindow.secondary.counterButton`, `multiwindow.secondary.dismissButton`.
+ *
+ * The secondary's counter button mutates state declared inside the secondary `Window {}` block,
+ * which keeps `RecompositionMonitor`'s per-surface attribution honest: a click there should
+ * recompose only the secondary's scene, never the main window's. Without this button, the only
+ * mutating control inside the secondary is the dismiss button, which closes the parent's `open`
+ * flag — that recomposes the *parent* composition, not the secondary's, and so wouldn't prove the
+ * monitor separates per-surface buckets correctly.
  */
 val MultiWindowScenario: Scenario =
     Scenario(
@@ -65,6 +73,10 @@ private fun MultiWindowContent() {
             state = state,
             title = "Spectre — secondary window",
         ) {
+            // State declared inside this `Window {}` block lives in the secondary window's
+            // composition, so mutating it recomposes the secondary's scene — exactly the signal
+            // RecompositionMonitorValidationTest needs to assert independent per-surface counters.
+            var secondaryCounter by remember { mutableIntStateOf(0) }
             Column(
                 modifier = Modifier.fillMaxSize().padding(16.dp),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -73,6 +85,12 @@ private fun MultiWindowContent() {
                     text = "I am a secondary window",
                     modifier = Modifier.testTag("multiwindow.secondary.text"),
                 )
+                Button(
+                    onClick = { secondaryCounter++ },
+                    modifier = Modifier.testTag("multiwindow.secondary.counterButton"),
+                ) {
+                    Text("Secondary clicks: $secondaryCounter")
+                }
                 Button(
                     onClick = { open = false },
                     modifier = Modifier.testTag("multiwindow.secondary.dismissButton"),

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/RecompositionMonitorValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/RecompositionMonitorValidationTest.kt
@@ -29,13 +29,17 @@ import org.junit.jupiter.api.TestMethodOrder
  * Compose recomposes, that the EDT-marshalled discovery path doesn't deadlock against Spectre's
  * other EDT users, that the StateFlow reconciler attaches new surfaces as they arrive, or that the
  * sliding-window rate measurement holds up under high-frequency recomposition. This class fills
- * those gaps by spawning the sample app via [SampleAppFixture] and asserting against four
+ * those gaps by spawning the sample app via [SampleAppFixture] and asserting against three
  * scenarios:
- * - **counter**: baseline single-surface attach, counter math, rate decay, per-surface reporting.
- * - **multiwindow**: a secondary `Window` gets its own `surfaceId`, its own counter, and detach
- *   clears its rate ring buffer when the window closes (while the lifetime `total` persists).
- * - **recomposition stress**: a ~60Hz ticker drives the rate well above an idle baseline, then
- *   [RecompositionMonitor.awaitRateBelow] confirms the rate decays after the ticker stops.
+ * - **counter**: baseline single-surface attach, counter math (Tests 1–3), rate decay (Test 4), and
+ *   per-surface reporting against the main window.
+ * - **multiwindow** (Test 5): a secondary `Window` gets its own `surfaceId`; clicking a button
+ *   inside that secondary window increments only the secondary's bucket (proves real per-surface
+ *   attribution, not just that the secondary appears in `perSurface()`); detach clears its rate
+ *   ring buffer when the window closes while the lifetime `total` persists.
+ * - **recomposition stress** (Test 6): a ~60Hz ticker drives `total` and `ratePerSecond` well above
+ *   an idle baseline, then [RecompositionMonitor.awaitRateBelow] confirms the rate decays after the
+ *   ticker stops.
  *
  * Run via `./gradlew :sample-desktop:validationTest`. Opt-in, requires a real display.
  */
@@ -231,6 +235,51 @@ class RecompositionMonitorValidationTest {
                     "Expected monitor to expose the secondary surface ($secondarySurfaceId) in " +
                         "perSurface(); got ${perSurfaceTwo.map { it.surfaceId }}",
                 )
+                // Identify the main window's surfaceId by elimination so the attribution
+                // assertion below is robust regardless of which one got the lower index.
+                val mainSurfaceId =
+                    perSurfaceTwo.map { it.surfaceId }.firstOrNull { it != secondarySurfaceId }
+                        ?: error(
+                            "Could not identify main surfaceId; ids=${perSurfaceTwo.map { it.surfaceId }}"
+                        )
+
+                // Real attribution check: click a button declared inside the `Window {}` block
+                // of MultiWindowScenario. That button mutates state owned by the secondary's
+                // composition, so the resulting recomposition pass must land on the secondary's
+                // CompositionObserver, not the main window's. If the monitor folded both surfaces
+                // into one bucket (or swapped buckets), this assertion would fail.
+                monitor.awaitCompositionIdle(quietPeriod = SETTLE_QUIET_PERIOD)
+                monitor.reset()
+                val secondaryCounter = waitForTestTag("multiwindow.secondary.counterButton")
+                repeat(SECONDARY_CLICKS) {
+                    click(secondaryCounter)
+                    monitor.awaitCompositionIdle(quietPeriod = SETTLE_QUIET_PERIOD)
+                }
+                val perSurfaceAfterClicks = monitor.perSurface()
+                println(
+                    "[monitor] after $SECONDARY_CLICKS secondary clicks: $perSurfaceAfterClicks"
+                )
+                val secondaryTotal =
+                    perSurfaceAfterClicks.firstOrNull { it.surfaceId == secondarySurfaceId }?.total
+                        ?: 0L
+                val mainTotal =
+                    perSurfaceAfterClicks.firstOrNull { it.surfaceId == mainSurfaceId }?.total ?: 0L
+                assertTrue(
+                    secondaryTotal >= SECONDARY_CLICKS.toLong(),
+                    "Expected secondary surface ($secondarySurfaceId) to count ≥$SECONDARY_CLICKS " +
+                        "recompositions from in-window clicks, got total=$secondaryTotal " +
+                        "(perSurface=$perSurfaceAfterClicks)",
+                )
+                // Per-surface attribution: clicks on a button inside the secondary's `Window {}`
+                // block mutate state owned by the secondary's composition, so they should NOT
+                // produce noticeable activity on the main surface. Allow a small margin for any
+                // ambient main-scene recomposition during the test window, but require the
+                // secondary's count to dominate by a healthy margin.
+                assertTrue(
+                    secondaryTotal > mainTotal,
+                    "Expected secondary total ($secondaryTotal) to exceed main total ($mainTotal) " +
+                        "after clicks in the secondary window; perSurface=$perSurfaceAfterClicks",
+                )
 
                 // Close the secondary window. After refresh, the reconciler detaches it — rate
                 // for that surfaceId must read 0 immediately (the lifetime total persists).
@@ -275,21 +324,31 @@ class RecompositionMonitorValidationTest {
                 monitor.reset()
 
                 // The stress scenario ticks every 16ms while running, producing ~60 recompositions
-                // per second on the main scene. Start it, let it run for one sliding-window worth
-                // of time so the rate stabilises, then assert it's well above an idle baseline.
+                // per second on the main scene. Start it and let it run for STRESS_RUN_DURATION;
+                // the assertion uses `total` as the primary signal because it accumulates
+                // monotonically and is robust to short scheduling stalls, while `ratePerSecond`
+                // measures only the last sliding window and is more sensitive to a single slow
+                // frame at sampling time. CI hardware that stalls briefly under load can drop
+                // the instantaneous rate below the threshold even when overall throughput is
+                // healthy; total only requires aggregate progress.
                 click(toggle)
                 kotlinx.coroutines.delay(STRESS_RUN_DURATION_MS)
 
                 val activeRate = monitor.ratePerSecond
                 val activeTotal = monitor.total
                 println("[monitor] under stress: total=$activeTotal, rate=${activeRate}/s")
+                // Primary signal: aggregate recompositions over the run window.
+                assertTrue(
+                    activeTotal >= STRESS_MIN_TOTAL,
+                    "Expected total ≥ $STRESS_MIN_TOTAL during stress (run=${STRESS_RUN_DURATION_MS}ms), " +
+                        "got $activeTotal",
+                )
+                // Secondary signal: instantaneous rate should be elevated, but allow a generous
+                // floor so CI hardware noise doesn't flake the suite. The total check above is
+                // the real test; this only catches "rate measurement is broken" regressions.
                 assertTrue(
                     activeRate >= STRESS_MIN_RATE,
                     "Expected ratePerSecond ≥ $STRESS_MIN_RATE during stress, got $activeRate",
-                )
-                assertTrue(
-                    activeTotal >= STRESS_MIN_TOTAL,
-                    "Expected total ≥ $STRESS_MIN_TOTAL during stress, got $activeTotal",
                 )
 
                 // Stop the ticker; the rate window should drain back below threshold via
@@ -315,6 +374,7 @@ class RecompositionMonitorValidationTest {
 
     private companion object {
         const val CLICKS: Int = 5
+        const val SECONDARY_CLICKS: Int = 3
         val ATTACH_TIMEOUT = 5.seconds
         val AWAIT_RATE_TIMEOUT = 3.seconds
         // Slightly longer than the monitor's default 50ms quiet period: Compose Desktop on a real
@@ -323,12 +383,14 @@ class RecompositionMonitorValidationTest {
         // scene, and produce its recomposition pass before we declare idle.
         val SETTLE_QUIET_PERIOD = 150.milliseconds
 
-        // Stress thresholds: the recomp scenario ticks at ~60Hz. Take the rate measurement after
-        // letting it run for STRESS_RUN_DURATION_MS so the 1s sliding window is fully populated.
-        // MIN_RATE is well below 60 to absorb scheduling jitter on slower CI hardware.
-        const val STRESS_RUN_DURATION_MS: Long = 1_200L
-        const val STRESS_MIN_RATE: Double = 20.0
-        const val STRESS_MIN_TOTAL: Long = 20L
+        // Stress thresholds. The recomp scenario ticks at ~60Hz, so a 2.0s run produces ~120
+        // recompositions in the ideal case; MIN_TOTAL=40 is roughly a third of that, leaving
+        // generous headroom for CI scheduling jitter without making the test a no-op. MIN_RATE
+        // is a sanity floor on the instantaneous-rate path — well below the steady-state ~60/s
+        // so a single slow frame doesn't trip it.
+        const val STRESS_RUN_DURATION_MS: Long = 2_000L
+        const val STRESS_MIN_RATE: Double = 15.0
+        const val STRESS_MIN_TOTAL: Long = 40L
         const val STRESS_CALM_THRESHOLD: Double = 5.0
         val STRESS_CALM_TIMEOUT = 3.seconds
     }

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/RecompositionMonitorValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/RecompositionMonitorValidationTest.kt
@@ -1,0 +1,185 @@
+@file:OptIn(
+    dev.sebastiano.spectre.core.InternalSpectreApi::class,
+    dev.sebastiano.spectre.core.perf.ExperimentalSpectreApi::class,
+)
+
+package dev.sebastiano.spectre.sample.validation
+
+import dev.sebastiano.spectre.core.perf.RecompositionMonitor
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.TestMethodOrder
+
+/**
+ * End-to-end coverage for [RecompositionMonitor] against a live Compose Desktop window.
+ *
+ * The unit tests in `:core` exercise the counter math through an internal seam and the reflection
+ * chain through a fake hierarchy keyed by field name. They cannot verify that the chain still lines
+ * up with the real CMP internal field names, that the `CompositionObserver` actually fires when
+ * Compose recomposes, that the EDT-marshalled discovery path doesn't deadlock against Spectre's
+ * other EDT users, or that disposal teardown is clean. This class fills all four gaps by spawning
+ * the sample app via [SampleAppFixture] and asserting against the counter scenario.
+ *
+ * Run via `./gradlew :sample-desktop:validationTest`. Opt-in, requires a real display.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+class RecompositionMonitorValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre recomposition monitor validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    @Order(1)
+    fun `monitor attaches to the live ComposeWindow recomposer`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            waitForTestTag("incrementButton")
+
+            monitorRecompositions().use { monitor ->
+                // The monitor subscribes to the WindowTracker StateFlow on Dispatchers.Default;
+                // attachment happens asynchronously inside readOnEdt as soon as the first
+                // emission is processed. Driving a refresh and polling activeSurfaces gives the
+                // reconciler a deterministic chance to install observers without a fixed sleep.
+                refreshWindows()
+                eventually("monitor to attach a surface", timeout = ATTACH_TIMEOUT) {
+                    if (monitor.activeSurfaces > 0) Unit else null
+                }
+
+                val active = monitor.activeSurfaces
+                println("[monitor] attached surfaces: $active")
+                assertTrue(active > 0, "Expected ≥1 attached surface; got $active")
+            }
+        }
+    }
+
+    @Test
+    @Order(2)
+    fun `clicking the counter increments the lifetime total`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val button = waitForTestTag("incrementButton")
+
+            monitorRecompositions().use { monitor ->
+                refreshWindows()
+                eventually("monitor to attach", timeout = ATTACH_TIMEOUT) {
+                    if (monitor.activeSurfaces > 0) Unit else null
+                }
+
+                // Drain any composition activity carried over from scenario navigation, then zero
+                // the counters so the assertion measures only what the clicks produce.
+                monitor.awaitCompositionIdle(quietPeriod = SETTLE_QUIET_PERIOD)
+                monitor.reset()
+
+                repeat(CLICKS) {
+                    click(button)
+                    // Let each click's recomposition complete before issuing the next one — the
+                    // assertion needs distinct, observable passes, not an aggregated batch.
+                    monitor.awaitCompositionIdle(quietPeriod = SETTLE_QUIET_PERIOD)
+                }
+
+                val snapshot = monitor.snapshot()
+                println(
+                    "[monitor] after $CLICKS clicks: total=${snapshot.total}, " +
+                        "surfaces=${snapshot.activeSurfaces}, rate=${snapshot.ratePerSecond}/s"
+                )
+                // Compose may coalesce multiple invalidations into a single pass on the same
+                // frame, so we assert ≥1 pass per click is a *lower* bound, not equality.
+                assertTrue(
+                    snapshot.total >= CLICKS.toLong(),
+                    "Expected at least $CLICKS recompositions, got ${snapshot.total}",
+                )
+            }
+        }
+    }
+
+    @Test
+    @Order(3)
+    fun `perSurface reports the live surface with a non-zero total after activity`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val button = waitForTestTag("incrementButton")
+
+            monitorRecompositions().use { monitor ->
+                refreshWindows()
+                eventually("monitor to attach", timeout = ATTACH_TIMEOUT) {
+                    if (monitor.activeSurfaces > 0) Unit else null
+                }
+                monitor.awaitCompositionIdle(quietPeriod = SETTLE_QUIET_PERIOD)
+                monitor.reset()
+
+                click(button)
+                monitor.awaitCompositionIdle(quietPeriod = SETTLE_QUIET_PERIOD)
+
+                val perSurface = monitor.perSurface()
+                println("[monitor] perSurface: $perSurface")
+                assertTrue(perSurface.isNotEmpty(), "perSurface must list at least one surface")
+                val countingSurfaces = perSurface.filter { it.total > 0 }
+                assertTrue(
+                    countingSurfaces.isNotEmpty(),
+                    "Expected at least one surface with total>0 after clicking; got $perSurface",
+                )
+                // Surface ids are assigned by WindowTracker as `prefix:N` (e.g. "window:0"). We
+                // don't lock the exact suffix to avoid coupling to discovery order, but every id
+                // must follow that shape — drift here would mean monitor reconciliation has
+                // diverged from the tracker's naming scheme.
+                assertTrue(
+                    countingSurfaces.all { it.surfaceId.contains(":") },
+                    "Surface ids should be of form 'prefix:N'; got ${countingSurfaces.map { it.surfaceId }}",
+                )
+            }
+        }
+    }
+
+    @Test
+    @Order(4)
+    fun `awaitRateBelow returns true after the UI settles`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val button = waitForTestTag("incrementButton")
+
+            monitorRecompositions().use { monitor ->
+                refreshWindows()
+                eventually("monitor to attach", timeout = ATTACH_TIMEOUT) {
+                    if (monitor.activeSurfaces > 0) Unit else null
+                }
+
+                // Click to push the sliding window above zero, then assert the rate decays to
+                // below the threshold once the UI settles. Generous threshold so machine noise
+                // doesn't trip the assertion — the goal is "no thrashing", not a tight bound.
+                click(button)
+                val settled = monitor.awaitRateBelow(threshold = 10.0, timeout = AWAIT_RATE_TIMEOUT)
+                println("[monitor] settled below 10/s within timeout: $settled")
+                assertTrue(settled, "Expected ratePerSecond to drop below 10/s after settling")
+            }
+        }
+    }
+
+    private companion object {
+        const val CLICKS: Int = 5
+        val ATTACH_TIMEOUT = 5.seconds
+        val AWAIT_RATE_TIMEOUT = 3.seconds
+        // Slightly longer than the monitor's default 50ms quiet period: Compose Desktop on a real
+        // display can delay the post-input recomposition by a frame or two under load, and a
+        // 150ms quiet window gives the click event time to land on the EDT, be dispatched to the
+        // scene, and produce its recomposition pass before we declare idle.
+        val SETTLE_QUIET_PERIOD = 150.milliseconds
+    }
+}

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/RecompositionMonitorValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/RecompositionMonitorValidationTest.kt
@@ -27,8 +27,15 @@ import org.junit.jupiter.api.TestMethodOrder
  * chain through a fake hierarchy keyed by field name. They cannot verify that the chain still lines
  * up with the real CMP internal field names, that the `CompositionObserver` actually fires when
  * Compose recomposes, that the EDT-marshalled discovery path doesn't deadlock against Spectre's
- * other EDT users, or that disposal teardown is clean. This class fills all four gaps by spawning
- * the sample app via [SampleAppFixture] and asserting against the counter scenario.
+ * other EDT users, that the StateFlow reconciler attaches new surfaces as they arrive, or that the
+ * sliding-window rate measurement holds up under high-frequency recomposition. This class fills
+ * those gaps by spawning the sample app via [SampleAppFixture] and asserting against four
+ * scenarios:
+ * - **counter**: baseline single-surface attach, counter math, rate decay, per-surface reporting.
+ * - **multiwindow**: a secondary `Window` gets its own `surfaceId`, its own counter, and detach
+ *   clears its rate ring buffer when the window closes (while the lifetime `total` persists).
+ * - **recomposition stress**: a ~60Hz ticker drives the rate well above an idle baseline, then
+ *   [RecompositionMonitor.awaitRateBelow] confirms the rate decays after the ticker stops.
  *
  * Run via `./gradlew :sample-desktop:validationTest`. Opt-in, requires a real display.
  */
@@ -172,6 +179,140 @@ class RecompositionMonitorValidationTest {
         }
     }
 
+    @Test
+    @Order(5)
+    fun `secondary Window gets its own surfaceId and independent counter`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.multiwindow")
+            val toggleButton = waitForTestTag("multiwindow.toggleButton")
+
+            monitorRecompositions().use { monitor ->
+                refreshWindows()
+                eventually("monitor to attach main surface", timeout = ATTACH_TIMEOUT) {
+                    if (monitor.activeSurfaces >= 1) Unit else null
+                }
+                val initialSurfaces = monitor.activeSurfaces
+                monitor.awaitCompositionIdle(quietPeriod = SETTLE_QUIET_PERIOD)
+                monitor.reset()
+
+                // Open the secondary window. WindowTracker won't pick it up until refreshWindows
+                // fires the next StateFlow emission, after which the monitor's reconciler should
+                // hop to the EDT, resolve the secondary's Recomposer, and attach a fresh surface.
+                click(toggleButton)
+                val secondaryText =
+                    eventually("secondary window's text to appear", timeout = ATTACH_TIMEOUT) {
+                        findOneByTestTag("multiwindow.secondary.text")
+                    }
+                eventually("monitor to attach the secondary surface", timeout = ATTACH_TIMEOUT) {
+                    if (monitor.activeSurfaces > initialSurfaces) Unit else null
+                }
+                val twoSurfaces = monitor.activeSurfaces
+                val perSurfaceTwo = monitor.perSurface()
+                println(
+                    "[monitor] after opening secondary window: surfaces=$twoSurfaces, " +
+                        "perSurface=$perSurfaceTwo"
+                )
+                assertTrue(
+                    twoSurfaces > initialSurfaces,
+                    "Expected activeSurfaces to grow when secondary window opens; " +
+                        "was $initialSurfaces, now $twoSurfaces",
+                )
+                val ids = perSurfaceTwo.map { it.surfaceId }
+                assertTrue(
+                    ids.distinct().size == ids.size,
+                    "Surface ids should be distinct across surfaces; got $ids",
+                )
+                // The text node lives in the secondary's semantics tree, so its TrackedWindow
+                // surfaceId is the right key for asserting per-surface attribution.
+                val secondarySurfaceId = secondaryText.surfaceId
+                println("[monitor] secondary surfaceId: $secondarySurfaceId")
+                assertTrue(
+                    perSurfaceTwo.any { it.surfaceId == secondarySurfaceId },
+                    "Expected monitor to expose the secondary surface ($secondarySurfaceId) in " +
+                        "perSurface(); got ${perSurfaceTwo.map { it.surfaceId }}",
+                )
+
+                // Close the secondary window. After refresh, the reconciler detaches it — rate
+                // for that surfaceId must read 0 immediately (the lifetime total persists).
+                val dismissButton = waitForTestTag("multiwindow.secondary.dismissButton")
+                click(dismissButton)
+                waitUntilGone("multiwindow.secondary.text", timeout = ATTACH_TIMEOUT)
+                refreshWindows()
+                eventually("secondary surface's rate to drop to zero", timeout = ATTACH_TIMEOUT) {
+                    val secondaryRate =
+                        monitor
+                            .perSurface()
+                            .firstOrNull { it.surfaceId == secondarySurfaceId }
+                            ?.ratePerSecond
+                    if (secondaryRate != null && secondaryRate == 0.0) Unit else null
+                }
+                val perSurfaceAfter = monitor.perSurface()
+                println("[monitor] after closing secondary: perSurface=$perSurfaceAfter")
+                val secondaryAfter = perSurfaceAfter.firstOrNull {
+                    it.surfaceId == secondarySurfaceId
+                }
+                assertTrue(
+                    secondaryAfter != null && secondaryAfter.ratePerSecond == 0.0,
+                    "Closed surface should report rate=0; got $secondaryAfter",
+                )
+            }
+        }
+    }
+
+    @Test
+    @Order(6)
+    fun `recomposition stress drives rate above threshold then settles`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.recomposition")
+            val toggle = waitForTestTag("recomp.toggleButton")
+
+            monitorRecompositions().use { monitor ->
+                refreshWindows()
+                eventually("monitor to attach", timeout = ATTACH_TIMEOUT) {
+                    if (monitor.activeSurfaces > 0) Unit else null
+                }
+                monitor.awaitCompositionIdle(quietPeriod = SETTLE_QUIET_PERIOD)
+                monitor.reset()
+
+                // The stress scenario ticks every 16ms while running, producing ~60 recompositions
+                // per second on the main scene. Start it, let it run for one sliding-window worth
+                // of time so the rate stabilises, then assert it's well above an idle baseline.
+                click(toggle)
+                kotlinx.coroutines.delay(STRESS_RUN_DURATION_MS)
+
+                val activeRate = monitor.ratePerSecond
+                val activeTotal = monitor.total
+                println("[monitor] under stress: total=$activeTotal, rate=${activeRate}/s")
+                assertTrue(
+                    activeRate >= STRESS_MIN_RATE,
+                    "Expected ratePerSecond ≥ $STRESS_MIN_RATE during stress, got $activeRate",
+                )
+                assertTrue(
+                    activeTotal >= STRESS_MIN_TOTAL,
+                    "Expected total ≥ $STRESS_MIN_TOTAL during stress, got $activeTotal",
+                )
+
+                // Stop the ticker; the rate window should drain back below threshold via
+                // awaitRateBelow. Validates both the rate decay and the await helper under
+                // realistic post-thrashing conditions.
+                click(toggle)
+                val calmed =
+                    monitor.awaitRateBelow(
+                        threshold = STRESS_CALM_THRESHOLD,
+                        timeout = STRESS_CALM_TIMEOUT,
+                    )
+                println(
+                    "[monitor] after stop: rate=${monitor.ratePerSecond}/s, calmed=$calmed " +
+                        "(threshold=$STRESS_CALM_THRESHOLD)"
+                )
+                assertTrue(
+                    calmed,
+                    "Expected rate to drop below $STRESS_CALM_THRESHOLD/s within $STRESS_CALM_TIMEOUT",
+                )
+            }
+        }
+    }
+
     private companion object {
         const val CLICKS: Int = 5
         val ATTACH_TIMEOUT = 5.seconds
@@ -181,5 +322,14 @@ class RecompositionMonitorValidationTest {
         // 150ms quiet window gives the click event time to land on the EDT, be dispatched to the
         // scene, and produce its recomposition pass before we declare idle.
         val SETTLE_QUIET_PERIOD = 150.milliseconds
+
+        // Stress thresholds: the recomp scenario ticks at ~60Hz. Take the rate measurement after
+        // letting it run for STRESS_RUN_DURATION_MS so the 1s sliding window is fully populated.
+        // MIN_RATE is well below 60 to absorb scheduling jitter on slower CI hardware.
+        const val STRESS_RUN_DURATION_MS: Long = 1_200L
+        const val STRESS_MIN_RATE: Double = 20.0
+        const val STRESS_MIN_TOTAL: Long = 20L
+        const val STRESS_CALM_THRESHOLD: Double = 5.0
+        val STRESS_CALM_TIMEOUT = 3.seconds
     }
 }

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
@@ -87,7 +87,7 @@ class SampleAppFixture(
         while (System.nanoTime() < deadline) {
             bootstrapTracker.refresh()
             val tracked =
-                bootstrapTracker.trackedWindows.firstOrNull {
+                bootstrapTracker.trackedWindows.value.firstOrNull {
                     runCatching { (it.window as? java.awt.Frame)?.title }.getOrNull() == title
                 }
             if (tracked != null) {


### PR DESCRIPTION
## Summary

- New `RecompositionMonitor` that observes Compose recomposition counts and rates across every tracked surface. Hooks into the Compose tooling APIs (`Recomposer.observe` + `CompositionObserver.onBeginComposition`); per-pass cost is one atomic increment plus a ring-buffer append.
- Piggybacks on `WindowTracker` discovery — host calls `automator.monitorRecompositions()` and gets a configured monitor. No manual wiring per `Recomposer`.
- Three wait helpers: `awaitCompositionIdle` (cheapest), `awaitRateBelow`, plus the existing `waitForIdle` / `waitForVisualIdle` family. Documented when to reach for each.

## What's in the branch

Eight commits, layered so review can land in chunks:

1. **`b41a891`** — Fix `TrackedWindow.surfaceId` so it's actually stable across refreshes (the docs at `AutomatorTree.kt:29` already claimed it was). New `SurfaceIdAssigner` with reference-keyed weak-ref cache.
2. **`cc7d782`** — Promote `WindowTracker.trackedWindows` from `List` to `StateFlow`. Relies on the equality fix from (1) so `distinctUntilChanged` works correctly.
3. **`4ee9af4`** — `RecompositionMonitor` + `RecomposerInspector` + `@ExperimentalSpectreApi` annotation + the `monitorRecompositions()` facade.
4. **`62a352e`** — Review-pass fixes: EDT marshalling for reflection, per-Composition handle disposal on unregister, detach clears rate window, perf package in the allowlist test, `findRecomposerInHostChain` made `internal`.
5. **`482c804`** — Regenerate ABI snapshot after the visibility tightening; drop dead `IdentityRef.referent()`.
6. **`d5eea03`** — Sample-desktop validation suite (4 tests against counter scenario).
7. **`6122ead`** — Extend validation: multi-window (new surface attaches, detach clears rate) + recomposition stress (rate measurement at ~60Hz).
8. **`a02c6dc`** — Review-pass fixes: CI workflows include the new validation class; multi-window now proves *real* per-surface attribution (clicking inside secondary increments only the secondary's bucket); KDoc cleanup; stress thresholds reframed with `total` as primary signal.

## Notable design choices

- **Overlay-popup recomposers are not resolved in this MVP.** Their `Recomposer` lives behind a separate reflection chain inside `WindowComposeSceneLayer`; `RecomposerInspector.findRecomposer` returns `null` for those surfaces. Documented in KDoc.
- **No host-provided `Recomposer` API.** The monitor walks the same CMP host chain `OverlayLayerInspector` already uses (composePanel → _composeContainer → mediator → scene → recomposer → recomposer) inside `readOnEdt {}`. Degrades gracefully (returns `null`) when CMP renames an internal field.
- **`@ExperimentalSpectreApi` opt-in annotation** (warning level) parallels the existing `@InternalSpectreApi` (error level). Required for the monitor surface so users acknowledge the API shape may change.

## Test plan

- [x] `./gradlew check` green (detekt, ktfmt, ABI snapshot, all unit tests, all modules)
- [x] `./gradlew :sample-desktop:validationTest -Dspectre.sample.fixture.uiElement=true` — 6/6 pass locally on macOS interactive display
- [x] CI workflows (`validation-linux.yml`, `validation-windows.yml`) updated with new required-class entry — will surface on this PR
- [x] Public-surface allowlist test catches drift in the new perf-package types

### Live-validation output snapshot
```
[monitor] after 3 secondary clicks:
  [SurfaceRecompositions(window:0, total=0, ratePerSecond=0.0),
   SurfaceRecompositions(window:1, total=4, ratePerSecond=2.0)]   ← real attribution
[monitor] under stress: total=105, rate=51.0/s                     ← ~60Hz observed
[monitor] after stop: rate=4.0/s, calmed=true (threshold=5.0)
[monitor] after closing secondary:
  [..., SurfaceRecompositions(window:1, total=4, ratePerSecond=0.0)] ← detach worked
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)