### PR TITLE
Enforce per-source-set detekt in ./gradlew check; fix surfaced findings

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
@@ -36,9 +36,15 @@ internal class BlockingSuspendInvoker(private val timeoutMs: Long = DEFAULT_TIME
      * suspend function's eventual result, or throws the exception that resumed the continuation
      * with failure.
      */
+    // Both spreads below (`*args` into `arrayOf`, `*argsWithCont` into the Java reflection
+    // call) are unavoidable: we need to append `cont` to the caller-supplied vararg array,
+    // then re-spread the result into `Method.invoke`'s Java-side `Object...` parameter so
+    // Kotlin doesn't pass the array as a single argument. The array is small (caller-supplied
+    // suspend-function args + 1 continuation), so the per-call copy is not material.
+    @Suppress("SpreadOperator")
     fun invoke(method: Method, target: Any, vararg args: Any?): Any? {
         val cont = LatchingContinuation()
-        @Suppress("SpreadOperator") val argsWithCont: Array<Any?> = arrayOf(*args, cont)
+        val argsWithCont: Array<Any?> = arrayOf(*args, cont)
         val raw = method.invoke(target, *argsWithCont)
         return if (raw === COROUTINE_SUSPENDED) cont.await(timeoutMs) else raw
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -50,6 +50,16 @@ tasks.withType<Detekt>().configureEach {
     exclude(*generatedSourceExcludes)
 }
 
+// The detekt 2.x aggregator (`:detekt`) is a no-op marker that does NOT transitively
+// depend on the per-source-set `:detektMain` / `:detektTest` tasks the plugin also
+// registers. Without this fan-out, `./gradlew check` would skip the source-set tasks
+// where type-resolution-aware rules (UnsafeCallOnNullableType, InjectDispatcher, …)
+// actually run, so findings would never reach CI. `tasks.matching` stays lazy so
+// modules that don't register a `detektTest` (no test source set) are tolerated.
+val perSourceSetDetektNames = setOf("detektMain", "detektTest")
+
+tasks.named("detekt") { dependsOn(tasks.matching { it.name in perSourceSetDetektNames }) }
+
 subprojects {
     apply(plugin = "base")
 
@@ -75,6 +85,8 @@ subprojects {
             jvmTarget = "21"
             exclude(*generatedSourceExcludes)
         }
+
+        tasks.named("detekt") { dependsOn(tasks.matching { it.name in perSourceSetDetektNames }) }
     }
 
     tasks

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -278,7 +278,7 @@ public final class dev/sebastiano/spectre/core/perf/RecompositionMonitor : java/
 	public static final field Companion Ldev/sebastiano/spectre/core/perf/RecompositionMonitor$Companion;
 	public synthetic fun <init> (JILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (JLkotlin/time/TimeSource$WithComparableMarks;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLkotlin/time/TimeSource$WithComparableMarks;Lkotlinx/coroutines/CoroutineDispatcher;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun awaitCompositionIdle-2d-g_3Q (JJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitCompositionIdle-2d-g_3Q$default (Ldev/sebastiano/spectre/core/perf/RecompositionMonitor;JJJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun awaitRateBelow-vLdBGDU (DJJLkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -469,7 +469,10 @@ private constructor(
                 .apply { isDaemon = true }
         thread.start()
         return if (latch.await(budgetMs, TimeUnit.MILLISECONDS)) {
-            resultRef.get()!!.getOrThrow()
+            requireNotNull(resultRef.get()) {
+                    "spectre-bounded-worker counted down the latch without publishing a Result"
+                }
+                .getOrThrow()
         } else {
             thread.interrupt()
             // Brief grace window to let cooperative blockers (invokeAndWait) honour the

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/EdtUtils.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/EdtUtils.kt
@@ -7,5 +7,8 @@ internal fun <T> readOnEdt(block: () -> T): T {
 
     var result: Result<T>? = null
     SwingUtilities.invokeAndWait { result = runCatching(block) }
-    return result!!.getOrThrow()
+    return requireNotNull(result) {
+            "SwingUtilities.invokeAndWait returned without the EDT block setting the result"
+        }
+        .getOrThrow()
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -16,6 +16,7 @@ import java.awt.image.BufferedImage
 import javax.swing.SwingUtilities
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
@@ -618,7 +619,15 @@ private fun createAwtRobot(): Robot =
         isAutoWaitForIdle = false
     }
 
-private suspend fun runOffEdt(robot: RobotAdapter, block: suspend () -> Unit) {
+// `dispatcher` defaults to `Dispatchers.IO` because real `java.awt.Robot` calls block and IO is
+// sized for blocking work, but lives in the canonical injection slot (default parameter) so
+// tests/callers can swap it. detekt's `InjectDispatcher` rule treats a default-parameter value
+// as the accepted injection seam.
+private suspend fun runOffEdt(
+    robot: RobotAdapter,
+    block: suspend () -> Unit,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
     // Adapters that don't need the off-EDT marshal (synthetic, headless-throwing) can run
     // inline even on the EDT — switching to another dispatcher would force the synthetic
     // adapter to bounce IO → EDT for every dispatch when the caller is already on the EDT,
@@ -628,9 +637,7 @@ private suspend fun runOffEdt(robot: RobotAdapter, block: suspend () -> Unit) {
         block()
         return
     }
-    // Real `java.awt.Robot` calls block. `Dispatchers.IO` is sized for blocking I/O work and
-    // suspends the calling EDT coroutine without parking the EDT thread.
-    withContext(Dispatchers.IO) { block() }
+    withContext(dispatcher) { block() }
 }
 
 internal fun shortcutModifierKeyCode(isMacOs: Boolean): Int =

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitor.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecompositionMonitor.kt
@@ -21,6 +21,7 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 import kotlin.time.TimeSource
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -53,6 +54,11 @@ public class RecompositionMonitor
 internal constructor(
     private val windowDuration: Duration = DEFAULT_WINDOW,
     private val timeSource: TimeSource.WithComparableMarks = TimeSource.Monotonic,
+    // Lives in the constructor's canonical injection slot so tests can swap it. The default
+    // (`Dispatchers.Default`) preserves the previous property-initialiser behaviour. detekt's
+    // `InjectDispatcher` rule treats a default constructor parameter as the accepted seam,
+    // unlike a bare `Dispatchers.Default` reference in a property initialiser.
+    dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : AutoCloseable {
 
     /** Default user-facing constructor with the wall-clock time source. */
@@ -63,7 +69,7 @@ internal constructor(
     private val ownedJob = SupervisorJob()
 
     /** Test-visible accessor for the owned scope so unit tests can assert cancellation. */
-    internal val scopeForTests: CoroutineScope = CoroutineScope(ownedJob + Dispatchers.Default)
+    internal val scopeForTests: CoroutineScope = CoroutineScope(ownedJob + dispatcher)
 
     private val surfaces = ConcurrentHashMap<String, SurfaceTracker>()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ androidx-lifecycle = "2.10.0"
 androidx-tracing = "2.0.0-alpha06"
 composeMultiplatform = "1.10.3"
 composeRules = "0.5.6"
-detekt = "2.0.0-alpha.2"
+detekt = "2.0.0-alpha.3"
 intellijIdea = "2026.1.1"
 # JetBrains' intellij-ide-starter for the #42 IDE-hosted UI test. Pinned to the same build
 # our IDE itself runs (2026.1.1 == 261.23567.138) so the framework matches the IDE's

--- a/recording/api/recording.api
+++ b/recording/api/recording.api
@@ -14,8 +14,8 @@ public final class dev/sebastiano/spectre/recording/AutoRecorder {
 }
 
 public final class dev/sebastiano/spectre/recording/AutoScreenshotter {
-	public fun <init> (Ldev/sebastiano/spectre/recording/WindowScreenshotter;Ldev/sebastiano/spectre/recording/WindowScreenshotter;Ldev/sebastiano/spectre/recording/RegionScreenshotter;)V
-	public synthetic fun <init> (Ldev/sebastiano/spectre/recording/WindowScreenshotter;Ldev/sebastiano/spectre/recording/WindowScreenshotter;Ldev/sebastiano/spectre/recording/RegionScreenshotter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/sebastiano/spectre/recording/WindowScreenshotter;Ldev/sebastiano/spectre/recording/WindowScreenshotter;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/recording/WindowScreenshotter;Ldev/sebastiano/spectre/recording/WindowScreenshotter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun captureWindow (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;J)Ljava/awt/image/BufferedImage;
 	public static synthetic fun captureWindow$default (Ldev/sebastiano/spectre/recording/AutoScreenshotter;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JILjava/lang/Object;)Ljava/awt/image/BufferedImage;
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -204,9 +204,12 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
             process.outputStream?.use { it.write('q'.code) }
         } catch (_: IOException) {
             // ffmpeg may have already exited; the waitFor below confirms.
-        } catch (t: Throwable) {
-            // Any failure here still goes to the SIGTERM fallback.
-            if (t is InterruptedException) Thread.currentThread().interrupt()
+        } catch (_: InterruptedException) {
+            // Cancellation still drops through to the SIGTERM fallback; re-flag the thread so
+            // the caller observes the interrupt after we've cleaned up the subprocess.
+            Thread.currentThread().interrupt()
+        } catch (_: Throwable) {
+            // Any other failure here still goes to the SIGTERM fallback.
         }
         // Catch InterruptedException around every waitFor so cancellation never short-circuits
         // the SIGTERM/SIGKILL fallback path. We still call destroyForcibly() in that case so
@@ -246,7 +249,7 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
             // Even after destroyForcibly(), ffmpeg refused to die within the wait window.
             // Surface this as a hard failure rather than letting the caller observe
             // isStopped=true while the process is still mutating the output file.
-            throw IllegalStateException(
+            error(
                 "ffmpeg did not exit after destroyForcibly() within ${FORCE_KILL_SECONDS}s — " +
                     "output at $output is in an undefined state."
             )
@@ -277,7 +280,7 @@ private class FfmpegRecordingHandle(private val process: Process, override val o
                     exit == POSIX_SIGTERM_EXIT ||
                     exit == FFMPEG_SIGKILL_EXIT)
         if (!isExpectedSelfSignal) {
-            throw IllegalStateException(
+            error(
                 "ffmpeg exited with code $exit during recording — output at $output may be " +
                     "truncated or missing. Common causes: disk full, encoder error, device " +
                     "failure during capture, or external termination."
@@ -333,7 +336,7 @@ internal fun spawnFfmpegRecording(
                 }
             Thread.currentThread().interrupt()
             if (!terminated) {
-                throw IllegalStateException(
+                error(
                     "ffmpeg refused to die after destroyForcibly() during start() interrupt — " +
                         "leaking an orphan recorder is not safe; output at $output is in an " +
                         "undefined state."
@@ -342,7 +345,7 @@ internal fun spawnFfmpegRecording(
             throw e
         }
     if (exitedDuringProbe) {
-        throw IllegalStateException(
+        error(
             "ffmpeg exited immediately (code ${process.exitValue()}) — recording did not start. " +
                 "Common causes: missing macOS Screen Recording permission, invalid codec, " +
                 "unavailable avfoundation/gdigrab device, or a Windows gdigrab `title=` that " +

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotter.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotter.kt
@@ -130,7 +130,7 @@ internal constructor(
             writeCommand(process.outputStream, command)
             process.outputStream.close()
             if (!eventLatch.await(SCREENSHOT_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
-                throw IllegalStateException(
+                error(
                     "Timed out after ${SCREENSHOT_TIMEOUT_MS}ms waiting for Linux screenshot " +
                         "helper."
                 )

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/WindowScreenshotter.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/WindowScreenshotter.kt
@@ -31,8 +31,6 @@ internal constructor(
     public constructor(
         sckScreenshotter: WindowScreenshotter = ScreenCaptureKitScreenshotter(),
         windowsWindowScreenshotter: WindowScreenshotter? = defaultWindowsWindowScreenshotter(),
-        @Suppress("UNUSED_PARAMETER")
-        x11RegionScreenshotter: RegionScreenshotter = UnusedLegacyX11RegionScreenshotter,
     ) : this(
         sckScreenshotter = sckScreenshotter,
         windowsWindowScreenshotter = windowsWindowScreenshotter,
@@ -121,13 +119,4 @@ public interface WindowScreenshotter {
 
 public interface RegionScreenshotter {
     public fun captureRegion(region: Rectangle): BufferedImage
-}
-
-private object UnusedLegacyX11RegionScreenshotter : RegionScreenshotter {
-    override fun captureRegion(region: Rectangle): BufferedImage =
-        error(
-            "AutoScreenshotter no longer uses the legacy x11RegionScreenshotter constructor " +
-                "parameter. Instantiate LinuxNativeScreenshotter directly for Linux region " +
-                "screenshots."
-        )
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
@@ -176,7 +176,7 @@ private constructor(
         )
     }
 
-    @Suppress("LongParameterList", "TooGenericExceptionCaught", "LoopWithTooManyJumpStatements")
+    @Suppress("LongParameterList", "TooGenericExceptionCaught")
     private fun readerLoop(
         reader: BufferedReader,
         started: AtomicReference<Event.Started?>,
@@ -185,26 +185,32 @@ private constructor(
         startedLatch: CountDownLatch,
         stoppedLatch: CountDownLatch,
     ) {
-        while (true) {
-            val line = reader.readLine() ?: break
-            if (line.isBlank()) continue
-            val event =
-                try {
-                    json.decodeFromString(Event.serializer(), line)
-                } catch (e: Throwable) {
-                    errorEvent.compareAndSet(
-                        null,
-                        Event.Error(
-                            kind = "ProtocolDecode",
-                            message =
-                                "failed to parse helper event line " +
-                                    "'${line.take(MALFORMED_LINE_PREVIEW_LENGTH)}': ${e.message}",
-                        ),
-                    )
-                    startedLatch.countDown()
-                    stoppedLatch.countDown()
-                    return
-                }
+        // `reader.lineSequence()` yields `Sequence<String>` directly (vs the platform-nullable
+        // `readLine(): String?`), and the `val event: Event` declaration is split from the
+        // assignment-in-try below. Both are workarounds for detekt 2.x's K2-based
+        // UnreachableCode rule, which cascades a false positive across a loop body when the
+        // loop guard touches a cross-module nullable type (#5186) or when an assignment uses
+        // a `try { ... } catch { ... return }` expression. With the two-step assignment the
+        // analyzer sees a plain `try` statement and the rest of the loop body stays
+        // reachable.
+        for (line in reader.lineSequence().filter { it.isNotBlank() }) {
+            val event: Event
+            try {
+                event = json.decodeFromString(Event.serializer(), line)
+            } catch (e: Throwable) {
+                errorEvent.compareAndSet(
+                    null,
+                    Event.Error(
+                        kind = "ProtocolDecode",
+                        message =
+                            "failed to parse helper event line " +
+                                "'${line.take(MALFORMED_LINE_PREVIEW_LENGTH)}': ${e.message}",
+                    ),
+                )
+                startedLatch.countDown()
+                stoppedLatch.countDown()
+                return
+            }
             when (event) {
                 is Event.Started -> {
                     started.set(event)
@@ -481,7 +487,7 @@ private class GstRecordingHandle(
         readerThread.join()
         val exit = process.exitValue()
         if (exit != 0) {
-            throw IllegalStateException(
+            error(
                 "spectre-wayland-helper exited with non-zero status $exit. Stopped event " +
                     "received was ${stoppedRef.get()}; check helper stderr (forwarded to this " +
                     "process's stderr) for the underlying cause."

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -124,7 +124,7 @@ internal constructor(
                     } else {
                         process.exitValue()
                     }
-                throw IllegalStateException(messageForHelperExit(exit, output, argv))
+                error(messageForHelperExit(exit, output, argv))
             }
 
             val handle =
@@ -310,8 +310,12 @@ private class ScreenCaptureKitRecordingHandle(
             process.outputStream?.use { it.write('q'.code) }
         } catch (_: IOException) {
             // helper may have already exited; the waitFor below confirms.
-        } catch (t: Throwable) {
-            if (t is InterruptedException) Thread.currentThread().interrupt()
+        } catch (_: InterruptedException) {
+            // Cancellation drops through to the SIGTERM fallback below; re-flag the thread
+            // so the caller observes the interrupt after we've torn down the subprocess.
+            Thread.currentThread().interrupt()
+        } catch (_: Throwable) {
+            // Any other failure here still goes to the SIGTERM fallback.
         }
         var interrupted = false
         val gracefulExit =
@@ -341,7 +345,7 @@ private class ScreenCaptureKitRecordingHandle(
         }
         if (interrupted) Thread.currentThread().interrupt()
         if (process.isAlive) {
-            throw IllegalStateException(
+            error(
                 "spectre-screencapture did not exit after destroyForcibly() within ${FORCE_KILL_SECONDS}s — " +
                     "output at $output is in an undefined state."
             )
@@ -374,7 +378,7 @@ private class ScreenCaptureKitRecordingHandle(
         // exit lets callers see that the recording's output is unsafe to use. (FfmpegRecorder
         // has a sentSignalOurselves exemption because ffmpeg has no graceful SIGTERM handler;
         // SCK does, so the exemption isn't appropriate here.)
-        throw IllegalStateException(
+        error(
             "spectre-screencapture exited with code $exit during recording — output at $output " +
                 "may be truncated or missing."
         )

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/TitledWindow.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/TitledWindow.kt
@@ -33,7 +33,7 @@ public fun Frame.asTitledWindow(): TitledWindow =
         override var title: String?
             get() = onEdt { this@asTitledWindow.title }
             set(value) {
-                onEdt { this@asTitledWindow.title = value ?: "" }
+                onEdt { this@asTitledWindow.title = value.orEmpty() }
             }
 
         override val bounds: Rectangle

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureArguments.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureArguments.kt
@@ -33,7 +33,7 @@ internal data class WindowsGraphicsCaptureArguments(
                 }
             }
             WindowsGraphicsCaptureSource.Region -> {
-                require(region != null) { "region is required for region capture" }
+                requireNotNull(region) { "region is required for region capture" }
                 require(region.width > 0 && region.height > 0) {
                     "region dimensions must be positive, was ${region.width}x${region.height}"
                 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureRecorder.kt
@@ -152,7 +152,7 @@ internal constructor(
                     process.destroyForcibly()
                     -1
                 }
-            throw IllegalStateException(
+            error(
                 messageForWindowsGraphicsCaptureHelperExit(exit, argv) +
                     if (line == null) "" else " First stdout line: $line"
             )
@@ -226,7 +226,7 @@ private class WindowsGraphicsCaptureRecordingHandle(
                             false
                         }
                     if (!terminatedAfterForce && process.isAlive) {
-                        throw IllegalStateException(
+                        error(
                             "spectre-window-capture did not exit after destroyForcibly() " +
                                 "within ${FORCE_STOP_TIMEOUT_SECONDS}s. Argv: $argv"
                         )
@@ -236,9 +236,7 @@ private class WindowsGraphicsCaptureRecordingHandle(
         }
         if (interrupted) Thread.currentThread().interrupt()
         if (process.isAlive) {
-            throw IllegalStateException(
-                "spectre-window-capture is still running after stop. Argv: $argv"
-            )
+            error("spectre-window-capture is still running after stop. Argv: $argv")
         }
         val exit = process.exitValue()
         check(exit == 0 || sentTerminationOurselves) {

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
@@ -469,8 +469,7 @@ private class StubWindowRecorder(
             StubBehavior.Succeeds -> NoopHandle(output)
             StubBehavior.HelperNotBundled ->
                 throw HelperNotBundledException("test [$name]: helper not bundled")
-            StubBehavior.RuntimeFailure ->
-                throw IllegalStateException("test [$name]: runtime failure")
+            StubBehavior.RuntimeFailure -> error("test [$name]: runtime failure")
             StubBehavior.ShouldNeverBeCalled ->
                 error("StubWindowRecorder[$name] was not supposed to be invoked in this test")
         }

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import dev.sebastiano.spectre.core.RobotDriver
 import java.awt.Rectangle
 import java.awt.Window
+import java.util.Locale
 import java.util.concurrent.atomic.AtomicReference
 import javax.swing.JFrame
 import kotlin.math.abs
@@ -372,7 +373,7 @@ internal suspend fun scenarioShortcut(driver: RobotDriver, state: SmokeState): S
     )
 }
 
-internal suspend fun scenarioScreenshot(driver: RobotDriver, state: SmokeState): ScenarioResult {
+internal fun scenarioScreenshot(driver: RobotDriver, state: SmokeState): ScenarioResult {
     val target = awtCenter(state, state.colorPatchBounds)
     if (target == null) {
         return ScenarioResult("screenshot of color patch", false, "no target rect available")
@@ -426,7 +427,8 @@ internal suspend fun scenarioScreenshot(driver: RobotDriver, state: SmokeState):
         "screenshot of color patch",
         passed = passed,
         detail =
-            "sampled=#${"%06X".format(sampledRgb)} expected=#${"%06X".format(expectedRgb)} " +
+            "sampled=#${"%06X".format(Locale.ROOT, sampledRgb)} " +
+                "expected=#${"%06X".format(Locale.ROOT, expectedRgb)} " +
                 "image=${image.width}x${image.height} captureRegion=" +
                 "(${captureRegion.x},${captureRegion.y})+${captureRegion.width}x${captureRegion.height}",
     )
@@ -466,10 +468,7 @@ internal suspend fun runFocusedScenarios(
     return results
 }
 
-internal suspend fun scenarioStartsUnfocused(
-    state: SmokeState,
-    distractor: JFrame?,
-): ScenarioResult {
+internal fun scenarioStartsUnfocused(state: SmokeState, distractor: JFrame?): ScenarioResult {
     val sut = state.frame
     val sutFocused = sut?.isFocused == true
     val distractorFocused = distractor?.isFocused == true


### PR DESCRIPTION
## Summary

- **CI gap fix**: detekt 2.x's `:detekt` aggregator is a no-op marker that didn't transitively depend on the per-source-set `:detektMain` / `:detektTest` tasks, so `./gradlew check` silently skipped every type-resolution-aware finding (UnsafeCallOnNullableType, InjectDispatcher, UnreachableCode, …). Wired the aggregator to fan out to per-source-set tasks at both root and subproject level.
- **Detekt bump**: 2.0.0-alpha.2 → 2.0.0-alpha.3.
- **40 findings cleared** across `:core`, `:recording`, `:sample-desktop`, `:agent` (the ones the gap was hiding) — no `@Suppress`, no baselines, no config loosening, except for one structurally-unavoidable spread-operator suppression on `BlockingSuspendInvoker.invoke` with a rationale comment.

## Notable judgement calls

- `RecompositionMonitor`'s `Dispatchers.Default` moves from a property initialiser to a default constructor parameter so detekt's accepted injection seam applies (internal-constructor ABI bump, snapshot refreshed).
- `WaylandPortalRecorder.readerLoop` cascaded 13 `UnreachableCode` false positives — root cause is a detekt #5186-class K2 confusion with `val x = try {...} catch {...; return}`. Rewrote the loop with `reader.lineSequence()` and split `val event: Event` from `try { event = ... }` to keep the rest of the body reachable in the analyzer's view.
- `AutoScreenshotter` had an unused `x11RegionScreenshotter` placeholder parameter (already `@Suppress("UNUSED_PARAMETER")`) wired to a throw-only placeholder object. Deleted both — no internal caller passed it (ABI bump, snapshot refreshed).

## Verification

- `./gradlew check` is green locally.
- Plumbing-revert test: temporarily reverting just `EdtUtils.kt`'s fix makes `./gradlew :core:check` fail with `:core:detektMain ... Analysis failed with 1 issues` — confirms `check` now actually catches per-source-set findings (it did not before this change).

## Test plan

- [ ] CI `check` job passes on the PR.
- [ ] No new ktfmt / detekt findings introduced.
- [ ] `:core` and `:recording` ABI snapshot diffs match the intentional changes called out above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)