### PR TITLE
Stabilize macOS recording helper builds

### DIFF
--- a/docs/STATIC-ANALYSIS.md
+++ b/docs/STATIC-ANALYSIS.md
@@ -34,9 +34,9 @@ Notes:
 ## Style Choices
 
 - `ktfmt` uses KotlinLang style in this repo.
-- Detekt follows the same 2.x line as Compose Pi and builds on the default rule set using a
-  Pi-inspired profile tuned for Compose/Desktop work: 120-char lines, a looser
-  return-count/complexity envelope, and Compose-friendly naming exceptions.
+- Detekt follows the 2.x line and builds on the default rule set using a profile tuned for
+  Compose/Desktop work: 120-char lines, a looser return-count/complexity envelope, and
+  Compose-friendly naming exceptions.
 - Compose-bearing modules also load the upstream Compose Rules Detekt plugin. We keep its defaults
   unless the repo develops a clear recurring need for local overrides.
 - Generated and `build/` outputs are excluded from both Detekt and ktfmt tasks.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -56,6 +56,8 @@ Some concerns still need live manual verification even with good automated tests
 - popup discovery across different layer modes
 - Robot focus behaviour and click targeting
 - recording permission and capture behaviour on macOS
+- AWT/Compose Desktop painting and `Robot` capture when the test JVM runs under a macOS
+  `sandbox-exec` profile; see [Running on CI](guide/ci.md#macos-sandbox-exec-runners)
 
 Use `sample-desktop` to make those checks reproducible. If a manual validation step is required
 for a change, note it explicitly in the final report.

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -45,6 +45,93 @@ Synthetic typing posts key events into the window hierarchy and does not require
 the foreground Dock application. Clipboard-backed `pasteText(...)` still needs
 `apple.awt.UIElement=false`, because that path goes through macOS clipboard services.
 
+## macOS `sandbox-exec` runners
+
+If your local agent, test harness, or CI wrapper launches Gradle inside a macOS
+`sandbox-exec` profile, the sandbox must allow the desktop services used by AWT,
+Swing, Compose Desktop, and `java.awt.Robot`. This is separate from JVM headless
+mode: `-Djava.awt.headless=false` is still required, but it does not grant access
+to the WindowServer, Core Animation, input, or screen-capture services.
+
+A working profile needs Mach lookup access to these services:
+
+| Service                            | Why Spectre/Compose Desktop needs it                                                                                                                                      |
+|------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `com.apple.hiservices-xpcservice`  | AWT/Compose Desktop startup. Missing access commonly logs `Connection Invalid error for service com.apple.hiservices-xpcservice`.                                         |
+| `com.apple.windowserver.active`    | WindowServer integration for desktop windows.                                                                                                                             |
+| `com.apple.windowmanager.server`   | Window-manager transactions. Without it, AppKit can log `WMClientWindowManager: Invalid connection` and `SLSTransaction commit with no context`.                          |
+| `com.apple.CARenderServer`         | Actual Core Animation painting. Without it, `Frame.isVisible()`/`Frame.isShowing()` can both be `true` while no window appears on screen.                                 |
+| `com.apple.tsm.uiserver`           | Text Services Manager and input plumbing.                                                                                                                                 |
+| `com.apple.carboncore.csnameddata` | Carbon named data lookup used by the desktop stack.                                                                                                                       |
+| `com.apple.dock.server`            | Dock/window integration.                                                                                                                                                  |
+| `com.apple.dock.fullscreen`        | Full-screen/Dock integration used by AppKit.                                                                                                                              |
+| `com.apple.iohideventsystem`       | Real `Robot` input paths. Synthetic Spectre input does not need OS-level input delivery, but real `RobotDriver()` does.                                                   |
+| `com.apple.tccd.system`            | TCC checks, including screen-capture and accessibility-style checks.                                                                                                      |
+| `com.apple.replayd`                | `Robot.createScreenCapture(...)`, ScreenCaptureKit, and ReplayKit capture plumbing. Without it, a capture can hang after the `Robot` is created.                          |
+| `com.apple.logd.events`            | Log/event integration observed on the Robot/capture path. Treat `com.apple.diagnosticd` as noisy rather than a baseline requirement unless your harness proves otherwise. |
+
+Think of the requirements in layers:
+
+- **Window creation** needs HiServices, WindowServer/window-manager, Text Services,
+  Carbon named data, and Dock integration.
+- **Actual painting** needs `com.apple.CARenderServer`. Java visibility state is not
+  proof that macOS has painted the window.
+- **Real `Robot` input and screen capture** need the input/TCC/capture services,
+  especially `com.apple.iohideventsystem`, `com.apple.tccd.system`, and
+  `com.apple.replayd`.
+- **Synthetic Spectre input** avoids OS-level mouse/keyboard delivery, but the JVM
+  still needs enough AWT/Compose Desktop access to create and paint the target
+  window. Screenshots and `waitForVisualIdle()` still go through capture paths.
+
+macOS Screen Recording permission is also required for capture. Grant it to the
+app that launched the JVM — Terminal.app, iTerm2, IntelliJ IDEA, or your runner app —
+then fully quit and restart that app. TCC can be granted correctly and capture can
+still hang if the sandbox profile does not allow `com.apple.replayd`.
+
+When validating sandbox profile changes, avoid stale Gradle daemons:
+
+```shell
+./gradlew --no-daemon spectreTest --tests '*SpectreSmokeTest'
+```
+
+A normal `./gradlew spectreTest ...` may reuse a daemon launched under an older
+sandbox profile. Use `./gradlew --stop` only deliberately: if your desktop app or
+runner itself was launched via Gradle, stopping all Gradle daemons can kill that
+parent process too.
+
+For painting/capture debugging, a useful probe is a small always-on-top Swing frame
+filled with a known colour, placed at a known location, followed by
+`Robot.createScreenCapture(Rectangle(x, y, 1, 1))`. If `Frame.isVisible()` and
+`Frame.isShowing()` are `true` but the sampled pixel is the desktop background,
+look at `com.apple.CARenderServer` and `com.apple.windowmanager.server`. If the
+capture hangs after creating the `Robot`, look at Screen Recording permission and
+`com.apple.replayd`.
+
+The macOS `log` tool cannot run inside `sandbox-exec`:
+
+```text
+log: Cannot run while sandboxed
+```
+
+If your runner enforces `sandbox-exec`, provide a narrow diagnostic lane outside the
+sandbox for read-only commands such as `log show ...`, `/usr/bin/log show ...`,
+`log stream ...`, and `/usr/bin/log stream ...`. Keep it read-only: reject shell
+metacharacters and mutating subcommands such as `log collect` and `log erase`. If
+your policy logger supports reason codes, label this escape clearly, e.g.,
+`macos-log-diagnostic-lane`.
+
+Useful diagnostics:
+
+```shell
+/usr/bin/log show --last 3m --style compact --predicate 'process == "java" OR eventMessage CONTAINS "Sandbox:" OR eventMessage CONTAINS "ClientCallsAuxiliary" OR eventMessage CONTAINS "deny"'
+/usr/bin/log show --last 2m --style compact --predicate 'processID == <PID> OR eventMessage CONTAINS "<PID>"'
+```
+
+Useful patterns to search for include `Sandbox: java(...) deny(1) mach-lookup`,
+`Service "com.apple.CARenderServer" failed bootstrap look up`,
+`WMClientWindowManager: Invalid connection`, `ScreenCaptureKit`, `ReplayKit`,
+`com.apple.replayd`, and `kTCCServiceScreenCapture`.
+
 ## Recording tests
 
 Keep recording tests tagged separately from normal UI tests. Linux CI can validate Xorg / `xvfb`

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -204,6 +204,40 @@ ls "$XDG_RUNTIME_DIR" | grep wayland   # should be empty
 
 See [Recording limitations](../RECORDING-LIMITATIONS.md) for the full Wayland story.
 
+## "macOS `sandbox-exec` blocks my Compose Desktop/Spectre test"
+
+A macOS process sandbox can block AWT, Swing, Compose Desktop, and `java.awt.Robot`
+even when the JVM is not headless. If your Gradle test runs inside `sandbox-exec`,
+the sandbox profile must allow the desktop Mach services documented in
+[Running on CI](ci.md#macos-sandbox-exec-runners).
+
+| Symptom                                                                      | Likely cause                                                 | What to check                                                                                                       |
+|------------------------------------------------------------------------------|--------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
+| `Connection Invalid error for service com.apple.hiservices-xpcservice`       | Missing HiServices lookup                                    | Allow `com.apple.hiservices-xpcservice`.                                                                            |
+| `Frame.isVisible()`/`Frame.isShowing()` are `true`, but no window appears    | Missing render/window-manager services                       | Allow `com.apple.CARenderServer` and `com.apple.windowmanager.server`; also verify `com.apple.windowserver.active`. |
+| Pixel probes sample the desktop background instead of the test window colour | The window exists in Java state but macOS is not painting it | Check `com.apple.CARenderServer` first, then window-manager logs.                                                   |
+| `Robot.createScreenCapture(...)` hangs after the `Robot` is created          | Missing capture service or TCC grant                         | Grant Screen Recording to the launching app, restart that app, and allow `com.apple.replayd`.                       |
+| `log: Cannot run while sandboxed`                                            | `/usr/bin/log` is itself blocked by `sandbox-exec`           | Use a narrow read-only macOS log diagnostic lane outside the sandbox.                                               |
+| Spectre times out waiting for/capturing a window                             | Stale Gradle daemon or missing UI Mach services              | Re-run with `./gradlew --no-daemon spectreTest --tests '*SpectreSmokeTest'` and inspect sandbox denies.             |
+
+Screen Recording belongs to the app that launched the JVM, not to `java` itself.
+If you grant permission to Terminal.app, iTerm2, IntelliJ IDEA, or another launcher,
+fully quit and restart that app before retrying. TCC permission alone is not enough
+inside a sandbox: `Robot` capture can still hang until `com.apple.replayd` is
+allowed.
+
+For missing-service diagnosis, inspect recent macOS logs from outside the sandbox:
+
+```shell
+/usr/bin/log show --last 3m --style compact --predicate 'process == "java" OR eventMessage CONTAINS "Sandbox:" OR eventMessage CONTAINS "ClientCallsAuxiliary" OR eventMessage CONTAINS "deny"'
+/usr/bin/log show --last 2m --style compact --predicate 'processID == <PID> OR eventMessage CONTAINS "<PID>"'
+```
+
+Look for patterns such as `Sandbox: java(...) deny(1) mach-lookup`,
+`Service "com.apple.CARenderServer" failed bootstrap look up`,
+`WMClientWindowManager: Invalid connection`, `ScreenCaptureKit`, `ReplayKit`,
+`com.apple.replayd`, and `kTCCServiceScreenCapture`.
+
 ## "macOS recording errors out or produces no file"
 
 - **Screen Recording permission.** macOS gates screen capture behind an explicit

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -97,7 +97,9 @@ val buildScreenCaptureKitHelper by
         group = "build"
         onlyIf { OperatingSystem.current().isMacOsX }
         workingDir = swiftHelperSource.asFile
-        commandLine("swift", "build", "-c", "release")
+        // --disable-sandbox prevents SwiftPM's internal `sandbox-exec` manifest compilation
+        // from failing when the host process runs inside a macOS seatbelt sandbox.
+        commandLine("swift", "build", "-c", "release", "--disable-sandbox")
         inputs.dir(swiftHelperSource.dir("Sources"))
         inputs.file(swiftHelperSource.file("Package.swift"))
         outputs.file(swiftHelperBinary)
@@ -136,7 +138,7 @@ val perArchSwiftBuildTasks = universalArchitectures.map { arch ->
         group = "build"
         onlyIf { OperatingSystem.current().isMacOsX }
         workingDir = swiftHelperSource.asFile
-        commandLine("swift", "build", "-c", "release", "--triple", triple)
+        commandLine("swift", "build", "-c", "release", "--disable-sandbox", "--triple", triple)
         inputs.dir(swiftHelperSource.dir("Sources"))
         inputs.file(swiftHelperSource.file("Package.swift"))
         outputs.file(perArchOutput)

--- a/recording/native/macos/Package.swift
+++ b/recording/native/macos/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 import PackageDescription
 
 // Out-of-process helper that Spectre forks per recording. The JVM side
@@ -16,17 +16,20 @@ let package = Package(
     targets: [
         .target(
             name: "SpectreScreenCaptureCore",
-            path: "Sources/SpectreScreenCaptureCore"
+            path: "Sources/SpectreScreenCaptureCore",
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .executableTarget(
             name: "SpectreScreenCapture",
             dependencies: ["SpectreScreenCaptureCore"],
-            path: "Sources/SpectreScreenCapture"
+            path: "Sources/SpectreScreenCapture",
+            swiftSettings: [.swiftLanguageMode(.v5)]
         ),
         .testTarget(
             name: "SpectreScreenCaptureCoreTests",
             dependencies: ["SpectreScreenCaptureCore"],
-            path: "Tests/SpectreScreenCaptureCoreTests"
+            path: "Tests/SpectreScreenCaptureCoreTests",
+            swiftSettings: [.swiftLanguageMode(.v5)]
         )
     ]
 )

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
@@ -13,19 +13,44 @@ import java.nio.file.attribute.PosixFilePermissions
  * The Gradle `assembleScreenCaptureKitHelper` task stages the binary at
  * `native/macos/spectre-screencapture` inside the jar — this class is the corresponding read side.
  * Lifecycle:
- * 1. First [extract] call opens the resource, copies it to [targetDirProvider]'s temp dir, and
- *    chmods it executable.
- * 2. Subsequent calls return the cached path without re-extracting (the in-memory cache is
+ * 1. First [extract] call checks for the [OVERRIDE_ENV] env var and returns that path directly if
+ *    set (dev-iteration escape hatch, skips JAR extraction).
+ * 2. Otherwise it opens the classpath resource, copies it to [HELPER_DIR_PROPERTY] (if set) or
+ *    [targetDirProvider]'s directory, and chmods it executable.
+ * 3. Subsequent calls return the cached path without re-extracting (the in-memory cache is
  *    per-instance; create one extractor per recorder process and reuse).
- * 3. Caller is responsible for the lifetime of the temp file. Defaults stash it under
- *    `java.io.tmpdir/spectre-screencapture-<random>/` so a JVM exit cleans it up eventually but
- *    doesn't pin live recording.
+ * 4. Caller is responsible for the lifetime of the file. When [HELPER_DIR_PROPERTY] is not set the
+ *    default stashes it under `java.io.tmpdir/spectre-screencapture-<random>/` so a JVM exit cleans
+ *    it up eventually but doesn't pin live recording.
  *
- * Both seams (resource locator + target dir) are injectable so unit tests can drive the extractor
- * with arbitrary bytes against arbitrary directories without touching the production classpath /
- * temp dir.
+ * All four seams (env lookup, system-property lookup, resource locator, target dir) are injectable
+ * so unit tests can drive the extractor with arbitrary bytes against arbitrary directories without
+ * touching env / system properties / classpath / temp dir.
+ *
+ * ## macOS TCC and stable extraction paths
+ *
+ * On macOS, `AVAssetWriter.startWriting()` requires Screen Recording permission (System Settings →
+ * Privacy & Security → Screen & System Audio Recording). macOS identifies unsigned or ad-hoc-signed
+ * binaries by their path on disk, so the permission grant is lost every time the binary lands in a
+ * new random temp directory.
+ *
+ * To allow a persistent TCC grant, set [HELPER_DIR_PROPERTY] to a stable directory before the test
+ * JVM starts. From Gradle:
+ * ```kotlin
+ * systemProperty(
+ *     "spectre.recording.screencapturekit.helperDir",
+ *     layout.buildDirectory.dir("spectre-helper").get().asFile.absolutePath,
+ * )
+ * ```
+ *
+ * Then grant Screen Recording to `<helperDir>/spectre-screencapture` once in System Settings. The
+ * binary is re-extracted to the same path on every subsequent run, so TCC continues to recognise
+ * it. A `./gradlew clean` removes the file, but the TCC grant survives and takes effect again the
+ * next time the binary is extracted to the same path.
  */
 internal class HelperBinaryExtractor(
+    private val envLookup: (String) -> String? = System::getenv,
+    private val sysPropLookup: (String) -> String? = System::getProperty,
     private val resourceLocator: () -> InputStream? = ::defaultClasspathLookup,
     private val targetDirProvider: () -> Path = ::defaultTargetDir,
 ) {
@@ -36,6 +61,23 @@ internal class HelperBinaryExtractor(
         cached?.let {
             return it
         }
+
+        // Env var override: use a pre-existing binary at the given path directly, skipping
+        // classpath extraction. Mirrors WaylandHelperBinaryExtractor's SPECTRE_WAYLAND_HELPER
+        // pattern. Developer-only escape hatch for iterating on the Swift helper without
+        // rebuilding the JAR. Never set this in environments that ingest untrusted input.
+        envLookup(OVERRIDE_ENV)
+            ?.takeIf { it.isNotBlank() }
+            ?.let { override ->
+                val path = Path.of(override)
+                check(Files.isExecutable(path)) {
+                    "$OVERRIDE_ENV points at '$path' but it is not an executable file. " +
+                        "Fix the env var or unset it to use the bundled helper."
+                }
+                cached = path
+                return path
+            }
+
         val source =
             resourceLocator()
                 ?: throw HelperNotBundledException(
@@ -44,7 +86,14 @@ internal class HelperBinaryExtractor(
                         "via the assembleScreenCaptureKitHelper task — verify the module was " +
                         "built on macOS with the Swift toolchain available."
                 )
-        val target = targetDirProvider().resolve(BINARY_NAME)
+        // Stable-dir system property: extract to a caller-controlled directory instead of a
+        // fresh temp dir. When set the binary lands at the same path on every JVM launch, so
+        // macOS TCC can persistently identify it. Without it the default produces a new random
+        // temp dir each run and TCC grants evaporate. See class-level KDoc for setup details.
+        val dir =
+            sysPropLookup(HELPER_DIR_PROPERTY)?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
+                ?: targetDirProvider()
+        val target = dir.resolve(BINARY_NAME)
         Files.createDirectories(target.parent)
         source.use { stream -> Files.copy(stream, target, StandardCopyOption.REPLACE_EXISTING) }
         markExecutable(target)
@@ -72,6 +121,23 @@ internal class HelperBinaryExtractor(
     private companion object {
         const val BINARY_NAME: String = "spectre-screencapture"
         const val RESOURCE_PATH: String = "native/macos/$BINARY_NAME"
+
+        /**
+         * Environment variable that, when set, points the extractor at a pre-existing
+         * `spectre-screencapture` binary and skips classpath extraction entirely. Mirrors
+         * [dev.sebastiano.spectre.recording.portal.WaylandHelperBinaryExtractor]'s
+         * `SPECTRE_WAYLAND_HELPER` escape hatch. Developer-only; do not use in production recording
+         * pipelines or environments that ingest untrusted input.
+         */
+        const val OVERRIDE_ENV: String = "SPECTRE_SCREENCAPTURE_HELPER"
+
+        /**
+         * JVM system property that pins the extraction directory to a stable, persistent path
+         * instead of the default random temp directory. Required for macOS TCC Screen Recording
+         * grants to survive across JVM launches — see the class-level KDoc for the full rationale
+         * and Gradle wiring instructions.
+         */
+        const val HELPER_DIR_PROPERTY: String = "spectre.recording.screencapturekit.helperDir"
 
         @JvmStatic
         fun defaultClasspathLookup(): InputStream? =

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
@@ -36,6 +36,7 @@ class HelperBinaryExtractorTest {
             byteArrayOf(0x7F, 0x45, 0x4C, 0x46, 0x02, 0x01, 0x01, 0x00) // ELF header bytes
         val extractor =
             HelperBinaryExtractor(
+                envLookup = { null },
                 resourceLocator = { ByteArrayInputStream(payload) },
                 targetDirProvider = { tempRoot },
             )
@@ -54,6 +55,7 @@ class HelperBinaryExtractorTest {
         var locatorCalls = 0
         val extractor =
             HelperBinaryExtractor(
+                envLookup = { null },
                 resourceLocator = {
                     locatorCalls += 1
                     ByteArrayInputStream(byteArrayOf(0x01, 0x02, 0x03))
@@ -71,7 +73,11 @@ class HelperBinaryExtractorTest {
     @Test
     fun `extract throws a meaningful error when the resource is missing`() {
         val extractor =
-            HelperBinaryExtractor(resourceLocator = { null }, targetDirProvider = { tempRoot })
+            HelperBinaryExtractor(
+                envLookup = { null },
+                resourceLocator = { null },
+                targetDirProvider = { tempRoot },
+            )
 
         val ex = assertFailsWith<IllegalStateException> { extractor.extract() }
         assertNotNull(ex.message)
@@ -90,7 +96,8 @@ class HelperBinaryExtractorTest {
         val isMacOs = System.getProperty("os.name").lowercase().contains("mac")
         if (!isMacOs) return
 
-        val extractor = HelperBinaryExtractor(targetDirProvider = { tempRoot })
+        val extractor =
+            HelperBinaryExtractor(envLookup = { null }, targetDirProvider = { tempRoot })
         val path = extractor.extract()
         assertTrue(path.exists())
         assertTrue(Files.isExecutable(path))

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
@@ -4,6 +4,7 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
 import kotlin.io.path.deleteRecursively
 import kotlin.io.path.exists
 import kotlin.io.path.readBytes
@@ -14,6 +15,10 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
+private const val BINARY_NAME: String = "spectre-screencapture"
+private const val OVERRIDE_ENV: String = "SPECTRE_SCREENCAPTURE_HELPER"
+private const val HELPER_DIR_PROPERTY: String = "spectre.recording.screencapturekit.helperDir"
+
 @OptIn(kotlin.io.path.ExperimentalPathApi::class)
 class HelperBinaryExtractorTest {
 
@@ -23,6 +28,8 @@ class HelperBinaryExtractorTest {
     fun tearDown() {
         if (tempRoot.exists()) tempRoot.deleteRecursively()
     }
+
+    // ── baseline extraction ──────────────────────────────────────────────────
 
     @Test
     fun `extract writes the resource bytes to disk and marks the file executable`() {
@@ -89,6 +96,182 @@ class HelperBinaryExtractorTest {
         assertTrue(path.exists())
         assertTrue(Files.isExecutable(path))
         assertTrue(Files.size(path) > 0, "Bundled helper must not be a zero-byte file")
+    }
+
+    // ── SPECTRE_SCREENCAPTURE_HELPER env-var override ────────────────────────
+
+    @Test
+    fun `env-var override returns the target path without extracting from the classpath`() {
+        val fakeHelper = tempRoot.resolve("pre-extracted-spectre-screencapture")
+        fakeHelper.toFile().writeBytes(byteArrayOf(0x01, 0x02))
+        Files.setPosixFilePermissions(fakeHelper, PosixFilePermissions.fromString("rwxr-xr-x"))
+
+        var locatorCalled = false
+        val extractor =
+            HelperBinaryExtractor(
+                envLookup = { key -> if (key == OVERRIDE_ENV) fakeHelper.toString() else null },
+                resourceLocator = {
+                    locatorCalled = true
+                    ByteArrayInputStream(byteArrayOf())
+                },
+                targetDirProvider = { tempRoot.resolve("should-not-be-used") },
+            )
+
+        val path = extractor.extract()
+
+        assertEquals(fakeHelper, path, "Env-var override must return the pointed-to path")
+        assertTrue(!locatorCalled, "Classpath resource must not be opened when env-var is set")
+    }
+
+    @Test
+    fun `env-var override is cached — subsequent calls return the same path`() {
+        val fakeHelper = tempRoot.resolve("pre-extracted-spectre-screencapture")
+        fakeHelper.toFile().writeBytes(byteArrayOf(0x01))
+        Files.setPosixFilePermissions(fakeHelper, PosixFilePermissions.fromString("rwxr-xr-x"))
+
+        val extractor =
+            HelperBinaryExtractor(
+                envLookup = { key -> if (key == OVERRIDE_ENV) fakeHelper.toString() else null }
+            )
+
+        val first = extractor.extract()
+        val second = extractor.extract()
+        assertEquals(first, second, "Cached override path must be returned on repeat calls")
+    }
+
+    @Test
+    fun `env-var override with non-executable path throws a clear error`() {
+        val notExecutable = tempRoot.resolve("not-executable")
+        notExecutable.toFile().writeBytes(byteArrayOf(0x01))
+        Files.setPosixFilePermissions(notExecutable, PosixFilePermissions.fromString("rw-r--r--"))
+
+        val extractor =
+            HelperBinaryExtractor(
+                envLookup = { key -> if (key == OVERRIDE_ENV) notExecutable.toString() else null }
+            )
+
+        val ex = assertFailsWith<IllegalStateException> { extractor.extract() }
+        assertNotNull(ex.message)
+        assertTrue(
+            ex.message!!.contains(OVERRIDE_ENV),
+            "Error must name the env var so the user knows which setting to fix; got: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `blank env-var value falls through to normal extraction`() {
+        val payload = byteArrayOf(0x7F, 0x01)
+        var locatorCalled = false
+        val extractor =
+            HelperBinaryExtractor(
+                envLookup = { key -> if (key == OVERRIDE_ENV) "   " else null },
+                resourceLocator = {
+                    locatorCalled = true
+                    ByteArrayInputStream(payload)
+                },
+                targetDirProvider = { tempRoot },
+            )
+
+        extractor.extract()
+
+        assertTrue(locatorCalled, "Blank env-var value must not suppress normal extraction")
+    }
+
+    // ── spectre.recording.screencapturekit.helperDir system property ─────────
+
+    @Test
+    fun `helperDir system property extracts binary into the given directory`() {
+        val stableDir = tempRoot.resolve("stable")
+        val payload = byteArrayOf(0x7F, 0x45, 0x4C, 0x46)
+
+        var targetDirCalled = false
+        val extractor =
+            HelperBinaryExtractor(
+                sysPropLookup = { key ->
+                    if (key == HELPER_DIR_PROPERTY) stableDir.toString() else null
+                },
+                resourceLocator = { ByteArrayInputStream(payload) },
+                targetDirProvider = {
+                    targetDirCalled = true
+                    tempRoot.resolve("default-temp")
+                },
+            )
+
+        val path = extractor.extract()
+
+        assertEquals(
+            stableDir.resolve(BINARY_NAME),
+            path,
+            "Binary must land inside the directory specified by the system property",
+        )
+        assertContentEquals(payload, path.readBytes())
+        assertTrue(Files.isExecutable(path))
+        assertTrue(
+            !targetDirCalled,
+            "Default targetDirProvider must not be called when the system property is set",
+        )
+    }
+
+    @Test
+    fun `helperDir system property creates the directory if it does not exist`() {
+        val nonExistentDir = tempRoot.resolve("a").resolve("b").resolve("c")
+        val extractor =
+            HelperBinaryExtractor(
+                sysPropLookup = { key ->
+                    if (key == HELPER_DIR_PROPERTY) nonExistentDir.toString() else null
+                },
+                resourceLocator = { ByteArrayInputStream(byteArrayOf(0x01)) },
+            )
+
+        val path = extractor.extract()
+
+        assertTrue(path.exists(), "Extracted binary must exist even when the dir was created")
+    }
+
+    @Test
+    fun `blank helperDir system property falls through to targetDirProvider`() {
+        var targetDirCalled = false
+        val extractor =
+            HelperBinaryExtractor(
+                sysPropLookup = { key -> if (key == HELPER_DIR_PROPERTY) "  " else null },
+                resourceLocator = { ByteArrayInputStream(byteArrayOf(0x01)) },
+                targetDirProvider = {
+                    targetDirCalled = true
+                    tempRoot
+                },
+            )
+
+        extractor.extract()
+
+        assertTrue(
+            targetDirCalled,
+            "Blank helperDir system property must fall through to targetDirProvider",
+        )
+    }
+
+    @Test
+    fun `env-var override takes priority over helperDir system property`() {
+        val fakeHelper = tempRoot.resolve("env-override-binary")
+        fakeHelper.toFile().writeBytes(byteArrayOf(0x01))
+        Files.setPosixFilePermissions(fakeHelper, PosixFilePermissions.fromString("rwxr-xr-x"))
+
+        var locatorCalled = false
+        val extractor =
+            HelperBinaryExtractor(
+                envLookup = { key -> if (key == OVERRIDE_ENV) fakeHelper.toString() else null },
+                sysPropLookup = { key ->
+                    if (key == HELPER_DIR_PROPERTY) tempRoot.resolve("stable").toString() else null
+                },
+                resourceLocator = {
+                    locatorCalled = true
+                    ByteArrayInputStream(byteArrayOf())
+                },
+            )
+
+        val path = extractor.extract()
+
+        assertEquals(fakeHelper, path, "Env-var override must win over helperDir property")
+        assertTrue(!locatorCalled, "Classpath resource must not be read when env-var wins")
     }
 }
 

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
@@ -4,7 +4,6 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.attribute.PosixFilePermissions
 import kotlin.io.path.deleteRecursively
 import kotlin.io.path.exists
 import kotlin.io.path.readBytes
@@ -102,9 +101,7 @@ class HelperBinaryExtractorTest {
 
     @Test
     fun `env-var override returns the target path without extracting from the classpath`() {
-        val fakeHelper = tempRoot.resolve("pre-extracted-spectre-screencapture")
-        fakeHelper.toFile().writeBytes(byteArrayOf(0x01, 0x02))
-        Files.setPosixFilePermissions(fakeHelper, PosixFilePermissions.fromString("rwxr-xr-x"))
+        val fakeHelper = createExecutableHelper("pre-extracted-spectre-screencapture", 0x01, 0x02)
 
         var locatorCalled = false
         val extractor =
@@ -125,9 +122,7 @@ class HelperBinaryExtractorTest {
 
     @Test
     fun `env-var override is cached — subsequent calls return the same path`() {
-        val fakeHelper = tempRoot.resolve("pre-extracted-spectre-screencapture")
-        fakeHelper.toFile().writeBytes(byteArrayOf(0x01))
-        Files.setPosixFilePermissions(fakeHelper, PosixFilePermissions.fromString("rwxr-xr-x"))
+        val fakeHelper = createExecutableHelper("pre-extracted-spectre-screencapture", 0x01)
 
         val extractor =
             HelperBinaryExtractor(
@@ -140,14 +135,12 @@ class HelperBinaryExtractorTest {
     }
 
     @Test
-    fun `env-var override with non-executable path throws a clear error`() {
-        val notExecutable = tempRoot.resolve("not-executable")
-        notExecutable.toFile().writeBytes(byteArrayOf(0x01))
-        Files.setPosixFilePermissions(notExecutable, PosixFilePermissions.fromString("rw-r--r--"))
+    fun `env-var override with unusable path throws a clear error`() {
+        val unusablePath = tempRoot.resolve("missing-helper")
 
         val extractor =
             HelperBinaryExtractor(
-                envLookup = { key -> if (key == OVERRIDE_ENV) notExecutable.toString() else null }
+                envLookup = { key -> if (key == OVERRIDE_ENV) unusablePath.toString() else null }
             )
 
         val ex = assertFailsWith<IllegalStateException> { extractor.extract() }
@@ -251,9 +244,7 @@ class HelperBinaryExtractorTest {
 
     @Test
     fun `env-var override takes priority over helperDir system property`() {
-        val fakeHelper = tempRoot.resolve("env-override-binary")
-        fakeHelper.toFile().writeBytes(byteArrayOf(0x01))
-        Files.setPosixFilePermissions(fakeHelper, PosixFilePermissions.fromString("rwxr-xr-x"))
+        val fakeHelper = createExecutableHelper("env-override-binary", 0x01)
 
         var locatorCalled = false
         val extractor =
@@ -272,6 +263,18 @@ class HelperBinaryExtractorTest {
 
         assertEquals(fakeHelper, path, "Env-var override must win over helperDir property")
         assertTrue(!locatorCalled, "Classpath resource must not be read when env-var wins")
+    }
+
+    private fun createExecutableHelper(name: String, vararg bytes: Int): Path {
+        val path = tempRoot.resolve(name)
+        path.toFile().writeBytes(bytes.map { it.toByte() }.toByteArray())
+        check(path.toFile().setExecutable(true, false)) {
+            "Test setup could not mark $path executable"
+        }
+        check(Files.isExecutable(path)) {
+            "Test setup produced a helper that is not executable: $path"
+        }
+        return path
     }
 }
 


### PR DESCRIPTION
## Summary

- extract the ScreenCaptureKit helper to a stable caller-controlled directory and add a dev override env var
- make SwiftPM helper builds work under nested macOS sandboxes and Xcode 26 / Swift 6.3.2
- keep helper extractor internals private/Wayland-consistent and make tests portable across Windows filesystems
- document macOS sandbox-exec requirements for desktop/Robot/capture tests

## Validation

- `recording/native/macos`: `swift test --disable-sandbox`
- `./gradlew :recording:ktfmtCheck :recording:test --tests "dev.sebastiano.spectre.recording.screencapturekit.HelperBinaryExtractorTest" -PstubMacHelperForTesting`
- attempted `./gradlew check`: blocked locally while extracting the IntelliJ Platform DMG via `hdiutil` in this sandboxed environment

Known separate issue: full `:recording:check -PstubMacHelperForTesting` currently fails `ScreenCaptureKitHelperContractTest` because the stub Mach-O fixture is not the real Swift CLI; handoff is in `.plans/sck-helper-contract-stub-failure-handoff.md`.
