### PR TITLE
Publish agent runtime artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -419,6 +419,8 @@ jobs:
             :recording-macos:publishToMavenCentral \
             :recording-linux:publishToMavenCentral \
             :recording-windows:publishToMavenCentral \
+            :agent:publishToMavenCentral \
+            :agent-runtime:publishToMavenCentral \
             :testing:publishToMavenCentral \
             -PVERSION_NAME="$RELEASE_VERSION" \
             -PprebuiltMacHelperPath="$RUNNER_TEMP/mac-helper/spectre-screencapture" \

--- a/README.md
+++ b/README.md
@@ -57,10 +57,16 @@ npx skills add rock3r/spectre --skill spectre
   window screenshots where available (ScreenCaptureKit on macOS, Windows Graphics Capture
   on Windows, X11 region fallback on Linux). `AutoRecorder` / `AutoScreenshotter` pick per call. See
   [`docs/RECORDING-LIMITATIONS.md`](docs/RECORDING-LIMITATIONS.md).
+- `recording-macos` — runtime-only macOS ScreenCaptureKit helper resources for native
+  window/region recording and still screenshots.
+- `recording-linux` — runtime-only Linux helper resources for native Xorg and Wayland capture.
 - `recording-windows` — runtime-only Windows Graphics Capture helper resources for native
   window/region recording and still screenshots. Runtime machines need Windows 10 version
   1903+, .NET 8 Desktop Runtime, and Windows App Runtime 1.8; contributors building the
   helper need the .NET 8 SDK.
+- `agent` — experimental local attach transport for driving a Spectre-instrumented JVM from a
+  separate process.
+- `agent-runtime` — loadable Java-agent runtime jar used by `agent` when attaching to a target JVM.
 - `testing` — JUnit 5 extension and JUnit 4 rule.
 - `sample-desktop` — Compose Desktop app for manual smokes.
 - `sample-intellij-plugin` — in-tree IntelliJ plugin hosting a Jewel tool window. Unpublished;

--- a/agent-runtime/build.gradle.kts
+++ b/agent-runtime/build.gradle.kts
@@ -1,0 +1,113 @@
+import java.io.File
+import java.util.jar.Attributes
+import java.util.jar.Manifest
+import java.util.zip.ZipFile
+
+plugins {
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.ktfmt)
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.mavenPublish)
+}
+
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+}
+
+dependencies {
+    implementation(projects.agent)
+
+    detektPlugins(libs.compose.rules.detekt)
+}
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }
+
+val runtimeClasspath = configurations.named("runtimeClasspath")
+
+tasks.named<Jar>("jar") {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    manifest {
+        attributes(
+            mapOf(
+                Attributes.Name.MANIFEST_VERSION.toString() to "1.0",
+                "Agent-Class" to "dev.sebastiano.spectre.agent.runtime.SpectreAgent",
+                "Premain-Class" to "dev.sebastiano.spectre.agent.runtime.SpectreAgent",
+                "Can-Redefine-Classes" to "false",
+                "Can-Retransform-Classes" to "false",
+                "Can-Set-Native-Method-Prefix" to "false",
+            )
+        )
+    }
+
+    from({ runtimeClasspath.get().filter(::includeInAgentRuntimeJar).map(::zipTree) }) {
+        exclude("META-INF/MANIFEST.MF")
+        exclude("META-INF/*.SF")
+        exclude("META-INF/*.DSA")
+        exclude("META-INF/*.RSA")
+        exclude("META-INF/INDEX.LIST")
+    }
+}
+
+val verifyAgentRuntimeJarContents by tasks.registering {
+    description =
+        "Asserts the agent runtime JAR is loadable by the Attach API and stays thin: no " +
+            "Compose, Skiko, Kotlin stdlib, coroutines, or Spectre core classes."
+    group = "verification"
+
+    val jarFile = tasks.named<Jar>("jar").flatMap { it.archiveFile }
+    dependsOn(jarFile)
+    inputs.file(jarFile)
+
+    doLast {
+        val jar = jarFile.get().asFile
+        ZipFile(jar).use { zip ->
+            val manifest =
+                zip.getInputStream(zip.getEntry("META-INF/MANIFEST.MF")).use { input ->
+                    Manifest(input)
+                }
+            val attrs = manifest.mainAttributes
+            val expectedAgentClass = "dev.sebastiano.spectre.agent.runtime.SpectreAgent"
+            require(attrs.getValue("Agent-Class") == expectedAgentClass) {
+                "Agent runtime jar is missing Agent-Class=$expectedAgentClass"
+            }
+            require(attrs.getValue("Premain-Class") == expectedAgentClass) {
+                "Agent runtime jar is missing Premain-Class=$expectedAgentClass"
+            }
+
+            val forbiddenPrefixes =
+                listOf(
+                    "androidx/compose/",
+                    "org/jetbrains/compose/",
+                    "org/jetbrains/skiko/",
+                    "dev/sebastiano/spectre/core/",
+                    "kotlin/Pair.class",
+                    "kotlinx/coroutines/",
+                )
+            val leaks =
+                zip.entries()
+                    .asSequence()
+                    .map { it.name }
+                    .filter { entry -> forbiddenPrefixes.any { entry.startsWith(it) } }
+            val leakList = leaks.toList()
+            require(leakList.isEmpty()) {
+                "Agent runtime jar contains forbidden classes:\n" +
+                    leakList.sorted().joinToString("\n") { "  - $it" }
+            }
+        }
+    }
+}
+
+tasks.named("check") { dependsOn(verifyAgentRuntimeJarContents) }
+
+private fun includeInAgentRuntimeJar(file: File): Boolean {
+    val name = file.name
+    return when {
+        name.startsWith("kotlin-stdlib") -> false
+        name.startsWith("kotlin-reflect") -> false
+        name.startsWith("kotlinx-coroutines") -> false
+        name.startsWith("annotations-") -> false
+        else -> true
+    }
+}

--- a/agent-runtime/gradle.properties
+++ b/agent-runtime/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=spectre-agent-runtime
+POM_NAME=Spectre Agent Runtime
+# See :core's gradle.properties for the Latin-1 / ASCII safety note.
+POM_DESCRIPTION=Loadable Java agent runtime for Spectre Agent. Add as a runtimeOnly or testRuntimeOnly dependency alongside spectre-agent so AgentAttach can load it into the target JVM.

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -43,6 +43,11 @@ public final class dev/sebastiano/spectre/agent/AttachPermissionDeniedException 
 	public fun <init> (JLjava/lang/String;)V
 }
 
+public final class dev/sebastiano/spectre/agent/AttachPlatformUnsupportedException : dev/sebastiano/spectre/agent/SpectreAttachException {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getOsName ()Ljava/lang/String;
+}
+
 public final class dev/sebastiano/spectre/agent/AttachUnsupportedException : dev/sebastiano/spectre/agent/SpectreAttachException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Throwable;)V

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -1,19 +1,11 @@
-import java.util.jar.Attributes
-import java.util.zip.ZipFile
+import org.gradle.jvm.tasks.Jar
 
 plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSerialization)
-    // GradleUp Shadow — builds the fat agent runtime JAR (`spectre-agent-runtime-*-all.jar`)
-    // that ends up loaded into target JVMs via `VirtualMachine.loadAgent(...)`. Manifest
-    // attributes (Agent-Class / Premain-Class) are configured on the `shadowJar` task below.
-    alias(libs.plugins.shadow)
-    // NB: `mavenPublish` is intentionally NOT applied. Per the issue #153 workshop plan
-    // (Q-1 resolution), `:agent` is unpublished for v1 — developers consume it via
-    // `mavenLocal` or a direct project dependency until the UX stabilises. A follow-up
-    // issue tracks Central publishing.
+    alias(libs.plugins.mavenPublish)
 }
 
 kotlin {
@@ -25,16 +17,6 @@ kotlin {
 }
 
 dependencies {
-    // `:core` is `compileOnly` by design: the agent module references Spectre's automator
-    // types (`ComposeAutomator`, `AutomatorNode`, …) at compile time so we can reflect on
-    // them in a type-checked way, but the runtime instances live in the *target* JVM's
-    // classloader after attach. Bundling `:core` into the agent fat JAR would defeat the
-    // thin-agent design — see plan UC-1 / E-1 in
-    // `.plans/2026-05-22-issue-153-agent-attach-workshop.md`. The fat-jar assertion task
-    // below enforces this.
-    compileOnly(projects.core)
-    compileOnly(libs.kotlinx.coroutines.core)
-
     // Wire-protocol serialization. CBOR is the only kotlinx-serialization format used by
     // the agent transport; JSON is intentionally not on the agent runtime classpath.
     implementation(libs.kotlinx.serialization.cbor)
@@ -58,126 +40,22 @@ dependencies {
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
 
-    // Expose the freshly-built fat agent JAR to AgentAttachIntegrationTest. The test reads
+    // Expose the freshly-built agent runtime JAR to AgentAttachIntegrationTest. The test reads
     // this system property and skips itself (via JUnit `assumeFalse`) if it's not set.
-    // Wired through the shadowJar provider so the test sees the same artifact that
-    // `:agent:check` produced.
-    val shadowJarFile =
-        tasks
-            .named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar")
-            .flatMap { it.archiveFile }
-    inputs.file(shadowJarFile)
-    dependsOn("shadowJar")
+    // Wired to `:agent-runtime:jar` so tests use the same Java-agent payload that publishing
+    // exposes as `spectre-agent-runtime`.
+    val runtimeJarFile =
+        project(":agent-runtime").tasks.named<Jar>("jar").flatMap { it.archiveFile }
+    inputs.file(runtimeJarFile)
+    dependsOn(runtimeJarFile)
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
             listOf(
-                "-Ddev.sebastiano.spectre.agent.runtimeJar=${shadowJarFile.get().asFile.absolutePath}"
+                "-Ddev.sebastiano.spectre.agent.runtimeJar=${runtimeJarFile.get().asFile.absolutePath}"
             )
         }
     )
 }
