### PR TITLE
Make synthetic screenshot parity test robust to non-interactive sessions

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -309,6 +309,12 @@ internal constructor(
      * Captures the given screen [region] (or the entire virtual desktop, if `null`) and returns the
      * pixels as a [BufferedImage].
      *
+     * **Dimensions.** The returned image is sized to the requested *logical* [region] regardless of
+     * display DPI scaling — `java.awt.Robot.createScreenCapture` downsamples HiDPI device pixels to
+     * the logical rectangle, so a 60×60 request yields a 60×60 image even on a 2× display. The
+     * device-resolution pixels are reachable only via `createMultiResolutionScreenCapture`, which
+     * this path deliberately does not use.
+     *
      * **Colour space.** The returned image is sRGB (`TYPE_INT_ARGB` / sRGB `ColorModel`), matching
      * `java.awt.Robot.createScreenCapture`'s contract. Pixel values are post-display-pipeline: what
      * the OS composited and what the framebuffer holds, not the source values your Compose code

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/LiveAwtAssumptions.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/LiveAwtAssumptions.kt
@@ -1,6 +1,11 @@
 package dev.sebastiano.spectre.core
 
+import java.awt.Color
 import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+import java.awt.Robot
+import java.util.Locale
+import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.Assumptions.assumeTrue
 
@@ -15,4 +20,61 @@ internal fun assumeLiveAwtAvailable() {
     assumeFalse(GraphicsEnvironment.isHeadless(), "Live AWT tests need a non-headless JVM")
 }
 
+/**
+ * Skips (rather than fails) the calling test when the current desktop session can't present a
+ * freshly rendered window into the framebuffer that `java.awt.Robot.createScreenCapture` reads.
+ *
+ * [assumeLiveAwtAvailable] only proves the JVM is non-headless; it can't distinguish a genuinely
+ * interactive, frontmost desktop from a locked console, an RDP/VNC session with no on-screen
+ * framebuffer, or an occluded/minimised worker. In those sessions a window can be shown and laid
+ * out yet never composited onto the captured pixels, so an on-screen pixel assertion samples the
+ * desktop background instead of the window — the exact symptom that made the synthetic-screenshot
+ * parity test fail on a non-interactive Windows box (capture returned the desktop's dark-grey
+ * background rather than the panel's red).
+ *
+ * The caller shows a solid-[expected]-colour [region] on screen first, then hands its screen bounds
+ * here. This probes with a *raw* [Robot] — independent of the code under test — polling until the
+ * region's centre pixel matches [expected] (exact, masked to RGB, so the probe never passes where
+ * the driver's own exact-match assertion would then fail) or the budget elapses. A match proves the
+ * session presents windows for capture and the caller proceeds. Because the probe is independent of
+ * the driver, a genuine capture-path regression (the raw probe sees the colour but the driver's
+ * screenshot does not) still fails the caller's assertion instead of being masked as a skip.
+ */
+internal fun assumeOnScreenCaptureReflects(
+    region: Rectangle,
+    expected: Color,
+    timeoutMillis: Long = CAPTURE_PROBE_TIMEOUT_MS,
+    pollMillis: Long = CAPTURE_PROBE_POLL_MS,
+) {
+    val robot = Robot()
+    val expectedRgb = expected.rgb and 0x00FFFFFF
+    val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis)
+    var lastRgb = robot.captureCenterRgb(region)
+    while (lastRgb != expectedRgb && System.nanoTime() < deadline) {
+        Thread.sleep(pollMillis)
+        lastRgb = robot.captureCenterRgb(region)
+    }
+    assumeTrue(
+        lastRgb == expectedRgb,
+        "On-screen framebuffer capture did not reflect a freshly shown window in this session " +
+            "(sampled #${"%06X".format(Locale.ROOT, lastRgb)} at the region centre, expected " +
+            "#${"%06X".format(Locale.ROOT, expectedRgb)}). This is expected on a locked console, " +
+            "an RDP/VNC session with no on-screen framebuffer, or an occluded worker; the live " +
+            "on-screen capture assertion is skipped there.",
+    )
+}
+
+/**
+ * Captures [region] and returns its centre pixel's RGB (alpha masked off). Samples the returned
+ * image's own centre rather than deriving coordinates from [region]: `createScreenCapture` sizes
+ * the image to the requested logical rectangle even under DPI scaling, so the two coincide today,
+ * but keying off the actual image keeps this correct if that ever changes.
+ */
+private fun Robot.captureCenterRgb(region: Rectangle): Int {
+    val image = createScreenCapture(region)
+    return image.getRGB(image.width / 2, image.height / 2) and 0x00FFFFFF
+}
+
 private const val LIVE_AWT_OPT_IN_PROPERTY = "spectre.test.liveAwt"
