### PR TITLE
Deprecate Windows ffmpeg AutoRecorder fallback

### DIFF
--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -52,11 +52,11 @@ failure modes, and the section below
   screenshots use the shared .NET helper from `spectre-recording-windows`. The helper
   uses Windows Graphics Capture, is published for x64 and arm64, and does not require
   ffmpeg. It is framework-dependent, so Windows users need .NET 8 Desktop Runtime and
-  Windows App Runtime 1.8 installed. `AutoRecorder.startRegion(...)` falls back to
-  `FfmpegRecorder`/`gdigrab` when that helper artifact is absent, or when the caller
+  Windows App Runtime 1.8 installed. `AutoRecorder.startRegion(...)` no longer falls back
+  to `FfmpegRecorder`/`gdigrab` when that helper artifact is absent, or when the caller
   sets Windows region options that WGC cannot honour (`RecordingOptions.codec` or
-  `screenIndex`). `FfmpegRecorder` also remains available as a deprecated explicit legacy
-  backend.
+  `screenIndex`); those cases fail loudly instead. `FfmpegRecorder` remains available only
+  as a deprecated explicit legacy backend.
 - **Linux Xorg/Xvfb sessions** — helper-driven GStreamer `ximagesrc` capture. Reads `DISPLAY`.
   `LinuxX11Recorder` records fixed regions or a named X11 window; `LinuxNativeScreenshotter`
   writes one-frame PNGs through the same helper. Routine

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -21,6 +21,14 @@ routers that pick the right one per call.
     fallback is no longer used by `AutoRecorder` or `AutoScreenshotter`; `ffmpeg` on
     `PATH` is only relevant if you instantiate the explicit legacy ffmpeg backends.
 
+!!! note "Windows migration note"
+    Windows window, region, and fullscreen recording now use the
+    `spectre-recording-windows` helper through Windows Graphics Capture. `AutoRecorder`
+    no longer falls back to ffmpeg/gdigrab when the helper artifact is absent or when
+    Windows-incompatible options such as custom `RecordingOptions.codec` or `screenIndex`
+    are supplied; those cases fail at `start(...)` with an actionable error. `ffmpeg` on
+    `PATH` is only relevant if you instantiate the explicit legacy ffmpeg backends.
+
 ## Still Window Screenshots
 
 `ComposeAutomator.screenshot(...)` lives in `spectre-core` and captures a rectangle
@@ -210,14 +218,13 @@ A few details worth knowing:
   SCK failures — permission denied, target window not found, helper crashed during
   init — propagate as exceptions rather than falling back silently, so you see
   the real cause.
-- **Windows WGC helper fallback.** If `spectre-recording-windows` is absent at
-  runtime, `AutoRecorder.startRegion(...)` falls back to the legacy
-  `FfmpegRecorder`/`gdigrab` region path for compatibility with older
-  `spectre-recording`-only setups. `startRegion(...)` also uses the legacy ffmpeg
-  path when you set Windows options that WGC cannot honour, such as a custom
-  `RecordingOptions.codec` or `screenIndex`. Window-targeted recording, fullscreen
-  recording through `WindowsGraphicsCaptureRecorder`, and still window screenshots
-  require the helper artifact; operational WGC failures still propagate.
+- **Windows WGC helper is required for AutoRecorder.** If `spectre-recording-windows`
+  is absent at runtime, `AutoRecorder.startRegion(...)` fails loudly instead of
+  falling back to legacy `FfmpegRecorder`/`gdigrab`. Windows options that WGC cannot
+  honour, such as a custom `RecordingOptions.codec` or `screenIndex`, also fail
+  rather than changing backends. Window-targeted recording, fullscreen recording
+  through `WindowsGraphicsCaptureRecorder`, and still window screenshots all require
+  the helper artifact; operational WGC failures propagate.
 - **Linux Xorg/Xvfb uses the Linux helper by default.** `AutoRecorder` no longer uses
   `ffmpeg` for the Linux Xorg/Xvfb route. Region and window capture go through the
   bundled Rust helper from `spectre-recording-linux`, which spawns `gst-launch-1.0`