-
-// ---------------------------------------------------------------------------------------
-// Shadow fat-jar configuration for the agent runtime artifact.
-//
-// `shadowJar` produces `agent/build/libs/agent-<version>-all.jar`. The manifest carries
-// the Java Agent attributes; `Can-Redefine-Classes` / `Can-Retransform-Classes` are
-// explicitly `false` because Spectre's agent only bootstraps an in-target IPC server —
-// it does not instrument bytecode.
-//
-// The fat JAR includes:
-//   - the module's compiled classes (`dev.sebastiano.spectre.agent.*`)
-//   - kotlinx-serialization-cbor + kotlinx-serialization-core + kotlinx-io
-//
-// It must NOT include (verified by `verifyAgentJarContents`):
-//   - `dev.sebastiano.spectre.core.*`  (`compileOnly` keeps it out)
-//   - `androidx.compose.*` / `org.jetbrains.compose.*`  (Compose is not declared)
-//   - `org.jetbrains.skiko.*`           (Skiko is not declared)
-//   - `kotlin.*` from `kotlin-stdlib`   (resolved from target — see exclusion below)
-//   - `kotlinx.coroutines.*`            (declared compileOnly above)
-// ---------------------------------------------------------------------------------------
-
-tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
-    archiveClassifier.set("all")
-    manifest {
-        attributes(
-            mapOf(
-                Attributes.Name.MANIFEST_VERSION.toString() to "1.0",
-                "Agent-Class" to "dev.sebastiano.spectre.agent.runtime.SpectreAgent",
-                "Premain-Class" to "dev.sebastiano.spectre.agent.runtime.SpectreAgent",
-                "Can-Redefine-Classes" to "false",
-                "Can-Retransform-Classes" to "false",
-                "Can-Set-Native-Method-Prefix" to "false",
-            )
-        )
-    }
-    // The Kotlin stdlib is provided by the target JVM (Spectre `:core` pulls it in;
-    // Compose-instrumented apps already have it). Bundling our copy risks classloader
-    // surprises if the target has a different version. Same logic for coroutines: declared
-    // `compileOnly` above so it isn't pulled in here, but the exclude is defence-in-depth.
-    dependencies {
-        exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib.*"))
-        exclude(dependency("org.jetbrains.kotlinx:kotlinx-coroutines-.*"))
-        exclude(dependency("org.jetbrains:annotations"))
-    }
-    // Minimize the JAR; agents should be small to keep load-time cost low.
-    minimize {
-        // kotlinx-serialization-cbor needs serializers discovered reflectively; keep
-        // them all rather than risking minimize stripping a transitively-used type.
-        exclude(dependency("org.jetbrains.kotlinx:kotlinx-serialization-cbor:.*"))
-        exclude(dependency("org.jetbrains.kotlinx:kotlinx-serialization-core:.*"))
-    }
-}
-
-// Verification task that asserts the thin-agent invariants on the produced fat JAR.
-// Runs as part of `:agent:check` so regressions are caught before any push. Plan
-// requirement AC-1 / R-2.
-val verifyAgentJarContents by tasks.registering {
-    description =
-        "Asserts the agent fat JAR contains only the thin-agent payload: no Compose, " +
-            "Skiko, Kotlin stdlib, or Spectre core classes leaked in via Shadow."
-    group = "verification"
-    val shadowJarTask = tasks.named("shadowJar")
-    dependsOn(shadowJarTask)
-    val jarFile = shadowJarTask.map { (it.outputs.files.singleFile) }
-    inputs.file(jarFile)
-    doLast {
-        val jar = jarFile.get()
-        val forbiddenPrefixes =
-            listOf(
-                "androidx/compose/",
-                "org/jetbrains/compose/",
-                "org/jetbrains/skiko/",
-                "dev/sebastiano/spectre/core/",
-                "kotlin/Pair.class", // sentinel: any class directly under `kotlin/` means
-                // the stdlib leaked in.
-            )
-        val leaks = mutableListOf<String>()
-        ZipFile(jar).use { zip ->
-            val entries = zip.entries()
-            while (entries.hasMoreElements()) {
-                val entry = entries.nextElement()
-                if (forbiddenPrefixes.any { entry.name.startsWith(it) }) {
-                    leaks += entry.name
-                }
-            }
-        }
-        if (leaks.isNotEmpty()) {
-            throw GradleException(
-                "Agent fat JAR contains forbidden classes — the thin-agent invariant " +
-                    "is broken. See `.plans/2026-05-22-issue-153-agent-attach-workshop.md` " +
-                    "UC-1 / E-1. Leaks:\n" +
-                    leaks.sorted().joinToString("\n") { "  - $it" }
-            )
-        }
-        logger.lifecycle(
-            "verifyAgentJarContents: agent fat JAR is thin (${jar.name}, " +
-                "${jar.length() / 1024} KiB)."
-        )
-    }
-}
-
-tasks.named("check") { dependsOn(verifyAgentJarContents) }
 
 // ---------------------------------------------------------------------------------------
 // `attachSpike` — manual M-1 verification entry point. Wraps the standalone `AttachSpike`
