### PR TITLE
Add daemon startup coordination

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.cli.daemon
 
 import java.io.IOException
 import java.net.ConnectException
+import java.net.SocketException
 import java.nio.file.NoSuchFileException
 
 /** Connects to the daemon, starting it once when the endpoint is absent. */
@@ -36,5 +37,11 @@ public class DaemonStartupCoordinator(
     }
 
     private fun isAbsentEndpoint(exception: IOException): Boolean =
-        exception is ConnectException || exception is NoSuchFileException
+        exception is ConnectException ||
+            exception is NoSuchFileException ||
+            (exception is SocketException && exception.message == MISSING_UNIX_SOCKET_MESSAGE)
+
+    private companion object {
+        private const val MISSING_UNIX_SOCKET_MESSAGE: String = "No such file or directory"
+    }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
@@ -1,6 +1,8 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import java.io.IOException
+import java.net.ConnectException
+import java.nio.file.NoSuchFileException
 
 /** Connects to the daemon, starting it once when the endpoint is absent. */
 public class DaemonStartupCoordinator(
@@ -12,9 +14,27 @@ public class DaemonStartupCoordinator(
     public fun connectOrStart() {
         try {
             connect()
-        } catch (_: IOException) {
-            start()
-            connect()
+        } catch (exception: IOException) {
+            if (!isAbsentEndpoint(exception)) throw exception
+            startOrConnectAfterRace()
         }
     }
+
+    private fun startOrConnectAfterRace() {
+        try {
+            start()
+        } catch (startFailure: IOException) {
+            try {
+                connect()
+                return
+            } catch (connectFailure: IOException) {
+                startFailure.addSuppressed(connectFailure)
+                throw startFailure
+            }
+        }
+        connect()
+    }
+
+    private fun isAbsentEndpoint(exception: IOException): Boolean =
+        exception is ConnectException || exception is NoSuchFileException
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
@@ -1,0 +1,20 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.io.IOException
+
+/** Connects to the daemon, starting it once when the endpoint is absent. */
+public class DaemonStartupCoordinator(
+    private val connect: () -> Unit,
+    private val start: () -> Unit,
+) {
+    /** Connects immediately or starts the daemon before one retry. */
+    @Throws(IOException::class)
+    public fun connectOrStart() {
+        try {
+            connect()
+        } catch (_: IOException) {
+            start()
+            connect()
+        }
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
@@ -1,8 +1,11 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import java.io.IOException
+import java.net.ConnectException
+import java.nio.file.NoSuchFileException
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 
 class DaemonStartupCoordinatorTest {
     @Test
@@ -13,9 +16,63 @@ class DaemonStartupCoordinatorTest {
         DaemonStartupCoordinator(
                 connect = {
                     attempts++
-                    if (attempts == 1) throw IOException("missing")
+                    if (attempts == 1) throw ConnectException("missing")
                 },
                 start = { starts++ },
+            )
+            .connectOrStart()
+
+        assertEquals(2, attempts)
+        assertEquals(1, starts)
+    }
+
+    @Test
+    fun `starts once and retries when the socket path is absent`() {
+        var attempts = 0
+        var starts = 0
+
+        DaemonStartupCoordinator(
+                connect = {
+                    attempts++
+                    if (attempts == 1) throw NoSuchFileException("daemon.sock")
+                },
+                start = { starts++ },
+            )
+            .connectOrStart()
+
+        assertEquals(2, attempts)
+        assertEquals(1, starts)
+    }
+
+    @Test
+    fun `does not start for a daemon protocol failure`() {
+        var starts = 0
+
+        assertFailsWith<IOException> {
+            DaemonStartupCoordinator(
+                    connect = { throw IOException("Daemon handshake failed") },
+                    start = { starts++ },
+                )
+                .connectOrStart()
+        }
+
+        assertEquals(0, starts)
+    }
+
+    @Test
+    fun `retries connect when startup races with another client`() {
+        var attempts = 0
+        var starts = 0
+
+        DaemonStartupCoordinator(
+                connect = {
+                    attempts++
+                    if (attempts == 1) throw ConnectException("missing")
+                },
+                start = {
+                    starts++
+                    throw DaemonAlreadyRunningException(java.nio.file.Path.of("daemon.sock"))
+                },
             )
             .connectOrStart()
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.cli.daemon
 
 import java.io.IOException
 import java.net.ConnectException
+import java.net.SocketException
 import java.nio.file.NoSuchFileException
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -45,12 +46,45 @@ class DaemonStartupCoordinatorTest {
     }
 
     @Test
+    fun `starts once when Unix socket connection reports a missing path`() {
+        var attempts = 0
+        var starts = 0
+
+        DaemonStartupCoordinator(
+                connect = {
+                    attempts++
+                    if (attempts == 1) throw SocketException("No such file or directory")
+                },
+                start = { starts++ },
+            )
+            .connectOrStart()
+
+        assertEquals(2, attempts)
+        assertEquals(1, starts)
+    }
+
+    @Test
     fun `does not start for a daemon protocol failure`() {
         var starts = 0
 
         assertFailsWith<IOException> {
             DaemonStartupCoordinator(
                     connect = { throw IOException("Daemon handshake failed") },
+                    start = { starts++ },
+                )
+                .connectOrStart()
+        }
+
+        assertEquals(0, starts)
+    }
+
+    @Test
+    fun `does not start for a non-absence socket failure`() {
+        var starts = 0
+
+        assertFailsWith<SocketException> {
+            DaemonStartupCoordinator(
+                    connect = { throw SocketException("Connection reset") },
                     start = { starts++ },
                 )
                 .connectOrStart()

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
@@ -1,0 +1,25 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.io.IOException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DaemonStartupCoordinatorTest {
+    @Test
+    fun `starts once and retries when the daemon is absent`() {
+        var attempts = 0
+        var starts = 0
+
+        DaemonStartupCoordinator(
+                connect = {
+                    attempts++
+                    if (attempts == 1) throw IOException("missing")
+                },
+                start = { starts++ },
+            )
+            .connectOrStart()
+
+        assertEquals(2, attempts)
+        assertEquals(1, starts)
+    }
+}


### PR DESCRIPTION
## Summary
- add a testable connect-or-start coordinator
- retry a daemon connection once after startup

## Testing
- ./gradlew :cli:test --tests '*DaemonStartupCoordinatorTest*'
- ./gradlew check