### PR TITLE
Own agent sessions in daemon registry

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
 
 dependencies {
     implementation(projects.agent)
+    runtimeOnly(projects.agentRuntime)
     implementation(libs.kotlinx.serialization.cbor)
 
     detektPlugins(libs.compose.rules.detekt)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -248,6 +248,7 @@ public constructor(
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
         running.set(false)
+        runCatching { registry.close() }
         runCatching { activeClient.getAndSet(null)?.close() }
         val removedSocket =
             runCatching {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -1,8 +1,17 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.AgentAttach
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.SpectreAttachException
+
 /** In-memory session table for one daemon process. */
-public class DaemonSessionRegistry {
-    private val sessionsByPid: MutableMap<Long, DaemonSessionSummary> = linkedMapOf()
+@OptIn(ExperimentalSpectreAgentApi::class)
+public class DaemonSessionRegistry(
+    private val attachAutomator: (Long) -> AutoCloseable = { targetPid ->
+        AgentAttach.attach(targetPid)
+    }
+) {
+    private val sessionsByPid: MutableMap<Long, DaemonSession> = linkedMapOf()
 
     public val isShutdown: Boolean
         get() = shutdown
@@ -26,8 +35,27 @@ public class DaemonSessionRegistry {
                 message = "daemon shutdown is already in progress",
             )
         }
-        val session = sessionsByPid.getOrPut(targetPid) { targetPid.toSessionSummary() }
-        return DaemonResponse.Attached(sessionId = session.sessionId, targetPid = session.targetPid)
+        sessionsByPid[targetPid]?.let { session ->
+            return DaemonResponse.Attached(
+                sessionId = session.summary.sessionId,
+                targetPid = session.summary.targetPid,
+            )
+        }
+        val attached =
+            try {
+                attachAutomator(targetPid)
+            } catch (exception: SpectreAttachException) {
+                return DaemonResponse.Error(
+                    code = DaemonErrorCode.AttachFailed,
+                    message = exception.message ?: "Failed to attach to process $targetPid",
+                )
+            }
+        val session = DaemonSession(summary = targetPid.toSessionSummary(), automator = attached)
+        sessionsByPid[targetPid] = session
+        return DaemonResponse.Attached(
+            sessionId = session.summary.sessionId,
+            targetPid = session.summary.targetPid,
+        )
     }
 
     private fun detach(sessionId: String): DaemonResponse {
@@ -37,19 +65,30 @@ public class DaemonSessionRegistry {
                     code = DaemonErrorCode.SessionNotFound,
                     message = "session not found: $sessionId",
                 )
-        sessionsByPid.remove(removed.key)
+        sessionsByPid.remove(removed.key)?.automator?.close()
         return DaemonResponse.Detached(sessionId = sessionId)
     }
 
     private fun listSessions(): DaemonResponse =
-        DaemonResponse.Sessions(sessions = sessionsByPid.values.sortedBy { it.targetPid })
+        DaemonResponse.Sessions(
+            sessions = sessionsByPid.values.map { it.summary }.sortedBy { it.targetPid }
+        )
 
     private fun shutdown(): DaemonResponse {
         shutdown = true
+        sessionsByPid.values.forEach { session -> session.automator.close() }
         sessionsByPid.clear()
         return DaemonResponse.ShuttingDown
     }
 
     private fun Long.toSessionSummary(): DaemonSessionSummary =
         DaemonSessionSummary(sessionId = "pid-$this", targetPid = this)
+
+    private data class DaemonSession(
+        val summary: DaemonSessionSummary,
+        val automator: AutoCloseable,
+    ) {
+        val sessionId: String
+            get() = summary.sessionId
+    }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -10,7 +10,7 @@ public class DaemonSessionRegistry(
     private val attachAutomator: (Long) -> AutoCloseable = { targetPid ->
         AgentAttach.attach(targetPid)
     }
-) {
+) : AutoCloseable {
     private val sessionsByPid: MutableMap<Long, DaemonSession> = linkedMapOf()
 
     public val isShutdown: Boolean
@@ -18,6 +18,7 @@ public class DaemonSessionRegistry(
 
     private var shutdown: Boolean = false
 
+    @Synchronized
     public fun handle(request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.Hello ->
@@ -75,10 +76,15 @@ public class DaemonSessionRegistry(
         )
 
     private fun shutdown(): DaemonResponse {
+        close()
+        return DaemonResponse.ShuttingDown
+    }
+
+    @Synchronized
+    override fun close() {
         shutdown = true
         sessionsByPid.values.forEach { session -> session.automator.close() }
         sessionsByPid.clear()
-        return DaemonResponse.ShuttingDown
     }
 
     private fun Long.toSessionSummary(): DaemonSessionSummary =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
@@ -66,7 +66,7 @@ class DaemonClientTest {
     @Test
     fun `sends a handshake before forwarding requests to the daemon`() {
         val socketPath = temporaryDaemonClientSocketPath()
-        val server = DaemonServer(socketPath)
+        val server = DaemonServer(socketPath, registry = testDaemonSessionRegistry())
 
         try {
             DaemonClient(socketPath).use { client ->
@@ -118,3 +118,7 @@ private fun testRuntimeClassPath(): String =
     requireNotNull(System.getProperty("spectre.cli.testRuntimeClasspath")) {
         "Missing CLI test runtime classpath"
     }
+
+private fun testDaemonSessionRegistry(): DaemonSessionRegistry = DaemonSessionRegistry {
+    AutoCloseable {}
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
@@ -1,13 +1,26 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import java.io.File
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class DaemonClientTest {
+    @Test
+    fun `daemon runtime classpath includes the loadable agent runtime`() {
+        val runtimeEntries = testRuntimeClassPath().split(File.pathSeparator)
+
+        assertTrue(
+            runtimeEntries.any { entry ->
+                File(entry).name.startsWith("agent-runtime-") && entry.endsWith(".jar")
+            }
+        )
+    }
+
     @Test
     fun `starts a detached daemon process for the first request`() {
         val socketPath = temporaryDaemonClientSocketPath()

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -17,6 +17,25 @@ import kotlin.test.assertTrue
 
 class DaemonServerTest {
     @Test
+    fun `close detaches all owned agent sessions`() {
+        val socketPath = temporarySocketPath()
+        var closes = 0
+        val registry = DaemonSessionRegistry { AutoCloseable { closes++ } }
+        val server = DaemonServer(socketPath, registry = registry)
+
+        try {
+            registry.handle(DaemonRequest.Attach(1234))
+
+            server.close()
+
+            assertEquals(1, closes)
+        } finally {
+            server.close()
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
     fun `close unblocks an idle connected client`() {
         val socketPath = temporarySocketPath()
         val server = DaemonServer(socketPath)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -322,7 +322,7 @@ class DaemonServerTest {
     @Test
     fun `serves lifecycle requests over a unix domain socket and removes it on shutdown`() {
         val socketPath = temporarySocketPath()
-        val server = DaemonServer(socketPath)
+        val server = DaemonServer(socketPath, registry = DaemonSessionRegistry { AutoCloseable {} })
 
         try {
             SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
@@ -1,14 +1,49 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.AttachUnsupportedException
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class DaemonSessionRegistryTest {
+    @OptIn(ExperimentalSpectreAgentApi::class)
+    @Test
+    fun `maps agent attach failures to protocol errors`() {
+        val registry = DaemonSessionRegistry { throw AttachUnsupportedException() }
+
+        val response = assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Attach(1234)))
+
+        assertEquals(DaemonErrorCode.AttachFailed, response.code)
+    }
+
+    @Test
+    fun `closes the attached session when detached`() {
+        var closes = 0
+        val registry = DaemonSessionRegistry { AutoCloseable { closes++ } }
+
+        registry.handle(DaemonRequest.Attach(1234))
+        registry.handle(DaemonRequest.Detach("pid-1234"))
+
+        assertEquals(1, closes)
+    }
+
+    @Test
+    fun `closes every attached session when shutting down`() {
+        var closes = 0
+        val registry = DaemonSessionRegistry { AutoCloseable { closes++ } }
+
+        registry.handle(DaemonRequest.Attach(1234))
+        registry.handle(DaemonRequest.Attach(5678))
+        registry.handle(DaemonRequest.Shutdown)
+
+        assertEquals(2, closes)
+    }
+
     @Test
     fun `attach creates stable session ids keyed by pid`() {
-        val registry = DaemonSessionRegistry()
+        val registry = testRegistry()
 
         val first = assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(1234)))
         val second = assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(1234)))
@@ -19,7 +54,7 @@ class DaemonSessionRegistryTest {
 
     @Test
     fun `list sessions returns attached pid summaries`() {
-        val registry = DaemonSessionRegistry()
+        val registry = testRegistry()
 
         registry.handle(DaemonRequest.Attach(1234))
         registry.handle(DaemonRequest.Attach(5678))
@@ -37,7 +72,7 @@ class DaemonSessionRegistryTest {
 
     @Test
     fun `detach removes sessions by id and reports missing sessions`() {
-        val registry = DaemonSessionRegistry()
+        val registry = testRegistry()
         registry.handle(DaemonRequest.Attach(1234))
 
         assertEquals(
@@ -56,7 +91,7 @@ class DaemonSessionRegistryTest {
 
     @Test
     fun `shutdown clears sessions and rejects subsequent attach`() {
-        val registry = DaemonSessionRegistry()
+        val registry = testRegistry()
         registry.handle(DaemonRequest.Attach(1234))
 
         assertEquals(DaemonResponse.ShuttingDown, registry.handle(DaemonRequest.Shutdown))
@@ -70,3 +105,5 @@ class DaemonSessionRegistryTest {
         assertEquals(DaemonErrorCode.ShutdownInProgress, rejected.code)
     }
 }
+
+private fun testRegistry(): DaemonSessionRegistry = DaemonSessionRegistry { AutoCloseable {} }


### PR DESCRIPTION
## Summary
- retain one live AgentAttach session per daemon PID
- detach live agent sessions on explicit detach and daemon shutdown
- map typed attach failures to daemon protocol errors

## Verification
- ./gradlew check