@@ -191,10 +69,12 @@ tasks.named("check") { dependsOn(verifyAgentJarContents) }
 
 tasks.register<JavaExec>("attachSpike") {
     description =
-        "M-1 verification: attaches the Spectre agent fat JAR to a running JVM identified " +
+        "M-1 verification: attaches the Spectre agent runtime JAR to a running JVM identified " +
             "by -Ppid=<pid>. Output appears in the target JVM's stderr."
     group = "verification"
-    dependsOn("shadowJar")
+    val runtimeJarFile =
+        project(":agent-runtime").tasks.named<Jar>("jar").flatMap { it.archiveFile }
+    dependsOn(runtimeJarFile)
 
     // The pid is taken per-invocation via `-Ppid=<pid>`, which would invalidate the
     // configuration cache on every run anyway. Wrapping the args lookup in a
@@ -206,11 +86,6 @@ tasks.register<JavaExec>("attachSpike") {
     classpath = sourceSets["main"].runtimeClasspath
     mainClass.set("dev.sebastiano.spectre.agent.spike.AttachSpike")
 
-    val shadowJarFile =
-        tasks
-            .named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar")
-            .flatMap { it.archiveFile }
-
     doFirst {
         val pid =
             providers.gradleProperty("pid").orNull
@@ -218,6 +93,6 @@ tasks.register<JavaExec>("attachSpike") {
                     "attachSpike requires -Ppid=<target JVM pid>. Find the target via " +
                         "`jps` (look for the main class you want to attach to)."
                 )
-        args = listOf(pid, shadowJarFile.get().asFile.absolutePath)
+        args = listOf(pid, runtimeJarFile.get().asFile.absolutePath)
     }
 }

--- a/agent/gradle.properties
+++ b/agent/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=spectre-agent
+POM_NAME=Spectre Agent
+# See :core's gradle.properties for the Latin-1 / ASCII safety note.
+POM_DESCRIPTION=Experimental local attach API for driving a Spectre-instrumented JVM from a separate process.

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -18,9 +18,9 @@ import java.nio.file.Paths
  * } // Detach + cleanup on AutoCloseable.close()
  * ```
  *
- * Implementation: locates the agent fat JAR, runs Attach-API preconditions (per plan D-13), picks a
- * fresh UDS path, calls `VirtualMachine.attach(pid).loadAgent(jar, udsPath)`, polls for the UDS
- * path to appear, and connects an [IpcClient].
+ * Implementation: locates the loadable agent runtime JAR, runs Attach-API preconditions (per plan
+ * D-13), picks a fresh UDS path, calls `VirtualMachine.attach(pid).loadAgent(jar, udsPath)`, polls
+ * for the UDS path to appear, and connects an [IpcClient].
  */
 @ExperimentalSpectreAgentApi
 public object AgentAttach {
@@ -28,15 +28,16 @@ public object AgentAttach {
     /** Attach to the JVM identified by [pid] and return a connected [AttachedAutomator]. */
     @Throws(SpectreAttachException::class)
     public fun attach(pid: Long, options: AttachOptions = AttachOptions()): AttachedAutomator {
+        AgentPlatformPreflight.requireSupported()
         val agentJar = resolveAgentJar(options)
         val udsPath = options.udsPath ?: AttachOptions.defaultUdsPath(pid)
         // Pre-flight: ensure the path doesn't already exist (collisions would confuse the bind).
         Files.deleteIfExists(udsPath)
 
-        // Same-UID preflight (plan D-13). The Attach API's underlying error when UIDs differ is
+        // Same-user preflight (plan D-13). The Attach API's underlying error when users differ is
         // generic ("Operation not permitted") and hard to diagnose; this gives a clear message
         // before we even open the VM connection.
-        checkSameUid(pid)
+        checkSameUser(pid)
 
         val (vmClass, vm) = openVirtualMachine(pid)
         try {
@@ -65,10 +66,10 @@ public object AgentAttach {
     }
 
     /**
-     * Resolve the agent fat JAR by trying in order:
+     * Resolve the agent runtime JAR by trying in order:
      * 1. [AttachOptions.agentJarPath] if non-null.
      * 2. The system property `dev.sebastiano.spectre.agent.runtimeJar`.
-     * 3. `<cwd>/agent/build/libs/agent-*-all.jar` (any match).
+     * 3. `<cwd>/agent-runtime/build/libs/agent-runtime-*.jar` (any match).
      */
     @Suppress("ReturnCount")
     private fun resolveAgentJar(options: AttachOptions): Path {
@@ -86,20 +87,24 @@ public object AgentAttach {
             if (Files.isRegularFile(path)) return path
         }
 
-        val cwdGuess = Paths.get(System.getProperty("user.dir")).resolve("agent/build/libs")
+        val classpathRuntime =
+            AgentJarResolution.findRuntimeJarOnClasspath(System.getProperty("java.class.path"))
+        if (classpathRuntime != null) return classpathRuntime
+
+        val cwdGuess = Paths.get(System.getProperty("user.dir")).resolve("agent-runtime/build/libs")
         if (Files.isDirectory(cwdGuess)) {
             val match =
                 Files.list(cwdGuess).use { stream ->
                     stream
                         .filter { p ->
                             val n = p.fileName.toString()
-                            n.startsWith("agent-") && n.endsWith("-all.jar")
+                            n.startsWith("agent-runtime-") && n.endsWith(".jar")
                         }
                         .findFirst()
                         .orElse(null)
                 }
             if (match != null) return match
-            tried.add(cwdGuess.resolve("agent-*-all.jar"))
+            tried.add(cwdGuess.resolve("agent-runtime-*.jar"))
         }
 
         throw AgentJarNotFoundException(tried)
@@ -134,15 +139,16 @@ public object AgentAttach {
     }
 
     /**
-     * Same-UID preflight. The Attach API's POSIX implementation requires both processes share an
-     * effective UID; otherwise the rendezvous file under `/tmp/.java_pid<pid>` is unreadable and
-     * `VirtualMachine.attach` fails with a hard-to-diagnose error.
+     * Same-user preflight. The Attach API's POSIX implementation requires both processes to be
+     * attach-compatible under the OS user/permission rules; otherwise the rendezvous file under
+     * `/tmp/.java_pid<pid>` is unreadable and `VirtualMachine.attach` fails with a hard-to-diagnose
+     * error.
      *
-     * We use `ProcessHandle` which is portable; missing process info (some sandboxes return empty
-     * `user()`) is treated as "can't tell — let the attach proceed and surface whatever error it
-     * gives".
+     * We use `ProcessHandle` which is portable and gives user names rather than numeric UIDs;
+     * missing process info (some sandboxes return empty `user()`) is treated as "can't tell — let
+     * the attach proceed and surface whatever error it gives".
      */
-    private fun checkSameUid(targetPid: Long) {
+    private fun checkSameUser(targetPid: Long) {
         val handle = ProcessHandle.of(targetPid).orElse(null) ?: return
         val targetUser = handle.info().user().orElse(null) ?: return
         val currentUser = System.getProperty("user.name") ?: return

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -93,16 +93,7 @@ public object AgentAttach {
 
         val cwdGuess = Paths.get(System.getProperty("user.dir")).resolve("agent-runtime/build/libs")
         if (Files.isDirectory(cwdGuess)) {
-            val match =
-                Files.list(cwdGuess).use { stream ->
-                    stream
-                        .filter { p ->
-                            val n = p.fileName.toString()
-                            n.startsWith("agent-runtime-") && n.endsWith(".jar")
-                        }
-                        .findFirst()
-                        .orElse(null)
-                }
+            val match = AgentJarResolution.findRuntimeJarInDirectory(cwdGuess)
             if (match != null) return match
             tried.add(cwdGuess.resolve("agent-runtime-*.jar"))
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
@@ -1,0 +1,20 @@
+package dev.sebastiano.spectre.agent
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+
+internal object AgentJarResolution {
+    fun findRuntimeJarOnClasspath(classPath: String): Path? =
+        classPath
+            .split(File.pathSeparator)
+            .asSequence()
+            .filter { it.isNotBlank() }
+            .map(Path::of)
+            .firstOrNull { path ->
+                val name = path.fileName?.toString().orEmpty()
+                Files.isRegularFile(path) &&
+                    name.endsWith(".jar") &&
+                    (name.startsWith("spectre-agent-runtime-") || name.startsWith("agent-runtime-"))
+            }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
@@ -11,10 +11,23 @@ internal object AgentJarResolution {
             .asSequence()
             .filter { it.isNotBlank() }
             .map(Path::of)
-            .firstOrNull { path ->
-                val name = path.fileName?.toString().orEmpty()
-                Files.isRegularFile(path) &&
-                    name.endsWith(".jar") &&
-                    (name.startsWith("spectre-agent-runtime-") || name.startsWith("agent-runtime-"))
-            }
+            .firstOrNull(::isRuntimeJar)
+
+    fun findRuntimeJarInDirectory(directory: Path): Path? =
+        Files.list(directory).use { stream ->
+            stream
+                .filter(::isRuntimeJar)
+                .sorted(compareBy { it.fileName.toString() })
+                .findFirst()
+                .orElse(null)
+        }
+
+    private fun isRuntimeJar(path: Path): Boolean =
+        Files.isRegularFile(path) && isRuntimeJarName(path.fileName?.toString().orEmpty())
+
+    private fun isRuntimeJarName(name: String): Boolean =
+        name.endsWith(".jar") &&
+            !name.endsWith("-sources.jar") &&
+            !name.endsWith("-javadoc.jar") &&
+            (name.startsWith("spectre-agent-runtime-") || name.startsWith("agent-runtime-"))
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentPlatformPreflight.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentPlatformPreflight.kt
@@ -1,0 +1,10 @@
+package dev.sebastiano.spectre.agent
+
+@ExperimentalSpectreAgentApi
+internal object AgentPlatformPreflight {
+    fun requireSupported(osName: String = System.getProperty("os.name").orEmpty()) {
+        if (osName.startsWith("Windows", ignoreCase = true)) {
+            throw AttachPlatformUnsupportedException(osName)
+        }
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
@@ -18,6 +18,15 @@ public class AttachUnsupportedException(cause: Throwable? = null) :
         cause,
     )
 
+/** Thrown when the current operating system does not support the agent transport. */
+@ExperimentalSpectreAgentApi
+public class AttachPlatformUnsupportedException(public val osName: String) :
+    SpectreAttachException(
+        "The Spectre agent transport is currently supported on macOS and Linux only. " +
+            "This JVM reports os.name='$osName'. Windows support needs a named-pipe " +
+            "transport instead of Unix Domain Sockets."
+    )
+
 /**
  * Thrown when the agent failed to come up at the configured UDS path within
  * [AttachOptions.attachTimeoutMs].
@@ -40,9 +49,9 @@ public class AgentBootstrapTimeoutException(udsPath: java.nio.file.Path, timeout
 /**
  * Thrown when the target JVM is owned by a different OS user than the attacher.
  *
- * The JDK Attach API requires same-UID on POSIX. We pre-check this via
- * `ProcessHandle.of(pid).info().user()` because the underlying error from `VirtualMachine.attach`
- * is generic and hard to diagnose.
+ * The JDK Attach API requires compatible same-user ownership on POSIX. We pre-check this with
+ * `ProcessHandle.of(pid).info().user()`, which reports user names rather than numeric UIDs, because
+ * the underlying error from `VirtualMachine.attach` is generic and hard to diagnose.
  */
 @ExperimentalSpectreAgentApi
 public class AttachPermissionDeniedException(targetPid: Long, targetUser: String?) :
@@ -61,9 +70,11 @@ public class AttachPermissionDeniedException(targetPid: Long, targetUser: String
 @ExperimentalSpectreAgentApi
 public class AgentJarNotFoundException(searched: List<java.nio.file.Path>) :
     SpectreAttachException(
-        "Could not locate the Spectre agent fat JAR. Searched:\n" +
+        "Could not locate the Spectre agent runtime JAR. Searched:\n" +
             searched.joinToString("\n") { "  - $it" } +
-            "\n\nRun `./gradlew :agent:shadowJar` or pass AttachOptions(agentJarPath = ...)."
+            "\n\nAdd the `spectre-agent-runtime` jar to the attacher's runtime classpath, " +
+            "run `./gradlew :agent-runtime:jar`, or pass " +
+            "AttachOptions(agentJarPath = ...)."
     )
 
 /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -10,22 +10,26 @@ import java.util.UUID
  * Lookup order for the agent JAR (when [agentJarPath] isn't explicitly set):
  * 1. The system property `dev.sebastiano.spectre.agent.runtimeJar` (used by Spectre's own
  *    integration tests so they don't have to know the absolute build path).
- * 2. `<cwd>/agent/build/libs/agent-<version>-all.jar` if the worktree layout matches.
+ * 2. A `spectre-agent-runtime-<version>.jar` or `agent-runtime-<version>.jar` entry on the
+ *    attacher's `java.class.path`.
+ * 3. `<cwd>/agent-runtime/build/libs/agent-runtime-<version>.jar` if the worktree layout matches.
  *
  * The fallback throws when none of the candidates exist, with a message pointing the user at
- * `./gradlew :agent:shadowJar` to produce the JAR.
+ * `./gradlew :agent-runtime:jar` to produce the JAR.
  *
- * **JEP 451 flag detection** is **not** implemented in v1. The previous draft tried to read a
+ * **JEP 451 flag detection** is **not** implemented yet. The previous draft tried to read a
  * `jdk.internal.vm.dynamic.agent.loading` system property that doesn't actually exist;
  * `VirtualMachine.getSystemProperties()` returns system properties, not HotSpot VM flags. Until we
  * wire up a reliable preflight (likely through `HotSpotDiagnosticMXBean` via the Attach API's local
  * management agent), we rely on the JVM's own JEP 451 stderr warning to tell users when the flag is
- * missing. Tracked as a v1.1 follow-up.
+ * missing.
  *
- * @property agentJarPath fat agent JAR to load (Shadow's `*-all.jar`).
+ * @property agentJarPath loadable agent runtime JAR to pass to `VirtualMachine.loadAgent`.
  * @property udsPath Unix Domain Socket path the agent should bind on (must NOT exist already;
- *   defaults to `/tmp/sp-a-<pid>-<8char-uuid>.sock` with a fresh UUID per `attach()` call so
- *   concurrent attaches don't collide).
+ *   defaults to `/tmp/sp-a-<pid>-<8char-uuid>/agent.sock` with a fresh UUID per `attach()` call so
+ *   concurrent attaches don't collide). If you override this with a path under an existing
+ *   directory, you own that parent directory's permissions; Spectre only tightens directories it
+ *   creates itself.
  * @property attachTimeoutMs how long to wait for the agent's bootstrap + IPC server to come up.
  */
 @ExperimentalSpectreAgentApi
@@ -38,14 +42,14 @@ public data class AttachOptions(
         public const val DEFAULT_ATTACH_TIMEOUT_MS: Long = 5_000
 
         /**
-         * Default UDS path: `/tmp/sp-a-<pid>-<8char-uuid>.sock`. Deliberately short to stay inside
-         * Unix's `sun_path` limit (~104 chars on macOS, ~108 on Linux). `java.io.tmpdir` resolves
-         * to a much longer path on macOS (`/var/folders/...`) and can blow past the limit, so we
-         * hard-code `/tmp` (symlinked to `/private/tmp` on macOS).
+         * Default UDS path: `/tmp/sp-a-<pid>-<8char-uuid>/agent.sock`. Deliberately short to stay
+         * inside Unix's `sun_path` limit (~104 chars on macOS, ~108 on Linux). `java.io.tmpdir`
+         * resolves to a much longer path on macOS (`/var/folders/...`) and can blow past the limit,
+         * so we hard-code `/tmp` (symlinked to `/private/tmp` on macOS).
          */
         public fun defaultUdsPath(targetPid: Long): Path {
             val shortUuid = UUID.randomUUID().toString().take(SHORT_UUID_LENGTH)
-            return Paths.get("/tmp", "sp-a-${targetPid}-${shortUuid}.sock")
+            return Paths.get("/tmp", "sp-a-${targetPid}-${shortUuid}", "agent.sock")
         }
 
         private const val SHORT_UUID_LENGTH = 8

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -5,6 +5,7 @@ import dev.sebastiano.spectre.agent.transport.AgentResponse
 import dev.sebastiano.spectre.agent.transport.IpcClient
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
+import dev.sebastiano.spectre.agent.transport.logLabel
 import java.io.IOException
 
 /**
@@ -14,8 +15,8 @@ import java.io.IOException
  * [AgentRequest.Detach] over the wire (Path A of the plan's D-7) before tearing down the underlying
  * socket. The target JVM's shutdown hook (Path B) covers crash cleanup.
  *
- * Operation set is the v1 wire surface (D-4): windows, allNodes, findByTestTag, click, typeText,
- * screenshot, plus detach. Streaming/long-poll ops are out of scope for v1 (Q-3).
+ * Current wire surface (D-4): windows, allNodes, findByTestTag, click, typeText, screenshot, plus
+ * detach. Streaming/long-poll ops are deferred follow-ups (Q-3).
  *
  * Not thread-safe. Callers needing concurrent automator access must serialise externally.
  *
@@ -106,7 +107,7 @@ internal constructor(
         check(!closed) { "AttachedAutomator is closed" }
         val resp = client.send(request)
         if (resp is AgentResponse.Error) {
-            throw IOException("Agent reported error for $request: ${resp.message}")
+            throw IOException("Agent reported error for ${request.logLabel}: ${resp.message}")
         }
         return resp
     }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/ExperimentalSpectreAgentApi.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/ExperimentalSpectreAgentApi.kt
@@ -8,7 +8,7 @@ package dev.sebastiano.spectre.agent
  * `@OptIn(ExperimentalSpectreAgentApi::class)`.
  *
  * The agent attach surface (`AgentAttach`, `AttachedAutomator`, `AttachOptions`,
- * `SpectreProcesses`) carries this annotation in v1 until the UX has stabilised — see issue
+ * `SpectreProcesses`) carries this annotation until the UX has stabilised — see issue
  * [#153](https://github.com/rock3r/spectre/issues/153).
  */
 @RequiresOptIn(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
@@ -26,7 +26,7 @@ import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
  *   by a later `resumeWith` call from wherever the coroutine completes.
  *
  * A timeout guards against hangs (a misbehaving Compose tree, a robot driver stuck on a permission
- * dialog, …). The default [timeoutMs] of 30 s is generous for any single UI op; if v1.1 adds
+ * dialog, …). The default [timeoutMs] of 30 s is generous for any single UI op; if Spectre adds
  * genuinely long-running ops like `waitForVisualIdle` they should be modelled as their own
  * streaming wire op rather than relying on this synchronous bridge.
  */

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
@@ -11,7 +11,7 @@ import java.util.concurrent.atomic.AtomicReference
  *
  * Listed in the agent JAR's manifest as both `Premain-Class` and `Agent-Class`:
  * - [premain] is invoked when the JVM is started with
- *   `-javaagent:spectre-agent-runtime-<v>-all.jar=<udsPath>`.
+ *   `-javaagent:spectre-agent-runtime-<version>.jar=<udsPath>`.
  * - [agentmain] is invoked when the JAR is dynamically loaded via
  *   [com.sun.tools.attach.VirtualMachine.loadAgent].
  *

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -15,8 +15,8 @@ import java.nio.file.Path
  * synchronously sends [AgentRequest]s with [send].
  *
  * Single-shot send/receive: each [send] writes one framed CBOR request and reads the next framed
- * response. The wire protocol is strictly request/response in v1 (no streaming), so this is safe to
- * use without explicit pipelining.
+ * response. The current wire protocol is strictly request/response (no streaming), so this is safe
+ * to use without explicit pipelining.
  *
  * Not thread-safe — callers that need concurrent automator access should synchronise externally.
  * The `AttachedAutomator` wrapper exposes only serial operations.
@@ -54,7 +54,7 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
         val responseBytes =
             Framing.readFrame(input)
                 ?: throw EOFException(
-                    "Agent closed the connection before sending a response to $request"
+                    "Agent closed the connection before sending a response to ${request.logLabel}"
                 )
         return WireCodec.decodeResponse(responseBytes)
     }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -19,9 +19,10 @@ import java.util.concurrent.atomic.AtomicBoolean
  * connection at a time, and dispatches each [AgentRequest] frame to [handler], writing the
  * resulting [AgentResponse] back over the same channel.
  *
- * V1 limits itself to one concurrent attached client — Spectre's automation model is intrinsically
- * serial (one set of windows, one focus state, one input device), so layering client multiplexing
- * on top would just paint over reality. Multi-client support, if it ever lands, is a v1.1 problem.
+ * The current transport limits itself to one concurrent attached client — Spectre's automation
+ * model is intrinsically serial (one set of windows, one focus state, one input device), so
+ * layering client multiplexing on top would just paint over reality. Multi-client support, if it
+ * ever lands, is a follow-up.
  *
  * The accept loop runs on a single daemon thread; per-request work happens inline on that thread.
  * [close] interrupts the loop, closes the server channel, and unlinks the UDS path.
@@ -36,6 +37,8 @@ constructor(
     private val handler: AgentRequestHandler,
     private val onDetach: () -> Unit = {},
 ) : AutoCloseable {
+    private var createdParentDir: Path? = null
+
     private val serverChannel: ServerSocketChannel =
         ServerSocketChannel.open(StandardProtocolFamily.UNIX).also { channel ->
             // Outer `success` sentinel + `finally` so the channel is unconditionally closed on
@@ -48,6 +51,7 @@ constructor(
             // the contract by observing `openFileDescriptorCount`.
             var success = false
             try {
+                createdParentDir = createMissingParentDirectory(udsPath)
                 // Clean up any orphaned socket file from a previous crash; Linux/macOS refuse to
                 // bind if the path already exists, even when stale.
                 Files.deleteIfExists(udsPath)
@@ -78,6 +82,7 @@ constructor(
                 if (!success) {
                     runCatching { channel.close() }
                     runCatching { Files.deleteIfExists(udsPath) }
+                    runCatching { createdParentDir?.let(Files::deleteIfExists) }
                 }
             }
         }
@@ -242,6 +247,11 @@ constructor(
         } catch (_: IOException) {
             // Best-effort — if the file is gone or undeletable, the shutdown hook reaps it.
         }
+        try {
+            createdParentDir?.let(Files::deleteIfExists)
+        } catch (_: IOException) {
+            // Best-effort — if the parent is gone or non-empty, leaving it is safer.
+        }
         acceptThread.interrupt()
     }
 }
@@ -264,3 +274,35 @@ private val OWNER_ONLY_PERMS =
             "Expected OWNER_ONLY_PERMS to be 0600 (rw-------), got $it"
         }
     }
+
+private val OWNER_ONLY_DIRECTORY_PERMS =
+    PosixFilePermissions.fromString("rwx------").also {
+        require(
+            it ==
+                setOf(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE,
+                )
+        ) {
+            "Expected OWNER_ONLY_DIRECTORY_PERMS to be 0700 (rwx------), got $it"
+        }
+    }
+
+private fun createMissingParentDirectory(udsPath: Path): Path? {
+    val parent = udsPath.parent ?: return null
+    if (Files.exists(parent)) return null
+    return try {
+        Files.createDirectories(
+            parent,
+            PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMS),
+        )
+        parent
+    } catch (ex: UnsupportedOperationException) {
+        throw IOException(
+            "Filesystem at $parent doesn't support POSIX permissions; refusing to create " +
+                "an agent UDS parent without 0700 access control.",
+            ex,
+        )
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -14,10 +14,10 @@ import kotlinx.serialization.Serializable
  * share types with) the HTTP transport at `:server`; see plan UC-2 in
  * `.plans/2026-05-22-issue-153-agent-attach-workshop.md`.
  *
- * The v1 operation surface (D-4 in the plan) is exactly the operations the HTTP transport exposes
- * today: windows, allNodes, findByTestTag, click, typeText, screenshot, plus the new detach.
- * Streaming/long-poll ops (`waitForVisualIdle`, idling resources, `withTracing`) are deferred to
- * v1.1 (Q-3 resolution).
+ * The current operation surface (D-4 in the plan) mirrors the operations the HTTP transport exposes
+ * today: windows, allNodes, findByTestTag, click, typeText, screenshot, plus detach.
+ * Streaming/long-poll ops (`waitForVisualIdle`, idling resources, `withTracing`) are deferred
+ * follow-ups (Q-3 resolution).
  */
 @Serializable
 internal sealed interface AgentRequest {
@@ -68,6 +68,20 @@ internal sealed interface AgentRequest {
     @Serializable @SerialName("detach") data object Detach : AgentRequest
 }
 
+/** Payload-free operation label for diagnostics. Never include caller-controlled request data. */
+internal val AgentRequest.logLabel: String
+    get() =
+        when (this) {
+            AgentRequest.Ping -> "ping"
+            AgentRequest.Windows -> "windows"
+            AgentRequest.AllNodes -> "allNodes"
+            is AgentRequest.FindByTestTag -> "findByTestTag"
+            is AgentRequest.Click -> "click"
+            is AgentRequest.TypeText -> "typeText"
+            AgentRequest.Screenshot -> "screenshot"
+            AgentRequest.Detach -> "detach"
+        }
+
 /** Server-to-client response envelope. */
 @Serializable
 internal sealed interface AgentResponse {
@@ -104,7 +118,7 @@ internal sealed interface AgentResponse {
 
     /**
      * Server-side failure. Carries a human-readable [message]; the structured failure type isn't
-     * exposed across the wire (yet) to keep the v1 protocol small.
+     * exposed across the wire yet to keep the protocol small.
      */
     @Serializable @SerialName("error") data class Error(val message: String) : AgentResponse
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -58,16 +58,15 @@ import org.junit.jupiter.api.condition.OS
  * future change makes the strict assertions flaky, fix the root cause; don't relax the contract.
  *
  * Gating:
- * - **Disabled on Windows** via `@EnabledOnOs(OS.LINUX, OS.MAC)`. Per the v1 docs the agent
- *   transport is macOS+Linux only — `AgentAttach.attach` short-circuits with
- *   `AttachPermissionDeniedException` on Windows runners (the same-UID preflight via
- *   `ProcessHandle.info().user()` returns a value the POSIX-shaped check rejects). Until Windows
- *   support lands (named pipes via JNA/junixsocket follow-up), this test is skipped rather than
- *   asserting Windows-specific failure shapes.
+ * - **Disabled on Windows** via `@EnabledOnOs(OS.LINUX, OS.MAC)`. The current agent transport is
+ *   macOS+Linux only — `AgentAttach.attach` short-circuits with
+ *   `AttachPlatformUnsupportedException` on Windows runners. Until Windows support lands (named
+ *   pipes via JNA/junixsocket follow-up), this test is skipped rather than asserting
+ *   Windows-specific failure shapes.
  * - Skipped on headless JVMs (`java.awt.GraphicsEnvironment.isHeadless()`). Compose Desktop refuses
  *   to create a `JFrame + ComposePanel` without a display.
  * - Skipped when `dev.sebastiano.spectre.agent.runtimeJar` isn't set. Gradle's `:agent:test` task
- *   sets it from the `:agent:shadowJar` output.
+ *   sets it from the `:agent-runtime:jar` output.
  */
 @EnabledOnOs(OS.LINUX, OS.MAC)
 class AgentAttachIntegrationTest {
@@ -240,13 +239,13 @@ class AgentAttachIntegrationTest {
         val prop = System.getProperty("dev.sebastiano.spectre.agent.runtimeJar")
         assumeFalse(
             prop.isNullOrBlank(),
-            "Requires -Ddev.sebastiano.spectre.agent.runtimeJar=<path/to/agent-*-all.jar>; the " +
+            "Requires -Ddev.sebastiano.spectre.agent.runtimeJar=<path/to/agent-runtime.jar>; the " +
                 ":agent:test task sets it automatically.",
         )
         val path = Paths.get(prop!!)
         assumeFalse(
             !Files.isRegularFile(path),
-            "Agent runtime JAR not found at $path; run `./gradlew :agent:shadowJar` first.",
+            "Agent runtime JAR not found at $path; run `./gradlew :agent-runtime:jar` first.",
         )
         return path
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
@@ -20,6 +20,27 @@ class AgentJarResolutionTest {
     }
 
     @Test
+    fun `skips auxiliary agent runtime jars on classpath`() {
+        val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
+        val sourcesJar = Files.createFile(dir.resolve("spectre-agent-runtime-0.2.0-sources.jar"))
+        val javadocJar = Files.createFile(dir.resolve("spectre-agent-runtime-0.2.0-javadoc.jar"))
+        val runtimeJar = Files.createFile(dir.resolve("spectre-agent-runtime-0.2.0.jar"))
+        val classPath = listOf(sourcesJar, javadocJar, runtimeJar).joinToString(File.pathSeparator)
+
+        assertEquals(runtimeJar, AgentJarResolution.findRuntimeJarOnClasspath(classPath))
+    }
+
+    @Test
+    fun `skips auxiliary agent runtime jars in directory fallback`() {
+        val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
+        Files.createFile(dir.resolve("agent-runtime-0.2.0-sources.jar"))
+        Files.createFile(dir.resolve("agent-runtime-0.2.0-javadoc.jar"))
+        val runtimeJar = Files.createFile(dir.resolve("agent-runtime-0.2.0.jar"))
+
+        assertEquals(runtimeJar, AgentJarResolution.findRuntimeJarInDirectory(dir))
+    }
+
+    @Test
     fun `ignores non-runtime agent jar on classpath`() {
         val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
         val apiJar = Files.createFile(dir.resolve("spectre-agent-0.2.0.jar"))

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
@@ -1,0 +1,37 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AgentJarResolutionTest {
+    @Test
+    fun `finds published agent runtime jar on classpath`() {
+        val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
+        val runtimeJar = Files.createFile(dir.resolve("spectre-agent-runtime-0.2.0.jar"))
+        val apiJar = Files.createFile(dir.resolve("spectre-agent-0.2.0.jar"))
+        val classPath = listOf(apiJar, runtimeJar).joinToString(File.pathSeparator)
+
+        assertEquals(runtimeJar, AgentJarResolution.findRuntimeJarOnClasspath(classPath))
+    }
+
+    @Test
+    fun `ignores non-runtime agent jar on classpath`() {
+        val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
+        val apiJar = Files.createFile(dir.resolve("spectre-agent-0.2.0.jar"))
+
+        assertEquals(null, AgentJarResolution.findRuntimeJarOnClasspath(apiJar.toString()))
+    }
+
+    @Test
+    fun `default UDS path uses a per-attach private directory`() {
+        val path = AttachOptions.defaultUdsPath(targetPid = 1234)
+
+        assertEquals("agent.sock", path.fileName.toString())
+        assertTrue(path.parent.fileName.toString().startsWith("sp-a-1234-"))
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentPlatformPreflightTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentPlatformPreflightTest.kt
@@ -1,0 +1,25 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class AgentPlatformPreflightTest {
+    @Test
+    fun `Windows fails with a dedicated unsupported platform exception`() {
+        val ex =
+            assertFailsWith<AttachPlatformUnsupportedException> {
+                AgentPlatformPreflight.requireSupported(osName = "Windows 11")
+            }
+
+        assertEquals("Windows 11", ex.osName)
+    }
+
+    @Test
+    fun `macOS and Linux pass the agent platform preflight`() {
+        AgentPlatformPreflight.requireSupported(osName = "Mac OS X")
+        AgentPlatformPreflight.requireSupported(osName = "Linux")
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -4,6 +4,7 @@ package dev.sebastiano.spectre.agent.transport
 
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
 import java.util.UUID
 import kotlin.io.path.deleteIfExists
 import kotlin.test.AfterTest
@@ -28,9 +29,9 @@ import org.junit.jupiter.api.condition.OS
  * UUID prefix keeps us well within bounds.
  *
  * **Disabled on Windows** via `@EnabledOnOs(OS.LINUX, OS.MAC)`. The agent transport is macOS+Linux
- * only in v1 — Windows support (named pipes via JNA/junixsocket) is a tracked follow-up. The
- * hard-coded `/tmp/...` UDS path is meaningless on Windows and the test would `SocketException` on
- * connect rather than exercising the round-trip contract.
+ * only in the current preview — Windows support (named pipes via JNA/junixsocket) is a tracked
+ * follow-up. The hard-coded `/tmp/...` UDS path is meaningless on Windows and the test would
+ * `SocketException` on connect rather than exercising the round-trip contract.
  */
 @EnabledOnOs(OS.LINUX, OS.MAC)
 class IpcRoundTripTest {
@@ -57,6 +58,25 @@ class IpcRoundTripTest {
                 assertEquals(AgentResponse.Pong, resp)
             }
         }
+    }
+
+    @Test
+    fun `server creates missing UDS parent owner-only and removes it on close`() {
+        val parent = Path.of("/tmp", "sp-t-${UUID.randomUUID().toString().take(8)}")
+        val nestedUdsPath = parent.resolve("agent.sock")
+
+        val server = IpcServer(nestedUdsPath, stubHandler())
+        server.use {
+            awaitSocket(nestedUdsPath)
+            assertEquals(
+                OWNER_ONLY_DIRECTORY_PERMS,
+                Files.getPosixFilePermissions(parent),
+                "created UDS parent should be owner-only",
+            )
+        }
+
+        assertTrue(!Files.exists(nestedUdsPath), "UDS path should be removed after close")
+        assertTrue(!Files.exists(parent), "private UDS parent should be removed after close")
     }
 
     @Test
@@ -441,5 +461,11 @@ class IpcRoundTripTest {
         const val FD_LEAK_WARMUP: Int = 5
         const val FD_LEAK_ITERATIONS: Int = 50
         const val FD_LEAK_TOLERANCE: Long = 10
+        val OWNER_ONLY_DIRECTORY_PERMS =
+            setOf(
+                PosixFilePermission.OWNER_READ,
+                PosixFilePermission.OWNER_WRITE,
+                PosixFilePermission.OWNER_EXECUTE,
+            )
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
@@ -4,6 +4,7 @@ package dev.sebastiano.spectre.agent.transport
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 /**
  * Round-trip tests for [WireCodec]. Each variant of [AgentRequest] / [AgentResponse] gets a
@@ -44,6 +45,15 @@ class WireCodecTest {
     fun `TypeText round-trips with unicode payload`() {
         val req = AgentRequest.TypeText(text = "hello 🦀 world café")
         assertEquals(req, WireCodec.decodeRequest(WireCodec.encode(req)))
+    }
+
+    @Test
+    fun `request log label redacts TypeText payload`() {
+        val req = AgentRequest.TypeText(text = "password=super-secret")
+
+        assertEquals("typeText", req.logLabel)
+        assertFalse(req.logLabel.contains("super-secret"))
+        assertFalse(req.logLabel.contains(req.text))
     }
 
     @Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SourcesJar
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.extensions.DetektExtension
+import java.util.jar.JarFile
 import java.util.zip.ZipFile
 import javax.xml.parsers.DocumentBuilderFactory
 import org.gradle.api.tasks.SourceTask
@@ -95,10 +96,10 @@ subprojects {
 
     // --- Maven Central publishing convention (#84) -------------------------------------------
     //
-    // Library modules (:core, :server, :recording, :testing) apply `com.vanniktech.maven.publish`
-    // in their own build scripts. This block fires only when the plugin is present, so samples
-    // never accidentally pick up a `publish` task — the issue requires the artefact set to be
-    // exactly the four library modules.
+    // Library modules apply `com.vanniktech.maven.publish` in their own build scripts. This
+    // block fires only when the plugin is present, so samples and fixtures never accidentally
+    // pick up a `publish` task. Keep the expected artifact set in sync with
+    // `publishedLibraryProjects` and docs/PUBLISHING.md.
     //
     // POM scalars (name, description, licence URL, SCM, developer) come from gradle.properties:
     // `POM_*` in the root file is the source of truth for everything shared; per-module
@@ -184,6 +185,8 @@ val publishedLibraryProjects =
         ":recording-macos",
         ":recording-linux",
         ":recording-windows",
+        ":agent",
+        ":agent-runtime",
         ":testing",
     )
 
@@ -304,7 +307,7 @@ val verifyMavenLocalPublication by tasks.registering {
             }
             val baseName = "$artifactId-$version"
             val expectedArtefacts =
-                listOf(
+                mutableListOf(
                     "$baseName.jar",
                     "$baseName-sources.jar",
                     "$baseName-javadoc.jar",
@@ -402,6 +405,48 @@ val verifyMavenLocalPublication by tasks.registering {
                             errors +=
                                 "$moduleName: published jar (${jar.name}) has empty " +
                                     "helper entry `$path`"
+                        }
+                    }
+                }
+            }
+            if (moduleName == ":agent-runtime") {
+                val runtimeJar = moduleDir.resolve("$baseName.jar")
+                if (runtimeJar.isFile) {
+                    JarFile(runtimeJar).use { jar ->
+                        val manifest = jar.manifest
+                        val attributes = manifest?.mainAttributes
+                        val agentClass = attributes?.getValue("Agent-Class")
+                        val premainClass = attributes?.getValue("Premain-Class")
+                        val expectedAgentClass = "dev.sebastiano.spectre.agent.runtime.SpectreAgent"
+                        if (agentClass != expectedAgentClass) {
+                            errors +=
+                                ":agent-runtime: jar (${runtimeJar.name}) has Agent-Class " +
+                                    "'$agentClass', expected '$expectedAgentClass'"
+                        }
+                        if (premainClass != expectedAgentClass) {
+                            errors +=
+                                ":agent-runtime: jar (${runtimeJar.name}) has Premain-Class " +
+                                    "'$premainClass', expected '$expectedAgentClass'"
+                        }
+                        val forbiddenPrefixes =
+                            listOf(
+                                "androidx/compose/",
+                                "org/jetbrains/compose/",
+                                "org/jetbrains/skiko/",
+                                "dev/sebastiano/spectre/core/",
+                                "kotlin/Pair.class",
+                                "kotlinx/coroutines/",
+                            )
+                        val leaks =
+                            jar.entries()
+                                .asSequence()
+                                .map { it.name }
+                                .filter { entry -> forbiddenPrefixes.any { entry.startsWith(it) } }
+                        val leakList = leaks.toList()
+                        if (leakList.isNotEmpty()) {
+                            errors +=
+                                ":agent-runtime: jar (${runtimeJar.name}) contains forbidden " +
+                                    "classes: ${leakList.sorted().joinToString()}"
                         }
                     }
                 }

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,7 +1,7 @@
 # Publishing
 
 Spectre's library modules (`:core`, `:server`, `:recording`, `:recording-macos`,
-`:recording-linux`, `:testing`) publish to Sonatype Central via the
+`:recording-linux`, `:recording-windows`, `:agent`, `:agent-runtime`, `:testing`) publish to Sonatype Central via the
 [`com.vanniktech.maven.publish`][vanniktech] plugin.
 The sample modules (`:sample-desktop`, `:sample-intellij-plugin`) never apply
 the plugin — they're deliverables, not libraries.
@@ -20,7 +20,7 @@ published library module.
 
 [release-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/release.yml
 
-Four jobs run on tag push:
+Five jobs run on tag push:
 
 1. **`release-gate`** (Linux runner) — validates the tag shape, runs
    `./gradlew check`, installs the docs dependencies, and runs
@@ -35,11 +35,14 @@ Four jobs run on tag push:
    toolchain dance documented in [`ci.yml`][ci-yml]: dpkg multi-arch +
    per-arch libdbus sysroot + cross-linker). Uploads the per-arch binaries as a
    GitHub Actions artefact.
-4. **`publish`** (Linux runner, depends on the gate and both helper jobs) — downloads the helper
-   artefacts, runs `:verifyMavenLocalPublication` to assert the publication
-   shape, then runs `publishToMavenCentral` against the
-   [Sonatype Central Portal][central-portal]. Finally creates a draft GitHub
-   release with the recording API jar and platform helper jars attached.
+4. **`windows-helper`** (Windows runner, depends on `release-gate`) — builds the
+   .NET Windows Graphics Capture helper for `x64` and `arm64`, then uploads the
+   per-arch helper directories as a GitHub Actions artefact.
+5. **`publish`** (Linux runner, depends on the gate and all helper jobs) — downloads the
+   helper artefacts, runs `:verifyMavenLocalPublication` to assert the publication shape, then
+   runs `publishToMavenCentral` against the [Sonatype Central Portal][central-portal].
+   Finally creates a draft GitHub release with the recording API jar and platform helper jars
+   attached.
 
 [ci-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/ci.yml
 [central-portal]: https://central.sonatype.com/
@@ -53,7 +56,7 @@ sanity-checked the artefacts side-by-side.
 Manual promotion checklist:
 
 - Confirm the tag points at the intended, already-reviewed `main` SHA.
-- Inspect the Central Portal staging deployment for all six modules, including
+- Inspect the Central Portal staging deployment for all nine modules, including
   POM metadata, sources jars, javadoc jars, and Gradle module metadata.
 - Confirm `spectre-recording-<version>.jar` contains no `native/...` entries.
 - Confirm `spectre-recording-macos-<version>.jar` contains
@@ -61,6 +64,11 @@ Manual promotion checklist:
 - Confirm `spectre-recording-linux-<version>.jar` contains
   `native/linux/x86_64/spectre-wayland-helper` and
   `native/linux/aarch64/spectre-wayland-helper`.
+- Confirm `spectre-recording-windows-<version>.jar` contains
+  `native/windows/x64/spectre-window-capture.exe` and
+  `native/windows/arm64/spectre-window-capture.exe`.
+- Confirm `spectre-agent-runtime-<version>.jar` exists and its manifest declares
+  `Agent-Class: dev.sebastiano.spectre.agent.runtime.SpectreAgent`.
 - Promote the Central staging deployment from the Central Portal UI.
 - Undraft the GitHub release with `gh release edit <tag> --draft=false`.
 
@@ -97,8 +105,9 @@ signing convention only fires when `ORG_GRADLE_PROJECT_signingInMemoryKey` is
 set. The `:verifyMavenLocalPublication` task drives the full shape check:
 
 ```shell
