### PR TITLE
[codex] Add Linux native capture helper paths

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ spectre
 ├── server/                  — optional transport layer for cross-JVM access
 ├── recording/               — screenshot / recording API and common JVM implementation
 ├── recording-macos/         — runtime-only macOS ScreenCaptureKit helper artifact
-├── recording-linux/         — runtime-only Linux Wayland helper artifact
+├── recording-linux/         — runtime-only Linux capture helper artifact
 ├── recording-windows/       — runtime-only Windows Graphics Capture helper artifact
 ├── testing/                 — test fixtures and JUnit-facing helpers built on top of public APIs
 ├── sample-desktop/          — small manual-test harness app for spike validation
@@ -104,22 +104,26 @@ Expected long-term responsibilities:
 
 Current backends:
 
-- `FfmpegRecorder` — region capture via a system `ffmpeg` binary, with the input device
-  picked per OS by `FfmpegBackend.detect()`: `avfoundation` on macOS, `gdigrab` on
-  Windows, and `x11grab` on Linux Xorg. (Linux Wayland is rejected here; see
-  `LinuxX11Grab.checkNotWayland`.)
+- `FfmpegRecorder` — deprecated legacy explicit region capture via a system `ffmpeg`
+  binary, with the input device picked per OS by `FfmpegBackend.detect()`: `avfoundation`
+  on macOS, `gdigrab` on Windows, and legacy explicit `x11grab` on Linux Xorg. (Linux
+  Wayland is rejected here; use the portal-backed Linux helper path instead.)
 - `windows.WindowsGraphicsCaptureRecorder` — Windows-only MP4 capture via the shared
   .NET Windows Graphics Capture helper packaged by `:recording-windows` for x64 and
   arm64. Window mode follows movement automatically and ignores occluders; region mode
   records a fixed monitor rectangle and is also used for fullscreen recording.
-- `FfmpegWindowRecorder` — legacy explicit Windows-only window-targeted capture via
+- `FfmpegWindowRecorder` — deprecated legacy explicit Windows-only window-targeted capture via
   `gdigrab title=`. Window movement is followed automatically; occlusion doesn't matter.
 - `windows.WindowsWindowScreenshotter` — Windows-only still window screenshots via a
   shared framework-dependent .NET Windows Graphics Capture helper packaged by
   `:recording-windows` for x64 and arm64.
-- `FfmpegRegionScreenshotter` — Linux X11 still screenshot fallback via one-frame `x11grab`
-  region capture; the target must be visible and frontmost because this is not true window
-  capture.
+- `LinuxX11Recorder` — Linux Xorg/Xvfb region and named-window capture via the
+  `spectre-recording-linux` helper and GStreamer `ximagesrc`.
+- `LinuxNativeScreenshotter` — Linux still screenshots via the same helper: GStreamer
+  `ximagesrc` on Xorg/Xvfb, and one-frame portal/PipeWire capture on Wayland.
+- `FfmpegRegionScreenshotter` — deprecated legacy explicit Linux X11 still screenshot
+  fallback via one-frame `x11grab` region capture; the target must be visible and frontmost
+  because this is not true window capture.
 - `screencapturekit.ScreenCaptureKitRecorder` — macOS-only window-targeted capture via a
   Swift helper (`recording/native/macos/`). The helper is built by Gradle on macOS,
   staged under `recording/build/generated/screenCaptureHelper/...`, and packaged by
@@ -132,11 +136,10 @@ Current backends:
   The helper hands the PipeWire FD to `gst-launch-1.0`.
 - `AutoRecorder` — high-level router that picks per call from `startWindow(...)` /
   `startRegion(...)` + OS detection: Wayland portal first, then macOS SCK for window
-  capture, Windows Graphics Capture for window and region capture, and ffmpeg region
-  capture for macOS / Linux Xorg explicit regions.
+  capture, Windows Graphics Capture for window and region capture, Linux helper capture
+  for Linux Xorg/Xvfb window and region capture, and ffmpeg region capture for macOS.
 - `AutoScreenshotter` — high-level still screenshot router: macOS SCK window source,
-  Windows Graphics Capture, Linux X11 region fallback, and loud unsupported failure for
-  Linux Wayland still screenshots until the portal helper can return image buffers.
+  Windows Graphics Capture, and Linux helper still capture on Xorg/Xvfb and Wayland.
 
 ### `testing`
 

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -135,8 +135,9 @@ corresponding doc page is touched:
   `Window.focusOwner`, so `typeText` works in `apple.awt.UIElement=true` helper JVMs.
   Keep documenting `pasteText` and OS recording as separate macOS-service paths that
   UIElement mode can still break.
-- **Linux Wayland + `LinuxX11Grab` throws.** It does not silently produce black
-  frames. The thrown message points users at `AutoRecorder`/`WaylandPortalRecorder`.
+- **Linux Wayland routes through the portal.** Xorg/Xvfb capture uses the Linux
+  helper's GStreamer `ximagesrc` path; native Wayland capture uses the portal helper.
+  Do not document a silent X11 fallback on Wayland.
 
 ## Style conventions
 

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -9,7 +9,7 @@ a video file, and each has its own limitations:
 - **Region capture** — records a fixed `Rectangle` of the virtual desktop, frame by
   frame. The source of pixels is the OS framebuffer (or the platform's nearest
   equivalent — `avfoundation` on macOS, Windows Graphics Capture on Windows,
-  `x11grab` on Linux Xorg, or the Wayland compositor's PipeWire stream on Linux
+  GStreamer `ximagesrc` on Linux Xorg/Xvfb, or the Wayland compositor's PipeWire stream on Linux
   Wayland). Whatever is showing
   on screen inside that rectangle goes into the file, regardless of which window is
   there. Region capture is the only path available when the Compose surface has no
@@ -26,14 +26,16 @@ Backend → mode mapping:
 
 | Backend                       | Mode                                                |
 | ----------------------------- | --------------------------------------------------- |
-| `FfmpegRecorder`              | Region capture (`avfoundation`/legacy explicit `gdigrab`/`x11grab`).|
-| `FfmpegRegionScreenshotter`   | Linux X11 still-image region fallback (`x11grab`).  |
+| `FfmpegRecorder`              | Deprecated legacy explicit region capture (`avfoundation`/`gdigrab`/`x11grab`).|
+| `FfmpegRegionScreenshotter`   | Deprecated legacy explicit Linux X11 still-image region fallback (`x11grab`).  |
+| `LinuxX11Recorder`            | Linux Xorg/Xvfb region and named-window capture via GStreamer `ximagesrc`. |
+| `LinuxNativeScreenshotter`    | Linux Xorg/Xvfb screenshots via `ximagesrc`, and Linux Wayland screenshots via portal/PipeWire one-frame capture. |
 | `WaylandPortalRecorder`       | Region capture, sourced from the Wayland portal (`SourceType.MONITOR`). |
 | `WaylandPortalWindowRecorder` | Window-targeted (Linux Wayland, portal `SourceType.WINDOW` — only the picked window's pixels are captured). |
 | `ScreenCaptureKitRecorder`    | Window-targeted (macOS).                            |
 | `ScreenCaptureKitScreenshotter` | Window-targeted still screenshots (macOS).         |
 | `WindowsGraphicsCaptureRecorder` | Window-targeted and region capture (Windows Graphics Capture). |
-| `FfmpegWindowRecorder`        | Legacy window-targeted (Windows, `gdigrab title=`). |
+| `FfmpegWindowRecorder`        | Deprecated legacy window-targeted (Windows, `gdigrab title=`). |
 | `WindowsWindowScreenshotter`  | Window-targeted still screenshots (Windows Graphics Capture helper). |
 | `AutoRecorder`                | Routes to the right one based on `TitledWindow?`.   |
 | `AutoScreenshotter`           | Routes still screenshots by platform and window.    |
@@ -53,12 +55,24 @@ failure modes, and the section below
   Windows App Runtime 1.8 installed. `AutoRecorder.startRegion(...)` falls back to
   `FfmpegRecorder`/`gdigrab` when that helper artifact is absent, or when the caller
   sets Windows region options that WGC cannot honour (`RecordingOptions.codec` or
-  `screenIndex`). `FfmpegRecorder` also remains available as an explicit legacy backend.
-- **Linux Xorg sessions** — `x11grab` region capture. Reads `DISPLAY`. Routine
+  `screenIndex`). `FfmpegRecorder` also remains available as a deprecated explicit legacy
+  backend.
+- **Linux Xorg/Xvfb sessions** — helper-driven GStreamer `ximagesrc` capture. Reads `DISPLAY`.
+  `LinuxX11Recorder` records fixed regions or a named X11 window; `LinuxNativeScreenshotter`
+  writes one-frame PNGs through the same helper. Routine
   validation has only been on Ubuntu 22.04's Xorg session (one machine, one X server build)
   and on CI under `xvfb-run` (Xorg protocol over a virtual framebuffer, no GPU). Other
   Xorg WMs/distros fall under the "Linux is best-effort, contributions welcome" line in
