### PR TITLE
Add daemon process lifecycle

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcess.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcess.kt
@@ -1,0 +1,40 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.io.IOException
+import java.nio.file.Path
+
+/** Owns the daemon server lifecycle for one long-lived daemon process. */
+public class DaemonProcess
+@Throws(IOException::class)
+public constructor(
+    private val socketPath: Path,
+    private val serverFactory: (Path) -> DaemonServer = ::DaemonServer,
+) : AutoCloseable {
+    private val lifecycleLock: Any = Any()
+    private var server: DaemonServer? = null
+    private var closed: Boolean = false
+
+    /** Blocks until the daemon receives a shutdown request or [close] is called. */
+    @Throws(IOException::class, InterruptedException::class)
+    public fun runUntilShutdown() {
+        val activeServer =
+            synchronized(lifecycleLock) {
+                check(!closed) { "Daemon process is closed" }
+                server ?: serverFactory(socketPath).also { server = it }
+            }
+        activeServer.awaitTermination(TERMINATION_WAIT_MILLIS)
+    }
+
+    /** Stops the daemon when the hosting process is asked to exit. */
+    override fun close() {
+        synchronized(lifecycleLock) {
+                closed = true
+                server
+            }
+            ?.close()
+    }
+
+    private companion object {
+        private const val TERMINATION_WAIT_MILLIS: Long = Long.MAX_VALUE
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
@@ -1,0 +1,90 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+class DaemonProcessTest {
+    @Test
+    fun `close before run prevents starting a daemon`() {
+        val socketPath = temporarySocketPath()
+        val daemon = DaemonProcess(socketPath)
+        daemon.close()
+        val runner = Thread(daemon::runUntilShutdown)
+
+        try {
+            runner.start()
+            runner.join(2_000)
+
+            assertFalse(runner.isAlive)
+            assertFalse(Files.exists(socketPath))
+        } finally {
+            daemon.close()
+            runner.join(2_000)
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
+    fun `runs the daemon until a protocol shutdown request`() {
+        val socketPath = temporarySocketPath()
+        val daemon = DaemonProcess(socketPath)
+        val runner = Thread(daemon::runUntilShutdown)
+
+        try {
+            runner.start()
+            awaitSocket(socketPath)
+
+            SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(UnixDomainSocketAddress.of(socketPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+                DaemonWireCodec.writeRequest(
+                    output,
+                    DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
+                )
+                assertEquals(
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonWireCodec.readResponse(input),
+                )
+                DaemonWireCodec.writeRequest(output, DaemonRequest.Shutdown)
+                assertEquals(DaemonResponse.ShuttingDown, DaemonWireCodec.readResponse(input))
+            }
+
+            runner.join(2_000)
+            assertFalse(runner.isAlive)
+            assertFalse(Files.exists(socketPath))
+        } finally {
+            daemon.close()
+            runner.join(2_000)
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+}
+
+private fun awaitSocket(socketPath: Path) {
+    repeat(MAX_SOCKET_WAIT_ATTEMPTS) {
+        if (Files.exists(socketPath)) return
+        Thread.sleep(SOCKET_WAIT_MILLIS)
+    }
+    error("Timed out waiting for daemon socket $socketPath")
+}
+
+private fun temporarySocketPath(): Path =
+    Path.of("/tmp", "sp-d-${UUID.randomUUID().toString().take(8)}", "daemon", "daemon.sock")
+
+private fun deleteTemporarySocketPath(socketPath: Path) {
+    Files.deleteIfExists(socketPath)
+    Files.deleteIfExists(socketPath.parent)
+    Files.deleteIfExists(socketPath.parent.parent)
+}
+
+private const val MAX_SOCKET_WAIT_ATTEMPTS: Int = 100
+private const val SOCKET_WAIT_MILLIS: Long = 10

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
@@ -4,6 +4,7 @@ import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
 import java.nio.channels.SocketChannel
+import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
@@ -78,7 +79,11 @@ private fun awaitSocket(socketPath: Path) {
 }
 
 private fun temporarySocketPath(): Path =
-    Path.of("/tmp", "sp-d-${UUID.randomUUID().toString().take(8)}", "daemon", "daemon.sock")
+    if ("posix" in FileSystems.getDefault().supportedFileAttributeViews()) {
+        Path.of("/tmp", "sp-d-${UUID.randomUUID().toString().take(8)}", "daemon", "daemon.sock")
+    } else {
+        Files.createTempDirectory("spectre-daemon-test").resolve("daemon").resolve("daemon.sock")
+    }
 
 private fun deleteTemporarySocketPath(socketPath: Path) {
     Files.deleteIfExists(socketPath)


### PR DESCRIPTION
## Summary
- add a daemon process lifecycle owner around the UDS server
- verify protocol shutdown ends the process and removes its socket
- prevent a closed process wrapper from starting a daemon later

## Testing
- ./gradlew :cli:test --tests '*DaemonProcessTest*'
- ./gradlew check