### PR TITLE
Add daemon session registry

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -1,0 +1,55 @@
+package dev.sebastiano.spectre.cli.daemon
+
+/** In-memory session table for one daemon process. */
+public class DaemonSessionRegistry {
+    private val sessionsByPid: MutableMap<Long, DaemonSessionSummary> = linkedMapOf()
+
+    public val isShutdown: Boolean
+        get() = shutdown
+
+    private var shutdown: Boolean = false
+
+    public fun handle(request: DaemonRequest): DaemonResponse =
+        when (request) {
+            is DaemonRequest.Hello ->
+                DaemonResponse.Hello(daemonVersion = DaemonProtocol.CurrentVersion)
+            is DaemonRequest.Attach -> attach(request.targetPid)
+            is DaemonRequest.Detach -> detach(request.sessionId)
+            DaemonRequest.ListSessions -> listSessions()
+            DaemonRequest.Shutdown -> shutdown()
+        }
+
+    private fun attach(targetPid: Long): DaemonResponse {
+        if (shutdown) {
+            return DaemonResponse.Error(
+                code = DaemonErrorCode.ShutdownInProgress,
+                message = "daemon shutdown is already in progress",
+            )
+        }
+        val session = sessionsByPid.getOrPut(targetPid) { targetPid.toSessionSummary() }
+        return DaemonResponse.Attached(sessionId = session.sessionId, targetPid = session.targetPid)
+    }
+
+    private fun detach(sessionId: String): DaemonResponse {
+        val removed =
+            sessionsByPid.entries.firstOrNull { (_, session) -> session.sessionId == sessionId }
+                ?: return DaemonResponse.Error(
+                    code = DaemonErrorCode.SessionNotFound,
+                    message = "session not found: $sessionId",
+                )
+        sessionsByPid.remove(removed.key)
+        return DaemonResponse.Detached(sessionId = sessionId)
+    }
+
+    private fun listSessions(): DaemonResponse =
+        DaemonResponse.Sessions(sessions = sessionsByPid.values.sortedBy { it.targetPid })
+
+    private fun shutdown(): DaemonResponse {
+        shutdown = true
+        sessionsByPid.clear()
+        return DaemonResponse.ShuttingDown
+    }
+
+    private fun Long.toSessionSummary(): DaemonSessionSummary =
+        DaemonSessionSummary(sessionId = "pid-$this", targetPid = this)
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
@@ -1,0 +1,72 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class DaemonSessionRegistryTest {
+    @Test
+    fun `attach creates stable session ids keyed by pid`() {
+        val registry = DaemonSessionRegistry()
+
+        val first = assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(1234)))
+        val second = assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(1234)))
+
+        assertEquals(first, second)
+        assertEquals("pid-1234", first.sessionId)
+    }
+
+    @Test
+    fun `list sessions returns attached pid summaries`() {
+        val registry = DaemonSessionRegistry()
+
+        registry.handle(DaemonRequest.Attach(1234))
+        registry.handle(DaemonRequest.Attach(5678))
+
+        val response =
+            assertIs<DaemonResponse.Sessions>(registry.handle(DaemonRequest.ListSessions))
+        assertEquals(
+            listOf(
+                DaemonSessionSummary(sessionId = "pid-1234", targetPid = 1234),
+                DaemonSessionSummary(sessionId = "pid-5678", targetPid = 5678),
+            ),
+            response.sessions,
+        )
+    }
+
+    @Test
+    fun `detach removes sessions by id and reports missing sessions`() {
+        val registry = DaemonSessionRegistry()
+        registry.handle(DaemonRequest.Attach(1234))
+
+        assertEquals(
+            DaemonResponse.Detached("pid-1234"),
+            registry.handle(DaemonRequest.Detach("pid-1234")),
+        )
+        assertEquals(
+            DaemonResponse.Sessions(emptyList()),
+            registry.handle(DaemonRequest.ListSessions),
+        )
+
+        val missing =
+            assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Detach("pid-1234")))
+        assertEquals(DaemonErrorCode.SessionNotFound, missing.code)
+    }
+
+    @Test
+    fun `shutdown clears sessions and rejects subsequent attach`() {
+        val registry = DaemonSessionRegistry()
+        registry.handle(DaemonRequest.Attach(1234))
+
+        assertEquals(DaemonResponse.ShuttingDown, registry.handle(DaemonRequest.Shutdown))
+        assertTrue(registry.isShutdown)
+        assertEquals(
+            DaemonResponse.Sessions(emptyList()),
+            registry.handle(DaemonRequest.ListSessions),
+        )
+
+        val rejected = assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Attach(5678)))
+        assertEquals(DaemonErrorCode.ShutdownInProgress, rejected.code)
+    }
+}


### PR DESCRIPTION
## Summary
- Add an in-memory daemon session registry that handles hello, attach, detach, list sessions, and shutdown requests.
- Keep session IDs deterministic for the bootstrap daemon core slice.
- Cover attach reuse, list ordering, detach errors, and shutdown rejection behavior with tests.

Part of #173. Advances #174.

## Testing
- ./gradlew :cli:test --tests '*DaemonSessionRegistryTest*'
- ./gradlew check