-  the README.
+  the README. `AutoRecorder` and `AutoScreenshotter` no longer use ffmpeg for this route;
+  install `spectre-recording-linux` and the GStreamer packages instead. The helper's
+  recording pipeline currently supports only `RecordingOptions.codec = "libx264"` or
+  `"x264enc"`; unsupported codec strings fail at `start(...)` with a targeted error rather
+  than building a broken GStreamer pipeline. The explicit ffmpeg classes remain available
+  only as deprecated compatibility escape hatches.
+  Native Wayland sessions with XWayland are different: Mutter does not expose the composited
+  desktop through the XWayland root framebuffer, so root-region `ximagesrc` capture can be black
+  except for the cursor. `AutoRecorder` detects Wayland before this backend and routes region
+  capture through the portal; do not force the X11 backend in that environment.
 - **Linux Wayland sessions** — `gst-launch-1.0` driven through the
   `xdg-desktop-portal` ScreenCast interface, with the PipeWire FD passed to the encoder by a
   small Rust helper binary from `spectre-recording-linux` (`spectre-wayland-helper`, sources at
@@ -67,8 +81,9 @@ failure modes, and the section below
   monitor, helper crops to the requested rectangle) and `WaylandPortalWindowRecorder`
   (window-targeted, portal `SourceType.WINDOW` — user picks a specific window, the
   granted PipeWire stream contains only that window's pixels, the helper crops to the
-  window's pixel size, #85). Both spawn the helper and talk to it over stdin/stdout via
-  newline-delimited JSON. **First call within a session pops the compositor's
+  window's pixel size, #85). `LinuxNativeScreenshotter` uses the same helper for one-frame
+  portal/PipeWire PNG capture. All of these paths spawn the helper and talk to it over
+  stdin/stdout via newline-delimited JSON. **First call within a session pops the compositor's
   "share your screen" dialog** (asking for a window or a monitor depending on which
   recorder is running); subsequent calls reuse the grant via the portal's `restore_token`.
   Why the helper: a pure-JVM attempt hit a dbus-java UnixFD-unmarshalling bug that wasn't
@@ -77,7 +92,8 @@ failure modes, and the section below
   `fcntl(F_SETFD, ...)` knob. The helper-as-subprocess shape also matches the
   `spectre-recording-macos` SCK helper (`recording/native/macos/`) on the JVM side.
 
-  **Window-targeted Wayland needs `xprop` on `PATH`.** Mutter renders window-source-type
+  **Window-targeted Wayland needs `xprop` on `PATH` and GTK/Mutter-style frame extents.**
+  Mutter renders window-source-type
   streams with the WM-imposed invisible-shadow extents around the visible window —
   typically 25 px on each side for GTK CSD windows on GNOME — but AWT's
   `Frame.getBounds()` reports only the inner window. `WaylandPortalWindowRecorder` queries
@@ -91,7 +107,14 @@ failure modes, and the section below
   `TitledWindow` with a null/blank title, the recorder throws `IllegalStateException`
   rather than producing a silently-misaligned recording. The fallback is explicit
   region capture: call `AutoRecorder.startRegion(...)`, or instantiate
-  `WaylandPortalRecorder` directly.
+  `WaylandPortalRecorder` directly. Installing `xprop` only fixes the missing-binary
+  case; it will not make Qt, JavaFX, Electron, SDL, KDE, or wlroots windows publish the
+  GTK-specific property.
+
+  Wayland still screenshots use the same portal grant model as video. They are supported
+  only when the compositor's ScreenCast portal can provide the requested monitor or window
+  stream and the user accepts the dialog. In unattended SSH/headless runs, a hidden or
+  unanswered portal dialog surfaces as a helper timeout rather than a silent blank PNG.
 
   Validated end-to-end on Ubuntu 22.04/GNOME 42/mutter, Ubuntu 24.04/GNOME 46/mutter, and
   Ubuntu 26.04/GNOME 50/mutter (real-pixel mp4 with the smoke runner, 2026-05-02 and

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -39,12 +39,13 @@ out of scope.
    a testing affordance for the same machine and the same user, not a remote-control
    protocol. See [Agent attach](guide/agent.md).
 5. **Bundled native helpers are trusted artifacts.** Spectre extracts and executes Swift
-   (`spectre-screencapture`) and Rust (`spectre-wayland-helper`) helpers from the published jar
+   (`spectre-screencapture`), Rust/Linux (`spectre-wayland-helper`), and Windows
+   (`spectre-window-capture.exe`) helpers from the published jar
    resources. The extraction path is process-private; the helpers are launched with `argv`
    lists (never shell strings). Developer-only override env vars exist for local iteration
    and are explicitly documented as such — see the
    [`SPECTRE_WAYLAND_HELPER` note](#developer-only-override-env-vars) below.
-6. **External binaries (ffmpeg, xprop, osascript) come from the host PATH.** Spectre does not
+6. **External binaries (ffmpeg, GStreamer, xprop, osascript) come from the host PATH.** Spectre does not
    pin versions and treats them as prerequisites of the host environment.
 
 ## Capabilities and their exposure
@@ -54,7 +55,7 @@ out of scope.
 | Move mouse / press keys | `RobotDriver.click`, `swipe`, `pressKey`, `scrollWheel` | In-process; trusted-local HTTP via `/spectre/click` |
 | Modify clipboard | `RobotDriver.pasteText` (save / set / paste / restore) | In-process |
 | Capture pixels | `RobotDriver.screenshot(region)` — **captures any rectangle of the virtual desktop**, not just the app under test; `AutoScreenshotter` for native/window-targeted still screenshots where available | In-process; trusted-local HTTP via `/spectre/screenshot` for `RobotDriver`; `AutoScreenshotter` is in-process only |
-| Record video | `AutoRecorder`, `FfmpegRecorder`, `ScreenCaptureKitRecorder`, `WaylandPortalRecorder` | In-process only |
+| Record video | `AutoRecorder`, native recorders, deprecated explicit `FfmpegRecorder`, `WaylandPortalRecorder` | In-process only |
 | Execute a helper binary | `HelperBinaryExtractor` (SCK), `WaylandHelperBinaryExtractor` | Local file system, JVM process |
 | Expose any of the above over HTTP | `installSpectreRoutes` mounts the windows / nodes / click / typeText / screenshot routes | **Unauthenticated, plaintext** — host application chooses bind address |
 | Expose any of the above over UDS | `:agent`'s `IpcServer` mounts the same surface plus detach over a Unix Domain Socket | **Unauthenticated** — filesystem mode 0600 (same UID); macOS + Linux only in v1 |
@@ -106,7 +107,7 @@ expansion); items that are hygiene fixes get their own issues.
   the display, including unrelated windows. A per-window / per-node API for remote callers
   is tracked under #96.
 - **Recording output-path validation.** Spectre passes the caller-supplied output path
-  through to ffmpeg / the helpers without rejecting `/dev/`, `/proc/`, symlinks, or
+  through to ffmpeg, GStreamer, or the helpers without rejecting `/dev/`, `/proc/`, symlinks, or
   not-yet-existing parents. Standalone follow-up issue, separate from #96.
 - **`pasteText` clipboard-restore robustness.** A failure during the post-paste restore is
   swallowed via `runCatching` (clipboard may be left holding the typed text). Standalone

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -134,8 +134,8 @@ Spectre is JVM-first and targets desktop OSes.
 | --- | --- | --- |
 | **macOS** | Primary | Full support. AWT Robot input, ScreenCaptureKit recording (with `spectre-recording-macos` helper), TCC permission diagnostics. |
 | **Windows** | Full | AWT Robot input + Windows Graphics Capture region/window recording. |
-| **Linux Xorg** | Full | AWT Robot input + `x11grab` region recording. Validated against Xvfb in CI. |
-| **Linux Wayland** | Best-effort | Portal-mediated capture via `WaylandPortalRecorder` / `WaylandPortalWindowRecorder`. **Validated on GNOME/Mutter only**; KDE / sway / wlroots compositors may behave differently and are not exercised in CI. Real Robot input is unavailable on Wayland — use the synthetic adapter for tests. |
+| **Linux Xorg** | Full | AWT Robot input + helper/GStreamer Xorg/Xvfb recording and screenshots. Validated against Xvfb in CI. |
+| **Linux Wayland** | Best-effort | Portal-mediated capture via `WaylandPortalRecorder`, `WaylandPortalWindowRecorder`, and `LinuxNativeScreenshotter`. **Validated on GNOME/Mutter only**; KDE / sway / wlroots compositors may behave differently and are not exercised in CI. Real Robot input is unavailable on Wayland — use the synthetic adapter for tests. |
 | **BSD** | Unsupported | Not built or tested. |
 
 ## AndroidX-style stability expectations

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -42,7 +42,7 @@ dependencies {
     // Optional, depending on what you need:
     testImplementation("dev.sebastiano.spectre:spectre-recording:<version>")
     testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-macos:<version>") // macOS SCK helper
-    testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-linux:<version>") // Linux Wayland helper
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-linux:<version>") // Linux capture helper
     testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-windows:<version>") // Windows WGC helper
     testImplementation("dev.sebastiano.spectre:spectre-server:<version>")
 }
@@ -143,9 +143,9 @@ Maven Local:
 | ----------- | -------------------------------------------------------------------------------- |
 | `core`      | `ComposeAutomator`, semantics tree reader, selectors, `RobotDriver` for input.    |
 | `testing`   | `ComposeAutomatorExtension` (JUnit 5), `ComposeAutomatorRule` (JUnit 4).         |
-| `recording` | Region and window-targeted screen capture API (`AutoRecorder`, `FfmpegRecorder`, …). |
+| `recording` | Region and window-targeted screen capture API (`AutoRecorder`, native helpers, deprecated ffmpeg escape hatches, …). |
 | `recording-macos` | Runtime-only macOS ScreenCaptureKit helper resources for `recording`. |
-| `recording-linux` | Runtime-only Linux Wayland helper resources for `recording`. |
+| `recording-linux` | Runtime-only Linux capture helper resources for `recording`. |
 | `recording-windows` | Runtime-only Windows Graphics Capture helper resources for `recording`. |
 | `server`    | Embedded HTTP transport (Ktor) and `HttpComposeAutomator` for cross-JVM access. **Experimental**; see [Security notes](../SECURITY.md). |
 

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -249,7 +249,7 @@ A few things to know about IDE-hosted Compose surfaces:
     1. **Region-capture the tool window's screen bounds.** Compute the tool window
        component's `boundsOnScreen` and pass it to `AutoRecorder.startRegion(...)`.
        `AutoRecorder` routes that through platform region capture (Windows Graphics
-       Capture on Windows, `ffmpeg` on macOS / Linux Xorg, or the Wayland portal on
+       Capture on Windows, `ffmpeg` on macOS, the Linux helper on Xorg/Xvfb, or the Wayland portal on
        Linux Wayland). Works everywhere; the trade-off is
        that anything overlapping the captured rectangle — the IDE's chrome,
        notifications, popups that escape the tool window's bounds — appears in the

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -126,8 +126,8 @@ Returns a `BufferedImage` you can save, hash, or compare against a baseline.
     overlaps the rectangle, those overlapping pixels can appear in the image; if the
     target is partially off-screen, Spectre can only capture the visible screen area.
     For top-level windows, `spectre-recording` also exposes `AutoScreenshotter`,
-    which uses native/window-targeted backends on macOS and Windows, and an explicit
-    X11 region fallback on Linux X11.
+    which uses native/window-targeted backends on macOS and Windows, and the Linux
+    helper on Xorg/Xvfb and Wayland.
 
 !!! note "Captures are normalised to sRGB"
     The returned `BufferedImage` is always sRGB (`TYPE_INT_ARGB` with an sRGB

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -5,13 +5,21 @@ tests. It exposes small surfaces backed by platform-specific implementations and
 routers that pick the right one per call.
 
 !!! note "External dependencies"
-    The recording backends shell out to platform tools — `ffmpeg` for macOS / Linux X11
-    region capture, plus small native helpers for macOS, Linux Wayland, and Windows
-    Graphics Capture. Windows window, region, and fullscreen recording use the Windows
-    Graphics Capture helper when `spectre-recording-windows` is present.
+    The recording backends shell out to platform tools — `ffmpeg` for macOS and legacy
+    explicit backends, plus small native helpers for macOS, Linux, and Windows Graphics
+    Capture. Linux Xorg/Xvfb and Wayland capture both use the Linux helper from
+    `spectre-recording-linux`, with GStreamer doing the actual encoding or PNG writing.
+    Windows window, region, and fullscreen recording use the Windows Graphics Capture
+    helper when `spectre-recording-windows` is present.
     Add `spectre-recording-macos`, `spectre-recording-linux`, and/or
     `spectre-recording-windows` as runtime-only dependencies for those helpers. See
     [Recording limitations](../RECORDING-LIMITATIONS.md) for the per-platform notes.
+
+!!! note "Linux migration note"
+    Linux Xorg/Xvfb recording and screenshots now use the bundled
+    `spectre-recording-linux` helper with GStreamer. The previous Linux ffmpeg/x11grab
+    fallback is no longer used by `AutoRecorder` or `AutoScreenshotter`; `ffmpeg` on
+    `PATH` is only relevant if you instantiate the explicit legacy ffmpeg backends.
 
 ## Still Window Screenshots
 
@@ -35,8 +43,8 @@ ImageIO.write(image, "png", File("build/reports/window.png"))
 | --- | --- | --- | --- |
 | macOS | ScreenCaptureKit helper (`spectre-screencapture --mode screenshot`) | Captures the window source, not overlapping apps | Requires `spectre-recording-macos` at runtime and Screen Recording permission |
 | Windows | Windows Graphics Capture helper (`spectre-window-capture.exe`) | Captures the named top-level window | Requires `spectre-recording-windows`, Windows 10 version 1903 or newer, .NET 8 Desktop Runtime, Windows App Runtime 1.8, and a non-blank exact window title |
-| Linux X11 | ffmpeg `x11grab` region fallback | Captures visible screen pixels | The target window must be visible/frontmost, same limitation as `ComposeAutomator.screenshot(...)` |
-| Linux Wayland | Unsupported for still images today | N/A | Use `WaylandPortalWindowRecorder` for video. One-shot still capture needs a helper extension that returns image buffers instead of video files |
+| Linux Xorg/Xvfb | Linux helper + GStreamer `ximagesrc` | Captures visible screen pixels | The target window must be visible/frontmost, same limitation as `ComposeAutomator.screenshot(...)`; window mode needs a non-blank exact title |
+| Linux Wayland | Linux helper + portal/PipeWire one-frame capture | Portal-scoped; region mode captures the selected monitor stream, window mode captures the selected window stream | Requires the compositor portal dialog to be accepted. Window mode needs `xprop` and `_GTK_FRAME_EXTENTS`, same as `WaylandPortalWindowRecorder` |
 
 Embedded `ComposePanel` surfaces without a top-level OS window still need region
 screenshots, because native window APIs need a real top-level window to bind to.
@@ -60,12 +68,16 @@ Expected results by platform:
   `spectre-recording-windows`. The smoke should print a non-empty PNG path. Open it and
   confirm it contains only the smoke window; ffmpeg is not required for still screenshots,
   but runtime users need .NET 8 Desktop Runtime and Windows App Runtime 1.8 installed.
-- **Linux X11** — run from an Xorg/XWayland session with `DISPLAY` set and `ffmpeg` on
-  `PATH`. The task uses the explicit `x11grab` region fallback, so keep the smoke window
-  visible/frontmost. Open the printed PNG and confirm it contains the smoke window.
-- **Linux Wayland** — still screenshots intentionally report unsupported today. The smoke
-  exits successfully only after verifying the `UnsupportedOperationException` message.
-  To test the window-targeted Wayland path that exists today, run:
+- **Linux Xorg/Xvfb** — run from a real Xorg/Xvfb display with `DISPLAY` set and
+  `spectre-recording-linux` on the runtime classpath. The task uses the Linux helper's
+  GStreamer `ximagesrc` path, so keep the smoke window visible/frontmost. Open the printed
+  PNG and confirm it contains the smoke window. Do not force this smoke through XWayland
+  inside a native Wayland compositor: Mutter's XWayland root framebuffer is black even though
+  the pointer is visible. Normal Wayland sessions should validate the portal route below.
+- **Linux Wayland** — run with `WAYLAND_DISPLAY`, `XDG_RUNTIME_DIR`, and the D-Bus session
+  bus visible to the JVM. The task asks the compositor portal for a window stream and writes
+  a one-frame PNG after you accept the dialog. If the dialog is hidden or rejected, the helper
+  fails loudly with the portal error or timeout. To test window-targeted Wayland video, run:
 
   ```bash
   ./gradlew :recording:runWaylandPortalWindowSmoke
@@ -99,8 +111,8 @@ interface Recorder {
 
 You start a recording, you get a `RecordingHandle`, you stop the handle when you're
 done. Implementations spawn the underlying process eagerly and fail fast when startup
-is clearly broken, but ffmpeg-backed recorders do not prove that the first frame has
-already landed in `output` before `start()` returns.
+is clearly broken. Some process-backed recorders still cannot prove that the first frame
+has already landed in `output` before `start()` returns.
 
 ## Recorder capability matrix
 
@@ -110,10 +122,11 @@ view for when you want to know what each backend can and cannot do.
 
 | Recorder | Capture shape | Follows window resize? | Captures occluding windows / popups? | Prerequisites | Platforms |
 | --- | --- | --- | --- | --- | --- |
-| `FfmpegRecorder` | Screen region (fixed `Rectangle`) | No — region fixed at `start()` | Yes — anything visible inside the region lands in the frame, including occluding apps and overlapping Compose `OnWindow` popups | `ffmpeg` on `PATH`; macOS Screen Recording TCC for the launching app | macOS · Windows legacy/explicit · Linux Xorg |
+| `FfmpegRecorder` (deprecated) | Screen region (fixed `Rectangle`) | No — region fixed at `start()` | Yes — anything visible inside the region lands in the frame, including occluding apps and overlapping Compose `OnWindow` popups | `ffmpeg` on `PATH`; macOS Screen Recording TCC for the launching app | macOS · Windows legacy/explicit · Linux X11 legacy/explicit |
 | `WindowsGraphicsCaptureRecorder` | Named window (exact title + owner pid) or screen region | Window mode follows the target window across moves; region mode is fixed at `start()` | Window mode captures only the target window's pixels, so occluders are excluded and separate `OnWindow` popups are not captured. Region/fullscreen mode captures the visible monitor pixels inside the requested rectangle, including overlapping windows and popups | `spectre-recording-windows` runtime helper (`spectre-window-capture.exe`); Windows 10 version 1903 or newer; .NET 8 Desktop Runtime; Windows App Runtime 1.8 | Windows |
-| `FfmpegWindowRecorder` | Legacy named window (`gdigrab title=`) | Yes — `gdigrab` retracks the window across moves and resizes | No — only the window's pixels are captured. Compose `OnWindow` popups land in a separate OS window with a different title, so they are **not** captured. `OnSameCanvas` / `OnComponent` popups are part of the window surface and are captured | `ffmpeg` on `PATH`; visible window with a non-blank exact title | Windows |
+| `FfmpegWindowRecorder` (deprecated) | Legacy named window (`gdigrab title=`) | Yes — `gdigrab` retracks the window across moves and resizes | No — only the window's pixels are captured. Compose `OnWindow` popups land in a separate OS window with a different title, so they are **not** captured. `OnSameCanvas` / `OnComponent` popups are part of the window surface and are captured | `ffmpeg` on `PATH`; visible window with a non-blank exact title | Windows |
 | `ScreenCaptureKitRecorder` | Named window (pid + title substring) | Yes — reads the window backing store directly, follows moves and resizes | No — same window-source semantics as WGC. `OnWindow` popups not captured; `OnSameCanvas` / `OnComponent` captured | `spectre-recording-macos` runtime helper (`spectre-screencapture`); macOS Screen Recording TCC for the launching app | macOS |
+| `LinuxX11Recorder` | Screen region or named X11 window (`ximagesrc`) | Region mode is fixed at `start()`; window mode uses GStreamer's `xname` source selection | Captures visible X server pixels for the selected source; occluding apps can appear in region capture | `spectre-recording-linux` runtime helper; `gst-launch-1.0` with `ximagesrc`, `videorate`, `x264enc`, and `mp4mux`; `DISPLAY` | Linux Xorg/Xvfb; named XWayland windows only when the process is deliberately forced onto the X11 backend |
 | `WaylandPortalRecorder` | Monitor region (portal `SourceType.MONITOR`, cropped) | No — monitor-level source | Depends on the compositor. Validated on GNOME/Mutter to include the user's overlays but exclude apps occluding the recorded region | `spectre-recording-linux` runtime helper (`spectre-wayland-helper`); `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`. First call pops the compositor's "share screen" dialog | Linux Wayland |
 | `WaylandPortalWindowRecorder` | Named window (portal `SourceType.WINDOW` + fixed crop) | **No.** The crop is computed once from `_GTK_FRAME_EXTENTS` at `start()` and stays at those pixel coordinates for the rest of the recording. If the user moves or resizes the window during the recording, the crop no longer aligns with the window's pixels (typically the recording shows blank / black for the unrendered area of the original rectangle) — see `WaylandPortalWindowRecorder`'s KDoc for the detailed rationale | No — only the picked window's pixels are in the stream. `OnWindow` popups not captured | `spectre-recording-linux` runtime helper; `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`; `xprop` on `PATH`; compositor must publish `_GTK_FRAME_EXTENTS` (GNOME/Mutter verified; older Mutter / KDE / sway may not — the recorder throws rather than producing misaligned video) | Linux Wayland |
 
@@ -125,8 +138,9 @@ user moving or resizing the window mid-recording.
 Embedded-host implications: `ComposePanel`s without a top-level OS window — including
 Jewel-hosted Compose inside an IntelliJ plugin tool window — have no exact window title for
 the native Windows helper to bind to and no top-level window for the SCK helper to discover.
-`AutoRecorder` falls through to region capture (`FfmpegRecorder` on macOS / Linux Xorg,
-`WindowsGraphicsCaptureRecorder` on Windows, and `WaylandPortalRecorder` on Linux Wayland)
+`AutoRecorder` falls through to region capture (`FfmpegRecorder` on macOS,
+`WindowsGraphicsCaptureRecorder` on Windows, `LinuxX11Recorder` on Linux Xorg/Xvfb,
+and `WaylandPortalRecorder` on Linux Wayland)
 for those surfaces. Linux support is
 best-effort: portal capture is exercised against GNOME/Mutter on Ubuntu 22.04 and 24.04;
 KDE / sway / wlroots may behave differently and are not validated.
@@ -183,7 +197,8 @@ The routing is platform-keyed. Read the row that matches your OS:
 | **macOS**               | `null`                            | `FfmpegRecorder` region capture (`avfoundation`).                    |
 | **Windows**             | non-null with a non-blank title   | `WindowsGraphicsCaptureRecorder` (`spectre-recording-windows` helper). |
 | **Windows**             | `null`, or non-null with no title | `WindowsGraphicsCaptureRecorder` region capture.                     |
-| **Linux Xorg**          | any                               | `FfmpegRecorder` region capture (`x11grab`).                         |
+| **Linux Xorg/Xvfb**     | non-null with a non-blank title   | `LinuxX11Recorder` window capture (`ximagesrc xname`).               |
+| **Linux Xorg/Xvfb**     | `null`, or non-null with no title | `LinuxX11Recorder` region capture (`ximagesrc`).                     |
 | **Linux Wayland**       | non-null                          | `WaylandPortalWindowRecorder` (portal `Window` source type — only the picked window's pixels, window-sized output). |
 | **Linux Wayland**       | `null`                            | `WaylandPortalRecorder` (portal `Monitor` source type — region capture). |
 
@@ -203,8 +218,17 @@ A few details worth knowing:
   `RecordingOptions.codec` or `screenIndex`. Window-targeted recording, fullscreen
   recording through `WindowsGraphicsCaptureRecorder`, and still window screenshots
   require the helper artifact; operational WGC failures still propagate.
+- **Linux Xorg/Xvfb uses the Linux helper by default.** `AutoRecorder` no longer uses
+  `ffmpeg` for the Linux Xorg/Xvfb route. Region and window capture go through the
+  bundled Rust helper from `spectre-recording-linux`, which spawns `gst-launch-1.0`
+  with `ximagesrc`. The explicit `FfmpegRecorder`, `FfmpegWindowRecorder`,
+  `FfmpegRegionScreenshotter`, and `FfmpegWindowScreenshotter` classes are deprecated legacy
+  escape hatches; use them only if you intentionally need the old ffmpeg backends. The helper's recording pipeline currently supports
+  `RecordingOptions.codec = "libx264"` or `"x264enc"` only; arbitrary GStreamer encoder
+  strings are rejected with a clear error until Spectre grows a structured encoder
+  pipeline configuration.
 - **Linux Wayland always uses the portal** (when a portal recorder is wired up),
-  regardless of whether `window` is null, because `LinuxX11Grab` refuses to run on
+  regardless of whether `window` is null, because X11 capture is not valid for native
   Wayland sessions. With `window != null` the router picks the window-targeted portal
   recorder (`WaylandPortalWindowRecorder`, `SourceType.WINDOW`): the dialog asks the
   user to pick a window, the granted PipeWire stream contains only that window's pixels
@@ -214,10 +238,11 @@ A few details worth knowing:
   `SourceType.MONITOR`): the dialog asks for a monitor, and the helper crops the
   monitor stream to the requested rectangle. The first call pops the compositor's
   "share your screen" dialog; subsequent calls in the same JVM run reuse the grant.
-- **Linux Wayland helper.** Both portal recorders run the same small Rust binary
-  (`spectre-wayland-helper`) from the `spectre-recording-linux` runtime artifact. It drives
+- **Linux helper.** Both portal recorders run the same small Rust binary
+  (`spectre-wayland-helper`) from the `spectre-recording-linux` runtime artifact. The
+  same binary also owns Linux Xorg/Xvfb capture. On Wayland it drives
   `xdg-desktop-portal`'s ScreenCast interface and hands a PipeWire FD to
-  `gst-launch-1.0`.
+  `gst-launch-1.0`; on Xorg/Xvfb it runs GStreamer's `ximagesrc` directly.
 - **Window-targeted Wayland needs `xprop`.** `WaylandPortalWindowRecorder` queries the
   X11 `_GTK_FRAME_EXTENTS` property on the JFrame's XWayland window via the `xprop`
   binary to compute the right stream-relative crop (Mutter renders window-source streams
@@ -227,7 +252,9 @@ A few details worth knowing:
   package on minimal images. If `xprop` isn't available or the window's WM doesn't
   publish `_GTK_FRAME_EXTENTS` (older Mutter, non-GTK CSD, KDE / sway with server-side
   decorations), the recorder throws `IllegalStateException` rather than producing a
-  misaligned mp4. Use explicit region capture instead by calling `startRegion(...)`. See
+  misaligned mp4. Installing `xprop` only fixes the missing-binary case; Qt, JavaFX,
+  Electron, SDL, and other non-GTK windows may still lack the property. Use explicit
+  region capture instead by calling `startRegion(...)`. See
   [Recording limitations](../RECORDING-LIMITATIONS.md#platform) for more.
 
 ## Lower-level backends
@@ -236,10 +263,12 @@ If you know exactly which backend you want, instantiate it directly and skip the
 
 | Backend                       | Use it for                                                                |
 | ----------------------------- | ------------------------------------------------------------------------- |
-| `FfmpegRecorder`              | Region capture on macOS, Windows, and Linux Xorg. (Throws on Wayland — use `WaylandPortalRecorder` there.) Default for "no window in mind". |
+| `FfmpegRecorder`              | Deprecated legacy explicit region capture on macOS and explicit Windows/Linux ffmpeg backends. (Throws on Wayland — use `WaylandPortalRecorder` there.) |
 | `WindowsGraphicsCaptureRecorder` | Windows-only window-targeted and region/fullscreen capture via the `spectre-recording-windows` Windows Graphics Capture helper. |
-| `FfmpegWindowRecorder`        | Legacy explicit Windows-only window-targeted capture via `gdigrab title=`. |
+| `FfmpegWindowRecorder`        | Deprecated legacy explicit Windows-only window-targeted capture via `gdigrab title=`. |
 | `WindowsWindowScreenshotter`  | Windows-only still window screenshots via the `spectre-recording-windows` Windows Graphics Capture helper. |
+| `LinuxX11Recorder`            | Linux Xorg/Xvfb region and named-window capture via the `spectre-recording-linux` helper and GStreamer `ximagesrc`. |
+| `LinuxNativeScreenshotter`    | Linux Xorg/Xvfb screenshots via `ximagesrc`, and Linux Wayland screenshots via portal/PipeWire one-frame capture. |
 | `ScreenCaptureKitRecorder`    | macOS-only window-targeted capture via the `spectre-recording-macos` Swift helper. |
 | `WaylandPortalRecorder`       | Linux Wayland region capture via `xdg-desktop-portal` (`SourceType.MONITOR`) and the `spectre-recording-linux` Rust helper. |
 | `WaylandPortalWindowRecorder` | Linux Wayland window-targeted capture via `xdg-desktop-portal` (`SourceType.WINDOW`). Window-sized output containing only the picked window's pixels. |
@@ -293,13 +322,27 @@ trade-offs.
   `AutoRecorder.startRegion(...)` can fall back to `ffmpeg`/`gdigrab` when the helper
   artifact is absent; otherwise `ffmpeg` is only needed if you instantiate the explicit
   legacy ffmpeg backends.
-- **Linux Xorg** — `ffmpeg` with the `x11grab` input enabled (default in distro builds).
-- **Linux Wayland** — `gst-launch-1.0` plus the GStreamer plugins for H.264/Matroska.
-  Add `dev.sebastiano.spectre:spectre-recording-linux:<version>` as a runtime-only
-  dependency. Its jar carries the Rust helper under `native/linux/<arch>/`.
-  Recording requires a
-  Wayland compositor that exposes `org.freedesktop.portal.ScreenCast`; tested against
-  GNOME/mutter on Ubuntu 22.04 and 24.04.
+- **Linux Xorg/Xvfb** — add `dev.sebastiano.spectre:spectre-recording-linux:<version>`
+  as a runtime-only dependency. Runtime machines need `gst-launch-1.0` plus GStreamer
+  plugins for `ximagesrc`, H.264, MP4 muxing, PNG encoding, and colour conversion.
+  On Debian/Ubuntu:
+
+  ```bash
+  sudo apt install gstreamer1.0-tools gstreamer1.0-plugins-base \
+      gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly x11-utils
+  ```
+
+  `x11-utils` supplies `xprop` for window-mode metadata.
+- **Linux Wayland** — use the same `spectre-recording-linux` runtime dependency and
+  GStreamer packages, plus `gstreamer1.0-pipewire`, `xdg-desktop-portal`, and a Wayland
+  compositor that exposes `org.freedesktop.portal.ScreenCast`; tested against
+  GNOME/mutter on Ubuntu 22.04 and 24.04. On Debian/Ubuntu:
+
+  ```bash
+  sudo apt install gstreamer1.0-tools gstreamer1.0-plugins-base \
+      gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly \
+      gstreamer1.0-pipewire xdg-desktop-portal x11-utils
+  ```
 
 For the full set of trade-offs (frame drop behaviour, minimum dimensions, crop
 pitfalls, audio support) see [Recording limitations](../RECORDING-LIMITATIONS.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,8 +38,8 @@ familiar — Spectre brings the same "find a node, do a thing, assert" loop to C
   and can't fight over OS focus.
 - **Recording and screenshots built in.** Region capture, plus window-targeted recording
   and still screenshots where the platform exposes them (ScreenCaptureKit on macOS,
-  Windows Graphics Capture on Windows, x11grab fallback on Linux X11, portal video
-  capture on Wayland). The
+  Windows Graphics Capture on Windows, helper-driven Xorg/Xvfb and portal/PipeWire
+  capture on Linux). The
   [`AutoRecorder` and `AutoScreenshotter`](guide/recording.md) pick the right backend.
 - **JUnit-friendly.** Drop-in extension and rule for JUnit 5 and JUnit 4 manage a per-test
   automator instance for you.

--- a/recording/README.md
+++ b/recording/README.md
@@ -1,9 +1,9 @@
 # Recording
 
 Screen recording and native still-window screenshots for Spectre scenarios. Region capture
-(Windows Graphics Capture on Windows, ffmpeg on macOS / Linux Xorg, xdg-desktop-portal on
-Linux Wayland), window-targeted video capture, and still screenshot routing live side by
-side — pick by what you need.
+(Windows Graphics Capture on Windows, ffmpeg on macOS, the Linux helper/GStreamer on
+Xorg/Xvfb, xdg-desktop-portal on Linux Wayland), window-targeted video capture, and still
+screenshot routing live side by side — pick by what you need.
 
 The user-facing recorder capability matrix lives in
 [`docs/guide/recording.md`](../docs/guide/recording.md). This README is the in-tree
@@ -13,12 +13,16 @@ implementer's view of the same module.
 
 ### Region capture
 - `Recorder` — interface; produces a `RecordingHandle` for an in-progress capture.
-- `FfmpegRecorder` — ffmpeg-backed region capture. Shells out to a system `ffmpeg` and
+- `FfmpegRecorder` — deprecated legacy explicit ffmpeg-backed region capture. Shells out to a system `ffmpeg` and
   captures the requested region via `avfoundation` on macOS, legacy explicit `gdigrab` on
-  Windows, and `x11grab` on Linux Xorg. Throws on Linux Wayland — use
+  Windows, and legacy explicit `x11grab` on Linux Xorg. Throws on Linux Wayland — use
   `WaylandPortalRecorder` instead. Resolves the
   binary via `PATH` (`resolveFfmpegPath()`) by default; pass `ffmpegPath` to override (testing,
   non-`PATH` installs).
+- `LinuxX11Recorder` — Linux Xorg/Xvfb region and named-window capture through the bundled
+  Linux helper and GStreamer `ximagesrc`. This is the default Linux Xorg/Xvfb route used by
+  `AutoRecorder`; `ffmpeg` is no longer required for that path. The helper currently accepts
+  only `RecordingOptions.codec = "libx264"` or `"x264enc"` for recording.
 
 ### Window-targeted capture
 - `screencapturekit.ScreenCaptureKitRecorder` — forks a bundled Swift helper that drives
@@ -27,19 +31,20 @@ implementer's view of the same module.
   window moving across the screen. macOS only. Implements `WindowRecorder`.
 - `screencapturekit.WindowRecorder` — interface for window-targeted backends. SCK is the
   macOS implementation; `windows.WindowsGraphicsCaptureRecorder` covers Windows, and
-  `WaylandPortalWindowRecorder` covers Linux Wayland.
+  `LinuxX11Recorder`/`WaylandPortalWindowRecorder` cover Linux Xorg/Xvfb and Wayland.
 - `windows.WindowsGraphicsCaptureRecorder` — WGC + `MediaTranscoder` MP4 capture on Windows.
   Window mode follows the window across moves and captures the target window surface
   instead of a screen rectangle. Region/fullscreen mode records a fixed monitor rectangle.
   Both modes use the `spectre-recording-windows` runtime helper.
-- `FfmpegWindowRecorder` — legacy explicit `gdigrab title=` capture on Windows. Follows the
+- `FfmpegWindowRecorder` — deprecated legacy explicit `gdigrab title=` capture on Windows. Follows the
   window across moves and resizes; requires a non-blank exact title and `ffmpeg` on `PATH`.
 - `portal.WaylandPortalWindowRecorder` — Linux Wayland window-targeted capture via
   `xdg-desktop-portal`'s `SourceType.WINDOW`. Captures only the picked window's pixels (no
   leakage from occluding apps), but Spectre's crop is fixed at `start()` time — if the user
   moves or resizes the window during the recording, the crop no longer aligns with the
   window's pixels and the output is misaligned. Requires `xprop` and a compositor publishing
-  `_GTK_FRAME_EXTENTS` (validated on GNOME/Mutter).
+  `_GTK_FRAME_EXTENTS` (validated on GNOME/Mutter for GTK/XWayland windows; non-GTK toolkits
+  and other compositors may not publish it).
 
   Decision rationale + alternatives considered are written up in the bridge strategy doc kept
   in `.plans/`.
@@ -48,8 +53,9 @@ implementer's view of the same module.
 - `AutoRecorder` — high-level wrapper that takes a `WindowRecorder`, a `Recorder`, and the
   Linux portal recorders (when wired). Routing is Wayland-first (window-targeted portal,
   region portal, or loud failure if no portal recorder is wired), then macOS SCK for
-  window capture, Windows Graphics Capture for Windows window/region capture, and ffmpeg
-  region capture for macOS / Linux Xorg explicit regions. If the Windows WGC helper
+  window capture, Windows Graphics Capture for Windows window/region capture, Linux helper
+  capture for Linux Xorg/Xvfb window/region capture, and ffmpeg region capture for macOS.
+  If the Windows WGC helper
   artifact is absent, `startRegion(...)` falls back to the legacy ffmpeg `gdigrab`
   region path for compatibility. It also uses ffmpeg for Windows region calls with custom
   `RecordingOptions.codec` or `screenIndex`, because the WGC backend cannot honour those
@@ -57,19 +63,21 @@ implementer's view of the same module.
   (permissions denied, window not found, helper crash) propagate with actionable messages
   instead of silently changing capture semantics.
 - `AutoScreenshotter` — high-level still-image router. Uses ScreenCaptureKit window capture
-  on macOS, Windows Graphics Capture on Windows, and explicit `x11grab` region fallback on
-  Linux X11. Wayland still screenshots fail loudly for now; use `WaylandPortalWindowRecorder`
-  for window-scoped video until the helper can return image buffers.
+  on macOS, Windows Graphics Capture on Windows, and the Linux helper on Xorg/Xvfb and
+  Wayland. Wayland still screenshots require the compositor portal dialog to be accepted.
+  The explicit `FfmpegRegionScreenshotter` and `FfmpegWindowScreenshotter` classes are
+  deprecated legacy escape hatches.
 - `./gradlew :recording:runWindowScreenshotSmoke` — manual cross-platform smoke for
-  `AutoScreenshotter`. It writes a PNG on macOS, Windows, and Linux X11, and verifies the
-  expected unsupported message on Linux Wayland. For Wayland window-source video, run
-  `./gradlew :recording:runWaylandPortalWindowSmoke`.
+  `AutoScreenshotter`. It writes a PNG on macOS, Windows, Linux Xorg/Xvfb, and Linux
+  Wayland. For Wayland window-source video, run `./gradlew :recording:runWaylandPortalWindowSmoke`.
 
 ### Shared
-- `RecordingHandle` — `AutoCloseable`. Stop sends `q` on stdin (the documented clean-shutdown
-  signal for both ffmpeg and the ScreenCaptureKit helper), waits up to 5 s for a graceful exit,
-  then SIGTERM / SIGKILL fallback.
+- `RecordingHandle` — `AutoCloseable`. Stop uses the backend's clean-shutdown path (`q` for
+  ffmpeg/SCK-style helpers, JSON `Stop` for the Linux helper), waits for a graceful exit, then
+  escalates to process termination when the backend supports that lifecycle.
 - `RecordingOptions` — frame rate, cursor capture, codec.
+  Custom codecs are ffmpeg-backend-specific today; the Linux helper/GStreamer path rejects
+  non-x264 codec strings until encoder pipelines are represented structurally.
 - `MacOsRecordingPermissions.diagnose()` — best-effort startup diagnostic for Screen Recording
   and Accessibility permissions. Full native detection (`CGPreflightScreenCaptureAccess`,
   `AXIsProcessTrusted`) is a future improvement — the SCK helper detects TCC denial by exit
@@ -79,14 +87,16 @@ implementer's view of the same module.
 
 | Capability | Status |
 |---|---|
-| macOS region capture (`avfoundation`) | ✅ `FfmpegRecorder` |
+| macOS region capture (`avfoundation`) | ✅ deprecated `FfmpegRecorder` |
 | macOS window-targeted capture (ScreenCaptureKit) | ✅ `ScreenCaptureKitRecorder` |
 | Embedded `ComposePanel` (`windowHandle == 0L`) | ✅ region capture (window-targeted not applicable) |
 | Windows region/fullscreen capture (Windows Graphics Capture) | ✅ `WindowsGraphicsCaptureRecorder` |
-| Windows legacy region capture (`gdigrab`) | ✅ `FfmpegRecorder` |
+| Windows legacy region capture (`gdigrab`) | ✅ deprecated `FfmpegRecorder` |
 | Windows window-targeted capture (Windows Graphics Capture) | ✅ `WindowsGraphicsCaptureRecorder` |
-| Windows legacy window-targeted capture (`gdigrab title=`) | ✅ `FfmpegWindowRecorder` |
-| Linux Xorg region capture (`x11grab`) | ✅ `FfmpegRecorder` |
+| Windows legacy window-targeted capture (`gdigrab title=`) | ✅ deprecated `FfmpegWindowRecorder` |
+| Linux Xorg/Xvfb region/window capture (`ximagesrc`) | ✅ `LinuxX11Recorder` |
+| Linux Xorg legacy explicit region capture (`x11grab`) | ✅ deprecated `FfmpegRecorder` |
+| Linux still screenshots (`ximagesrc` or portal/PipeWire) | ✅ `LinuxNativeScreenshotter` |
 | Linux Wayland region capture (xdg-desktop-portal) | ✅ `WaylandPortalRecorder` |
 | Linux Wayland window-targeted capture (xdg-desktop-portal `SourceType.WINDOW`) | ✅ `WaylandPortalWindowRecorder` (fixed crop at `start()` — moves and resizes during recording break alignment) |
 | Audio | ⏸ deferred — add when asked |
@@ -271,7 +281,7 @@ permission grant needed for it.
 ## Build matrix: which helpers each host can produce
 
 Spectre's recording module ships three native helpers — the macOS ScreenCaptureKit helper
-(Swift, requires `swiftc` + macOS frameworks), the Linux Wayland helper (Rust, requires
+(Swift, requires `swiftc` + macOS frameworks), the Linux capture helper (Rust, requires
 `cargo` + `libdbus-1-dev`), and the Windows Graphics Capture helper (.NET 8 SDK). The
 macOS and Linux toolchains do not work cross-host, while the Windows helper is built on
 Windows for both x64 and arm64. The recording jar's layout is host-agnostic — the
@@ -282,10 +292,10 @@ needs is missing.
 
 | Host                | Default `./gradlew :recording:build`                                 | `-PuniversalHelper`               | `-PallLinuxArches`                                      |
 | ------------------- | -------------------------------------------------------------------- | --------------------------------- | ------------------------------------------------------- |
-| macOS (arm64)       | host-arch SCK (`native/macos/spectre-screencapture` thin arm64)      | universal SCK (arm64 + x86_64)    | no-op (host can't build Wayland helper)                 |
+| macOS (arm64)       | host-arch SCK (`native/macos/spectre-screencapture` thin arm64)      | universal SCK (arm64 + x86_64)    | no-op (host can't build Linux helper)                   |
 | macOS (x86_64)      | host-arch SCK (thin x86_64)                                          | universal SCK (arm64 + x86_64)    | no-op (same)                                            |
-| Linux x86_64        | host-arch Wayland (`native/linux/x86_64/spectre-wayland-helper`)     | no-op (host can't build SCK)      | x86_64 + aarch64 Wayland helpers                        |
-| Linux aarch64       | host-arch Wayland (`native/linux/aarch64/spectre-wayland-helper`)    | no-op (same)                      | x86_64 + aarch64 Wayland helpers                        |
+| Linux x86_64        | host-arch Linux helper (`native/linux/x86_64/spectre-wayland-helper`) | no-op (host can't build SCK)      | x86_64 + aarch64 Linux helpers                          |
+| Linux aarch64       | host-arch Linux helper (`native/linux/aarch64/spectre-wayland-helper`) | no-op (same)                      | x86_64 + aarch64 Linux helpers                          |
 | Windows             | x64 + arm64 WGC helper (`native/windows/<arch>/spectre-window-capture.exe`) | no-op                             | no-op                                                   |
 
 ### Project-property reference
@@ -297,7 +307,7 @@ needs is missing.
   universal helper, archives it, and submits it to Apple notarization via
   `xcrun notarytool`. Only used by the release workflow; needs Developer ID + notary
   credentials in env vars.
-- `-PallLinuxArches` — on Linux hosts, cross-compile both `x86_64` and `aarch64` Wayland
+- `-PallLinuxArches` — on Linux hosts, cross-compile both `x86_64` and `aarch64` Linux
   helpers from a single host. Requires the Rust `rustup target add` for the foreign
   arch and the matching cross-linker (`gcc-aarch64-linux-gnu` / `gcc-x86_64-linux-gnu`)
   plus the foreign-arch `libdbus-1-dev` sysroot. The CI workflow at
@@ -316,7 +326,7 @@ generated resources staged by `:recording`'s native build tasks:
 - `:recording-windows` expects both `native/windows/x64/spectre-window-capture.exe` and
   `native/windows/arm64/spectre-window-capture.exe` on Windows.
 
-When `-PallLinuxArches` is set the task expects both `x86_64` and `aarch64` Wayland
+When `-PallLinuxArches` is set the task expects both `x86_64` and `aarch64` Linux
 helpers. CI invokes it as
 
     ./gradlew :recording-linux:verifyRecordingLinuxHelpers -PallLinuxArches
@@ -331,7 +341,7 @@ artifacts:
 
 - `spectre-recording` — API/common JVM implementation only.
 - `spectre-recording-macos` — signed and notarized universal ScreenCaptureKit helper.
-- `spectre-recording-linux` — x86_64 and aarch64 Wayland helpers.
+- `spectre-recording-linux` — x86_64 and aarch64 Linux helpers.
 - `spectre-recording-windows` — x64 and arm64 Windows Graphics Capture helpers.
 
 Local builds still produce a host-shaped subset of helpers unless you opt into the

--- a/recording/api/recording.api
+++ b/recording/api/recording.api
@@ -53,6 +53,18 @@ public final class dev/sebastiano/spectre/recording/FfmpegWindowScreenshotter : 
 	public fun captureWindow (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;J)Ljava/awt/image/BufferedImage;
 }
 
+public final class dev/sebastiano/spectre/recording/LinuxNativeScreenshotter : dev/sebastiano/spectre/recording/RegionScreenshotter, dev/sebastiano/spectre/recording/WindowScreenshotter {
+	public fun <init> ()V
+	public fun captureRegion (Ljava/awt/Rectangle;)Ljava/awt/image/BufferedImage;
+	public fun captureWindow (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;J)Ljava/awt/image/BufferedImage;
+}
+
+public final class dev/sebastiano/spectre/recording/LinuxX11Recorder : dev/sebastiano/spectre/recording/Recorder, dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder {
+	public fun <init> ()V
+	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public fun start (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+}
+
 public final class dev/sebastiano/spectre/recording/MacOsRecordingPermissions {
 	public static final field INSTANCE Ldev/sebastiano/spectre/recording/MacOsRecordingPermissions;
 	public final fun diagnose ()Ldev/sebastiano/spectre/recording/PermissionDiagnostic;

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -5,7 +5,7 @@ import org.gradle.language.jvm.tasks.ProcessResources
 
 /**
  * Maps the host's `os.arch` system property to the Rust target-triple architecture name we ship the
- * Wayland helper under. JVM reports `amd64` for x86_64; Rust's targets call it `x86_64`. Same for
+ * Linux helper under. JVM reports `amd64` for x86_64; Rust's targets call it `x86_64`. Same for
  * `aarch64` (consistent with both JVM and Rust). Anything else falls through unchanged — the
  * recorder's [WaylandHelperBinaryExtractor] will surface a HelperNotBundledException naming the
  * unknown arch, which is more useful than a silent layout mismatch.
@@ -24,7 +24,7 @@ plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.kotlinJvm)
-    // kotlinx.serialization for the Wayland helper's JSON wire protocol (#77 stage 3).
+    // kotlinx.serialization for the Linux helper's JSON wire protocol.
     alias(libs.plugins.kotlinSerialization)
     // See `:core`'s build script for the rationale on the shared publish convention. Per-module
     // POM scalars live in this module's own `gradle.properties`. This module publishes the
@@ -47,10 +47,9 @@ dependencies {
     implementation(libs.kotlinx.coroutines.core)
 
     // kotlinx.serialization-json for the JVM ↔ spectre-wayland-helper protocol. The helper
-    // is a small Rust binary at `recording/native/linux/` that drives the xdg-desktop-portal
-    // handshake, holds the PipeWire FD, and spawns `gst-launch-1.0` with the FD inherited.
-    // The JVM talks to it over stdin/stdout via newline-delimited JSON. See
-    // [WaylandPortalRecorder] for the lifecycle.
+    // is a small Rust binary at `recording/native/linux/` that handles Linux capture:
+    // xdg-desktop-portal/PipeWire on Wayland and GStreamer `ximagesrc` on X11/XWayland.
+    // The JVM talks to it over stdin/stdout via newline-delimited JSON.
     implementation(libs.kotlinx.serialization.json)
 
     detektPlugins(libs.compose.rules.detekt)
@@ -535,14 +534,13 @@ tasks.named<ProcessResources>("processTestResources") {
 // host-platform mac build path: when a pre-built (or stub) helper is staged, the host build
 // would only overwrite the same destination and produce a jar inconsistent with the artefact
 // promised by the release CI. The host build is silenced when either prebuilt path is set.
-// --- Wayland Rust helper binary (issue #80) -------------------------------------------------
+// --- Linux Rust helper binary ---------------------------------------------------------------
 //
-// `WaylandPortalRecorder` ships a small Rust CLI (`recording/native/linux/`) that drives the
-// xdg-desktop-portal ScreenCast handshake, holds the PipeWire FD, and spawns gst-launch with
-// the FD inherited. The shape mirrors the macOS SCK helper above — out-of-process boundary,
-// stdin/stdout JSON protocol, jar-bundled per-arch — and the rationale for going native is
-// also the same: the JVM-side stage-2 attempt with dbus-java + JNR-POSIX hit a UnixFD-
-// unmarshalling bug that wasn't fixable trivially. See #80 comments for the bake-off log.
+// The Linux recorders ship a small Rust CLI (`recording/native/linux/`) that owns
+// GStreamer capture. On Wayland it drives the xdg-desktop-portal ScreenCast handshake,
+// holds the PipeWire FD, and spawns gst-launch with the FD inherited; on X11/XWayland it
+// spawns gst-launch with `ximagesrc`. The shape mirrors the macOS SCK helper above:
+// out-of-process boundary, stdin/stdout JSON protocol, jar-bundled per-arch.
 //
 // Build pipeline (Linux only — no-op on macOS/Windows):
 //   1. `cargo build --release` produces `target/release/spectre-wayland-helper`.
@@ -564,7 +562,7 @@ val waylandHelperResourceDest =
 
 val buildWaylandHelper by
     tasks.registering(Exec::class) {
-        description = "Builds the Linux Wayland Rust helper for the host architecture."
+        description = "Builds the Linux Rust helper for the host architecture."
         group = "build"
         onlyIf { OperatingSystem.current().isLinux }
         workingDir = waylandHelperSource.asFile
@@ -576,7 +574,7 @@ val buildWaylandHelper by
 
 val assembleWaylandHelper by
     tasks.registering(Copy::class) {
-        description = "Stages the Wayland helper binary into the resources tree."
+        description = "Stages the Linux helper binary into the resources tree."
         group = "build"
         onlyIf { OperatingSystem.current().isLinux }
         dependsOn(buildWaylandHelper)
@@ -647,7 +645,7 @@ val perArchCargoBuildTasks = linuxHelperTargets.map { target ->
     val perArchOutput =
         waylandHelperSource.dir("target/${target.triple}/release").file("spectre-wayland-helper")
     tasks.register<Exec>(taskName) {
-        description = "Cross-builds the Wayland helper for ${target.arch}."
+        description = "Cross-builds the Linux helper for ${target.arch}."
         group = "build"
         onlyIf { OperatingSystem.current().isLinux }
         workingDir = waylandHelperSource.asFile
@@ -685,7 +683,7 @@ val perArchStageTasks =
                 .dir("target/${target.triple}/release")
                 .file("spectre-wayland-helper")
         tasks.register<Copy>(taskName) {
-            description = "Stages the ${target.arch} Wayland helper into the resources tree."
+            description = "Stages the ${target.arch} Linux helper into the resources tree."
             group = "build"
             onlyIf { OperatingSystem.current().isLinux }
             dependsOn(buildTask)
@@ -696,7 +694,7 @@ val perArchStageTasks =
 
 val assembleWaylandHelperAllArches by tasks.registering {
     description =
-        "Stages the Wayland helper binary for both x86_64 and aarch64 Linux. Opt-in for " +
+        "Stages the Linux helper binary for both x86_64 and aarch64 Linux. Opt-in for " +
             "distribution builds (slower than host-arch). Wire into processResources by " +
             "passing -PallLinuxArches at invocation time."
     group = "build"
@@ -717,7 +715,7 @@ val useAllLinuxArches = providers.gradleProperty("allLinuxArches").isPresent
 // --- Pre-built native helpers for the release pipeline (#84) --------------------------------
 //
 // The release CI fans out: a macOS runner builds + signs + notarises the universal SCK
-// helper, a Linux runner cross-builds the x86_64 + aarch64 Wayland helpers, and a third
+// helper, a Linux runner cross-builds the x86_64 + aarch64 Linux helpers, and a third
 // "publish" job downloads both artefacts and runs the actual Maven Central upload from a
 // single host. The publish job's host OS can't rebuild every helper itself, so it stages
 // the pre-built ones via the project properties below and overrides the host-platform
@@ -810,7 +808,7 @@ val linuxHelpersDestDir: File =
 val stagePrebuiltLinuxHelpers by
     tasks.registering(Copy::class) {
         description =
-            "Stages pre-built Linux Wayland helpers from a directory tree. Sourced from " +
+            "Stages pre-built Linux helpers from a directory tree. Sourced from " +
                 "-PprebuiltLinuxHelpersDir=<dir> which must contain " +
                 "`x86_64/spectre-wayland-helper` and `aarch64/spectre-wayland-helper`."
         group = "build"
@@ -844,8 +842,8 @@ tasks.register<JavaExec>("runScreenCaptureKitSmoke") {
 }
 
 // Manual still-screenshot smoke for AutoScreenshotter. Opens a JFrame and writes a PNG on
-// macOS/Windows/Linux X11; on Linux Wayland it verifies the current unsupported still-image
-// contract and points users at the window-targeted portal video smoke.
+// macOS/Windows/Linux X11/XWayland/Linux Wayland. Wayland runs through the compositor's
+// portal dialog, so manual acceptance may be required.
 tasks.register<JavaExec>("runWindowScreenshotSmoke") {
     group = "verification"
     description =
@@ -905,7 +903,7 @@ tasks.register<JavaExec>("runFfmpegGdigrabSmoke") {
     mainClass.set("dev.sebastiano.spectre.recording.FfmpegGdigrabSmoke")
 }
 
-// Manual smoke for the Linux x11grab path (#75). Counterpart to the gdigrab/SCK smokes.
+// Manual smoke for the legacy explicit Linux x11grab path. Counterpart to the gdigrab/SCK smokes.
 // Requires a working X display (`DISPLAY` env var) — Wayland-only sessions without XWayland
 // will fail at ffmpeg-spawn time, which is the right failure mode for a manual smoke.
 tasks.register<JavaExec>("runFfmpegX11GrabSmoke") {
@@ -916,7 +914,17 @@ tasks.register<JavaExec>("runFfmpegX11GrabSmoke") {
     mainClass.set("dev.sebastiano.spectre.recording.FfmpegX11GrabSmoke")
 }
 
-// Manual smoke for the Wayland portal + PipeWire path (#77 stage 3). Pops the compositor's
+tasks.register<JavaExec>("runLinuxX11RecordingSmoke") {
+    group = "verification"
+    description =
+        "Boots a JFrame, records it for ~3s via the Linux helper's X11/XWayland path, " +
+            "prints output stats."
+    onlyIf { OperatingSystem.current().isLinux }
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.sebastiano.spectre.recording.LinuxX11RecordingSmoke")
+}
+
+// Manual smoke for the Wayland portal + PipeWire path. Pops the compositor's
 // screen-cast permission dialog on first run; subsequent runs reuse the grant. Linux-only
 // — the JVM-side recorder spawns the `spectre-wayland-helper` Rust binary that does the
 // portal D-Bus handshake + FD-passing into gst-launch.

--- a/recording/native/linux/src/gst.rs
+++ b/recording/native/linux/src/gst.rs
@@ -40,6 +40,18 @@ use crate::protocol::Region;
 use anyhow::{bail, Result};
 use std::path::Path;
 
+#[derive(Debug, Clone)]
+pub enum X11CaptureTarget {
+    Region {
+        display_name: Option<String>,
+        region: Region,
+    },
+    Window {
+        display_name: Option<String>,
+        title: String,
+    },
+}
+
 /// Build the argv list for `gst-launch-1.0` consuming the portal-granted PipeWire stream.
 /// Always emits `-e` (EOS-on-SIGTERM) — the recorder lifecycle relies on SIGTERM for clean
 /// shutdown.
@@ -139,29 +151,266 @@ pub fn build_pipewire_argv(
         "videoconvert".to_string(),
         "!".to_string(),
     ];
-    // x264 is the default codec. Other values are passed through unmodified — accepting any
-    // GStreamer encoder name here (e.g. `x265enc` for HEVC, `vaapih264enc` for hardware-
-    // accelerated H.264) without re-coding tuning flags.
-    if codec == "libx264" || codec == "x264enc" {
-        argv.extend([
-            "x264enc".to_string(),
-            "tune=zerolatency".to_string(),
-            "speed-preset=ultrafast".to_string(),
-            "!".to_string(),
-            "h264parse".to_string(),
-        ]);
-    } else {
-        argv.push(codec.to_string());
-    }
+    push_x264_encoder(&mut argv, codec)?;
     argv.extend([
         "!".to_string(),
         "mp4mux".to_string(),
         "faststart=true".to_string(),
         "!".to_string(),
         "filesink".to_string(),
-        format!("location={}", output.display()),
+        gst_string_property("location", &output.display().to_string()),
     ]);
     Ok(argv)
+}
+
+pub fn build_pipewire_png_argv(
+    pipewire_node_id: u32,
+    pipewire_fd: i32,
+    region: Region,
+    stream_size: (u32, u32),
+    output: &Path,
+) -> Result<Vec<String>> {
+    let (top, bottom, left, right) = pipewire_crop_insets(pipewire_fd, region, stream_size)?;
+    Ok(vec![
+        "gst-launch-1.0".to_string(),
+        "-q".to_string(),
+        "pipewiresrc".to_string(),
+        "num-buffers=1".to_string(),
+        format!("fd={pipewire_fd}"),
+        format!("path={pipewire_node_id}"),
+        "do-timestamp=true".to_string(),
+        "always-copy=true".to_string(),
+        "!".to_string(),
+        "videocrop".to_string(),
+        format!("top={top}"),
+        format!("bottom={bottom}"),
+        format!("left={left}"),
+        format!("right={right}"),
+        "!".to_string(),
+        "videoconvert".to_string(),
+        "!".to_string(),
+        "pngenc".to_string(),
+        "!".to_string(),
+        "filesink".to_string(),
+        gst_string_property("location", &output.display().to_string()),
+    ])
+}
+
+pub fn build_x11_recording_argv(
+    target: X11CaptureTarget,
+    frame_rate: u32,
+    capture_cursor: bool,
+    output: &Path,
+    codec: &str,
+) -> Result<Vec<String>> {
+    let mut argv = vec!["gst-launch-1.0".to_string(), "-e".to_string()];
+    append_x11_source(&mut argv, target, capture_cursor, false)?;
+    argv.extend([
+        "!".to_string(),
+        "videorate".to_string(),
+        "!".to_string(),
+        format!("video/x-raw,framerate={frame_rate}/1"),
+        "!".to_string(),
+        "videoconvert".to_string(),
+        "!".to_string(),
+    ]);
+    push_x264_encoder(&mut argv, codec)?;
+    argv.extend([
+        "!".to_string(),
+        "mp4mux".to_string(),
+        "faststart=true".to_string(),
+        "!".to_string(),
+        "filesink".to_string(),
+        gst_string_property("location", &output.display().to_string()),
+    ]);
+    Ok(argv)
+}
+
+pub fn build_x11_png_argv(
+    target: X11CaptureTarget,
+    capture_cursor: bool,
+    output: &Path,
+) -> Result<Vec<String>> {
+    let mut argv = vec!["gst-launch-1.0".to_string(), "-q".to_string()];
+    append_x11_source(&mut argv, target, capture_cursor, true)?;
+    argv.extend([
+        "!".to_string(),
+        "videoconvert".to_string(),
+        "!".to_string(),
+        "pngenc".to_string(),
+        "!".to_string(),
+        "filesink".to_string(),
+        gst_string_property("location", &output.display().to_string()),
+    ]);
+    Ok(argv)
+}
+
+fn append_x11_source(
+    argv: &mut Vec<String>,
+    target: X11CaptureTarget,
+    capture_cursor: bool,
+    one_frame: bool,
+) -> Result<()> {
+    argv.push("ximagesrc".to_string());
+    if one_frame {
+        argv.push("num-buffers=1".to_string());
+    }
+    match target {
+        X11CaptureTarget::Region {
+            display_name,
+            region,
+        } => {
+            let (end_x, end_y) = x11_inclusive_end(region)?;
+            if let Some(display) = non_blank(display_name) {
+                argv.push(gst_string_property("display-name", &display));
+            }
+            argv.extend([
+                format!("startx={}", region.x),
+                format!("starty={}", region.y),
+                format!("endx={end_x}"),
+                format!("endy={end_y}"),
+            ]);
+        }
+        X11CaptureTarget::Window {
+            display_name,
+            title,
+        } => {
+            let title = title.trim();
+            if title.is_empty() {
+                bail!("X11 window capture requires a non-blank window title");
+            }
+            if let Some(display) = non_blank(display_name) {
+                argv.push(gst_string_property("display-name", &display));
+            }
+            argv.push(gst_string_property("xname", title));
+        }
+    }
+    argv.extend([
+        format!("show-pointer={capture_cursor}"),
+        // XDamage can skip unchanged regions in a way that is efficient for live display but
+        // brittle for short smoke recordings and one-frame screenshots. Force full-frame reads.
+        "use-damage=false".to_string(),
+    ]);
+    Ok(())
+}
+
+fn push_x264_encoder(argv: &mut Vec<String>, codec: &str) -> Result<()> {
+    match codec.trim() {
+        "libx264" | "x264enc" => {
+            argv.extend([
+                "x264enc".to_string(),
+                "tune=zerolatency".to_string(),
+                "speed-preset=ultrafast".to_string(),
+                "!".to_string(),
+                "h264parse".to_string(),
+            ]);
+            Ok(())
+        }
+        other => bail!(
+            "Linux GStreamer recording currently supports RecordingOptions.codec values \
+             'libx264' and 'x264enc' only; got '{other}'. Arbitrary GStreamer encoder names \
+             need a structured pipeline builder so parser stages and encoder properties can be \
+             represented safely."
+        ),
+    }
+}
+
+fn gst_string_property(name: &str, value: &str) -> String {
+    format!("{name}={}", gst_quote(value))
+}
+
+fn gst_quote(value: &str) -> String {
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+fn x11_inclusive_end(region: Region) -> Result<(i64, i64)> {
+    validate_positive_region(region)?;
+    if region.x < 0 || region.y < 0 {
+        bail!(
+            "X11 ximagesrc requires non-negative region origins, was ({}, {})",
+            region.x,
+            region.y
+        );
+    }
+    Ok((
+        region.x as i64 + region.width as i64 - 1,
+        region.y as i64 + region.height as i64 - 1,
+    ))
+}
+
+fn pipewire_crop_insets(
+    pipewire_fd: i32,
+    region: Region,
+    stream_size: (u32, u32),
+) -> Result<(u32, u32, u32, u32)> {
+    validate_positive_region(region)?;
+    if region.x < 0 || region.y < 0 {
+        bail!(
+            "region origin must be non-negative for the videocrop filter, was ({}, {})",
+            region.x,
+            region.y
+        );
+    }
+    if pipewire_fd < 0 {
+        bail!(
+            "pipewire_fd must be a valid Unix FD (>= 0), was {}. Did OpenPipeWireRemote \
+             return a valid descriptor?",
+            pipewire_fd
+        );
+    }
+    let (stream_w, stream_h) = stream_size;
+    if stream_w == 0 || stream_h == 0 {
+        bail!(
+            "stream_size must have positive dimensions, was {}x{}",
+            stream_w,
+            stream_h
+        );
+    }
+    let region_right = region.x as i64 + region.width as i64;
+    let region_bottom = region.y as i64 + region.height as i64;
+    if region_right > stream_w as i64 {
+        bail!(
+            "region right edge {} exceeds stream width {}",
+            region_right,
+            stream_w
+        );
+    }
+    if region_bottom > stream_h as i64 {
+        bail!(
+            "region bottom edge {} exceeds stream height {}",
+            region_bottom,
+            stream_h
+        );
+    }
+    Ok((
+        region.y as u32,
+        stream_h - region_bottom as u32,
+        region.x as u32,
+        stream_w - region_right as u32,
+    ))
+}
+
+fn validate_positive_region(region: Region) -> Result<()> {
+    if region.width <= 0 || region.height <= 0 {
+        bail!(
+            "region must have positive dimensions, was {}x{}",
+            region.width,
+            region.height
+        );
+    }
+    Ok(())
+}
+
+fn non_blank(value: Option<String>) -> Option<String> {
+    value.and_then(|s| {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    })
 }
 
 #[cfg(test)]
@@ -224,7 +473,13 @@ mod tests {
         let argv = argv_for_default();
         assert_contains_sequence(
             &argv,
-            &["videocrop", "top=200", "bottom=400", "left=100", "right=1180"],
+            &[
+                "videocrop",
+                "top=200",
+                "bottom=400",
+                "left=100",
+                "right=1180",
+            ],
         );
     }
 
@@ -263,7 +518,7 @@ mod tests {
                 "faststart=true",
                 "!",
                 "filesink",
-                "location=/tmp/spectre/out.mp4",
+                "location=\"/tmp/spectre/out.mp4\"",
             ],
         );
     }
@@ -271,13 +526,25 @@ mod tests {
     #[test]
     fn argv_rejects_zero_or_negative_region_dimensions() {
         let bad_w_zero = build_pipewire_argv(
-            42, 17, region(0, 0, 0, 100), (1920, 1080), 30, true,
-            &PathBuf::from("/tmp/x"), "libx264",
+            42,
+            17,
+            region(0, 0, 0, 100),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
         );
         assert!(bad_w_zero.is_err(), "zero width should be rejected");
         let bad_h_zero = build_pipewire_argv(
-            42, 17, region(0, 0, 100, 0), (1920, 1080), 30, true,
-            &PathBuf::from("/tmp/x"), "libx264",
+            42,
+            17,
+            region(0, 0, 100, 0),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
         );
         assert!(bad_h_zero.is_err(), "zero height should be rejected");
 
@@ -286,13 +553,25 @@ mod tests {
         // domain check rejects both at once with a clear error rather than letting them
         // wrap into giant unsigned values further down the videocrop math.
         let bad_w_neg = build_pipewire_argv(
-            42, 17, region(0, 0, -10, 100), (1920, 1080), 30, true,
-            &PathBuf::from("/tmp/x"), "libx264",
+            42,
+            17,
+            region(0, 0, -10, 100),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
         );
         assert!(bad_w_neg.is_err(), "negative width should be rejected");
         let bad_h_neg = build_pipewire_argv(
-            42, 17, region(0, 0, 100, -5), (1920, 1080), 30, true,
-            &PathBuf::from("/tmp/x"), "libx264",
+            42,
+            17,
+            region(0, 0, 100, -5),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
         );
         assert!(bad_h_neg.is_err(), "negative height should be rejected");
     }
@@ -303,13 +582,25 @@ mod tests {
         // crops. Reject up-front so a misconfigured caller doesn't silently produce a
         // black mp4 the way the JVM/JNR-POSIX bake-off attempt did.
         let bad_x = build_pipewire_argv(
-            42, 17, region(-1, 0, 100, 100), (1920, 1080), 30, true,
-            &PathBuf::from("/tmp/x"), "libx264",
+            42,
+            17,
+            region(-1, 0, 100, 100),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
         );
         assert!(bad_x.is_err(), "negative x should be rejected");
         let bad_y = build_pipewire_argv(
-            42, 17, region(0, -10, 100, 100), (1920, 1080), 30, true,
-            &PathBuf::from("/tmp/x"), "libx264",
+            42,
+            17,
+            region(0, -10, 100, 100),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
         );
         assert!(bad_y.is_err(), "negative y should be rejected");
     }
@@ -317,15 +608,33 @@ mod tests {
     #[test]
     fn argv_rejects_region_exceeding_stream_bounds() {
         let too_wide = build_pipewire_argv(
-            42, 17, region(0, 0, 2000, 100), (1920, 1080), 30, true,
-            &PathBuf::from("/tmp/x"), "libx264",
+            42,
+            17,
+            region(0, 0, 2000, 100),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
         );
-        assert!(too_wide.is_err(), "region wider than stream should be rejected");
+        assert!(
+            too_wide.is_err(),
+            "region wider than stream should be rejected"
+        );
         let too_tall = build_pipewire_argv(
-            42, 17, region(0, 0, 100, 2000), (1920, 1080), 30, true,
-            &PathBuf::from("/tmp/x"), "libx264",
+            42,
+            17,
+            region(0, 0, 100, 2000),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
         );
-        assert!(too_tall.is_err(), "region taller than stream should be rejected");
+        assert!(
+            too_tall.is_err(),
+            "region taller than stream should be rejected"
+        );
     }
 
     #[test]
@@ -335,9 +644,193 @@ mod tests {
         // nodes. Reject up-front so a misconfigured caller doesn't silently produce a
         // black mp4.
         let bad = build_pipewire_argv(
-            42, -1, region(0, 0, 100, 100), (1920, 1080), 30, true,
-            &PathBuf::from("/tmp/x"), "libx264",
+            42,
+            -1,
+            region(0, 0, 100, 100),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
         );
-        assert!(bad.is_err(), "fd=-1 should be rejected (would produce 0-byte mp4)");
+        assert!(
+            bad.is_err(),
+            "fd=-1 should be rejected (would produce 0-byte mp4)"
+        );
+    }
+
+    #[test]
+    fn x11_region_recording_argv_uses_ximagesrc_bounds_without_ffmpeg() {
+        let argv = build_x11_recording_argv(
+            X11CaptureTarget::Region {
+                display_name: Some(":0".to_string()),
+                region: region(10, 20, 30, 40),
+            },
+            30,
+            false,
+            &PathBuf::from("/tmp/spectre/out.mp4"),
+            "libx264",
+        )
+        .unwrap();
+
+        assert_eq!(argv[0], "gst-launch-1.0");
+        assert_contains_sequence(
+            &argv,
+            &[
+                "ximagesrc",
+                "display-name=\":0\"",
+                "startx=10",
+                "starty=20",
+                "endx=39",
+                "endy=59",
+                "show-pointer=false",
+            ],
+        );
+        assert!(
+            !argv.iter().any(|arg| arg.contains("ffmpeg")),
+            "argv must not use ffmpeg"
+        );
+    }
+
+    #[test]
+    fn x11_window_recording_argv_targets_named_window() {
+        let argv = build_x11_recording_argv(
+            X11CaptureTarget::Window {
+                display_name: None,
+                title: "Spectre smoke".to_string(),
+            },
+            15,
+            true,
+            &PathBuf::from("/tmp/spectre/window.mp4"),
+            "libx264",
+        )
+        .unwrap();
+
+        assert_contains_sequence(
+            &argv,
+            &[
+                "ximagesrc",
+                "xname=\"Spectre smoke\"",
+                "show-pointer=true",
+                "use-damage=false",
+            ],
+        );
+        assert_contains_sequence(&argv, &["videorate", "!", "video/x-raw,framerate=15/1"]);
+    }
+
+    #[test]
+    fn x11_window_recording_argv_quotes_window_titles_for_gst_parse_launch() {
+        let argv = build_x11_recording_argv(
+            X11CaptureTarget::Window {
+                display_name: Some(":0".to_string()),
+                title: "Spectre \"smoke\" window".to_string(),
+            },
+            15,
+            true,
+            &PathBuf::from("/tmp/spectre/window with spaces.mp4"),
+            "libx264",
+        )
+        .unwrap();
+
+        assert_contains_sequence(
+            &argv,
+            &[
+                "ximagesrc",
+                "display-name=\":0\"",
+                "xname=\"Spectre \\\"smoke\\\" window\"",
+            ],
+        );
+        assert_contains_sequence(
+            &argv,
+            &[
+                "filesink",
+                "location=\"/tmp/spectre/window with spaces.mp4\"",
+            ],
+        );
+    }
+
+    #[test]
+    fn gstreamer_recording_argv_rejects_unsupported_codecs() {
+        let pipewire = build_pipewire_argv(
+            42,
+            17,
+            region(0, 0, 100, 100),
+            (1920, 1080),
+            30,
+            true,
+            &PathBuf::from("/tmp/out.mp4"),
+            "x265enc",
+        );
+        assert!(pipewire.is_err(), "x265enc needs an explicit parser stage");
+
+        let x11 = build_x11_recording_argv(
+            X11CaptureTarget::Region {
+                display_name: None,
+                region: region(0, 0, 100, 100),
+            },
+            30,
+            true,
+            &PathBuf::from("/tmp/out.mp4"),
+            "vaapih264enc bitrate=8000",
+        );
+        assert!(
+            x11.is_err(),
+            "multi-token encoder strings must not be passed through"
+        );
+    }
+
+    #[test]
+    fn x11_region_png_argv_captures_one_frame() {
+        let argv = build_x11_png_argv(
+            X11CaptureTarget::Region {
+                display_name: Some(":1".to_string()),
+                region: region(0, 0, 20, 10),
+            },
+            false,
+            &PathBuf::from("/tmp/spectre/shot.png"),
+        )
+        .unwrap();
+
+        assert_contains_sequence(
+            &argv,
+            &[
+                "ximagesrc",
+                "num-buffers=1",
+                "display-name=\":1\"",
+                "startx=0",
+                "starty=0",
+                "endx=19",
+                "endy=9",
+            ],
+        );
+        assert_contains_sequence(&argv, &["videoconvert", "!", "pngenc", "!", "filesink"]);
+    }
+
+    #[test]
+    fn pipewire_png_argv_uses_one_portal_frame_with_region_crop() {
+        let argv = build_pipewire_png_argv(
+            42,
+            17,
+            region(10, 20, 30, 40),
+            (100, 90),
+            &PathBuf::from("/tmp/spectre/wayland.png"),
+        )
+        .unwrap();
+
+        assert_contains_sequence(
+            &argv,
+            &[
+                "pipewiresrc",
+                "num-buffers=1",
+                "fd=17",
+                "path=42",
+                "do-timestamp=true",
+            ],
+        );
+        assert_contains_sequence(
+            &argv,
+            &["videocrop", "top=20", "bottom=30", "left=10", "right=60"],
+        );
+        assert_contains_sequence(&argv, &["videoconvert", "!", "pngenc", "!", "filesink"]);
     }
 }

--- a/recording/native/linux/src/main.rs
+++ b/recording/native/linux/src/main.rs
@@ -19,6 +19,7 @@ mod gst;
 mod portal;
 mod protocol;
 mod recorder;
+mod screenshot;
 
 use anyhow::Result;
 use protocol::{Command, Event};
@@ -38,8 +39,16 @@ fn main() -> Result<()> {
 
     // Read the Start command. If parsing fails (EOF, malformed JSON, Stop-without-Start),
     // emit a Protocol error event and exit cleanly via the writer thread.
-    let outcome: Result<()> = match read_start_command() {
-        Ok(start) => recorder::run(start, event_tx.clone()),
+    let outcome: Result<()> = match read_first_command() {
+        Ok(Command::Start(start)) => recorder::run(start, event_tx.clone()),
+        Ok(Command::Screenshot(screenshot)) => screenshot::run(screenshot, event_tx.clone()),
+        Ok(Command::Stop) => {
+            let _ = event_tx.send(Event::Error {
+                kind: "Protocol".into(),
+                message: "received Stop on stdin before any capture command".into(),
+            });
+            Ok(())
+        }
         Err(e) => {
             let _ = event_tx.send(Event::Error {
                 kind: "Protocol".into(),
@@ -92,20 +101,14 @@ fn writer_loop(rx: mpsc::Receiver<Event>) {
     }
 }
 
-/// Block on stdin until we receive the first JSON line; parse it as a [`Command::Start`].
-/// Anything else is a protocol error (the JVM is supposed to send Start first; Stop on a
-/// closed session is meaningless).
-fn read_start_command() -> Result<protocol::StartCommand> {
+/// Block on stdin until we receive the first JSON line and parse it as a helper command.
+/// Stop on a closed session is meaningless and is handled by `main` as a protocol error.
+fn read_first_command() -> Result<Command> {
     let stdin = std::io::stdin();
     let mut line = String::new();
     stdin.lock().read_line(&mut line)?;
     if line.is_empty() {
-        anyhow::bail!("EOF on stdin before receiving Start command");
+        anyhow::bail!("EOF on stdin before receiving a capture command");
     }
-    match serde_json::from_str::<Command>(line.trim())? {
-        Command::Start(start) => Ok(start),
-        Command::Stop => anyhow::bail!(
-            "received Stop on stdin before any Start; helper protocol expects Start first"
-        ),
-    }
+    Ok(serde_json::from_str::<Command>(line.trim())?)
 }

--- a/recording/native/linux/src/portal.rs
+++ b/recording/native/linux/src/portal.rs
@@ -51,7 +51,10 @@ pub struct StreamMetadata {
     pub node_id: u32,
     pub position: (i32, i32),
     pub size: (u32, u32),
+    pub source_type: Option<u32>,
 }
+
+pub const SOURCE_TYPE_WINDOW: u32 = 2;
 
 /// Active screen-cast session. Owns the D-Bus connection (closing it tears the session down)
 /// and the PipeWire FD (a Unix FD authorising a client to read the granted node).
@@ -82,8 +85,13 @@ pub fn open_screen_cast_session(
     let conn = Connection::new_session().context("opening session bus")?;
     let sender = sender_token(&conn).context("computing sender token")?;
     let counter = AtomicUsize::new(0);
-    let next_token =
-        |kind: &str| format!("spectre_{}_{}", kind, counter.fetch_add(1, Ordering::SeqCst));
+    let next_token = |kind: &str| {
+        format!(
+            "spectre_{}_{}",
+            kind,
+            counter.fetch_add(1, Ordering::SeqCst)
+        )
+    };
 
     // 1. CreateSession
     let create_token = next_token("create");
@@ -219,10 +227,8 @@ fn call_with_response<A: dbus::arg::AppendAll>(
     // call returns the request path, and we'd miss the signal otherwise.
     let captured: Arc<Mutex<Option<ResponsePayload>>> = Arc::new(Mutex::new(None));
     let captured_clone = Arc::clone(&captured);
-    let mut match_rule = dbus::message::MatchRule::new_signal(
-        REQUEST_RESPONSE_INTERFACE,
-        "Response",
-    );
+    let mut match_rule =
+        dbus::message::MatchRule::new_signal(REQUEST_RESPONSE_INTERFACE, "Response");
     match_rule.path = Some(request_path.clone().into());
     let token = conn
         .add_match(match_rule, move |(): (), _conn, msg| {
@@ -311,9 +317,7 @@ fn sender_token(conn: &Connection) -> Result<String> {
 
 /// Build a `PropMap` (a{sv}) from a fixed list of (key, variant) pairs. Saves repeating the
 /// `Variant(Box::new(...))` boilerplate at every call site.
-fn make_options<const N: usize>(
-    entries: [(&str, Variant<Box<dyn RefArg>>); N],
-) -> PropMap {
+fn make_options<const N: usize>(entries: [(&str, Variant<Box<dyn RefArg>>); N]) -> PropMap {
     entries
         .into_iter()
         .map(|(k, v)| (k.to_string(), v))
@@ -393,15 +397,13 @@ fn parse_first_stream(results: &PropMap) -> Result<StreamMetadata> {
     let node_id_arg = struct_fields
         .next()
         .context("first stream struct has no fields (expected u32 node_id then a{sv})")?;
-    let node_id = node_id_arg
-        .as_u64()
-        .with_context(|| {
-            format!(
-                "stream node_id field is not a u32 — got signature '{}', value {:?}",
-                node_id_arg.signature(),
-                node_id_arg
-            )
-        })? as u32;
+    let node_id = node_id_arg.as_u64().with_context(|| {
+        format!(
+            "stream node_id field is not a u32 — got signature '{}', value {:?}",
+            node_id_arg.signature(),
+            node_id_arg
+        )
+    })? as u32;
 
     // Properties dict. `size` is required regardless of source type. `position` is required
     // for monitor source streams (used in AWT-region → stream-relative coordinate translation
@@ -479,7 +481,6 @@ fn parse_first_stream(results: &PropMap) -> Result<StreamMetadata> {
     // with no `position` for window streams (#85). Monitor streams still bail loudly on
     // missing position so the multi-monitor coordinate translation in [`crate::recorder::run`]
     // stays correct.
-    const SOURCE_TYPE_WINDOW: u32 = 2;
     let position = match position {
         Some(p) => p,
         None if matches!(source_type, Some(SOURCE_TYPE_WINDOW)) => (0, 0),
@@ -510,6 +511,7 @@ fn parse_first_stream(results: &PropMap) -> Result<StreamMetadata> {
         node_id,
         position,
         size,
+        source_type,
     })
 }
 

--- a/recording/native/linux/src/protocol.rs
+++ b/recording/native/linux/src/protocol.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 #[serde(tag = "command", rename_all = "snake_case")]
 pub enum Command {
     Start(StartCommand),
+    Screenshot(ScreenshotCommand),
     Stop,
 }
 
@@ -21,15 +22,53 @@ pub enum Command {
 /// stream-relative coordinates internally once the portal hands back a stream position.
 #[derive(Debug, Clone, Deserialize)]
 pub struct StartCommand {
+    #[serde(default = "default_capture_backend")]
+    pub backend: CaptureBackend,
+    #[serde(default = "default_capture_target")]
+    pub target: CaptureTarget,
     /// Subset of source types the user can pick at the portal dialog. `monitor` is the only
     /// one Spectre's region recording supports today; window-targeted capture would need
     /// `window` plus a different post-portal flow.
+    #[serde(default)]
     pub source_types: Vec<SourceType>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub window_title: Option<String>,
     pub cursor_mode: CursorMode,
     pub frame_rate: u32,
     pub region: Region,
     pub output: String,
     pub codec: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ScreenshotCommand {
+    pub backend: CaptureBackend,
+    pub target: CaptureTarget,
+    #[serde(default)]
+    pub source_types: Vec<SourceType>,
+    #[serde(default)]
+    pub display_name: Option<String>,
+    #[serde(default)]
+    pub window_title: Option<String>,
+    pub cursor_mode: CursorMode,
+    pub region: Region,
+    pub output: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureBackend {
+    WaylandPortal,
+    X11,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum CaptureTarget {
+    Region,
+    Window,
 }
 
 #[derive(Debug, Clone, Copy, Deserialize)]
@@ -89,8 +128,18 @@ pub enum Event {
     FrameProgress { frames: u64 },
     /// Recording stopped cleanly: gst-launch exited 0, the mux finalised, the file is on disk.
     Stopped { output_size_bytes: u64 },
+    /// One-shot screenshot command completed and wrote a readable image file.
+    ScreenshotSaved { output_size_bytes: u64 },
     /// Anything that didn't reach a Stopped state. `kind` is a coarse category the JVM can
     /// pattern-match for surfacing the right exception type; `message` is the human-readable
     /// detail.
     Error { kind: String, message: String },
+}
+
+fn default_capture_backend() -> CaptureBackend {
+    CaptureBackend::WaylandPortal
+}
+
+fn default_capture_target() -> CaptureTarget {
+    CaptureTarget::Region
 }

--- a/recording/native/linux/src/recorder.rs
+++ b/recording/native/linux/src/recorder.rs
@@ -11,9 +11,9 @@
 //!  5. Wait for gst-launch to exit (either via the SIGTERM-EOS path or because it crashed).
 //!  6. Emit `Stopped` (with output file size) or `Error` (with cause), then return.
 
-use crate::gst::build_pipewire_argv;
-use crate::portal::{self, ScreenCastSession, DEFAULT_RESPONSE_TIMEOUT};
-use crate::protocol::{Event, StartCommand};
+use crate::gst::{build_pipewire_argv, build_x11_recording_argv, X11CaptureTarget};
+use crate::portal::{self, DEFAULT_RESPONSE_TIMEOUT, SOURCE_TYPE_WINDOW};
+use crate::protocol::{CaptureBackend, CaptureTarget, Event, StartCommand};
 use anyhow::{anyhow, Context, Result};
 use nix::fcntl::{fcntl, FcntlArg, FdFlag};
 use nix::sys::signal::{kill, Signal};
@@ -32,6 +32,13 @@ use std::time::{Duration, Instant};
 const SHUTDOWN_GRACE: Duration = Duration::from_secs(30);
 
 pub fn run(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
+    match start.backend {
+        CaptureBackend::WaylandPortal => run_wayland(start, events),
+        CaptureBackend::X11 => run_x11(start, events),
+    }
+}
+
+fn run_wayland(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
     // 1. Portal handshake — first call within a session pops the user's "share your screen"
     // dialog. Subsequent calls reuse the grant (transient persist mode).
     let session = portal::open_screen_cast_session(
@@ -40,6 +47,7 @@ pub fn run(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
         DEFAULT_RESPONSE_TIMEOUT,
     )
     .context("portal handshake")?;
+    ensure_window_source_if_requested(start.target, session.stream.source_type, "recording")?;
 
     // 2. Clear O_CLOEXEC on the PipeWire FD. Default-CLOEXEC FDs (the kernel sets it on
     // SCM_RIGHTS-delivered FDs for safety) wouldn't survive ProcessBuilder's exec call,
@@ -77,11 +85,12 @@ pub fn run(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
 
     eprintln!(
         "[helper] portal handshake OK: node={} fd={} stream={:?} position={:?} \
-         region-relative={:?}",
+         source_type={:?} region-relative={:?}",
         session.stream.node_id,
         session.pipewire_fd,
         session.stream.size,
         session.stream.position,
+        session.stream.source_type,
         (
             stream_relative_region.x,
             stream_relative_region.y,
@@ -187,12 +196,10 @@ pub fn run(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
     // thread is fine: it's reading our own stdin, so when the helper process exits the
     // descriptor is closed and the thread either reads EOF and exits, or gets killed by
     // process teardown. Either way the thread doesn't outlive the helper.
-    let mut exit_status: Option<std::process::ExitStatus> = None;
-    loop {
+    let exit = loop {
         match child.try_wait().context("polling gst-launch exit")? {
             Some(status) => {
-                exit_status = Some(status);
-                break;
+                break status;
             }
             None => {
                 let sigint_at = *sigint_sent_at.lock().unwrap();
@@ -211,8 +218,7 @@ pub fn run(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
                 thread::sleep(Duration::from_millis(50));
             }
         }
-    }
-    let exit = exit_status.unwrap();
+    };
     let elapsed = started_at.elapsed();
 
     // 7. Surface the outcome. The expected happy-path is exit code 0: gst-launch caught our
@@ -237,10 +243,167 @@ pub fn run(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
         return Ok(()); // Don't double-report — the Error event is the canonical signal.
     }
 
-    let output_size_bytes = std::fs::metadata(&start.output).map(|m| m.len()).unwrap_or(0);
+    let output_size_bytes = std::fs::metadata(&start.output)
+        .map(|m| m.len())
+        .unwrap_or(0);
     let _ = events.send(Event::Stopped { output_size_bytes });
 
     // session is dropped here — drops the D-Bus connection, releases the portal grant.
     drop(session);
+    Ok(())
+}
+
+fn run_x11(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
+    let target = match start.target {
+        CaptureTarget::Region => X11CaptureTarget::Region {
+            display_name: start.display_name.clone(),
+            region: start.region,
+        },
+        CaptureTarget::Window => X11CaptureTarget::Window {
+            display_name: start.display_name.clone(),
+            title: start
+                .window_title
+                .clone()
+                .ok_or_else(|| anyhow!("X11 window recording requires window_title"))?,
+        },
+    };
+    let argv = build_x11_recording_argv(
+        target,
+        start.frame_rate,
+        matches!(start.cursor_mode, crate::protocol::CursorMode::Embedded),
+        &PathBuf::from(&start.output),
+        &start.codec,
+    )
+    .context("building X11 gst-launch argv")?;
+    eprintln!(
+        "[helper] X11 capture argv ready: target={:?} region=({}, {}, {}, {})",
+        start.target, start.region.x, start.region.y, start.region.width, start.region.height
+    );
+    eprintln!("[helper] spawning: {argv:?}");
+    let (stream_size, stream_position) = match start.target {
+        CaptureTarget::Region => (
+            [
+                start.region.width.max(0) as u32,
+                start.region.height.max(0) as u32,
+            ],
+            [start.region.x, start.region.y],
+        ),
+        CaptureTarget::Window => ([0, 0], [0, 0]),
+    };
+    run_gst_lifecycle(
+        argv,
+        start.output,
+        events,
+        Event::Started {
+            node_id: 0,
+            stream_size,
+            stream_position,
+            gst_pid: 0,
+        },
+    )
+}
+
+fn ensure_window_source_if_requested(
+    target: CaptureTarget,
+    source_type: Option<u32>,
+    mode: &str,
+) -> Result<()> {
+    if target == CaptureTarget::Window && source_type != Some(SOURCE_TYPE_WINDOW) {
+        return Err(anyhow!(
+            "Wayland portal {mode} requested a window source, but the compositor returned \
+             source_type={source_type:?}. Spectre cannot window-crop a monitor-source stream \
+             safely; use region capture or a compositor/version that supports portal window \
+             sources."
+        ));
+    }
+    Ok(())
+}
+
+fn run_gst_lifecycle(
+    argv: Vec<String>,
+    output: String,
+    events: mpsc::Sender<Event>,
+    started_template: Event,
+) -> Result<()> {
+    let gst_stdout_target: OwnedFd = unsafe {
+        let raw = nix::unistd::dup(std::io::stderr().as_raw_fd())
+            .context("dup(stderr) so gst-launch stdout can redirect to helper stderr")?;
+        OwnedFd::from_raw_fd(raw)
+    };
+    let mut child = Command::new(&argv[0])
+        .args(&argv[1..])
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(gst_stdout_target))
+        .stderr(Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("spawning gst-launch from argv: {argv:?}"))?;
+    let gst_pid = child.id();
+    let started_at = Instant::now();
+
+    let _ = match started_template {
+        Event::Started {
+            node_id,
+            stream_size,
+            stream_position,
+            ..
+        } => events.send(Event::Started {
+            node_id,
+            stream_size,
+            stream_position,
+            gst_pid,
+        }),
+        _ => unreachable!("started_template must be Event::Started"),
+    };
+
+    let sigint_sent_at: Arc<Mutex<Option<Instant>>> = Arc::new(Mutex::new(None));
+    let sigint_sent_at_for_thread = Arc::clone(&sigint_sent_at);
+    let _stop_thread = thread::Builder::new()
+        .name("stop-watcher".into())
+        .spawn(move || {
+            let stdin = std::io::stdin();
+            let mut line = String::new();
+            let _ = stdin.lock().read_line(&mut line);
+            let _ = kill(Pid::from_raw(gst_pid as i32), Signal::SIGINT);
+            *sigint_sent_at_for_thread.lock().unwrap() = Some(Instant::now());
+        })
+        .context("spawning stop-watcher thread")?;
+
+    let exit = loop {
+        match child.try_wait().context("polling gst-launch exit")? {
+            Some(status) => break status,
+            None => {
+                let sigint_at = *sigint_sent_at.lock().unwrap();
+                if let Some(sent_at) = sigint_at {
+                    if sent_at.elapsed() > SHUTDOWN_GRACE {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        return Err(anyhow!(
+                            "gst-launch did not exit within {:?} of SIGINT — output at {} is in \
+                             an undefined state.",
+                            SHUTDOWN_GRACE,
+                            output,
+                        ));
+                    }
+                }
+                thread::sleep(Duration::from_millis(50));
+            }
+        }
+    };
+    let elapsed = started_at.elapsed();
+    if !exit.success() {
+        let _ = events.send(Event::Error {
+            kind: "EncoderCrashed".into(),
+            message: format!(
+                "gst-launch exited with status {exit:?} after {elapsed:?}. Common causes: \
+                 PipeWire/X11 source disconnect, encoder error (out of memory, codec missing), \
+                 disk full, output path on a read-only filesystem. Check the gst-launch log \
+                 for details."
+            ),
+        });
+        return Ok(());
+    }
+
+    let output_size_bytes = std::fs::metadata(&output).map(|m| m.len()).unwrap_or(0);
+    let _ = events.send(Event::Stopped { output_size_bytes });
     Ok(())
 }

--- a/recording/native/linux/src/screenshot.rs
+++ b/recording/native/linux/src/screenshot.rs
@@ -1,0 +1,160 @@
+//! One-shot screenshot orchestration for Linux capture sources.
+
+use crate::gst::{build_pipewire_png_argv, build_x11_png_argv, X11CaptureTarget};
+use crate::portal::{self, DEFAULT_RESPONSE_TIMEOUT, SOURCE_TYPE_WINDOW};
+use crate::protocol::{CaptureBackend, CaptureTarget, Event, ScreenshotCommand, SourceType};
+use anyhow::{anyhow, Context, Result};
+use nix::fcntl::{fcntl, FcntlArg, FdFlag};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+use std::os::unix::io::RawFd;
+use std::path::PathBuf;
+use std::process::{Command, ExitStatus, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+const SCREENSHOT_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub fn run(command: ScreenshotCommand, events: mpsc::Sender<Event>) -> Result<()> {
+    let output = PathBuf::from(&command.output);
+    match command.backend {
+        CaptureBackend::X11 => {
+            let argv = build_x11_screenshot_argv(&command, &output)?;
+            run_gst_oneshot(&argv)
+                .with_context(|| format!("running screenshot pipeline: {argv:?}"))?;
+        }
+        CaptureBackend::WaylandPortal => {
+            run_wayland_screenshot(&command, &output)?;
+        }
+    };
+    let output_size_bytes = std::fs::metadata(&command.output)
+        .with_context(|| format!("{:?} screenshot output was not written", command.backend))?
+        .len();
+    let _ = events.send(Event::ScreenshotSaved { output_size_bytes });
+    Ok(())
+}
+
+fn build_x11_screenshot_argv(command: &ScreenshotCommand, output: &PathBuf) -> Result<Vec<String>> {
+    let capture_cursor = matches!(command.cursor_mode, crate::protocol::CursorMode::Embedded);
+    let target = match command.target {
+        CaptureTarget::Region => X11CaptureTarget::Region {
+            display_name: command.display_name.clone(),
+            region: command.region,
+        },
+        CaptureTarget::Window => X11CaptureTarget::Window {
+            display_name: command.display_name.clone(),
+            title: command
+                .window_title
+                .clone()
+                .ok_or_else(|| anyhow!("X11 window screenshot requires window_title"))?,
+        },
+    };
+    build_x11_png_argv(target, capture_cursor, output)
+}
+
+fn run_wayland_screenshot(command: &ScreenshotCommand, output: &PathBuf) -> Result<()> {
+    let source_types = if command.source_types.is_empty() {
+        match command.target {
+            CaptureTarget::Region => vec![SourceType::Monitor],
+            CaptureTarget::Window => vec![SourceType::Window],
+        }
+    } else {
+        command.source_types.clone()
+    };
+    let session = portal::open_screen_cast_session(
+        &source_types,
+        command.cursor_mode,
+        DEFAULT_RESPONSE_TIMEOUT,
+    )
+    .context("portal screenshot handshake")?;
+    ensure_window_source_if_requested(command.target, session.stream.source_type)?;
+    clear_cloexec(session.pipewire_fd).context("allowing PipeWire FD inheritance")?;
+    let stream_relative_region = crate::protocol::Region {
+        x: command.region.x - session.stream.position.0,
+        y: command.region.y - session.stream.position.1,
+        width: command.region.width,
+        height: command.region.height,
+    };
+    let argv = build_pipewire_png_argv(
+        session.stream.node_id,
+        session.pipewire_fd,
+        stream_relative_region,
+        session.stream.size,
+        output,
+    )?;
+    run_gst_oneshot(&argv)
+        .with_context(|| format!("running Wayland screenshot pipeline: {argv:?}"))?;
+    drop(session);
+    Ok(())
+}
+
+fn ensure_window_source_if_requested(
+    target: CaptureTarget,
+    source_type: Option<u32>,
+) -> Result<()> {
+    if target == CaptureTarget::Window && source_type != Some(SOURCE_TYPE_WINDOW) {
+        anyhow::bail!(
+            "Wayland portal screenshot requested a window source, but the compositor returned \
+             source_type={source_type:?}. Spectre cannot window-crop a monitor-source stream \
+             safely; use an explicit region screenshot or a compositor/version that supports \
+             portal window sources."
+        );
+    }
+    Ok(())
+}
+
+fn clear_cloexec(fd: RawFd) -> Result<()> {
+    let mut flags =
+        FdFlag::from_bits_truncate(fcntl(fd, FcntlArg::F_GETFD).context("fcntl(F_GETFD)")?);
+    flags.remove(FdFlag::FD_CLOEXEC);
+    fcntl(fd, FcntlArg::F_SETFD(flags)).context("fcntl(F_SETFD, !CLOEXEC)")?;
+    Ok(())
+}
+
+fn run_gst_oneshot(argv: &[String]) -> Result<()> {
+    let gst_stdout_target: OwnedFd = unsafe {
+        let raw = nix::unistd::dup(std::io::stderr().as_raw_fd())
+            .context("dup(stderr) so gst-launch stdout can redirect to helper stderr")?;
+        OwnedFd::from_raw_fd(raw)
+    };
+    let mut child = Command::new(&argv[0])
+        .args(&argv[1..])
+        .stdin(Stdio::null())
+        .stdout(Stdio::from(gst_stdout_target))
+        .stderr(Stdio::inherit())
+        .spawn()
+        .with_context(|| format!("spawning gst-launch from argv: {argv:?}"))?;
+    let exit = child
+        .wait_timeout_like(SCREENSHOT_TIMEOUT)
+        .context("waiting for screenshot gst-launch to exit")?;
+    let Some(exit) = exit else {
+        let _ = child.kill();
+        let _ = child.wait();
+        anyhow::bail!(
+            "gst-launch did not exit within {:?} while capturing screenshot",
+            SCREENSHOT_TIMEOUT
+        );
+    };
+    if !exit.success() {
+        anyhow::bail!("gst-launch screenshot pipeline exited with status {exit:?}");
+    }
+    Ok(())
+}
+
+trait ChildWaitTimeout {
+    fn wait_timeout_like(&mut self, timeout: Duration) -> Result<Option<ExitStatus>>;
+}
+
+impl ChildWaitTimeout for std::process::Child {
+    fn wait_timeout_like(&mut self, timeout: Duration) -> Result<Option<ExitStatus>> {
+        let start = std::time::Instant::now();
+        loop {
+            if let Some(exit) = self.try_wait()? {
+                return Ok(Some(exit));
+            }
+            if start.elapsed() > timeout {
+                return Ok(None);
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -16,14 +16,15 @@ import java.nio.file.Path
 /**
  * High-level recorder with explicit capture modes.
  *
- * [startWindow] uses true window-targeted backends only: ScreenCaptureKit on macOS, Windows
- * Graphics Capture on Windows, and the Wayland portal window-source path on Linux Wayland. If the
- * requested window mode is unavailable, it throws with an actionable error instead of silently
- * falling back to region capture.
+ * [startWindow] uses window-scoped backends only: ScreenCaptureKit on macOS, Windows Graphics
+ * Capture on Windows, the Linux helper's Xorg/Xvfb named-window path, and the Wayland portal
+ * window-source path on Linux Wayland. If the requested window mode is unavailable, it throws with
+ * an actionable error instead of silently falling back to region capture.
  *
  * [startRegion] uses region capture only: Windows Graphics Capture on Windows, ffmpeg region
- * capture on macOS and Linux Xorg, and the Wayland portal monitor-source path on Linux Wayland. If
- * the requested region mode is unavailable, it throws instead of switching capture semantics.
+ * capture on macOS, the Linux helper's Xorg/Xvfb path, and the Wayland portal monitor-source path
+ * on Linux Wayland. If the requested region mode is unavailable, it throws instead of switching
+ * capture semantics.
  */
 public class AutoRecorder
 internal constructor(
@@ -31,18 +32,21 @@ internal constructor(
     private val ffmpegRecorder: Recorder,
     private val windowsWindowRecorder: WindowRecorder?,
     private val windowsRegionRecorder: Recorder?,
+    private val linuxRegionRecorder: Recorder?,
+    private val linuxWindowRecorder: WindowRecorder?,
     private val waylandPortalRecorder: Recorder?,
     private val waylandPortalWindowRecorder: WaylandWindowSourceRecorder?,
     private val waylandPortalRecorderFailure: Throwable?,
     private val waylandPortalWindowRecorderFailure: Throwable?,
     private val isMacOs: () -> Boolean,
     private val isWindows: () -> Boolean,
+    private val isLinux: () -> Boolean,
     private val isWayland: () -> Boolean,
 ) {
 
     public constructor(
         sckRecorder: WindowRecorder = ScreenCaptureKitRecorder(),
-        ffmpegRecorder: Recorder = FfmpegRecorder(),
+        ffmpegRecorder: Recorder = DefaultLegacyFfmpegRecorder,
         windowsWindowRecorder: WindowRecorder? = defaultWindowsWindowRecorder(),
         windowsRegionRecorder: Recorder? = defaultWindowsRegionRecorder(),
         waylandPortalRecorder: Recorder? = defaultPortals.region,
@@ -52,6 +56,8 @@ internal constructor(
         ffmpegRecorder = ffmpegRecorder,
         windowsWindowRecorder = windowsWindowRecorder,
         windowsRegionRecorder = windowsRegionRecorder,
+        linuxRegionRecorder = defaultLinuxRecorder,
+        linuxWindowRecorder = defaultLinuxRecorder,
         waylandPortalRecorder = waylandPortalRecorder,
         waylandPortalWindowRecorder = waylandPortalWindowRecorder,
         // A user who passed a non-null recorder owns its construction; we only surface our own
@@ -62,6 +68,7 @@ internal constructor(
             if (waylandPortalWindowRecorder == null) defaultPortals.windowFailure else null,
         isMacOs = ::defaultIsMacOs,
         isWindows = ::defaultIsWindows,
+        isLinux = ::defaultIsLinux,
         isWayland = ::defaultIsWayland,
     )
 
@@ -102,6 +109,14 @@ internal constructor(
             return recorder?.start(window, windowOwnerPid, output, options)
                 ?: throw unavailable("Windows window capture", null)
         }
+        if (isLinux()) {
+            require(!title.isNullOrBlank()) {
+                "AutoRecorder.startWindow requires a non-blank window title on Linux X11. " +
+                    "Use startRegion(...) explicitly if region capture is what you want."
+            }
+            return linuxWindowRecorder?.start(window, windowOwnerPid, output, options)
+                ?: throw unavailable("Linux X11 window capture", null)
+        }
         throw unsupportedWindowCapture()
     }
 
@@ -128,6 +143,10 @@ internal constructor(
             } catch (_: WindowsGraphicsCaptureHelperNotBundledException) {
                 ffmpegRecorder.start(region, output, options)
             }
+        }
+        if (isLinux()) {
+            return linuxRegionRecorder?.start(region, output, options)
+                ?: throw unavailable("Linux X11 region capture", null)
         }
         return ffmpegRecorder.start(region, output, options)
     }
@@ -196,6 +215,10 @@ internal constructor(
             WindowsGraphicsCaptureRecorder()
         }
 
+        val defaultLinuxRecorder: LinuxX11Recorder? by lazy {
+            if (defaultIsLinux()) LinuxX11Recorder() else null
+        }
+
         /**
          * Lazily resolves both portal recorders once per JVM (the first time the public no-arg
          * `AutoRecorder` constructor's defaults fire). Captures any construction failure so the
@@ -207,6 +230,16 @@ internal constructor(
             WaylandPortalRecorders.resolveDefaults(::defaultIsLinux)
         }
     }
+}
+
+private object DefaultLegacyFfmpegRecorder : Recorder {
+    @Suppress("DEPRECATION") private val delegate: FfmpegRecorder by lazy { FfmpegRecorder() }
+
+    override fun start(
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): RecordingHandle = delegate.start(region, output, options)
 }
 
 /**

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package dev.sebastiano.spectre.recording
 
 import java.awt.Rectangle
@@ -43,6 +45,10 @@ import java.util.concurrent.atomic.AtomicReference
  * The [processFactory] seam exists so the lifecycle can be unit-tested without spawning a real
  * `ffmpeg` (a fake factory can return a `Process`-like stand-in driven by an in-memory pipe).
  */
+@Deprecated(
+    "Legacy explicit ffmpeg backend. Prefer AutoRecorder or the platform-native recorder " +
+        "selected by AutoRecorder; this class remains only as a compatibility escape hatch."
+)
 public class FfmpegRecorder
 internal constructor(
     private val ffmpegPath: Path,

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegScreenshotters.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegScreenshotters.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package dev.sebastiano.spectre.recording
 
 import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
@@ -9,6 +11,10 @@ import java.nio.file.Path
 import javax.imageio.ImageIO
 
 /** Windows still screenshot backend using ffmpeg's `gdigrab title=` window source. */
+@Deprecated(
+    "Legacy explicit ffmpeg/gdigrab screenshot backend. Prefer AutoScreenshotter or " +
+        "WindowsWindowScreenshotter; this class remains only as a compatibility escape hatch."
+)
 public class FfmpegWindowScreenshotter
 internal constructor(
     private val ffmpegPath: Path,
@@ -37,6 +43,10 @@ internal constructor(
 }
 
 /** Linux X11 still screenshot backend using ffmpeg's `x11grab` region source. */
+@Deprecated(
+    "Legacy explicit ffmpeg/x11grab screenshot backend. Prefer AutoScreenshotter or " +
+        "LinuxNativeScreenshotter; this class remains only as a compatibility escape hatch."
+)
 public class FfmpegRegionScreenshotter
 internal constructor(
     private val ffmpegPath: Path,

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegWindowRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegWindowRecorder.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package dev.sebastiano.spectre.recording
 
 import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
@@ -34,6 +36,10 @@ import java.nio.file.Path
  * Construction mirrors [FfmpegRecorder]'s shape: an [ffmpegPath] resolved by default from `PATH`
  * via [FfmpegRecorder.resolveFfmpegPath], and a [processFactory] seam for tests.
  */
+@Deprecated(
+    "Legacy explicit ffmpeg/gdigrab window backend. Prefer AutoRecorder or " +
+        "WindowsGraphicsCaptureRecorder; this class remains only as a compatibility escape hatch."
+)
 public class FfmpegWindowRecorder
 internal constructor(
     private val ffmpegPath: Path,

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotter.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotter.kt
@@ -1,0 +1,260 @@
+package dev.sebastiano.spectre.recording
+
+import dev.sebastiano.spectre.recording.portal.CaptureBackend
+import dev.sebastiano.spectre.recording.portal.CaptureTarget
+import dev.sebastiano.spectre.recording.portal.Command
+import dev.sebastiano.spectre.recording.portal.CursorMode
+import dev.sebastiano.spectre.recording.portal.DefaultWaylandHelperBinaryExtractor
+import dev.sebastiano.spectre.recording.portal.Event
+import dev.sebastiano.spectre.recording.portal.Region
+import dev.sebastiano.spectre.recording.portal.SourceType
+import dev.sebastiano.spectre.recording.portal.WaylandHelperBinaryExtractor
+import dev.sebastiano.spectre.recording.portal.queryGtkFrameExtentsViaXprop
+import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
+import java.awt.Insets
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import java.io.BufferedReader
+import java.io.IOException
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import javax.imageio.ImageIO
+import kotlin.concurrent.thread
+import kotlin.io.path.deleteIfExists
+import kotlinx.serialization.json.Json
+
+/** Linux still screenshot backend backed by Spectre's bundled Linux capture helper. */
+public class LinuxNativeScreenshotter
+internal constructor(
+    private val helperExtractor: WaylandHelperBinaryExtractor,
+    private val processFactory: ProcessFactory,
+    private val isWayland: () -> Boolean,
+    private val displayNameProvider: () -> String?,
+    private val frameExtentsLookup: (String) -> Insets?,
+) : WindowScreenshotter, RegionScreenshotter {
+
+    public constructor() :
+        this(
+            helperExtractor = DefaultWaylandHelperBinaryExtractor.instance,
+            processFactory = SystemProcessFactory,
+            isWayland = HostPlatform::isWayland,
+            displayNameProvider = { System.getenv("DISPLAY") },
+            frameExtentsLookup = ::queryGtkFrameExtentsViaXprop,
+        )
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    override fun captureWindow(window: TitledWindow, windowOwnerPid: Long): BufferedImage {
+        val title = window.title
+        require(!title.isNullOrBlank()) {
+            "LinuxNativeScreenshotter requires a non-blank window title; got \"$title\"."
+        }
+        val wayland = isWayland()
+        val region =
+            if (wayland) {
+                val extents =
+                    frameExtentsLookup(title)
+                        ?: error(
+                            "Could not determine WM frame extents for window '$title' on this " +
+                                "Wayland session. The portal window screenshot path currently " +
+                                "depends on `_GTK_FRAME_EXTENTS`, which is usually available for " +
+                                "GTK/Mutter XWayland windows only. Missing `xprop`, a non-GTK " +
+                                "toolkit, an unsupported compositor, or no matching X11 window " +
+                                "can all produce this result; capture an explicit region instead."
+                        )
+                Rectangle(extents.left, extents.top, window.bounds.width, window.bounds.height)
+            } else {
+                window.bounds
+            }
+        return capture(
+            Command.Screenshot(
+                backend = if (wayland) CaptureBackend.WAYLAND_PORTAL else CaptureBackend.X11,
+                target = CaptureTarget.WINDOW,
+                sourceTypes = if (wayland) listOf(SourceType.WINDOW) else emptyList(),
+                displayName =
+                    if (wayland) null else displayNameProvider()?.takeIf { it.isNotBlank() },
+                windowTitle = title,
+                cursorMode = CursorMode.HIDDEN,
+                region = region.toProtocolRegion(),
+                output = tempPng().toAbsolutePath().toString(),
+            )
+        )
+    }
+
+    override fun captureRegion(region: Rectangle): BufferedImage {
+        val wayland = isWayland()
+        return capture(
+            Command.Screenshot(
+                backend = if (wayland) CaptureBackend.WAYLAND_PORTAL else CaptureBackend.X11,
+                target = CaptureTarget.REGION,
+                sourceTypes = if (wayland) listOf(SourceType.MONITOR) else emptyList(),
+                displayName =
+                    if (wayland) null else displayNameProvider()?.takeIf { it.isNotBlank() },
+                cursorMode = CursorMode.HIDDEN,
+                region = region.toProtocolRegion(),
+                output = tempPng().toAbsolutePath().toString(),
+            )
+        )
+    }
+
+    private fun capture(command: Command.Screenshot): BufferedImage {
+        val output = Path.of(command.output)
+        var process: Process? = null
+        var readerThread: Thread? = null
+        try {
+            output.toAbsolutePath().parent?.let(Files::createDirectories)
+            val helperPath = helperExtractor.extract()
+            process = processFactory.start(helperPath)
+            val eventLatch = CountDownLatch(1)
+            val eventResult = AtomicReference<Result<Event>?>()
+            readerThread =
+                thread(name = "linux-screenshot-helper-reader", isDaemon = true) {
+                    try {
+                        val result = runCatching {
+                            BufferedReader(
+                                    InputStreamReader(process.inputStream, StandardCharsets.UTF_8)
+                                )
+                                .use { readScreenshotTerminalEvent(it) }
+                        }
+                        eventResult.set(result)
+                    } finally {
+                        eventLatch.countDown()
+                    }
+                }
+            writeCommand(process.outputStream, command)
+            process.outputStream.close()
+            if (!eventLatch.await(SCREENSHOT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                throw IllegalStateException(
+                    "Timed out after ${SCREENSHOT_TIMEOUT_MS}ms waiting for Linux screenshot " +
+                        "helper."
+                )
+            }
+            val event =
+                eventResult.get()?.getOrThrow()
+                    ?: error("Linux screenshot helper reader finished without an event result")
+            when (event) {
+                is Event.ScreenshotSaved -> Unit
+                is Event.Error -> throw helperError(process, event)
+                else -> error("Unexpected helper event during screenshot capture: $event")
+            }
+            waitForCleanExit(process)
+            return ImageIO.read(output.toFile())
+                ?: error("Linux screenshot helper did not produce a readable PNG at $output")
+        } catch (e: InterruptedException) {
+            cleanupFailedCapture(process, readerThread)
+            Thread.currentThread().interrupt()
+            throw IllegalStateException("Interrupted while waiting for Linux screenshot helper", e)
+        } catch (e: IOException) {
+            cleanupFailedCapture(process, readerThread)
+            throw IllegalStateException("Linux screenshot helper failed", e)
+        } catch (e: IllegalStateException) {
+            cleanupFailedCapture(process, readerThread)
+            throw e
+        } catch (e: IllegalArgumentException) {
+            cleanupFailedCapture(process, readerThread)
+            throw e
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    private fun helperError(process: Process, event: Event.Error): IllegalStateException {
+        waitForProcessExitOrKill(process)
+        return IllegalStateException(
+            "spectre-wayland-helper reported an error during screenshot capture: " +
+                "kind=${event.kind} message=${event.message}"
+        )
+    }
+
+    private fun waitForCleanExit(process: Process) {
+        if (!process.waitFor(PROCESS_EXIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            process.destroyForcibly()
+            error(
+                "spectre-wayland-helper did not exit within ${PROCESS_EXIT_TIMEOUT_MS}ms " +
+                    "after screenshot capture."
+            )
+        }
+        val exit = process.exitValue()
+        check(exit == 0) {
+            "spectre-wayland-helper exited with non-zero status $exit during screenshot capture."
+        }
+    }
+
+    private fun waitForProcessExitOrKill(process: Process) {
+        if (!process.waitFor(PROCESS_EXIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            process.destroyForcibly()
+            process.waitFor(FORCED_EXIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+        }
+    }
+
+    private fun cleanupFailedCapture(process: Process?, readerThread: Thread?) {
+        process?.destroyForcibly()
+        @Suppress("SwallowedException")
+        try {
+            process?.inputStream?.close()
+        } catch (_: IOException) {
+            // Closing stdout is best-effort cleanup. The process kill above is the real guard.
+        }
+        @Suppress("SwallowedException")
+        try {
+            process?.waitFor(FORCED_EXIT_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            readerThread?.join(READER_JOIN_TIMEOUT_MS)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    private fun readScreenshotTerminalEvent(reader: BufferedReader): Event {
+        while (true) {
+            val line = reader.readLine() ?: error("helper closed stdout before screenshot result")
+            if (line.isBlank()) continue
+            val event = json.decodeFromString(Event.serializer(), line)
+            when (event) {
+                is Event.ScreenshotSaved,
+                is Event.Error -> return event
+                is Event.Started,
+                is Event.Stopped,
+                is Event.FrameProgress -> {
+                    // Ignore recording-only events until a terminal screenshot event arrives.
+                }
+            }
+        }
+    }
+
+    private fun writeCommand(stream: OutputStream, command: Command) {
+        val line = json.encodeToString(Command.serializer(), command) + "\n"
+        stream.write(line.toByteArray(StandardCharsets.UTF_8))
+        stream.flush()
+    }
+
+    internal interface ProcessFactory {
+        fun start(helperPath: Path): Process
+    }
+
+    internal object SystemProcessFactory : ProcessFactory {
+        override fun start(helperPath: Path): Process =
+            ProcessBuilder(helperPath.toString())
+                .redirectInput(ProcessBuilder.Redirect.PIPE)
+                .redirectOutput(ProcessBuilder.Redirect.PIPE)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start()
+    }
+
+    private companion object {
+        fun tempPng(): Path = Files.createTempFile("spectre-linux-screenshot-", ".png")
+
+        fun Rectangle.toProtocolRegion(): Region =
+            Region(x = x, y = y, width = width, height = height)
+    }
+}
+
+private const val SCREENSHOT_TIMEOUT_MS: Long = 90_000
+private const val PROCESS_EXIT_TIMEOUT_MS: Long = 5_000
+private const val FORCED_EXIT_TIMEOUT_MS: Long = 2_000
+private const val READER_JOIN_TIMEOUT_MS: Long = 2_000

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxX11Recorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxX11Recorder.kt
@@ -1,0 +1,76 @@
+package dev.sebastiano.spectre.recording
+
+import dev.sebastiano.spectre.recording.portal.CaptureBackend
+import dev.sebastiano.spectre.recording.portal.CaptureTarget
+import dev.sebastiano.spectre.recording.portal.Command
+import dev.sebastiano.spectre.recording.portal.CursorMode
+import dev.sebastiano.spectre.recording.portal.DefaultWaylandHelperBinaryExtractor
+import dev.sebastiano.spectre.recording.portal.Region
+import dev.sebastiano.spectre.recording.portal.WaylandHelperBinaryExtractor
+import dev.sebastiano.spectre.recording.portal.WaylandPortalRecorder
+import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
+import dev.sebastiano.spectre.recording.screencapturekit.WindowRecorder
+import java.awt.Rectangle
+import java.nio.file.Path
+
+/** Linux Xorg/Xvfb recorder backed by Spectre's bundled Linux helper and GStreamer. */
+public class LinuxX11Recorder
+internal constructor(
+    private val helperExtractor: WaylandHelperBinaryExtractor,
+    private val displayNameProvider: () -> String?,
+) : Recorder, WindowRecorder {
+
+    public constructor() :
+        this(
+            helperExtractor = DefaultWaylandHelperBinaryExtractor.instance,
+            displayNameProvider = { System.getenv("DISPLAY") },
+        )
+
+    override fun start(
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): RecordingHandle =
+        delegate(CaptureTarget.REGION, windowTitle = null).start(region, output, options)
+
+    override fun start(
+        window: TitledWindow,
+        windowOwnerPid: Long,
+        output: Path,
+        options: RecordingOptions,
+    ): RecordingHandle {
+        val title = window.title
+        require(!title.isNullOrBlank()) {
+            "LinuxX11Recorder requires a non-blank window title; got \"$title\"."
+        }
+        return delegate(CaptureTarget.WINDOW, windowTitle = title)
+            .start(window.bounds, output, options)
+    }
+
+    private fun delegate(target: CaptureTarget, windowTitle: String?): Recorder =
+        WaylandPortalRecorder.createForInternalUse(
+            helperExtractor = helperExtractor,
+            sourceTypes = emptyList(),
+            startCommandFactory = { region, output, options ->
+                Command.Start(
+                    backend = CaptureBackend.X11,
+                    target = target,
+                    sourceTypes = emptyList(),
+                    displayName = displayNameProvider()?.takeIf { it.isNotBlank() },
+                    windowTitle = windowTitle,
+                    cursorMode =
+                        if (options.captureCursor) CursorMode.EMBEDDED else CursorMode.HIDDEN,
+                    frameRate = options.frameRate,
+                    region =
+                        Region(
+                            x = region.x,
+                            y = region.y,
+                            width = region.width,
+                            height = region.height,
+                        ),
+                    output = output.toAbsolutePath().toString(),
+                    codec = options.codec,
+                )
+            },
+        )
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/Recorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/Recorder.kt
@@ -6,12 +6,14 @@ import java.nio.file.Path
 /**
  * Captures a region of the screen to a video file.
  *
- * The default region-capture implementation is [FfmpegRecorder], which shells out to a system
- * `ffmpeg` binary. Window-targeted capture lives behind separate
+ * Prefer [AutoRecorder] for platform routing. The legacy explicit [FfmpegRecorder] backend is
+ * deprecated and remains available only as a compatibility escape hatch. Window-targeted capture
+ * lives behind separate
  * [WindowRecorder][dev.sebastiano.spectre.recording.screencapturekit.WindowRecorder]
  * implementations: `ScreenCaptureKitRecorder` on macOS, `WindowsGraphicsCaptureRecorder` on
- * Windows, and `WaylandPortalWindowRecorder` on Linux Wayland. Tests and advanced consumers can
- * swap in their own [Recorder] implementation (e.g. an in-memory frame accumulator).
+ * Windows, `LinuxX11Recorder` on Xorg/Xvfb, and `WaylandPortalWindowRecorder` on Linux Wayland.
+ * Tests and advanced consumers can swap in their own [Recorder] implementation (e.g. an in-memory
+ * frame accumulator).
  */
 public interface Recorder {
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
@@ -10,8 +10,10 @@ public data class RecordingOptions(
     val captureCursor: Boolean = true,
     /**
      * H.264 encoder name. Leaves room for swapping `h264_videotoolbox` (macOS hw accel) for
-     * `libx264` (cross-platform software fallback) without restructuring the API. Other ffmpeg
-     * encoders work too if the platform supports them.
+     * `libx264` (cross-platform software fallback) without restructuring the API. The ffmpeg
+     * backends accept other ffmpeg encoder names when the platform supports them. Linux helper /
+     * GStreamer recording currently accepts only `libx264` and `x264enc`; other encoder pipelines
+     * need structured parser and property support before they can be represented safely.
      */
     val codec: String = DEFAULT_CODEC,
     /**

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/WindowScreenshotter.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/WindowScreenshotter.kt
@@ -12,16 +12,16 @@ import java.lang.ProcessHandle
  * Captures still screenshots from desktop surfaces.
  *
  * [captureWindow] uses true window-targeted capture where Spectre has one available: macOS
- * ScreenCaptureKit and the native Windows helper on Windows. On Linux X11 it falls back to region
- * capture for the supplied [TitledWindow.bounds]; callers must make the window visible and
- * frontmost for that fallback. Linux Wayland still screenshots are deliberately unsupported for now
- * because the current portal helper streams video, not one-shot image buffers.
+ * ScreenCaptureKit and the native Windows helper on Windows. On Linux, Spectre uses the bundled
+ * helper: GStreamer `ximagesrc` on Xorg/Xvfb and portal/PipeWire one-frame capture on Wayland.
+ * Linux Xorg/Xvfb callers must keep the target visible/frontmost; Wayland callers must accept the
+ * compositor portal dialog.
  */
 public class AutoScreenshotter
 internal constructor(
     private val sckScreenshotter: WindowScreenshotter,
     private val windowsWindowScreenshotter: WindowScreenshotter?,
-    private val x11RegionScreenshotter: RegionScreenshotter,
+    private val linuxWindowScreenshotter: WindowScreenshotter?,
     private val isMacOs: () -> Boolean,
     private val isWindows: () -> Boolean,
     private val isLinux: () -> Boolean,
@@ -31,11 +31,12 @@ internal constructor(
     public constructor(
         sckScreenshotter: WindowScreenshotter = ScreenCaptureKitScreenshotter(),
         windowsWindowScreenshotter: WindowScreenshotter? = defaultWindowsWindowScreenshotter(),
-        x11RegionScreenshotter: RegionScreenshotter = FfmpegRegionScreenshotter(),
+        @Suppress("UNUSED_PARAMETER")
+        x11RegionScreenshotter: RegionScreenshotter = UnusedLegacyX11RegionScreenshotter,
     ) : this(
         sckScreenshotter = sckScreenshotter,
         windowsWindowScreenshotter = windowsWindowScreenshotter,
-        x11RegionScreenshotter = x11RegionScreenshotter,
+        linuxWindowScreenshotter = defaultLinuxWindowScreenshotter,
         isMacOs = ::defaultIsMacOs,
         isWindows = ::defaultIsWindows,
         isLinux = ::defaultIsLinux,
@@ -46,14 +47,6 @@ internal constructor(
         window: TitledWindow,
         windowOwnerPid: Long = ProcessHandle.current().pid(),
     ): BufferedImage {
-        if (isWayland()) {
-            throw UnsupportedOperationException(
-                "Wayland still window screenshots are not supported yet. Spectre's Wayland " +
-                    "portal backend currently supports window-targeted recording via " +
-                    "WaylandPortalWindowRecorder; one-shot still capture needs a helper " +
-                    "extension that returns image buffers instead of video files."
-            )
-        }
         if (isMacOs()) {
             return try {
                 sckScreenshotter.captureWindow(window, windowOwnerPid)
@@ -71,7 +64,15 @@ internal constructor(
                 ?: throw unavailable("Windows window screenshot", null)
         }
         if (isLinux()) {
-            return x11RegionScreenshotter.captureRegion(window.bounds)
+            return linuxWindowScreenshotter?.captureWindow(window, windowOwnerPid)
+                ?: throw unavailable(
+                    if (isWayland()) {
+                        "Linux Wayland window screenshot"
+                    } else {
+                        "Linux X11 window screenshot"
+                    },
+                    null,
+                )
         }
         throw UnsupportedOperationException(
             "AutoScreenshotter.captureWindow is unsupported on this platform because no native " +
@@ -104,6 +105,10 @@ internal constructor(
                 null
             }
         }
+
+        val defaultLinuxWindowScreenshotter: LinuxNativeScreenshotter? by lazy {
+            if (defaultIsLinux()) LinuxNativeScreenshotter() else null
+        }
     }
 }
 
@@ -116,4 +121,13 @@ public interface WindowScreenshotter {
 
 public interface RegionScreenshotter {
     public fun captureRegion(region: Rectangle): BufferedImage
+}
+
+private object UnusedLegacyX11RegionScreenshotter : RegionScreenshotter {
+    override fun captureRegion(region: Rectangle): BufferedImage =
+        error(
+            "AutoScreenshotter no longer uses the legacy x11RegionScreenshotter constructor " +
+                "parameter. Instantiate LinuxNativeScreenshotter directly for Linux region " +
+                "screenshots."
+        )
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
@@ -32,6 +32,7 @@ internal class WaylandHelperBinaryExtractor(
 
     private var cached: Path? = null
 
+    @Synchronized
     fun extract(): Path {
         cached?.let {
             return it
@@ -127,11 +128,14 @@ internal class WaylandHelperBinaryExtractor(
 
 /**
  * Raised when the bundled helper binary isn't at the expected classpath resource. Distinct from a
- * bare `IllegalStateException` so [dev.sebastiano.spectre.recording.AutoRecorder] can pattern-match
- * the cross-platform-jar case (built on macOS or Windows, the Linux helper isn't in the jar) and
- * fall back to ffmpeg region capture rather than throwing.
+ * bare `IllegalStateException` so high-level routers can distinguish "helper not packaged" from
+ * operational capture failures.
  *
  * Mirrors [dev.sebastiano.spectre.recording.screencapturekit.HelperNotBundledException]'s role for
  * the SCK helper.
  */
 internal class HelperNotBundledException(message: String) : IllegalStateException(message)
+
+internal object DefaultWaylandHelperBinaryExtractor {
+    val instance: WaylandHelperBinaryExtractor by lazy { WaylandHelperBinaryExtractor() }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperProtocol.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperProtocol.kt
@@ -29,12 +29,29 @@ internal sealed interface Command {
     @Serializable
     @SerialName("start")
     data class Start(
+        @SerialName("backend") val backend: CaptureBackend = CaptureBackend.WAYLAND_PORTAL,
+        @SerialName("target") val target: CaptureTarget = CaptureTarget.REGION,
         @SerialName("source_types") val sourceTypes: List<SourceType>,
+        @SerialName("display_name") val displayName: String? = null,
+        @SerialName("window_title") val windowTitle: String? = null,
         @SerialName("cursor_mode") val cursorMode: CursorMode,
         @SerialName("frame_rate") val frameRate: Int,
         @SerialName("region") val region: Region,
         @SerialName("output") val output: String,
         @SerialName("codec") val codec: String,
+    ) : Command
+
+    @Serializable
+    @SerialName("screenshot")
+    data class Screenshot(
+        @SerialName("backend") val backend: CaptureBackend,
+        @SerialName("target") val target: CaptureTarget,
+        @SerialName("source_types") val sourceTypes: List<SourceType> = emptyList(),
+        @SerialName("display_name") val displayName: String? = null,
+        @SerialName("window_title") val windowTitle: String? = null,
+        @SerialName("cursor_mode") val cursorMode: CursorMode,
+        @SerialName("region") val region: Region,
+        @SerialName("output") val output: String,
     ) : Command
 
     @Serializable @SerialName("stop") data object Stop : Command
@@ -63,11 +80,27 @@ internal sealed interface Event {
     data class Stopped(@SerialName("output_size_bytes") val outputSizeBytes: Long) : Event
 
     @Serializable
+    @SerialName("screenshot_saved")
+    data class ScreenshotSaved(@SerialName("output_size_bytes") val outputSizeBytes: Long) : Event
+
+    @Serializable
     @SerialName("error")
     data class Error(
         @SerialName("kind") val kind: String,
         @SerialName("message") val message: String,
     ) : Event
+}
+
+@Serializable
+internal enum class CaptureBackend {
+    @SerialName("wayland_portal") WAYLAND_PORTAL,
+    @SerialName("x11") X11,
+}
+
+@Serializable
+internal enum class CaptureTarget {
+    @SerialName("region") REGION,
+    @SerialName("window") WINDOW,
 }
 
 @Serializable

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
@@ -55,9 +55,8 @@ import kotlinx.serialization.json.Json
  * Instantiating `WaylandPortalRecorder` directly assumes the bundled helper binary is present and
  * the host's xdg-desktop-portal is reachable. Failures from either are surfaced as
  * [IllegalStateException] with precise context — there is **no** silent no-op or automatic fallback
- * to another recorder. If you want a "just record" experience that degrades to ffmpeg region
- * capture when the portal isn't available, use [dev.sebastiano.spectre.recording.AutoRecorder]
- * instead; it owns the fallback-with-warning policy.
+ * to another recorder. If you want the high-level platform router, use
+ * [dev.sebastiano.spectre.recording.AutoRecorder] instead; it owns the OS/backend selection policy.
  */
 public class WaylandPortalRecorder
 private constructor(
@@ -76,13 +75,17 @@ private constructor(
      */
     public constructor() :
         this(
-            helperExtractor = WaylandHelperBinaryExtractor(),
+            helperExtractor = DefaultWaylandHelperBinaryExtractor.instance,
             processFactory = SystemProcessFactory,
             sourceTypes = listOf(SourceType.MONITOR),
             startedTimeout = DEFAULT_STARTED_TIMEOUT_MS,
             shutdownGraceMillis = DEFAULT_SHUTDOWN_GRACE_MS,
             processExitTimeoutMillis = DEFAULT_PROCESS_EXIT_TIMEOUT_MS,
         )
+
+    @Volatile
+    private var startCommandFactory: (Rectangle, Path, RecordingOptions) -> Command.Start =
+        defaultStartCommandFactory(sourceTypes)
 
     private val json = Json {
         ignoreUnknownKeys = true
@@ -117,24 +120,7 @@ private constructor(
 
         @Suppress("TooGenericExceptionCaught")
         try {
-            writeCommand(
-                process.outputStream,
-                Command.Start(
-                    sourceTypes = sourceTypes,
-                    cursorMode =
-                        if (options.captureCursor) CursorMode.EMBEDDED else CursorMode.HIDDEN,
-                    frameRate = options.frameRate,
-                    region =
-                        Region(
-                            x = region.x,
-                            y = region.y,
-                            width = region.width,
-                            height = region.height,
-                        ),
-                    output = output.toAbsolutePath().toString(),
-                    codec = options.codec,
-                ),
-            )
+            writeCommand(process.outputStream, startCommandFactory(region, output, options))
         } catch (e: IOException) {
             val launchFailure =
                 IllegalStateException(
@@ -233,6 +219,18 @@ private constructor(
                     startedLatch.countDown()
                     stoppedLatch.countDown()
                 }
+                is Event.ScreenshotSaved -> {
+                    errorEvent.compareAndSet(
+                        null,
+                        Event.Error(
+                            kind = "ProtocolUnexpectedEvent",
+                            message = "helper emitted screenshot_saved during recording start",
+                        ),
+                    )
+                    startedLatch.countDown()
+                    stoppedLatch.countDown()
+                    return
+                }
                 is Event.FrameProgress -> {
                     // Reserved for a future progress-streaming UX.
                 }
@@ -290,21 +288,51 @@ private constructor(
          */
         @JvmSynthetic
         internal fun createForInternalUse(
-            helperExtractor: WaylandHelperBinaryExtractor = WaylandHelperBinaryExtractor(),
+            helperExtractor: WaylandHelperBinaryExtractor =
+                DefaultWaylandHelperBinaryExtractor.instance,
             processFactory: ProcessFactory = SystemProcessFactory,
             sourceTypes: List<SourceType> = listOf(SourceType.MONITOR),
             startedTimeout: Long = DEFAULT_STARTED_TIMEOUT_MS,
             shutdownGraceMillis: Long = DEFAULT_SHUTDOWN_GRACE_MS,
             processExitTimeoutMillis: Long = DEFAULT_PROCESS_EXIT_TIMEOUT_MS,
+            startCommandFactory: (Rectangle, Path, RecordingOptions) -> Command.Start =
+                defaultStartCommandFactory(sourceTypes),
         ): WaylandPortalRecorder =
             WaylandPortalRecorder(
-                helperExtractor,
-                processFactory,
-                sourceTypes,
-                startedTimeout,
-                shutdownGraceMillis,
-                processExitTimeoutMillis,
+                    helperExtractor,
+                    processFactory,
+                    sourceTypes,
+                    startedTimeout,
+                    shutdownGraceMillis,
+                    processExitTimeoutMillis,
+                )
+                .also { recorder -> recorder.startCommandFactory = startCommandFactory }
+
+        fun defaultStartCommandFactory(
+            sourceTypes: List<SourceType>
+        ): (Rectangle, Path, RecordingOptions) -> Command.Start = { region, output, options ->
+            Command.Start(
+                backend = CaptureBackend.WAYLAND_PORTAL,
+                target =
+                    if (sourceTypes == listOf(SourceType.WINDOW)) {
+                        CaptureTarget.WINDOW
+                    } else {
+                        CaptureTarget.REGION
+                    },
+                sourceTypes = sourceTypes,
+                cursorMode = if (options.captureCursor) CursorMode.EMBEDDED else CursorMode.HIDDEN,
+                frameRate = options.frameRate,
+                region =
+                    Region(
+                        x = region.x,
+                        y = region.y,
+                        width = region.width,
+                        height = region.height,
+                    ),
+                output = output.toAbsolutePath().toString(),
+                codec = options.codec,
             )
+        }
     }
 }
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowRecorder.kt
@@ -139,10 +139,12 @@ private constructor(
                 ?: error(
                     "Could not determine WM frame extents for window '$title' on this Wayland " +
                         "session. The window-targeted recording path needs `_GTK_FRAME_EXTENTS` " +
-                        "via the system `xprop` binary to compute the stream-relative crop; " +
-                        "without it, the recording would be misaligned (close button clipped, " +
-                        "shadow leaking in). Install xprop (`apt install x11-utils`) or fall " +
-                        "back to WaylandPortalRecorder for region capture."
+                        "to compute the stream-relative crop; without it, the recording would " +
+                        "be misaligned (close button clipped, shadow leaking in). Missing " +
+                        "`xprop`, a non-GTK toolkit, an unsupported compositor, or no matching " +
+                        "X11 window can all produce this result. Install xprop only if the " +
+                        "binary is missing; otherwise fall back to WaylandPortalRecorder for " +
+                        "region capture."
                 )
         val streamRelativeCrop = Rectangle(extents.left, extents.top, region.width, region.height)
         return delegate.start(streamRelativeCrop, output, options)
@@ -165,7 +167,7 @@ private constructor(
  * in from the stream origin, leaving the shadow margin around it. Cropping the stream at the
  * extents gives us the visible window without the shadow padding.
  */
-private fun queryGtkFrameExtentsViaXprop(title: String): Insets? {
+internal fun queryGtkFrameExtentsViaXprop(title: String): Insets? {
     val process =
         try {
             ProcessBuilder("xprop", "-name", title, "_GTK_FRAME_EXTENTS")

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
@@ -136,12 +136,15 @@ class AutoRecorderTest {
     @Test
     fun `startRegion routes to Wayland region portal on Wayland hosts`() {
         val ffmpeg = StubRegionRecorder()
+        val linux = StubRegionRecorder()
         val portal = StubRegionRecorder()
         val recorder =
             autoRecorder(
                 ffmpegRecorder = ffmpeg,
+                linuxRegionRecorder = linux,
                 waylandPortalRecorder = portal,
                 isMacOs = { false },
+                isLinux = { true },
                 isWayland = { true },
             )
         val output = tempMov()
@@ -155,6 +158,32 @@ class AutoRecorderTest {
                 ffmpeg.startCalled,
                 "Wayland region capture must not fall through to ffmpeg",
             )
+            assertFalse(linux.startCalled, "Wayland region capture must use the portal recorder")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startRegion routes to Linux helper on Linux X11 hosts`() {
+        val ffmpeg = StubRegionRecorder()
+        val linux = StubRegionRecorder()
+        val recorder =
+            autoRecorder(
+                ffmpegRecorder = ffmpeg,
+                linuxRegionRecorder = linux,
+                isMacOs = { false },
+                isLinux = { true },
+                isWayland = { false },
+            )
+        val output = tempMov()
+        try {
+            val region = Rectangle(20, 30, 160, 90)
+
+            recorder.startRegion(region = region, output = output)
+
+            assertEquals(region, linux.lastRegion)
+            assertFalse(ffmpeg.startCalled, "Linux X11 region capture must not use ffmpeg")
         } finally {
             output.deleteIfExists()
         }
@@ -275,14 +304,17 @@ class AutoRecorderTest {
     @Test
     fun `startWindow routes to Wayland window portal with window bounds`() {
         val ffmpeg = StubRegionRecorder()
+        val linuxWindow = StubWindowRecorder(name = "linux")
         val portalRegion = StubRegionRecorder()
         val portalWindow = StubWaylandWindowSourceRecorder()
         val recorder =
             autoRecorder(
                 ffmpegRecorder = ffmpeg,
+                linuxWindowRecorder = linuxWindow,
                 waylandPortalRecorder = portalRegion,
                 waylandPortalWindowRecorder = portalWindow,
                 isMacOs = { false },
+                isLinux = { true },
                 isWayland = { true },
             )
         val output = tempMov()
@@ -296,7 +328,33 @@ class AutoRecorderTest {
             assertSame(window, portalWindow.lastWindow)
             assertEquals(bounds, portalWindow.lastRegion)
             assertFalse(portalRegion.startCalled, "Window mode must not use region portal")
+            assertEquals(0, linuxWindow.startCallCount)
             assertFalse(ffmpeg.startCalled)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startWindow routes to Linux helper on Linux X11 hosts`() {
+        val ffmpeg = StubRegionRecorder()
+        val linuxWindow = StubWindowRecorder(name = "linux")
+        val recorder =
+            autoRecorder(
+                ffmpegRecorder = ffmpeg,
+                linuxWindowRecorder = linuxWindow,
+                isMacOs = { false },
+                isLinux = { true },
+                isWayland = { false },
+            )
+        val output = tempMov()
+        try {
+            val window = StubTitledWindow(title = "MyApp")
+
+            recorder.startWindow(window = window, output = output)
+
+            assertEquals(1, linuxWindow.startCallCount)
+            assertFalse(ffmpeg.startCalled, "Linux X11 window capture must not use ffmpeg")
         } finally {
             output.deleteIfExists()
         }
@@ -358,12 +416,15 @@ private fun autoRecorder(
     ffmpegRecorder: Recorder = StubRegionRecorder(),
     windowsWindowRecorder: WindowRecorder? = null,
     windowsRegionRecorder: Recorder? = null,
+    linuxRegionRecorder: Recorder? = null,
+    linuxWindowRecorder: WindowRecorder? = null,
     waylandPortalRecorder: Recorder? = null,
     waylandPortalWindowRecorder: WaylandWindowSourceRecorder? = null,
     waylandPortalRecorderFailure: Throwable? = null,
     waylandPortalWindowRecorderFailure: Throwable? = null,
     isMacOs: () -> Boolean,
     isWindows: () -> Boolean = { false },
+    isLinux: () -> Boolean = { false },
     isWayland: () -> Boolean = { false },
 ): AutoRecorder =
     AutoRecorder(
@@ -371,12 +432,15 @@ private fun autoRecorder(
         ffmpegRecorder,
         windowsWindowRecorder,
         windowsRegionRecorder,
+        linuxRegionRecorder,
+        linuxWindowRecorder,
         waylandPortalRecorder,
         waylandPortalWindowRecorder,
         waylandPortalRecorderFailure,
         waylandPortalWindowRecorderFailure,
         isMacOs,
         isWindows,
+        isLinux,
         isWayland,
     )
 

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoScreenshotterTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoScreenshotterTest.kt
@@ -7,7 +7,6 @@ import java.awt.image.BufferedImage
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
@@ -17,12 +16,10 @@ class AutoScreenshotterTest {
     fun `captureWindow routes to SCK screenshotter on macOS`() {
         val sck = StubWindowScreenshotter()
         val windows = StubWindowScreenshotter()
-        val x11 = StubRegionScreenshotter()
         val screenshotter =
             autoScreenshotter(
                 sckScreenshotter = sck,
                 windowsWindowScreenshotter = windows,
-                x11RegionScreenshotter = x11,
                 isMacOs = { true },
             )
         val window = StubScreenshotWindow(title = "MyApp")
@@ -32,7 +29,6 @@ class AutoScreenshotterTest {
         assertEquals(1, sck.captureCallCount)
         assertSame(window, sck.lastWindow)
         assertEquals(0, windows.captureCallCount)
-        assertFalse(x11.captureCalled)
     }
 
     @Test
@@ -52,11 +48,9 @@ class AutoScreenshotterTest {
     @Test
     fun `captureWindow routes to Windows title screenshotter on Windows`() {
         val windows = StubWindowScreenshotter()
-        val x11 = StubRegionScreenshotter()
         val screenshotter =
             autoScreenshotter(
                 windowsWindowScreenshotter = windows,
-                x11RegionScreenshotter = x11,
                 isMacOs = { false },
                 isWindows = { true },
             )
@@ -66,7 +60,6 @@ class AutoScreenshotterTest {
 
         assertEquals(1, windows.captureCallCount)
         assertSame(window, windows.lastWindow)
-        assertFalse(x11.captureCalled)
     }
 
     @Test
@@ -89,13 +82,13 @@ class AutoScreenshotterTest {
     }
 
     @Test
-    fun `captureWindow uses explicit X11 region fallback on Linux X11`() {
-        val x11 = StubRegionScreenshotter()
+    fun `captureWindow routes to Linux helper on Linux X11`() {
+        val linux = StubWindowScreenshotter()
         val windows = StubWindowScreenshotter()
         val screenshotter =
             autoScreenshotter(
                 windowsWindowScreenshotter = windows,
-                x11RegionScreenshotter = x11,
+                linuxWindowScreenshotter = linux,
                 isMacOs = { false },
                 isWindows = { false },
                 isLinux = { true },
@@ -105,22 +98,26 @@ class AutoScreenshotterTest {
 
         screenshotter.captureWindow(StubScreenshotWindow(title = "MyApp", bounds = bounds))
 
-        assertEquals(bounds, x11.lastRegion)
+        assertEquals(1, linux.captureCallCount)
+        assertEquals("MyApp", linux.lastWindow?.title)
         assertEquals(0, windows.captureCallCount)
     }
 
     @Test
-    fun `captureWindow fails loudly on Wayland still screenshots`() {
+    fun `captureWindow routes to Linux helper on Wayland`() {
+        val linux = StubWindowScreenshotter()
         val screenshotter =
-            autoScreenshotter(isMacOs = { false }, isLinux = { true }, isWayland = { true })
+            autoScreenshotter(
+                linuxWindowScreenshotter = linux,
+                isMacOs = { false },
+                isLinux = { true },
+                isWayland = { true },
+            )
 
-        val error =
-            assertFailsWith<UnsupportedOperationException> {
-                screenshotter.captureWindow(StubScreenshotWindow(title = "MyApp"))
-            }
+        screenshotter.captureWindow(StubScreenshotWindow(title = "MyApp"))
 
-        assertTrue(error.message.orEmpty().contains("Wayland"))
-        assertTrue(error.message.orEmpty().contains("window-targeted recording"))
+        assertEquals(1, linux.captureCallCount)
+        assertEquals("MyApp", linux.lastWindow?.title)
     }
 
     @Test
@@ -139,7 +136,7 @@ class AutoScreenshotterTest {
 private fun autoScreenshotter(
     sckScreenshotter: WindowScreenshotter = StubWindowScreenshotter(),
     windowsWindowScreenshotter: WindowScreenshotter? = null,
-    x11RegionScreenshotter: RegionScreenshotter = StubRegionScreenshotter(),
+    linuxWindowScreenshotter: WindowScreenshotter? = null,
     isMacOs: () -> Boolean,
     isWindows: () -> Boolean = { false },
     isLinux: () -> Boolean = { false },
@@ -148,7 +145,7 @@ private fun autoScreenshotter(
     AutoScreenshotter(
         sckScreenshotter,
         windowsWindowScreenshotter,
-        x11RegionScreenshotter,
+        linuxWindowScreenshotter,
         isMacOs,
         isWindows,
         isLinux,
@@ -177,20 +174,6 @@ private class StubWindowScreenshotter(
             StubScreenshotBehavior.HelperNotBundled ->
                 throw HelperNotBundledException("test helper is missing")
         }
-    }
-}
-
-private class StubRegionScreenshotter : RegionScreenshotter {
-    var captureCalled: Boolean = false
-        private set
-
-    var lastRegion: Rectangle? = null
-        private set
-
-    override fun captureRegion(region: Rectangle): BufferedImage {
-        captureCalled = true
-        lastRegion = region
-        return BufferedImage(region.width, region.height, BufferedImage.TYPE_INT_ARGB)
     }
 }
 

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/DefaultWaylandHelperBinaryExtractorTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/DefaultWaylandHelperBinaryExtractorTest.kt
@@ -1,0 +1,30 @@
+package dev.sebastiano.spectre.recording
+
+import dev.sebastiano.spectre.recording.portal.DefaultWaylandHelperBinaryExtractor
+import dev.sebastiano.spectre.recording.portal.WaylandPortalRecorder
+import dev.sebastiano.spectre.recording.portal.WaylandPortalWindowRecorder
+import kotlin.test.Test
+import kotlin.test.assertSame
+
+class DefaultWaylandHelperBinaryExtractorTest {
+
+    @Test
+    fun `Linux helper backed defaults share one extractor`() {
+        val extractor = DefaultWaylandHelperBinaryExtractor.instance
+
+        assertSame(extractor, LinuxX11Recorder().helperExtractorForTest())
+        assertSame(extractor, LinuxNativeScreenshotter().helperExtractorForTest())
+        assertSame(extractor, WaylandPortalRecorder().helperExtractorForTest())
+        assertSame(
+            extractor,
+            WaylandPortalWindowRecorder().delegateForTest().helperExtractorForTest(),
+        )
+    }
+}
+
+private fun Any.helperExtractorForTest(): Any? = declaredField("helperExtractor").get(this)
+
+private fun WaylandPortalWindowRecorder.delegateForTest(): Any = declaredField("delegate").get(this)
+
+private fun Any.declaredField(name: String): java.lang.reflect.Field =
+    javaClass.getDeclaredField(name).apply { isAccessible = true }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegGdigrabSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegGdigrabSmoke.kt
@@ -1,4 +1,5 @@
 @file:JvmName("FfmpegGdigrabSmoke")
+@file:Suppress("DEPRECATION")
 
 package dev.sebastiano.spectre.recording
 

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package dev.sebastiano.spectre.recording
 
 import java.awt.Rectangle

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegScreenshotterTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegScreenshotterTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package dev.sebastiano.spectre.recording
 
 import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegWindowRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegWindowRecorderTest.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package dev.sebastiano.spectre.recording
 
 import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegX11GrabSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegX11GrabSmoke.kt
@@ -1,4 +1,5 @@
 @file:JvmName("FfmpegX11GrabSmoke")
+@file:Suppress("DEPRECATION")
 
 package dev.sebastiano.spectre.recording
 

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotterTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotterTest.kt
@@ -1,0 +1,115 @@
+package dev.sebastiano.spectre.recording
+
+import dev.sebastiano.spectre.recording.portal.WaylandHelperBinaryExtractor
+import java.awt.Rectangle
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class LinuxNativeScreenshotterTest {
+
+    @Test
+    fun `captureRegion destroys helper when command write fails`() {
+        val tempDir = Files.createTempDirectory("spectre-linux-screenshotter-test-")
+        val process = FakeScreenshotHelperProcess(stdin = ThrowingOutputStream())
+        val screenshotter = linuxScreenshotter(tempDir, process)
+
+        try {
+            assertFailsWith<IllegalStateException> {
+                screenshotter.captureRegion(Rectangle(0, 0, 10, 10))
+            }
+
+            assertTrue(process.destroyed, "failed command writes must not leak the helper")
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `captureRegion destroys helper when stdout event is malformed`() {
+        val tempDir = Files.createTempDirectory("spectre-linux-screenshotter-test-")
+        val process = FakeScreenshotHelperProcess(stdout = "not-json\n".byteInputStream())
+        val screenshotter = linuxScreenshotter(tempDir, process)
+
+        try {
+            assertFailsWith<RuntimeException> {
+                screenshotter.captureRegion(Rectangle(0, 0, 10, 10))
+            }
+
+            assertTrue(process.destroyed, "malformed helper events must not leak the helper")
+        } finally {
+            tempDir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun linuxScreenshotter(tempDir: Path, process: Process): LinuxNativeScreenshotter =
+        LinuxNativeScreenshotter(
+            helperExtractor =
+                WaylandHelperBinaryExtractor(
+                    envLookup = { null },
+                    resourceLocator = { ByteArrayInputStream(byteArrayOf(0x7f)) },
+                    targetDirProvider = { tempDir },
+                    archProvider = { "x86_64" },
+                ),
+            processFactory =
+                object : LinuxNativeScreenshotter.ProcessFactory {
+                    override fun start(helperPath: Path): Process = process
+                },
+            isWayland = { false },
+            displayNameProvider = { ":99" },
+            frameExtentsLookup = { null },
+        )
+}
+
+private class ThrowingOutputStream : OutputStream() {
+    override fun write(b: Int) {
+        throw IOException("simulated EPIPE")
+    }
+}
+
+private class FakeScreenshotHelperProcess(
+    private val stdout: InputStream = ByteArrayInputStream(ByteArray(0)),
+    private val stdin: OutputStream = ByteArrayOutputStream(),
+    private val exit: Int = 1,
+) : Process() {
+
+    var destroyed: Boolean = false
+        private set
+
+    override fun getOutputStream(): OutputStream = stdin
+
+    override fun getInputStream(): InputStream = stdout
+
+    override fun getErrorStream(): InputStream = ByteArrayInputStream(ByteArray(0))
+
+    override fun waitFor(): Int = exit
+
+    override fun waitFor(timeout: Long, unit: TimeUnit): Boolean = true
+
+    override fun exitValue(): Int = exit
+
+    override fun destroy() {
+        destroyed = true
+    }
+
+    override fun destroyForcibly(): Process {
+        destroyed = true
+        stdout.close()
+        return this
+    }
+
+    override fun isAlive(): Boolean = !destroyed
+
+    override fun toHandle(): ProcessHandle = ProcessHandle.current()
+
+    override fun onExit(): CompletableFuture<Process> = CompletableFuture.completedFuture(this)
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/LinuxX11RecordingSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/LinuxX11RecordingSmoke.kt
@@ -1,0 +1,200 @@
+@file:JvmName("LinuxX11RecordingSmoke")
+
+package dev.sebastiano.spectre.recording
+
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.Font
+import java.awt.Robot
+import java.awt.Toolkit
+import java.awt.Window
+import java.awt.image.BufferedImage
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.imageio.ImageIO
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.JWindow
+import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/**
+ * Manual end-to-end smoke for the Linux helper's Xorg/Xvfb region recording path. Run via
+ * `./gradlew :recording:runLinuxX11RecordingSmoke` from an X display; the task opens a small
+ * JFrame, records it for ~3 seconds through [AutoRecorder], and prints the resulting file path +
+ * size.
+ */
+fun main() {
+    var exitCode = 0
+    try {
+        runSmoke()
+    } catch (t: Throwable) {
+        System.err.println("Smoke failed: ${t.message}\n${t.stackTraceToString()}")
+        exitCode = 1
+    } finally {
+        exitProcess(exitCode)
+    }
+}
+
+private fun runSmoke() {
+    val output = Path.of(System.getProperty("java.io.tmpdir"), "spectre-linux-x11-smoke.mp4")
+    val midRecordingPng =
+        Path.of(System.getProperty("java.io.tmpdir"), "spectre-linux-x11-smoke.png")
+    Files.deleteIfExists(output)
+    Files.deleteIfExists(midRecordingPng)
+
+    val (window, label) = openSmokeWindow()
+    Thread.sleep(WINDOW_SETTLE_MS)
+    waitForVisibleFrame(window)
+
+    val frameBoundsAtStart = window.bounds
+    val handle =
+        AutoRecorder()
+            .startRegion(
+                region = frameBoundsAtStart,
+                output = output,
+                options = RecordingOptions(frameRate = 30, captureCursor = true),
+            )
+
+    println("Recording started -> $output (pid=${ProcessHandle.current().pid()})")
+
+    var ticks = 0
+    val animator =
+        Thread.ofPlatform().daemon().name("spectre-linux-x11-smoke-animator").start {
+            val deadline = System.nanoTime() + RECORD_DURATION_MS * 1_000_000L
+            while (System.nanoTime() < deadline && !Thread.currentThread().isInterrupted) {
+                ticks += 1
+                val current = ticks
+                SwingUtilities.invokeLater { label.text = "tick=$current" }
+                Thread.sleep(ANIMATION_INTERVAL_MS.toLong())
+            }
+        }
+
+    Thread.sleep(RECORD_DURATION_MS / 2)
+    val frameBounds = window.bounds
+    val robotShot = Robot().createScreenCapture(frameBounds)
+    ImageIO.write(robotShot, "png", File(midRecordingPng.toString()))
+    checkVisibleReferenceFrame(robotShot, frameBounds)
+    println("Robot screenshot of smoke window bounds $frameBounds -> $midRecordingPng")
+
+    animator.join()
+    println("Animation done; ticks fired: $ticks")
+
+    handle.stop()
+    val sizeBytes = if (Files.exists(output)) Files.size(output) else -1
+    println("Recording stopped -> $output ($sizeBytes bytes)")
+
+    SwingUtilities.invokeLater {
+        window.isVisible = false
+        window.dispose()
+    }
+}
+
+private fun waitForVisibleFrame(window: Window) {
+    val robot = Robot()
+    val deadline = System.nanoTime() + VISIBLE_FRAME_TIMEOUT_MS * NANOS_PER_MILLI
+    var lastShot: BufferedImage? = null
+    while (System.nanoTime() < deadline) {
+        val bounds = window.bounds
+        val shot = robot.createScreenCapture(bounds)
+        if (hasEnoughVisiblePixels(shot)) return
+        lastShot = shot
+        SwingUtilities.invokeAndWait {
+            window.toFront()
+            window.repaint()
+            Toolkit.getDefaultToolkit().sync()
+        }
+        robot.waitForIdle()
+        Thread.sleep(VISIBLE_FRAME_POLL_MS)
+    }
+    checkVisibleReferenceFrame(checkNotNull(lastShot), window.bounds)
+}
+
+private fun checkVisibleReferenceFrame(image: BufferedImage, bounds: java.awt.Rectangle) {
+    val visiblePixels = visiblePixelCount(image)
+    val totalPixels = totalPixelCount(image)
+    val minimumVisiblePixels = totalPixels / MIN_VISIBLE_PIXEL_DIVISOR
+    check(visiblePixels >= minimumVisiblePixels) {
+        "X11 region smoke reference screenshot for $bounds is effectively black " +
+            "($visiblePixels/$totalPixels visible pixels). If this is running inside a native " +
+            "Wayland session with XWayland, the X11 root framebuffer may not contain the " +
+            "composited desktop; run this smoke under a real Xorg/Xvfb display, or validate the " +
+            "normal Wayland portal route instead."
+    }
+}
+
+private fun hasEnoughVisiblePixels(image: BufferedImage): Boolean =
+    visiblePixelCount(image) >= totalPixelCount(image) / MIN_VISIBLE_PIXEL_DIVISOR
+
+private fun totalPixelCount(image: BufferedImage): Int = image.width * image.height
+
+private fun visiblePixelCount(image: BufferedImage): Int {
+    var visiblePixels = 0
+    for (y in 0 until image.height) {
+        for (x in 0 until image.width) {
+            val rgb = image.getRGB(x, y)
+            val red = rgb shr 16 and COLOR_MASK
+            val green = rgb shr 8 and COLOR_MASK
+            val blue = rgb and COLOR_MASK
+            if (red + green + blue > MIN_VISIBLE_RGB_SUM) visiblePixels += 1
+        }
+    }
+    return visiblePixels
+}
+
+private fun openSmokeWindow(): Pair<Window, JLabel> {
+    val ready = CountDownLatch(1)
+    var windowRef: Window? = null
+    var labelRef: JLabel? = null
+    SwingUtilities.invokeLater {
+        val label =
+            JLabel("tick=0", SwingConstants.CENTER).apply {
+                font = Font(Font.SANS_SERIF, Font.BOLD, LABEL_FONT_SIZE)
+                foreground = Color.BLACK
+            }
+        val panel =
+            JPanel(BorderLayout()).apply {
+                background = Color.WHITE
+                isOpaque = true
+                add(label, BorderLayout.CENTER)
+            }
+        val window =
+            JWindow().apply {
+                contentPane = panel
+                size = Dimension(WINDOW_WIDTH, WINDOW_HEIGHT)
+                setBounds(WINDOW_X, WINDOW_Y, WINDOW_WIDTH, WINDOW_HEIGHT)
+                isVisible = true
+                toFront()
+                repaint()
+                Toolkit.getDefaultToolkit().sync()
+            }
+        windowRef = window
+        labelRef = label
+        ready.countDown()
+    }
+    check(ready.await(WINDOW_OPEN_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        "Smoke window never came up within ${WINDOW_OPEN_TIMEOUT_SECONDS}s"
+    }
+    return checkNotNull(windowRef) to checkNotNull(labelRef)
+}
+
+private const val WINDOW_WIDTH = 480
+private const val WINDOW_HEIGHT = 240
+private const val WINDOW_X = 400
+private const val WINDOW_Y = 280
+private const val WINDOW_SETTLE_MS = 500L
+private const val WINDOW_OPEN_TIMEOUT_SECONDS = 5L
+private const val RECORD_DURATION_MS = 3_000L
+private const val ANIMATION_INTERVAL_MS = 50
+private const val LABEL_FONT_SIZE = 48
+private const val VISIBLE_FRAME_TIMEOUT_MS = 5_000L
+private const val VISIBLE_FRAME_POLL_MS = 100L
+private const val NANOS_PER_MILLI = 1_000_000L
+private const val COLOR_MASK = 0xff
+private const val MIN_VISIBLE_RGB_SUM = 60
+private const val MIN_VISIBLE_PIXEL_DIVISOR = 20

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/WindowScreenshotSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/WindowScreenshotSmoke.kt
@@ -2,7 +2,6 @@
 
 package dev.sebastiano.spectre.recording
 
-import dev.sebastiano.spectre.recording.FfmpegBackend.Companion.detectWaylandSession
 import dev.sebastiano.spectre.recording.screencapturekit.asTitledWindow
 import java.awt.BorderLayout
 import java.awt.Color
@@ -27,9 +26,8 @@ import kotlin.system.exitProcess
  * Expected behavior:
  * - macOS: captures a PNG through ScreenCaptureKit (`spectre-screencapture --mode screenshot`).
  * - Windows: captures a PNG through the Windows Graphics Capture helper.
- * - Linux X11: captures a PNG through ffmpeg `x11grab` region fallback.
- * - Linux Wayland: verifies the current still-screenshot unsupported error and exits successfully.
- *   Use `runWaylandPortalWindowSmoke` for the Wayland window-targeted video path.
+ * - Linux X11/XWayland: captures a PNG through the Linux helper's GStreamer `ximagesrc` path.
+ * - Linux Wayland: captures a PNG through the Linux helper's portal + PipeWire one-frame path.
  */
 fun main() {
     var exitCode = 0
@@ -59,23 +57,6 @@ private fun runSmoke() {
         Thread.sleep(WINDOW_SETTLE_MS)
 
         val screenshotter = AutoScreenshotter()
-        if (isWaylandSession()) {
-            val error =
-                runCatching { screenshotter.captureWindow(frame.asTitledWindow()) }
-                    .exceptionOrNull()
-            check(error is UnsupportedOperationException) {
-                "Expected Wayland still screenshot to be unsupported, got $error"
-            }
-            check(error.message.orEmpty().contains("Wayland")) {
-                "Expected Wayland guidance in unsupported message, got: ${error.message}"
-            }
-            println(
-                "Wayland still screenshot unsupported as expected; use " +
-                    "`./gradlew :recording:runWaylandPortalWindowSmoke` for window video."
-            )
-            return
-        }
-
         val image = screenshotter.captureWindow(frame.asTitledWindow())
         check(image.width > 1 && image.height > 1) {
             "Captured image has invalid dimensions: ${image.width}x${image.height}"
@@ -130,10 +111,6 @@ private fun openSmokeWindow(): Pair<JFrame, JLabel> {
     }
     return checkNotNull(frameRef) to checkNotNull(labelRef)
 }
-
-private fun isWaylandSession(): Boolean =
-    System.getProperty("os.name").orEmpty().lowercase().contains("linux") &&
-        detectWaylandSession(System::getenv)
 
 private const val WINDOW_WIDTH: Int = 360
 private const val WINDOW_HEIGHT: Int = 180


### PR DESCRIPTION
## Summary

Adds Linux native helper-backed capture paths for Xorg/Xvfb and Wayland so the default Linux recording/screenshot routes no longer depend on ffmpeg for X11/XWayland region capture.

## Details

- Extends the Linux Rust helper protocol with screenshot commands, explicit X11 vs Wayland backends, capture targets, and screenshot-saved events.
- Adds GStreamer `ximagesrc` pipelines for Xorg/Xvfb region/window recording and PNG screenshots, with quoted property values and a clear unsupported-codec failure for non-x264 helper paths.
- Adds `LinuxX11Recorder` and `LinuxNativeScreenshotter`, routes `AutoRecorder` / `AutoScreenshotter` through them, and keeps explicit ffmpeg classes as deprecated legacy escape hatches.
- Shares the Linux helper extractor across Linux recorder/screenshot/portal defaults and tightens helper process cleanup paths for screenshot failures.
- Updates docs, smoke runners, ABI baseline, and targeted unit coverage for Linux routing, screenshots, helper extraction, and deprecation behavior.

## Validation

- `./gradlew :recording:ktfmtCheck :recording:test --tests "*AutoRecorderTest" --tests "*AutoScreenshotterTest" --tests "*DefaultWaylandHelperBinaryExtractorTest" :recording:detekt :recording:checkKotlinAbi`
- `./gradlew check`
- Ubuntu VM: `cargo fmt --check && cargo test` in `recording/native/linux`
- Ubuntu VM: `./gradlew check`
- Ubuntu VM Xvfb: `xvfb-run -a -s '-screen 0 1280x800x24' env -u XDG_SESSION_TYPE -u WAYLAND_DISPLAY -u XDG_RUNTIME_DIR ./gradlew --no-daemon :recording:runLinuxX11RecordingSmoke`
- Ubuntu VM Xvfb: same environment with `:recording:runWindowScreenshotSmoke`

Proof artifacts collected under `.plans/spectre-linux-capture-proof-20260524-100618/`. Caveat: forced X11 capture under Mutter/XWayland can produce black root-framebuffer output; the valid X11 proof is from Xvfb/Xorg.