-# Publish all library modules + verify shape. Stub mac helper because Linux can't
-# build the real one; cross-arch Linux helpers come from the real Rust build.
+# Publish all library modules + verify shape. Stub mac helper because Linux cannot build the
+# real one; cross-arch Linux helpers come from the real Rust build. Windows helpers are only
+# expected when provided explicitly or when running on Windows.
 ./gradlew verifyMavenLocalPublication \
     -PstubMacHelperForTesting \
     -PallLinuxArches
@@ -120,6 +129,10 @@ It additionally asserts:
 - `:recording-macos` contains `native/macos/spectre-screencapture`
 - `:recording-linux` contains `native/linux/x86_64/spectre-wayland-helper` and
   `native/linux/aarch64/spectre-wayland-helper` when built with release helper inputs
+- `:recording-windows` contains `native/windows/x64/spectre-window-capture.exe` and
+  `native/windows/arm64/spectre-window-capture.exe` when built with release helper inputs
+- `:agent-runtime` publishes the Java Agent runtime jar; it must carry the Java Agent
+  manifest and must not bundle Compose, Skiko, Spectre core, or Kotlin stdlib classes
 
 If you have a real notarised mac helper on disk (e.g. downloaded from a
 previous release-CI run), point at it instead of the stub:
@@ -127,11 +140,14 @@ previous release-CI run), point at it instead of the stub:
 ```shell
 ./gradlew verifyMavenLocalPublication \
     -PprebuiltMacHelperPath=/path/to/SpectreScreenCapture \
-    -PprebuiltLinuxHelpersDir=/path/to/linux-helpers
+    -PprebuiltLinuxHelpersDir=/path/to/linux-helpers \
+    -PprebuiltWindowsHelpersDir=/path/to/windows-helpers
 ```
 
 The `prebuiltLinuxHelpersDir` directory must contain
 `x86_64/spectre-wayland-helper` and `aarch64/spectre-wayland-helper`.