@@ -319,9 +326,8 @@ trade-offs.
   still window screenshots. Runtime machines need Windows Graphics Capture support
   (Windows 10 version 1903 or newer), .NET 8 Desktop Runtime, and Windows App Runtime
   1.8; contributors and CI building that helper from source need the .NET 8 SDK.
-  `AutoRecorder.startRegion(...)` can fall back to `ffmpeg`/`gdigrab` when the helper
-  artifact is absent; otherwise `ffmpeg` is only needed if you instantiate the explicit
-  legacy ffmpeg backends.
+  `AutoRecorder.startRegion(...)` requires this helper; `ffmpeg` is only needed if you
+  instantiate the explicit legacy ffmpeg backends.
 - **Linux Xorg/Xvfb** — add `dev.sebastiano.spectre:spectre-recording-linux:<version>`
   as a runtime-only dependency. Runtime machines need `gst-launch-1.0` plus GStreamer
   plugins for `ximagesrc`, H.264, MP4 muxing, PNG encoding, and colour conversion.

--- a/recording/README.md
+++ b/recording/README.md
@@ -55,13 +55,11 @@ implementer's view of the same module.
   region portal, or loud failure if no portal recorder is wired), then macOS SCK for
   window capture, Windows Graphics Capture for Windows window/region capture, Linux helper
   capture for Linux Xorg/Xvfb window/region capture, and ffmpeg region capture for macOS.
