### PR TITLE
Route macOS region recording through SCK

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/MacOsTccGuard.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/MacOsTccGuard.kt
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit
 internal enum class TccStatus {
     Granted,
     Denied,
+    Locked,
     Unknown,
     NotApplicable,
 }
@@ -65,6 +66,7 @@ internal open class MacOsTccGuard(
             probe = screenRecordingProbe,
             store = { screenRecordingStatus = it },
             deniedMessage = SCREEN_RECORDING_DENIED_MESSAGE,
+            lockedMessage = SCREEN_RECORDING_LOCKED_MESSAGE,
             unknownWarning = SCREEN_RECORDING_UNKNOWN_WARNING,
         )
     }
@@ -74,12 +76,20 @@ internal open class MacOsTccGuard(
         probe: () -> TccStatus,
         store: (TccStatus) -> Unit,
         deniedMessage: String,
+        lockedMessage: String? = null,
         unknownWarning: String,
     ) {
         val firstCheck = cached == null
-        val status = cached ?: probe().also(store)
+        val status =
+            cached
+                ?: probe().also {
+                    // A locked screen is transient; do not memoise it as a permanent capture
+                    // denial for long-lived Gradle daemons or IDE-hosted test JVMs.
+                    if (it != TccStatus.Locked) store(it)
+                }
         when (status) {
             TccStatus.Denied -> error(deniedMessage)
+            TccStatus.Locked -> error(lockedMessage ?: deniedMessage)
             TccStatus.Unknown -> if (firstCheck) warn(unknownWarning)
             TccStatus.Granted,
             TccStatus.NotApplicable -> Unit
@@ -151,6 +161,43 @@ internal fun robotScreenRecordingProbe(screenCapture: ScreenCaptureAdapter): Tcc
     return TccStatus.Denied
 }
 
+internal fun macOsScreenRecordingProbe(screenCapture: ScreenCaptureAdapter): TccStatus {
+    if (macOsConsoleLockedProbe() == true) return TccStatus.Locked
+    return robotScreenRecordingProbe(screenCapture)
+}
+
+internal fun macOsConsoleLockStatus(ioregOutput: String): Boolean? {
+    val match = Regex(""""IOConsoleLocked"\s*=\s*(Yes|No)""").find(ioregOutput) ?: return null
+    return match.groupValues[1] == "Yes"
+}
+
+@Suppress("TooGenericExceptionCaught")
+private fun macOsConsoleLockedProbe(): Boolean? {
+    val process =
+        try {
+            ProcessBuilder("/usr/sbin/ioreg", "-n", "Root", "-d", "1", "-r")
+                .redirectErrorStream(true)
+                .start()
+        } catch (_: Throwable) {
+            return null
+        }
+    return try {
+        if (!process.waitFor(IOREG_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            null
+        } else {
+            macOsConsoleLockStatus(process.inputStream.bufferedReader().use { it.readText() })
+        }
+    } catch (_: InterruptedException) {
+        process.destroyForcibly()
+        Thread.currentThread().interrupt()
+        null
+    } catch (_: Throwable) {
+        process.destroyForcibly()
+        null
+    }
+}
+
 @Suppress("TooGenericExceptionCaught")
 private fun runOsascript(script: String): OsascriptResult? {
     // Mirrors `dev.sebastiano.spectre.recording.MacOsRecordingPermissions.runOsascript` — kept in
@@ -187,6 +234,7 @@ private fun runOsascript(script: String): OsascriptResult? {
 private data class OsascriptResult(val output: String, val exitCode: Int)
 
 private const val OSASCRIPT_TIMEOUT_SECONDS: Long = 3
+private const val IOREG_TIMEOUT_SECONDS: Long = 3
 private const val PROBE_SIZE_PX: Int = 32
 // Mask out the alpha channel from BufferedImage.TYPE_INT_ARGB pixels so probe checks see the
 // 24-bit RGB tuple. A TCC-denied capture returns RGB=0 across every pixel; alpha may not be 0
@@ -219,6 +267,13 @@ internal const val SCREEN_RECORDING_DENIED_MESSAGE: String =
         "launched this JVM. $PARENT_PROCESS_GUIDANCE On macOS 26+ the toggle grants " +
         "picker-based access only; the first direct screen-capture call also prompts a " +
         "second 'bypass the system private window picker' dialog that you must accept."
+
+internal const val SCREEN_RECORDING_LOCKED_MESSAGE: String =
+    "Spectre RobotDriver: macOS screen capture is unavailable because the console session is " +
+        "locked — Robot screen capture may return an all-black image while locked. Unlock the " +
+        "screen and retry. If capture still fails after unlocking, grant System Settings → " +
+        "Privacy & Security → Screen & System Audio Recording to the wrapping app that " +
+        "launched this JVM. $PARENT_PROCESS_GUIDANCE"
 
 internal const val SCREEN_RECORDING_UNKNOWN_WARNING: String =
     "Spectre RobotDriver: could not determine macOS Screen Recording TCC permission state " +

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -325,11 +325,13 @@ internal constructor(
      *
      * On macOS, the underlying `java.awt.Robot.createScreenCapture` requires the wrapping process
      * to hold Screen Recording TCC permission. Without it the call returns silently with an
-     * all-black image rather than throwing. The default [RobotDriver] guards against this: on the
-     * first `screenshot` call from a Mac, it probes Screen Recording TCC and throws
-     * [IllegalStateException] with an actionable remediation message if the probe sees an all-black
-     * capture. The probe and the resulting status are cached, so subsequent calls have no extra
-     * cost. Use [headless] to opt out entirely.
+     * all-black image rather than throwing; a locked console session can produce the same symptom.
+     * The default [RobotDriver] guards against this: on the first `screenshot` call from a Mac, it
+     * checks whether the console is locked, then probes Screen Recording TCC and throws
+     * [IllegalStateException] with an actionable remediation message if capture is blocked. Stable
+     * probe outcomes are cached, so subsequent calls have no extra cost; locked-screen outcomes are
+     * deliberately not cached so unlocking can recover in the same JVM. Use [headless] to opt out
+     * entirely.
      *
      * On Linux, captures work against X11 (real Xorg or XWayland-bridged X clients) but not against
      * native Wayland surfaces — Wayland's security model forbids cross-process framebuffer reads.
@@ -430,7 +432,7 @@ internal fun defaultTccGuardFor(
                 },
             screenRecordingProbe =
                 if (screenCapture.gatesMacOsScreenRecordingTcc) {
-                    { robotScreenRecordingProbe(screenCapture) }
+                    { macOsScreenRecordingProbe(screenCapture) }
                 } else {
                     { TccStatus.Granted }
                 },

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/MacOsTccGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/MacOsTccGuardTest.kt
@@ -57,6 +57,22 @@ class MacOsTccGuardTest {
     }
 
     @Test
+    fun `requireScreenRecording throws on Locked with lock guidance`() {
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Granted },
+                screenRecordingProbe = { TccStatus.Locked },
+                warn = {},
+            )
+
+        val error = assertFailsWith<IllegalStateException> { guard.requireScreenRecording() }
+
+        val message = error.message.orEmpty()
+        assertTrue("locked" in message.lowercase(), "expected locked-screen guidance: $message")
+        assertTrue("unlock" in message.lowercase(), "expected unlock instruction: $message")
+    }
+
+    @Test
     fun `requireAccessibility on Granted does not throw`() {
         val guard =
             MacOsTccGuard(
@@ -116,6 +132,25 @@ class MacOsTccGuardTest {
         repeat(5) { guard.requireScreenRecording() }
 
         assertEquals(1, probeInvocations)
+    }
+
+    @Test
+    fun `locked screen recording result is not cached`() {
+        var probeInvocations = 0
+        val guard =
+            MacOsTccGuard(
+                accessibilityProbe = { TccStatus.Granted },
+                screenRecordingProbe = {
+                    probeInvocations++
+                    if (probeInvocations == 1) TccStatus.Locked else TccStatus.Granted
+                },
+                warn = {},
+            )
+
+        assertFailsWith<IllegalStateException> { guard.requireScreenRecording() }
+        guard.requireScreenRecording()
+
+        assertEquals(2, probeInvocations)
     }
 
     @Test
@@ -263,5 +298,12 @@ class MacOsTccGuardTest {
         assertFailsWith<IllegalStateException> { guard.requireAccessibility() }
 
         assertEquals(1, probeInvocations, "probe should run only once even when denied")
+    }
+
+    @Test
+    fun `macOS console lock status parses ioreg output`() {
+        assertEquals(true, macOsConsoleLockStatus("\"IOConsoleLocked\" = Yes"))
+        assertEquals(false, macOsConsoleLockStatus("\"IOConsoleLocked\" = No"))
+        assertEquals(null, macOsConsoleLockStatus("\"IOConsoleUsers\" = ()"))
     }
 }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -124,9 +124,9 @@ Current backends:
 - `FfmpegRegionScreenshotter` — deprecated legacy explicit Linux X11 still screenshot
   fallback via one-frame `x11grab` region capture; the target must be visible and frontmost
   because this is not true window capture.
-- `screencapturekit.ScreenCaptureKitRecorder` — macOS-only window-targeted capture via a
-  Swift helper (`recording/native/macos/`). The helper is built by Gradle on macOS,
-  staged under `recording/build/generated/screenCaptureHelper/...`, and packaged by
+- `screencapturekit.ScreenCaptureKitRecorder` — macOS-only window-targeted and region
+  capture via a Swift helper (`recording/native/macos/`). The helper is built by Gradle on
+  macOS, staged under `recording/build/generated/screenCaptureHelper/...`, and packaged by
   `:recording-macos`.
 - `screencapturekit.ScreenCaptureKitScreenshotter` — macOS-only still window screenshots
   through the same Swift helper in `--mode screenshot`.
@@ -135,9 +135,9 @@ Current backends:
   (`recording/native/linux/spectre-wayland-helper`) packaged by `:recording-linux`.
   The helper hands the PipeWire FD to `gst-launch-1.0`.
 - `AutoRecorder` — high-level router that picks per call from `startWindow(...)` /
-  `startRegion(...)` + OS detection: Wayland portal first, then macOS SCK for window
-  capture, Windows Graphics Capture for window and region capture, Linux helper capture
-  for Linux Xorg/Xvfb window and region capture, and ffmpeg region capture for macOS.
+  `startRegion(...)` + OS detection: Wayland portal first, then macOS SCK for window and
+  region capture, Windows Graphics Capture for window and region capture, and Linux helper
+  capture for Linux Xorg/Xvfb window and region capture.
 - `AutoScreenshotter` — high-level still screenshot router: macOS SCK window source,
   Windows Graphics Capture, and Linux helper still capture on Xorg/Xvfb and Wayland.
 

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -8,7 +8,7 @@ a video file, and each has its own limitations:
 
 - **Region capture** — records a fixed `Rectangle` of the virtual desktop, frame by
   frame. The source of pixels is the OS framebuffer (or the platform's nearest
-  equivalent — `avfoundation` on macOS, Windows Graphics Capture on Windows,
+  equivalent — ScreenCaptureKit on macOS, Windows Graphics Capture on Windows,
   GStreamer `ximagesrc` on Linux Xorg/Xvfb, or the Wayland compositor's PipeWire stream on Linux
   Wayland). Whatever is showing
   on screen inside that rectangle goes into the file, regardless of which window is
@@ -32,7 +32,7 @@ Backend → mode mapping:
 | `LinuxNativeScreenshotter`    | Linux Xorg/Xvfb screenshots via `ximagesrc`, and Linux Wayland screenshots via portal/PipeWire one-frame capture. |
 | `WaylandPortalRecorder`       | Region capture, sourced from the Wayland portal (`SourceType.MONITOR`). |
 | `WaylandPortalWindowRecorder` | Window-targeted (Linux Wayland, portal `SourceType.WINDOW` — only the picked window's pixels are captured). |
-| `ScreenCaptureKitRecorder`    | Window-targeted (macOS).                            |
+| `ScreenCaptureKitRecorder`    | Region and window-targeted capture (macOS).         |
 | `ScreenCaptureKitScreenshotter` | Window-targeted still screenshots (macOS).         |
 | `WindowsGraphicsCaptureRecorder` | Window-targeted and region capture (Windows Graphics Capture). |
 | `FfmpegWindowRecorder`        | Deprecated legacy window-targeted (Windows, `gdigrab title=`). |
@@ -47,7 +47,13 @@ failure modes, and the section below
 
 ## Platform
 
-- **macOS** — `avfoundation` region capture. Requires the Screen Recording permission.
+- **macOS** — ScreenCaptureKit region and window capture through the
+  `spectre-recording-macos` helper. Requires the Screen Recording permission. `AutoRecorder`
+  no longer falls back to `FfmpegRecorder`/`avfoundation` when that helper artifact is absent
+  or when callers set SCK-incompatible options such as a custom `RecordingOptions.codec`.
+  `RecordingOptions.screenIndex` is the SCK display index: primary display first, then by
+  display frame `minX` and `minY`. The explicit `FfmpegRecorder` remains available only as a
+  deprecated legacy backend.
 - **Windows** — native window recording, region/fullscreen recording, and still window
   screenshots use the shared .NET helper from `spectre-recording-windows`. The helper
   uses Windows Graphics Capture, is published for x64 and arm64, and does not require
@@ -222,8 +228,12 @@ compositor and not raw framebuffer reads.
 ## Permissions and process lifecycle
 
 - The JVM process needs **macOS Screen Recording permission** (`MacOsRecordingPermissions`
-  documents the path). Without it, `ffmpeg` exits during the startup probe and `Recorder.start`
+  documents the path). Without it, the SCK helper exits during startup and `Recorder.start`
   surfaces an error rather than handing back a handle.
+- The macOS console session must be **unlocked**. A locked screen can make Robot
+  screenshots or ScreenCaptureKit recordings fail, or produce black/incorrect frames, even
+  when Screen Recording TCC is granted. Unlock the display and retry before treating the
+  failure as a missing permission.
 - The underlying encoder process/helper is spawned eagerly: by the time `start(...)`
   returns, frames are landing in the output file. A failure to spawn (binary/helper not
   available, codec unavailable, permission/device busy) surfaces as an exception from

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -189,8 +189,8 @@ public surface:
   `screenshot()` under a synthetic driver still uses the OS framebuffer via
   `Robot.createScreenCapture`, so screenshots show the pixels the display compositor
   currently exposes rather than a Swing repaint of the Compose host. On macOS this
-  still requires Screen Recording permission, but synthetic input itself does not need
-  Accessibility permission.
+  still requires Screen Recording permission and an unlocked screen, but synthetic input
+  itself does not need Accessibility permission.
 - **`RobotDriver.headless()`** — for read-only flows in headless CI where real OS I/O is
   unavailable. Every input, clipboard, and screenshot call throws
   `UnsupportedOperationException` so an accidental `automator.click(...)` /

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -5,9 +5,10 @@ tests. It exposes small surfaces backed by platform-specific implementations and
 routers that pick the right one per call.
 
 !!! note "External dependencies"
-    The recording backends shell out to platform tools — `ffmpeg` for macOS and legacy
-    explicit backends, plus small native helpers for macOS, Linux, and Windows Graphics
-    Capture. Linux Xorg/Xvfb and Wayland capture both use the Linux helper from
+    The recording backends shell out to platform tools — small native helpers for macOS,
+    Linux, and Windows Graphics Capture, plus `ffmpeg` only for deprecated explicit
+    legacy backends. macOS window and region recording both use the ScreenCaptureKit helper
+    from `spectre-recording-macos`. Linux Xorg/Xvfb and Wayland capture both use the Linux helper from
     `spectre-recording-linux`, with GStreamer doing the actual encoding or PNG writing.
     Windows window, region, and fullscreen recording use the Windows Graphics Capture
     helper when `spectre-recording-windows` is present.
@@ -28,6 +29,14 @@ routers that pick the right one per call.
     Windows-incompatible options such as custom `RecordingOptions.codec` or `screenIndex`
     are supplied; those cases fail at `start(...)` with an actionable error. `ffmpeg` on
     `PATH` is only relevant if you instantiate the explicit legacy ffmpeg backends.
+
+!!! note "macOS migration note"
+    macOS window and region recording now use the `spectre-recording-macos`
+    ScreenCaptureKit helper. `AutoRecorder` no longer falls back to ffmpeg/avfoundation
+    when that helper artifact is absent or when SCK-incompatible options such as a custom
+    `RecordingOptions.codec` are supplied; those cases fail at `start(...)` with an
+    actionable error. `ffmpeg` on `PATH` is only relevant if you instantiate the explicit
+    legacy ffmpeg backends.
 
 ## Still Window Screenshots
 
@@ -71,7 +80,9 @@ Expected results by platform:
   `spectre-screencapture --mode screenshot`, and the task prints a PNG path such as
   `$TMPDIR/spectre-window-screenshot-smoke.png`. Open the PNG and confirm the white window
   with `screenshot smoke` text is visible. If macOS denies Screen Recording, grant the
-  host JVM permission in System Settings, restart the JVM/terminal, and rerun.
+  host JVM permission in System Settings, restart the JVM/terminal, and rerun. If the
+  screen is locked, macOS can block or black out capture even when TCC is granted; unlock
+  the display and rerun before chasing permissions.
 - **Windows** — the same task uses the `spectre-window-capture.exe` helper from
   `spectre-recording-windows`. The smoke should print a non-empty PNG path. Open it and
   confirm it contains only the smoke window; ffmpeg is not required for still screenshots,
@@ -133,7 +144,7 @@ view for when you want to know what each backend can and cannot do.
 | `FfmpegRecorder` (deprecated) | Screen region (fixed `Rectangle`) | No — region fixed at `start()` | Yes — anything visible inside the region lands in the frame, including occluding apps and overlapping Compose `OnWindow` popups | `ffmpeg` on `PATH`; macOS Screen Recording TCC for the launching app | macOS · Windows legacy/explicit · Linux X11 legacy/explicit |
 | `WindowsGraphicsCaptureRecorder` | Named window (exact title + owner pid) or screen region | Window mode follows the target window across moves; region mode is fixed at `start()` | Window mode captures only the target window's pixels, so occluders are excluded and separate `OnWindow` popups are not captured. Region/fullscreen mode captures the visible monitor pixels inside the requested rectangle, including overlapping windows and popups | `spectre-recording-windows` runtime helper (`spectre-window-capture.exe`); Windows 10 version 1903 or newer; .NET 8 Desktop Runtime; Windows App Runtime 1.8 | Windows |
 | `FfmpegWindowRecorder` (deprecated) | Legacy named window (`gdigrab title=`) | Yes — `gdigrab` retracks the window across moves and resizes | No — only the window's pixels are captured. Compose `OnWindow` popups land in a separate OS window with a different title, so they are **not** captured. `OnSameCanvas` / `OnComponent` popups are part of the window surface and are captured | `ffmpeg` on `PATH`; visible window with a non-blank exact title | Windows |
-| `ScreenCaptureKitRecorder` | Named window (pid + title substring) | Yes — reads the window backing store directly, follows moves and resizes | No — same window-source semantics as WGC. `OnWindow` popups not captured; `OnSameCanvas` / `OnComponent` captured | `spectre-recording-macos` runtime helper (`spectre-screencapture`); macOS Screen Recording TCC for the launching app | macOS |
+| `ScreenCaptureKitRecorder` | Named window (pid + title substring) or screen region | Window mode reads the window backing store directly and follows moves/resizes; region mode is fixed at `start()` | Window mode has the same window-source semantics as WGC: occluders and `OnWindow` popups are not captured. Region mode captures visible display pixels in the requested rectangle, including overlapping windows and popups | `spectre-recording-macos` runtime helper (`spectre-screencapture`); macOS Screen Recording TCC for the launching app | macOS |
 | `LinuxX11Recorder` | Screen region or named X11 window (`ximagesrc`) | Region mode is fixed at `start()`; window mode uses GStreamer's `xname` source selection | Captures visible X server pixels for the selected source; occluding apps can appear in region capture | `spectre-recording-linux` runtime helper; `gst-launch-1.0` with `ximagesrc`, `videorate`, `x264enc`, and `mp4mux`; `DISPLAY` | Linux Xorg/Xvfb; named XWayland windows only when the process is deliberately forced onto the X11 backend |
 | `WaylandPortalRecorder` | Monitor region (portal `SourceType.MONITOR`, cropped) | No — monitor-level source | Depends on the compositor. Validated on GNOME/Mutter to include the user's overlays but exclude apps occluding the recorded region | `spectre-recording-linux` runtime helper (`spectre-wayland-helper`); `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`. First call pops the compositor's "share screen" dialog | Linux Wayland |
 | `WaylandPortalWindowRecorder` | Named window (portal `SourceType.WINDOW` + fixed crop) | **No.** The crop is computed once from `_GTK_FRAME_EXTENTS` at `start()` and stays at those pixel coordinates for the rest of the recording. If the user moves or resizes the window during the recording, the crop no longer aligns with the window's pixels (typically the recording shows blank / black for the unrendered area of the original rectangle) — see `WaylandPortalWindowRecorder`'s KDoc for the detailed rationale | No — only the picked window's pixels are in the stream. `OnWindow` popups not captured | `spectre-recording-linux` runtime helper; `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`; `xprop` on `PATH`; compositor must publish `_GTK_FRAME_EXTENTS` (GNOME/Mutter verified; older Mutter / KDE / sway may not — the recorder throws rather than producing misaligned video) | Linux Wayland |
@@ -146,7 +157,7 @@ user moving or resizing the window mid-recording.
 Embedded-host implications: `ComposePanel`s without a top-level OS window — including
 Jewel-hosted Compose inside an IntelliJ plugin tool window — have no exact window title for
 the native Windows helper to bind to and no top-level window for the SCK helper to discover.
-`AutoRecorder` falls through to region capture (`FfmpegRecorder` on macOS,
+`AutoRecorder` falls through to region capture (`ScreenCaptureKitRecorder` on macOS,
 `WindowsGraphicsCaptureRecorder` on Windows, `LinuxX11Recorder` on Linux Xorg/Xvfb,
 and `WaylandPortalRecorder` on Linux Wayland)
 for those surfaces. Linux support is
@@ -202,7 +213,7 @@ The routing is platform-keyed. Read the row that matches your OS:
 | Platform                | `window`                          | Backend chosen                                                       |
 | ----------------------- | --------------------------------- | -------------------------------------------------------------------- |
 | **macOS**               | non-null                          | `ScreenCaptureKitRecorder` (`spectre-recording-macos` helper).       |
-| **macOS**               | `null`                            | `FfmpegRecorder` region capture (`avfoundation`).                    |
+| **macOS**               | `null`                            | `ScreenCaptureKitRecorder` region capture (`spectre-recording-macos` helper). |
 | **Windows**             | non-null with a non-blank title   | `WindowsGraphicsCaptureRecorder` (`spectre-recording-windows` helper). |
 | **Windows**             | `null`, or non-null with no title | `WindowsGraphicsCaptureRecorder` region capture.                     |
 | **Linux Xorg/Xvfb**     | non-null with a non-blank title   | `LinuxX11Recorder` window capture (`ximagesrc xname`).               |
@@ -212,12 +223,13 @@ The routing is platform-keyed. Read the row that matches your OS:
 
 A few details worth knowing:
 
-- **macOS SCK helper fallback.** If the Swift helper isn't present on the runtime
-  classpath, the macOS + window path falls
-  back to `FfmpegRecorder` region capture with a warning on stderr. Operational
-  SCK failures — permission denied, target window not found, helper crashed during
-  init — propagate as exceptions rather than falling back silently, so you see
-  the real cause.
+- **macOS SCK helper is required for AutoRecorder.** If the Swift helper isn't present on
+  the runtime classpath, macOS window and region recording fail loudly instead of falling
+  back to `FfmpegRecorder`/`avfoundation`. Operational SCK failures — permission denied,
+  target window not found, helper crashed during init — propagate as exceptions, so you see
+  the real cause. Region capture supports `RecordingOptions.screenIndex` as the SCK display
+  index: primary display first, then by display frame `minX` and `minY`. Custom codec
+  strings are rejected because the helper writes H.264 through `AVAssetWriter`.
 - **Windows WGC helper is required for AutoRecorder.** If `spectre-recording-windows`
   is absent at runtime, `AutoRecorder.startRegion(...)` fails loudly instead of
   falling back to legacy `FfmpegRecorder`/`gdigrab`. Windows options that WGC cannot
@@ -276,7 +288,7 @@ If you know exactly which backend you want, instantiate it directly and skip the
 | `WindowsWindowScreenshotter`  | Windows-only still window screenshots via the `spectre-recording-windows` Windows Graphics Capture helper. |
 | `LinuxX11Recorder`            | Linux Xorg/Xvfb region and named-window capture via the `spectre-recording-linux` helper and GStreamer `ximagesrc`. |
 | `LinuxNativeScreenshotter`    | Linux Xorg/Xvfb screenshots via `ximagesrc`, and Linux Wayland screenshots via portal/PipeWire one-frame capture. |
-| `ScreenCaptureKitRecorder`    | macOS-only window-targeted capture via the `spectre-recording-macos` Swift helper. |
+| `ScreenCaptureKitRecorder`    | macOS-only window-targeted and region capture via the `spectre-recording-macos` Swift helper. |
 | `WaylandPortalRecorder`       | Linux Wayland region capture via `xdg-desktop-portal` (`SourceType.MONITOR`) and the `spectre-recording-linux` Rust helper. |
 | `WaylandPortalWindowRecorder` | Linux Wayland window-targeted capture via `xdg-desktop-portal` (`SourceType.WINDOW`). Window-sized output containing only the picked window's pixels. |
 
@@ -286,13 +298,15 @@ macOS has the most involved setup; the others are short. macOS first:
 
 ### macOS
 
-- `ffmpeg` on `PATH`.
 - Add `dev.sebastiano.spectre:spectre-recording-macos:<version>` as a runtime-only
   dependency. Its jar carries the notarized universal ScreenCaptureKit helper at
   `native/macos/spectre-screencapture`; the base `spectre-recording` artifact does not
   bundle this helper.
 - **Screen Recording TCC permission**, granted under System Settings → Privacy &
   Security → Screen Recording.
+- **An unlocked console session.** A locked macOS screen can make screenshots or
+  recordings fail, or produce black frames, even when Screen Recording TCC is already
+  granted.
 
 macOS attributes TCC to the **responsible parent process** — the binary that
 launched the JVM, not `java` itself. Grant the permission to whichever app opened

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -241,12 +241,14 @@ needs and throws on first use if either is denied:
   AppleEvents/Automation refusal, etc.) prints a one-shot stderr warning and
   proceeds.
 - **Screen Recording** — required for `Robot.createScreenCapture` to return real
-  pixels. Without it the call silently returns an all-black image. The probe runs
-  on the first `screenshot(...)` call: it captures a small region near the screen
+  pixels. Without it the call silently returns an all-black image. A locked
+  screen can produce the same symptom, so the probe first checks whether macOS
+  reports the console session as locked; if so, unlock the screen and retry. If
+  the session is unlocked, the probe captures a small region near the screen
   origin (which on macOS overlaps the menu bar) and treats an all-black result as
-  denial. False positives are vanishingly rare in practice; if your screen really
-  is fully black at the origin, switch to `RobotDriver.headless()` for tests
-  or grant Screen Recording to silence the probe.
+  denial. False positives are rare in practice; if your screen really is fully
+  black at the origin, switch to `RobotDriver.headless()` for tests or grant
+  Screen Recording to silence the probe.
 
 Fix: grant System Settings → Privacy & Security → Accessibility (or → Screen &
 System Audio Recording) to whichever app launched the JVM — IntelliJ, Terminal,

--- a/recording/README.md
+++ b/recording/README.md
@@ -1,7 +1,7 @@
 # Recording
 
 Screen recording and native still-window screenshots for Spectre scenarios. Region capture
-(Windows Graphics Capture on Windows, ffmpeg on macOS, the Linux helper/GStreamer on
+(ScreenCaptureKit on macOS, Windows Graphics Capture on Windows, the Linux helper/GStreamer on
 Xorg/Xvfb, xdg-desktop-portal on Linux Wayland), window-targeted video capture, and still
 screenshot routing live side by side — pick by what you need.
 
@@ -23,12 +23,17 @@ implementer's view of the same module.
   Linux helper and GStreamer `ximagesrc`. This is the default Linux Xorg/Xvfb route used by
   `AutoRecorder`; `ffmpeg` is no longer required for that path. The helper currently accepts
   only `RecordingOptions.codec = "libx264"` or `"x264enc"` for recording.
+- `screencapturekit.ScreenCaptureKitRecorder` — macOS ScreenCaptureKit region and
+  window-targeted capture through the bundled Swift helper. Region mode records a fixed
+  rectangle from the selected display; window mode follows the target window and captures
+  only its backing store.
 
 ### Window-targeted capture
 - `screencapturekit.ScreenCaptureKitRecorder` — forks a bundled Swift helper that drives
-  `SCStream` + `AVAssetWriter` against a single window identified by `(pid, title-substring)`.
-  Captures only that window's pixels even when partially occluded, and survives the host
-  window moving across the screen. macOS only. Implements `WindowRecorder`.
+  `SCStream` + `AVAssetWriter` against either a fixed display region or a single window
+  identified by `(pid, title-substring)`. Window capture records only that window's pixels
+  even when partially occluded, and survives the host window moving across the screen. macOS
+  only. Implements `Recorder` and `WindowRecorder`.
 - `screencapturekit.WindowRecorder` — interface for window-targeted backends. SCK is the
   macOS implementation; `windows.WindowsGraphicsCaptureRecorder` covers Windows, and
   `LinuxX11Recorder`/`WaylandPortalWindowRecorder` cover Linux Xorg/Xvfb and Wayland.
@@ -50,14 +55,14 @@ implementer's view of the same module.
   in `.plans/`.
 
 ### Auto-routing
-- `AutoRecorder` — high-level wrapper that takes a `WindowRecorder`, a `Recorder`, and the
+- `AutoRecorder` — high-level wrapper that takes platform recorders and the
   Linux portal recorders (when wired). Routing is Wayland-first (window-targeted portal,
   region portal, or loud failure if no portal recorder is wired), then macOS SCK for
   window capture, Windows Graphics Capture for Windows window/region capture, Linux helper
-  capture for Linux Xorg/Xvfb window/region capture, and ffmpeg region capture for macOS.
-  Windows region capture no longer falls back to ffmpeg when the WGC helper artifact is
-  absent, and WGC-unsupported options such as custom `RecordingOptions.codec` or
-  `screenIndex` now fail loudly. Operational native-helper failures after the helper is
+  capture for Linux Xorg/Xvfb window/region capture, and macOS SCK for macOS region capture.
+  macOS and Windows region capture no longer fall back to ffmpeg when native helper artifacts
+  are absent, and unsupported options such as custom `RecordingOptions.codec` now fail loudly.
+  Operational native-helper failures after the helper is
   found (permissions denied, window not found, helper crash) also propagate with actionable
   messages instead of silently changing capture semantics.
 - `AutoScreenshotter` — high-level still-image router. Uses ScreenCaptureKit window capture
@@ -73,9 +78,11 @@ implementer's view of the same module.
 - `RecordingHandle` — `AutoCloseable`. Stop uses the backend's clean-shutdown path (`q` for
   ffmpeg/SCK-style helpers, JSON `Stop` for the Linux helper), waits for a graceful exit, then
   escalates to process termination when the backend supports that lifecycle.
-- `RecordingOptions` — frame rate, cursor capture, codec.
-  Custom codecs are ffmpeg-backend-specific today; the Linux helper/GStreamer path rejects
-  non-x264 codec strings until encoder pipelines are represented structurally.
+- `RecordingOptions` — frame rate, cursor capture, codec, and display index. For macOS SCK
+  region capture, `screenIndex` is primary display first, then by display frame `minX` and
+  `minY`; explicit legacy `FfmpegRecorder` callers still get avfoundation device ordering.
+  Custom codecs are legacy ffmpeg-backend-specific today; the SCK/WGC/native-helper paths
+  reject unsupported codec strings until encoder pipelines are represented structurally.
 - `MacOsRecordingPermissions.diagnose()` — best-effort startup diagnostic for Screen Recording
   and Accessibility permissions. Full native detection (`CGPreflightScreenCaptureAccess`,
   `AXIsProcessTrusted`) is a future improvement — the SCK helper detects TCC denial by exit
@@ -85,7 +92,8 @@ implementer's view of the same module.
 
 | Capability | Status |
 |---|---|
-| macOS region capture (`avfoundation`) | ✅ deprecated `FfmpegRecorder` |
+| macOS region capture (ScreenCaptureKit) | ✅ `ScreenCaptureKitRecorder` |
+| macOS legacy region capture (`avfoundation`) | ✅ deprecated `FfmpegRecorder` |
 | macOS window-targeted capture (ScreenCaptureKit) | ✅ `ScreenCaptureKitRecorder` |
 | Embedded `ComposePanel` (`windowHandle == 0L`) | ✅ region capture (window-targeted not applicable) |
 | Windows region/fullscreen capture (Windows Graphics Capture) | ✅ `WindowsGraphicsCaptureRecorder` |
@@ -264,8 +272,8 @@ the whole recording" and "frames at the configured rate". Keep it that way.
 ## Permissions
 
 The JVM running Spectre needs two macOS permissions for recording to work:
-- **Screen Recording** — for ffmpeg's avfoundation capture, for `ScreenCaptureKitRecorder`'s
-  helper subprocess, and for AWT `Robot` screenshots.
+- **Screen Recording** — for `ScreenCaptureKitRecorder`'s region/window capture, explicit
+  legacy ffmpeg avfoundation capture, and AWT `Robot` screenshots.
 - **Accessibility** — for AWT `Robot` mouse / keyboard control.
 
 Grant them under **System Settings → Privacy & Security**, targeting whichever process is

--- a/recording/api/recording.api
+++ b/recording/api/recording.api
@@ -177,9 +177,10 @@ public final class dev/sebastiano/spectre/recording/portal/WaylandWindowSourceRe
 public final class dev/sebastiano/spectre/recording/screencapturekit/HelperNotBundledException : java/lang/IllegalStateException {
 }
 
-public final class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder : dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder {
+public final class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder : dev/sebastiano/spectre/recording/Recorder, dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder {
 	public fun <init> ()V
 	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public fun start (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public abstract interface class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder$ProcessFactory {

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -841,6 +841,17 @@ tasks.register<JavaExec>("runScreenCaptureKitSmoke") {
     mainClass.set("dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureKitRecorderSmoke")
 }
 
+// Manual macOS region smoke for the AutoRecorder route. Opens a JFrame, records its screen
+// rectangle through AutoRecorder.startRegion(...), and writes a mid-recording PNG for comparison.
+tasks.register<JavaExec>("runMacOsSckRegionSmoke") {
+    group = "verification"
+    description =
+        "Boots a JFrame, records its region for ~3s via AutoRecorder/SCK, prints output stats."
+    onlyIf { OperatingSystem.current().isMacOsX }
+    classpath = sourceSets["test"].runtimeClasspath
+    mainClass.set("dev.sebastiano.spectre.recording.MacOsSckRegionSmoke")
+}
+
 // Manual still-screenshot smoke for AutoScreenshotter. Opens a JFrame and writes a PNG on
 // macOS/Windows/Linux X11/XWayland/Linux Wayland. Wayland runs through the compositor's
 // portal dialog, so manual acceptance may be required.

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
@@ -12,11 +12,15 @@ import UniformTypeIdentifiers
 //
 // spectre-screencapture
 //   --mode <recording|screenshot>  Optional. Default recording.
-//   --pid <jvm pid>            Required. Filters CGWindowList by owner PID so we never
+//   --source <window|region>   Optional. Default window.
+//   --pid <jvm pid>            Required for window source. Filters CGWindowList by owner PID so we never
 //                              capture another process's window matching the discriminator.
-//   --title-contains <suffix>  Required. Substring match on the target window's kCGWindowName.
+//   --title-contains <suffix>  Required for window source. Substring match on the target window's kCGWindowName.
 //                              Spectre stamps a `Spectre/<uuid>` suffix on the ComposeWindow's
 //                              title for the recording's lifetime so this is unique.
+//   --region <x,y,w,h>         Required for region source. Coordinates use the selected
+//                              display's top-left ScreenCaptureKit sourceRect space.
+//   --display-index <int>      Optional for region source. Default 0; primary display first.
 //   --output <path>            Required. Destination .mov/.mp4 file. Overwritten if it exists.
 //   --fps <int>                Optional. Default 30.
 //   --cursor <true|false>      Optional. Default true.
@@ -64,8 +68,11 @@ struct CLIError: Error {
 
 struct Arguments {
     let mode: CaptureMode
-    let pid: pid_t
-    let titleContains: String
+    let source: CaptureSource
+    let pid: pid_t?
+    let titleContains: String?
+    let region: CaptureRegion?
+    let displayIndex: Int
     let output: URL
     let fps: Int
     let captureCursor: Bool
@@ -74,8 +81,11 @@ struct Arguments {
 
     static func parse(_ argv: [String]) throws -> Arguments {
         var mode = CaptureMode.recording
+        var source = CaptureSource.window
         var pid: pid_t?
         var titleContains: String?
+        var region: CaptureRegion?
+        var displayIndex = 0
         var output: String?
         var fps = 30
         var cursor = true
@@ -95,6 +105,11 @@ struct Arguments {
                     throw CLIError(code: 2, message: "--mode must be recording or screenshot")
                 }
                 mode = parsed
+            case "--source":
+                guard let parsed = CaptureSource(rawValue: value) else {
+                    throw CLIError(code: 2, message: "--source must be window or region")
+                }
+                source = parsed
             case "--pid":
                 guard let parsed = pid_t(value) else {
                     throw CLIError(code: 2, message: "--pid must be an integer")
@@ -102,6 +117,13 @@ struct Arguments {
                 pid = parsed
             case "--title-contains":
                 titleContains = value
+            case "--region":
+                region = try CaptureRegion.parse(value)
+            case "--display-index":
+                guard let parsed = Int(value), parsed >= 0 else {
+                    throw CLIError(code: 2, message: "--display-index must be >= 0")
+                }
+                displayIndex = parsed
             case "--output":
                 output = value
             case "--fps":
@@ -130,9 +152,17 @@ struct Arguments {
             i += 2
         }
 
-        guard let pid else { throw CLIError(code: 2, message: "--pid is required") }
-        guard let titleContains, !titleContains.isEmpty else {
-            throw CLIError(code: 2, message: "--title-contains is required")
+        switch source {
+        case .window:
+            guard pid != nil else { throw CLIError(code: 2, message: "--pid is required") }
+            guard let titleContains, !titleContains.isEmpty else {
+                throw CLIError(code: 2, message: "--title-contains is required")
+            }
+        case .region:
+            guard region != nil else { throw CLIError(code: 2, message: "--region is required") }
+            guard mode == .recording else {
+                throw CLIError(code: 2, message: "region source only supports --mode recording")
+            }
         }
         guard let output, !output.isEmpty else {
             throw CLIError(code: 2, message: "--output is required")
@@ -141,8 +171,11 @@ struct Arguments {
 
         return Arguments(
             mode: mode,
+            source: source,
             pid: pid,
             titleContains: titleContains,
+            region: region,
+            displayIndex: displayIndex,
             output: outputUrl,
             fps: fps,
             captureCursor: cursor,
@@ -155,6 +188,11 @@ struct Arguments {
 enum CaptureMode: String {
     case recording
     case screenshot
+}
+
+enum CaptureSource: String {
+    case window
+    case region
 }
 
 enum RecordingFileType: String {
@@ -175,6 +213,38 @@ enum RecordingFileType: String {
         case .mp4:
             return .mp4
         }
+    }
+}
+
+struct CaptureRegion {
+    let x: Int
+    let y: Int
+    let width: Int
+    let height: Int
+
+    static func parse(_ value: String) throws -> CaptureRegion {
+        let parts = value.split(separator: ",", omittingEmptySubsequences: false)
+        guard parts.count == 4, let x = Int(parts[0]), let y = Int(parts[1]),
+            let width = Int(parts[2]), let height = Int(parts[3])
+        else {
+            throw CLIError(code: 2, message: "--region must be x,y,width,height")
+        }
+        guard x >= 0, y >= 0, width > 0, height > 0 else {
+            throw CLIError(
+                code: 2,
+                message:
+                    "--region x/y must be non-negative and width/height must be positive")
+        }
+        return CaptureRegion(x: x, y: y, width: width, height: height)
+    }
+
+    func sourceRect() -> CGRect {
+        CGRect(
+            x: CGFloat(x),
+            y: CGFloat(y),
+            width: CGFloat(width),
+            height: CGFloat(height)
+        )
     }
 }
 
@@ -236,8 +306,8 @@ final class Recorder {
         // existing.
         try validateOutputPath(args.output)
 
-        let target = try await discoverTargetWindow()
-        try await startCapture(targetWindow: target)
+        let target = try await discoverTarget()
+        try await startCapture(target: target)
         var waitError: Error?
         if args.mode == .recording {
             await waitForStop()
@@ -299,7 +369,43 @@ final class Recorder {
         }
     }
 
+    private enum CaptureTarget {
+        case window(SCWindow)
+        case region(display: SCDisplay, region: CaptureRegion)
+    }
+
+    private func requirePid() throws -> pid_t {
+        guard let pid = args.pid else { throw CLIError(code: 2, message: "--pid is required") }
+        return pid
+    }
+
+    private func requireTitleContains() throws -> String {
+        guard let titleContains = args.titleContains, !titleContains.isEmpty else {
+            throw CLIError(code: 2, message: "--title-contains is required")
+        }
+        return titleContains
+    }
+
+    private func requireRegion() throws -> CaptureRegion {
+        guard let region = args.region else {
+            throw CLIError(code: 2, message: "--region is required")
+        }
+        return region
+    }
+
+    private func discoverTarget() async throws -> CaptureTarget {
+        switch args.source {
+        case .window:
+            return .window(try await discoverTargetWindow())
+        case .region:
+            let region = try requireRegion()
+            return .region(display: try await discoverTargetDisplay(), region: region)
+        }
+    }
+
     private func discoverTargetWindow() async throws -> SCWindow {
+        let pid = try requirePid()
+        let titleContains = try requireTitleContains()
         let deadline = Date().addingTimeInterval(Double(args.discoveryTimeoutMs) / 1000.0)
         repeat {
             let content: SCShareableContent
@@ -312,9 +418,9 @@ final class Recorder {
             }
 
             if let match = content.windows.first(where: { window in
-                guard window.owningApplication?.processID == args.pid else { return false }
+                guard window.owningApplication?.processID == pid else { return false }
                 guard let title = window.title, !title.isEmpty else { return false }
-                return title.contains(args.titleContains)
+                return title.contains(titleContains)
             }) {
                 return match
             }
@@ -325,34 +431,80 @@ final class Recorder {
         throw CLIError(
             code: 3,
             message:
-                "no window with pid=\(args.pid) and title containing '\(args.titleContains)' found within \(args.discoveryTimeoutMs) ms"
+                "no window with pid=\(pid) and title containing '\(titleContains)' found within \(args.discoveryTimeoutMs) ms"
         )
     }
 
-    private func startCapture(targetWindow: SCWindow) async throws {
-        // Use the backing-scale of the screen the target window actually lives on, not
-        // `NSScreen.main`'s. Mixed-DPI setups (Retina laptop + non-Retina external) would
-        // otherwise pick the wrong scale and produce stretched / cropped output for windows
-        // off the main screen. Falls back to NSScreen.main and finally a hardcoded 2.0 if
-        // neither lookup succeeds — neither degrades worse than the previous behaviour.
-        let scale = backingScaleFactor(for: targetWindow.frame)
-        let width = max(2, Int((targetWindow.frame.width * scale).rounded()))
-        let height = max(2, Int((targetWindow.frame.height * scale).rounded()))
+    private func discoverTargetDisplay() async throws -> SCDisplay {
+        let content: SCShareableContent
+        do {
+            content = try await SCShareableContent.excludingDesktopWindows(
+                false, onScreenWindowsOnly: true)
+        } catch {
+            throw CLIError(code: 4, message: "screen recording permission denied: \(error)")
+        }
+        let displays = sortedDisplays(content.displays)
+        guard args.displayIndex < displays.count else {
+            throw CLIError(
+                code: 3,
+                message:
+                    "display index \(args.displayIndex) is out of range; only \(displays.count) display(s) are shareable"
+            )
+        }
+        return displays[args.displayIndex]
+    }
 
-        // Window-attached filter — output is exactly the target window's pixels, sized to
-        // `config.width` × `config.height`, with no display-coordinate masking. Display-mode
-        // filters (`SCContentFilter(display:including:)`) deliver frames just as well but
-        // place the window inside the display's coordinate space, leaving large black areas
-        // outside the window in the output buffer.
-        //
-        // Earlier diagnostic runs suggested this filter dropped frames; that was actually the
-        // FrameOutput being released right after `startCapture` returned (we hadn't retained
-        // it as a member). With the strong reference in place SCStream delivers frames at the
-        // configured rate even for window-attached filters.
-        let filter = SCContentFilter(desktopIndependentWindow: targetWindow)
+    private func sortedDisplays(_ displays: [SCDisplay]) -> [SCDisplay] {
+        let mainDisplayId = CGMainDisplayID()
+        return displays.sorted { lhs, rhs in
+            if lhs.displayID == mainDisplayId { return true }
+            if rhs.displayID == mainDisplayId { return false }
+            if lhs.frame.minX != rhs.frame.minX { return lhs.frame.minX < rhs.frame.minX }
+            return lhs.frame.minY < rhs.frame.minY
+        }
+    }
+
+    private func startCapture(target: CaptureTarget) async throws {
+        let filter: SCContentFilter
+        let sourceRect: CGRect?
+        let width: Int
+        let height: Int
+
+        switch target {
+        case .window(let targetWindow):
+            // Use the backing-scale of the screen the target window actually lives on, not
+            // `NSScreen.main`'s. Mixed-DPI setups (Retina laptop + non-Retina external) would
+            // otherwise pick the wrong scale and produce stretched / cropped output for windows
+            // off the main screen. Falls back to NSScreen.main and finally a hardcoded 2.0 if
+            // neither lookup succeeds — neither degrades worse than the previous behaviour.
+            let scale = backingScaleFactor(for: targetWindow.frame)
+            width = max(2, Int((targetWindow.frame.width * scale).rounded()))
+            height = max(2, Int((targetWindow.frame.height * scale).rounded()))
+
+            // Window-attached filter — output is exactly the target window's pixels, sized to
+            // `config.width` × `config.height`, with no display-coordinate masking. Display-mode
+            // filters (`SCContentFilter(display:including:)`) deliver frames just as well but
+            // place the window inside the display's coordinate space, leaving large black areas
+            // outside the window in the output buffer.
+            //
+            // Earlier diagnostic runs suggested this filter dropped frames; that was actually the
+            // FrameOutput being released right after `startCapture` returned (we hadn't retained
+            // it as a member). With the strong reference in place SCStream delivers frames at the
+            // configured rate even for window-attached filters.
+            filter = SCContentFilter(desktopIndependentWindow: targetWindow)
+            sourceRect = nil
+        case .region(let display, let region):
+            width = max(2, region.width)
+            height = max(2, region.height)
+            filter = SCContentFilter(display: display, excludingWindows: [])
+            sourceRect = region.sourceRect()
+        }
         let config = SCStreamConfiguration()
         config.width = width
         config.height = height
+        if let sourceRect {
+            config.sourceRect = sourceRect
+        }
         config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(args.fps))
         config.showsCursor = args.captureCursor
         config.queueDepth = 8

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -21,15 +21,15 @@ import java.nio.file.Path
  * window-source path on Linux Wayland. If the requested window mode is unavailable, it throws with
  * an actionable error instead of silently falling back to region capture.
  *
- * [startRegion] uses region capture only: Windows Graphics Capture on Windows, ffmpeg region
- * capture on macOS, the Linux helper's Xorg/Xvfb path, and the Wayland portal monitor-source path
- * on Linux Wayland. If the requested region mode is unavailable, it throws instead of switching
- * capture semantics.
+ * [startRegion] uses region capture only: ScreenCaptureKit on macOS, Windows Graphics Capture on
+ * Windows, the Linux helper's Xorg/Xvfb path, and the Wayland portal monitor-source path on Linux
+ * Wayland. If the requested region mode is unavailable, it throws instead of switching capture
+ * semantics.
  */
 public class AutoRecorder
 internal constructor(
     private val sckRecorder: WindowRecorder,
-    private val ffmpegRecorder: Recorder,
+    private val macOsRegionRecorder: Recorder,
     private val windowsWindowRecorder: WindowRecorder?,
     private val windowsRegionRecorder: Recorder?,
     private val linuxRegionRecorder: Recorder?,
@@ -46,14 +46,14 @@ internal constructor(
 
     public constructor(
         sckRecorder: WindowRecorder = ScreenCaptureKitRecorder(),
-        ffmpegRecorder: Recorder = DefaultLegacyFfmpegRecorder,
+        macOsRegionRecorder: Recorder = sckRecorder as? Recorder ?: ScreenCaptureKitRecorder(),
         windowsWindowRecorder: WindowRecorder? = defaultWindowsWindowRecorder(),
         windowsRegionRecorder: Recorder? = defaultWindowsRegionRecorder(),
         waylandPortalRecorder: Recorder? = defaultPortals.region,
         waylandPortalWindowRecorder: WaylandWindowSourceRecorder? = defaultPortals.window,
     ) : this(
         sckRecorder = sckRecorder,
-        ffmpegRecorder = ffmpegRecorder,
+        macOsRegionRecorder = macOsRegionRecorder,
         windowsWindowRecorder = windowsWindowRecorder,
         windowsRegionRecorder = windowsRegionRecorder,
         linuxRegionRecorder = defaultLinuxRecorder,
@@ -140,11 +140,18 @@ internal constructor(
                 throw unavailable("Windows region capture", e)
             }
         }
+        if (isMacOs()) {
+            return try {
+                macOsRegionRecorder.start(region, output, options)
+            } catch (e: HelperNotBundledException) {
+                throw unavailable("macOS region capture", e)
+            }
+        }
         if (isLinux()) {
             return linuxRegionRecorder?.start(region, output, options)
                 ?: throw unavailable("Linux X11 region capture", null)
         }
-        return ffmpegRecorder.start(region, output, options)
+        throw unsupportedRegionCapture()
     }
 
     private fun unavailable(mode: String, cause: Throwable?): IllegalStateException {
@@ -159,6 +166,12 @@ internal constructor(
             "AutoRecorder.startWindow is unsupported on this platform because no true " +
                 "window-targeted recorder is available. Use startRegion(...) explicitly for " +
                 "region capture."
+        )
+
+    private fun unsupportedRegionCapture(): IllegalStateException =
+        IllegalStateException(
+            "AutoRecorder.startRegion is unsupported on this platform because no region recorder " +
+                "is available."
         )
 
     private companion object {
@@ -222,16 +235,6 @@ internal constructor(
             WaylandPortalRecorders.resolveDefaults(::defaultIsLinux)
         }
     }
-}
-
-private object DefaultLegacyFfmpegRecorder : Recorder {
-    @Suppress("DEPRECATION") private val delegate: FfmpegRecorder by lazy { FfmpegRecorder() }
-
-    override fun start(
-        region: Rectangle,
-        output: Path,
-        options: RecordingOptions,
-    ): RecordingHandle = delegate.start(region, output, options)
 }
 
 /**

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorder.kt
@@ -38,9 +38,9 @@ import java.util.concurrent.atomic.AtomicReference
  * overridden via the internal constructor for tests (so the produced argv is deterministic
  * regardless of the host OS).
  *
- * Window-targeted capture (`windowHandle != 0`) — i.e. ScreenCaptureKit on macOS — is handled by a
- * separate `WindowRecorder` and routed by [AutoRecorder]. Embedded ComposePanel surfaces with
- * `windowHandle == 0L` always fall through to region capture, which is what this recorder does.
+ * Platform-native auto-routed capture is handled outside this deprecated backend: ScreenCaptureKit
+ * on macOS, Windows Graphics Capture on Windows, and the Linux helper/portal paths. Instantiate
+ * this class directly only when you intentionally need the legacy ffmpeg behaviour.
  *
  * The [processFactory] seam exists so the lifecycle can be unit-tested without spawning a real
  * `ffmpeg` (a fake factory can return a `Process`-like stand-in driven by an in-memory pipe).
@@ -55,10 +55,9 @@ internal constructor(
     private val processFactory: ProcessFactory,
     // Provider — resolved on first [start] call rather than at construction time. Eagerly
     // calling `FfmpegBackend.detect()` from the public constructor would make `FfmpegRecorder()`
-    // (and `AutoRecorder()`'s default ffmpegRecorder) throw immediately on Linux/BSD even when
-    // recording is never attempted, breaking call sites that instantiate recorders during app
-    // startup. Deferring keeps construction OS-agnostic and surfaces the unsupported-host error
-    // only at the point of use.
+    // throw immediately on Linux/BSD even when recording is never attempted, breaking call sites
+    // that instantiate recorders during app startup. Deferring keeps construction OS-agnostic and
+    // surfaces the unsupported-host error only at the point of use.
     private val backendProvider: () -> FfmpegBackend,
 ) : Recorder {
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/RecordingOptions.kt
@@ -17,13 +17,11 @@ public data class RecordingOptions(
      */
     val codec: String = DEFAULT_CODEC,
     /**
-     * Index of the macOS display to capture from, used to build ffmpeg's avfoundation device name
-     * `Capture screen $screenIndex`. Defaults to `0` — the primary display. Multi-monitor users
-     * whose target region lives on a secondary display must set this to the matching index
-     * (typically the AWT `GraphicsDevice` index of the screen, but verify by running `ffmpeg -f
-     * avfoundation -list_devices true -i ""` once and matching the "Capture screen N" entries
-     * against your physical display arrangement). The crop coordinates in the region are
-     * interpreted relative to the chosen screen's top-left.
+     * Index of the display to capture for fixed-region recorders that support multiple displays.
+     * Defaults to `0` — the primary display. macOS ScreenCaptureKit region capture orders displays
+     * primary first, then by display frame `minX`, then by `minY`; region coordinates use the
+     * selected display's ScreenCaptureKit source-rect space. Explicit legacy [FfmpegRecorder]
+     * callers still get ffmpeg avfoundation device ordering (`Capture screen N`).
      */
     val screenIndex: Int = DEFAULT_SCREEN_INDEX,
 ) {

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperArguments.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperArguments.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.recording.screencapturekit
 
+import java.awt.Rectangle
 import java.nio.file.Path
 
 /**
@@ -16,8 +17,11 @@ import java.nio.file.Path
  */
 internal data class HelperArguments(
     val mode: String = "recording",
-    val pid: Long,
-    val titleContains: String,
+    val source: HelperSource,
+    val pid: Long? = null,
+    val titleContains: String? = null,
+    val region: Rectangle? = null,
+    val displayIndex: Int = 0,
     val output: Path,
     val fps: Int,
     val captureCursor: Boolean,
@@ -28,8 +32,28 @@ internal data class HelperArguments(
         require(mode == "recording" || mode == "screenshot") {
             "mode must be recording or screenshot (got $mode)"
         }
-        require(titleContains.isNotBlank()) {
-            "titleContains must be a non-blank substring; the helper rejects empty discriminators"
+        when (source) {
+            HelperSource.Window -> {
+                requireNotNull(pid) { "pid is required for window capture" }
+                val discriminator =
+                    requireNotNull(titleContains) { "titleContains is required for window capture" }
+                require(discriminator.isNotBlank()) {
+                    "titleContains must be a non-blank substring; the helper rejects empty discriminators"
+                }
+            }
+            HelperSource.Region -> {
+                val captureRegion =
+                    requireNotNull(region) { "region capture requires a non-empty region" }
+                require(captureRegion.width > 0 && captureRegion.height > 0) {
+                    "region capture requires a non-empty region; got $captureRegion"
+                }
+                require(captureRegion.x >= 0 && captureRegion.y >= 0) {
+                    "region capture requires an origin within the selected display; got $captureRegion"
+                }
+                require(displayIndex >= 0) {
+                    "displayIndex must be non-negative (got $displayIndex)"
+                }
+            }
         }
         require(fps > 0) { "fps must be positive (got $fps)" }
         require(discoveryTimeoutMs >= 0) {
@@ -46,10 +70,31 @@ internal data class HelperArguments(
         add(helperPath.toString())
         add("--mode")
         add(mode)
-        add("--pid")
-        add(pid.toString())
-        add("--title-contains")
-        add(titleContains)
+        add("--source")
+        add(source.cliValue)
+        when (source) {
+            HelperSource.Window -> {
+                add("--pid")
+                add(pid.toString())
+                add("--title-contains")
+                add(titleContains.orEmpty())
+            }
+            HelperSource.Region -> {
+                val captureRegion = requireNotNull(region)
+                add("--region")
+                add(
+                    listOf(
+                            captureRegion.x,
+                            captureRegion.y,
+                            captureRegion.width,
+                            captureRegion.height,
+                        )
+                        .joinToString(",")
+                )
+                add("--display-index")
+                add(displayIndex.toString())
+            }
+        }
         add("--fps")
         add(fps.toString())
         add("--cursor")
@@ -79,4 +124,9 @@ internal data class HelperArguments(
                 else -> RecordingFileType.Mov
             }
     }
+}
+
+internal enum class HelperSource(val cliValue: String) {
+    Window("window"),
+    Region("region"),
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -1,7 +1,9 @@
 package dev.sebastiano.spectre.recording.screencapturekit
 
+import dev.sebastiano.spectre.recording.Recorder
 import dev.sebastiano.spectre.recording.RecordingHandle
 import dev.sebastiano.spectre.recording.RecordingOptions
+import java.awt.Rectangle
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
@@ -11,25 +13,23 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Window-targeted recorder backed by ScreenCaptureKit via the bundled `spectre-screencapture` Swift
- * helper.
+ * macOS recorder backed by ScreenCaptureKit via the bundled `spectre-screencapture` Swift helper.
  *
  * Lifecycle:
- * 1. [start] extracts the helper binary, stamps a unique `Spectre/<id>` suffix on the target
- *    window's title (so the helper can find that exact window across the process boundary), builds
- *    the helper argv, and spawns the subprocess.
+ * 1. [start] extracts the helper binary, builds the helper argv, and spawns the subprocess. Window
+ *    capture also stamps a unique `Spectre/<id>` suffix on the target window's title so the helper
+ *    can find that exact window across the process boundary.
  * 2. The recorder waits a short startup probe to catch the common fast-fail exit codes
  *    ([HELPER_EXIT_BAD_ARGS], [HELPER_EXIT_WINDOW_NOT_FOUND], [HELPER_EXIT_TCC_DENIED]) and
- *    surfaces them with mapped error messages — restoring the title on failure so the user's app
- *    isn't left with a stale Spectre suffix.
+ *    surfaces them with mapped error messages. Window mode restores the title on every failure so
+ *    the user's app isn't left with a stale Spectre suffix.
  * 3. The returned [RecordingHandle] stops the helper by writing `q` to its stdin (mirrors
  *    `FfmpegRecorder`'s shutdown contract). Title restoration happens unconditionally during stop,
  *    including the crashed-mid-recording branch.
  *
- * Implements [WindowRecorder] (window-targeted) rather than the region-based
- * [dev.sebastiano.spectre.recording.Recorder] — ScreenCaptureKit is fundamentally window-attached
- * and coordinates aren't necessary. The high-level [dev.sebastiano.spectre.recording.AutoRecorder]
- * takes both backends and picks per call: SCK when there's a window on macOS, ffmpeg otherwise.
+ * Implements [WindowRecorder] for window-targeted capture and [Recorder] for fixed display-region
+ * capture. The high-level [dev.sebastiano.spectre.recording.AutoRecorder] routes both macOS
+ * recording modes here by default.
  *
  * macOS-only. On non-macOS hosts the helper isn't bundled; [start] fails early with a clear "helper
  * not found" error from [HelperBinaryExtractor].
@@ -38,7 +38,7 @@ public class ScreenCaptureKitRecorder
 internal constructor(
     private val helperExtractor: HelperBinaryExtractor,
     private val processFactory: ProcessFactory,
-) : WindowRecorder {
+) : WindowRecorder, Recorder {
 
     public constructor() : this(HelperBinaryExtractor(), SystemProcessFactory)
 
@@ -48,12 +48,13 @@ internal constructor(
         output: Path,
         options: RecordingOptions,
     ): RecordingHandle {
+        validateOptions(options)
         // Resolve everything that can fail without touching window state first. Anything we do
         // before `discriminator.apply()` doesn't need a restore path; anything after must
         // restore on every error branch (the original window title is held by the
         // discriminator and would otherwise stay dirty across a failed start).
         val helperPath = helperExtractor.extract()
-        Files.createDirectories(output.toAbsolutePath().parent ?: output.toAbsolutePath())
+        output.toAbsolutePath().parent?.let(Files::createDirectories)
 
         val discriminator = TitleDiscriminator(window)
         discriminator.apply()
@@ -64,6 +65,7 @@ internal constructor(
         try {
             val argv =
                 HelperArguments(
+                        source = HelperSource.Window,
                         pid = windowOwnerPid,
                         titleContains = discriminator.value,
                         output = output,
@@ -73,71 +75,113 @@ internal constructor(
                     )
                     .toArgv(helperPath)
 
-            val process = processFactory.start(argv)
-
-            // Wait for the helper to either:
-            //   - emit the READY marker on stdout (window discovered, SCK is streaming
-            //     frames), or
-            //   - exit with one of the documented fast-fail codes (2/3/4/5).
-            // A plain `process.waitFor(STARTUP_PROBE_MILLIS)`-style probe was racy: when the
-            // helper's window discovery took longer than the probe, start() reported success
-            // before the helper had actually started capturing. Reading stdout removes the
-            // race.
-            val ready =
-                try {
-                    awaitHelperReady(process, READY_WAIT_MILLIS)
-                } catch (e: InterruptedException) {
-                    // destroyForcibly() is asynchronous on the JVM. Without a bounded wait
-                    // here we can return from start() while the helper is still alive +
-                    // writing the output file — leaks a subprocess and leaves the recording
-                    // mutating after the caller thinks startup aborted. Mirror the non-ready
-                    // path's bounded wait so the helper is genuinely gone by the time we
-                    // propagate the interrupt.
-                    process.destroyForcibly()
-                    @Suppress("SwallowedException")
-                    try {
-                        process.waitFor(FORCE_KILL_DURING_START_SECONDS, TimeUnit.SECONDS)
-                    } catch (_: InterruptedException) {
-                        // A second interrupt during cleanup means the JVM is being torn down
-                        // anyway — daemon-process semantics will let the helper die with us.
-                    }
-                    Thread.currentThread().interrupt()
-                    throw e
-                }
-            if (!ready) {
-                val exit =
-                    if (process.isAlive) {
-                        process.destroyForcibly()
-                        // Bounded wait — destroyForcibly() is asynchronous and an unbounded
-                        // `waitFor()` can pin the calling thread indefinitely if the kernel
-                        // hasn't reaped the helper yet. If the helper still hasn't died after
-                        // the timeout, fall back to a sentinel exit code so we don't propagate
-                        // a hang into the caller.
-                        val terminated =
-                            try {
-                                process.waitFor(FORCE_KILL_DURING_START_SECONDS, TimeUnit.SECONDS)
-                            } catch (e: InterruptedException) {
-                                Thread.currentThread().interrupt()
-                                throw e
-                            }
-                        if (terminated) process.exitValue() else EXIT_HELPER_NOT_REAPED
-                    } else {
-                        process.exitValue()
-                    }
-                error(messageForHelperExit(exit, output, argv))
-            }
-
-            val handle =
-                ScreenCaptureKitRecordingHandle(
-                    process = process,
-                    output = output,
-                    discriminator = discriminator,
-                )
+            val handle = startHelper(output, argv, discriminator::restore)
             success = true
             return handle
         } finally {
             if (!success) discriminator.restore()
         }
+    }
+
+    override fun start(
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): RecordingHandle {
+        require(region.width > 0 && region.height > 0) {
+            "ScreenCaptureKitRecorder requires a non-empty region; got $region."
+        }
+        require(region.x >= 0 && region.y >= 0) {
+            "ScreenCaptureKitRecorder requires a region origin within the selected display; got $region."
+        }
+        validateOptions(options)
+        val helperPath = helperExtractor.extract()
+        output.toAbsolutePath().parent?.let(Files::createDirectories)
+        val argv =
+            HelperArguments(
+                    source = HelperSource.Region,
+                    region = region,
+                    displayIndex = options.screenIndex,
+                    output = output,
+                    fps = options.frameRate,
+                    captureCursor = options.captureCursor,
+                    discoveryTimeoutMs = DEFAULT_DISCOVERY_TIMEOUT_MS,
+                )
+                .toArgv(helperPath)
+        return startHelper(output, argv) {}
+    }
+
+    private fun validateOptions(options: RecordingOptions) {
+        require(options.codec == RecordingOptions.DEFAULT_CODEC) {
+            "ScreenCaptureKitRecorder does not support custom RecordingOptions.codec; " +
+                "got ${options.codec}."
+        }
+    }
+
+    private fun startHelper(
+        output: Path,
+        argv: List<String>,
+        cleanup: () -> Unit,
+    ): RecordingHandle {
+        val process = processFactory.start(argv)
+
+        // Wait for the helper to either:
+        //   - emit the READY marker on stdout (target discovered, SCK is streaming
+        //     frames), or
+        //   - exit with one of the documented fast-fail codes (2/3/4/5).
+        // A plain `process.waitFor(STARTUP_PROBE_MILLIS)`-style probe was racy: when the
+        // helper's window discovery took longer than the probe, start() reported success
+        // before the helper had actually started capturing. Reading stdout removes the
+        // race.
+        val ready =
+            try {
+                awaitHelperReady(process, READY_WAIT_MILLIS)
+            } catch (e: InterruptedException) {
+                // destroyForcibly() is asynchronous on the JVM. Without a bounded wait
+                // here we can return from start() while the helper is still alive +
+                // writing the output file — leaks a subprocess and leaves the recording
+                // mutating after the caller thinks startup aborted. Mirror the non-ready
+                // path's bounded wait so the helper is genuinely gone by the time we
+                // propagate the interrupt.
+                process.destroyForcibly()
+                @Suppress("SwallowedException")
+                try {
+                    process.waitFor(FORCE_KILL_DURING_START_SECONDS, TimeUnit.SECONDS)
+                } catch (_: InterruptedException) {
+                    // A second interrupt during cleanup means the JVM is being torn down
+                    // anyway — daemon-process semantics will let the helper die with us.
+                }
+                Thread.currentThread().interrupt()
+                throw e
+            }
+        if (!ready) {
+            val exit =
+                if (process.isAlive) {
+                    process.destroyForcibly()
+                    // Bounded wait — destroyForcibly() is asynchronous and an unbounded
+                    // `waitFor()` can pin the calling thread indefinitely if the kernel
+                    // hasn't reaped the helper yet. If the helper still hasn't died after
+                    // the timeout, fall back to a sentinel exit code so we don't propagate
+                    // a hang into the caller.
+                    val terminated =
+                        try {
+                            process.waitFor(FORCE_KILL_DURING_START_SECONDS, TimeUnit.SECONDS)
+                        } catch (e: InterruptedException) {
+                            Thread.currentThread().interrupt()
+                            throw e
+                        }
+                    if (terminated) process.exitValue() else EXIT_HELPER_NOT_REAPED
+                } else {
+                    process.exitValue()
+                }
+            error(messageForHelperExit(exit, output, argv))
+        }
+
+        return ScreenCaptureKitRecordingHandle(
+            process = process,
+            output = output,
+            cleanup = cleanup,
+        )
     }
 
     /**
@@ -218,10 +262,7 @@ internal constructor(
             when (exit) {
                 HELPER_EXIT_BAD_ARGS ->
                     "spectre-screencapture rejected its arguments (exit 2). Argv: $argv"
-                HELPER_EXIT_WINDOW_NOT_FOUND ->
-                    "spectre-screencapture could not find the target window within the discovery " +
-                        "timeout (exit 3). The window may not be on screen, or its title may have " +
-                        "been changed before the helper had time to scan. Argv: $argv"
+                HELPER_EXIT_WINDOW_NOT_FOUND -> messageForMissingCaptureSource(argv)
                 HELPER_EXIT_TCC_DENIED ->
                     "spectre-screencapture was denied Screen Recording permission (exit 4). " +
                         "Grant the JVM Screen Recording under System Settings → Privacy & Security " +
@@ -240,10 +281,25 @@ internal constructor(
     }
 }
 
+private fun messageForMissingCaptureSource(argv: List<String>): String =
+    if (argv.valueAfter("--source") == "region") {
+        "spectre-screencapture could not find the requested display for region capture " +
+            "(exit 3). Check RecordingOptions.screenIndex. Argv: $argv"
+    } else {
+        "spectre-screencapture could not find the target window within the discovery timeout " +
+            "(exit 3). The window may not be on screen, or its title may have been changed " +
+            "before the helper had time to scan. Argv: $argv"
+    }
+
+private fun List<String>.valueAfter(flag: String): String? {
+    val index = indexOf(flag)
+    return if (index >= 0 && index + 1 < size) this[index + 1] else null
+}
+
 private class ScreenCaptureKitRecordingHandle(
     private val process: Process,
     override val output: Path,
-    private val discriminator: TitleDiscriminator,
+    private val cleanup: () -> Unit,
 ) : RecordingHandle {
 
     private val stopInitiated = AtomicBoolean(false)
@@ -259,10 +315,10 @@ private class ScreenCaptureKitRecordingHandle(
             result.get()?.getOrThrow()
             return
         }
-        // Run both `stopInternal()` and `discriminator.restore()` even if the first one
-        // throws — restoring the window title is part of the cleanup contract even on the
-        // crash branch, otherwise the user's window stays dirtied with the Spectre/<id>
-        // suffix forever after a failed recording.
+        // Run both `stopInternal()` and `cleanup()` even if the first one throws — restoring the
+        // window title is part of the cleanup contract even on the crash branch, otherwise the
+        // user's window stays dirtied with the Spectre/<id> suffix forever after a failed
+        // recording. Region recordings pass a no-op cleanup.
         //
         // Both outcomes are folded into a single `Result` published BEFORE `countDown` so
         // every concurrent caller (the one that won the CAS race AND the ones blocked on
@@ -278,7 +334,7 @@ private class ScreenCaptureKitRecordingHandle(
         }
         // `stopInternal` re-sets the thread's interrupt flag if any of its `waitFor` calls saw
         // an interrupt — that's correct behaviour for propagating cancellation to the caller.
-        // But `discriminator.restore()` in the production AWT adapter goes through
+        // But window cleanup in the production AWT adapter goes through
         // `EventQueue.invokeAndWait`, whose internal `Object.wait` throws InterruptedException
         // immediately when the interrupt flag is set. That would skip title restoration on
         // every interrupted stop and leave the window dirty with a `Spectre/<id>` suffix
@@ -287,7 +343,7 @@ private class ScreenCaptureKitRecordingHandle(
         val wasInterrupted = Thread.interrupted()
         @Suppress("TooGenericExceptionCaught")
         try {
-            discriminator.restore()
+            cleanup()
         } catch (t: Throwable) {
             if (primary == null) primary = t else primary.addSuppressed(t)
         } finally {

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitScreenshotter.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitScreenshotter.kt
@@ -26,6 +26,7 @@ internal constructor(
             val argv =
                 HelperArguments(
                         mode = "screenshot",
+                        source = HelperSource.Window,
                         pid = windowOwnerPid,
                         titleContains = discriminator.value,
                         output = output,

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
@@ -19,16 +19,39 @@ import kotlin.test.assertTrue
 class AutoRecorderTest {
 
     @Test
-    fun `startRegion routes to ffmpeg on non-Wayland hosts`() {
+    fun `startRegion routes to ScreenCaptureKit on macOS`() {
         val ffmpeg = StubRegionRecorder()
-        val recorder = autoRecorder(ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val sckRegion = StubRegionRecorder()
+        val recorder = autoRecorder(macOsRegionRecorder = sckRegion, isMacOs = { true })
         val output = tempMov()
         try {
             val region = Rectangle(0, 0, 100, 100)
 
             recorder.startRegion(region = region, output = output)
 
-            assertEquals(region, ffmpeg.lastRegion)
+            assertEquals(region, sckRegion.lastRegion)
+            assertFalse(ffmpeg.startCalled, "macOS region capture must not fall through to ffmpeg")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startRegion fails loudly on macOS when SCK helper is not bundled`() {
+        val ffmpeg = StubRegionRecorder()
+        val recorder =
+            autoRecorder(macOsRegionRecorder = MissingSckHelperRecorder(), isMacOs = { true })
+        val output = tempMov()
+        try {
+            val region = Rectangle(0, 0, 100, 100)
+
+            val error =
+                assertFailsWith<IllegalStateException> {
+                    recorder.startRegion(region = region, output = output)
+                }
+
+            assertTrue(error.message.orEmpty().contains("macOS region capture"))
+            assertFalse(ffmpeg.startCalled)
         } finally {
             output.deleteIfExists()
         }
@@ -40,7 +63,6 @@ class AutoRecorderTest {
         val windowsRegion = StubRegionRecorder()
         val recorder =
             autoRecorder(
-                ffmpegRecorder = ffmpeg,
                 windowsRegionRecorder = windowsRegion,
                 isMacOs = { false },
                 isWindows = { true },
@@ -67,7 +89,6 @@ class AutoRecorderTest {
         val windowsRegion = UnsupportedWindowsOptionsRecorder()
         val recorder =
             autoRecorder(
-                ffmpegRecorder = ffmpeg,
                 windowsRegionRecorder = windowsRegion,
                 isMacOs = { false },
                 isWindows = { true },
@@ -95,7 +116,6 @@ class AutoRecorderTest {
         val ffmpeg = StubRegionRecorder()
         val recorder =
             autoRecorder(
-                ffmpegRecorder = ffmpeg,
                 windowsRegionRecorder = MissingWindowsHelperRecorder(),
                 isMacOs = { false },
                 isWindows = { true },
@@ -120,12 +140,7 @@ class AutoRecorderTest {
     fun `startRegion fails loudly when Windows region recorder is unavailable`() {
         val ffmpeg = StubRegionRecorder()
         val recorder =
-            autoRecorder(
-                ffmpegRecorder = ffmpeg,
-                windowsRegionRecorder = null,
-                isMacOs = { false },
-                isWindows = { true },
-            )
+            autoRecorder(windowsRegionRecorder = null, isMacOs = { false }, isWindows = { true })
         val output = tempMov()
         try {
             val error =
@@ -147,7 +162,6 @@ class AutoRecorderTest {
         val portal = StubRegionRecorder()
         val recorder =
             autoRecorder(
-                ffmpegRecorder = ffmpeg,
                 linuxRegionRecorder = linux,
                 waylandPortalRecorder = portal,
                 isMacOs = { false },
@@ -177,7 +191,6 @@ class AutoRecorderTest {
         val linux = StubRegionRecorder()
         val recorder =
             autoRecorder(
-                ffmpegRecorder = ffmpeg,
                 linuxRegionRecorder = linux,
                 isMacOs = { false },
                 isLinux = { true },
@@ -224,7 +237,7 @@ class AutoRecorderTest {
     fun `startWindow routes to SCK on macOS`() {
         val sck = StubWindowRecorder(name = "sck")
         val ffmpeg = StubRegionRecorder()
-        val recorder = autoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val recorder = autoRecorder(sckRecorder = sck, isMacOs = { true })
         val output = tempMov()
         try {
             val window = StubTitledWindow(title = "MyApp")
@@ -242,7 +255,7 @@ class AutoRecorderTest {
     fun `startWindow propagates missing SCK helper as loud window-capture failure`() {
         val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.HelperNotBundled)
         val ffmpeg = StubRegionRecorder()
-        val recorder = autoRecorder(sckRecorder = sck, ffmpegRecorder = ffmpeg, isMacOs = { true })
+        val recorder = autoRecorder(sckRecorder = sck, isMacOs = { true })
         val output = tempMov()
         try {
             val error =
@@ -266,7 +279,6 @@ class AutoRecorderTest {
         val windowRecorder = StubWindowRecorder(name = "ffmpegWindow")
         val recorder =
             autoRecorder(
-                ffmpegRecorder = ffmpeg,
                 windowsWindowRecorder = windowRecorder,
                 isMacOs = { false },
                 isWindows = { true },
@@ -288,7 +300,6 @@ class AutoRecorderTest {
         val windowRecorder = StubWindowRecorder(name = "ffmpegWindow")
         val recorder =
             autoRecorder(
-                ffmpegRecorder = ffmpeg,
                 windowsWindowRecorder = windowRecorder,
                 isMacOs = { false },
                 isWindows = { true },
@@ -316,7 +327,6 @@ class AutoRecorderTest {
         val portalWindow = StubWaylandWindowSourceRecorder()
         val recorder =
             autoRecorder(
-                ffmpegRecorder = ffmpeg,
                 linuxWindowRecorder = linuxWindow,
                 waylandPortalRecorder = portalRegion,
                 waylandPortalWindowRecorder = portalWindow,
@@ -348,7 +358,6 @@ class AutoRecorderTest {
         val linuxWindow = StubWindowRecorder(name = "linux")
         val recorder =
             autoRecorder(
-                ffmpegRecorder = ffmpeg,
                 linuxWindowRecorder = linuxWindow,
                 isMacOs = { false },
                 isLinux = { true },
@@ -397,7 +406,7 @@ class AutoRecorderTest {
     @Test
     fun `startWindow fails loudly on unsupported window-capture platforms`() {
         val ffmpeg = StubRegionRecorder()
-        val recorder = autoRecorder(ffmpegRecorder = ffmpeg, isMacOs = { false })
+        val recorder = autoRecorder(isMacOs = { false })
         val output = tempMov()
         try {
             val error =
@@ -420,11 +429,11 @@ class AutoRecorderTest {
 
 private fun autoRecorder(
     sckRecorder: WindowRecorder = StubWindowRecorder(name = "sck"),
-    ffmpegRecorder: Recorder = StubRegionRecorder(),
     windowsWindowRecorder: WindowRecorder? = null,
     windowsRegionRecorder: Recorder? = null,
     linuxRegionRecorder: Recorder? = null,
     linuxWindowRecorder: WindowRecorder? = null,
+    macOsRegionRecorder: Recorder = StubRegionRecorder(),
     waylandPortalRecorder: Recorder? = null,
     waylandPortalWindowRecorder: WaylandWindowSourceRecorder? = null,
     waylandPortalRecorderFailure: Throwable? = null,
@@ -436,7 +445,7 @@ private fun autoRecorder(
 ): AutoRecorder =
     AutoRecorder(
         sckRecorder,
-        ffmpegRecorder,
+        macOsRegionRecorder,
         windowsWindowRecorder,
         windowsRegionRecorder,
         linuxRegionRecorder,
@@ -502,6 +511,16 @@ private class StubRegionRecorder : Recorder {
         lastRegion = region
         lastOptions = options
         return NoopHandle(output)
+    }
+}
+
+private class MissingSckHelperRecorder : Recorder {
+    override fun start(
+        region: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+    ): RecordingHandle {
+        throw HelperNotBundledException("test: helper not bundled")
     }
 }
 

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegRecorderTest.kt
@@ -201,9 +201,8 @@ class FfmpegRecorderTest {
     fun `construction does not resolve the backend so unsupported hosts can build a recorder`() {
         // Codex regression report on PR #51: prior to deferred resolution, an Ubuntu CI runner
         // (or a Linux/BSD developer box) would see `FfmpegRecorder()` throw at construction
-        // because `FfmpegBackend.detect()` rejects non-mac/non-Windows hosts. AutoRecorder's
-        // default ffmpegRecorder argument would crash app startup even when recording was never
-        // attempted. Pin: the backend lambda must NOT be invoked during construction.
+        // because `FfmpegBackend.detect()` rejects non-mac/non-Windows hosts. Pin: the backend
+        // lambda must NOT be invoked during construction.
         var resolveCount = 0
         val recorder =
             FfmpegRecorder(FfmpegRecorder.PROBE_PATH, RecordingProcessFactory()) {

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/MacOsSckRegionSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/MacOsSckRegionSmoke.kt
@@ -1,0 +1,157 @@
+@file:JvmName("MacOsSckRegionSmoke")
+
+package dev.sebastiano.spectre.recording
+
+import java.awt.BorderLayout
+import java.awt.Color
+import java.awt.Dimension
+import java.awt.Font
+import java.awt.Point
+import java.awt.Rectangle
+import java.awt.Robot
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import javax.imageio.ImageIO
+import javax.swing.JFrame
+import javax.swing.JLabel
+import javax.swing.JPanel
+import javax.swing.SwingConstants
+import javax.swing.SwingUtilities
+import kotlin.system.exitProcess
+
+/**
+ * Manual macOS-only smoke for SCK-backed region recording through [AutoRecorder]. Run via
+ * `./gradlew :recording:runMacOsSckRegionSmoke`.
+ */
+fun main() {
+    var exitCode = 0
+    try {
+        runRegionSmoke()
+    } catch (t: Throwable) {
+        System.err.println("Smoke failed: ${t.message}\n${t.stackTraceToString()}")
+        exitCode = 1
+    } finally {
+        exitProcess(exitCode)
+    }
+}
+
+private fun runRegionSmoke() {
+    check(System.getProperty("os.name").orEmpty().lowercase().contains("mac")) {
+        "ScreenCaptureKit region smoke only runs on macOS."
+    }
+
+    val output = Path.of(System.getProperty("java.io.tmpdir"), "spectre-sck-region-smoke.mov")
+    val midRecordingPng =
+        Path.of(System.getProperty("java.io.tmpdir"), "spectre-sck-region-smoke.png")
+    Files.deleteIfExists(output)
+    Files.deleteIfExists(midRecordingPng)
+
+    val (frame, label) = openRegionSmokeWindow()
+    try {
+        Thread.sleep(WINDOW_SETTLE_MS)
+        val region = runOnEdt {
+            frame.toFront()
+            frame.requestFocus()
+            val location = frame.locationOnScreen
+            Rectangle(location.x, location.y, frame.width, frame.height)
+        }
+
+        val handle =
+            AutoRecorder()
+                .startRegion(
+                    region = region,
+                    output = output,
+                    options = RecordingOptions(frameRate = 30, captureCursor = true),
+                )
+
+        println("SCK region recording started for $region -> $output")
+        var ticks = 0
+        val animator =
+            Thread.ofPlatform().daemon().name("spectre-sck-region-animator").start {
+                val deadline = System.nanoTime() + RECORD_DURATION_MS * 1_000_000L
+                while (System.nanoTime() < deadline && !Thread.currentThread().isInterrupted) {
+                    ticks += 1
+                    val current = ticks
+                    SwingUtilities.invokeLater { label.text = "region tick=$current" }
+                    Thread.sleep(ANIMATION_INTERVAL_MS.toLong())
+                }
+            }
+
+        Thread.sleep(RECORD_DURATION_MS / 2)
+        val robotShot = Robot().createScreenCapture(region)
+        ImageIO.write(robotShot, "png", File(midRecordingPng.toString()))
+        println("Robot screenshot of recorded region $region -> $midRecordingPng")
+
+        animator.join()
+        handle.stop()
+
+        val bytes = Files.size(output)
+        check(bytes > MINIMUM_RECORDING_BYTES) {
+            "Expected a non-empty MOV larger than $MINIMUM_RECORDING_BYTES bytes, got $bytes at $output"
+        }
+        println("SCK region recording stopped -> $output ($bytes bytes, ticks=$ticks)")
+    } finally {
+        SwingUtilities.invokeLater {
+            frame.isVisible = false
+            frame.dispose()
+        }
+    }
+}
+
+private fun openRegionSmokeWindow(): Pair<JFrame, JLabel> {
+    val ready = CountDownLatch(1)
+    var frameRef: JFrame? = null
+    var labelRef: JLabel? = null
+    SwingUtilities.invokeLater {
+        val label =
+            JLabel("region tick=0", SwingConstants.CENTER).apply {
+                font = Font(Font.SANS_SERIF, Font.BOLD, LABEL_FONT_SIZE)
+                foreground = Color.BLACK
+            }
+        val panel =
+            JPanel(BorderLayout()).apply {
+                background = Color.WHITE
+                isOpaque = true
+                add(label, BorderLayout.CENTER)
+            }
+        val frame =
+            JFrame("Spectre SCK region smoke").apply {
+                defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                contentPane = panel
+                preferredSize = Dimension(WINDOW_WIDTH, WINDOW_HEIGHT)
+                pack()
+                location = Point(WINDOW_X, WINDOW_Y)
+                isAlwaysOnTop = true
+                isVisible = true
+                toFront()
+                requestFocus()
+            }
+        frameRef = frame
+        labelRef = label
+        ready.countDown()
+    }
+    check(ready.await(WINDOW_READY_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        "Timed out opening SCK region smoke window"
+    }
+    return checkNotNull(frameRef) to checkNotNull(labelRef)
+}
+
+private fun <T> runOnEdt(block: () -> T): T {
+    var result: Result<T>? = null
+    SwingUtilities.invokeAndWait { result = runCatching(block) }
+    return checkNotNull(result).getOrThrow()
+}
+
+private const val WINDOW_WIDTH = 460
+private const val WINDOW_HEIGHT = 220
+private const val WINDOW_X = 120
+private const val WINDOW_Y = 140
+private const val WINDOW_SETTLE_MS = 500L
+private const val WINDOW_READY_TIMEOUT_SECONDS = 5L
+private const val RECORD_DURATION_MS = 3_000L
+private const val ANIMATION_INTERVAL_MS = 50
+private const val LABEL_FONT_SIZE = 36
+private const val MINIMUM_RECORDING_BYTES = 10_000L

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperArgumentsTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperArgumentsTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.recording.screencapturekit
 
+import java.awt.Rectangle
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,6 +15,7 @@ class HelperArgumentsTest {
         val output = Path.of("/tmp/recording.mov")
         val args =
             HelperArguments(
+                source = HelperSource.Window,
                 pid = 4242,
                 titleContains = "Spectre/abc123",
                 output = output,
@@ -33,6 +35,7 @@ class HelperArgumentsTest {
         val helper = Path.of("/tmp/spectre-screencapture")
         val args =
             HelperArguments(
+                source = HelperSource.Window,
                 pid = 4242,
                 titleContains = "Spectre/abc123",
                 output = Path.of("/tmp/out.mov"),
@@ -43,12 +46,13 @@ class HelperArgumentsTest {
 
         val argv = args.toArgv(helper)
 
-        // The helper's CLI documents `--mode`, `--pid`, `--title-contains`, `--fps`,
+        // The helper's CLI documents `--mode`, `--source`, `--pid`, `--title-contains`, `--fps`,
         // `--cursor`, `--discovery-timeout-ms`, `--output`. Every emitted flag must be one
         // of those.
         val expectedFlags =
             setOf(
                 "--mode",
+                "--source",
                 "--pid",
                 "--title-contains",
                 "--fps",
@@ -62,10 +66,32 @@ class HelperArgumentsTest {
     }
 
     @Test
+    fun `toArgv emits region source flags`() {
+        val helper = Path.of("/tmp/spectre-screencapture")
+        val args =
+            HelperArguments(
+                source = HelperSource.Region,
+                region = Rectangle(10, 20, 300, 200),
+                displayIndex = 2,
+                output = Path.of("/tmp/out.mov"),
+                fps = 30,
+                captureCursor = true,
+                discoveryTimeoutMs = 2000,
+            )
+
+        val argv = args.toArgv(helper)
+
+        assertEquals("region", argv[argv.indexOf("--source") + 1])
+        assertEquals("10,20,300,200", argv[argv.indexOf("--region") + 1])
+        assertEquals("2", argv[argv.indexOf("--display-index") + 1])
+    }
+
+    @Test
     fun `toArgv encodes captureCursor as the literal true or false expected by the helper`() {
         val helper = Path.of("/tmp/spectre-screencapture")
         val baseline =
             HelperArguments(
+                source = HelperSource.Window,
                 pid = 1,
                 titleContains = "x",
                 output = Path.of("/tmp/o.mov"),
@@ -88,6 +114,7 @@ class HelperArgumentsTest {
         val helper = Path.of("/tmp/spectre-screencapture")
         val baseline =
             HelperArguments(
+                source = HelperSource.Window,
                 pid = 1,
                 titleContains = "x",
                 output = Path.of("/tmp/o.mov"),
@@ -108,6 +135,7 @@ class HelperArgumentsTest {
         val helper = Path.of("/tmp/spectre-screencapture")
         val args =
             HelperArguments(
+                source = HelperSource.Window,
                 pid = 99_999,
                 titleContains = "x",
                 output = Path.of("/tmp/o.mov"),
@@ -128,6 +156,7 @@ class HelperArgumentsTest {
         val helper = Path.of("/tmp/spectre-screencapture")
         val args =
             HelperArguments(
+                source = HelperSource.Window,
                 pid = 1,
                 titleContains = "x",
                 output = Path.of("/tmp/o.mp4"),
@@ -146,6 +175,7 @@ class HelperArgumentsTest {
         val helper = Path.of("/tmp/spectre-screencapture")
         val args =
             HelperArguments(
+                source = HelperSource.Window,
                 pid = 1,
                 titleContains = "x",
                 output = Path.of("/tmp/o.mov"),
@@ -167,6 +197,7 @@ class HelperArgumentsTest {
         val ex =
             assertFailsWith<IllegalArgumentException> {
                 HelperArguments(
+                    source = HelperSource.Window,
                     pid = 1,
                     titleContains = "   ",
                     output = Path.of("/tmp/o.mov"),
@@ -182,6 +213,7 @@ class HelperArgumentsTest {
     fun `constructor rejects non-positive fps`() {
         assertFailsWith<IllegalArgumentException> {
             HelperArguments(
+                source = HelperSource.Window,
                 pid = 1,
                 titleContains = "x",
                 output = Path.of("/tmp/o.mov"),
@@ -196,6 +228,7 @@ class HelperArgumentsTest {
     fun `constructor rejects negative discoveryTimeout`() {
         assertFailsWith<IllegalArgumentException> {
             HelperArguments(
+                source = HelperSource.Window,
                 pid = 1,
                 titleContains = "x",
                 output = Path.of("/tmp/o.mov"),
@@ -204,5 +237,22 @@ class HelperArgumentsTest {
                 discoveryTimeoutMs = -1,
             )
         }
+    }
+
+    @Test
+    fun `constructor rejects negative region origins`() {
+        val ex =
+            assertFailsWith<IllegalArgumentException> {
+                HelperArguments(
+                    source = HelperSource.Region,
+                    region = Rectangle(-1, 0, 10, 10),
+                    output = Path.of("/tmp/o.mov"),
+                    fps = 30,
+                    captureCursor = true,
+                    discoveryTimeoutMs = 0,
+                )
+            }
+
+        assertTrue(ex.message?.contains("origin") == true)
     }
 }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitHelperContractTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitHelperContractTest.kt
@@ -155,6 +155,24 @@ class ScreenCaptureKitHelperContractTest {
     }
 
     @Test
+    fun `helper exits 2 on unknown source`() {
+        val exit =
+            runHelper(
+                listOf(
+                    "--source",
+                    "display",
+                    "--pid",
+                    "1",
+                    "--title-contains",
+                    "x",
+                    "--output",
+                    output.toString(),
+                )
+            )
+        assertEquals(2, exit, "--source accepts only window or region")
+    }
+
+    @Test
     fun `helper exits 2 on unknown file type`() {
         val exit =
             runHelper(
@@ -170,6 +188,67 @@ class ScreenCaptureKitHelperContractTest {
                 )
             )
         assertEquals(2, exit, "--file-type accepts only 'mov' or 'mp4'")
+    }
+
+    @Test
+    fun `helper exits 2 on malformed region`() {
+        val exit =
+            runHelper(
+                listOf("--source", "region", "--region", "10,20,30", "--output", output.toString())
+            )
+        assertEquals(2, exit, "Malformed --region must exit 2")
+    }
+
+    @Test
+    fun `helper exits 2 on negative region origin`() {
+        val exit =
+            runHelper(
+                listOf(
+                    "--source",
+                    "region",
+                    "--region",
+                    "-1,20,30,40",
+                    "--output",
+                    output.toString(),
+                )
+            )
+        assertEquals(2, exit, "Negative region origins must exit 2")
+    }
+
+    @Test
+    fun `helper exits 2 on region screenshot mode`() {
+        val exit =
+            runHelper(
+                listOf(
+                    "--mode",
+                    "screenshot",
+                    "--source",
+                    "region",
+                    "--region",
+                    "10,20,30,40",
+                    "--output",
+                    output.toString(),
+                )
+            )
+        assertEquals(2, exit, "Region source is recording-only until Kotlin exposes screenshots")
+    }
+
+    @Test
+    fun `helper exits 2 on negative display index`() {
+        val exit =
+            runHelper(
+                listOf(
+                    "--source",
+                    "region",
+                    "--region",
+                    "10,20,30,40",
+                    "--display-index",
+                    "-1",
+                    "--output",
+                    output.toString(),
+                )
+            )
+        assertEquals(2, exit, "Negative --display-index must exit 2")
     }
 
     @Test

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorderTest.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.recording.screencapturekit
 
 import dev.sebastiano.spectre.recording.RecordingOptions
+import java.awt.Rectangle
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.io.InputStream
@@ -97,6 +98,30 @@ class ScreenCaptureKitRecorderTest {
             )
             // Title must be restored even when start fails.
             assertEquals("MyApp", window.title)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `start with region surfaces helper exit-3 as missing display`() {
+        val process = InstantlyExitingFakeProcess(exitCode = 3)
+        val output = Files.createTempFile("spectre-sck-test-", ".mov")
+        val (recorder, _) = newRecorder(process = process)
+        try {
+            val ex =
+                assertFailsWith<IllegalStateException> {
+                    recorder.start(
+                        region = Rectangle(10, 20, 320, 180),
+                        output = output,
+                        options = RecordingOptions(screenIndex = 5),
+                    )
+                }
+
+            assertTrue(
+                ex.message?.contains("display") == true,
+                "Error must mention the missing display for region capture; got: ${ex.message}",
+            )
         } finally {
             output.deleteIfExists()
         }
@@ -205,6 +230,117 @@ class ScreenCaptureKitRecorderTest {
                 ProcessHandle.current().pid().toString(),
                 factory.lastArgv[factory.lastArgv.indexOf("--pid") + 1],
             )
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `start with region spawns the helper with region source arguments`() {
+        val output = Files.createTempFile("spectre-sck-test-", ".mov")
+        val (recorder, factory) = newRecorder()
+        try {
+            recorder.start(
+                region = Rectangle(10, 20, 320, 180),
+                output = output,
+                options = RecordingOptions(frameRate = 24, captureCursor = false, screenIndex = 1),
+            )
+
+            val argv = factory.lastArgv
+            assertTrue(argv.isNotEmpty())
+            assertContainsSequence(argv, listOf("--source", "region"))
+            assertContainsSequence(argv, listOf("--region", "10,20,320,180"))
+            assertContainsSequence(argv, listOf("--display-index", "1"))
+            assertContainsSequence(argv, listOf("--fps", "24"))
+            assertContainsSequence(argv, listOf("--cursor", "false"))
+            assertEquals(output.toString(), argv.last())
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `start with region rejects custom codec before spawning helper`() {
+        val output = Files.createTempFile("spectre-sck-test-", ".mov")
+        val (recorder, factory) = newRecorder()
+        try {
+            val error =
+                assertFailsWith<IllegalArgumentException> {
+                    recorder.start(
+                        region = Rectangle(10, 20, 320, 180),
+                        output = output,
+                        options = RecordingOptions(codec = "hevc"),
+                    )
+                }
+
+            assertTrue(error.message.orEmpty().contains("custom RecordingOptions.codec"))
+            assertTrue(factory.lastArgv.isEmpty())
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `start with window rejects custom codec before mutating the title`() {
+        val window = FakeTitledWindow(initialTitle = "MyApp")
+        val output = Files.createTempFile("spectre-sck-test-", ".mov")
+        val (recorder, factory) = newRecorder()
+        try {
+            val error =
+                assertFailsWith<IllegalArgumentException> {
+                    recorder.start(
+                        window = window,
+                        windowOwnerPid = 4242L,
+                        output = output,
+                        options = RecordingOptions(codec = "hevc"),
+                    )
+                }
+
+            assertTrue(error.message.orEmpty().contains("custom RecordingOptions.codec"))
+            assertEquals("MyApp", window.title)
+            assertTrue(factory.lastArgv.isEmpty())
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `start with region rejects negative origins before spawning helper`() {
+        val output = Files.createTempFile("spectre-sck-test-", ".mov")
+        val (recorder, factory) = newRecorder()
+        try {
+            val error =
+                assertFailsWith<IllegalArgumentException> {
+                    recorder.start(
+                        region = Rectangle(-1, 20, 320, 180),
+                        output = output,
+                        options = RecordingOptions(),
+                    )
+                }
+
+            assertTrue(error.message.orEmpty().contains("origin"))
+            assertTrue(factory.lastArgv.isEmpty())
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `start with region rejects empty regions before spawning helper`() {
+        val output = Files.createTempFile("spectre-sck-test-", ".mov")
+        val (recorder, factory) = newRecorder()
+        try {
+            val error =
+                assertFailsWith<IllegalArgumentException> {
+                    recorder.start(
+                        region = Rectangle(10, 20, 0, 180),
+                        output = output,
+                        options = RecordingOptions(),
+                    )
+                }
+
+            assertTrue(error.message.orEmpty().contains("non-empty region"))
+            assertTrue(factory.lastArgv.isEmpty())
         } finally {
             output.deleteIfExists()
         }
@@ -330,4 +466,12 @@ private class InstantlyExitingFakeProcess(private val exitCode: Int) : Process()
     override fun toHandle(): ProcessHandle = ProcessHandle.current()
 
     override fun onExit(): CompletableFuture<Process> = CompletableFuture.completedFuture(this)
+}
+
+private fun assertContainsSequence(actual: List<String>, expected: List<String>) {
+    val window =
+        actual.windowed(size = expected.size, step = 1, partialWindows = false).firstOrNull {
+            it == expected
+        }
+    assertTrue(window != null, "Expected argv to contain $expected, got $actual")
 }

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -246,6 +246,11 @@ automator.screenshot(windowIndex = 0)   // a tracked window
 Always `waitForVisualIdle()` immediately before screenshotting — otherwise
 you may capture a mid-animation frame.
 
+On macOS, screenshots need an unlocked console session in addition to Screen
+Recording TCC. A locked screen can make `Robot.createScreenCapture` return black
+pixels; current Spectre checks the macOS `IOConsoleLocked` flag first and tells
+the caller to unlock/retry before pointing at TCC.
+
 For a **top-level window-scoped still screenshot**, use `AutoScreenshotter`
 from `:recording` instead of `ComposeAutomator.screenshot(...)`. This is
 separate from video recording:

--- a/skills/spectre/references/recording.md
+++ b/skills/spectre/references/recording.md
@@ -15,7 +15,7 @@ the pixels for one top-level OS window:
 |---|---|---|
 | macOS | ScreenCaptureKit still-image mode | `spectre-recording-macos` |
 | Windows | Windows Graphics Capture helper (`spectre-window-capture.exe`) | `spectre-recording-windows` |
-| Linux X11 / XWayland | `x11grab` region fallback | none beyond ffmpeg |
+| Linux X11 / XWayland | Linux helper (`ximagesrc`) | `spectre-recording-linux` |
 | Linux Wayland | unsupported for still images | use video portal path instead |
 
 Windows still screenshots and native window/region recording share the same Windows Graphics
@@ -33,9 +33,9 @@ source need the .NET 8 SDK. The local verification task is:
 
 | Platform | `startWindow` | `startRegion` |
 |---|---|---|
-| macOS | ScreenCaptureKit (native) | ffmpeg region capture |
+| macOS | ScreenCaptureKit (native) | ScreenCaptureKit helper; missing helper artifacts and SCK-unsupported options (`codec`) fail loudly instead of falling back to ffmpeg/avfoundation. `screenIndex` is the SCK display index: primary first, then by frame `minX`/`minY` |
 | Windows | Windows Graphics Capture helper | Windows Graphics Capture helper; missing helper artifacts and WGC-unsupported options (`codec`, `screenIndex`) fail loudly instead of falling back to ffmpeg |
-| Linux X11 / XWayland | unsupported | ffmpeg `x11grab` |
+| Linux X11 / XWayland | Linux helper | Linux helper |
 | Linux Wayland (GNOME/Mutter) | xdg-desktop-portal window source | xdg-desktop-portal monitor source |
 
 ```kotlin
@@ -70,6 +70,14 @@ Two trade-offs, pick deliberately:
 Embedded `ComposePanel` instances have no top-level window title, so use
 `startRegion(...)` with an explicit rectangle. `startWindow(...)` fails loudly when a
 true window-targeted backend is unavailable.
+
+For macOS region capture, `RecordingOptions.screenIndex` is interpreted by the SCK helper:
+display `0` is the primary display, then remaining displays are sorted by frame `minX` and
+`minY`. Explicit legacy `FfmpegRecorder` callers still get avfoundation device ordering.
+
+macOS capture also requires an unlocked console session. If a smoke or test suddenly reports
+black screenshots/frames or a permission-looking capture failure, unlock the screen and retry
+before debugging TCC; Robot screenshot diagnostics check `IOConsoleLocked` for this case.
 
 ## Linux Wayland caveats
 


### PR DESCRIPTION
## Summary
- expand the macOS ScreenCaptureKit helper to support region recording and mp4/mov file-type routing after rebasing on the latest main mp4 fix
- route AutoRecorder.startRegion on macOS through SCK so ffmpeg remains only an explicit deprecated fallback helper
- add locked-screen diagnostics/docs for Robot screenshots and macOS capture troubleshooting

## Validation
- ./gradlew check
- /private/tmp/spectre-docs-venv/bin/python -m mkdocs build --strict
- ./gradlew :recording:runWindowScreenshotSmoke, visually inspected /var/folders/mw/bycfzdjn599dxyrvqp7nxkdh0000gn/T/spectre-window-screenshot-smoke.png
- ./gradlew :recording:runScreenCaptureKitSmoke, extracted /private/tmp/spectre-sck-smoke-frame-postfix.png from /var/folders/mw/bycfzdjn599dxyrvqp7nxkdh0000gn/T/spectre-sck-smoke.mp4 and visually confirmed the tick window
- ./gradlew :recording:runMacOsSckRegionSmoke, extracted /private/tmp/spectre-sck-region-smoke-frame-fixed.png from /var/folders/mw/bycfzdjn599dxyrvqp7nxkdh0000gn/T/spectre-sck-region-smoke.mov and visually confirmed the fixed region crop

## Notes
- Initial full check failed while the screen was locked; after unlocking, ./gradlew check passed. This PR documents that failure mode and makes Robot screenshot diagnostics report a locked console session separately from TCC denial.