### PR TITLE
Enable agent attach on Windows: preflight, path, tests, docs

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentPlatformPreflight.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentPlatformPreflight.kt
@@ -1,10 +1,45 @@
 package dev.sebastiano.spectre.agent
 
+import java.io.IOException
+import java.net.StandardProtocolFamily
+import java.nio.channels.ServerSocketChannel
+
+/**
+ * Gate for [AgentAttach.attach]: the agent transport rides on native `AF_UNIX` sockets, so the host
+ * must support them.
+ *
+ * Linux and macOS have supported `AF_UNIX` since the JDK 16 minimum Spectre targets, so they pass
+ * unconditionally. Windows gained native `AF_UNIX` in Windows 10 version 1803 / Windows Server
+ * 2019; rather than parse a build number (`os.version` is just `"10.0"` on both Windows 10 and 11),
+ * we probe the actual capability by opening — without binding — a `ServerSocketChannel` in the
+ * `UNIX` protocol family. That throws [UnsupportedOperationException] on hosts without `AF_UNIX`.
+ */
 @ExperimentalSpectreAgentApi
 internal object AgentPlatformPreflight {
-    fun requireSupported(osName: String = System.getProperty("os.name").orEmpty()) {
-        if (osName.startsWith("Windows", ignoreCase = true)) {
-            throw AttachPlatformUnsupportedException(osName)
-        }
+    fun requireSupported(
+        osName: String = System.getProperty("os.name").orEmpty(),
+        afUnixSupported: () -> Boolean = ::isAfUnixSupported,
+    ) {
+        // Only Windows needs the capability check; Linux/macOS always have AF_UNIX on JDK 16+.
+        if (!osName.startsWith("Windows", ignoreCase = true)) return
+        if (!afUnixSupported()) throw AttachPlatformUnsupportedException(osName)
     }
+
+    /**
+     * True when this JVM can open an `AF_UNIX` socket channel. Opening without binding creates no
+     * filesystem entry; it throws [UnsupportedOperationException] on platforms without native
+     * `AF_UNIX` (pre-1803 Windows).
+     */
+    private fun isAfUnixSupported(): Boolean =
+        try {
+            ServerSocketChannel.open(StandardProtocolFamily.UNIX).use { true }
+        } catch (_: UnsupportedOperationException) {
+            false
+        } catch (_: IOException) {
+            // An unexpected low-level failure opening the (unbound) probe channel is not evidence
+            // that AF_UNIX is unsupported — only UnsupportedOperationException is. Treat it as
+            // supported and let the real bind in IpcServer surface any genuine problem, rather than
+            // letting a raw IOException escape the SpectreAttachException contract of attach().
+            true
+        }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
@@ -22,9 +22,9 @@ public class AttachUnsupportedException(cause: Throwable? = null) :
 @ExperimentalSpectreAgentApi
 public class AttachPlatformUnsupportedException(public val osName: String) :
     SpectreAttachException(
-        "The Spectre agent transport is currently supported on macOS and Linux only. " +
-            "This JVM reports os.name='$osName'. Windows support needs a named-pipe " +
-            "transport instead of Unix Domain Sockets."
+        "The Spectre agent transport requires native AF_UNIX socket support. This JVM reports " +
+            "os.name='$osName' without it. On Windows, native AF_UNIX requires Windows 10 " +
+            "version 1803 / Windows Server 2019 or newer."
     )
 
 /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -42,15 +42,33 @@ public data class AttachOptions(
         public const val DEFAULT_ATTACH_TIMEOUT_MS: Long = 5_000
 
         /**
-         * Default UDS path: `/tmp/sp-a-<pid>-<8char-uuid>/agent.sock`. Deliberately short to stay
-         * inside Unix's `sun_path` limit (~104 chars on macOS, ~108 on Linux). `java.io.tmpdir`
-         * resolves to a much longer path on macOS (`/var/folders/...`) and can blow past the limit,
-         * so we hard-code `/tmp` (symlinked to `/private/tmp` on macOS).
+         * Default UDS path: `<base>/sp-a-<pid>-<8char-uuid>/agent.sock`.
+         *
+         * The base directory is platform-aware and deliberately short to stay inside the `sun_path`
+         * limit (~104 chars on macOS, ~108 on Linux and Windows):
+         * - **Linux/macOS**: hard-coded `/tmp` (symlinked to `/private/tmp` on macOS).
+         *   `java.io.tmpdir` resolves to a much longer `/var/folders/...` on macOS and can blow
+         *   past the limit.
+         * - **Windows**: `java.io.tmpdir` (i.e. `%TEMP%`, per-user ACL'd). `/tmp` is meaningless on
+         *   Windows — `Paths.get("/tmp", …)` yields the drive-relative `\tmp\…`, outside the
+         *   protected per-user temp area.
          */
         public fun defaultUdsPath(targetPid: Long): Path {
             val shortUuid = UUID.randomUUID().toString().take(SHORT_UUID_LENGTH)
-            return Paths.get("/tmp", "sp-a-${targetPid}-${shortUuid}", "agent.sock")
+            val base = udsBaseDir(System.getProperty("os.name").orEmpty(), TMP_DIR)
+            return Paths.get(base, "sp-a-${targetPid}-${shortUuid}", "agent.sock")
         }
+
+        /**
+         * Base directory for the default UDS path: `java.io.tmpdir` (`%TEMP%`) on Windows, `/tmp`
+         * elsewhere. Extracted for testing — `java.nio.file.Path` construction is
+         * filesystem-specific so the selection logic is validated as strings here.
+         */
+        internal fun udsBaseDir(osName: String, tmpDir: String): String =
+            if (osName.startsWith("Windows", ignoreCase = true)) tmpDir else "/tmp"
+
+        private val TMP_DIR: String
+            get() = System.getProperty("java.io.tmpdir").orEmpty()
 
         private const val SHORT_UUID_LENGTH = 8
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -60,17 +60,17 @@ import org.junit.jupiter.api.condition.OS
  * developers can diagnose real keyboard regressions.
  *
  * Gating:
- * - **Disabled on Windows** via `@EnabledOnOs(OS.LINUX, OS.MAC)`. The current agent transport is
- *   macOS+Linux only — `AgentAttach.attach` short-circuits with
- *   `AttachPlatformUnsupportedException` on Windows runners. Until Windows support lands (named
- *   pipes via JNA/junixsocket follow-up), this test is skipped rather than asserting
- *   Windows-specific failure shapes.
+ * - **Runs on Linux, macOS, and Windows** via `@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)`. The
+ *   agent transport rides native `AF_UNIX` on all three (#196); the fixture is spawned with the
+ *   platform's `java`/`java.exe`.
  * - Skipped on headless JVMs (`java.awt.GraphicsEnvironment.isHeadless()`). Compose Desktop refuses
  *   to create a `JFrame + ComposePanel` without a display.
  * - Skipped when `dev.sebastiano.spectre.agent.runtimeJar` isn't set. Gradle's `:agent:test` task
  *   sets it from the `:agent-runtime:jar` output.
+ * - Real-keyboard `typeText` tolerates a CI-only loss of OS keyboard focus on any platform (see
+ *   `typeTextOrSkipCiFocusLoss`); the attach/click/focus contract is still asserted.
  */
-@EnabledOnOs(OS.LINUX, OS.MAC)
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
 class AgentAttachIntegrationTest {
     private val orphanUdsFiles = mutableListOf<Path>()
 
@@ -187,7 +187,13 @@ class AgentAttachIntegrationTest {
     }
 
     private fun spawnComposeFixture(): FixtureProcess {
-        val javaBin = Paths.get(System.getProperty("java.home"), "bin", "java").toString()
+        // ProcessBuilder does not append `.exe` for an absolute path on Windows, so pick the
+        // launcher name explicitly.
+        val javaExe =
+            if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
+                "java.exe"
+            else "java"
+        val javaBin = Paths.get(System.getProperty("java.home"), "bin", javaExe).toString()
         val classpath = System.getProperty("java.class.path")
         val process =
             ProcessBuilder(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentPlatformPreflightTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentPlatformPreflightTest.kt
@@ -5,21 +5,42 @@ package dev.sebastiano.spectre.agent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 
 class AgentPlatformPreflightTest {
     @Test
-    fun `Windows fails with a dedicated unsupported platform exception`() {
-        val ex =
-            assertFailsWith<AttachPlatformUnsupportedException> {
-                AgentPlatformPreflight.requireSupported(osName = "Windows 11")
-            }
-
-        assertEquals("Windows 11", ex.osName)
+    fun `Windows passes when AF_UNIX is supported`() {
+        AgentPlatformPreflight.requireSupported(osName = "Windows 11", afUnixSupported = { true })
     }
 
     @Test
-    fun `macOS and Linux pass the agent platform preflight`() {
-        AgentPlatformPreflight.requireSupported(osName = "Mac OS X")
-        AgentPlatformPreflight.requireSupported(osName = "Linux")
+    fun `Windows without AF_UNIX fails with a dedicated unsupported platform exception`() {
+        val ex =
+            assertFailsWith<AttachPlatformUnsupportedException> {
+                AgentPlatformPreflight.requireSupported(
+                    osName = "Windows 10",
+                    afUnixSupported = { false },
+                )
+            }
+        assertEquals("Windows 10", ex.osName)
+    }
+
+    @Test
+    fun `macOS and Linux pass without probing AF_UNIX`() {
+        var probed = false
+        val probe = {
+            probed = true
+            true
+        }
+        AgentPlatformPreflight.requireSupported(osName = "Mac OS X", afUnixSupported = probe)
+        AgentPlatformPreflight.requireSupported(osName = "Linux", afUnixSupported = probe)
+        assertFalse(probed, "non-Windows platforms must not probe AF_UNIX")
+    }
+
+    @Test
+    fun `the real AF_UNIX probe passes on this supported host`() {
+        // Every leg of the dev/CI matrix (Linux, macOS, Windows 10 1803+/Server 2019+) supports
+        // native AF_UNIX, so the default probe against the real os.name must not throw.
+        AgentPlatformPreflight.requireSupported()
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
@@ -1,0 +1,60 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+class AttachOptionsTest {
+    // ---- base-dir selection (pure, platform-agnostic) ----
+
+    @Test
+    fun `udsBaseDir uses the JVM temp dir on Windows`() {
+        assertEquals(
+            "C:\\Users\\x\\AppData\\Local\\Temp",
+            AttachOptions.udsBaseDir("Windows 11", "C:\\Users\\x\\AppData\\Local\\Temp"),
+        )
+    }
+
+    @Test
+    fun `udsBaseDir uses slash tmp on POSIX`() {
+        assertEquals("/tmp", AttachOptions.udsBaseDir("Linux", "/var/folders/ignored"))
+        assertEquals("/tmp", AttachOptions.udsBaseDir("Mac OS X", "/var/folders/ignored"))
+    }
+
+    // ---- default path structure (platform-agnostic) ----
+
+    @Test
+    fun `defaultUdsPath ends in the per-attach dir plus agent socket`() {
+        val p = AttachOptions.defaultUdsPath(1234L)
+        assertEquals("agent.sock", p.fileName.toString())
+        assertTrue(
+            p.parent.fileName.toString().startsWith("sp-a-1234-"),
+            "per-attach dir should be sp-a-<pid>-<uuid>, got ${p.parent.fileName}",
+        )
+    }
+
+    // ---- real path per platform ----
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    fun `defaultUdsPath is absolute and under the JVM temp dir on Windows`() {
+        val p = AttachOptions.defaultUdsPath(1234L)
+        assertTrue(p.isAbsolute, "UDS path must be absolute on Windows, got $p")
+        assertTrue(
+            p.startsWith(Path.of(System.getProperty("java.io.tmpdir"))),
+            "UDS path must live under java.io.tmpdir (%TEMP%) on Windows, got $p",
+        )
+    }
+
+    @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC)
+    fun `defaultUdsPath is under slash tmp on POSIX`() {
+        val p = AttachOptions.defaultUdsPath(1234L)
+        assertTrue(p.startsWith(Path.of("/tmp")), "UDS path must live under /tmp on POSIX, got $p")
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -24,21 +24,20 @@ import org.junit.jupiter.api.condition.OS
  * canned responses — the real `ReflectiveAutomatorHandler` is exercised in M-7/M-8's child-JVM
  * integration tests where a real `ComposeAutomator` exists.
  *
- * Each test creates a unique UDS path under `java.io.tmpdir` and cleans up via @AfterTest. Paths
- * must be short enough to fit Unix's sun_path limit (~104 chars on macOS, ~108 on Linux); a short
- * UUID prefix keeps us well within bounds.
+ * Each test creates a unique UDS path via [udsBase] and cleans up via @AfterTest. The base
+ * directory is platform-aware — `/tmp` on POSIX, `%TEMP%` (`java.io.tmpdir`) on Windows, where
+ * `/tmp` is meaningless — and short enough to fit the `sun_path` limit (~104 chars macOS, ~108
+ * Linux/Windows); a short UUID prefix keeps us well within bounds.
  *
- * **Disabled on Windows** via `@EnabledOnOs(OS.LINUX, OS.MAC)`. The agent transport is macOS+Linux
- * only in the current preview — Windows support (named pipes via JNA/junixsocket) is a tracked
- * follow-up. The hard-coded `/tmp/...` UDS path is meaningless on Windows and the test would
- * `SocketException` on connect rather than exercising the round-trip contract.
+ * Runs on Windows too (native `AF_UNIX`, #196). Two POSIX-mode-specific cases carry a method-level
+ * `@EnabledOnOs(OS.LINUX, OS.MAC)`: the parent-permissions assertion and the FD-leak probe (which
+ * needs `UnixOperatingSystemMXBean`). The Windows analog — owner-only ACLs on the created dir and
+ * socket plus cleanup on close — lives in [IpcServerWindowsAclTest].
  */
-@EnabledOnOs(OS.LINUX, OS.MAC)
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
 class IpcRoundTripTest {
-    // Use `/tmp` directly rather than `java.io.tmpdir` — on macOS the latter resolves to
-    // `/var/folders/...` which can push the path past Unix's 104-char `sun_path` limit.
-    // `/tmp` is symlinked to `/private/tmp` (12 chars) and works on both macOS and Linux.
-    private val udsPath: Path = Path.of("/tmp", "sp-t-${UUID.randomUUID().toString().take(8)}.sock")
+    private val udsPath: Path =
+        udsBase().resolve("sp-t-${UUID.randomUUID().toString().take(8)}.sock")
 
     @AfterTest
     fun cleanUp() {
@@ -61,6 +60,10 @@ class IpcRoundTripTest {
     }
 
     @Test
+    @EnabledOnOs(
+        OS.LINUX,
+        OS.MAC,
+    ) // POSIX mode assertion; Windows ACL analog: IpcServerWindowsAclTest
     fun `server creates missing UDS parent owner-only and removes it on close`() {
         val parent = Path.of("/tmp", "sp-t-${UUID.randomUUID().toString().take(8)}")
         val nestedUdsPath = parent.resolve("agent.sock")
@@ -230,6 +233,7 @@ class IpcRoundTripTest {
     }
 
     @Test
+    @EnabledOnOs(OS.LINUX, OS.MAC) // relies on UnixOperatingSystemMXBean.openFileDescriptorCount
     fun `IpcServer constructor releases the ServerSocketChannel when bind fails`() {
         // Regression for Bugbot LOW finding on commit 82be70e: in the `IpcServer` constructor,
         // `ServerSocketChannel.open()` opens a channel, but if `bind()` (or the `deleteIfExists`
@@ -449,6 +453,14 @@ class IpcRoundTripTest {
         }
         error("UDS file $path did not appear within ${timeoutMs} ms")
     }
+
+    // Short, platform-appropriate base dir for UDS paths: `/tmp` on POSIX (macOS `java.io.tmpdir`
+    // is `/var/folders/...` and can exceed sun_path); `%TEMP%` on Windows, where `/tmp` is
+    // drive-relative nonsense. Reads only system properties, so it's safe from a property init.
+    private fun udsBase(): Path =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
+            Path.of(System.getProperty("java.io.tmpdir"))
+        else Path.of("/tmp")
 
     private companion object {
         // Comfortably above macOS's ~104-byte and Linux's ~108-byte `sun_path` cap so the

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -65,7 +65,7 @@ out of scope.
 | Record video | `AutoRecorder`, native recorders, deprecated explicit `FfmpegRecorder`, `WaylandPortalRecorder` | In-process only |
 | Execute a helper binary | `HelperBinaryExtractor` (SCK), `WaylandHelperBinaryExtractor` | Local file system, JVM process |
 | Expose any of the above over HTTP | `installSpectreRoutes` mounts the windows / nodes / click / typeText / screenshot routes | **Unauthenticated, plaintext** — host application chooses bind address |
-| Expose any of the above over UDS | `:agent`'s `IpcServer` mounts the same surface plus detach over a Unix Domain Socket | **Unauthenticated** — owner-only filesystem access (POSIX mode 0600 on Linux/macOS, owner-only ACL on Windows/NTFS); same OS user only. Windows attach enablement is tracked under #193 |
+| Expose any of the above over UDS | `:agent`'s `IpcServer` mounts the same surface plus detach over a Unix Domain Socket | **Unauthenticated** — owner-only filesystem access (POSIX mode 0600 on Linux/macOS, owner-only ACL on Windows/NTFS); same OS user only. Supported on Linux, macOS, and Windows (10 version 1803 / Server 2019+) |
 
 The HTTP exposure column is the most important one to internalise: there are **no auth
 tokens, no TLS, and no origin checks** on any route. The transport is intentionally a
@@ -125,7 +125,7 @@ expansion); items that are hygiene fixes get their own issues.
   regardless — the same reality as `root` on a POSIX mode-0600 socket. The same-user preflight on
   Windows also treats elevated and non-elevated processes of the same account as the same user
   (they share the account SID); Windows may still deny the OS-level attach across integrity levels.
-  These are accepted for the same-machine, same-user testing model. Tracked under #193.
+  These are accepted for the same-machine, same-user testing model.
 - **Helper-extraction cleanup.** Extracted helper binaries are not `deleteOnExit`-registered.
   This is hygiene, not security (the extraction path is process-private and writable only by
   the user), but a tidy-up follow-up is worth tracking.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -56,9 +56,9 @@ Three experimental markers exist today:
   marker.
 - **`@ExperimentalSpectreAgentApi`** covers the entire `agent` module's attach-side public
   surface — `AgentAttach`, `AttachedAutomator`, `AttachOptions`, `SpectreProcesses`, and the
-  wire DTOs. Tracked under #153; the marker stays in place while the attach UX, Windows
-  transport shape, streaming wire ops (`waitForVisualIdle` etc.), and automated
-  IntelliJ-hosted Compose attach tests settle.
+  wire DTOs. Tracked under #153; the marker stays in place while the attach UX, streaming wire
+  ops (`waitForVisualIdle` etc.), and automated IntelliJ-hosted Compose attach tests settle.
+  The transport itself runs on Linux, macOS, and Windows (native `AF_UNIX`).
 
 Consumers opt in either at file level or call site:
 
@@ -137,7 +137,7 @@ Spectre is JVM-first and targets desktop OSes.
 | Platform | Tier | Notes |
 | --- | --- | --- |
 | **macOS** | Primary | Full support. AWT Robot input, ScreenCaptureKit recording (with `spectre-recording-macos` helper), TCC permission diagnostics. |
-| **Windows** | Full | AWT Robot input + Windows Graphics Capture region/window recording. |
+| **Windows** | Full | AWT Robot input + Windows Graphics Capture region/window recording + agent attach over native `AF_UNIX` (Windows 10 1803 / Server 2019+). |
 | **Linux Xorg** | Full | AWT Robot input + helper/GStreamer Xorg/Xvfb recording and screenshots. Validated against Xvfb in CI. |
 | **Linux Wayland** | Best-effort | Portal-mediated capture via `WaylandPortalRecorder`, `WaylandPortalWindowRecorder`, and `LinuxNativeScreenshotter`. **Validated on GNOME/Mutter only**; KDE / sway / wlroots compositors may behave differently and are not exercised in CI. Real Robot input is unavailable on Wayland — use the synthetic adapter for tests. |
 | **BSD** | Unsupported | Not built or tested. |

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -27,8 +27,9 @@ For comparison with the other transports, see [Cross-JVM access](cross-jvm.md) (
     The agent transport is **local only** and intended for **trusted dev/test
     environments**. Trust model:
 
-    - Communication is over a **Unix Domain Socket** under a short private directory in `/tmp/`.
-      Filesystem permissions (directory mode 0700, socket mode 0600) are the only access control.
+    - Communication is over a **Unix Domain Socket** under a short private directory (`/tmp/` on
+      Linux/macOS, `%TEMP%` on Windows). Filesystem permissions are the only access control —
+      directory mode 0700 / socket mode 0600 on POSIX, or an owner-only ACL on Windows/NTFS.
     - The attaching JVM must run as the same OS user as the target JVM.
     - There is **no authentication** and **no encryption** on the wire.
     - The published `spectre-agent` API jar is for the attaching JVM. The
@@ -45,8 +46,10 @@ For comparison with the other transports, see [Cross-JVM access](cross-jvm.md) (
 - The target JVM must include **Spectre `:core`** on its classpath. The agent does not
   inject Spectre into the target; it reflectively bootstraps off the `:core` that's
   already loaded. The agent JAR itself is supplied by the attaching JVM at attach time.
-- **macOS and Linux only** in the current preview. Windows support is tracked as a follow-up (named pipes
-  via JNA or junixsocket).
+- **Linux, macOS, and Windows.** The transport uses native Unix Domain Sockets (`AF_UNIX`) on all
+  three — no named pipes, no extra dependencies. Windows requires **Windows 10 version 1803 /
+  Windows Server 2019 or newer**, when native `AF_UNIX` landed; older Windows fails the attach
+  preflight with a clear message.
 - The target JVM should be started with **`-XX:+EnableDynamicAgentLoading`**. Without it,
   attach prints a stderr warning per
   [JEP 451](https://openjdk.org/jeps/451) and a future JDK will reject the attach
@@ -202,14 +205,15 @@ cleanup.
 ```kotlin
 AttachOptions(
     agentJarPath = null,        // null = auto-locate (see "Artifact roles" above)
-    udsPath = null,             // null = /tmp/sp-a-<pid>-<8char-uuid>/agent.sock
+    udsPath = null,             // null = <tmp>/sp-a-<pid>-<8char-uuid>/agent.sock (/tmp on POSIX, %TEMP% on Windows)
     attachTimeoutMs = 5_000,    // how long to wait for the agent's IPC server to come up
 )
 ```
 
 If you override `udsPath` with a path under an existing directory, you own that parent
-directory's permissions. Spectre creates the default per-attach directory as mode 0700 and the
-socket as mode 0600, but it does not chmod directories it did not create.
+directory's permissions. Spectre creates the default per-attach directory and socket owner-only —
+mode 0700/0600 on POSIX, an owner-only ACL (owner full control, inherited ACEs dropped) on
+Windows — but it does not tighten directories it did not create.
 
 `AgentAttach.attach` runs a **same-user preflight** via `ProcessHandle` and throws
 `AttachPermissionDeniedException` if the target JVM is owned by a different OS user (the
@@ -250,7 +254,8 @@ hierarchy.
 
 ## Current limitations
 
-- **macOS and Linux only.** Windows support is a tracked follow-up.
+- **Windows needs 10 version 1803 / Server 2019 or newer.** That's when native `AF_UNIX` landed;
+  older Windows fails the attach preflight with `AttachPlatformUnsupportedException`.
 - **No streaming ops.** `waitForVisualIdle` and friends are HTTP-only or in-process only for now.
 - **IntelliJ-hosted Compose**: the classloader-disambiguation rule (D-14 in the plan) was
   designed to handle `PluginClassLoader` chains but isn't automatically tested yet. If
@@ -266,8 +271,9 @@ hierarchy.
 # Terminal A — start a Spectre-instrumented app
 ./gradlew :sample-desktop:run
 
-# Find its PID
-ps -A | grep "dev.sebastiano.spectre.sample.MainKt" | awk '{print $1}'
+# Find its PID (cross-platform: jps ships with the JDK)
+jps -l | grep "dev.sebastiano.spectre.sample.MainKt"
+# POSIX alternative: ps -A | grep "…MainKt" | awk '{print $1}'
 
 # Terminal B — attach the agent. The agent's stderr lands in Terminal A.
 ./gradlew :agent:attachSpike -Ppid=<pid>


### PR DESCRIPTION
Closes #196. Final step of epic #193, after the #194 spike (GO: native `AF_UNIX` on Windows) and #195 (owner-only ACL trust boundary, #220).

Lifts the platform gate and makes Windows a tested, documented platform for agent attach. The transport and trust boundary already landed; this flips the switch.

## What changed

- **`AgentPlatformPreflight`** — lift the Windows gate. `os.version` is `"10.0"` on both Windows 10 and 11, so instead of parsing a build number we **probe the actual `AF_UNIX` capability** by opening (without binding) a `ServerSocketChannel(UNIX)`; hosts without it (pre-1803 Windows / pre-2019 Server) are rejected with a clear message. Injectable for tests. `AttachPlatformUnsupportedException`'s text is rewritten (the "named-pipe transport" plan is gone).
- **`AttachOptions.defaultUdsPath`** — platform-aware base dir: `%TEMP%` (`java.io.tmpdir`) on Windows, `/tmp` on POSIX. On Windows `Paths.get("/tmp", …)` was drive-relative (`\tmp\…`), outside the per-user-ACL'd temp area.
- **`IpcRoundTripTest`** — now runs on Windows over a portable base dir (9 real `AF_UNIX` round-trips). Two inherently-POSIX cases keep a method-level `@EnabledOnOs(LINUX, MAC)` (the mode-0700 assertion and the `UnixOperatingSystemMXBean` FD-leak probe); the Windows dir+socket ACL analog is `IpcServerWindowsAclTest` (from #195).
- **`AgentAttachIntegrationTest`** — now runs on Windows; the fixture is spawned with `java.exe`. The real-keyboard `typeText` subpath is already CI-tolerant of OS focus loss on any platform.
- **Docs** — `docs/guide/agent.md`, `docs/STABILITY.md`, `docs/SECURITY.md`: drop "macOS and Linux only" and the stale "tracked under #193" notes; document the Windows minimum version and the owner-only ACL model.

`SpectreProcesses.findByName` needs no change — it matches `VirtualMachine.list()` display names (JDK Attach), not OS process names.

## Testing

- **Full `./gradlew check` green locally on Windows** (JBR 21), under CI semantics (`CI=true`, matching GitHub) — all modules, including `:agent:check` with the attach → exercise → detach integration test.
- New `AttachOptionsTest` (base-dir selection + per-OS path); rewritten `AgentPlatformPreflightTest` (capability-probe contract). `IpcRoundTripTest`: 9 ran / 2 POSIX-gated skips on Windows.
- Both an adversarial code review and a plan-alignment review were run in isolated contexts and came back clean (the plan-alignment pass caught a stale SECURITY.md line, now fixed).

## CI

`.github/workflows/windows.yml`'s `check-windows` job already path-triggers on `agent/**` and runs `./gradlew check` on `windows-latest`, so the newly-enabled Windows tests execute automatically — no workflow edit needed. This PR's own `check-windows` run is the acceptance gate.

## Follow-ups (chips filed, not blocking)

- Harden `AgentAttachIntegrationTest` against Windows foreground-lock: it passes on CI / under `CI=true`, but hard-fails on a busy dev desktop when the spawned fixture window can't steal OS focus from the terminal/IDE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