+The `prebuiltWindowsHelpersDir` directory must contain
+`x64/spectre-window-capture.exe` and `arm64/spectre-window-capture.exe`.
 
 ## Coordinates
 
@@ -142,6 +158,9 @@ The `prebuiltLinuxHelpersDir` directory must contain
 | `:recording` | `dev.sebastiano.spectre:spectre-recording:<version>` |
 | `:recording-macos` | `dev.sebastiano.spectre:spectre-recording-macos:<version>` |
 | `:recording-linux` | `dev.sebastiano.spectre:spectre-recording-linux:<version>` |
+| `:recording-windows` | `dev.sebastiano.spectre:spectre-recording-windows:<version>` |
+| `:agent` | `dev.sebastiano.spectre:spectre-agent:<version>` |
+| `:agent-runtime` | `dev.sebastiano.spectre:spectre-agent-runtime:<version>` |
 | `:testing` | `dev.sebastiano.spectre:spectre-testing:<version>` |
 
 The shared metadata (group, license, SCM, developer) lives in

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -31,9 +31,11 @@ out of scope.
    `installSpectreRoutes` expose click, keystroke, and screenshot capture to anyone who can
    reach the bound port. Bind to `127.0.0.1`. Anything network-reachable broadens the threat
    model beyond what this release covers.
