### PR TITLE
Cover daemon auto-spawn end to end

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -19,4 +19,10 @@ dependencies {
     testImplementation(libs.kotlin.testJunit5)
 }
 
-tasks.withType<Test>().configureEach { useJUnitPlatform() }
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    systemProperty(
+        "spectre.cli.testRuntimeClasspath",
+        sourceSets.test.get().runtimeClasspath.asPath,
+    )
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
@@ -9,6 +9,27 @@ import kotlin.test.assertEquals
 
 class DaemonClientTest {
     @Test
+    fun `starts a detached daemon process for the first request`() {
+        val socketPath = temporaryDaemonClientSocketPath()
+
+        try {
+            DaemonClient(socketPath).use { client ->
+                assertEquals(
+                    DaemonResponse.Sessions(emptyList()),
+                    client.requestOrStart(DaemonRequest.ListSessions) {
+                        DaemonProcessLauncher(socketPath).start()
+                    },
+                )
+                assertEquals(DaemonResponse.ShuttingDown, client.request(DaemonRequest.Shutdown))
+            }
+
+            awaitDaemonClientSocketRemoval(socketPath)
+        } finally {
+            deleteTemporaryDaemonClientSocketPath(socketPath)
+        }
+    }
+
+    @Test
     fun `starts the daemon then sends the first request when the socket is absent`() {
         val socketPath = temporaryDaemonClientSocketPath()
         var server: DaemonServer? = null
@@ -72,3 +93,14 @@ private fun deleteTemporaryDaemonClientSocketPath(socketPath: Path) {
     Files.deleteIfExists(socketPath.parent)
     Files.deleteIfExists(socketPath.parent.parent)
 }
+
+private fun awaitDaemonClientSocketRemoval(socketPath: Path) {
+    repeat(MAX_SOCKET_REMOVAL_ATTEMPTS) {
+        if (!Files.exists(socketPath)) return
+        Thread.sleep(SOCKET_REMOVAL_WAIT_MILLIS)
+    }
+    error("Timed out waiting for daemon socket removal")
+}
+
+private const val MAX_SOCKET_REMOVAL_ATTEMPTS: Int = 100
+private const val SOCKET_REMOVAL_WAIT_MILLIS: Long = 10

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
@@ -19,7 +19,12 @@ class DaemonClientTest {
                 assertEquals(
                     DaemonResponse.Sessions(emptyList()),
                     client.requestOrStart(DaemonRequest.ListSessions) {
-                        process = DaemonProcessLauncher(socketPath).start()
+                        process =
+                            DaemonProcessLauncher(
+                                    socketPath = socketPath,
+                                    classPath = testRuntimeClassPath(),
+                                )
+                                .start()
                     },
                 )
                 assertEquals(DaemonResponse.ShuttingDown, client.request(DaemonRequest.Shutdown))
@@ -108,3 +113,8 @@ private fun awaitDaemonClientSocketRemoval(socketPath: Path) {
 
 private const val MAX_SOCKET_REMOVAL_ATTEMPTS: Int = 100
 private const val SOCKET_REMOVAL_WAIT_MILLIS: Long = 10
+
+private fun testRuntimeClassPath(): String =
+    requireNotNull(System.getProperty("spectre.cli.testRuntimeClasspath")) {
+        "Missing CLI test runtime classpath"
+    }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
@@ -11,20 +11,24 @@ class DaemonClientTest {
     @Test
     fun `starts a detached daemon process for the first request`() {
         val socketPath = temporaryDaemonClientSocketPath()
+        var process: Process? = null
+        var shutdownConfirmed = false
 
         try {
             DaemonClient(socketPath).use { client ->
                 assertEquals(
                     DaemonResponse.Sessions(emptyList()),
                     client.requestOrStart(DaemonRequest.ListSessions) {
-                        DaemonProcessLauncher(socketPath).start()
+                        process = DaemonProcessLauncher(socketPath).start()
                     },
                 )
                 assertEquals(DaemonResponse.ShuttingDown, client.request(DaemonRequest.Shutdown))
+                shutdownConfirmed = true
             }
 
             awaitDaemonClientSocketRemoval(socketPath)
         } finally {
+            if (!shutdownConfirmed) process?.destroyForcibly()?.waitFor()
             deleteTemporaryDaemonClientSocketPath(socketPath)
         }
     }


### PR DESCRIPTION
## Summary
- exercise first-request daemon auto-spawn through a detached JVM process
- verify protocol response, shutdown, and socket cleanup

## Testing
- ./gradlew :cli:test --tests '*DaemonClientTest*'
- ./gradlew check