### PR TITLE
Add CLI daemon protocol foundation

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.ktfmt)
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.kotlinSerialization)
+}
+
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+}
+
+dependencies {
+    implementation(libs.kotlinx.serialization.cbor)
+
+    detektPlugins(libs.compose.rules.detekt)
+
+    testImplementation(libs.kotlin.testJunit5)
+}
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -1,0 +1,46 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.Cbor
+
+/** Shared client/daemon wire protocol metadata for Spectre's agent-facing entrypoints. */
+@OptIn(ExperimentalSerializationApi::class)
+public object DaemonProtocol {
+    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 0)
+
+    public val cbor: Cbor = Cbor {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
+
+    public fun checkCompatibility(
+        client: DaemonProtocolVersion,
+        daemon: DaemonProtocolVersion,
+    ): VersionCompatibility =
+        when {
+            client.major != daemon.major -> VersionCompatibility.MajorMismatch
+            daemon.minor < client.minor -> VersionCompatibility.DaemonTooOld
+            else -> VersionCompatibility.Compatible
+        }
+}
+
+@Serializable public data class DaemonProtocolVersion(public val major: Int, public val minor: Int)
+
+public enum class VersionCompatibility {
+    Compatible,
+    MajorMismatch,
+    DaemonTooOld,
+}
+
+@Serializable
+public sealed interface DaemonRequest {
+    @Serializable
+    public data class Hello(public val clientVersion: DaemonProtocolVersion) : DaemonRequest
+}
+
+@Serializable
+public sealed interface DaemonResponse {
+    @Serializable
+    public data class Hello(public val daemonVersion: DaemonProtocolVersion) : DaemonResponse
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
@@ -1,0 +1,46 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlinx.serialization.ExperimentalSerializationApi
+
+@OptIn(ExperimentalSerializationApi::class)
+class DaemonHandshakeTest {
+    @Test
+    fun `hello request round trips through cbor with current protocol version`() {
+        val wire: DaemonRequest = DaemonRequest.Hello(clientVersion = DaemonProtocol.CurrentVersion)
+
+        val bytes = DaemonProtocol.cbor.encodeToByteArray(DaemonRequest.serializer(), wire)
+        val decoded = DaemonProtocol.cbor.decodeFromByteArray(DaemonRequest.serializer(), bytes)
+
+        val hello = assertIs<DaemonRequest.Hello>(decoded)
+        assertEquals(1, hello.clientVersion.major)
+        assertEquals(0, hello.clientVersion.minor)
+    }
+
+    @Test
+    fun `version compatibility requires matching major and daemon minor not older than client`() {
+        assertEquals(
+            VersionCompatibility.Compatible,
+            DaemonProtocol.checkCompatibility(
+                client = DaemonProtocolVersion(major = 1, minor = 0),
+                daemon = DaemonProtocolVersion(major = 1, minor = 1),
+            ),
+        )
+        assertEquals(
+            VersionCompatibility.MajorMismatch,
+            DaemonProtocol.checkCompatibility(
+                client = DaemonProtocolVersion(major = 1, minor = 0),
+                daemon = DaemonProtocolVersion(major = 2, minor = 0),
+            ),
+        )
+        assertEquals(
+            VersionCompatibility.DaemonTooOld,
+            DaemonProtocol.checkCompatibility(
+                client = DaemonProtocolVersion(major = 1, minor = 1),
+                daemon = DaemonProtocolVersion(major = 1, minor = 0),
+            ),
+        )
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,6 +6,7 @@
 spectre
 ├── core/                    — shared automation model and desktop automation primitives
 ├── server/                  — optional transport layer for cross-JVM access
+├── cli/                     — agent-facing CLI / daemon / MCP entrypoint
 ├── recording/               — screenshot / recording API and common JVM implementation
 ├── recording-macos/         — runtime-only macOS ScreenCaptureKit helper artifact
 ├── recording-linux/         — runtime-only Linux capture helper artifact
@@ -78,6 +79,18 @@ Expected long-term responsibilities:
 - remote client
 
 Keep server concerns out of the core data model unless they are genuinely transport-independent.
+
+
+### `cli`
+
+The `cli` module is the agent-facing entrypoint track for issue #173. It owns the thin
+`spectre` client surface, the long-lived per-user session daemon contract, and the future
+`mcp` facade. The first checked-in surface is the client↔daemon handshake protocol: both
+frontends must speak the same versioned CBOR messages before issuing session commands.
+
+The CLI/daemon protocol intentionally lives outside `agent-runtime`: the daemon may use
+`jdk.attach` and the existing agent transport, while the runtime jar must stay thin enough
+to load into arbitrary target JVMs.
 
 ### `recording`
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -96,6 +96,8 @@ include(":agent")
 
 include(":agent-runtime")
 
+include(":cli")
+
 // Tiny non-publishable Compose Desktop app used only as a target for `:agent`'s integration
 // test (`AgentAttachIntegrationTest`). Lives outside `:agent`'s test source set so the agent
 // module doesn't have to apply Compose plugins module-wide.


### PR DESCRIPTION
### Motivation

- Begin the #173 epic by introducing a dedicated `cli` track for agent-facing CLI / daemon / MCP work. 
- Establish a minimal, versioned client↔daemon wire contract so future CLI/daemon/MCP pieces can interoperate safely. 

### Description

- Add a new non-published `:cli` Gradle module with Kotlin/JVM, `kotlinx.serialization.cbor`, Detekt, ktfmt, and JUnit test wiring (`cli/build.gradle.kts`).
- Introduce `DaemonProtocol` (CBOR config, `CurrentVersion`, and `checkCompatibility`) plus serializable `DaemonRequest`/`DaemonResponse` and `DaemonProtocolVersion` (`cli/src/main/kotlin/.../DaemonProtocol.kt`).
- Add TDD coverage in `DaemonHandshakeTest` that verifies CBOR round-trip and major/minor compatibility semantics (`cli/src/test/kotlin/.../DaemonHandshakeTest.kt`).
- Document the new `cli` module in `docs/ARCHITECTURE.md` and include the module in `settings.gradle.kts`.

### Testing

- Ran `./gradlew :cli:test --tests '*DaemonHandshakeTest*'` and confirmed the handshake tests pass after implementation. 
- Ran `./gradlew :cli:check` which completed successfully (ktfmt/Detekt/tests for the module). 
- Ran full `./gradlew check`; the first attempt surfaced a missing system dependency for the in-repo Linux recording helper (`libdbus-1-dev`), installed it via `apt-get install -y libdbus-1-dev pkg-config`, and re-ran `./gradlew check` to completion successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a54e8b28974832bace33a47f7e00b83)