### PR TITLE
Add daemon protocol client

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -1,0 +1,46 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.io.IOException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.Path
+
+/** One-request client for the local Spectre daemon protocol. */
+public class DaemonClient(public val socketPath: Path) : AutoCloseable {
+    /** Sends one compatible request and returns the daemon's response. */
+    @Throws(IOException::class)
+    public fun request(request: DaemonRequest): DaemonResponse =
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+            channel.connect(UnixDomainSocketAddress.of(socketPath))
+            val input = Channels.newInputStream(channel)
+            val output = Channels.newOutputStream(channel)
+            requireCompatibleDaemon(output, input)
+            DaemonWireCodec.writeRequest(output, request)
+            DaemonWireCodec.readResponse(input)
+                ?: throw IOException("Daemon closed the connection before responding")
+        }
+
+    private fun requireCompatibleDaemon(output: java.io.OutputStream, input: java.io.InputStream) {
+        DaemonWireCodec.writeRequest(output, DaemonRequest.Hello(DaemonProtocol.CurrentVersion))
+        when (val response = DaemonWireCodec.readResponse(input)) {
+            is DaemonResponse.Hello ->
+                check(
+                    DaemonProtocol.checkCompatibility(
+                        client = DaemonProtocol.CurrentVersion,
+                        daemon = response.daemonVersion,
+                    ) == VersionCompatibility.Compatible
+                ) {
+                    "Incompatible daemon protocol version ${response.daemonVersion}"
+                }
+            is DaemonResponse.Error ->
+                throw IOException("Daemon handshake failed: ${response.message}")
+            null ->
+                throw IOException("Daemon closed the connection before completing the handshake")
+            else -> throw IOException("Daemon returned an unexpected handshake response")
+        }
+    }
+
+    override fun close(): Unit = Unit
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
@@ -1,0 +1,49 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DaemonClientTest {
+    @Test
+    fun `sends a handshake before forwarding requests to the daemon`() {
+        val socketPath = temporaryDaemonClientSocketPath()
+        val server = DaemonServer(socketPath)
+
+        try {
+            DaemonClient(socketPath).use { client ->
+                assertEquals(
+                    DaemonResponse.Attached(sessionId = "pid-1234", targetPid = 1234),
+                    client.request(DaemonRequest.Attach(1234)),
+                )
+                assertEquals(
+                    DaemonResponse.Sessions(
+                        sessions =
+                            listOf(DaemonSessionSummary(sessionId = "pid-1234", targetPid = 1234))
+                    ),
+                    client.request(DaemonRequest.ListSessions),
+                )
+            }
+        } finally {
+            server.close()
+            server.awaitTermination()
+            deleteTemporaryDaemonClientSocketPath(socketPath)
+        }
+    }
+}
+
+private fun temporaryDaemonClientSocketPath(): Path =
+    if ("posix" in FileSystems.getDefault().supportedFileAttributeViews()) {
+        Path.of("/tmp", "sp-d-${UUID.randomUUID().toString().take(8)}", "daemon", "daemon.sock")
+    } else {
+        Files.createTempDirectory("spectre-daemon-test").resolve("daemon").resolve("daemon.sock")
+    }
+
+private fun deleteTemporaryDaemonClientSocketPath(socketPath: Path) {
+    Files.deleteIfExists(socketPath)
+    Files.deleteIfExists(socketPath.parent)
+    Files.deleteIfExists(socketPath.parent.parent)
+}


### PR DESCRIPTION
## Summary
- add a one-request Unix socket daemon client
- require and validate the protocol hello before forwarding a request
- cover a real client/server attach and list-sessions round trip

## Testing
- ./gradlew :cli:test --tests '*DaemonClientTest*'
- ./gradlew check