### PR TITLE
Use stable native helper extraction paths

### DIFF
--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -330,12 +330,13 @@ Spectre extracts the ScreenCaptureKit helper from `spectre-recording-macos` befo
 it. By default, it uses a stable per-user path:
 
 ```text
-~/Library/Application Support/spectre/helpers/spectre-screencapture/spectre-screencapture
+~/Library/Application Support/spectre/helpers/spectre-screencapture/<helper-hash>/spectre-screencapture
 ```
 
-Grant Screen Recording to that helper once in System Settings. The helper name appears twice
-because Spectre keeps each native helper in its own subdirectory. Later runs re-extract the helper
-to the same path, so macOS continues to recognise it.
+Grant Screen Recording to that helper once in System Settings. Spectre includes a short helper
+content hash in the path, so native-helper fixes in future Spectre versions get a fresh extracted
+binary instead of silently reusing stale bytes. Later runs of the same helper binary re-extract to
+the same path, so macOS continues to recognise it.
 
 If you prefer a project-specific helper location, set the extraction directory before the test JVM
 starts:

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -326,6 +326,31 @@ run again". See
 [Troubleshooting](troubleshooting.md#macos-recording-errors-out-or-produces-no-file)
 for failure modes when permission is missing or attached to the wrong binary.
 
+Spectre extracts the ScreenCaptureKit helper from `spectre-recording-macos` before running
+it. By default, it uses a stable per-user path:
+
+```text
+~/Library/Application Support/spectre/helpers/spectre-screencapture/spectre-screencapture
+```
+
+Grant Screen Recording to that helper once in System Settings. The helper name appears twice
+because Spectre keeps each native helper in its own subdirectory. Later runs re-extract the helper
+to the same path, so macOS continues to recognise it.
+
+If you prefer a project-specific helper location, set the extraction directory before the test JVM
+starts:
+
+```kotlin
+systemProperty(
+    "spectre.recording.screencapturekit.helperDir",
+    layout.buildDirectory.dir("spectre-helper").get().asFile.absolutePath,
+)
+```
+
+Then grant Screen Recording to `<helperDir>/spectre-screencapture` instead. If `./gradlew clean`
+removes that file, the TCC grant still applies the next time Spectre extracts the helper to the
+same path.
+
 `apple.awt.UIElement=true` helper/test JVMs are useful with `RobotDriver.synthetic(...)`
 for focus-safe per-character `typeText`, but clipboard-backed `pasteText` and recording
 still go through macOS services outside Spectre's synthetic key path. Prefer a normal
@@ -334,6 +359,10 @@ Recording TCC grants. See [Running on CI](ci.md#macos-helper-jvms) for the CI-si
 trade-offs.
 
 ### Other platforms
+
+Spectre extracts bundled native helpers to stable per-user directories on every platform:
+`~/Library/Application Support/spectre/helpers` on macOS, `%LOCALAPPDATA%\\spectre\\helpers`
+on Windows, and `$XDG_CACHE_HOME/spectre/helpers` or `~/.cache/spectre/helpers` on Linux.
 
 - **Windows** — add `dev.sebastiano.spectre:spectre-recording-windows:<version>` as a
   runtime-only dependency for native window recording, region/fullscreen recording, and

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/HelperExtractionPaths.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/HelperExtractionPaths.kt
@@ -1,0 +1,35 @@
+package dev.sebastiano.spectre.recording
+
+import java.nio.file.Path
+
+internal object HelperExtractionPaths {
+    fun defaultHelperDir(
+        helperName: String,
+        osName: String = System.getProperty("os.name").orEmpty(),
+        userHome: String = System.getProperty("user.home").orEmpty(),
+        getenv: (String) -> String? = System::getenv,
+    ): Path =
+        stableBaseDir(osName = osName, userHome = userHome, getenv = getenv).resolve(helperName)
+
+    private fun stableBaseDir(osName: String, userHome: String, getenv: (String) -> String?): Path {
+        val normalizedOs = osName.lowercase()
+        return when {
+            normalizedOs.contains("mac") ->
+                Path.of(userHome, "Library", "Application Support", "spectre", "helpers")
+            normalizedOs.contains("win") -> windowsBaseDir(userHome, getenv)
+            else -> linuxBaseDir(userHome, getenv)
+        }
+    }
+
+    private fun windowsBaseDir(userHome: String, getenv: (String) -> String?): Path {
+        val localAppData = getenv("LOCALAPPDATA")?.takeIf { it.isNotBlank() }
+        val base = localAppData?.let { Path.of(it) } ?: Path.of(userHome, "AppData", "Local")
+        return base.resolve("spectre").resolve("helpers")
+    }
+
+    private fun linuxBaseDir(userHome: String, getenv: (String) -> String?): Path {
+        val xdgCacheHome = getenv("XDG_CACHE_HOME")?.takeIf { it.isNotBlank() }
+        val base = xdgCacheHome?.let { Path.of(it) } ?: Path.of(userHome, ".cache")
+        return base.resolve("spectre").resolve("helpers")
+    }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/HelperExtractionPaths.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/HelperExtractionPaths.kt
@@ -4,6 +4,7 @@ import java.nio.channels.FileChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardOpenOption
+import java.security.MessageDigest
 
 internal object HelperExtractionPaths {
     fun defaultHelperDir(
@@ -13,6 +14,15 @@ internal object HelperExtractionPaths {
         getenv: (String) -> String? = System::getenv,
     ): Path =
         stableBaseDir(osName = osName, userHome = userHome, getenv = getenv).resolve(helperName)
+
+    fun helperFingerprint(bytes: ByteArray): String =
+        MessageDigest.getInstance("SHA-256").digest(bytes).joinToString(
+            separator = "",
+            limit = FINGERPRINT_BYTE_COUNT,
+            truncated = "",
+        ) {
+            (it.toInt() and BYTE_MASK).toString(HEX_RADIX).padStart(HEX_BYTE_WIDTH, '0')
+        }
 
     private fun stableBaseDir(osName: String, userHome: String, getenv: (String) -> String?): Path {
         val normalizedOs = osName.lowercase()
@@ -49,4 +59,8 @@ internal object HelperExtractionPaths {
     }
 
     private const val LOCK_FILE_NAME: String = ".extract.lock"
+    private const val FINGERPRINT_BYTE_COUNT: Int = 6
+    private const val BYTE_MASK: Int = 0xff
+    private const val HEX_RADIX: Int = 16
+    private const val HEX_BYTE_WIDTH: Int = 2
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/HelperExtractionPaths.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/HelperExtractionPaths.kt
@@ -1,6 +1,9 @@
 package dev.sebastiano.spectre.recording
 
+import java.nio.channels.FileChannel
+import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardOpenOption
 
 internal object HelperExtractionPaths {
     fun defaultHelperDir(
@@ -27,9 +30,23 @@ internal object HelperExtractionPaths {
         return base.resolve("spectre").resolve("helpers")
     }
 
+    @Synchronized
+    fun <T> withExtractionLock(dir: Path, body: () -> T): T {
+        Files.createDirectories(dir)
+        val lockPath = dir.resolve(LOCK_FILE_NAME)
+        FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE).use {
+            channel ->
+            channel.lock().use {
+                return body()
+            }
+        }
+    }
+
     private fun linuxBaseDir(userHome: String, getenv: (String) -> String?): Path {
         val xdgCacheHome = getenv("XDG_CACHE_HOME")?.takeIf { it.isNotBlank() }
         val base = xdgCacheHome?.let { Path.of(it) } ?: Path.of(userHome, ".cache")
         return base.resolve("spectre").resolve("helpers")
     }
+
+    private const val LOCK_FILE_NAME: String = ".extract.lock"
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
@@ -61,30 +61,33 @@ internal class WaylandHelperBinaryExtractor(
 
         val arch = archProvider()
         val resourcePath = "$RESOURCE_PATH_BASE/$arch/$BINARY_NAME"
-        val target = targetDirProvider().resolve(BINARY_NAME)
+        val helperBytes =
+            resourceLocator(resourcePath)?.use { it.readBytes() }
+                ?: throw HelperNotBundledException(
+                    "Bundled helper binary not found at classpath resource '$resourcePath'. The " +
+                        "recording module's Linux build stages 'spectre-wayland-helper' there via " +
+                        "the assembleWaylandHelper task — verify the module was built on Linux " +
+                        "with the Rust toolchain (cargo) available, or set $OVERRIDE_ENV to a " +
+                        "locally-built binary path for dev iteration."
+                )
+        val target =
+            targetDirProvider()
+                .resolve(HelperExtractionPaths.helperFingerprint(helperBytes))
+                .resolve(BINARY_NAME)
         val extracted =
             HelperExtractionPaths.withExtractionLock(target.parent) {
-                if (Files.exists(target)) {
-                    markExecutable(target)
-                } else {
-                    val source =
-                        resourceLocator(resourcePath)
-                            ?: throw HelperNotBundledException(
-                                "Bundled helper binary not found at classpath resource " +
-                                    "'$resourcePath'. The recording module's Linux build stages " +
-                                    "'spectre-wayland-helper' there via the assembleWaylandHelper " +
-                                    "task — verify the module was built on Linux with the Rust " +
-                                    "toolchain (cargo) available, or set $OVERRIDE_ENV to a " +
-                                    "locally-built binary path for dev iteration."
-                            )
-                    source.use { stream -> Files.copy(stream, target) }
-                    markExecutable(target)
+                if (!Files.exists(target) || !target.readBytesContentEquals(helperBytes)) {
+                    Files.write(target, helperBytes)
                 }
+                markExecutable(target)
                 target
             }
         cached = extracted
         return extracted
     }
+
+    private fun Path.readBytesContentEquals(expected: ByteArray): Boolean =
+        Files.readAllBytes(this).contentEquals(expected)
 
     private fun markExecutable(path: Path) {
         // POSIX path: explicit mode bits so we get rwxr-xr-x rather than relying on the

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.recording.portal
 
+import dev.sebastiano.spectre.recording.HelperExtractionPaths
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
@@ -105,7 +106,7 @@ internal class WaylandHelperBinaryExtractor(
             WaylandHelperBinaryExtractor::class.java.classLoader.getResourceAsStream(resource)
 
         @JvmStatic
-        fun defaultTargetDir(): Path = Files.createTempDirectory("spectre-wayland-helper-")
+        fun defaultTargetDir(): Path = HelperExtractionPaths.defaultHelperDir(BINARY_NAME)
 
         /**
          * Map JVM's `os.arch` to the directory name we ship the helper under. The values mirror

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperBinaryExtractor.kt
@@ -4,7 +4,6 @@ import dev.sebastiano.spectre.recording.HelperExtractionPaths
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.PosixFilePermissions
 
 /**
@@ -62,21 +61,29 @@ internal class WaylandHelperBinaryExtractor(
 
         val arch = archProvider()
         val resourcePath = "$RESOURCE_PATH_BASE/$arch/$BINARY_NAME"
-        val source =
-            resourceLocator(resourcePath)
-                ?: throw HelperNotBundledException(
-                    "Bundled helper binary not found at classpath resource '$resourcePath'. " +
-                        "The recording module's Linux build stages 'spectre-wayland-helper' " +
-                        "there via the assembleWaylandHelper task — verify the module was " +
-                        "built on Linux with the Rust toolchain (cargo) available, or set " +
-                        "$OVERRIDE_ENV to a locally-built binary path for dev iteration."
-                )
         val target = targetDirProvider().resolve(BINARY_NAME)
-        Files.createDirectories(target.parent)
-        source.use { stream -> Files.copy(stream, target, StandardCopyOption.REPLACE_EXISTING) }
-        markExecutable(target)
-        cached = target
-        return target
+        val extracted =
+            HelperExtractionPaths.withExtractionLock(target.parent) {
+                if (Files.exists(target)) {
+                    markExecutable(target)
+                } else {
+                    val source =
+                        resourceLocator(resourcePath)
+                            ?: throw HelperNotBundledException(
+                                "Bundled helper binary not found at classpath resource " +
+                                    "'$resourcePath'. The recording module's Linux build stages " +
+                                    "'spectre-wayland-helper' there via the assembleWaylandHelper " +
+                                    "task — verify the module was built on Linux with the Rust " +
+                                    "toolchain (cargo) available, or set $OVERRIDE_ENV to a " +
+                                    "locally-built binary path for dev iteration."
+                            )
+                    source.use { stream -> Files.copy(stream, target) }
+                    markExecutable(target)
+                }
+                target
+            }
+        cached = extracted
+        return extracted
     }
 
     private fun markExecutable(path: Path) {

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
@@ -69,35 +69,37 @@ internal class HelperBinaryExtractor(
                 return path
             }
 
+        val helperBytes =
+            resourceLocator()?.use { it.readBytes() }
+                ?: throw HelperNotBundledException(
+                    "Bundled helper binary not found at classpath resource '$RESOURCE_PATH'. " +
+                        "The recording module's macOS build stages 'spectre-screencapture' " +
+                        "there via the assembleScreenCaptureKitHelper task — verify the module " +
+                        "was built on macOS with the Swift toolchain available."
+                )
         // Stable-dir system property: extract to a caller-controlled directory instead of the
-        // stable default. In both cases the binary lands at the same path on every JVM launch, so
+        // fingerprinted stable default. In both cases the binary lands at a repeatable path so
         // macOS TCC can persistently identify it. See class-level KDoc for setup details.
-        val dir =
+        val propertyDir =
             sysPropLookup(HELPER_DIR_PROPERTY)?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
-                ?: targetDirProvider()
+        val dir =
+            propertyDir
+                ?: targetDirProvider().resolve(HelperExtractionPaths.helperFingerprint(helperBytes))
         val target = dir.resolve(BINARY_NAME)
         val extracted =
             HelperExtractionPaths.withExtractionLock(target.parent) {
-                if (Files.exists(target)) {
-                    markExecutable(target)
-                } else {
-                    val source =
-                        resourceLocator()
-                            ?: throw HelperNotBundledException(
-                                "Bundled helper binary not found at classpath resource " +
-                                    "'$RESOURCE_PATH'. The recording module's macOS build " +
-                                    "stages 'spectre-screencapture' there via the " +
-                                    "assembleScreenCaptureKitHelper task — verify the module " +
-                                    "was built on macOS with the Swift toolchain available."
-                            )
-                    source.use { stream -> Files.copy(stream, target) }
-                    markExecutable(target)
+                if (!Files.exists(target) || !target.readBytesContentEquals(helperBytes)) {
+                    Files.write(target, helperBytes)
                 }
+                markExecutable(target)
                 target
             }
         cached = extracted
         return extracted
     }
+
+    private fun Path.readBytesContentEquals(expected: ByteArray): Boolean =
+        Files.readAllBytes(this).contentEquals(expected)
 
     private fun markExecutable(path: Path) {
         // POSIX path: explicit mode bits so we get rwxr-xr-x rather than relying on the JVM's

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.recording.screencapturekit
 
+import dev.sebastiano.spectre.recording.HelperExtractionPaths
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
@@ -19,9 +20,8 @@ import java.nio.file.attribute.PosixFilePermissions
  *    [targetDirProvider]'s directory, and chmods it executable.
  * 3. Subsequent calls return the cached path without re-extracting (the in-memory cache is
  *    per-instance; create one extractor per recorder process and reuse).
- * 4. Caller is responsible for the lifetime of the file. When [HELPER_DIR_PROPERTY] is not set the
- *    default stashes it under `java.io.tmpdir/spectre-screencapture-<random>/` so a JVM exit cleans
- *    it up eventually but doesn't pin live recording.
+ * 4. Caller is responsible for the lifetime of the file. By default the helper lands in Spectre's
+ *    stable per-user helper directory so macOS TCC can keep recognising the same executable path.
  *
  * All four seams (env lookup, system-property lookup, resource locator, target dir) are injectable
  * so unit tests can drive the extractor with arbitrary bytes against arbitrary directories without
@@ -34,19 +34,10 @@ import java.nio.file.attribute.PosixFilePermissions
  * binaries by their path on disk, so the permission grant is lost every time the binary lands in a
  * new random temp directory.
  *
- * To allow a persistent TCC grant, set [HELPER_DIR_PROPERTY] to a stable directory before the test
- * JVM starts. From Gradle:
- * ```kotlin
- * systemProperty(
- *     "spectre.recording.screencapturekit.helperDir",
- *     layout.buildDirectory.dir("spectre-helper").get().asFile.absolutePath,
- * )
- * ```
- *
- * Then grant Screen Recording to `<helperDir>/spectre-screencapture` once in System Settings. The
- * binary is re-extracted to the same path on every subsequent run, so TCC continues to recognise
- * it. A `./gradlew clean` removes the file, but the TCC grant survives and takes effect again the
- * next time the binary is extracted to the same path.
+ * The default extraction directory is stable across runs. If you want to control the exact path,
+ * set [HELPER_DIR_PROPERTY] before the test JVM starts. Then grant Screen Recording to
+ * `<helperDir>/spectre-screencapture` once in System Settings. The binary is re-extracted to the
+ * same path on every subsequent run, so TCC continues to recognise it.
  */
 internal class HelperBinaryExtractor(
     private val envLookup: (String) -> String? = System::getenv,
@@ -57,6 +48,7 @@ internal class HelperBinaryExtractor(
 
     private var cached: Path? = null
 
+    @Synchronized
     fun extract(): Path {
         cached?.let {
             return it
@@ -86,10 +78,9 @@ internal class HelperBinaryExtractor(
                         "via the assembleScreenCaptureKitHelper task — verify the module was " +
                         "built on macOS with the Swift toolchain available."
                 )
-        // Stable-dir system property: extract to a caller-controlled directory instead of a
-        // fresh temp dir. When set the binary lands at the same path on every JVM launch, so
-        // macOS TCC can persistently identify it. Without it the default produces a new random
-        // temp dir each run and TCC grants evaporate. See class-level KDoc for setup details.
+        // Stable-dir system property: extract to a caller-controlled directory instead of the
+        // stable default. In both cases the binary lands at the same path on every JVM launch, so
+        // macOS TCC can persistently identify it. See class-level KDoc for setup details.
         val dir =
             sysPropLookup(HELPER_DIR_PROPERTY)?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
                 ?: targetDirProvider()
@@ -132,10 +123,8 @@ internal class HelperBinaryExtractor(
         const val OVERRIDE_ENV: String = "SPECTRE_SCREENCAPTURE_HELPER"
 
         /**
-         * JVM system property that pins the extraction directory to a stable, persistent path
-         * instead of the default random temp directory. Required for macOS TCC Screen Recording
-         * grants to survive across JVM launches — see the class-level KDoc for the full rationale
-         * and Gradle wiring instructions.
+         * JVM system property that overrides the default stable extraction directory. Useful when a
+         * project wants the helper at a repo- or build-specific path for macOS TCC grants.
          */
         const val HELPER_DIR_PROPERTY: String = "spectre.recording.screencapturekit.helperDir"
 
@@ -144,6 +133,6 @@ internal class HelperBinaryExtractor(
             HelperBinaryExtractor::class.java.classLoader.getResourceAsStream(RESOURCE_PATH)
 
         @JvmStatic
-        fun defaultTargetDir(): Path = Files.createTempDirectory("spectre-screencapture-")
+        fun defaultTargetDir(): Path = HelperExtractionPaths.defaultHelperDir(BINARY_NAME)
     }
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
@@ -4,7 +4,6 @@ import dev.sebastiano.spectre.recording.HelperExtractionPaths
 import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
 import java.nio.file.attribute.PosixFilePermissions
 
 /**
@@ -70,14 +69,6 @@ internal class HelperBinaryExtractor(
                 return path
             }
 
-        val source =
-            resourceLocator()
-                ?: throw HelperNotBundledException(
-                    "Bundled helper binary not found at classpath resource '$RESOURCE_PATH'. " +
-                        "The recording module's macOS build stages 'spectre-screencapture' there " +
-                        "via the assembleScreenCaptureKitHelper task — verify the module was " +
-                        "built on macOS with the Swift toolchain available."
-                )
         // Stable-dir system property: extract to a caller-controlled directory instead of the
         // stable default. In both cases the binary lands at the same path on every JVM launch, so
         // macOS TCC can persistently identify it. See class-level KDoc for setup details.
@@ -85,11 +76,27 @@ internal class HelperBinaryExtractor(
             sysPropLookup(HELPER_DIR_PROPERTY)?.takeIf { it.isNotBlank() }?.let { Path.of(it) }
                 ?: targetDirProvider()
         val target = dir.resolve(BINARY_NAME)
-        Files.createDirectories(target.parent)
-        source.use { stream -> Files.copy(stream, target, StandardCopyOption.REPLACE_EXISTING) }
-        markExecutable(target)
-        cached = target
-        return target
+        val extracted =
+            HelperExtractionPaths.withExtractionLock(target.parent) {
+                if (Files.exists(target)) {
+                    markExecutable(target)
+                } else {
+                    val source =
+                        resourceLocator()
+                            ?: throw HelperNotBundledException(
+                                "Bundled helper binary not found at classpath resource " +
+                                    "'$RESOURCE_PATH'. The recording module's macOS build " +
+                                    "stages 'spectre-screencapture' there via the " +
+                                    "assembleScreenCaptureKitHelper task — verify the module " +
+                                    "was built on macOS with the Swift toolchain available."
+                            )
+                    source.use { stream -> Files.copy(stream, target) }
+                    markExecutable(target)
+                }
+                target
+            }
+        cached = extracted
+        return extracted
     }
 
     private fun markExecutable(path: Path) {

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.recording.windows
 
+import dev.sebastiano.spectre.recording.HelperExtractionPaths
 import java.io.InputStream
 import java.net.JarURLConnection
 import java.nio.file.Files
@@ -56,7 +57,8 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
         const val LEGACY_SCREENSHOT_HELPER_ENV: String = "SPECTRE_WINDOWS_SCREENSHOT_HELPER"
 
         @JvmStatic
-        fun defaultTargetDir(): Path = Files.createTempDirectory("spectre-window-capture-")
+        fun defaultTargetDir(): Path =
+            HelperExtractionPaths.defaultHelperDir("spectre-window-capture")
 
         fun resourcePath(osArch: String): String =
             "native/windows/${windowsArch(osArch)}/$BINARY_NAME"

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
@@ -33,22 +33,28 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
             return it
         }
         val target = targetDirProvider().resolve(windowsArch(osArch())).resolve(BINARY_NAME)
-        Files.createDirectories(target.parent)
-        val source = resourceLocator()
-        if (source != null) {
-            source.use { stream -> Files.copy(stream, target, StandardCopyOption.REPLACE_EXISTING) }
-        } else {
-            copyBundledHelperDirectory(target.parent, osArch())
-            if (!Files.exists(target)) {
-                throw WindowsGraphicsCaptureHelperNotBundledException(
-                    "Bundled Windows Graphics Capture helper not found at classpath resource " +
-                        "'${resourcePath(osArch())}'. Add spectre-recording-windows as a " +
-                        "runtime dependency when using native Windows capture."
-                )
+        val extracted =
+            HelperExtractionPaths.withExtractionLock(target.parent) {
+                if (!Files.exists(target)) {
+                    val source = resourceLocator()
+                    if (source != null) {
+                        source.use { stream -> Files.copy(stream, target) }
+                    } else {
+                        copyBundledHelperDirectory(target.parent, osArch())
+                        if (!Files.exists(target)) {
+                            throw WindowsGraphicsCaptureHelperNotBundledException(
+                                "Bundled Windows Graphics Capture helper not found at classpath " +
+                                    "resource '${resourcePath(osArch())}'. Add " +
+                                    "spectre-recording-windows as a runtime dependency when " +
+                                    "using native Windows capture."
+                            )
+                        }
+                    }
+                }
+                target
             }
-        }
-        cached = target
-        return target
+        cached = extracted
+        return extracted
     }
 
     private companion object {

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
@@ -6,7 +6,6 @@ import java.io.InputStream
 import java.net.JarURLConnection
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.StandardCopyOption
 import java.util.jar.JarFile
 
 internal class WindowsGraphicsCaptureHelperBinaryExtractor(
@@ -56,7 +55,7 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
                 if (!Files.exists(target) || !target.readBytesContentEquals(helperBytes)) {
                     Files.write(target, helperBytes)
                 }
-                copyBundledHelperDirectory(target.parent, osArch(), skipExisting = true)
+                copyBundledHelperDirectory(target.parent, osArch())
                 target
             }
         cached = extracted
@@ -132,11 +131,7 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
             return HelperExtractionPaths.helperFingerprint(bytes.toByteArray())
         }
 
-        fun copyBundledHelperDirectory(
-            targetDir: Path,
-            osArch: String,
-            skipExisting: Boolean = false,
-        ) {
+        fun copyBundledHelperDirectory(targetDir: Path, osArch: String) {
             val prefix = "native/windows/${windowsArch(osArch)}/"
             val loader = WindowsGraphicsCaptureHelperBinaryExtractor::class.java.classLoader
             val exeUrl = loader.getResource("$prefix$BINARY_NAME") ?: return
@@ -147,33 +142,35 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
                         entries
                             .filter { Files.isRegularFile(it) }
                             .forEach { source ->
-                                val target = targetDir.resolve(source.fileName.toString())
-                                if (!skipExisting || !Files.exists(target)) {
-                                    Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING)
-                                }
+                                copyIfDifferent(
+                                    source,
+                                    targetDir.resolve(source.fileName.toString()),
+                                )
                             }
                     }
                 }
                 "jar" -> {
                     val connection = exeUrl.openConnection() as JarURLConnection
-                    copyJarPrefix(connection.jarFile, prefix, targetDir, skipExisting)
+                    copyJarPrefix(connection.jarFile, prefix, targetDir)
                 }
                 else ->
                     loader.getResourceAsStream("$prefix$BINARY_NAME")?.use { stream ->
-                        val target = targetDir.resolve(BINARY_NAME)
-                        if (!skipExisting || !Files.exists(target)) {
-                            Files.copy(stream, target, StandardCopyOption.REPLACE_EXISTING)
-                        }
+                        copyIfDifferent(stream.readBytes(), targetDir.resolve(BINARY_NAME))
                     }
             }
         }
 
-        private fun copyJarPrefix(
-            jar: JarFile,
-            prefix: String,
-            targetDir: Path,
-            skipExisting: Boolean,
-        ) {
+        private fun copyIfDifferent(source: Path, target: Path) {
+            copyIfDifferent(Files.readAllBytes(source), target)
+        }
+
+        private fun copyIfDifferent(sourceBytes: ByteArray, target: Path) {
+            if (!Files.exists(target) || !Files.readAllBytes(target).contentEquals(sourceBytes)) {
+                Files.write(target, sourceBytes)
+            }
+        }
+
+        private fun copyJarPrefix(jar: JarFile, prefix: String, targetDir: Path) {
             jar.entries()
                 .asSequence()
                 .filter { !it.isDirectory && it.name.startsWith(prefix) }
@@ -181,10 +178,7 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
                     val relative = entry.name.removePrefix(prefix)
                     if (!relative.contains('/')) {
                         jar.getInputStream(entry).use { stream ->
-                            val target = targetDir.resolve(relative)
-                            if (!skipExisting || !Files.exists(target)) {
-                                Files.copy(stream, target, StandardCopyOption.REPLACE_EXISTING)
-                            }
+                            copyIfDifferent(stream.readBytes(), targetDir.resolve(relative))
                         }
                     }
                 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
@@ -32,30 +32,33 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
         cached?.let {
             return it
         }
-        val target = targetDirProvider().resolve(windowsArch(osArch())).resolve(BINARY_NAME)
+        val helperBytes =
+            resourceLocator()?.use { it.readBytes() }
+                ?: bundledHelperBytes(osArch())
+                ?: throw WindowsGraphicsCaptureHelperNotBundledException(
+                    "Bundled Windows Graphics Capture helper not found at classpath resource " +
+                        "'${resourcePath(osArch())}'. Add spectre-recording-windows as a " +
+                        "runtime dependency when using native Windows capture."
+                )
+        val target =
+            targetDirProvider()
+                .resolve(HelperExtractionPaths.helperFingerprint(helperBytes))
+                .resolve(windowsArch(osArch()))
+                .resolve(BINARY_NAME)
         val extracted =
             HelperExtractionPaths.withExtractionLock(target.parent) {
-                if (!Files.exists(target)) {
-                    val source = resourceLocator()
-                    if (source != null) {
-                        source.use { stream -> Files.copy(stream, target) }
-                    } else {
-                        copyBundledHelperDirectory(target.parent, osArch())
-                        if (!Files.exists(target)) {
-                            throw WindowsGraphicsCaptureHelperNotBundledException(
-                                "Bundled Windows Graphics Capture helper not found at classpath " +
-                                    "resource '${resourcePath(osArch())}'. Add " +
-                                    "spectre-recording-windows as a runtime dependency when " +
-                                    "using native Windows capture."
-                            )
-                        }
-                    }
+                if (!Files.exists(target) || !target.readBytesContentEquals(helperBytes)) {
+                    Files.write(target, helperBytes)
                 }
+                copyBundledHelperDirectory(target.parent, osArch(), skipExisting = true)
                 target
             }
         cached = extracted
         return extracted
     }
+
+    private fun Path.readBytesContentEquals(expected: ByteArray): Boolean =
+        Files.readAllBytes(this).contentEquals(expected)
 
     private companion object {
         const val BINARY_NAME: String = "spectre-window-capture.exe"
@@ -81,7 +84,16 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
                     )
             }
 
-        fun copyBundledHelperDirectory(targetDir: Path, osArch: String) {
+        fun bundledHelperBytes(osArch: String): ByteArray? {
+            val loader = WindowsGraphicsCaptureHelperBinaryExtractor::class.java.classLoader
+            return loader.getResourceAsStream(resourcePath(osArch))?.use { it.readBytes() }
+        }
+
+        fun copyBundledHelperDirectory(
+            targetDir: Path,
+            osArch: String,
+            skipExisting: Boolean = false,
+        ) {
             val prefix = "native/windows/${windowsArch(osArch)}/"
             val loader = WindowsGraphicsCaptureHelperBinaryExtractor::class.java.classLoader
             val exeUrl = loader.getResource("$prefix$BINARY_NAME") ?: return
@@ -92,30 +104,33 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
                         entries
                             .filter { Files.isRegularFile(it) }
                             .forEach { source ->
-                                Files.copy(
-                                    source,
-                                    targetDir.resolve(source.fileName.toString()),
-                                    StandardCopyOption.REPLACE_EXISTING,
-                                )
+                                val target = targetDir.resolve(source.fileName.toString())
+                                if (!skipExisting || !Files.exists(target)) {
+                                    Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING)
+                                }
                             }
                     }
                 }
                 "jar" -> {
                     val connection = exeUrl.openConnection() as JarURLConnection
-                    copyJarPrefix(connection.jarFile, prefix, targetDir)
+                    copyJarPrefix(connection.jarFile, prefix, targetDir, skipExisting)
                 }
                 else ->
                     loader.getResourceAsStream("$prefix$BINARY_NAME")?.use { stream ->
-                        Files.copy(
-                            stream,
-                            targetDir.resolve(BINARY_NAME),
-                            StandardCopyOption.REPLACE_EXISTING,
-                        )
+                        val target = targetDir.resolve(BINARY_NAME)
+                        if (!skipExisting || !Files.exists(target)) {
+                            Files.copy(stream, target, StandardCopyOption.REPLACE_EXISTING)
+                        }
                     }
             }
         }
 
-        private fun copyJarPrefix(jar: JarFile, prefix: String, targetDir: Path) {
+        private fun copyJarPrefix(
+            jar: JarFile,
+            prefix: String,
+            targetDir: Path,
+            skipExisting: Boolean,
+        ) {
             jar.entries()
                 .asSequence()
                 .filter { !it.isDirectory && it.name.startsWith(prefix) }
@@ -123,11 +138,10 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
                     val relative = entry.name.removePrefix(prefix)
                     if (!relative.contains('/')) {
                         jar.getInputStream(entry).use { stream ->
-                            Files.copy(
-                                stream,
-                                targetDir.resolve(relative),
-                                StandardCopyOption.REPLACE_EXISTING,
-                            )
+                            val target = targetDir.resolve(relative)
+                            if (!skipExisting || !Files.exists(target)) {
+                                Files.copy(stream, target, StandardCopyOption.REPLACE_EXISTING)
+                            }
                         }
                     }
                 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.recording.windows
 
 import dev.sebastiano.spectre.recording.HelperExtractionPaths
+import java.io.ByteArrayOutputStream
 import java.io.InputStream
 import java.net.JarURLConnection
 import java.nio.file.Files
@@ -32,17 +33,22 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
         cached?.let {
             return it
         }
+        val overrideBytes = resourceLocator()?.use { it.readBytes() }
         val helperBytes =
-            resourceLocator()?.use { it.readBytes() }
+            overrideBytes
                 ?: bundledHelperBytes(osArch())
                 ?: throw WindowsGraphicsCaptureHelperNotBundledException(
                     "Bundled Windows Graphics Capture helper not found at classpath resource " +
                         "'${resourcePath(osArch())}'. Add spectre-recording-windows as a " +
                         "runtime dependency when using native Windows capture."
                 )
+        val fingerprint =
+            overrideBytes?.let { HelperExtractionPaths.helperFingerprint(it) }
+                ?: bundledHelperDirectoryFingerprint(osArch())
+                ?: HelperExtractionPaths.helperFingerprint(helperBytes)
         val target =
             targetDirProvider()
-                .resolve(HelperExtractionPaths.helperFingerprint(helperBytes))
+                .resolve(fingerprint)
                 .resolve(windowsArch(osArch()))
                 .resolve(BINARY_NAME)
         val extracted =
@@ -87,6 +93,43 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
         fun bundledHelperBytes(osArch: String): ByteArray? {
             val loader = WindowsGraphicsCaptureHelperBinaryExtractor::class.java.classLoader
             return loader.getResourceAsStream(resourcePath(osArch))?.use { it.readBytes() }
+        }
+
+        fun bundledHelperDirectoryFingerprint(osArch: String): String? {
+            val prefix = "native/windows/${windowsArch(osArch)}/"
+            val loader = WindowsGraphicsCaptureHelperBinaryExtractor::class.java.classLoader
+            val exeUrl = loader.getResource("$prefix$BINARY_NAME") ?: return null
+            val bytes = ByteArrayOutputStream()
+            when (exeUrl.protocol) {
+                "file" -> {
+                    val sourceDir = Path.of(exeUrl.toURI()).parent
+                    Files.list(sourceDir).use { entries ->
+                        entries
+                            .filter { Files.isRegularFile(it) }
+                            .sorted(Comparator.comparing { it.fileName.toString() })
+                            .forEach { source ->
+                                bytes.write(source.fileName.toString().toByteArray(Charsets.UTF_8))
+                                bytes.write(Files.readAllBytes(source))
+                            }
+                    }
+                }
+                "jar" -> {
+                    val connection = exeUrl.openConnection() as JarURLConnection
+                    connection.jarFile
+                        .entries()
+                        .asSequence()
+                        .filter { !it.isDirectory && it.name.startsWith(prefix) }
+                        .sortedBy { it.name }
+                        .forEach { entry ->
+                            bytes.write(entry.name.removePrefix(prefix).toByteArray(Charsets.UTF_8))
+                            connection.jarFile.getInputStream(entry).use {
+                                bytes.write(it.readBytes())
+                            }
+                        }
+                }
+                else -> bytes.write(bundledHelperBytes(osArch) ?: return null)
+            }
+            return HelperExtractionPaths.helperFingerprint(bytes.toByteArray())
         }
 
         fun copyBundledHelperDirectory(

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureHelperBinaryExtractor.kt
@@ -55,7 +55,9 @@ internal class WindowsGraphicsCaptureHelperBinaryExtractor(
                 if (!Files.exists(target) || !target.readBytesContentEquals(helperBytes)) {
                     Files.write(target, helperBytes)
                 }
-                copyBundledHelperDirectory(target.parent, osArch())
+                if (overrideBytes == null) {
+                    copyBundledHelperDirectory(target.parent, osArch())
+                }
                 target
             }
         cached = extracted

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/HelperExtractionPathsTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/HelperExtractionPathsTest.kt
@@ -1,0 +1,104 @@
+package dev.sebastiano.spectre.recording
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class HelperExtractionPathsTest {
+
+    @Test
+    fun `macOS helpers default under Application Support`() {
+        val dir =
+            HelperExtractionPaths.defaultHelperDir(
+                helperName = "spectre-screencapture",
+                osName = "Mac OS X",
+                userHome = "/Users/alice",
+                getenv = { null },
+            )
+
+        assertEquals(
+            Path.of(
+                "/Users/alice",
+                "Library",
+                "Application Support",
+                "spectre",
+                "helpers",
+                "spectre-screencapture",
+            ),
+            dir,
+        )
+    }
+
+    @Test
+    fun `Windows helpers default under LOCALAPPDATA`() {
+        val dir =
+            HelperExtractionPaths.defaultHelperDir(
+                helperName = "spectre-window-capture",
+                osName = "Windows 11",
+                userHome = "C:/Users/Alice",
+                getenv = { key ->
+                    if (key == "LOCALAPPDATA") "C:/Users/Alice/AppData/Local" else null
+                },
+            )
+
+        assertEquals(
+            Path.of("C:/Users/Alice/AppData/Local", "spectre", "helpers", "spectre-window-capture"),
+            dir,
+        )
+    }
+
+    @Test
+    fun `Windows helpers fall back to user profile local app data`() {
+        val dir =
+            HelperExtractionPaths.defaultHelperDir(
+                helperName = "spectre-window-capture",
+                osName = "Windows 11",
+                userHome = "C:/Users/Alice",
+                getenv = { null },
+            )
+
+        assertEquals(
+            Path.of(
+                "C:/Users/Alice",
+                "AppData",
+                "Local",
+                "spectre",
+                "helpers",
+                "spectre-window-capture",
+            ),
+            dir,
+        )
+    }
+
+    @Test
+    fun `Linux helpers default under XDG cache home`() {
+        val dir =
+            HelperExtractionPaths.defaultHelperDir(
+                helperName = "spectre-wayland-helper",
+                osName = "Linux",
+                userHome = "/home/alice",
+                getenv = { key -> if (key == "XDG_CACHE_HOME") "/var/cache/alice" else null },
+            )
+
+        assertEquals(
+            Path.of("/var/cache/alice", "spectre", "helpers", "spectre-wayland-helper"),
+            dir,
+        )
+    }
+
+    @Test
+    fun `Linux helpers fall back to dot cache`() {
+        val dir =
+            HelperExtractionPaths.defaultHelperDir(
+                helperName = "spectre-wayland-helper",
+                osName = "Linux",
+                userHome = "/home/alice",
+                getenv = { null },
+            )
+
+        assertEquals(
+            Path.of("/home/alice", ".cache", "spectre", "helpers", "spectre-wayland-helper"),
+            dir,
+        )
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
@@ -49,6 +49,22 @@ class HelperBinaryExtractorTest {
     }
 
     @Test
+    fun `extract reuses an existing stable helper without opening the resource`() {
+        val existing = createExecutableHelper(BINARY_NAME, 0x09, 0x08, 0x07)
+        val extractor =
+            HelperBinaryExtractor(
+                envLookup = { null },
+                resourceLocator = { error("resource should not be opened when helper exists") },
+                targetDirProvider = { tempRoot },
+            )
+
+        val path = extractor.extract()
+
+        assertEquals(existing, path)
+        assertContentEquals(byteArrayOf(0x09, 0x08, 0x07), path.readBytes())
+    }
+
+    @Test
     fun `extract is idempotent — second call returns the same path without re-reading the resource`() {
         // Caching matters because every Recorder instance asks for the helper, and re-extracting
         // means another temp file + another stream copy + another chmod for no value.

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.recording.screencapturekit
 
+import dev.sebastiano.spectre.recording.HelperExtractionPaths
 import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.nio.file.Files
@@ -49,19 +50,74 @@ class HelperBinaryExtractorTest {
     }
 
     @Test
-    fun `extract reuses an existing stable helper without opening the resource`() {
-        val existing = createExecutableHelper(BINARY_NAME, 0x09, 0x08, 0x07)
+    fun `extract reuses same-byte stable helper path`() {
+        val payload = byteArrayOf(0x09, 0x08, 0x07)
+        val existingDir = tempRoot.resolve(HelperExtractionPaths.helperFingerprint(payload))
+        Files.createDirectories(existingDir)
+        val existing = existingDir.resolve(BINARY_NAME)
+        Files.write(existing, payload)
+        check(existing.toFile().setExecutable(true, false))
         val extractor =
             HelperBinaryExtractor(
                 envLookup = { null },
-                resourceLocator = { error("resource should not be opened when helper exists") },
+                resourceLocator = { ByteArrayInputStream(payload) },
                 targetDirProvider = { tempRoot },
             )
 
         val path = extractor.extract()
 
         assertEquals(existing, path)
-        assertContentEquals(byteArrayOf(0x09, 0x08, 0x07), path.readBytes())
+        assertContentEquals(payload, path.readBytes())
+    }
+
+    @Test
+    fun `extract uses a new stable helper path when bundled bytes change`() {
+        val oldPayload = byteArrayOf(0x01)
+        val newPayload = byteArrayOf(0x02)
+        val oldDir = tempRoot.resolve(HelperExtractionPaths.helperFingerprint(oldPayload))
+        Files.createDirectories(oldDir)
+        Files.write(oldDir.resolve(BINARY_NAME), oldPayload)
+        val extractor =
+            HelperBinaryExtractor(
+                envLookup = { null },
+                resourceLocator = { ByteArrayInputStream(newPayload) },
+                targetDirProvider = { tempRoot },
+            )
+
+        val path = extractor.extract()
+
+        assertEquals(
+            tempRoot
+                .resolve(HelperExtractionPaths.helperFingerprint(newPayload))
+                .resolve(BINARY_NAME),
+            path,
+        )
+        assertContentEquals(newPayload, path.readBytes())
+        assertContentEquals(oldPayload, oldDir.resolve(BINARY_NAME).readBytes())
+    }
+
+    @Test
+    fun `helperDir system property refreshes stale helper bytes in place`() {
+        val stale = byteArrayOf(0x01)
+        val fresh = byteArrayOf(0x02)
+        val stableDir = tempRoot.resolve("stable")
+        Files.createDirectories(stableDir)
+        val target = stableDir.resolve(BINARY_NAME)
+        Files.write(target, stale)
+        val extractor =
+            HelperBinaryExtractor(
+                envLookup = { null },
+                sysPropLookup = { key ->
+                    if (key == HELPER_DIR_PROPERTY) stableDir.toString() else null
+                },
+                resourceLocator = { ByteArrayInputStream(fresh) },
+                targetDirProvider = { tempRoot.resolve("default") },
+            )
+
+        val path = extractor.extract()
+
+        assertEquals(target, path)
+        assertContentEquals(fresh, path.readBytes())
     }
 
     @Test

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/windows/WindowsWindowScreenshotterTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/windows/WindowsWindowScreenshotterTest.kt
@@ -124,6 +124,26 @@ class WindowsWindowScreenshotterTest {
     }
 
     @Test
+    fun `extractor reuses an existing helper without overwriting it`() {
+        val targetDir = Files.createTempDirectory("spectre-windows-helper-test")
+        val existing = targetDir.resolve("x64").resolve("spectre-window-capture.exe")
+        Files.createDirectories(existing.parent)
+        Files.write(existing, byteArrayOf(9, 8, 7))
+        val extractor =
+            WindowsGraphicsCaptureHelperBinaryExtractor(
+                resourceLocator = { error("resource should not be opened when helper exists") },
+                targetDirProvider = { targetDir },
+                getenv = { null },
+                osArch = { "amd64" },
+            )
+
+        val path = extractor.extract()
+
+        assertEquals(existing, path)
+        assertTrue(Files.readAllBytes(path).contentEquals(byteArrayOf(9, 8, 7)))
+    }
+
+    @Test
     fun `extractor rejects unsupported architecture`() {
         val extractor =
             WindowsGraphicsCaptureHelperBinaryExtractor(

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/windows/WindowsWindowScreenshotterTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/windows/WindowsWindowScreenshotterTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.recording.windows
 
+import dev.sebastiano.spectre.recording.HelperExtractionPaths
 import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
 import java.awt.Rectangle
 import java.awt.image.BufferedImage
@@ -120,18 +121,27 @@ class WindowsWindowScreenshotterTest {
         assertEquals(first, second)
         assertEquals(1, opened)
         assertEquals("arm64", first.parent.fileName.toString())
+        assertEquals(
+            HelperExtractionPaths.helperFingerprint(byteArrayOf(1, 2, 3)),
+            first.parent.parent.fileName.toString(),
+        )
         assertTrue(Files.readAllBytes(first).contentEquals(byteArrayOf(1, 2, 3)))
     }
 
     @Test
     fun `extractor reuses an existing helper without overwriting it`() {
         val targetDir = Files.createTempDirectory("spectre-windows-helper-test")
-        val existing = targetDir.resolve("x64").resolve("spectre-window-capture.exe")
+        val payload = byteArrayOf(9, 8, 7)
+        val existing =
+            targetDir
+                .resolve(HelperExtractionPaths.helperFingerprint(payload))
+                .resolve("x64")
+                .resolve("spectre-window-capture.exe")
         Files.createDirectories(existing.parent)
-        Files.write(existing, byteArrayOf(9, 8, 7))
+        Files.write(existing, payload)
         val extractor =
             WindowsGraphicsCaptureHelperBinaryExtractor(
-                resourceLocator = { error("resource should not be opened when helper exists") },
+                resourceLocator = { ByteArrayInputStream(payload) },
                 targetDirProvider = { targetDir },
                 getenv = { null },
                 osArch = { "amd64" },
@@ -140,7 +150,7 @@ class WindowsWindowScreenshotterTest {
         val path = extractor.extract()
 
         assertEquals(existing, path)
-        assertTrue(Files.readAllBytes(path).contentEquals(byteArrayOf(9, 8, 7)))
+        assertTrue(Files.readAllBytes(path).contentEquals(payload))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- extract bundled native helpers to stable per-user helper directories by default
- keep the macOS helperDir override for project-specific TCC setups
- document the default macOS helper path, TCC flow, and cross-platform helper locations

## Validation
- ./gradlew :recording:test --tests "dev.sebastiano.spectre.recording.HelperExtractionPathsTest"
- ./gradlew :recording:test --tests "dev.sebastiano.spectre.recording.HelperExtractionPathsTest" --tests "dev.sebastiano.spectre.recording.screencapturekit.HelperBinaryExtractorTest" --tests "dev.sebastiano.spectre.recording.DefaultWaylandHelperBinaryExtractorTest" --tests "dev.sebastiano.spectre.recording.windows.WindowsWindowScreenshotterTest.extractor*"
- ./gradlew :recording:ktfmtFormat :recording:check
- /tmp/spectre-docs-venv/bin/mkdocs build --strict
- ./gradlew check (blocked locally before project checks by IntelliJ Platform DMG hdiutil extraction for cached idea-2026.1.1-aarch64.dmg)
