### PR TITLE
Port the agent attach trust boundary to Windows (ACLs + same-user preflight)

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -132,22 +132,12 @@ public object AgentAttach {
     }
 
     /**
-     * Same-user preflight. The Attach API's POSIX implementation requires both processes to be
-     * attach-compatible under the OS user/permission rules; otherwise the rendezvous file under
-     * `/tmp/.java_pid<pid>` is unreadable and `VirtualMachine.attach` fails with a hard-to-diagnose
-     * error.
-     *
-     * We use `ProcessHandle` which is portable and gives user names rather than numeric UIDs;
-     * missing process info (some sandboxes return empty `user()`) is treated as "can't tell — let
-     * the attach proceed and surface whatever error it gives".
+     * Same-user preflight, delegated to the per-platform [AttachUserPreflight] seam. See that type
+     * for the rationale (the JDK Attach API only rendezvous across same-user processes) and the
+     * per-OS ownership-comparison semantics.
      */
     private fun checkSameUser(targetPid: Long) {
-        val handle = ProcessHandle.of(targetPid).orElse(null) ?: return
-        val targetUser = handle.info().user().orElse(null) ?: return
-        val currentUser = System.getProperty("user.name") ?: return
-        if (targetUser != currentUser) {
-            throw AttachPermissionDeniedException(targetPid, targetUser)
-        }
+        AttachUserPreflight.forOs().requireSameUser(targetPid)
     }
 
     private fun loadAgentReflectively(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflight.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflight.kt
@@ -1,0 +1,97 @@
+package dev.sebastiano.spectre.agent
+
+/**
+ * Same-user preflight for [AgentAttach.attach], expressed as a per-platform seam so the ownership
+ * check can differ by OS without the caller branching on `os.name`.
+ *
+ * The JDK Attach API only rendezvous across processes owned by the same OS user (on POSIX the
+ * `/tmp/.java_pid<pid>` file is unreadable otherwise; on Windows the named-pipe handshake is
+ * ACL-scoped to the owner). The underlying `VirtualMachine.attach` error is generic and hard to
+ * diagnose, so we pre-check ownership and throw a dedicated [AttachPermissionDeniedException] with
+ * a clear message before opening the VM connection.
+ *
+ * **Advisory, not authoritative.** The real boundary is the OS. When ownership cannot be determined
+ * (sandboxes return an empty `ProcessHandle.user()`), the preflight proceeds and lets the attach
+ * surface whatever the OS reports.
+ *
+ * Both implementations resolve the current *and* target owner through the same
+ * `ProcessHandle.info().user()` API so the two strings are directly comparable. The previous
+ * implementation compared `ProcessHandle.user()` (which is `DOMAIN\name` on Windows) against
+ * `System.getProperty("user.name")` (bare) — a mismatch that wrongly rejected the same user
+ * attaching to their own JVM on Windows.
+ *
+ * The per-platform split leaves room for #166 (numeric POSIX UID comparison) and a future Windows
+ * SID/elevation refinement to drop in without reshaping call sites.
+ */
+@ExperimentalSpectreAgentApi
+internal interface AttachUserPreflight {
+    /**
+     * Throws [AttachPermissionDeniedException] when [targetPid] is owned by a different OS user
+     * than the current process. Returns normally when the users match or ownership is unknown.
+     */
+    fun requireSameUser(targetPid: Long)
+
+    companion object {
+        /** Select the preflight implementation for [osName]. */
+        fun forOs(osName: String = System.getProperty("os.name").orEmpty()): AttachUserPreflight =
+            if (osName.startsWith("Windows", ignoreCase = true)) WindowsUserPreflight()
+            else PosixUserPreflight()
+    }
+}
+
+/**
+ * POSIX same-user preflight: case-sensitive username equality via `ProcessHandle.info().user()`.
+ *
+ * #166 will refine this to a numeric UID comparison (name equality can false-negative under
+ * directory services, domain prefixes, or localized name formatting) and keep the name path as a
+ * fallback when a numeric UID is unavailable.
+ */
+@ExperimentalSpectreAgentApi
+internal class PosixUserPreflight(
+    private val currentUser: () -> String? = defaultCurrentUser,
+    private val targetUser: (Long) -> String? = defaultTargetUser,
+) : AttachUserPreflight {
+    override fun requireSameUser(targetPid: Long) {
+        requireSameUserOwnership(targetPid, currentUser(), targetUser(targetPid)) { it }
+    }
+}
+
+/**
+ * Windows same-user preflight: case-insensitive equality of the `DOMAIN\name` form that
+ * `ProcessHandle.info().user()` returns on Windows (usernames and domains are case-insensitive).
+ *
+ * Two same-user processes at *different* integrity levels (elevated vs non-elevated) share the same
+ * account and therefore pass this preflight; Windows may still deny the OS-level attach across
+ * integrity levels, which surfaces from `VirtualMachine.attach` itself. The preflight is advisory.
+ */
+@ExperimentalSpectreAgentApi
+internal class WindowsUserPreflight(
+    private val currentUser: () -> String? = defaultCurrentUser,
+    private val targetUser: (Long) -> String? = defaultTargetUser,
+) : AttachUserPreflight {
+    override fun requireSameUser(targetPid: Long) {
+        requireSameUserOwnership(targetPid, currentUser(), targetUser(targetPid)) { it.lowercase() }
+    }
+}
+
+private inline fun requireSameUserOwnership(
+    targetPid: Long,
+    current: String?,
+    target: String?,
+    normalize: (String) -> String,
+) {
+    // Undeterminable ownership must not block the attach — the OS remains the real boundary.
+    if (current == null || target == null) return
+    if (normalize(current) != normalize(target)) {
+        @OptIn(ExperimentalSpectreAgentApi::class)
+        throw AttachPermissionDeniedException(targetPid, target)
+    }
+}
+
+private val defaultCurrentUser: () -> String? = {
+    ProcessHandle.current().info().user().orElse(null)
+}
+
+private val defaultTargetUser: (Long) -> String? = { pid ->
+    ProcessHandle.of(pid).flatMap { it.info().user() }.orElse(null)
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -7,11 +7,8 @@ import java.nio.channels.Channels
 import java.nio.channels.ClosedChannelException
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
-import java.nio.file.FileSystemException
 import java.nio.file.Files
 import java.nio.file.Path
-import java.nio.file.attribute.PosixFilePermission
-import java.nio.file.attribute.PosixFilePermissions
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -39,11 +36,13 @@ constructor(
 ) : AutoCloseable {
     private var createdParentDir: Path? = null
 
+    private val protection: SocketFileProtection = SocketFileProtection.forPath(udsPath)
+
     private val serverChannel: ServerSocketChannel =
         ServerSocketChannel.open(StandardProtocolFamily.UNIX).also { channel ->
             // Outer `success` sentinel + `finally` so the channel is unconditionally closed on
             // ANY constructor-time failure (bind throwing on a too-long path, `deleteIfExists`
-            // failing, the POSIX permission tightening throwing, ...). Without this, an opened
+            // failing, the owner-only protection throwing, ...). Without this, an opened
             // `ServerSocketChannel` whose bind fails would leak a native file descriptor for
             // the rest of the JVM's lifetime — `ServerSocketChannel` has no finalizer or
             // cleaner. Bugbot caught it (LOW); the regression test
@@ -51,32 +50,15 @@ constructor(
             // the contract by observing `openFileDescriptorCount`.
             var success = false
             try {
-                createdParentDir = createMissingParentDirectory(udsPath)
-                // Clean up any orphaned socket file from a previous crash; Linux/macOS refuse to
+                createdParentDir = protection.createMissingParentDirectory(udsPath)
+                // Clean up any orphaned socket file from a previous crash; the OS refuses to
                 // bind if the path already exists, even when stale.
                 Files.deleteIfExists(udsPath)
                 channel.bind(UnixDomainSocketAddress.of(udsPath))
-                // Tighten the socket file permissions to mode 0600 (owner read/write). UDS file
-                // creation respects the process umask, which on common defaults (022) leaves the
-                // socket group/world-readable — broader than the local-only trust model claims.
-                // Explicitly setting the permissions immediately after bind closes that gap.
-                try {
-                    Files.setPosixFilePermissions(udsPath, OWNER_ONLY_PERMS)
-                } catch (ex: UnsupportedOperationException) {
-                    // Non-POSIX filesystem (e.g. Windows in some setups). Bubble up as an
-                    // IOException; the outer `finally` handles channel close + UDS unlink so
-                    // we don't expose a permissionless socket.
-                    throw IOException(
-                        "Filesystem at $udsPath doesn't support POSIX permissions; refusing " +
-                            "to expose a UDS without 0600 access control.",
-                        ex,
-                    )
-                } catch (ex: FileSystemException) {
-                    throw IOException(
-                        "Failed to set 0600 permissions on UDS at $udsPath: ${ex.message}",
-                        ex,
-                    )
-                }
+                // Tighten the freshly-bound socket to owner-only access (POSIX mode 0600 /
+                // Windows owner-only ACL). UDS file creation otherwise respects the ambient umask
+                // or inherited ACL, which is broader than the local-only trust model claims.
+                protection.protectSocketFile(udsPath)
                 success = true
             } finally {
                 if (!success) {
@@ -263,46 +245,4 @@ constructor(
  */
 internal fun interface AgentRequestHandler {
     fun handle(request: AgentRequest): AgentResponse
-}
-
-private val OWNER_ONLY_PERMS =
-    PosixFilePermissions.fromString("rw-------").also {
-        // Sanity assertion: the parsed set should be exactly OWNER_READ + OWNER_WRITE. Cheap
-        // self-check so a typo here surfaces at module-init time rather than only when a peer
-        // tries to connect.
-        require(it == setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)) {
-            "Expected OWNER_ONLY_PERMS to be 0600 (rw-------), got $it"
-        }
-    }
-
-private val OWNER_ONLY_DIRECTORY_PERMS =
-    PosixFilePermissions.fromString("rwx------").also {
-        require(
-            it ==
-                setOf(
-                    PosixFilePermission.OWNER_READ,
-                    PosixFilePermission.OWNER_WRITE,
-                    PosixFilePermission.OWNER_EXECUTE,
-                )
-        ) {
-            "Expected OWNER_ONLY_DIRECTORY_PERMS to be 0700 (rwx------), got $it"
-        }
-    }
-
-private fun createMissingParentDirectory(udsPath: Path): Path? {
-    val parent = udsPath.parent ?: return null
-    if (Files.exists(parent)) return null
-    return try {
-        Files.createDirectories(
-            parent,
-            PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMS),
-        )
-        parent
-    } catch (ex: UnsupportedOperationException) {
-        throw IOException(
-            "Filesystem at $parent doesn't support POSIX permissions; refusing to create " +
-                "an agent UDS parent without 0700 access control.",
-            ex,
-        )
-    }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/SocketFileProtection.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/SocketFileProtection.kt
@@ -1,0 +1,166 @@
+package dev.sebastiano.spectre.agent.transport
+
+import java.io.IOException
+import java.nio.file.FileSystemException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.AclEntry
+import java.nio.file.attribute.AclEntryPermission
+import java.nio.file.attribute.AclEntryType
+import java.nio.file.attribute.AclFileAttributeView
+import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.EnumSet
+
+/**
+ * Per-filesystem owner-only protection for the agent's UDS directory and socket file.
+ *
+ * The trust model (see docs/SECURITY.md) is same-user, local-only: the private per-attach directory
+ * and the socket inside it must be reachable only by the OS user that created them. That intent
+ * maps to POSIX modes `0700`/`0600` on Linux/macOS and to an owner-only ACL on Windows/NTFS (POSIX
+ * modes are meaningless on NTFS). This seam keeps [IpcServer] free of the platform branch and
+ * gives #195's ACL work a single home.
+ *
+ * Selected by [forPath] from the filesystem's supported attribute views: `posix` present →
+ * [PosixSocketFileProtection]; otherwise [WindowsAclSocketFileProtection].
+ */
+internal sealed interface SocketFileProtection {
+    /**
+     * If [udsPath]'s parent directory does not exist, create it (with owner-only protection) and
+     * return it so the caller can clean it up. Returns `null` when the parent already exists —
+     * Spectre only tightens directories it creates itself.
+     */
+    @Throws(IOException::class)
+    fun createMissingParentDirectory(udsPath: Path): Path? {
+        val parent = udsPath.parent ?: return null
+        if (Files.exists(parent)) return null
+        createProtectedDirectory(parent)
+        return parent
+    }
+
+    /** Create [dir] (and any missing ancestors) with owner-only protection. */
+    @Throws(IOException::class) fun createProtectedDirectory(dir: Path)
+
+    /**
+     * Tighten the freshly-bound socket file at [udsPath] to owner-only access. Called immediately
+     * after `bind`, since UDS file creation otherwise respects the ambient umask / inherited ACL.
+     */
+    @Throws(IOException::class) fun protectSocketFile(udsPath: Path)
+
+    companion object {
+        /** Select the protection strategy for the filesystem backing [path]. */
+        fun forPath(path: Path): SocketFileProtection =
+            forViews(path.fileSystem.supportedFileAttributeViews())
+
+        /**
+         * Selection seam (exposed for tests): POSIX modes when the filesystem supports them, else
+         * Windows ACLs.
+         */
+        fun forViews(supportedViews: Set<String>): SocketFileProtection =
+            if ("posix" in supportedViews) PosixSocketFileProtection
+            else WindowsAclSocketFileProtection
+    }
+}
+
+/** POSIX protection: directory mode `0700`, socket mode `0600`. */
+internal object PosixSocketFileProtection : SocketFileProtection {
+    override fun createProtectedDirectory(dir: Path) {
+        try {
+            Files.createDirectories(
+                dir,
+                PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMS),
+            )
+        } catch (ex: UnsupportedOperationException) {
+            throw IOException(
+                "Filesystem at $dir doesn't support POSIX permissions; refusing to create " +
+                    "an agent UDS parent without 0700 access control.",
+                ex,
+            )
+        }
+    }
+
+    override fun protectSocketFile(udsPath: Path) {
+        // UDS file creation respects the process umask, which on common defaults (022) leaves the
+        // socket group/world-readable — broader than the local-only trust model claims. Setting
+        // the permissions immediately after bind closes that gap.
+        try {
+            Files.setPosixFilePermissions(udsPath, OWNER_ONLY_PERMS)
+        } catch (ex: UnsupportedOperationException) {
+            throw IOException(
+                "Filesystem at $udsPath doesn't support POSIX permissions; refusing to expose " +
+                    "a UDS without 0600 access control.",
+                ex,
+            )
+        } catch (ex: FileSystemException) {
+            throw IOException(
+                "Failed to set 0600 permissions on UDS at $udsPath: ${ex.message}",
+                ex,
+            )
+        }
+    }
+}
+
+/**
+ * Windows protection: an owner-only ACL, mirroring POSIX `0700`/`0600` on NTFS.
+ *
+ * Replacing a path's ACL with a single explicit ALLOW ACE for the owner (full control, no
+ * inheritance flags) collapses the DACL to exactly that entry and drops all inherited ACEs —
+ * verified on NTFS, where a default `%TEMP%` subdirectory otherwise inherits SYSTEM,
+ * Administrators, and group ACEs. `Administrators`/`SYSTEM` retain access at the OS level
+ * regardless (they can take ownership of anything); that residual exposure is an accepted risk
+ * documented in docs/SECURITY.md.
+ */
+internal object WindowsAclSocketFileProtection : SocketFileProtection {
+    override fun createProtectedDirectory(dir: Path) {
+        Files.createDirectories(dir)
+        setOwnerOnlyAcl(dir)
+    }
+
+    override fun protectSocketFile(udsPath: Path) {
+        setOwnerOnlyAcl(udsPath)
+    }
+
+    private fun setOwnerOnlyAcl(path: Path) {
+        val view =
+            Files.getFileAttributeView(path, AclFileAttributeView::class.java)
+                ?: throw IOException(
+                    "Filesystem at $path doesn't support ACLs; refusing to expose a UDS without " +
+                        "an owner-only ACL."
+                )
+        val ownerOnly =
+            AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(view.owner)
+                .setPermissions(EnumSet.allOf(AclEntryPermission::class.java))
+                .build()
+        try {
+            view.acl = listOf(ownerOnly)
+        } catch (ex: IOException) {
+            throw IOException("Failed to set an owner-only ACL on $path: ${ex.message}", ex)
+        }
+    }
+}
+
+private val OWNER_ONLY_PERMS =
+    PosixFilePermissions.fromString("rw-------").also {
+        // Sanity assertion: the parsed set should be exactly OWNER_READ + OWNER_WRITE. Cheap
+        // self-check so a typo here surfaces at module-init time rather than only when a peer
+        // tries to connect.
+        require(it == setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)) {
+            "Expected OWNER_ONLY_PERMS to be 0600 (rw-------), got $it"
+        }
+    }
+
+private val OWNER_ONLY_DIRECTORY_PERMS =
+    PosixFilePermissions.fromString("rwx------").also {
+        require(
+            it ==
+                setOf(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE,
+                )
+        ) {
+            "Expected OWNER_ONLY_DIRECTORY_PERMS to be 0700 (rwx------), got $it"
+        }
+    }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflightTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflightTest.kt
@@ -1,0 +1,88 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class AttachUserPreflightTest {
+
+    private val targetPid = 4242L
+
+    // ---- POSIX preflight: case-sensitive username equality (ProcessHandle.user() both sides) ----
+
+    @Test
+    fun `posix preflight passes when target and current users match`() {
+        preflight(posix = true, current = "rock3r", target = "rock3r").requireSameUser(targetPid)
+    }
+
+    @Test
+    fun `posix preflight throws when users differ`() {
+        val ex =
+            assertFailsWith<AttachPermissionDeniedException> {
+                preflight(posix = true, current = "rock3r", target = "root")
+                    .requireSameUser(targetPid)
+            }
+        // message names the offending target user
+        assert(ex.message!!.contains("root"))
+    }
+
+    @Test
+    fun `posix preflight is case-sensitive`() {
+        assertFailsWith<AttachPermissionDeniedException> {
+            preflight(posix = true, current = "Rock3r", target = "rock3r")
+                .requireSameUser(targetPid)
+        }
+    }
+
+    // ---- Windows preflight: case-insensitive, DOMAIN\name on BOTH sides (the bug fix) ----
+
+    @Test
+    fun `windows preflight passes for same DOMAIN and user`() {
+        preflight(posix = false, current = "MATTONE\\rock3r", target = "MATTONE\\rock3r")
+            .requireSameUser(targetPid)
+    }
+
+    @Test
+    fun `windows preflight is case-insensitive on domain and user`() {
+        preflight(posix = false, current = "MATTONE\\Rock3r", target = "mattone\\rock3r")
+            .requireSameUser(targetPid)
+    }
+
+    @Test
+    fun `windows preflight throws for a different same-domain user`() {
+        assertFailsWith<AttachPermissionDeniedException> {
+            preflight(posix = false, current = "MATTONE\\rock3r", target = "MATTONE\\alice")
+                .requireSameUser(targetPid)
+        }
+    }
+
+    // ---- Undeterminable ownership must NOT block the attach (advisory preflight) ----
+
+    @Test
+    fun `preflight proceeds when target user is unavailable`() {
+        preflight(posix = true, current = "rock3r", target = null).requireSameUser(targetPid)
+    }
+
+    @Test
+    fun `preflight proceeds when current user is unavailable`() {
+        preflight(posix = false, current = null, target = "MATTONE\\rock3r")
+            .requireSameUser(targetPid)
+    }
+
+    // ---- Factory selects the platform impl by os.name ----
+
+    @Test
+    fun `factory returns a Windows impl on Windows and a POSIX impl elsewhere`() {
+        assert(AttachUserPreflight.forOs("Windows 11") is WindowsUserPreflight)
+        assert(AttachUserPreflight.forOs("Mac OS X") is PosixUserPreflight)
+        assert(AttachUserPreflight.forOs("Linux") is PosixUserPreflight)
+    }
+
+    private fun preflight(posix: Boolean, current: String?, target: String?): AttachUserPreflight {
+        val currentResolver = { current }
+        val targetResolver = { _: Long -> target }
+        return if (posix) PosixUserPreflight(currentResolver, targetResolver)
+        else WindowsUserPreflight(currentResolver, targetResolver)
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcServerWindowsAclTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcServerWindowsAclTest.kt
@@ -1,0 +1,60 @@
+package dev.sebastiano.spectre.agent.transport
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * Windows-only integration test for [IpcServer]'s trust boundary (#195): the real bind path must
+ * create the private parent directory with an owner-only ACL, tighten the freshly-bound socket to
+ * an owner-only ACL, serve a client, and clean both up on close — the NTFS analog of the POSIX
+ * `server creates missing UDS parent owner-only and removes it on close` test in
+ * [IpcRoundTripTest].
+ */
+@EnabledOnOs(OS.WINDOWS)
+class IpcServerWindowsAclTest {
+    private val cleanup = mutableListOf<Path>()
+
+    @AfterTest
+    fun tearDown() {
+        cleanup.asReversed().forEach { runCatching { it.deleteIfExists() } }
+    }
+
+    @Test
+    fun `IpcServer creates an owner-only dir plus socket ACL, serves a client, and cleans up on close`() {
+        val base = Files.createTempDirectory("sp-ipc-win-").also { cleanup.add(it) }
+        val parent = base.resolve("sp-a-${UUID.randomUUID().toString().take(8)}")
+        val uds = parent.resolve("agent.sock")
+        cleanup.add(parent)
+
+        IpcServer(uds, AgentRequestHandler { AgentResponse.Pong }).use {
+            awaitSocket(uds)
+            assertOwnerOnlyAcl(parent)
+            assertOwnerOnlyAcl(uds)
+
+            // Functional proof: the protected socket still serves a real CBOR round-trip.
+            IpcClient(uds).use { client ->
+                assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+            }
+        }
+
+        assertFalse(Files.exists(uds), "socket should be unlinked after close")
+        assertFalse(Files.exists(parent), "private parent dir should be removed after close")
+    }
+
+    private fun awaitSocket(path: Path, timeoutMs: Long = 2_000) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.exists(path)) return
+            Thread.sleep(10)
+        }
+        error("UDS file $path did not appear within $timeoutMs ms")
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/OwnerOnlyAclAssertions.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/OwnerOnlyAclAssertions.kt
@@ -1,0 +1,31 @@
+package dev.sebastiano.spectre.agent.transport
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.AclEntryPermission
+import java.nio.file.attribute.AclEntryType
+import java.nio.file.attribute.AclFileAttributeView
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Asserts [path] carries exactly one ACE: an ALLOW full-control entry for the owner, with no
+ * inheritance flags (i.e. inherited ACEs were dropped) — the NTFS mirror of POSIX 0700/0600.
+ */
+internal fun assertOwnerOnlyAcl(path: Path) {
+    val view = Files.getFileAttributeView(path, AclFileAttributeView::class.java)
+    val acl = view.acl
+    assertEquals(1, acl.size, "expected exactly one ACE (no inherited ACEs), got: $acl")
+    val entry = acl.single()
+    assertEquals(AclEntryType.ALLOW, entry.type())
+    assertEquals(view.owner, entry.principal(), "the sole ACE must be the owner")
+    assertEquals(
+        AclEntryPermission.values().toSet(),
+        entry.permissions(),
+        "the owner must have full control",
+    )
+    assertTrue(
+        entry.flags().isEmpty(),
+        "the ACE must not carry inheritance flags: ${entry.flags()}",
+    )
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/SocketFileProtectionTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/SocketFileProtectionTest.kt
@@ -1,0 +1,73 @@
+package dev.sebastiano.spectre.agent.transport
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+class SocketFileProtectionTest {
+    private val cleanup = mutableListOf<Path>()
+
+    @AfterTest
+    fun tearDown() {
+        cleanup.asReversed().forEach { runCatching { it.deleteIfExists() } }
+    }
+
+    // ---- Platform-agnostic: factory selects the impl by supported attribute views ----
+
+    @Test
+    fun `forViews selects the POSIX impl when posix is supported`() {
+        assertIs<PosixSocketFileProtection>(
+            SocketFileProtection.forViews(setOf("basic", "posix", "owner", "unix"))
+        )
+    }
+
+    @Test
+    fun `forViews selects the Windows ACL impl when posix is absent`() {
+        assertIs<WindowsAclSocketFileProtection>(
+            SocketFileProtection.forViews(setOf("basic", "owner", "dos", "acl", "user"))
+        )
+    }
+
+    // ---- Windows: created dir + protected file carry a single owner-only full-control ACE ----
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `Windows createMissingParentDirectory yields an owner-only ACL and returns the created dir`() {
+        val base = Files.createTempDirectory("sp-prot-").also { cleanup.add(it) }
+        val uds = base.resolve("sp-a-${UUID.randomUUID().toString().take(8)}").resolve("agent.sock")
+        cleanup.add(uds.parent)
+
+        val protection = SocketFileProtection.forPath(uds)
+        assertIs<WindowsAclSocketFileProtection>(protection)
+
+        val created = protection.createMissingParentDirectory(uds)
+        assertEquals(uds.parent, created, "should return the directory it created")
+        assertOwnerOnlyAcl(uds.parent)
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `Windows createMissingParentDirectory returns null when the parent already exists`() {
+        val base = Files.createTempDirectory("sp-prot-").also { cleanup.add(it) }
+        val uds = base.resolve("agent.sock")
+        assertEquals(null, SocketFileProtection.forPath(uds).createMissingParentDirectory(uds))
+    }
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `Windows protectSocketFile tightens the socket file to an owner-only ACL`() {
+        val base = Files.createTempDirectory("sp-prot-").also { cleanup.add(it) }
+        val socket = base.resolve("agent.sock").also { Files.createFile(it) }
+        cleanup.add(socket)
+
+        SocketFileProtection.forPath(socket).protectSocketFile(socket)
+        assertOwnerOnlyAcl(socket)
+    }
+}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -32,8 +32,13 @@ out of scope.
    reach the bound port. Bind to `127.0.0.1`. Anything network-reachable broadens the threat
    model beyond what this release covers.
 4. **The agent transport assumes a same-user peer.** `:agent`'s Unix Domain Socket is created
-   under a short private directory in `/tmp/`. The directory is mode 0700 and the socket is mode
-   0600, both set explicitly by `IpcServer` to defend against permissive umasks.
+   under a short private directory (in `/tmp/` on Linux/macOS, under `%TEMP%` on Windows). On
+   Linux/macOS the directory is mode 0700 and the socket is mode 0600. On Windows/NTFS, where
+   POSIX modes are meaningless, `IpcServer` instead applies an **owner-only ACL** — a single
+   ALLOW full-control ACE for the owning user, with inherited ACEs dropped — to both the private
+   directory and the socket file. Either way the protection is set explicitly by `IpcServer` to
+   defend against permissive umasks or inherited ACLs, and the same-user preflight compares the
+   attacher's and target's process owners (`ProcessHandle`) rather than trusting the socket alone.
    If callers override `AttachOptions.udsPath` with a path under an existing directory, they own
    that parent directory's permissions; Spectre only tightens directories it creates itself.
    Any process running as the same OS user can connect and drive the target. There is no
@@ -60,7 +65,7 @@ out of scope.
 | Record video | `AutoRecorder`, native recorders, deprecated explicit `FfmpegRecorder`, `WaylandPortalRecorder` | In-process only |
 | Execute a helper binary | `HelperBinaryExtractor` (SCK), `WaylandHelperBinaryExtractor` | Local file system, JVM process |
 | Expose any of the above over HTTP | `installSpectreRoutes` mounts the windows / nodes / click / typeText / screenshot routes | **Unauthenticated, plaintext** — host application chooses bind address |
-| Expose any of the above over UDS | `:agent`'s `IpcServer` mounts the same surface plus detach over a Unix Domain Socket | **Unauthenticated** — filesystem mode 0600 (same UID); macOS + Linux only in the current preview |
+| Expose any of the above over UDS | `:agent`'s `IpcServer` mounts the same surface plus detach over a Unix Domain Socket | **Unauthenticated** — owner-only filesystem access (POSIX mode 0600 on Linux/macOS, owner-only ACL on Windows/NTFS); same OS user only. Windows attach enablement is tracked under #193 |
 
 The HTTP exposure column is the most important one to internalise: there are **no auth
 tokens, no TLS, and no origin checks** on any route. The transport is intentionally a
@@ -114,6 +119,13 @@ expansion); items that are hygiene fixes get their own issues.
 - **`pasteText` clipboard-restore robustness.** A failure during the post-paste restore is
   swallowed via `runCatching` (clipboard may be left holding the typed text). Standalone
   follow-up issue.
+- **Windows agent socket: local administrators and SYSTEM retain access.** The owner-only ACL on
+  the agent's private directory and socket blocks other standard users, but members of the local
+  `Administrators` group and `SYSTEM` can take ownership of any file and therefore read or connect
+  regardless — the same reality as `root` on a POSIX mode-0600 socket. The same-user preflight on
+  Windows also treats elevated and non-elevated processes of the same account as the same user
+  (they share the account SID); Windows may still deny the OS-level attach across integrity levels.
+  These are accepted for the same-machine, same-user testing model. Tracked under #193.
 - **Helper-extraction cleanup.** Extracted helper binaries are not `deleteOnExit`-registered.
   This is hygiene, not security (the extraction path is process-private and writable only by
   the user), but a tidy-up follow-up is worth tracking.


### PR DESCRIPTION
Closes #195. Part of #193. Depends on the #194 spike (GO: native `AF_UNIX` carries the transport on Windows).

Ports the agent transport's trust boundary to Windows behind two per-platform seams, so the
existing UDS transport can protect its socket and preflight ownership on Windows without callers
branching on `os.name`. **Windows attach stays gated in `AgentPlatformPreflight` until #196** — this
PR adds and tests the machinery; #196 flips the switch (gates, path scheme, CI, docs).

## What changed

- **`SocketFileProtection`** (new seam, selected by `supportedFileAttributeViews()`):
  - POSIX impl preserves today's exact behavior — dir `0700`, socket `0600` (extracted verbatim
    from `IpcServer`).
  - Windows impl sets an owner-only `AclFileAttributeView` ACE (full control, inherited ACEs
    dropped) on **both** the private per-attach directory and the socket file — the NTFS mirror of
    `0700`/`0600`. Verified on NTFS that `setAcl(listOf(ownerFullControl))` collapses the DACL to a
    single owner ACE.
  - `IpcServer` now delegates to it (and is ~58 lines lighter).
- **`AttachUserPreflight`** (new seam): resolves the **current and target** owner through the same
  `ProcessHandle.info().user()` API so `DOMAIN\name` compares to `DOMAIN\name`. The previous check
  compared `ProcessHandle.user()` against bare `System.getProperty("user.name")`, which **wrongly
  rejected the same user attaching to their own JVM on Windows**. Windows is case-insensitive, POSIX
  case-sensitive; leaves a drop-in point for #166 (POSIX numeric UID). `AgentAttach.checkSameUser`
  delegates to it.
- **`docs/SECURITY.md`**: documents the Windows owner-only ACL model and its accepted risks
  (`Administrators`/`SYSTEM` retain access; elevated vs non-elevated same-user semantics).

## Testing

- `./gradlew :agent:check` green on Windows (ktfmt, detekt, ABI — no public API change, tests).
- New tests (15, all run on Windows, 0 skipped): `AttachUserPreflightTest` (per-platform ownership
  comparison incl. the `DOMAIN\name` fix), `SocketFileProtectionTest` (factory selection + Windows
  ACL assertions), `IpcServerWindowsAclTest` (real `IpcServer` → owner-only ACLs on dir + socket →
  CBOR round-trip → cleanup on close).
- POSIX behavior is preserved by construction; the POSIX-gated `IpcRoundTripTest` continues to cover
  it on Linux/macOS CI.

## Not in this PR

- Lifting the Windows platform gate, the `%TEMP%` default-path scheme, enabling `OS.WINDOWS` on the
  integration tests, Windows CI wiring, and the user-facing docs — all #196.
- A pre-existing, unrelated `:core` on-screen screenshot test (`SyntheticInputParityTest`) is
  environment-sensitive on a non-interactive desktop; tracked separately (not touched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
