### PR TITLE
Add CLI daemon frame codec

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -98,6 +98,16 @@ public final class dev/sebastiano/spectre/agent/runtime/SpectreAgent {
 	public static final fun premain (Ljava/lang/String;Ljava/lang/instrument/Instrumentation;)V
 }
 
+public final class dev/sebastiano/spectre/agent/transport/Framing {
+	public static final field INSTANCE Ldev/sebastiano/spectre/agent/transport/Framing;
+	public final fun readFrame (Ljava/io/InputStream;)[B
+	public final fun writeFrame (Ljava/io/OutputStream;[B)V
+}
+
+public final class dev/sebastiano/spectre/agent/transport/FramingKt {
+	public static final field MAX_FRAME_BYTES I
+}
+
 public final class dev/sebastiano/spectre/agent/transport/NodeSnapshotDto {
 	public static final field Companion Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLdev/sebastiano/spectre/agent/transport/RectDto;)V

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.agent.transport
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import java.io.EOFException
 import java.io.InputStream
 import java.io.OutputStream
@@ -9,7 +10,7 @@ import java.nio.ByteOrder
 /**
  * Default upper bound on a single frame's payload. Screenshots are the bulkiest reasonable case.
  */
-internal const val MAX_FRAME_BYTES: Int = 16 * 1024 * 1024
+@ExperimentalSpectreAgentApi public const val MAX_FRAME_BYTES: Int = 16 * 1024 * 1024
 
 /**
  * Length-prefixed binary framing for the agent's IPC wire protocol.
@@ -24,13 +25,14 @@ internal const val MAX_FRAME_BYTES: Int = 16 * 1024 * 1024
  * same code drives Unix-domain-socket connections, pipe-pair tests, and any future transport that
  * produces stream-like endpoints.
  */
-internal object Framing {
+@ExperimentalSpectreAgentApi
+public object Framing {
     /**
      * Writes one frame: the 4-byte big-endian header followed by [payload]. Flushes the stream so
      * the receiver doesn't block waiting for buffered bytes.
      */
     @Throws(java.io.IOException::class)
-    fun writeFrame(output: OutputStream, payload: ByteArray) {
+    public fun writeFrame(output: OutputStream, payload: ByteArray) {
         require(payload.size <= MAX_FRAME_BYTES) {
             "Frame payload size ${payload.size} exceeds MAX_FRAME_BYTES=$MAX_FRAME_BYTES"
         }
@@ -50,7 +52,7 @@ internal object Framing {
      * mid-frame, and [IllegalStateException] on negative or over-cap lengths.
      */
     @Throws(java.io.IOException::class)
-    fun readFrame(input: InputStream): ByteArray? {
+    public fun readFrame(input: InputStream): ByteArray? {
         val header = readFullyOrNull(input, HEADER_BYTES) ?: return null
         val length = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN).int
         check(length in 0..MAX_FRAME_BYTES) {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
 }
 
 dependencies {
+    implementation(projects.agent)
     implementation(libs.kotlinx.serialization.cbor)
 
     detektPlugins(libs.compose.rules.detekt)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFraming.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFraming.kt
@@ -1,0 +1,26 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.Framing
+import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES
+import java.io.InputStream
+import java.io.OutputStream
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+/** Length-prefixed binary framing for the Spectre CLI/daemon wire protocol. */
+public object DaemonFraming {
+    /** Default upper bound on a single daemon frame payload. */
+    public const val MaxFrameBytes: Int = MAX_FRAME_BYTES
+
+    /** Write one `[4-byte big-endian length][payload]` frame and flush [output]. */
+    @Throws(java.io.IOException::class)
+    public fun writeFrame(output: OutputStream, payload: ByteArray): Unit =
+        Framing.writeFrame(output, payload)
+
+    /**
+     * Read one frame payload, return `null` on clean EOF before a header starts, and fail on
+     * truncated frames or invalid lengths.
+     */
+    @Throws(java.io.IOException::class)
+    public fun readFrame(input: InputStream): ByteArray? = Framing.readFrame(input)
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFramingTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFramingTest.kt
@@ -1,0 +1,57 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.EOFException
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+
+class DaemonFramingTest {
+    @Test
+    fun `writeFrame prefixes payload with four byte big endian length`() {
+        val output = ByteArrayOutputStream()
+
+        DaemonFraming.writeFrame(output, byteArrayOf(0x41, 0x42, 0x43))
+
+        assertContentEquals(byteArrayOf(0, 0, 0, 3, 0x41, 0x42, 0x43), output.toByteArray())
+    }
+
+    @Test
+    fun `readFrame returns payload and clean eof returns null`() {
+        val input = ByteArrayInputStream(byteArrayOf(0, 0, 0, 2, 0x7a, 0x7b))
+
+        assertContentEquals(byteArrayOf(0x7a, 0x7b), DaemonFraming.readFrame(input))
+        assertNull(DaemonFraming.readFrame(input))
+    }
+
+    @Test
+    fun `readFrame rejects truncated header truncated payload and invalid length`() {
+        assertFailsWith<EOFException> {
+            DaemonFraming.readFrame(ByteArrayInputStream(byteArrayOf(0, 0)))
+        }
+        assertFailsWith<EOFException> {
+            DaemonFraming.readFrame(ByteArrayInputStream(byteArrayOf(0, 0, 0, 4, 1, 2)))
+        }
+        assertFailsWith<IllegalStateException> {
+            DaemonFraming.readFrame(ByteArrayInputStream(byteArrayOf(-1, -1, -1, -1)))
+        }
+    }
+
+    @Test
+    fun `writeFrame rejects payloads above daemon frame cap`() {
+        val tooLarge = ByteArray(DaemonFraming.MaxFrameBytes + 1)
+
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                DaemonFraming.writeFrame(ByteArrayOutputStream(), tooLarge)
+            }
+
+        assertEquals(
+            "Frame payload size ${tooLarge.size} exceeds MAX_FRAME_BYTES=${DaemonFraming.MaxFrameBytes}",
+            error.message,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add length-prefixed binary framing for the CLI daemon protocol.
- Cover big-endian frame writes, clean EOF, truncated frames, invalid lengths, and frame cap enforcement.

## Testing
- ./gradlew :cli:test --tests '*DaemonFramingTest*'
- ./gradlew :cli:check
- ./gradlew check

Part of #173.