### PR TITLE
Skip SCK helper contract tests for stub helper

### DIFF
--- a/.idea/ktfmt.xml
+++ b/.idea/ktfmt.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KtfmtSettings">
+    <option name="enableKtfmt" value="Enabled" />
+    <option name="uiFormatterStyle" value="Kotlinlang" />
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -58,7 +58,14 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 }
 
-tasks.withType<Test>().configureEach { useJUnitPlatform() }
+val useStubMacHelperForTesting = providers.gradleProperty("stubMacHelperForTesting").isPresent
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    if (useStubMacHelperForTesting) {
+        systemProperty("spectre.test.stubMacHelperForTesting", "true")
+    }
+}
 
 // --- ScreenCaptureKit helper binary (issue #18) ----------------------------------------------
 //
@@ -402,7 +409,6 @@ val prebuiltMacHelperPath = providers.gradleProperty("prebuiltMacHelperPath")
 val prebuiltLinuxHelpersDir = providers.gradleProperty("prebuiltLinuxHelpersDir")
 val prebuiltWindowsHelperPath = providers.gradleProperty("prebuiltWindowsHelperPath")
 val prebuiltWindowsHelpersDir = providers.gradleProperty("prebuiltWindowsHelpersDir")
-val useStubMacHelperForTesting = providers.gradleProperty("stubMacHelperForTesting").isPresent
 
 // --- Windows .NET Graphics Capture helper --------------------------------------------------
 //
@@ -738,9 +744,9 @@ val useAllLinuxArches = providers.gradleProperty("allLinuxArches").isPresent
 // becomes the prebuilt staging task instead of the host-built one — so a Linux publish
 // runner can produce a recording jar bundling the macOS helper without a Swift toolchain.
 // `prebuiltMacHelperPath`, `prebuiltLinuxHelpersDir`, and `useStubMacHelperForTesting` are
-// declared earlier in the file (right after the universal-helper switches) so the host-
-// platform `processResources` hookups can gate themselves on them — see the comment there
-// for why the prebuilt path is mutually exclusive with the host build.
+// declared earlier in the file so the test and host-platform `processResources` hookups can
+// gate themselves on them — see the comment there for why the prebuilt path is mutually
+// exclusive with the host build.
 
 // `rootProject` is not config-cache-serialisable, so resolve to a plain File at config time
 // and capture only that into the `from(...)` provider mapping.

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitHelperContractTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitHelperContractTest.kt
@@ -32,6 +32,10 @@ class ScreenCaptureKitHelperContractTest {
     @BeforeTest
     fun setUp() {
         assumeTrue(
+            !System.getProperty("spectre.test.stubMacHelperForTesting").toBoolean(),
+            "ScreenCaptureKit helper contract tests require the real Swift helper, not the stub fixture",
+        )
+        assumeTrue(
             System.getProperty("os.name").orEmpty().lowercase().contains("mac"),
             "Helper binary is only bundled on macOS hosts",
         )


### PR DESCRIPTION
## Summary
- propagate -PstubMacHelperForTesting into recording test JVMs as spectre.test.stubMacHelperForTesting
- skip ScreenCaptureKitHelperContractTest when the stub helper fixture is active
- keep the real-helper contract path unchanged when no stub flag is present

## Validation
- ./gradlew :recording:test --tests "dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureKitHelperContractTest" -PstubMacHelperForTesting (green; 16 skipped)
- ./gradlew :recording:test --tests "dev.sebastiano.spectre.recording.screencapturekit.HelperBinaryExtractorTest" -PstubMacHelperForTesting (green)
- ./gradlew :recording:ktfmtCheck :recording:detektMain (green; detekt reports existing compiler-analysis warnings but succeeds)
- local vibe-check reviewer: no findings

Note: ./gradlew check was attempted twice but failed before project checks because the IntelliJ Platform Gradle plugin could not extract the cached IDEA 2026.1.1 aarch64 DMG via hdiutil for :sample-intellij-plugin:compileJava; hdiutil verify reports the cached DMG checksum is valid.