### PR TITLE
Add daemon process entrypoint

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonMain.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonMain.kt
@@ -1,0 +1,26 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.io.IOException
+import java.nio.file.Path
+
+/** Runnable entrypoint for one Spectre daemon process. */
+public object DaemonMain {
+    /** Starts the daemon at the socket supplied by [arguments]. */
+    @Throws(IOException::class, InterruptedException::class)
+    public fun run(arguments: List<String>) {
+        DaemonProcess(socketPath(arguments)).use { process -> process.runUntilShutdown() }
+    }
+
+    /** Extracts the socket location from the daemon-only command line. */
+    public fun socketPath(arguments: List<String>): Path {
+        require(arguments.size == 2 && arguments.first() == SOCKET_OPTION) {
+            "Usage: spectre-daemon --socket <path>"
+        }
+        return Path.of(arguments[1])
+    }
+
+    private const val SOCKET_OPTION: String = "--socket"
+}
+
+@Throws(IOException::class, InterruptedException::class)
+public fun main(arguments: Array<String>): Unit = DaemonMain.run(arguments.asList())

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonMainTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonMainTest.kt
@@ -1,0 +1,21 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class DaemonMainTest {
+    @Test
+    fun `parses the required socket argument`() {
+        assertEquals(
+            Path.of("/tmp/spectre.sock"),
+            DaemonMain.socketPath(listOf("--socket", "/tmp/spectre.sock")),
+        )
+    }
+
+    @Test
+    fun `rejects missing socket argument`() {
+        assertFailsWith<IllegalArgumentException> { DaemonMain.socketPath(emptyList()) }
+    }
+}


### PR DESCRIPTION
## Summary
- add the runnable daemon-only entrypoint
- require an explicit socket path
- delegate process lifetime to the daemon runtime

## Testing
- ./gradlew :cli:test --tests '*DaemonMainTest*'
- ./gradlew check