### PR TITLE
Add default daemon endpoint

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpoint.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpoint.kt
@@ -1,10 +1,31 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import java.nio.file.Path
+import java.security.MessageDigest
+import java.util.HexFormat
 
 /** Canonical per-user endpoint shared by daemon clients and launchers. */
 public object DaemonEndpoint {
     /** Returns the daemon socket path below the supplied user home directory. */
-    public fun defaultSocketPath(userHome: Path = Path.of(System.getProperty("user.home"))): Path =
-        userHome.resolve(".spectre").resolve("daemon").resolve("daemon.sock")
+    public fun defaultSocketPath(
+        osName: String = System.getProperty("os.name").orEmpty(),
+        tempDirectory: String = System.getProperty("java.io.tmpdir").orEmpty(),
+        userName: String = System.getProperty("user.name").orEmpty(),
+    ): Path =
+        Path.of(
+            baseDirectory(osName, tempDirectory),
+            "sp-d-${shortUserId(userName)}",
+            "daemon.sock",
+        )
+
+    /** Selects the platform-specific short base directory for daemon sockets. */
+    internal fun baseDirectory(osName: String, tempDirectory: String): String =
+        if (osName.startsWith("Windows", ignoreCase = true)) tempDirectory else "/tmp"
+
+    private fun shortUserId(userName: String): String =
+        HexFormat.of()
+            .formatHex(MessageDigest.getInstance("SHA-256").digest(userName.toByteArray()))
+            .take(SHORT_USER_ID_LENGTH)
+
+    private const val SHORT_USER_ID_LENGTH: Int = 8
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpoint.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpoint.kt
@@ -1,0 +1,10 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Path
+
+/** Canonical per-user endpoint shared by daemon clients and launchers. */
+public object DaemonEndpoint {
+    /** Returns the daemon socket path below the supplied user home directory. */
+    public fun defaultSocketPath(userHome: Path = Path.of(System.getProperty("user.home"))): Path =
+        userHome.resolve(".spectre").resolve("daemon").resolve("daemon.sock")
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpoint.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpoint.kt
@@ -13,10 +13,11 @@ public object DaemonEndpoint {
         userName: String = System.getProperty("user.name").orEmpty(),
     ): Path =
         Path.of(
-            baseDirectory(osName, tempDirectory),
-            "sp-d-${shortUserId(userName)}",
-            "daemon.sock",
-        )
+                baseDirectory(osName, tempDirectory),
+                "sp-d-${shortUserId(userName)}",
+                "daemon.sock",
+            )
+            .also(::requireSocketPathFits)
 
     /** Selects the platform-specific short base directory for daemon sockets. */
     internal fun baseDirectory(osName: String, tempDirectory: String): String =
@@ -27,5 +28,12 @@ public object DaemonEndpoint {
             .formatHex(MessageDigest.getInstance("SHA-256").digest(userName.toByteArray()))
             .take(SHORT_USER_ID_LENGTH)
 
+    private fun requireSocketPathFits(socketPath: Path) {
+        require(socketPath.toString().toByteArray().size <= MAX_SOCKET_PATH_BYTES) {
+            "Daemon socket path exceeds $MAX_SOCKET_PATH_BYTES bytes: $socketPath"
+        }
+    }
+
     private const val SHORT_USER_ID_LENGTH: Int = 8
+    private const val MAX_SOCKET_PATH_BYTES: Int = 100
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -409,6 +409,13 @@ private data object Posix : DaemonSocketProtection {
         if (Files.getPosixFilePermissions(directory) != OWNER_ONLY_DIRECTORY_PERMISSIONS) {
             throw IOException("Existing daemon socket directory $directory must be owner-only")
         }
+        val owner = Files.getOwner(directory, NOFOLLOW_LINKS).name
+        val currentUser = Files.getOwner(Path.of(System.getProperty("user.home"))).name
+        if (owner != "root" && owner != currentUser) {
+            throw IOException(
+                "Existing daemon socket directory $directory must be owned by root or user"
+            )
+        }
     }
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -381,7 +381,7 @@ private sealed interface DaemonSocketProtection {
 
     private fun isTrustedOwner(directory: Path): Boolean {
         val owner = Files.getOwner(directory, NOFOLLOW_LINKS).name
-        val currentUser = Files.getOwner(Path.of(System.getProperty("user.home"))).name
+        val currentUser = System.getProperty("user.name")
         return owner == "root" || owner == currentUser
     }
 
@@ -410,7 +410,7 @@ private data object Posix : DaemonSocketProtection {
             throw IOException("Existing daemon socket directory $directory must be owner-only")
         }
         val owner = Files.getOwner(directory, NOFOLLOW_LINKS).name
-        val currentUser = Files.getOwner(Path.of(System.getProperty("user.home"))).name
+        val currentUser = System.getProperty("user.name")
         if (owner != "root" && owner != currentUser) {
             throw IOException(
                 "Existing daemon socket directory $directory must be owned by root or user"

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.cli.daemon
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class DaemonEndpointTest {
     @Test
@@ -18,13 +19,13 @@ class DaemonEndpointTest {
     }
 
     @Test
-    fun `uses the windows temp directory on windows`() {
-        assertEquals(
-            "C:\\Users\\alice\\AppData\\Local\\Temp",
-            DaemonEndpoint.baseDirectory(
+    fun `rejects a socket path too long for unix domain sockets`() {
+        assertFailsWith<IllegalArgumentException> {
+            DaemonEndpoint.defaultSocketPath(
                 osName = "Windows 11",
-                tempDirectory = "C:\\Users\\alice\\AppData\\Local\\Temp",
-            ),
-        )
+                tempDirectory = "C:\\Users\\${"a".repeat(80)}\\AppData\\Local\\Temp",
+                userName = "alice",
+            )
+        }
     }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
@@ -1,0 +1,15 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DaemonEndpointTest {
+    @Test
+    fun `places the default socket under the users spectre directory`() {
+        assertEquals(
+            Path.of("/home/alice/.spectre/daemon/daemon.sock"),
+            DaemonEndpoint.defaultSocketPath(Path.of("/home/alice")),
+        )
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
@@ -1,15 +1,30 @@
 package dev.sebastiano.spectre.cli.daemon
 
-import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class DaemonEndpointTest {
     @Test
-    fun `places the default socket under the users spectre directory`() {
+    fun `uses a short deterministic per-user directory under the posix temp base`() {
         assertEquals(
-            Path.of("/home/alice/.spectre/daemon/daemon.sock"),
-            DaemonEndpoint.defaultSocketPath(Path.of("/home/alice")),
+            "/tmp/sp-d-2bd806c9/daemon.sock",
+            DaemonEndpoint.defaultSocketPath(
+                    osName = "Mac OS X",
+                    tempDirectory = "/var/folders/long",
+                    userName = "alice",
+                )
+                .toString(),
+        )
+    }
+
+    @Test
+    fun `uses the windows temp directory on windows`() {
+        assertEquals(
+            "C:\\Users\\alice\\AppData\\Local\\Temp",
+            DaemonEndpoint.baseDirectory(
+                osName = "Windows 11",
+                tempDirectory = "C:\\Users\\alice\\AppData\\Local\\Temp",
+            ),
         )
     }
 }


### PR DESCRIPTION
## Summary
- add a shared per-user daemon socket location
- cover endpoint derivation from user home

## Testing
- ./gradlew :cli:test --tests '*DaemonEndpointTest*'
- ./gradlew check