### PR TITLE
Make the agent attach fixture always-on-top so real Robot input works on Windows

### DIFF
--- a/agent-test-fixture/src/main/kotlin/dev/sebastiano/spectre/agent/fixture/ComposeFixtureMain.kt
+++ b/agent-test-fixture/src/main/kotlin/dev/sebastiano/spectre/agent/fixture/ComposeFixtureMain.kt
@@ -36,6 +36,17 @@ import javax.swing.WindowConstants
  * Spectre's IntelliJ-hosted path uses, behaves deterministically under headless detection, and lets
  * `main()` print the sentinel itself after the EDT has finished its first paint pass.
  *
+ * **Why `isAlwaysOnTop`?** The integration test drives the attached agent's *real* `java.awt.Robot`
+ * click and keyboard paths against this window. On Windows, foreground-stealing prevention stops a
+ * JVM spawned by another foreground process (the Gradle/IDE terminal running the test) from raising
+ * its window via `toFront()` alone, so Robot clicks would land on the terminal and the text field
+ * would never take focus — a spurious hard failure that isn't a real regression. `isAlwaysOnTop`
+ * puts the fixture above the spawning terminal so Robot clicks hit Compose pixels and a genuine
+ * click grants OS keyboard focus. This is the same pattern `sample-desktop`'s `WindowsRobotSmoke`
+ * relies on (its finding #1). It's inert elsewhere: `LinuxRobotSmoke` keeps it on too (a no-op
+ * under Xvfb's minimal focus stacking), and `MacOsRobotSmoke` documents it as unnecessary on macOS
+ * (AppKit has no foreground-stealing prevention), so leaving it enabled there does no harm.
+ *
  * Lives in a separate Gradle module from `:agent` because applying the Compose Compiler plugin
  * module-wide to `:agent` would pull `@Composable` processing into the production agent runtime,
  * which has no business knowing about Compose.
@@ -58,6 +69,10 @@ fun main() {
                 defaultCloseOperation = WindowConstants.EXIT_ON_CLOSE
                 size = Dimension(FIXTURE_WIDTH_PX, FIXTURE_HEIGHT_PX)
                 setLocationRelativeTo(null)
+                // Keep the fixture above the spawning terminal so the agent's real java.awt.Robot
+                // clicks land on Compose pixels and can take OS keyboard focus on Windows. See the
+                // `isAlwaysOnTop` rationale in this file's KDoc.
+                isAlwaysOnTop = true
             }
 
         val composePanel =

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -62,7 +62,10 @@ import org.junit.jupiter.api.condition.OS
  * Gating:
  * - **Runs on Linux, macOS, and Windows** via `@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)`. The
  *   agent transport rides native `AF_UNIX` on all three (#196); the fixture is spawned with the
- *   platform's `java`/`java.exe`.
+ *   platform's `java`/`java.exe`. The fixture window is `isAlwaysOnTop` so the agent's real
+ *   `java.awt.Robot` clicks land on it and can take OS keyboard focus even when a foreground
+ *   terminal/IDE spawned the test on Windows (foreground-stealing prevention) — otherwise the
+ *   focus-dependent subpath would spuriously hard-fail locally. See `ComposeFixtureMain`'s KDoc.
  * - Skipped on headless JVMs (`java.awt.GraphicsEnvironment.isHeadless()`). Compose Desktop refuses
  *   to create a `JFrame + ComposePanel` without a display.
  * - Skipped when `dev.sebastiano.spectre.agent.runtimeJar` isn't set. Gradle's `:agent:test` task


### PR DESCRIPTION
## Problem

`AgentAttachIntegrationTest` (`attach exercise detach cycle works against a real Compose fixture`) drives the attached agent's **real `java.awt.Robot`** click + `typeText` paths against the `:agent-test-fixture` window. On a Windows dev box run from a foreground terminal/IDE, Windows foreground-stealing prevention keeps the background-spawned fixture *behind* that terminal — `toFront()`/`requestFocus()` can't raise it, so Robot clicks land on the terminal and the text field never takes focus. The test then hard-fails at `waitForFocusedTextField → error(...)` even though nothing regressed.

It passes on CI (which sets `CI=true` and skips the focus-dependent subpath via `isCi()`) and passes locally with `CI=true`, so this was purely a poor local Windows DX issue — a developer running it from an IDE sees a hard failure that isn't a real regression.

## Fix

Set `isAlwaysOnTop = true` on the fixture's `JFrame` so it sits above the spawning terminal. A genuine Robot click then lands on Compose pixels and grants OS keyboard focus. This is the pattern `sample-desktop`'s `WindowsRobotSmoke` established as required for real-Robot Windows tests (its finding #1). It's inert on macOS (AppKit has no foreground-stealing prevention, per `MacOsRobotSmoke` finding #1) and on Linux/Xvfb (`LinuxRobotSmoke` keeps it on as a no-op).

The test's skip/gating logic is **intentionally unchanged**, so macOS/Linux and CI behavior are preserved and a genuine `typeText` regression still fails hard. Windows local runs now get **full keyboard coverage** rather than a skip — strictly stronger than before.

### Why not detect focus-ownership and skip instead?

The task originally weighed a second option: expose the target's OS-keyboard-focus state and skip the subpath when it's not owned. I implemented and then **empirically rejected** it: on Windows, the underlying AWT signal (`KeyboardFocusManager`/`Frame.isActive()` — the same guard `typeText` uses) reports an *occluded, non-foreground* window as "active", so the skip never triggered and the test still hard-failed. Fixing the root cause (getting the click to land) is both more reliable and preserves regression detection, so that's the approach here.

## Verification

- Reproduced the original failure locally by occluding the screen center with a foreground window → hard-failed at `waitForFocusedTextField`.
- With `isAlwaysOnTop`, the test **passes with full keyboard coverage** even against an aggressive foreground-stealing occluder, across all 3 attach/exercise/detach cycles.
- Full `:agent:test` green; `ktfmt` + `detekt` clean on the changed modules.

## Known residual (inherent to real-Robot testing, pre-existing)

A genuinely hostile always-on-top foreground app (e.g. a UAC prompt or screen-recorder overlay) could still deny focus and cause a local hard-fail; and the documented cold-JVM first-click drop is absorbed by the existing retry loop in `waitForFocusedTextField`. Neither is introduced by this change.

Surfaced while enabling `AgentAttachIntegrationTest` on Windows for #196.

🤖 Generated with [Claude Code](https://claude.com/claude-code)