### PR TITLE
Add detached daemon process launcher

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -1,0 +1,45 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.io.IOException
+import java.nio.file.Path
+
+/** Starts a detached JVM hosting [DaemonMain] for one local socket endpoint. */
+public class DaemonProcessLauncher(
+    private val socketPath: Path,
+    private val javaExecutable: String = defaultJavaExecutable(),
+    private val classPath: String = System.getProperty("java.class.path"),
+) {
+    /** Launches the daemon process without inheriting this client's standard streams. */
+    @Throws(IOException::class)
+    public fun start(): Process =
+        ProcessBuilder(command())
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+
+    /** Returns the isolated daemon command without starting a process. */
+    public fun command(): List<String> =
+        listOf(
+            javaExecutable,
+            "-cp",
+            classPath,
+            DAEMON_MAIN_CLASS,
+            "--socket",
+            socketPath.toString(),
+        )
+
+    private companion object {
+        private const val DAEMON_MAIN_CLASS: String =
+            "dev.sebastiano.spectre.cli.daemon.DaemonMainKt"
+
+        private fun defaultJavaExecutable(): String {
+            val executable =
+                if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+                    "java.exe"
+                } else {
+                    "java"
+                }
+            return Path.of(System.getProperty("java.home"), "bin", executable).toString()
+        }
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncherTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncherTest.kt
@@ -1,0 +1,30 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DaemonProcessLauncherTest {
+    @Test
+    fun `builds a daemon-only Java command for its socket`() {
+        val command =
+            DaemonProcessLauncher(
+                    socketPath = Path.of("/tmp/spectre/daemon.sock"),
+                    javaExecutable = "/jdk/bin/java",
+                    classPath = "spectre.jar",
+                )
+                .command()
+
+        assertEquals(
+            listOf(
+                "/jdk/bin/java",
+                "-cp",
+                "spectre.jar",
+                "dev.sebastiano.spectre.cli.daemon.DaemonMainKt",
+                "--socket",
+                "/tmp/spectre/daemon.sock",
+            ),
+            command,
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- build an isolated JVM command for the daemon-only entrypoint
- launch it with client standard streams detached
- cover command construction

## Testing
- ./gradlew :cli:test --tests '*DaemonProcessLauncherTest*'
- ./gradlew check