### PR TITLE
Start daemon from client requests

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -9,6 +9,11 @@ import java.nio.file.Path
 
 /** One-request client for the local Spectre daemon protocol. */
 public class DaemonClient(public val socketPath: Path) : AutoCloseable {
+    /** Starts the daemon when its endpoint is absent, then sends [request]. */
+    @Throws(IOException::class)
+    public fun requestOrStart(request: DaemonRequest, start: () -> Unit): DaemonResponse =
+        DaemonStartupCoordinator(connect = { request(request) }, start = start).connectOrStart()
+
     /** Sends one compatible request and returns the daemon's response. */
     @Throws(IOException::class)
     public fun request(request: DaemonRequest): DaemonResponse =

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
@@ -6,34 +6,33 @@ import java.net.SocketException
 import java.nio.file.NoSuchFileException
 
 /** Connects to the daemon, starting it once when the endpoint is absent. */
-public class DaemonStartupCoordinator(
-    private val connect: () -> Unit,
+public class DaemonStartupCoordinator<T>(
+    private val connect: () -> T,
     private val start: () -> Unit,
 ) {
     /** Connects immediately or starts the daemon before one retry. */
     @Throws(IOException::class)
-    public fun connectOrStart() {
+    public fun connectOrStart(): T {
         try {
-            connect()
+            return connect()
         } catch (exception: IOException) {
             if (!isAbsentEndpoint(exception)) throw exception
-            startOrConnectAfterRace()
+            return startOrConnectAfterRace()
         }
     }
 
-    private fun startOrConnectAfterRace() {
+    private fun startOrConnectAfterRace(): T {
         try {
             start()
         } catch (startFailure: IOException) {
             try {
-                connect()
-                return
+                return connect()
             } catch (connectFailure: IOException) {
                 startFailure.addSuppressed(connectFailure)
                 throw startFailure
             }
         }
-        connect()
+        return connect()
     }
 
     private fun isAbsentEndpoint(exception: IOException): Boolean =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
@@ -9,6 +9,31 @@ import kotlin.test.assertEquals
 
 class DaemonClientTest {
     @Test
+    fun `starts the daemon then sends the first request when the socket is absent`() {
+        val socketPath = temporaryDaemonClientSocketPath()
+        var server: DaemonServer? = null
+        var starts = 0
+
+        try {
+            DaemonClient(socketPath).use { client ->
+                assertEquals(
+                    DaemonResponse.Sessions(emptyList()),
+                    client.requestOrStart(DaemonRequest.ListSessions) {
+                        starts++
+                        server = DaemonServer(socketPath)
+                    },
+                )
+            }
+
+            assertEquals(1, starts)
+        } finally {
+            server?.close()
+            server?.awaitTermination()
+            deleteTemporaryDaemonClientSocketPath(socketPath)
+        }
+    }
+
+    @Test
     fun `sends a handshake before forwarding requests to the daemon`() {
         val socketPath = temporaryDaemonClientSocketPath()
         val server = DaemonServer(socketPath)


### PR DESCRIPTION
## Summary
- return the successful daemon connection result from startup coordination
- expose a client request path that starts an absent daemon then retries the actual request
- cover first client request startup against a real daemon server

## Testing
- ./gradlew :cli:test --tests '*DaemonClientTest*' --tests '*DaemonStartupCoordinatorTest*'
- ./gradlew check