-  If the Windows WGC helper
-  artifact is absent, `startRegion(...)` falls back to the legacy ffmpeg `gdigrab`
-  region path for compatibility. It also uses ffmpeg for Windows region calls with custom
-  `RecordingOptions.codec` or `screenIndex`, because the WGC backend cannot honour those
-  ffmpeg-specific knobs. Operational native-helper failures after the helper is found
-  (permissions denied, window not found, helper crash) propagate with actionable messages
-  instead of silently changing capture semantics.
+  Windows region capture no longer falls back to ffmpeg when the WGC helper artifact is
+  absent, and WGC-unsupported options such as custom `RecordingOptions.codec` or
+  `screenIndex` now fail loudly. Operational native-helper failures after the helper is
+  found (permissions denied, window not found, helper crash) also propagate with actionable
+  messages instead of silently changing capture semantics.
 - `AutoScreenshotter` — high-level still-image router. Uses ScreenCaptureKit window capture
   on macOS, Windows Graphics Capture on Windows, and the Linux helper on Xorg/Xvfb and
   Wayland. Wayland still screenshots require the compositor portal dialog to be accepted.

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -132,16 +132,12 @@ internal constructor(
             return recorder.start(region, output, options)
         }
         if (isWindows()) {
-            if (options.usesLegacyFfmpegOnlyWindowsOptions()) {
-                return ffmpegRecorder.start(region, output, options)
-            }
-
             val recorder =
                 windowsRegionRecorder ?: throw unavailable("Windows region capture", null)
             return try {
                 recorder.start(region, output, options)
-            } catch (_: WindowsGraphicsCaptureHelperNotBundledException) {
-                ffmpegRecorder.start(region, output, options)
+            } catch (e: WindowsGraphicsCaptureHelperNotBundledException) {
+                throw unavailable("Windows region capture", e)
             }
         }
         if (isLinux()) {
@@ -164,10 +160,6 @@ internal constructor(
                 "window-targeted recorder is available. Use startRegion(...) explicitly for " +
                 "region capture."
         )
-
-    private fun RecordingOptions.usesLegacyFfmpegOnlyWindowsOptions(): Boolean =
-        codec != RecordingOptions.DEFAULT_CODEC ||
-            screenIndex != RecordingOptions.DEFAULT_SCREEN_INDEX
 
     private companion object {
         @JvmStatic fun defaultIsMacOs(): Boolean = HostPlatform.isMacOs()

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
@@ -62,9 +62,9 @@ class AutoRecorderTest {
     }
 
     @Test
-    fun `startRegion routes Windows custom ffmpeg options to ffmpeg`() {
+    fun `startRegion rejects Windows custom ffmpeg options instead of falling back to ffmpeg`() {
         val ffmpeg = StubRegionRecorder()
-        val windowsRegion = StubRegionRecorder()
+        val windowsRegion = UnsupportedWindowsOptionsRecorder()
         val recorder =
             autoRecorder(
                 ffmpegRecorder = ffmpeg,
@@ -77,18 +77,21 @@ class AutoRecorderTest {
             val region = Rectangle(10, 20, 300, 200)
             val options = RecordingOptions(codec = "libx264rgb")
 
-            recorder.startRegion(region = region, output = output, options = options)
+            val error =
+                assertFailsWith<IllegalArgumentException> {
+                    recorder.startRegion(region = region, output = output, options = options)
+                }
 
-            assertEquals(region, ffmpeg.lastRegion)
-            assertEquals(options, ffmpeg.lastOptions)
-            assertFalse(windowsRegion.startCalled)
+            assertTrue(error.message.orEmpty().contains("custom RecordingOptions.codec"))
+            assertFalse(ffmpeg.startCalled)
+            assertTrue(windowsRegion.startCalled)
         } finally {
             output.deleteIfExists()
         }
     }
 
     @Test
-    fun `startRegion falls back to ffmpeg on Windows when WGC helper is not bundled`() {
+    fun `startRegion fails loudly on Windows when WGC helper is not bundled`() {
         val ffmpeg = StubRegionRecorder()
         val recorder =
             autoRecorder(
@@ -101,9 +104,13 @@ class AutoRecorderTest {
         try {
             val region = Rectangle(10, 20, 300, 200)
 
-            recorder.startRegion(region = region, output = output)
+            val error =
+                assertFailsWith<IllegalStateException> {
+                    recorder.startRegion(region = region, output = output)
+                }
 
-            assertEquals(region, ffmpeg.lastRegion)
+            assertTrue(error.message.orEmpty().contains("Windows region capture"))
+            assertFalse(ffmpeg.startCalled)
         } finally {
             output.deleteIfExists()
         }
@@ -505,6 +512,23 @@ private class MissingWindowsHelperRecorder : Recorder {
         options: RecordingOptions,
     ): RecordingHandle {
         throw WindowsGraphicsCaptureHelperNotBundledException("missing helper")
+    }
+}
+
+private class UnsupportedWindowsOptionsRecorder : Recorder {
+    var startCalled: Boolean = false
+        private set
+
+    override fun start(
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): RecordingHandle {
+        startCalled = true
+        throw IllegalArgumentException(
+            "WindowsGraphicsCaptureRecorder does not support custom RecordingOptions.codec; " +
+                "got ${options.codec}."
+        )
     }
 }
 

--- a/skills/spectre/references/recording.md
+++ b/skills/spectre/references/recording.md
@@ -34,7 +34,7 @@ source need the .NET 8 SDK. The local verification task is:
 | Platform | `startWindow` | `startRegion` |
 |---|---|---|
 | macOS | ScreenCaptureKit (native) | ffmpeg region capture |
-| Windows | Windows Graphics Capture helper | Windows Graphics Capture helper, with ffmpeg `gdigrab` fallback if the helper artifact is absent or the call uses ffmpeg-only options (`codec`, `screenIndex`) |
+| Windows | Windows Graphics Capture helper | Windows Graphics Capture helper; missing helper artifacts and WGC-unsupported options (`codec`, `screenIndex`) fail loudly instead of falling back to ffmpeg |
 | Linux X11 / XWayland | unsupported | ffmpeg `x11grab` |
 | Linux Wayland (GNOME/Mutter) | xdg-desktop-portal window source | xdg-desktop-portal monitor source |
 


### PR DESCRIPTION
## Summary
- stop AutoRecorder from falling back to ffmpeg/gdigrab for Windows region capture
- surface missing Windows Graphics Capture helper artifacts as loud Windows capture failures
- document that Windows AutoRecorder now requires the WGC helper, while explicit ffmpeg backends remain deprecated escape hatches

## Verification
- ./gradlew :recording:test --tests dev.sebastiano.spectre.recording.AutoRecorderTest
- ./gradlew :recording:check
- /private/tmp/spectre-docs-venv/bin/python -m mkdocs build --strict

Full local ./gradlew check was attempted but is blocked in this macOS session by Screen Recording TCC denial in :agent:test AgentAttachIntegrationTest during RobotDriver screenshot; CI should provide the merge gate.