### PR TITLE
Add daemon session command protocol

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -37,10 +37,43 @@ public enum class VersionCompatibility {
 public sealed interface DaemonRequest {
     @Serializable
     public data class Hello(public val clientVersion: DaemonProtocolVersion) : DaemonRequest
+
+    @Serializable public data class Attach(public val targetPid: Long) : DaemonRequest
+
+    @Serializable public data class Detach(public val sessionId: String) : DaemonRequest
+
+    @Serializable public data object ListSessions : DaemonRequest
+
+    @Serializable public data object Shutdown : DaemonRequest
 }
 
 @Serializable
 public sealed interface DaemonResponse {
     @Serializable
     public data class Hello(public val daemonVersion: DaemonProtocolVersion) : DaemonResponse
+
+    @Serializable
+    public data class Attached(public val sessionId: String, public val targetPid: Long) :
+        DaemonResponse
+
+    @Serializable public data class Detached(public val sessionId: String) : DaemonResponse
+
+    @Serializable
+    public data class Sessions(public val sessions: List<DaemonSessionSummary>) : DaemonResponse
+
+    @Serializable public data object ShuttingDown : DaemonResponse
+
+    @Serializable
+    public data class Error(public val code: DaemonErrorCode, public val message: String) :
+        DaemonResponse
+}
+
+@Serializable
+public data class DaemonSessionSummary(public val sessionId: String, public val targetPid: Long)
+
+public enum class DaemonErrorCode {
+    SessionNotFound,
+    AttachFailed,
+    ProtocolError,
+    ShutdownInProgress,
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -37,7 +37,6 @@ public enum class VersionCompatibility {
 @Serializable
 public sealed interface DaemonRequest {
     @Serializable
-    @SerialName("hello")
     public data class Hello(public val clientVersion: DaemonProtocolVersion) : DaemonRequest
 
     @Serializable
@@ -56,7 +55,6 @@ public sealed interface DaemonRequest {
 @Serializable
 public sealed interface DaemonResponse {
     @Serializable
-    @SerialName("hello")
     public data class Hello(public val daemonVersion: DaemonProtocolVersion) : DaemonResponse
 
     @Serializable

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.cbor.Cbor
 
@@ -36,34 +37,45 @@ public enum class VersionCompatibility {
 @Serializable
 public sealed interface DaemonRequest {
     @Serializable
+    @SerialName("hello")
     public data class Hello(public val clientVersion: DaemonProtocolVersion) : DaemonRequest
 
-    @Serializable public data class Attach(public val targetPid: Long) : DaemonRequest
+    @Serializable
+    @SerialName("attach")
+    public data class Attach(public val targetPid: Long) : DaemonRequest
 
-    @Serializable public data class Detach(public val sessionId: String) : DaemonRequest
+    @Serializable
+    @SerialName("detach")
+    public data class Detach(public val sessionId: String) : DaemonRequest
 
-    @Serializable public data object ListSessions : DaemonRequest
+    @Serializable @SerialName("listSessions") public data object ListSessions : DaemonRequest
 
-    @Serializable public data object Shutdown : DaemonRequest
+    @Serializable @SerialName("shutdown") public data object Shutdown : DaemonRequest
 }
 
 @Serializable
 public sealed interface DaemonResponse {
     @Serializable
+    @SerialName("hello")
     public data class Hello(public val daemonVersion: DaemonProtocolVersion) : DaemonResponse
 
     @Serializable
+    @SerialName("attached")
     public data class Attached(public val sessionId: String, public val targetPid: Long) :
         DaemonResponse
 
-    @Serializable public data class Detached(public val sessionId: String) : DaemonResponse
+    @Serializable
+    @SerialName("detached")
+    public data class Detached(public val sessionId: String) : DaemonResponse
 
     @Serializable
+    @SerialName("sessions")
     public data class Sessions(public val sessions: List<DaemonSessionSummary>) : DaemonResponse
 
-    @Serializable public data object ShuttingDown : DaemonResponse
+    @Serializable @SerialName("shuttingDown") public data object ShuttingDown : DaemonResponse
 
     @Serializable
+    @SerialName("error")
     public data class Error(public val code: DaemonErrorCode, public val message: String) :
         DaemonResponse
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -7,7 +7,7 @@ import kotlinx.serialization.cbor.Cbor
 /** Shared client/daemon wire protocol metadata for Spectre's agent-facing entrypoints. */
 @OptIn(ExperimentalSerializationApi::class)
 public object DaemonProtocol {
-    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 0)
+    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 1)
 
     public val cbor: Cbor = Cbor {
         ignoreUnknownKeys = true

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
@@ -44,3 +44,46 @@ class DaemonHandshakeTest {
         )
     }
 }
+
+@OptIn(ExperimentalSerializationApi::class)
+class DaemonSessionCommandProtocolTest {
+    @Test
+    fun `session lifecycle requests round trip through cbor`() {
+        val requests =
+            listOf<DaemonRequest>(
+                DaemonRequest.Attach(targetPid = 1234),
+                DaemonRequest.Detach(sessionId = "session-1234"),
+                DaemonRequest.ListSessions,
+                DaemonRequest.Shutdown,
+            )
+
+        val decoded = requests.map { request ->
+            val bytes = DaemonProtocol.cbor.encodeToByteArray(DaemonRequest.serializer(), request)
+            DaemonProtocol.cbor.decodeFromByteArray(DaemonRequest.serializer(), bytes)
+        }
+
+        assertEquals(requests, decoded)
+    }
+
+    @Test
+    fun `session lifecycle responses round trip through cbor`() {
+        val responses =
+            listOf<DaemonResponse>(
+                DaemonResponse.Attached(sessionId = "session-1234", targetPid = 1234),
+                DaemonResponse.Detached(sessionId = "session-1234"),
+                DaemonResponse.Sessions(
+                    sessions =
+                        listOf(DaemonSessionSummary(sessionId = "session-1234", targetPid = 1234))
+                ),
+                DaemonResponse.ShuttingDown,
+                DaemonResponse.Error(code = DaemonErrorCode.SessionNotFound, message = "missing"),
+            )
+
+        val decoded = responses.map { response ->
+            val bytes = DaemonProtocol.cbor.encodeToByteArray(DaemonResponse.serializer(), response)
+            DaemonProtocol.cbor.decodeFromByteArray(DaemonResponse.serializer(), bytes)
+        }
+
+        assertEquals(responses, decoded)
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
@@ -16,7 +16,7 @@ class DaemonHandshakeTest {
 
         val hello = assertIs<DaemonRequest.Hello>(decoded)
         assertEquals(1, hello.clientVersion.major)
-        assertEquals(0, hello.clientVersion.minor)
+        assertEquals(1, hello.clientVersion.minor)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add daemon protocol request messages for attach, detach, list sessions, and shutdown.
- Add daemon protocol response messages for attached/detached sessions, session lists, shutdown, and typed errors.
- Cover lifecycle request/response CBOR round trips with contract tests.

Part of #173. Advances #174.

## Testing
- ./gradlew :cli:test --tests '*DaemonSessionCommandProtocolTest*'
- ./gradlew check