-4. **The agent transport assumes a same-UID peer.** `:agent`'s Unix Domain Socket in
-   `/tmp/` is protected by filesystem permissions only (mode 0600, owner-only, set
-   explicitly by `IpcServer` immediately after bind to defend against permissive umasks).
+4. **The agent transport assumes a same-user peer.** `:agent`'s Unix Domain Socket is created
+   under a short private directory in `/tmp/`. The directory is mode 0700 and the socket is mode
+   0600, both set explicitly by `IpcServer` to defend against permissive umasks.
+   If callers override `AttachOptions.udsPath` with a path under an existing directory, they own
+   that parent directory's permissions; Spectre only tightens directories it creates itself.
    Any process running as the same OS user can connect and drive the target. There is no
    authentication, no encryption, and no origin check. The agent transport is intentionally
    a testing affordance for the same machine and the same user, not a remote-control
@@ -58,7 +60,7 @@ out of scope.
 | Record video | `AutoRecorder`, native recorders, deprecated explicit `FfmpegRecorder`, `WaylandPortalRecorder` | In-process only |
 | Execute a helper binary | `HelperBinaryExtractor` (SCK), `WaylandHelperBinaryExtractor` | Local file system, JVM process |
 | Expose any of the above over HTTP | `installSpectreRoutes` mounts the windows / nodes / click / typeText / screenshot routes | **Unauthenticated, plaintext** — host application chooses bind address |
-| Expose any of the above over UDS | `:agent`'s `IpcServer` mounts the same surface plus detach over a Unix Domain Socket | **Unauthenticated** — filesystem mode 0600 (same UID); macOS + Linux only in v1 |
+| Expose any of the above over UDS | `:agent`'s `IpcServer` mounts the same surface plus detach over a Unix Domain Socket | **Unauthenticated** — filesystem mode 0600 (same UID); macOS + Linux only in the current preview |
 
 The HTTP exposure column is the most important one to internalise: there are **no auth
 tokens, no TLS, and no origin checks** on any route. The transport is intentionally a

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -52,9 +52,9 @@ Two experimental markers exist today:
   marker.
 - **`@ExperimentalSpectreAgentApi`** covers the entire `agent` module's attach-side public
   surface — `AgentAttach`, `AttachedAutomator`, `AttachOptions`, `SpectreProcesses`, and the
-  wire DTOs. Tracked under #153; the marker stays in place at least until v1.1 lands the
-  Windows-named-pipe support, the streaming wire ops (`waitForVisualIdle` etc.), and the
-  automated IntelliJ-hosted Compose attach tests.
+  wire DTOs. Tracked under #153; the marker stays in place while the attach UX, Windows
+  transport shape, streaming wire ops (`waitForVisualIdle` etc.), and automated
+  IntelliJ-hosted Compose attach tests settle.
 
 Consumers opt in either at file level or call site:
 

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -11,7 +11,7 @@ This is the right transport when:
 - You want to inspect a long-running Spectre-aware app interactively (the future
   `spectre attach <pid>` CLI builds on this surface).
 - You're driving an IntelliJ-hosted Compose surface from a sister process. *Note: see the
-  v1 limitations below — IntelliJ support is gated until further validation.*
+  current limitations below — IntelliJ support is gated until further validation.*
 
 For comparison with the other transports, see [Cross-JVM access](cross-jvm.md) (HTTP) and
 [IntelliJ-hosted Compose](intellij.md) (in-process via `intellij-ide-starter`).
