### PR TITLE
Wait for daemon startup readiness

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
@@ -10,7 +10,7 @@ public class DaemonStartupCoordinator<T>(
     private val connect: () -> T,
     private val start: () -> Unit,
 ) {
-    /** Connects immediately or starts the daemon before one retry. */
+    /** Connects immediately or starts the daemon before waiting for its endpoint. */
     @Throws(IOException::class)
     public fun connectOrStart(): T {
         try {
@@ -26,13 +26,34 @@ public class DaemonStartupCoordinator<T>(
             start()
         } catch (startFailure: IOException) {
             try {
-                return connect()
+                return connectUntilReady()
             } catch (connectFailure: IOException) {
                 startFailure.addSuppressed(connectFailure)
                 throw startFailure
             }
         }
+        return connectUntilReady()
+    }
+
+    private fun connectUntilReady(): T {
+        repeat(MAXIMUM_STARTUP_CONNECTION_ATTEMPTS - 1) {
+            try {
+                return connect()
+            } catch (exception: IOException) {
+                if (!isAbsentEndpoint(exception)) throw exception
+                waitForEndpoint()
+            }
+        }
         return connect()
+    }
+
+    private fun waitForEndpoint() {
+        try {
+            Thread.sleep(STARTUP_RETRY_DELAY_MILLIS)
+        } catch (exception: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw IOException("Interrupted while waiting for the daemon endpoint", exception)
+        }
     }
 
     private fun isAbsentEndpoint(exception: IOException): Boolean =
@@ -42,5 +63,7 @@ public class DaemonStartupCoordinator<T>(
 
     private companion object {
         private const val MISSING_UNIX_SOCKET_MESSAGE: String = "No such file or directory"
+        private const val MAXIMUM_STARTUP_CONNECTION_ATTEMPTS: Int = 100
+        private const val STARTUP_RETRY_DELAY_MILLIS: Long = 10
     }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
@@ -28,6 +28,7 @@ public class DaemonStartupCoordinator<T>(
             try {
                 return connectUntilReady()
             } catch (connectFailure: IOException) {
+                if (connectFailure.cause is InterruptedException) throw connectFailure
                 startFailure.addSuppressed(connectFailure)
                 throw startFailure
             }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
@@ -7,6 +7,7 @@ import java.nio.file.NoSuchFileException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class DaemonStartupCoordinatorTest {
     @Test
@@ -130,5 +131,30 @@ class DaemonStartupCoordinatorTest {
 
         assertEquals(3, attempts)
         assertEquals(1, starts)
+    }
+
+    @Test
+    fun `reports interruption when startup races with another client`() {
+        Thread.currentThread().interrupt()
+
+        try {
+            val failure =
+                assertFailsWith<IOException> {
+                    DaemonStartupCoordinator<Unit>(
+                            connect = { throw ConnectException("missing") },
+                            start = {
+                                throw DaemonAlreadyRunningException(
+                                    java.nio.file.Path.of("daemon.sock")
+                                )
+                            },
+                        )
+                        .connectOrStart()
+                }
+
+            assertTrue(failure.cause is InterruptedException)
+            assertTrue(Thread.currentThread().isInterrupted)
+        } finally {
+            Thread.interrupted()
+        }
     }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
@@ -113,4 +113,22 @@ class DaemonStartupCoordinatorTest {
         assertEquals(2, attempts)
         assertEquals(1, starts)
     }
+
+    @Test
+    fun `retries an absent endpoint while the started daemon becomes ready`() {
+        var attempts = 0
+        var starts = 0
+
+        DaemonStartupCoordinator(
+                connect = {
+                    attempts++
+                    if (attempts < 3) throw ConnectException("missing")
+                },
+                start = { starts++ },
+            )
+            .connectOrStart()
+
+        assertEquals(3, attempts)
+        assertEquals(1, starts)
+    }
 }


### PR DESCRIPTION
## Summary
- retry absent daemon endpoint connections while a newly started process becomes ready
- preserve immediate propagation of non-absence connection failures
- preserve interrupt status when readiness waiting is interrupted

## Testing
- ./gradlew :cli:test --tests '*DaemonStartupCoordinatorTest*'
- ./gradlew check