### PR TITLE
Add daemon Unix socket server

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -305,6 +305,7 @@ private sealed interface DaemonSocketProtection {
         val parent = socketPath.parent ?: Path.of("").toAbsolutePath()
         if (Files.exists(parent, NOFOLLOW_LINKS)) {
             rejectSymbolicLink(parent)
+            parent.parent?.let(::validateExistingAncestor)
             validateExistingDirectory(parent)
             return emptyList()
         }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -8,6 +8,7 @@ import java.nio.channels.ClosedChannelException
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.attribute.AclEntry
 import java.nio.file.attribute.AclEntryPermission
@@ -38,9 +39,10 @@ public constructor(
     private val serverChannel: ServerSocketChannel =
         ServerSocketChannel.open(StandardProtocolFamily.UNIX).also { channel ->
             var bound = false
+            var socketBound = false
             try {
-                Files.deleteIfExists(socketPath)
-                channel.bind(UnixDomainSocketAddress.of(socketPath))
+                bindOrRecoverStaleSocket(channel)
+                socketBound = true
                 socketProtection.protectSocket(socketPath)
                 bound = true
             } finally {
@@ -48,7 +50,7 @@ public constructor(
                     // Preserve the original bind/protection error. Best-effort cleanup must not
                     // obscure the actionable failure or leak an opened native socket descriptor.
                     runCatching { channel.close() }
-                    runCatching { Files.deleteIfExists(socketPath) }
+                    if (socketBound) runCatching { Files.deleteIfExists(socketPath) }
                     runCatching { createdParent?.let(Files::deleteIfExists) }
                 }
             }
@@ -99,11 +101,15 @@ public constructor(
             while (running.get()) {
                 val request = DaemonWireCodec.readRequest(input) ?: return
                 val response = registry.handle(request)
-                DaemonWireCodec.writeResponse(output, response)
-                if (request is DaemonRequest.Shutdown) {
-                    close()
-                    return
+                val isShutdown = request is DaemonRequest.Shutdown
+                try {
+                    DaemonWireCodec.writeResponse(output, response)
+                } finally {
+                    // The registry transitions before the response is written. A disconnected
+                    // client must not leave this process listening in that shut-down state.
+                    if (isShutdown) close()
                 }
+                if (isShutdown) return
             }
         }
     }
@@ -114,6 +120,32 @@ public constructor(
                 "(${exception.javaClass.simpleName}): ${exception.message ?: "<no message>"}"
         )
     }
+
+    private fun bindOrRecoverStaleSocket(channel: ServerSocketChannel) {
+        try {
+            channel.bind(UnixDomainSocketAddress.of(socketPath))
+            return
+        } catch (exception: IOException) {
+            if (!Files.exists(socketPath)) throw exception
+        }
+
+        if (isDaemonListening(socketPath)) throw DaemonAlreadyRunningException(socketPath)
+
+        Files.deleteIfExists(socketPath)
+        channel.bind(UnixDomainSocketAddress.of(socketPath))
+    }
+
+    private fun isDaemonListening(path: Path): Boolean =
+        try {
+            SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(UnixDomainSocketAddress.of(path))
+                true
+            }
+        } catch (_: java.net.ConnectException) {
+            false
+        } catch (_: NoSuchFileException) {
+            false
+        }
 
     /**
      * Stops accepting clients and removes the socket plus any parent directory created by this
@@ -132,6 +164,10 @@ public constructor(
         private const val DEFAULT_TERMINATION_TIMEOUT_MILLIS: Long = 5_000
     }
 }
+
+/** Thrown instead of replacing an existing daemon that is still accepting local connections. */
+public class DaemonAlreadyRunningException(socketPath: Path) :
+    IOException("A Spectre daemon is already listening at $socketPath")
 
 /**
  * Keeps the daemon's per-user UDS directory and socket private on POSIX and Windows filesystems.

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -15,6 +15,7 @@ import java.nio.file.attribute.AclEntry
 import java.nio.file.attribute.AclEntryPermission
 import java.nio.file.attribute.AclEntryType
 import java.nio.file.attribute.AclFileAttributeView
+import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFilePermissions
 import java.util.EnumSet
 import java.util.concurrent.atomic.AtomicBoolean
@@ -146,11 +147,20 @@ public constructor(
     }
 
     private fun requireStaleSocket(path: Path) {
-        if ("unix" !in path.fileSystem.supportedFileAttributeViews()) {
-            throw IOException("Unable to verify stale daemon socket $path on this filesystem")
+        if ("unix" in path.fileSystem.supportedFileAttributeViews()) {
+            val mode = Files.getAttribute(path, "unix:mode", NOFOLLOW_LINKS) as Int
+            if (mode and FILE_TYPE_MASK != UNIX_SOCKET_FILE_TYPE) {
+                throw IOException("Refusing to replace non-socket daemon path $path")
+            }
+            return
         }
-        val mode = Files.getAttribute(path, "unix:mode", NOFOLLOW_LINKS) as Int
-        if (mode and FILE_TYPE_MASK != UNIX_SOCKET_FILE_TYPE) {
+
+        // Windows exposes an AF_UNIX socket as an "other" filesystem entry, while it does not
+        // expose Unix FIFO/device nodes at an ordinary Path. Keep this platform-specific fallback
+        // so a crashed Windows daemon can recover its socket without weakening Unix's exact mode
+        // check, which protects user-owned FIFOs and device nodes.
+        val attributes = Files.readAttributes(path, BasicFileAttributes::class.java, NOFOLLOW_LINKS)
+        if (!isWindows() || !attributes.isOther) {
             throw IOException("Refusing to replace non-socket daemon path $path")
         }
     }
@@ -183,6 +193,9 @@ public constructor(
 
     private companion object {
         private const val DEFAULT_TERMINATION_TIMEOUT_MILLIS: Long = 5_000
+
+        private fun isWindows(): Boolean =
+            System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
     }
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -8,12 +8,14 @@ import java.nio.channels.ClosedChannelException
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
+import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 import java.nio.file.attribute.AclEntry
 import java.nio.file.attribute.AclEntryPermission
 import java.nio.file.attribute.AclEntryType
 import java.nio.file.attribute.AclFileAttributeView
+import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFilePermissions
 import java.util.EnumSet
 import java.util.concurrent.atomic.AtomicBoolean
@@ -70,6 +72,7 @@ public constructor(
     @Throws(InterruptedException::class)
     public fun awaitTermination(timeoutMillis: Long = DEFAULT_TERMINATION_TIMEOUT_MILLIS): Boolean {
         require(timeoutMillis >= 0) { "timeoutMillis must be non-negative" }
+        if (timeoutMillis == 0L) return !acceptThread.isAlive
         acceptThread.join(timeoutMillis)
         return !acceptThread.isAlive
     }
@@ -131,8 +134,16 @@ public constructor(
 
         if (isDaemonListening(socketPath)) throw DaemonAlreadyRunningException(socketPath)
 
+        requireStaleSocket(socketPath)
         Files.deleteIfExists(socketPath)
         channel.bind(UnixDomainSocketAddress.of(socketPath))
+    }
+
+    private fun requireStaleSocket(path: Path) {
+        val attributes = Files.readAttributes(path, BasicFileAttributes::class.java, NOFOLLOW_LINKS)
+        if (!attributes.isOther) {
+            throw IOException("Refusing to replace non-socket daemon path $path")
+        }
     }
 
     private fun isDaemonListening(path: Path): Boolean =

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -13,7 +13,7 @@ import java.nio.file.Files
 import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardOpenOption.CREATE_NEW
 import java.nio.file.StandardOpenOption.WRITE
 import java.nio.file.attribute.AclEntry
 import java.nio.file.attribute.AclEntryPermission
@@ -166,14 +166,19 @@ public constructor(
         val lockPath = socketPath.resolveSibling("${socketPath.fileName}.lock")
         val jvmLock = staleSocketRecoveryLocks.computeIfAbsent(lockPath) { Any() }
         synchronized(jvmLock) {
+            var createdLock = false
             try {
-                FileChannel.open(lockPath, CREATE, WRITE).use { channel ->
-                    channel.lock().use { action() }
-                }
+                val channel =
+                    try {
+                        FileChannel.open(lockPath, CREATE_NEW, WRITE).also { createdLock = true }
+                    } catch (_: FileAlreadyExistsException) {
+                        FileChannel.open(lockPath, WRITE)
+                    }
+                channel.use { channel -> channel.lock().use { action() } }
             } finally {
-                // The lock is retained through a successful bind. Removing it only after releasing
-                // the lock cannot expose a newly bound socket to another recovery attempt.
-                Files.deleteIfExists(lockPath)
+                // An existing lock may have been created by the user or another process. Remove
+                // only the lock atomically created by this server.
+                if (createdLock) Files.deleteIfExists(lockPath)
             }
         }
     }
@@ -217,8 +222,17 @@ public constructor(
         if (!closed.compareAndSet(false, true)) return
         running.set(false)
         runCatching { activeClient.getAndSet(null)?.close() }
-        runCatching { serverChannel.close() }
-        runCatching { Files.deleteIfExists(socketPath) }
+        val removedSocket =
+            runCatching {
+                    // Hold the same lock as stale recovery before closing the channel. Otherwise a
+                    // successor can bind after close and before this server unlinks the path.
+                    withStaleSocketRecoveryLock {
+                        serverChannel.close()
+                        Files.deleteIfExists(socketPath)
+                    }
+                }
+                .isSuccess
+        if (!removedSocket) runCatching { serverChannel.close() }
         removeCreatedParents()
         acceptThread.interrupt()
     }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -15,10 +15,10 @@ import java.nio.file.attribute.AclEntry
 import java.nio.file.attribute.AclEntryPermission
 import java.nio.file.attribute.AclEntryType
 import java.nio.file.attribute.AclFileAttributeView
-import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFilePermissions
 import java.util.EnumSet
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Long-lived local daemon endpoint for the CLI/MCP protocol.
@@ -34,6 +34,7 @@ public constructor(
 ) : AutoCloseable {
     private val running: AtomicBoolean = AtomicBoolean(true)
     private val closed: AtomicBoolean = AtomicBoolean(false)
+    private val activeClient: AtomicReference<SocketChannel?> = AtomicReference(null)
     private val socketProtection: DaemonSocketProtection =
         DaemonSocketProtection.forPath(socketPath)
     private val createdParent: Path? = socketProtection.createMissingParent(socketPath)
@@ -98,22 +99,27 @@ public constructor(
     }
 
     private fun handleConnection(client: SocketChannel) {
-        client.use { channel ->
-            val input = Channels.newInputStream(channel)
-            val output = Channels.newOutputStream(channel)
-            while (running.get()) {
-                val request = DaemonWireCodec.readRequest(input) ?: return
-                val response = registry.handle(request)
-                val isShutdown = request is DaemonRequest.Shutdown
-                try {
-                    DaemonWireCodec.writeResponse(output, response)
-                } finally {
-                    // The registry transitions before the response is written. A disconnected
-                    // client must not leave this process listening in that shut-down state.
-                    if (isShutdown) close()
+        activeClient.set(client)
+        try {
+            client.use { channel ->
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+                while (running.get()) {
+                    val request = DaemonWireCodec.readRequest(input) ?: return
+                    val response = registry.handle(request)
+                    val isShutdown = request is DaemonRequest.Shutdown
+                    try {
+                        DaemonWireCodec.writeResponse(output, response)
+                    } finally {
+                        // The registry transitions before the response is written. A disconnected
+                        // client must not leave this process listening in that shut-down state.
+                        if (isShutdown) close()
+                    }
+                    if (isShutdown) return
                 }
-                if (isShutdown) return
             }
+        } finally {
+            activeClient.compareAndSet(client, null)
         }
     }
 
@@ -140,8 +146,11 @@ public constructor(
     }
 
     private fun requireStaleSocket(path: Path) {
-        val attributes = Files.readAttributes(path, BasicFileAttributes::class.java, NOFOLLOW_LINKS)
-        if (!attributes.isOther) {
+        if ("unix" !in path.fileSystem.supportedFileAttributeViews()) {
+            throw IOException("Unable to verify stale daemon socket $path on this filesystem")
+        }
+        val mode = Files.getAttribute(path, "unix:mode", NOFOLLOW_LINKS) as Int
+        if (mode and FILE_TYPE_MASK != UNIX_SOCKET_FILE_TYPE) {
             throw IOException("Refusing to replace non-socket daemon path $path")
         }
     }
@@ -165,6 +174,7 @@ public constructor(
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
         running.set(false)
+        runCatching { activeClient.getAndSet(null)?.close() }
         runCatching { serverChannel.close() }
         runCatching { Files.deleteIfExists(socketPath) }
         runCatching { createdParent?.let(Files::deleteIfExists) }
@@ -241,3 +251,5 @@ private data object WindowsAcl : DaemonSocketProtection {
 
 private val OWNER_ONLY_DIRECTORY_PERMISSIONS = PosixFilePermissions.fromString("rwx------")
 private val OWNER_ONLY_SOCKET_PERMISSIONS = PosixFilePermissions.fromString("rw-------")
+private const val FILE_TYPE_MASK: Int = 0xF000
+private const val UNIX_SOCKET_FILE_TYPE: Int = 0xC000

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -51,7 +51,7 @@ public constructor(
         DaemonSocketProtection.forPath(recoveryLockPath)
 
     init {
-        recoveryLockProtection.createMissingParents(recoveryLockPath)
+        recoveryLockProtection.createMissingParents(recoveryLockPath, validateAncestor = false)
     }
 
     private val serverChannel: ServerSocketChannel =
@@ -301,7 +301,7 @@ public class DaemonAlreadyRunningException(socketPath: Path) :
  */
 private sealed interface DaemonSocketProtection {
     @Throws(IOException::class)
-    fun createMissingParents(socketPath: Path): List<Path> {
+    fun createMissingParents(socketPath: Path, validateAncestor: Boolean = true): List<Path> {
         val parent = socketPath.parent ?: Path.of("").toAbsolutePath()
         if (Files.exists(parent, NOFOLLOW_LINKS)) {
             rejectSymbolicLink(parent)
@@ -312,7 +312,13 @@ private sealed interface DaemonSocketProtection {
             generateSequence(parent) { path -> path.parent }
                 .takeWhile { path -> !Files.exists(path, NOFOLLOW_LINKS) }
                 .toList()
-        missingParents.last().parent?.let(::validateExistingAncestor)
+        missingParents.last().parent?.let { ancestor ->
+            if (validateAncestor) {
+                validateExistingAncestor(ancestor)
+            } else {
+                rejectSymbolicLink(ancestor)
+            }
+        }
         val createdParents = mutableListOf<Path>()
         try {
             missingParents.asReversed().forEach { path ->
@@ -320,6 +326,7 @@ private sealed interface DaemonSocketProtection {
                     createProtectedDirectory(path)
                     createdParents.add(path)
                 } catch (_: FileAlreadyExistsException) {
+                    rejectSymbolicLink(path)
                     validateExistingDirectory(path)
                 }
             }
@@ -347,6 +354,7 @@ private sealed interface DaemonSocketProtection {
                 "Daemon socket ancestor $directory must not be group or world writable"
             )
         }
+        validateExistingDirectory(directory)
     }
 
     private fun rejectSymbolicLink(path: Path) {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -1,0 +1,196 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.io.IOException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.ClosedChannelException
+import java.nio.channels.ServerSocketChannel
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.AclEntry
+import java.nio.file.attribute.AclEntryPermission
+import java.nio.file.attribute.AclEntryType
+import java.nio.file.attribute.AclFileAttributeView
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.EnumSet
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Long-lived local daemon endpoint for the CLI/MCP protocol.
+ *
+ * The server accepts one request/response connection at a time. Automation sessions are inherently
+ * serial, and the registry supplies deterministic lifecycle semantics for every connection.
+ */
+public class DaemonServer
+@Throws(IOException::class)
+public constructor(
+    private val socketPath: Path,
+    private val registry: DaemonSessionRegistry = DaemonSessionRegistry(),
+) : AutoCloseable {
+    private val running: AtomicBoolean = AtomicBoolean(true)
+    private val closed: AtomicBoolean = AtomicBoolean(false)
+    private val socketProtection: DaemonSocketProtection =
+        DaemonSocketProtection.forPath(socketPath)
+    private val createdParent: Path? = socketProtection.createMissingParent(socketPath)
+
+    private val serverChannel: ServerSocketChannel =
+        ServerSocketChannel.open(StandardProtocolFamily.UNIX).also { channel ->
+            var bound = false
+            try {
+                Files.deleteIfExists(socketPath)
+                channel.bind(UnixDomainSocketAddress.of(socketPath))
+                socketProtection.protectSocket(socketPath)
+                bound = true
+            } finally {
+                if (!bound) {
+                    // Preserve the original bind/protection error. Best-effort cleanup must not
+                    // obscure the actionable failure or leak an opened native socket descriptor.
+                    runCatching { channel.close() }
+                    runCatching { Files.deleteIfExists(socketPath) }
+                    runCatching { createdParent?.let(Files::deleteIfExists) }
+                }
+            }
+        }
+
+    private val acceptThread: Thread =
+        Thread(::acceptLoop, "spectre-daemon-accept").apply {
+            isDaemon = true
+            start()
+        }
+
+    /** The local socket path currently owned by this server. */
+    public val listeningAt: Path
+        get() = socketPath
+
+    /** Waits for the accept thread to exit, returning false only when [timeoutMillis] elapses. */
+    @Throws(InterruptedException::class)
+    public fun awaitTermination(timeoutMillis: Long = DEFAULT_TERMINATION_TIMEOUT_MILLIS): Boolean {
+        require(timeoutMillis >= 0) { "timeoutMillis must be non-negative" }
+        acceptThread.join(timeoutMillis)
+        return !acceptThread.isAlive
+    }
+
+    private fun acceptLoop() {
+        while (running.get()) {
+            val client =
+                try {
+                    serverChannel.accept() ?: return
+                } catch (_: ClosedChannelException) {
+                    return
+                } catch (exception: IOException) {
+                    if (running.get()) logConnectionFailure(exception)
+                    return
+                }
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                handleConnection(client)
+            } catch (exception: Exception) {
+                if (running.get()) logConnectionFailure(exception)
+            }
+        }
+    }
+
+    private fun handleConnection(client: SocketChannel) {
+        client.use { channel ->
+            val input = Channels.newInputStream(channel)
+            val output = Channels.newOutputStream(channel)
+            while (running.get()) {
+                val request = DaemonWireCodec.readRequest(input) ?: return
+                val response = registry.handle(request)
+                DaemonWireCodec.writeResponse(output, response)
+                if (request is DaemonRequest.Shutdown) {
+                    close()
+                    return
+                }
+            }
+        }
+    }
+
+    private fun logConnectionFailure(exception: Exception) {
+        System.err.println(
+            "[spectre-daemon] connection terminated " +
+                "(${exception.javaClass.simpleName}): ${exception.message ?: "<no message>"}"
+        )
+    }
+
+    /**
+     * Stops accepting clients and removes the socket plus any parent directory created by this
+     * server.
+     */
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        running.set(false)
+        runCatching { serverChannel.close() }
+        runCatching { Files.deleteIfExists(socketPath) }
+        runCatching { createdParent?.let(Files::deleteIfExists) }
+        acceptThread.interrupt()
+    }
+
+    private companion object {
+        private const val DEFAULT_TERMINATION_TIMEOUT_MILLIS: Long = 5_000
+    }
+}
+
+/**
+ * Keeps the daemon's per-user UDS directory and socket private on POSIX and Windows filesystems.
+ */
+private sealed interface DaemonSocketProtection {
+    @Throws(IOException::class)
+    fun createMissingParent(socketPath: Path): Path? {
+        val parent = socketPath.parent ?: return null
+        if (Files.exists(parent)) return null
+        createProtectedDirectory(parent)
+        return parent
+    }
+
+    @Throws(IOException::class) fun createProtectedDirectory(directory: Path)
+
+    @Throws(IOException::class) fun protectSocket(socketPath: Path)
+
+    companion object {
+        fun forPath(path: Path): DaemonSocketProtection =
+            if ("posix" in path.fileSystem.supportedFileAttributeViews()) Posix else WindowsAcl
+    }
+}
+
+private data object Posix : DaemonSocketProtection {
+    override fun createProtectedDirectory(directory: Path) {
+        Files.createDirectories(
+            directory,
+            PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMISSIONS),
+        )
+    }
+
+    override fun protectSocket(socketPath: Path) {
+        Files.setPosixFilePermissions(socketPath, OWNER_ONLY_SOCKET_PERMISSIONS)
+    }
+}
+
+private data object WindowsAcl : DaemonSocketProtection {
+    override fun createProtectedDirectory(directory: Path) {
+        Files.createDirectories(directory)
+        setOwnerOnlyAcl(directory)
+    }
+
+    override fun protectSocket(socketPath: Path) {
+        setOwnerOnlyAcl(socketPath)
+    }
+
+    private fun setOwnerOnlyAcl(path: Path) {
+        val view =
+            Files.getFileAttributeView(path, AclFileAttributeView::class.java)
+                ?: throw IOException("Filesystem at $path does not support ACLs")
+        val ownerOnly =
+            AclEntry.newBuilder()
+                .setType(AclEntryType.ALLOW)
+                .setPrincipal(view.owner)
+                .setPermissions(EnumSet.allOf(AclEntryPermission::class.java))
+                .build()
+        view.acl = listOf(ownerOnly)
+    }
+}
+
+private val OWNER_ONLY_DIRECTORY_PERMISSIONS = PosixFilePermissions.fromString("rwx------")
+private val OWNER_ONLY_SOCKET_PERMISSIONS = PosixFilePermissions.fromString("rw-------")

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -282,13 +282,13 @@ public constructor(
         private val staleSocketRecoveryLocks: ConcurrentHashMap<Path, Any> = ConcurrentHashMap()
 
         private fun daemonRecoveryLockPath(socketPath: Path): Path {
+            val canonicalSocketPath =
+                (socketPath.parent ?: Path.of("")).toRealPath().resolve(socketPath.fileName)
             val digest =
                 HexFormat.of()
                     .formatHex(
                         MessageDigest.getInstance("SHA-256")
-                            .digest(
-                                socketPath.toAbsolutePath().normalize().toString().toByteArray()
-                            )
+                            .digest(canonicalSocketPath.toString().toByteArray())
                     )
             return Path.of(System.getProperty("user.home"), ".spectre", "daemon-locks", digest)
         }
@@ -357,7 +357,7 @@ private sealed interface DaemonSocketProtection {
         rejectSymbolicLink(directory)
         if ("unix" in directory.fileSystem.supportedFileAttributeViews()) {
             val mode = Files.getAttribute(directory, "unix:mode", NOFOLLOW_LINKS) as Int
-            if (mode and STICKY_BIT != 0) return
+            if (mode and STICKY_BIT != 0 && isTrustedStickyDirectory(directory)) return
             if (mode and GROUP_OR_OTHER_WRITE_BITS == 0) return
             throw IOException(
                 "Daemon socket ancestor $directory must not be group or world writable"
@@ -375,6 +375,12 @@ private sealed interface DaemonSocketProtection {
         path == Path.of("/tmp") &&
             runCatching { Files.readSymbolicLink(path) == Path.of("private/tmp") }
                 .getOrDefault(false)
+
+    private fun isTrustedStickyDirectory(directory: Path): Boolean {
+        val owner = Files.getOwner(directory, NOFOLLOW_LINKS).name
+        val currentUser = Files.getOwner(Path.of(System.getProperty("user.home"))).name
+        return owner == "root" || owner == currentUser
+    }
 
     @Throws(IOException::class) fun protectSocket(socketPath: Path)
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -357,7 +357,10 @@ private sealed interface DaemonSocketProtection {
         rejectSymbolicLink(directory)
         if ("unix" in directory.fileSystem.supportedFileAttributeViews()) {
             val mode = Files.getAttribute(directory, "unix:mode", NOFOLLOW_LINKS) as Int
-            if (mode and STICKY_BIT != 0 && isTrustedStickyDirectory(directory)) return
+            if (!isTrustedOwner(directory)) {
+                throw IOException("Daemon socket ancestor $directory must be owned by root or user")
+            }
+            if (mode and STICKY_BIT != 0) return
             if (mode and GROUP_OR_OTHER_WRITE_BITS == 0) return
             throw IOException(
                 "Daemon socket ancestor $directory must not be group or world writable"
@@ -376,7 +379,7 @@ private sealed interface DaemonSocketProtection {
             runCatching { Files.readSymbolicLink(path) == Path.of("private/tmp") }
                 .getOrDefault(false)
 
-    private fun isTrustedStickyDirectory(directory: Path): Boolean {
+    private fun isTrustedOwner(directory: Path): Boolean {
         val owner = Files.getOwner(directory, NOFOLLOW_LINKS).name
         val currentUser = Files.getOwner(Path.of(System.getProperty("user.home"))).name
         return owner == "root" || owner == currentUser

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -214,10 +214,7 @@ public constructor(
             false
         }
 
-    /**
-     * Stops accepting clients and removes the socket plus any parent directory created by this
-     * server.
-     */
+    /** Stops accepting clients and attempts to remove the socket plus server-created parents. */
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
         running.set(false)
@@ -227,8 +224,13 @@ public constructor(
                     // Hold the same lock as stale recovery before closing the channel. Otherwise a
                     // successor can bind after close and before this server unlinks the path.
                     withStaleSocketRecoveryLock {
-                        serverChannel.close()
-                        Files.deleteIfExists(socketPath)
+                        try {
+                            serverChannel.close()
+                        } finally {
+                            // Keep the recovery lock until the delete has at least been attempted.
+                            // Retrying after releasing the lock could unlink a successor daemon.
+                            runCatching { Files.deleteIfExists(socketPath) }
+                        }
                     }
                 }
                 .isSuccess

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -302,7 +302,7 @@ public class DaemonAlreadyRunningException(socketPath: Path) :
 private sealed interface DaemonSocketProtection {
     @Throws(IOException::class)
     fun createMissingParents(socketPath: Path, validateAncestor: Boolean = true): List<Path> {
-        val parent = socketPath.parent ?: Path.of("").toAbsolutePath()
+        val parent = (socketPath.parent ?: Path.of("")).toAbsolutePath().normalize()
         if (Files.exists(parent, NOFOLLOW_LINKS)) {
             rejectSymbolicLink(parent)
             parent.parent?.let { validateAncestorChain(it, validateAncestor) }
@@ -344,7 +344,7 @@ private sealed interface DaemonSocketProtection {
                 if (validateAncestor) {
                     validateExistingAncestor(path)
                 } else {
-                    rejectSymbolicLink(path)
+                    if (!isTrustedTempAlias(path)) rejectSymbolicLink(path)
                 }
             }
     }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -8,6 +8,7 @@ import java.nio.channels.ClosedChannelException
 import java.nio.channels.FileChannel
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.NoSuchFileException
@@ -247,21 +248,31 @@ private sealed interface DaemonSocketProtection {
     @Throws(IOException::class)
     fun createMissingParents(socketPath: Path): List<Path> {
         val parent = socketPath.parent ?: return emptyList()
-        if (Files.exists(parent)) {
+        if (Files.exists(parent, NOFOLLOW_LINKS)) {
             validateExistingDirectory(parent)
             return emptyList()
         }
         val missingParents =
             generateSequence(parent) { path -> path.parent }
-                .takeWhile { path -> !Files.exists(path) }
+                .takeWhile { path -> !Files.exists(path, NOFOLLOW_LINKS) }
                 .toList()
+        val createdParents = mutableListOf<Path>()
         try {
-            missingParents.asReversed().forEach(::createProtectedDirectory)
+            missingParents.asReversed().forEach { path ->
+                try {
+                    createProtectedDirectory(path)
+                    createdParents.add(path)
+                } catch (_: FileAlreadyExistsException) {
+                    validateExistingDirectory(path)
+                }
+            }
         } catch (exception: IOException) {
-            missingParents.forEach { path -> runCatching { Files.deleteIfExists(path) } }
+            createdParents.asReversed().forEach { path ->
+                runCatching { Files.deleteIfExists(path) }
+            }
             throw exception
         }
-        return missingParents
+        return createdParents.asReversed()
     }
 
     @Throws(IOException::class) fun createProtectedDirectory(directory: Path)
@@ -278,7 +289,7 @@ private sealed interface DaemonSocketProtection {
 
 private data object Posix : DaemonSocketProtection {
     override fun createProtectedDirectory(directory: Path) {
-        Files.createDirectories(
+        Files.createDirectory(
             directory,
             PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMISSIONS),
         )
@@ -297,8 +308,13 @@ private data object Posix : DaemonSocketProtection {
 
 private data object WindowsAcl : DaemonSocketProtection {
     override fun createProtectedDirectory(directory: Path) {
-        Files.createDirectories(directory)
-        setOwnerOnlyAcl(directory)
+        Files.createDirectory(directory)
+        try {
+            setOwnerOnlyAcl(directory)
+        } catch (exception: IOException) {
+            runCatching { Files.deleteIfExists(directory) }
+            throw exception
+        }
     }
 
     override fun protectSocket(socketPath: Path) {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -342,8 +342,11 @@ private sealed interface DaemonSocketProtection {
         if ("unix" in directory.fileSystem.supportedFileAttributeViews()) {
             val mode = Files.getAttribute(directory, "unix:mode", NOFOLLOW_LINKS) as Int
             if (mode and STICKY_BIT != 0) return
+            if (mode and GROUP_OR_OTHER_WRITE_BITS == 0) return
+            throw IOException(
+                "Daemon socket ancestor $directory must not be group or world writable"
+            )
         }
-        validateExistingDirectory(directory)
     }
 
     private fun rejectSymbolicLink(path: Path) {
@@ -437,3 +440,4 @@ private val ALL_ACL_PERMISSIONS: Set<AclEntryPermission> =
 private const val FILE_TYPE_MASK: Int = 0xF000
 private const val UNIX_SOCKET_FILE_TYPE: Int = 0xC000
 private const val STICKY_BIT: Int = 0x200
+private const val GROUP_OR_OTHER_WRITE_BITS: Int = 0x12

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -305,13 +305,7 @@ private sealed interface DaemonSocketProtection {
         val parent = socketPath.parent ?: Path.of("").toAbsolutePath()
         if (Files.exists(parent, NOFOLLOW_LINKS)) {
             rejectSymbolicLink(parent)
-            parent.parent?.let { ancestor ->
-                if (validateAncestor) {
-                    validateExistingAncestor(ancestor)
-                } else {
-                    rejectSymbolicLink(ancestor)
-                }
-            }
+            parent.parent?.let { validateAncestorChain(it, validateAncestor) }
             validateExistingDirectory(parent)
             return emptyList()
         }
@@ -319,13 +313,7 @@ private sealed interface DaemonSocketProtection {
             generateSequence(parent) { path -> path.parent }
                 .takeWhile { path -> !Files.exists(path, NOFOLLOW_LINKS) }
                 .toList()
-        missingParents.last().parent?.let { ancestor ->
-            if (validateAncestor) {
-                validateExistingAncestor(ancestor)
-            } else {
-                rejectSymbolicLink(ancestor)
-            }
-        }
+        missingParents.last().parent?.let { validateAncestorChain(it, validateAncestor) }
         val createdParents = mutableListOf<Path>()
         try {
             missingParents.asReversed().forEach { path ->
@@ -349,6 +337,17 @@ private sealed interface DaemonSocketProtection {
     @Throws(IOException::class) fun createProtectedDirectory(directory: Path)
 
     @Throws(IOException::class) fun validateExistingDirectory(directory: Path)
+
+    private fun validateAncestorChain(ancestor: Path, validateAncestor: Boolean) {
+        generateSequence(ancestor) { path -> path.parent }
+            .forEach { path ->
+                if (validateAncestor) {
+                    validateExistingAncestor(path)
+                } else {
+                    rejectSymbolicLink(path)
+                }
+            }
+    }
 
     private fun validateExistingAncestor(directory: Path) {
         if (isTrustedTempAlias(directory)) return

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -13,7 +13,7 @@ import java.nio.file.Files
 import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
-import java.nio.file.StandardOpenOption.CREATE_NEW
+import java.nio.file.StandardOpenOption.CREATE
 import java.nio.file.StandardOpenOption.WRITE
 import java.nio.file.attribute.AclEntry
 import java.nio.file.attribute.AclEntryPermission
@@ -21,7 +21,9 @@ import java.nio.file.attribute.AclEntryType
 import java.nio.file.attribute.AclFileAttributeView
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFilePermissions
+import java.security.MessageDigest
 import java.util.EnumSet
+import java.util.HexFormat
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -44,6 +46,13 @@ public constructor(
     private val socketProtection: DaemonSocketProtection =
         DaemonSocketProtection.forPath(socketPath)
     private val createdParents: List<Path> = socketProtection.createMissingParents(socketPath)
+    private val recoveryLockPath: Path = daemonRecoveryLockPath(socketPath)
+    private val recoveryLockProtection: DaemonSocketProtection =
+        DaemonSocketProtection.forPath(recoveryLockPath)
+
+    init {
+        recoveryLockProtection.createMissingParents(recoveryLockPath)
+    }
 
     private val serverChannel: ServerSocketChannel =
         ServerSocketChannel.open(StandardProtocolFamily.UNIX).also { channel ->
@@ -163,22 +172,10 @@ public constructor(
     }
 
     private inline fun withStaleSocketRecoveryLock(action: () -> Unit) {
-        val lockPath = socketPath.resolveSibling("${socketPath.fileName}.lock")
-        val jvmLock = staleSocketRecoveryLocks.computeIfAbsent(lockPath) { Any() }
+        val jvmLock = staleSocketRecoveryLocks.computeIfAbsent(recoveryLockPath) { Any() }
         synchronized(jvmLock) {
-            var createdLock = false
-            try {
-                val channel =
-                    try {
-                        FileChannel.open(lockPath, CREATE_NEW, WRITE).also { createdLock = true }
-                    } catch (_: FileAlreadyExistsException) {
-                        FileChannel.open(lockPath, WRITE)
-                    }
-                channel.use { channel -> channel.lock().use { action() } }
-            } finally {
-                // An existing lock may have been created by the user or another process. Remove
-                // only the lock atomically created by this server.
-                if (createdLock) Files.deleteIfExists(lockPath)
+            FileChannel.open(recoveryLockPath, CREATE, WRITE).use { channel ->
+                channel.lock().use { action() }
             }
         }
     }
@@ -250,6 +247,18 @@ public constructor(
             System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
 
         private val staleSocketRecoveryLocks: ConcurrentHashMap<Path, Any> = ConcurrentHashMap()
+
+        private fun daemonRecoveryLockPath(socketPath: Path): Path {
+            val digest =
+                HexFormat.of()
+                    .formatHex(
+                        MessageDigest.getInstance("SHA-256")
+                            .digest(
+                                socketPath.toAbsolutePath().normalize().toString().toByteArray()
+                            )
+                    )
+            return Path.of(System.getProperty("user.home"), ".spectre", "daemon-locks", digest)
+        }
     }
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -263,7 +263,7 @@ public class DaemonAlreadyRunningException(socketPath: Path) :
 private sealed interface DaemonSocketProtection {
     @Throws(IOException::class)
     fun createMissingParents(socketPath: Path): List<Path> {
-        val parent = socketPath.parent ?: return emptyList()
+        val parent = socketPath.parent ?: Path.of("").toAbsolutePath()
         if (Files.exists(parent, NOFOLLOW_LINKS)) {
             validateExistingDirectory(parent)
             return emptyList()

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -42,7 +42,7 @@ public constructor(
     private val activeClient: AtomicReference<SocketChannel?> = AtomicReference(null)
     private val socketProtection: DaemonSocketProtection =
         DaemonSocketProtection.forPath(socketPath)
-    private val createdParent: Path? = socketProtection.createMissingParent(socketPath)
+    private val createdParents: List<Path> = socketProtection.createMissingParents(socketPath)
 
     private val serverChannel: ServerSocketChannel =
         ServerSocketChannel.open(StandardProtocolFamily.UNIX).also { channel ->
@@ -59,7 +59,7 @@ public constructor(
                     // obscure the actionable failure or leak an opened native socket descriptor.
                     runCatching { channel.close() }
                     if (socketBound) runCatching { Files.deleteIfExists(socketPath) }
-                    runCatching { createdParent?.let(Files::deleteIfExists) }
+                    removeCreatedParents()
                 }
             }
         }
@@ -218,8 +218,12 @@ public constructor(
         runCatching { activeClient.getAndSet(null)?.close() }
         runCatching { serverChannel.close() }
         runCatching { Files.deleteIfExists(socketPath) }
-        runCatching { createdParent?.let(Files::deleteIfExists) }
+        removeCreatedParents()
         acceptThread.interrupt()
+    }
+
+    private fun removeCreatedParents() {
+        createdParents.forEach { parent -> runCatching { Files.deleteIfExists(parent) } }
     }
 
     private companion object {
@@ -241,14 +245,23 @@ public class DaemonAlreadyRunningException(socketPath: Path) :
  */
 private sealed interface DaemonSocketProtection {
     @Throws(IOException::class)
-    fun createMissingParent(socketPath: Path): Path? {
-        val parent = socketPath.parent ?: return null
+    fun createMissingParents(socketPath: Path): List<Path> {
+        val parent = socketPath.parent ?: return emptyList()
         if (Files.exists(parent)) {
             validateExistingDirectory(parent)
-            return null
+            return emptyList()
         }
-        createProtectedDirectory(parent)
-        return parent
+        val missingParents =
+            generateSequence(parent) { path -> path.parent }
+                .takeWhile { path -> !Files.exists(path) }
+                .toList()
+        try {
+            missingParents.asReversed().forEach(::createProtectedDirectory)
+        } catch (exception: IOException) {
+            missingParents.forEach { path -> runCatching { Files.deleteIfExists(path) } }
+            throw exception
+        }
+        return missingParents
     }
 
     @Throws(IOException::class) fun createProtectedDirectory(directory: Path)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -5,12 +5,15 @@ import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
 import java.nio.channels.ClosedChannelException
+import java.nio.channels.FileChannel
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.NoSuchFileException
 import java.nio.file.Path
+import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardOpenOption.WRITE
 import java.nio.file.attribute.AclEntry
 import java.nio.file.attribute.AclEntryPermission
 import java.nio.file.attribute.AclEntryType
@@ -18,6 +21,7 @@ import java.nio.file.attribute.AclFileAttributeView
 import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFilePermissions
 import java.util.EnumSet
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
@@ -139,11 +143,38 @@ public constructor(
             if (!Files.exists(socketPath)) throw exception
         }
 
-        if (isDaemonListening(socketPath)) throw DaemonAlreadyRunningException(socketPath)
+        withStaleSocketRecoveryLock {
+            // Another process may have recovered the stale path while this process waited for the
+            // lock. Rebinding before the liveness probe avoids unlinking its live socket.
+            try {
+                channel.bind(UnixDomainSocketAddress.of(socketPath))
+                return@withStaleSocketRecoveryLock
+            } catch (exception: IOException) {
+                if (!Files.exists(socketPath)) throw exception
+            }
 
-        requireStaleSocket(socketPath)
-        Files.deleteIfExists(socketPath)
-        channel.bind(UnixDomainSocketAddress.of(socketPath))
+            if (isDaemonListening(socketPath)) throw DaemonAlreadyRunningException(socketPath)
+
+            requireStaleSocket(socketPath)
+            Files.deleteIfExists(socketPath)
+            channel.bind(UnixDomainSocketAddress.of(socketPath))
+        }
+    }
+
+    private inline fun withStaleSocketRecoveryLock(action: () -> Unit) {
+        val lockPath = socketPath.resolveSibling("${socketPath.fileName}.lock")
+        val jvmLock = staleSocketRecoveryLocks.computeIfAbsent(lockPath) { Any() }
+        synchronized(jvmLock) {
+            try {
+                FileChannel.open(lockPath, CREATE, WRITE).use { channel ->
+                    channel.lock().use { action() }
+                }
+            } finally {
+                // The lock is retained through a successful bind. Removing it only after releasing
+                // the lock cannot expose a newly bound socket to another recovery attempt.
+                Files.deleteIfExists(lockPath)
+            }
+        }
     }
 
     private fun requireStaleSocket(path: Path) {
@@ -196,6 +227,8 @@ public constructor(
 
         private fun isWindows(): Boolean =
             System.getProperty("os.name").startsWith("Windows", ignoreCase = true)
+
+        private val staleSocketRecoveryLocks: ConcurrentHashMap<Path, Any> = ConcurrentHashMap()
     }
 }
 
@@ -210,12 +243,17 @@ private sealed interface DaemonSocketProtection {
     @Throws(IOException::class)
     fun createMissingParent(socketPath: Path): Path? {
         val parent = socketPath.parent ?: return null
-        if (Files.exists(parent)) return null
+        if (Files.exists(parent)) {
+            protectExistingDirectory(parent)
+            return null
+        }
         createProtectedDirectory(parent)
         return parent
     }
 
     @Throws(IOException::class) fun createProtectedDirectory(directory: Path)
+
+    @Throws(IOException::class) fun protectExistingDirectory(directory: Path)
 
     @Throws(IOException::class) fun protectSocket(socketPath: Path)
 
@@ -236,6 +274,10 @@ private data object Posix : DaemonSocketProtection {
     override fun protectSocket(socketPath: Path) {
         Files.setPosixFilePermissions(socketPath, OWNER_ONLY_SOCKET_PERMISSIONS)
     }
+
+    override fun protectExistingDirectory(directory: Path) {
+        Files.setPosixFilePermissions(directory, OWNER_ONLY_DIRECTORY_PERMISSIONS)
+    }
 }
 
 private data object WindowsAcl : DaemonSocketProtection {
@@ -246,6 +288,10 @@ private data object WindowsAcl : DaemonSocketProtection {
 
     override fun protectSocket(socketPath: Path) {
         setOwnerOnlyAcl(socketPath)
+    }
+
+    override fun protectExistingDirectory(directory: Path) {
+        setOwnerOnlyAcl(directory)
     }
 
     private fun setOwnerOnlyAcl(path: Path) {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -119,10 +119,14 @@ public constructor(
             client.use { channel ->
                 val input = Channels.newInputStream(channel)
                 val output = Channels.newOutputStream(channel)
+                var handshakeComplete = false
                 while (running.get()) {
                     val request = DaemonWireCodec.readRequest(input) ?: return
-                    val response = registry.handle(request)
-                    val isShutdown = request is DaemonRequest.Shutdown
+                    val response = handleRequest(request, handshakeComplete)
+                    if (request is DaemonRequest.Hello) {
+                        handshakeComplete = response is DaemonResponse.Hello
+                    }
+                    val isShutdown = request is DaemonRequest.Shutdown && handshakeComplete
                     try {
                         DaemonWireCodec.writeResponse(output, response)
                     } finally {
@@ -137,6 +141,32 @@ public constructor(
             activeClient.compareAndSet(client, null)
         }
     }
+
+    private fun handleRequest(request: DaemonRequest, handshakeComplete: Boolean): DaemonResponse =
+        when (request) {
+            is DaemonRequest.Hello ->
+                when (
+                    DaemonProtocol.checkCompatibility(
+                        request.clientVersion,
+                        DaemonProtocol.CurrentVersion,
+                    )
+                ) {
+                    VersionCompatibility.Compatible -> registry.handle(request)
+                    else ->
+                        DaemonResponse.Error(
+                            code = DaemonErrorCode.ProtocolError,
+                            message = "incompatible daemon protocol version",
+                        )
+                }
+            else ->
+                if (handshakeComplete) registry.handle(request)
+                else {
+                    DaemonResponse.Error(
+                        code = DaemonErrorCode.ProtocolError,
+                        message = "send a compatible Hello request before session commands",
+                    )
+                }
+        }
 
     private fun logConnectionFailure(exception: Exception) {
         System.err.println(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -304,6 +304,7 @@ private sealed interface DaemonSocketProtection {
     fun createMissingParents(socketPath: Path): List<Path> {
         val parent = socketPath.parent ?: Path.of("").toAbsolutePath()
         if (Files.exists(parent, NOFOLLOW_LINKS)) {
+            rejectSymbolicLink(parent)
             validateExistingDirectory(parent)
             return emptyList()
         }
@@ -311,6 +312,7 @@ private sealed interface DaemonSocketProtection {
             generateSequence(parent) { path -> path.parent }
                 .takeWhile { path -> !Files.exists(path, NOFOLLOW_LINKS) }
                 .toList()
+        missingParents.last().parent?.let(::validateExistingAncestor)
         val createdParents = mutableListOf<Path>()
         try {
             missingParents.asReversed().forEach { path ->
@@ -333,6 +335,27 @@ private sealed interface DaemonSocketProtection {
     @Throws(IOException::class) fun createProtectedDirectory(directory: Path)
 
     @Throws(IOException::class) fun validateExistingDirectory(directory: Path)
+
+    private fun validateExistingAncestor(directory: Path) {
+        if (isTrustedTempAlias(directory)) return
+        rejectSymbolicLink(directory)
+        if ("unix" in directory.fileSystem.supportedFileAttributeViews()) {
+            val mode = Files.getAttribute(directory, "unix:mode", NOFOLLOW_LINKS) as Int
+            if (mode and STICKY_BIT != 0) return
+        }
+        validateExistingDirectory(directory)
+    }
+
+    private fun rejectSymbolicLink(path: Path) {
+        if (Files.isSymbolicLink(path)) {
+            throw IOException("Daemon socket directories must not be symbolic links: $path")
+        }
+    }
+
+    private fun isTrustedTempAlias(path: Path): Boolean =
+        path == Path.of("/tmp") &&
+            runCatching { Files.readSymbolicLink(path) == Path.of("private/tmp") }
+                .getOrDefault(false)
 
     @Throws(IOException::class) fun protectSocket(socketPath: Path)
 
@@ -413,3 +436,4 @@ private val ALL_ACL_PERMISSIONS: Set<AclEntryPermission> =
     EnumSet.allOf(AclEntryPermission::class.java)
 private const val FILE_TYPE_MASK: Int = 0xF000
 private const val UNIX_SOCKET_FILE_TYPE: Int = 0xC000
+private const val STICKY_BIT: Int = 0x200

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -305,7 +305,13 @@ private sealed interface DaemonSocketProtection {
         val parent = socketPath.parent ?: Path.of("").toAbsolutePath()
         if (Files.exists(parent, NOFOLLOW_LINKS)) {
             rejectSymbolicLink(parent)
-            parent.parent?.let(::validateExistingAncestor)
+            parent.parent?.let { ancestor ->
+                if (validateAncestor) {
+                    validateExistingAncestor(ancestor)
+                } else {
+                    rejectSymbolicLink(ancestor)
+                }
+            }
             validateExistingDirectory(parent)
             return emptyList()
         }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -37,9 +37,12 @@ import java.util.concurrent.atomic.AtomicReference
 public class DaemonServer
 @Throws(IOException::class)
 public constructor(
-    private val socketPath: Path,
+    socketPath: Path,
     private val registry: DaemonSessionRegistry = DaemonSessionRegistry(),
 ) : AutoCloseable {
+    private val socketPath: Path = socketPath.also { path ->
+        require(path == path.normalize()) { "Daemon socket path must not contain dot segments" }
+    }
     private val running: AtomicBoolean = AtomicBoolean(true)
     private val closed: AtomicBoolean = AtomicBoolean(false)
     private val activeClient: AtomicReference<SocketChannel?> = AtomicReference(null)
@@ -360,7 +363,6 @@ private sealed interface DaemonSocketProtection {
                 "Daemon socket ancestor $directory must not be group or world writable"
             )
         }
-        validateExistingDirectory(directory)
     }
 
     private fun rejectSymbolicLink(path: Path) {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -244,7 +244,7 @@ private sealed interface DaemonSocketProtection {
     fun createMissingParent(socketPath: Path): Path? {
         val parent = socketPath.parent ?: return null
         if (Files.exists(parent)) {
-            protectExistingDirectory(parent)
+            validateExistingDirectory(parent)
             return null
         }
         createProtectedDirectory(parent)
@@ -253,7 +253,7 @@ private sealed interface DaemonSocketProtection {
 
     @Throws(IOException::class) fun createProtectedDirectory(directory: Path)
 
-    @Throws(IOException::class) fun protectExistingDirectory(directory: Path)
+    @Throws(IOException::class) fun validateExistingDirectory(directory: Path)
 
     @Throws(IOException::class) fun protectSocket(socketPath: Path)
 
@@ -275,8 +275,10 @@ private data object Posix : DaemonSocketProtection {
         Files.setPosixFilePermissions(socketPath, OWNER_ONLY_SOCKET_PERMISSIONS)
     }
 
-    override fun protectExistingDirectory(directory: Path) {
-        Files.setPosixFilePermissions(directory, OWNER_ONLY_DIRECTORY_PERMISSIONS)
+    override fun validateExistingDirectory(directory: Path) {
+        if (Files.getPosixFilePermissions(directory) != OWNER_ONLY_DIRECTORY_PERMISSIONS) {
+            throw IOException("Existing daemon socket directory $directory must be owner-only")
+        }
     }
 }
 
@@ -290,8 +292,21 @@ private data object WindowsAcl : DaemonSocketProtection {
         setOwnerOnlyAcl(socketPath)
     }
 
-    override fun protectExistingDirectory(directory: Path) {
-        setOwnerOnlyAcl(directory)
+    override fun validateExistingDirectory(directory: Path) {
+        val view =
+            Files.getFileAttributeView(directory, AclFileAttributeView::class.java)
+                ?: throw IOException("Filesystem at $directory does not support ACLs")
+        val owner = view.owner
+        if (
+            view.acl.isEmpty() ||
+                view.acl.any { entry ->
+                    entry.type() != AclEntryType.ALLOW ||
+                        entry.principal() != owner ||
+                        !entry.permissions().containsAll(ALL_ACL_PERMISSIONS)
+                }
+        ) {
+            throw IOException("Existing daemon socket directory $directory must be owner-only")
+        }
     }
 
     private fun setOwnerOnlyAcl(path: Path) {
@@ -310,5 +325,7 @@ private data object WindowsAcl : DaemonSocketProtection {
 
 private val OWNER_ONLY_DIRECTORY_PERMISSIONS = PosixFilePermissions.fromString("rwx------")
 private val OWNER_ONLY_SOCKET_PERMISSIONS = PosixFilePermissions.fromString("rw-------")
+private val ALL_ACL_PERMISSIONS: Set<AclEntryPermission> =
+    EnumSet.allOf(AclEntryPermission::class.java)
 private const val FILE_TYPE_MASK: Int = 0xF000
 private const val UNIX_SOCKET_FILE_TYPE: Int = 0xC000

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -18,7 +18,7 @@ import kotlin.test.assertTrue
 class DaemonServerTest {
     @Test
     fun `close unblocks an idle connected client`() {
-        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val socketPath = temporarySocketPath()
         val server = DaemonServer(socketPath)
         val client = SocketChannel.open(java.net.StandardProtocolFamily.UNIX)
         client.connect(java.net.UnixDomainSocketAddress.of(socketPath))
@@ -29,25 +29,31 @@ class DaemonServerTest {
         } finally {
             client.close()
             server.close()
-            Files.deleteIfExists(socketPath.parent)
+            deleteTemporarySocketPath(socketPath)
         }
     }
 
     @Test
     fun `does not replace a regular file at the daemon socket path`() {
-        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val socketPath = temporarySocketPath()
+        val bootstrapServer = DaemonServer(socketPath.resolveSibling("bootstrap.sock"))
         Files.writeString(socketPath, "keep me")
 
-        assertFailsWith<java.io.IOException> { DaemonServer(socketPath) }
+        try {
+            assertFailsWith<java.io.IOException> { DaemonServer(socketPath) }
 
-        assertEquals("keep me", Files.readString(socketPath))
-        Files.deleteIfExists(socketPath)
-        Files.deleteIfExists(socketPath.parent)
+            assertEquals("keep me", Files.readString(socketPath))
+        } finally {
+            Files.deleteIfExists(socketPath)
+            bootstrapServer.close()
+            assertTrue(bootstrapServer.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
     }
 
     @Test
     fun `zero termination timeout does not block`() {
-        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val socketPath = temporarySocketPath()
         val server = DaemonServer(socketPath)
 
         try {
@@ -55,13 +61,14 @@ class DaemonServerTest {
         } finally {
             server.close()
             assertTrue(server.awaitTermination())
-            Files.deleteIfExists(socketPath.parent)
+            deleteTemporarySocketPath(socketPath)
         }
     }
 
     @Test
     fun `replaces a stale daemon socket`() {
-        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val socketPath = temporarySocketPath()
+        val bootstrapServer = DaemonServer(socketPath.resolveSibling("bootstrap.sock"))
         ServerSocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
             channel.bind(java.net.UnixDomainSocketAddress.of(socketPath))
         }
@@ -83,13 +90,15 @@ class DaemonServerTest {
         } finally {
             server.close()
             assertTrue(server.awaitTermination())
-            Files.deleteIfExists(socketPath.parent)
+            bootstrapServer.close()
+            assertTrue(bootstrapServer.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
         }
     }
 
     @Test
     fun `refuses to replace a live daemon socket`() {
-        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val socketPath = temporarySocketPath()
         val firstServer = DaemonServer(socketPath)
 
         try {
@@ -111,7 +120,7 @@ class DaemonServerTest {
         } finally {
             firstServer.close()
             assertTrue(firstServer.awaitTermination())
-            Files.deleteIfExists(socketPath.parent)
+            deleteTemporarySocketPath(socketPath)
         }
     }
 
@@ -165,7 +174,7 @@ class DaemonServerTest {
 
     @Test
     fun `serves lifecycle requests over a unix domain socket and removes it on shutdown`() {
-        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val socketPath = temporarySocketPath()
         val server = DaemonServer(socketPath)
 
         try {
@@ -197,13 +206,13 @@ class DaemonServerTest {
             assertFalse(Files.exists(socketPath))
         } finally {
             server.close()
-            Files.deleteIfExists(socketPath.parent)
+            deleteTemporarySocketPath(socketPath)
         }
     }
 
     @Test
     fun `keeps accepting requests after a malformed client frame`() {
-        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val socketPath = temporarySocketPath()
         val server = DaemonServer(socketPath)
 
         try {
@@ -225,7 +234,20 @@ class DaemonServerTest {
         } finally {
             server.close()
             assertTrue(server.awaitTermination())
-            Files.deleteIfExists(socketPath.parent)
+            deleteTemporarySocketPath(socketPath)
         }
     }
+}
+
+private fun temporarySocketPath(): Path =
+    if ("posix" in FileSystems.getDefault().supportedFileAttributeViews()) {
+        Path.of("/tmp", "sp-d-${UUID.randomUUID().toString().take(8)}", "daemon", "daemon.sock")
+    } else {
+        Files.createTempDirectory("spectre-daemon-test").resolve("daemon").resolve("daemon.sock")
+    }
+
+private fun deleteTemporarySocketPath(socketPath: Path) {
+    Files.deleteIfExists(socketPath)
+    Files.deleteIfExists(socketPath.parent)
+    Files.deleteIfExists(socketPath.parent.parent)
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -205,6 +205,26 @@ class DaemonServerTest {
     }
 
     @Test
+    fun `refuses an existing socket directory below a writable ancestor`() {
+        if ("posix" !in FileSystems.getDefault().supportedFileAttributeViews()) return
+
+        val ancestor = Files.createTempDirectory("spectre-daemon-test")
+        val socketDirectory = Files.createDirectory(ancestor.resolve("socket-directory"))
+        Files.setPosixFilePermissions(ancestor, PosixFilePermissions.fromString("rwxrwxrwx"))
+        Files.setPosixFilePermissions(socketDirectory, PosixFilePermissions.fromString("rwx------"))
+
+        try {
+            assertFailsWith<java.io.IOException> {
+                DaemonServer(socketDirectory.resolve("daemon.sock"))
+            }
+        } finally {
+            Files.deleteIfExists(socketDirectory.resolve("daemon.sock"))
+            Files.deleteIfExists(socketDirectory)
+            Files.deleteIfExists(ancestor)
+        }
+    }
+
+    @Test
     fun `refuses a bare relative socket path in a permissive working directory`() {
         if ("posix" !in FileSystems.getDefault().supportedFileAttributeViews()) return
         if (

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -197,6 +197,13 @@ class DaemonServerTest {
     }
 
     @Test
+    fun `refuses a bare relative socket path in a permissive working directory`() {
+        if ("posix" !in FileSystems.getDefault().supportedFileAttributeViews()) return
+
+        assertFailsWith<java.io.IOException> { DaemonServer(Path.of("daemon.sock")) }
+    }
+
+    @Test
     fun `preserves a dangling symlink in the socket path`() {
         val temporaryDirectory = Files.createTempDirectory("spectre-daemon-test")
         val danglingLink = temporaryDirectory.resolve("link")

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -145,6 +145,26 @@ class DaemonServerTest {
     }
 
     @Test
+    fun `hardens an existing socket directory`() {
+        if ("posix" !in FileSystems.getDefault().supportedFileAttributeViews()) return
+
+        val socketParent = Files.createTempDirectory("spectre-daemon-test")
+        Files.setPosixFilePermissions(socketParent, PosixFilePermissions.fromString("rwxrwxrwx"))
+        val server = DaemonServer(socketParent.resolve("daemon.sock"))
+
+        try {
+            assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(socketParent),
+            )
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            Files.deleteIfExists(socketParent)
+        }
+    }
+
+    @Test
     fun `serves lifecycle requests over a unix domain socket and removes it on shutdown`() {
         val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
         val server = DaemonServer(socketPath)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -205,7 +205,9 @@ class DaemonServerTest {
             assertTrue(server.awaitTermination())
             assertFalse(Files.exists(socketPath))
             assertFalse(Files.exists(socketPath.parent))
-            assertFalse(Files.exists(socketPath.parent.parent))
+            if ("posix" in FileSystems.getDefault().supportedFileAttributeViews()) {
+                assertFalse(Files.exists(socketPath.parent.parent))
+            }
         } finally {
             server.close()
             deleteTemporarySocketPath(socketPath)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -81,6 +81,14 @@ class DaemonServerTest {
                 channel.connect(java.net.UnixDomainSocketAddress.of(socketPath))
                 val input = Channels.newInputStream(channel)
                 val output = Channels.newOutputStream(channel)
+                DaemonWireCodec.writeRequest(
+                    output,
+                    DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
+                )
+                assertEquals(
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonWireCodec.readResponse(input),
+                )
                 DaemonWireCodec.writeRequest(output, DaemonRequest.ListSessions)
                 assertEquals(
                     DaemonResponse.Sessions(emptyList()),
@@ -199,8 +207,62 @@ class DaemonServerTest {
     @Test
     fun `refuses a bare relative socket path in a permissive working directory`() {
         if ("posix" !in FileSystems.getDefault().supportedFileAttributeViews()) return
+        if (
+            Files.getPosixFilePermissions(Path.of("")) ==
+                PosixFilePermissions.fromString("rwx------")
+        ) {
+            return
+        }
 
         assertFailsWith<java.io.IOException> { DaemonServer(Path.of("daemon.sock")) }
+    }
+
+    @Test
+    fun `requires a compatible hello before session commands`() {
+        val socketPath = temporarySocketPath()
+        val server = DaemonServer(socketPath)
+
+        try {
+            SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(java.net.UnixDomainSocketAddress.of(socketPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+
+                DaemonWireCodec.writeRequest(output, DaemonRequest.Attach(1234))
+                assertEquals(
+                    DaemonResponse.Error(
+                        DaemonErrorCode.ProtocolError,
+                        "send a compatible Hello request before session commands",
+                    ),
+                    DaemonWireCodec.readResponse(input),
+                )
+
+                DaemonWireCodec.writeRequest(
+                    output,
+                    DaemonRequest.Hello(DaemonProtocolVersion(major = 2, minor = 0)),
+                )
+                assertEquals(
+                    DaemonResponse.Error(
+                        DaemonErrorCode.ProtocolError,
+                        "incompatible daemon protocol version",
+                    ),
+                    DaemonWireCodec.readResponse(input),
+                )
+
+                DaemonWireCodec.writeRequest(output, DaemonRequest.Attach(1234))
+                assertEquals(
+                    DaemonResponse.Error(
+                        DaemonErrorCode.ProtocolError,
+                        "send a compatible Hello request before session commands",
+                    ),
+                    DaemonWireCodec.readResponse(input),
+                )
+            }
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
     }
 
     @Test
@@ -277,6 +339,14 @@ class DaemonServerTest {
                 channel.connect(java.net.UnixDomainSocketAddress.of(socketPath))
                 val input = Channels.newInputStream(channel)
                 val output = Channels.newOutputStream(channel)
+                DaemonWireCodec.writeRequest(
+                    output,
+                    DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
+                )
+                assertEquals(
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonWireCodec.readResponse(input),
+                )
                 DaemonWireCodec.writeRequest(output, DaemonRequest.ListSessions)
 
                 val response =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -204,6 +204,8 @@ class DaemonServerTest {
 
             assertTrue(server.awaitTermination())
             assertFalse(Files.exists(socketPath))
+            assertFalse(Files.exists(socketPath.parent))
+            assertFalse(Files.exists(socketPath.parent.parent))
         } finally {
             server.close()
             deleteTemporarySocketPath(socketPath)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -283,6 +283,23 @@ class DaemonServerTest {
     }
 
     @Test
+    fun `refuses a socket parent that is a symbolic link`() {
+        val temporaryDirectory = Files.createTempDirectory("spectre-daemon-test")
+        val socketDirectory = Files.createDirectory(temporaryDirectory.resolve("socket-directory"))
+        val socketLink = temporaryDirectory.resolve("socket-link")
+        Files.createSymbolicLink(socketLink, socketDirectory)
+
+        try {
+            assertFailsWith<java.io.IOException> { DaemonServer(socketLink.resolve("daemon.sock")) }
+            assertTrue(Files.isSymbolicLink(socketLink))
+        } finally {
+            Files.deleteIfExists(socketLink)
+            Files.deleteIfExists(socketDirectory)
+            Files.deleteIfExists(temporaryDirectory)
+        }
+    }
+
+    @Test
     fun `serves lifecycle requests over a unix domain socket and removes it on shutdown`() {
         val socketPath = temporarySocketPath()
         val server = DaemonServer(socketPath)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -97,6 +97,30 @@ class DaemonServerTest {
     }
 
     @Test
+    fun `preserves an existing recovery lock file`() {
+        val socketPath = temporarySocketPath()
+        val bootstrapServer = DaemonServer(socketPath.resolveSibling("bootstrap.sock"))
+        val lockPath = socketPath.resolveSibling("${socketPath.fileName}.lock")
+        Files.writeString(lockPath, "preserve me")
+        ServerSocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+            channel.bind(java.net.UnixDomainSocketAddress.of(socketPath))
+        }
+
+        val server = DaemonServer(socketPath)
+
+        try {
+            assertEquals("preserve me", Files.readString(lockPath))
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            Files.deleteIfExists(lockPath)
+            bootstrapServer.close()
+            assertTrue(bootstrapServer.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
     fun `refuses to replace a live daemon socket`() {
         val socketPath = temporarySocketPath()
         val firstServer = DaemonServer(socketPath)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -173,6 +173,23 @@ class DaemonServerTest {
     }
 
     @Test
+    fun `preserves a dangling symlink in the socket path`() {
+        val temporaryDirectory = Files.createTempDirectory("spectre-daemon-test")
+        val danglingLink = temporaryDirectory.resolve("link")
+        Files.createSymbolicLink(danglingLink, temporaryDirectory.resolve("missing-target"))
+
+        try {
+            assertFailsWith<java.io.IOException> {
+                DaemonServer(danglingLink.resolve("daemon.sock"))
+            }
+            assertTrue(Files.isSymbolicLink(danglingLink))
+        } finally {
+            Files.deleteIfExists(danglingLink)
+            Files.deleteIfExists(temporaryDirectory)
+        }
+    }
+
+    @Test
     fun `serves lifecycle requests over a unix domain socket and removes it on shutdown`() {
         val socketPath = temporarySocketPath()
         val server = DaemonServer(socketPath)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -17,6 +17,23 @@ import kotlin.test.assertTrue
 
 class DaemonServerTest {
     @Test
+    fun `close unblocks an idle connected client`() {
+        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val server = DaemonServer(socketPath)
+        val client = SocketChannel.open(java.net.StandardProtocolFamily.UNIX)
+        client.connect(java.net.UnixDomainSocketAddress.of(socketPath))
+
+        try {
+            server.close()
+            assertTrue(server.awaitTermination(timeoutMillis = 2_000))
+        } finally {
+            client.close()
+            server.close()
+            Files.deleteIfExists(socketPath.parent)
+        }
+    }
+
+    @Test
     fun `does not replace a regular file at the daemon socket path`() {
         val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
         Files.writeString(socketPath, "keep me")

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -145,21 +145,20 @@ class DaemonServerTest {
     }
 
     @Test
-    fun `hardens an existing socket directory`() {
+    fun `refuses an existing socket directory with permissive permissions`() {
         if ("posix" !in FileSystems.getDefault().supportedFileAttributeViews()) return
 
         val socketParent = Files.createTempDirectory("spectre-daemon-test")
         Files.setPosixFilePermissions(socketParent, PosixFilePermissions.fromString("rwxrwxrwx"))
-        val server = DaemonServer(socketParent.resolve("daemon.sock"))
-
+        val socketPath = socketParent.resolve("daemon.sock")
         try {
+            assertFailsWith<java.io.IOException> { DaemonServer(socketPath) }
             assertEquals(
-                PosixFilePermissions.fromString("rwx------"),
+                PosixFilePermissions.fromString("rwxrwxrwx"),
                 Files.getPosixFilePermissions(socketParent),
             )
         } finally {
-            server.close()
-            assertTrue(server.awaitTermination())
+            Files.deleteIfExists(socketPath)
             Files.deleteIfExists(socketParent)
         }
     }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import java.nio.channels.Channels
+import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.FileSystems
 import java.nio.file.Files
@@ -9,11 +10,68 @@ import java.nio.file.attribute.PosixFilePermissions
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class DaemonServerTest {
+    @Test
+    fun `replaces a stale daemon socket`() {
+        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        ServerSocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+            channel.bind(java.net.UnixDomainSocketAddress.of(socketPath))
+        }
+        assertTrue(Files.exists(socketPath))
+
+        val server = DaemonServer(socketPath)
+
+        try {
+            SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(java.net.UnixDomainSocketAddress.of(socketPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+                DaemonWireCodec.writeRequest(output, DaemonRequest.ListSessions)
+                assertEquals(
+                    DaemonResponse.Sessions(emptyList()),
+                    DaemonWireCodec.readResponse(input),
+                )
+            }
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            Files.deleteIfExists(socketPath.parent)
+        }
+    }
+
+    @Test
+    fun `refuses to replace a live daemon socket`() {
+        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val firstServer = DaemonServer(socketPath)
+
+        try {
+            assertFailsWith<DaemonAlreadyRunningException> { DaemonServer(socketPath) }
+
+            SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(java.net.UnixDomainSocketAddress.of(socketPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+                DaemonWireCodec.writeRequest(
+                    output,
+                    DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
+                )
+                assertEquals(
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonWireCodec.readResponse(input),
+                )
+            }
+        } finally {
+            firstServer.close()
+            assertTrue(firstServer.awaitTermination())
+            Files.deleteIfExists(socketPath.parent)
+        }
+    }
+
     @Test
     fun `creates an owner-only socket directory and socket file`() {
         if ("posix" !in FileSystems.getDefault().supportedFileAttributeViews()) return

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -17,6 +17,32 @@ import kotlin.test.assertTrue
 
 class DaemonServerTest {
     @Test
+    fun `does not replace a regular file at the daemon socket path`() {
+        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        Files.writeString(socketPath, "keep me")
+
+        assertFailsWith<java.io.IOException> { DaemonServer(socketPath) }
+
+        assertEquals("keep me", Files.readString(socketPath))
+        Files.deleteIfExists(socketPath)
+        Files.deleteIfExists(socketPath.parent)
+    }
+
+    @Test
+    fun `zero termination timeout does not block`() {
+        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val server = DaemonServer(socketPath)
+
+        try {
+            assertFalse(server.awaitTermination(timeoutMillis = 0))
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            Files.deleteIfExists(socketPath.parent)
+        }
+    }
+
+    @Test
     fun `replaces a stale daemon socket`() {
         val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
         ServerSocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -1,0 +1,111 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class DaemonServerTest {
+    @Test
+    fun `creates an owner-only socket directory and socket file`() {
+        if ("posix" !in FileSystems.getDefault().supportedFileAttributeViews()) return
+
+        // AF_UNIX paths are capped at about 104 bytes on macOS. Use /tmp rather than Gradle's
+        // deeply nested test directory so the test exercises the intended permissions, not a
+        // platform path-length limit.
+        val tempDirectory = Path.of("/tmp", "sp-d-${UUID.randomUUID().toString().take(8)}")
+        val socketParent = tempDirectory.resolve("private")
+        val socketPath = socketParent.resolve("daemon.sock")
+        val server = DaemonServer(socketPath)
+
+        try {
+            assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(socketParent),
+            )
+            assertEquals(
+                PosixFilePermissions.fromString("rw-------"),
+                Files.getPosixFilePermissions(socketPath),
+            )
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            Files.deleteIfExists(socketParent)
+            Files.deleteIfExists(tempDirectory)
+        }
+    }
+
+    @Test
+    fun `serves lifecycle requests over a unix domain socket and removes it on shutdown`() {
+        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val server = DaemonServer(socketPath)
+
+        try {
+            SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(java.net.UnixDomainSocketAddress.of(socketPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+
+                DaemonWireCodec.writeRequest(
+                    output,
+                    DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
+                )
+                assertEquals(
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonWireCodec.readResponse(input),
+                )
+
+                DaemonWireCodec.writeRequest(output, DaemonRequest.Attach(1234))
+                assertEquals(
+                    DaemonResponse.Attached(sessionId = "pid-1234", targetPid = 1234),
+                    DaemonWireCodec.readResponse(input),
+                )
+
+                DaemonWireCodec.writeRequest(output, DaemonRequest.Shutdown)
+                assertEquals(DaemonResponse.ShuttingDown, DaemonWireCodec.readResponse(input))
+            }
+
+            assertTrue(server.awaitTermination())
+            assertFalse(Files.exists(socketPath))
+        } finally {
+            server.close()
+            Files.deleteIfExists(socketPath.parent)
+        }
+    }
+
+    @Test
+    fun `keeps accepting requests after a malformed client frame`() {
+        val socketPath = Files.createTempDirectory("spectre-daemon-test").resolve("daemon.sock")
+        val server = DaemonServer(socketPath)
+
+        try {
+            SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(java.net.UnixDomainSocketAddress.of(socketPath))
+                Channels.newOutputStream(channel).write(byteArrayOf(-1, -1, -1, -1))
+            }
+
+            SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(java.net.UnixDomainSocketAddress.of(socketPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+                DaemonWireCodec.writeRequest(output, DaemonRequest.ListSessions)
+
+                val response =
+                    assertIs<DaemonResponse.Sessions>(DaemonWireCodec.readResponse(input))
+                assertTrue(response.sessions.isEmpty())
+            }
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            Files.deleteIfExists(socketPath.parent)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a local Unix-domain-socket daemon server for the CLI protocol
- protect daemon socket paths with owner-only POSIX permissions or Windows ACLs
- cover lifecycle dispatch, clean shutdown, malformed client recovery, and socket permissions

## Testing
- ./gradlew :cli:test --tests '*DaemonServerTest*'
- ./gradlew check