@@ -27,13 +27,13 @@ For comparison with the other transports, see [Cross-JVM access](cross-jvm.md) (
     The agent transport is **local only** and intended for **trusted dev/test
     environments**. Trust model:
 
-    - Communication is over a **Unix Domain Socket** in `/tmp/`. Filesystem permissions
-      (mode 0600, owner-only) are the only access control.
+    - Communication is over a **Unix Domain Socket** under a short private directory in `/tmp/`.
+      Filesystem permissions (directory mode 0700, socket mode 0600) are the only access control.
     - The attaching JVM must run as the same OS user as the target JVM.
     - There is **no authentication** and **no encryption** on the wire.
-    - The agent module is **unpublished in v1** — no Maven Central, no `mavenLocal`.
-      Consume via a direct project dependency or an explicit `AttachOptions.agentJarPath`.
-      See [Target setup](#target-setup) below.
+    - The published `spectre-agent` API jar is for the attaching JVM. The
+      `spectre-agent-runtime` jar gets loaded into the target JVM. See
+      [Artifact roles](#artifact-roles) below.
 
     See [Security notes](../SECURITY.md) for the full risk register.
 
@@ -45,32 +45,100 @@ For comparison with the other transports, see [Cross-JVM access](cross-jvm.md) (
 - The target JVM must include **Spectre `:core`** on its classpath. The agent does not
   inject Spectre into the target; it reflectively bootstraps off the `:core` that's
   already loaded. The agent JAR itself is supplied by the attaching JVM at attach time.
-- **macOS and Linux only** in v1. Windows support is tracked as a follow-up (named pipes
+- **macOS and Linux only** in the current preview. Windows support is tracked as a follow-up (named pipes
   via JNA or junixsocket).
 - The target JVM should be started with **`-XX:+EnableDynamicAgentLoading`**. Without it,
   attach prints a stderr warning per
   [JEP 451](https://openjdk.org/jeps/451) and a future JDK will reject the attach
   entirely.
 
-## Target setup
+## Artifact roles
 
-The agent JAR is a thin bootstrap. It reflectively locates `ComposeAutomator` in the
-target's classloader at attach time, so the target **must already have Spectre `:core`
-on its classpath** — typically as a normal runtime dependency. The agent JAR doesn't
-need to be on the target's classpath; it gets loaded via `VirtualMachine.loadAgent`.
+Agent attach involves two JVMs:
+
+- **Target JVM** — the Compose app you want to inspect or drive.
+- **Attacher JVM** — the test, inspector, or tool process that calls `AgentAttach.attach(pid)`.
+
+The target JVM must already have Spectre `:core` on its classpath. The agent runtime does
+not inject `:core`; it reflectively locates `ComposeAutomator` in the target's classloader
+after it has been loaded into that JVM.
 
 ```kotlin
 // build.gradle.kts of the target application
 dependencies {
     implementation("dev.sebastiano.spectre:core:<version>")
-    // No `:agent` dependency needed in the target. The agent fat JAR is supplied by the
-    // attaching JVM (the test/inspector) and loaded into this process at attach time.
+    // No `spectre-agent` or `spectre-agent-runtime` dependency is needed in the target.
+    // The attacher supplies the runtime jar to the JDK Attach API.
 }
 ```
 
-**`:agent` is not published to Maven Central or `mavenLocal` in v1.** The module
-deliberately doesn't apply `mavenPublish` — see plan Q-1 (track Central publishing as a
-v1.1 follow-up). Today, attaching-side consumers have two supported paths:
+The attacher JVM usually needs two artifacts:
+
+- `spectre-agent` — the normal API jar that your test/inspector code compiles against.
+- `spectre-agent-runtime` — the loadable Java-agent runtime jar that gets passed to
+  `VirtualMachine.loadAgent(...)`.
+
+The easiest Gradle shape is a normal implementation dependency plus a runtime-only dependency on
+the loadable runtime artifact:
+
+```kotlin
+dependencies {
+    implementation("dev.sebastiano.spectre:spectre-agent:<version>")
+    runtimeOnly("dev.sebastiano.spectre:spectre-agent-runtime:<version>")
+}
+```
+
+`AgentAttach` auto-discovers `spectre-agent-runtime-<version>.jar` from the attacher's runtime
+classpath. In practice, `runtimeOnly(...)` makes Gradle launch the attacher with the runtime jar
+listed in `java.class.path`; Spectre scans that classpath, takes the physical jar path, and passes
+that path to `VirtualMachine.loadAgent(...)`. The attacher does not call classes from the runtime
+jar directly, and the target still does not need `spectre-agent-runtime` declared as a dependency.
+
+## How attach works
+
+`AgentAttach.attach(pid)` performs this sequence:
+
+1. Resolve the loadable `spectre-agent-runtime-<version>.jar`.
+2. Create a fresh Unix Domain Socket path such as `/tmp/sp-a-<pid>-<8char-uuid>/agent.sock`.
+3. Run attach preflights, including the same-OS-user check.
+4. Call `VirtualMachine.attach(pid).loadAgent(runtimeJarPath, udsPath)`.
+5. The target JVM loads the runtime jar and invokes `SpectreAgent.agentmain(...)`.
+6. Inside the target JVM, `SpectreAgent` finds `ComposeAutomator` from the target's existing
+   `:core` dependency, creates an in-process automator, and starts an IPC server on the UDS path.
+7. The attacher connects an `IpcClient` to that socket and returns `AttachedAutomator`.
+
+After that, calls such as `windows()`, `findByTestTag(...)`, `click(...)`, and `screenshot()` are
+small CBOR requests over the socket. They execute inside the target JVM against the in-process
+automator, then return DTOs or bytes to the attacher.
+
+## Custom runtime jar path
+
+Classpath auto-discovery is the default, but it only works when the runtime jar is visible as a
+physical `spectre-agent-runtime-<version>.jar` entry in the attacher's `java.class.path`. Custom
+launchers, shaded tools, module-path launches, and ad-hoc scripts may hide that file. In those
+cases, point Spectre at the runtime jar explicitly:
+
+```kotlin
+import dev.sebastiano.spectre.agent.AgentAttach
+import dev.sebastiano.spectre.agent.AttachOptions
+import java.nio.file.Path
+
+AgentAttach.attach(
+    pid = targetPid,
+    options =
+        AttachOptions(
+            agentJarPath = Path.of("/abs/path/to/spectre-agent-runtime-<version>.jar"),
+        ),
+)
+```
+
+Equivalent: set `-Ddev.sebastiano.spectre.agent.runtimeJar=<path>` on the attacher's JVM.
+
+When working inside the Spectre repo, `AgentAttach` also falls back to
+`<cwd>/agent-runtime/build/libs/agent-runtime-*.jar` so local manual recipes keep working after
+`./gradlew :agent-runtime:jar`.
+
+Consumers that cannot use the published Maven coordinate still have two supported paths:
 
 1. **As a project dependency** (you're inside the Spectre repo or a Gradle composite
    build that includes it):
@@ -79,27 +147,12 @@ v1.1 follow-up). Today, attaching-side consumers have two supported paths:
     // build.gradle.kts of the test/attacher module
     dependencies {
         implementation(projects.agent)
+        runtimeOnly(projects.agentRuntime)
     }
     ```
 
-2. **As a path to the fat agent JAR** — useful when the attacher and target are wired
-   up out-of-band (e.g. CI scripts, ad-hoc inspector tools). Build the JAR once with
-   `./gradlew :agent:shadowJar` (output at `agent/build/libs/agent-*-all.jar`) and tell
-   `AgentAttach` where to find it via:
-
-    ```kotlin
-    AgentAttach.attach(
-        pid = targetPid,
-        options = AttachOptions(agentJarPath = Path.of("/abs/path/to/agent-*-all.jar")),
-    )
-    ```
-
-    Equivalent: set `-Ddev.sebastiano.spectre.agent.runtimeJar=<path>` on the attacher's
-    JVM. Spectre's own `:agent:test` task uses this property to point integration tests
-    at the freshly-built shadow JAR.
-
-If neither is set explicitly, `AgentAttach` falls back to scanning
-`<cwd>/agent/build/libs/agent-*-all.jar` — convenient for in-repo manual recipes only.
+2. **As an explicit path** via `AttachOptions.agentJarPath` or
+   `dev.sebastiano.spectre.agent.runtimeJar`, as shown above.
 
 Start the target with the dynamic-agent flag (suppresses the JEP 451 stderr warning):
 
@@ -142,21 +195,25 @@ cleanup.
 
 ```kotlin
 AttachOptions(
-    agentJarPath = null,        // null = auto-locate (see "Target setup" above)
-    udsPath = null,             // null = /tmp/sp-a-<pid>-<8char-uuid>.sock
+    agentJarPath = null,        // null = auto-locate (see "Artifact roles" above)
+    udsPath = null,             // null = /tmp/sp-a-<pid>-<8char-uuid>/agent.sock
     attachTimeoutMs = 5_000,    // how long to wait for the agent's IPC server to come up
 )
 ```
 
-`AgentAttach.attach` runs a **same-UID preflight** via `ProcessHandle` and throws
+If you override `udsPath` with a path under an existing directory, you own that parent
+directory's permissions. Spectre creates the default per-attach directory as mode 0700 and the
+socket as mode 0600, but it does not chmod directories it did not create.
+
+`AgentAttach.attach` runs a **same-user preflight** via `ProcessHandle` and throws
 `AttachPermissionDeniedException` if the target JVM is owned by a different OS user (the
-JDK Attach API only works across same-UID processes on POSIX).
+JDK Attach API only works across attach-compatible same-user processes on POSIX).
 
-The JEP 451 `-XX:+EnableDynamicAgentLoading` flag is **not** verified by Spectre in v1 —
-the JVM itself prints a stderr warning if it's missing, which is the source of truth.
-v1.1 will add a reliable preflight via `HotSpotDiagnosticMXBean`.
+The JEP 451 `-XX:+EnableDynamicAgentLoading` flag is **not** verified by Spectre yet — the
+JVM itself prints a stderr warning if it's missing, which is the source of truth. A follow-up
+can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 
-## Operation set (v1)
+## Operation set
 
 `AttachedAutomator` exposes the same operations as the HTTP transport, plus `detach`:
 
@@ -171,7 +228,7 @@ v1.1 will add a reliable preflight via `HotSpotDiagnosticMXBean`.
 | `close()` (auto)      | `AgentRequest.Detach`            | tear-down         |
 
 Streaming / long-poll ops (`waitForVisualIdle`, idling resources, `withTracing`) are
-deferred to v1.1.
+deferred to a follow-up.
 
 ## Wire format
 
@@ -185,20 +242,17 @@ DTOs live in `dev.sebastiano.spectre.agent.transport.*`. Both sides share the sa
 classes; CBOR's `@SerialName` discriminators pin each variant in the sealed-interface
 hierarchy.
 
-## v1 limitations
+## Current limitations
 
 - **macOS and Linux only.** Windows support is a tracked follow-up.
-- **No streaming ops.** `waitForVisualIdle` and friends are HTTP-only or in-process only
-  until v1.1.
+- **No streaming ops.** `waitForVisualIdle` and friends are HTTP-only or in-process only for now.
 - **IntelliJ-hosted Compose**: the classloader-disambiguation rule (D-14 in the plan) was
-  designed to handle `PluginClassLoader` chains but isn't automatically tested in v1. If
+  designed to handle `PluginClassLoader` chains but isn't automatically tested yet. If
   you hit issues attaching to an IntelliJ-hosted target, file a Spectre issue with the
   `agent-attach` label.
-- **Unpublished — no Maven Central, no `mavenLocal`.** `:agent` doesn't apply
-  `mavenPublish` in v1. Attaching-side consumers use a direct project dependency
-  (`implementation(projects.agent)`) or point at the built fat JAR via
-  `AttachOptions.agentJarPath` / `-Ddev.sebastiano.spectre.agent.runtimeJar=...`. See
-  [Target setup](#target-setup) above.
+- **Runtime jar is separate from the API jar.** The normal `spectre-agent` dependency is not the
+  jar loaded into the target JVM. Add `spectre-agent-runtime`, pass
+  `AttachOptions.agentJarPath`, or set `-Ddev.sebastiano.spectre.agent.runtimeJar=...`.
 
 ## Manual verification recipe
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -11,6 +11,8 @@ Spectre publishes these library modules to Maven Central:
 | `recording-linux` | `dev.sebastiano.spectre:spectre-recording-linux:<version>` |
 | `recording-windows` | `dev.sebastiano.spectre:spectre-recording-windows:<version>` |
 | `server` | `dev.sebastiano.spectre:spectre-server:<version>` |
+| `agent` | `dev.sebastiano.spectre:spectre-agent:<version>` |
+| `agent-runtime` | `dev.sebastiano.spectre:spectre-agent-runtime:<version>` |
 
 !!! note "Before a release tag is published"
     The `main` branch declares `0.1.0-SNAPSHOT`. Until a tagged release has been published
@@ -45,6 +47,8 @@ dependencies {
     testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-linux:<version>") // Linux capture helper
     testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-windows:<version>") // Windows WGC helper
     testImplementation("dev.sebastiano.spectre:spectre-server:<version>")
+    testImplementation("dev.sebastiano.spectre:spectre-agent:<version>")
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-agent-runtime:<version>") // Java-agent runtime
 }
 ```
 
@@ -55,6 +59,19 @@ production application code.
 
 If you depend on `server`, you also need to add a Ktor server engine yourself — Spectre
 intentionally doesn't bundle one. See [Cross-JVM access](cross-jvm.md) for the choice.
+
+If you depend on `agent`, keep the artifact roles separate:
+
+- Add `spectre-agent` to the attacher's compile/test classpath. This is the API containing
+  `AgentAttach`, `AttachedAutomator`, and `AttachOptions`.
+- Add `spectre-agent-runtime` to the attacher's runtime/test-runtime classpath. `AgentAttach`
+  locates that physical jar and passes it to `VirtualMachine.loadAgent(...)`.
+- Add `spectre-core` to the target app. The target does not need `spectre-agent` or
+  `spectre-agent-runtime` declared as dependencies.
+
+Custom launchers that do not expose the runtime jar on `java.class.path` can pass an explicit
+`AttachOptions.agentJarPath` or set `-Ddev.sebastiano.spectre.agent.runtimeJar=<path>`. See
+[Agent attach](agent.md) for the full attach flow and custom path examples.
 
 You also need the JUnit version that matches the wrapper you'll use:
 
@@ -105,6 +122,10 @@ includeBuild("../spectre") {
             .using(project(":recording-windows"))
         substitute(module("dev.sebastiano.spectre:spectre-server"))
             .using(project(":server"))
+        substitute(module("dev.sebastiano.spectre:spectre-agent"))
+            .using(project(":agent"))
+        substitute(module("dev.sebastiano.spectre:spectre-agent-runtime"))
+            .using(project(":agent-runtime"))
     }
 }
 ```
@@ -123,6 +144,8 @@ dependencies {
     testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-linux")
     testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-windows")
     testImplementation("dev.sebastiano.spectre:spectre-server")
+    testImplementation("dev.sebastiano.spectre:spectre-agent")
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-agent-runtime")
 }
 ```
 
@@ -148,10 +171,12 @@ Maven Local:
 | `recording-linux` | Runtime-only Linux capture helper resources for `recording`. |
 | `recording-windows` | Runtime-only Windows Graphics Capture helper resources for `recording`. |
 | `server`    | Embedded HTTP transport (Ktor) and `HttpComposeAutomator` for cross-JVM access. **Experimental**; see [Security notes](../SECURITY.md). |
+| `agent`     | Local attach transport API. **Experimental**; see [Agent attach](agent.md). |
+| `agent-runtime` | Loadable Java-agent runtime for `agent`; add as runtime-only beside the API jar. |
 
 Most projects only need `core` + `testing`. Add `recording` if you want video output for
 test runs, add the platform helper artifact(s) for the OSes you run recording tests on, and
-add `server` if your test process needs to reach a UI in a different JVM.
+add `server` or `agent` if your test process needs to reach a UI in a different JVM.
 
 ## Next
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -94,6 +94,8 @@ include(":testing")
 
 include(":agent")
 
+include(":agent-runtime")
+
 // Tiny non-publishable Compose Desktop app used only as a target for `:agent`'s integration
 // test (`AgentAttachIntegrationTest`). Lives outside `:agent`'s test source set so the agent
 // module doesn't have to apply Compose plugins module-wide.

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spectre
-description: Use when writing, debugging, or reviewing tests that drive a real, on-screen Compose Desktop window with Spectre — the JVM/Kotlin library for automating live Compose Desktop UIs (and IntelliJ/Jewel-hosted Compose) via the semantics tree plus java.awt.Robot or synthetic AWT input. Trigger on mentions of `ComposeAutomator`, `RobotDriver`, `AutomatorNode`, `findByTestTag`, `waitForNode`, `waitForIdle`, "automate a Compose window", "live/real-window Compose Desktop UI test", screenshotting or recording a Compose Desktop window, or any task involving `dev.sebastiano.spectre.*` imports. Also use when the user is writing JUnit 4/5 tests against Compose Desktop **and** the test opens a real top-level window — but NOT when the user wants the off-screen `runComposeUiTest` / `createComposeRule` / `onNodeWithTag` framework, which is a different tool.
+description: Use when writing, debugging, or reviewing tests that drive a real, on-screen Compose Desktop window with Spectre — the JVM/Kotlin library for automating live Compose Desktop UIs (and IntelliJ/Jewel-hosted Compose) via the semantics tree plus java.awt.Robot, synthetic AWT input, HTTP, or Java-agent attach. Trigger on mentions of `ComposeAutomator`, `RobotDriver`, `AutomatorNode`, `AgentAttach`, `AttachedAutomator`, `AttachOptions`, `findByTestTag`, `waitForNode`, `waitForIdle`, "automate a Compose window", "live/real-window Compose Desktop UI test", cross-JVM Compose automation, attaching to a running Compose JVM, screenshotting or recording a Compose Desktop window, or any task involving `dev.sebastiano.spectre.*` imports. Also use when the user is writing JUnit 4/5 tests against Compose Desktop **and** the test opens a real top-level window — but NOT when the user wants the off-screen `runComposeUiTest` / `createComposeRule` / `onNodeWithTag` framework, which is a different tool.
 ---
 
 # Spectre
@@ -13,6 +13,16 @@ window, reads its semantics tree, and feeds it real OS input via
 
 Pick Spectre when the test needs to exercise the actual window, popups,
 IntelliJ/Jewel-hosted Compose, or to record a real video of the UI.
+
+## User guide source of truth
+
+Use the published docs as the source of truth when answering setup questions:
+
+- Installation and coordinates: <https://spectre.sebastiano.dev/guide/installation/>
+- Agent attach: <https://spectre.sebastiano.dev/guide/agent/>
+- Cross-JVM HTTP transport: <https://spectre.sebastiano.dev/guide/cross-jvm/>
+
+In the Spectre repository, the same pages live under `docs/guide/`.
 
 ## The 30-second mental model
 
@@ -282,6 +292,10 @@ touches that area*; they are not needed for the common case.
   pooled-thread requirement, and the `synthetic` driver. If the work also
   involves Jewel popups, `ComposePanel` embedding, or `SwingBridgeTheme`,
   the repo-local `jewel-swing-interop` skill applies as well.
+- **Java-agent attach** → `references/agent.md` — `AgentAttach`,
+  `AttachedAutomator`, `AttachOptions`, the `spectre-agent` /
+  `spectre-agent-runtime` split, runtime jar auto-discovery, and custom
+  attach paths.
 
 ## Common pitfalls (memorise these)
 
@@ -303,9 +317,8 @@ touches that area*; they are not needed for the common case.
 
 ## What Spectre is NOT (don't pretend it is)
 
-- It is **not** published to Maven Central yet. Consumers wire it as a
-  composite build or local clone. Do not suggest `implementation("dev.sebastiano.spectre:…")`
-  unless the user confirms artifacts exist.
+- If a tagged release is not available on Maven Central yet, consumers wire Spectre as a
+  composite build or local clone. Check the installation guide before giving coordinates.
 - It is **not** `compose-test` / `runComposeUiTest` / `onNodeWithTag`. Don't
   mix those APIs into a Spectre test.
 - It does **not** capture audio. Recording is video-only.

--- a/skills/spectre/references/agent.md
+++ b/skills/spectre/references/agent.md
@@ -1,0 +1,101 @@
+# Agent Attach
+
+Use this reference when the user asks about `AgentAttach`, `AttachedAutomator`,
+`AttachOptions`, attaching to a running Compose JVM, or the `spectre-agent` /
+`spectre-agent-runtime` dependency shape.
+
+## Source of truth
+
+- Published user guide: <https://spectre.sebastiano.dev/guide/agent/>
+- Published installation guide: <https://spectre.sebastiano.dev/guide/installation/>
+- Repo docs, when working inside Spectre: `docs/guide/agent.md` and
+  `docs/guide/installation.md`
+
+Prefer the user guide for detailed setup. Keep answers aligned with it.
+
+## Mental model
+
+Agent attach involves two JVMs:
+
+- **Target JVM**: the Compose app being inspected or driven. It must already have
+  `spectre-core` on its classpath.
+- **Attacher JVM**: the test, inspector, or tool process that calls `AgentAttach.attach(pid)`.
+  It compiles against `spectre-agent` and normally has `spectre-agent-runtime` on its runtime
+  classpath.
+
+Do not tell users to add `spectre-agent` or `spectre-agent-runtime` to the target app unless they
+are also writing the attacher in that same process. The runtime jar is supplied by the attacher and
+loaded into the target through the JDK Attach API.
+
+## Dependencies
+
+For the target app:
+
+```kotlin
+dependencies {
+    implementation("dev.sebastiano.spectre:spectre-core:<version>")
+}
+```
+
+For the attacher/test process:
+
+```kotlin
+dependencies {
+    implementation("dev.sebastiano.spectre:spectre-agent:<version>")
+    runtimeOnly("dev.sebastiano.spectre:spectre-agent-runtime:<version>")
+}
+```
+
+Use `testImplementation` / `testRuntimeOnly` instead when the attacher is a test source set.
+
+Do not recommend an `-all` classifier. `spectre-agent-runtime` is a separate artifactId because it
+is the loadable Java-agent runtime, not the normal API jar.
+
+## What happens during attach
+
+`AgentAttach.attach(pid)`:
+
+1. Resolves the loadable `spectre-agent-runtime-<version>.jar`.
+2. Creates a fresh Unix Domain Socket path such as
+   `/tmp/sp-a-<pid>-<8char-uuid>/agent.sock`.
+3. Runs attach preflights such as platform support and same-OS-user checks.
+4. Calls `VirtualMachine.attach(pid).loadAgent(runtimeJarPath, udsPath)`.
+5. Lets the target JVM invoke `SpectreAgent.agentmain(...)`.
+6. In the target JVM, finds `ComposeAutomator` from the target's existing `spectre-core`
+   dependency, creates an in-process automator, and starts a UDS IPC server.
+7. Connects the attach-side `IpcClient` and returns `AttachedAutomator`.
+
+After that, `AttachedAutomator` methods send small IPC requests to the target JVM.
+
+## Runtime jar discovery and custom attach
+
+Classpath auto-discovery means `AgentAttach` scans the attacher's `java.class.path` for a physical
+`spectre-agent-runtime-*.jar`, then passes that jar path to `VirtualMachine.loadAgent(...)`.
+It does not mean the target app declared `spectre-agent-runtime`, and it does not mean user code
+should call runtime classes directly.
+
+If a custom launcher, shaded distribution, module-path launch, or script hides the physical runtime
+jar from `java.class.path`, use one of these explicit forms:
+
+```kotlin
+AgentAttach.attach(
+    pid = targetPid,
+    options =
+        AttachOptions(
+            agentJarPath = Path.of("/abs/path/to/spectre-agent-runtime-<version>.jar"),
+        ),
+)
+```
+
+Or set this on the attacher JVM:
+
+```text
+-Ddev.sebastiano.spectre.agent.runtimeJar=/abs/path/to/spectre-agent-runtime-<version>.jar
+```
+
+## Caveats to mention
+
+- Current preview support is macOS and Linux only.
+- The attacher and target must run as the same OS user.
+- The target should start with `-XX:+EnableDynamicAgentLoading`.
+- Communication is local UDS IPC, unauthenticated, and intended for trusted dev/test machines.


### PR DESCRIPTION
## Summary
- split the Java-agent runtime into the publishable spectre-agent-runtime artifact while keeping spectre-agent as the attach API
- add runtime jar discovery, platform preflight, request-log redaction, and private UDS parent handling
- update publishing checks, release workflow, docs, and the Spectre user-facing skill for the two-artifact attach model

## Verification
- ./gradlew :agent:test --tests 'dev.sebastiano.spectre.agent.AgentAttachIntegrationTest'
- ./gradlew check
- ./gradlew verifyMavenLocalPublication -PstubMacHelperForTesting
- /private/tmp/spectre-docs-venv/bin/mkdocs build --strict --site-dir /private/tmp/spectre-mkdocs-agent-runtime