+private const val CAPTURE_PROBE_TIMEOUT_MS = 5_000L
+private const val CAPTURE_PROBE_POLL_MS = 25L

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
@@ -368,20 +368,39 @@ class SyntheticInputParityTest {
     fun `synthetic screenshot uses framebuffer capture for the requested dimensions`() {
         assumeLiveAwtAvailable()
         val target = ColoredPanel(Color.RED)
-        val frame = showFrameOnEdt(target)
+        // isAlwaysOnTop: on Windows a JVM spawned by Gradle/IntelliJ can't raise its window past
+        // the foreground terminal with toFront() alone (foreground-stealing prevention), so a real
+        // framebuffer capture at the window coords reads the terminal/desktop pixels instead of the
+        // panel. showFrameOnEdt raises always-on-top frames to front once realised. Mirrors the
+        // established real-Robot Windows pattern — see WindowsRobotSmoke.
+        val frame = showFrameOnEdt(target) { isAlwaysOnTop = true }
         try {
-            val driver = RobotDriver.synthetic(frame.frame)
             val origin = frame.targetTopLeftOnScreen(target)
             // Capture a sub-region inside the panel — keeps the test robust against frame
             // padding / WM decorations that could pollute pixels near the edges.
             val captureRegion =
                 Rectangle(origin.x + 20, origin.y + 20, REGION_SIZE_PX, REGION_SIZE_PX)
+            // Even when frontmost, a locked console / RDP-VNC session with no on-screen framebuffer
+            // / occluded worker can show the window yet never composite it into the captured pixels
+            // — the exact failure this hit on a non-interactive Windows box (capture returned the
+            // desktop's dark-grey background, not red). assumeLiveAwtAvailable()'s headless check
+            // doesn't catch that. Probe on-screen capture independently of the driver and skip
+            // there; a genuine capture-path regression (probe sees red, driver doesn't) still fails
+            // below rather than being masked as a skip.
+            assumeOnScreenCaptureReflects(captureRegion, Color.RED)
+            val driver = RobotDriver.synthetic(frame.frame)
             val image = waitForScreenshotColor(driver, captureRegion, Color.RED)
+            // java.awt.Robot.createScreenCapture returns an image sized to the *requested logical*
+            // rectangle regardless of display DPI scaling: verified on Windows at forced
+            // sun.java2d.uiScale=2, where a 60×60 logical request still yields a 60×60 image (the
+            // 2× device pixels surface only via createMultiResolutionScreenCapture). So
+            // REGION_SIZE_PX is the correct expectation on HiDPI too — no scale factor applies.
             assertEquals(REGION_SIZE_PX, image.width, "image width must match requested width")
             assertEquals(REGION_SIZE_PX, image.height, "image height must match requested height")
-            // Sample a pixel inside the captured region. Synthetic input still uses real
-            // framebuffer capture for screenshots, so the visible red panel should come through.
-            val sampledRgb = image.getRGB(REGION_SIZE_PX / 2, REGION_SIZE_PX / 2)
+            // Sample the captured image's own centre rather than a hardcoded offset, so the pixel
+            // assertion stays correct even if a capture ever returns a differently sized image.
+            // Synthetic input still uses real framebuffer capture, so the red panel comes through.
+            val sampledRgb = image.getRGB(image.width / 2, image.height / 2)
             val sampled = Color(sampledRgb)
             assertEquals(
                 Color.RED.rgb and 0x00FFFFFF,
@@ -411,6 +430,12 @@ class SyntheticInputParityTest {
                     size = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
                     setLocation(FRAME_OFFSET_PX, FRAME_OFFSET_PX)
                     isVisible = true
+                    // A frame that opted into always-on-top is a screen-capture target and must be
+                    // the frontmost, composited surface for a real framebuffer read to see its
+                    // pixels. Raise it now that it's realised — toFront() before isVisible is a
+                    // no-op. Synthetic-input-only frames skip this: they dispatch AWT events
+                    // straight into the hierarchy and don't depend on OS z-order.
+                    if (isAlwaysOnTop) toFront()
                 }
         }
         val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(SHOW_TIMEOUT_SECONDS)
@@ -436,8 +461,7 @@ class SyntheticInputParityTest {
         return latest
     }
 
-    private fun BufferedImage.centerRgb(): Int =
-        getRGB(REGION_SIZE_PX / 2, REGION_SIZE_PX / 2) and 0x00FFFFFF
+    private fun BufferedImage.centerRgb(): Int = getRGB(width / 2, height / 2) and 0x00FFFFFF
 
     private fun drainEdt() {
         // Drain twice: the first invokeAndWait flushes events already on the queue, the second


### PR DESCRIPTION
## What

`SyntheticInputParityTest.\`synthetic screenshot uses framebuffer capture for the requested dimensions\`` does a real on-screen `Robot` framebuffer capture of a red `JFrame` and asserts the centre pixel is red. It failed consistently on a Windows dev box whose desktop session wasn't frontmost — the capture returned the desktop's dark-grey background (`#474747`) instead of red. It surfaced while running `./gradlew check` for #195; it's unrelated to that epic.

Root cause: the frame set neither `isAlwaysOnTop` nor `toFront()`, so a JVM spawned by Gradle/IntelliJ couldn't raise its window past the foreground terminal (Windows foreground-stealing prevention) and the framebuffer read whatever was on top. `assumeLiveAwtAvailable()`'s headless check can't catch this — the JVM is non-headless, just non-presentable.

## Fix

Two parts, mirroring the established real-Robot Windows pattern documented in `WindowsRobotSmoke`:

- **Present the window.** Show the frame `isAlwaysOnTop = true` and `toFront()` once realised (scoped in `showFrameOnEdt` to always-on-top frames, so the synthetic-input-only tests are untouched). Fixes the common case: a genuinely interactive session where the window just wasn't frontmost. This alone made the test pass on the previously-failing box.
- **Skip when truly non-presentable.** Gate the pixel assertion behind `assumeOnScreenCaptureReflects` — a probe that uses a *raw* `Robot` (independent of the driver under test) to poll until the region reflects the expected colour, and `assumeTrue`-skips when it never does. Cleanly skips on a locked console / RDP-VNC / occluded worker, while a genuine capture-path regression (probe sees red, driver doesn't) still **fails** rather than being masked as a skip.

## HiDPI

While here, verified empirically (forced `-Dsun.java2d.uiScale=2`) that `Robot.createScreenCapture` returns an image sized to the requested **logical** rectangle regardless of DPI — a 60×60 request stays 60×60 on a 2× display; device pixels are reachable only via `createMultiResolutionScreenCapture`. So the dimension asserts were already HiDPI-correct (no scale factor applies). Documented the contract in the `RobotDriver.screenshot` KDoc and switched pixel sampling to the captured image's own centre instead of a hardcoded offset.

## Test plan

- `:core:check` green locally (Windows/JBR 21), including `checkKotlinAbi` (KDoc-only main change, no ABI delta).
- `SyntheticInputParityTest`: 8 passed, 0 skipped, 0 failed — the screenshot test now **passes** on this box (interactive-but-not-frontmost case).
- On CI: Linux `:check` is headless → `assumeLiveAwtAvailable()` skips these live-AWT tests as before; Windows/macOS `:check` run them headed. The change is strictly more robust — it can only make those greener (present → pass as before; can't present → skip instead of fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)