### PR TITLE
Dispatch automation operations through daemon sessions

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpoint.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpoint.kt
@@ -15,7 +15,7 @@ public object DaemonEndpoint {
         Path.of(
                 baseDirectory(osName, tempDirectory),
                 "sp-d-${shortUserId(userName)}",
-                "daemon.sock",
+                "daemon-v${DaemonProtocol.CurrentVersion.major}-${DaemonProtocol.CurrentVersion.minor}.sock",
             )
             .also(::requireSocketPathFits)
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -1,5 +1,8 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -8,7 +11,7 @@ import kotlinx.serialization.cbor.Cbor
 /** Shared client/daemon wire protocol metadata for Spectre's agent-facing entrypoints. */
 @OptIn(ExperimentalSerializationApi::class)
 public object DaemonProtocol {
-    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 1)
+    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 2)
 
     public val cbor: Cbor = Cbor {
         ignoreUnknownKeys = true
@@ -34,6 +37,7 @@ public enum class VersionCompatibility {
     DaemonTooOld,
 }
 
+@OptIn(ExperimentalSpectreAgentApi::class)
 @Serializable
 public sealed interface DaemonRequest {
     @Serializable
@@ -49,9 +53,37 @@ public sealed interface DaemonRequest {
 
     @Serializable @SerialName("listSessions") public data object ListSessions : DaemonRequest
 
+    @Serializable
+    @SerialName("windows")
+    public data class Windows(public val sessionId: String) : DaemonRequest
+
+    @Serializable
+    @SerialName("allNodes")
+    public data class AllNodes(public val sessionId: String) : DaemonRequest
+
+    @Serializable
+    @SerialName("findByTestTag")
+    public data class FindByTestTag(public val sessionId: String, public val tag: String) :
+        DaemonRequest
+
+    @Serializable
+    @SerialName("click")
+    public data class Click(public val sessionId: String, public val nodeKey: String) :
+        DaemonRequest
+
+    @Serializable
+    @SerialName("typeText")
+    public data class TypeText(public val sessionId: String, public val text: String) :
+        DaemonRequest
+
+    @Serializable
+    @SerialName("screenshot")
+    public data class Screenshot(public val sessionId: String) : DaemonRequest
+
     @Serializable @SerialName("shutdown") public data object Shutdown : DaemonRequest
 }
 
+@OptIn(ExperimentalSpectreAgentApi::class)
 @Serializable
 public sealed interface DaemonResponse {
     @Serializable
@@ -70,6 +102,34 @@ public sealed interface DaemonResponse {
     @SerialName("sessions")
     public data class Sessions(public val sessions: List<DaemonSessionSummary>) : DaemonResponse
 
+    @Serializable
+    @SerialName("windows")
+    public data class Windows(
+        public val sessionId: String,
+        public val windows: List<WindowSummaryDto>,
+    ) : DaemonResponse
+
+    @Serializable
+    @SerialName("nodes")
+    public data class Nodes(public val sessionId: String, public val nodes: List<NodeSnapshotDto>) :
+        DaemonResponse
+
+    @Serializable
+    @SerialName("completed")
+    public data class Completed(public val sessionId: String) : DaemonResponse
+
+    @Serializable
+    @SerialName("screenshot")
+    public data class Screenshot(public val sessionId: String, public val pngBytes: ByteArray) :
+        DaemonResponse {
+        override fun equals(other: Any?): Boolean =
+            other is Screenshot &&
+                sessionId == other.sessionId &&
+                pngBytes.contentEquals(other.pngBytes)
+
+        override fun hashCode(): Int = 31 * sessionId.hashCode() + pngBytes.contentHashCode()
+    }
+
     @Serializable @SerialName("shuttingDown") public data object ShuttingDown : DaemonResponse
 
     @Serializable
@@ -86,4 +146,5 @@ public enum class DaemonErrorCode {
     AttachFailed,
     ProtocolError,
     ShutdownInProgress,
+    OperationFailed,
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
@@ -1,0 +1,41 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.AttachedAutomator
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
+import java.io.IOException
+
+/** Operation surface retained by one daemon session. */
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal interface DaemonSessionAutomator : AutoCloseable {
+    @Throws(IOException::class) fun windows(): List<WindowSummaryDto>
+
+    @Throws(IOException::class) fun allNodes(): List<NodeSnapshotDto>
+
+    @Throws(IOException::class) fun findByTestTag(tag: String): List<NodeSnapshotDto>
+
+    @Throws(IOException::class) fun click(nodeKey: String)
+
+    @Throws(IOException::class) fun typeText(text: String)
+
+    @Throws(IOException::class) fun screenshot(): ByteArray
+}
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal class AttachedDaemonSession(private val delegate: AttachedAutomator) :
+    DaemonSessionAutomator {
+    override fun windows(): List<WindowSummaryDto> = delegate.windows()
+
+    override fun allNodes(): List<NodeSnapshotDto> = delegate.allNodes()
+
+    override fun findByTestTag(tag: String): List<NodeSnapshotDto> = delegate.findByTestTag(tag)
+
+    override fun click(nodeKey: String): Unit = delegate.click(nodeKey)
+
+    override fun typeText(text: String): Unit = delegate.typeText(text)
+
+    override fun screenshot(): ByteArray = delegate.screenshot()
+
+    override fun close(): Unit = delegate.close()
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -3,12 +3,14 @@ package dev.sebastiano.spectre.cli.daemon
 import dev.sebastiano.spectre.agent.AgentAttach
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.SpectreAttachException
+import java.io.IOException
 
 /** In-memory session table for one daemon process. */
 @OptIn(ExperimentalSpectreAgentApi::class)
-public class DaemonSessionRegistry(
-    private val attachAutomator: (Long) -> AutoCloseable = { targetPid ->
-        AgentAttach.attach(targetPid)
+public class DaemonSessionRegistry
+internal constructor(
+    private val attachAutomator: (Long) -> DaemonSessionAutomator = { targetPid ->
+        AttachedDaemonSession(AgentAttach.attach(targetPid))
     }
 ) : AutoCloseable {
     private val sessionsByPid: MutableMap<Long, DaemonSession> = linkedMapOf()
@@ -26,6 +28,12 @@ public class DaemonSessionRegistry(
             is DaemonRequest.Attach -> attach(request.targetPid)
             is DaemonRequest.Detach -> detach(request.sessionId)
             DaemonRequest.ListSessions -> listSessions()
+            is DaemonRequest.Windows -> windows(request.sessionId)
+            is DaemonRequest.AllNodes -> allNodes(request.sessionId)
+            is DaemonRequest.FindByTestTag -> findByTestTag(request.sessionId, request.tag)
+            is DaemonRequest.Click -> click(request.sessionId, request.nodeKey)
+            is DaemonRequest.TypeText -> typeText(request.sessionId, request.text)
+            is DaemonRequest.Screenshot -> screenshot(request.sessionId)
             DaemonRequest.Shutdown -> shutdown()
         }
 
@@ -75,6 +83,61 @@ public class DaemonSessionRegistry(
             sessions = sessionsByPid.values.map { it.summary }.sortedBy { it.targetPid }
         )
 
+    private fun windows(sessionId: String): DaemonResponse =
+        invoke(sessionId) { automator ->
+            DaemonResponse.Windows(sessionId = sessionId, windows = automator.windows())
+        }
+
+    private fun allNodes(sessionId: String): DaemonResponse =
+        invoke(sessionId) { automator ->
+            DaemonResponse.Nodes(sessionId = sessionId, nodes = automator.allNodes())
+        }
+
+    private fun findByTestTag(sessionId: String, tag: String): DaemonResponse =
+        invoke(sessionId) { automator ->
+            DaemonResponse.Nodes(sessionId = sessionId, nodes = automator.findByTestTag(tag))
+        }
+
+    private fun click(sessionId: String, nodeKey: String): DaemonResponse =
+        invoke(sessionId) { automator ->
+            automator.click(nodeKey)
+            DaemonResponse.Completed(sessionId)
+        }
+
+    private fun typeText(sessionId: String, text: String): DaemonResponse =
+        invoke(sessionId) { automator ->
+            automator.typeText(text)
+            DaemonResponse.Completed(sessionId)
+        }
+
+    private fun screenshot(sessionId: String): DaemonResponse =
+        invoke(sessionId) { automator ->
+            DaemonResponse.Screenshot(sessionId = sessionId, pngBytes = automator.screenshot())
+        }
+
+    private fun invoke(
+        sessionId: String,
+        operation: (DaemonSessionAutomator) -> DaemonResponse,
+    ): DaemonResponse {
+        val session =
+            sessionsByPid.values.firstOrNull { it.sessionId == sessionId }
+                ?: return sessionNotFound(sessionId)
+        return try {
+            operation(session.automator)
+        } catch (exception: IOException) {
+            DaemonResponse.Error(
+                code = DaemonErrorCode.OperationFailed,
+                message = exception.message ?: "session operation failed",
+            )
+        }
+    }
+
+    private fun sessionNotFound(sessionId: String): DaemonResponse.Error =
+        DaemonResponse.Error(
+            code = DaemonErrorCode.SessionNotFound,
+            message = "session not found: $sessionId",
+        )
+
     private fun shutdown(): DaemonResponse {
         close()
         return DaemonResponse.ShuttingDown
@@ -92,7 +155,7 @@ public class DaemonSessionRegistry(
 
     private data class DaemonSession(
         val summary: DaemonSessionSummary,
-        val automator: AutoCloseable,
+        val automator: DaemonSessionAutomator,
     ) {
         val sessionId: String
             get() = summary.sessionId

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClientTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import java.io.File
 import java.nio.file.FileSystems
 import java.nio.file.Files
@@ -9,6 +10,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalSpectreAgentApi::class)
 class DaemonClientTest {
     @Test
     fun `daemon runtime classpath includes the loadable agent runtime`() {
@@ -132,6 +134,7 @@ private fun testRuntimeClassPath(): String =
         "Missing CLI test runtime classpath"
     }
 
+@OptIn(ExperimentalSpectreAgentApi::class)
 private fun testDaemonSessionRegistry(): DaemonSessionRegistry = DaemonSessionRegistry {
-    AutoCloseable {}
+    TestDaemonSessionAutomator()
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
@@ -8,7 +8,7 @@ class DaemonEndpointTest {
     @Test
     fun `uses a short deterministic per-user directory under the posix temp base`() {
         assertEquals(
-            "/tmp/sp-d-2bd806c9/daemon.sock",
+            "/tmp/sp-d-2bd806c9/daemon-v1-2.sock",
             DaemonEndpoint.defaultSocketPath(
                     osName = "Mac OS X",
                     tempDirectory = "/var/folders/long",

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
@@ -1,5 +1,9 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.RectDto
+import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
@@ -16,7 +20,7 @@ class DaemonHandshakeTest {
 
         val hello = assertIs<DaemonRequest.Hello>(decoded)
         assertEquals(1, hello.clientVersion.major)
-        assertEquals(1, hello.clientVersion.minor)
+        assertEquals(2, hello.clientVersion.minor)
     }
 
     @Test
@@ -47,6 +51,67 @@ class DaemonHandshakeTest {
 
 @OptIn(ExperimentalSerializationApi::class)
 class DaemonSessionCommandProtocolTest {
+    @OptIn(ExperimentalSpectreAgentApi::class)
+    @Test
+    fun `session operation requests round trip through cbor`() {
+        val requests =
+            listOf<DaemonRequest>(
+                DaemonRequest.Windows("session-1234"),
+                DaemonRequest.AllNodes("session-1234"),
+                DaemonRequest.FindByTestTag("session-1234", "submit"),
+                DaemonRequest.Click("session-1234", "main:0:1"),
+                DaemonRequest.TypeText("session-1234", "hello"),
+                DaemonRequest.Screenshot("session-1234"),
+            )
+
+        val decoded = requests.map(::roundTripRequest)
+
+        assertEquals(requests, decoded)
+    }
+
+    @OptIn(ExperimentalSpectreAgentApi::class)
+    @Test
+    fun `session operation responses round trip through cbor`() {
+        val bounds = RectDto(x = 0, y = 0, width = 100, height = 100)
+        val responses =
+            listOf<DaemonResponse>(
+                DaemonResponse.Windows(
+                    sessionId = "session-1234",
+                    windows =
+                        listOf(
+                            WindowSummaryDto(
+                                index = 0,
+                                surfaceId = "main",
+                                title = "Fixture",
+                                isPopup = false,
+                                bounds = bounds,
+                            )
+                        ),
+                ),
+                DaemonResponse.Nodes(
+                    sessionId = "session-1234",
+                    nodes =
+                        listOf(
+                            NodeSnapshotDto(
+                                key = "main:0:1",
+                                testTag = "submit",
+                                texts = listOf("Submit"),
+                                role = "Button",
+                                contentDescription = null,
+                                isVisible = true,
+                                bounds = bounds,
+                            )
+                        ),
+                ),
+                DaemonResponse.Completed("session-1234"),
+                DaemonResponse.Screenshot("session-1234", byteArrayOf(1, 2, 3)),
+            )
+
+        val decoded = responses.map(::roundTripResponse)
+
+        assertEquals(responses, decoded)
+    }
+
     @Test
     fun `session lifecycle requests round trip through cbor`() {
         val requests =
@@ -57,10 +122,7 @@ class DaemonSessionCommandProtocolTest {
                 DaemonRequest.Shutdown,
             )
 
-        val decoded = requests.map { request ->
-            val bytes = DaemonProtocol.cbor.encodeToByteArray(DaemonRequest.serializer(), request)
-            DaemonProtocol.cbor.decodeFromByteArray(DaemonRequest.serializer(), bytes)
-        }
+        val decoded = requests.map(::roundTripRequest)
 
         assertEquals(requests, decoded)
     }
@@ -79,11 +141,18 @@ class DaemonSessionCommandProtocolTest {
                 DaemonResponse.Error(code = DaemonErrorCode.SessionNotFound, message = "missing"),
             )
 
-        val decoded = responses.map { response ->
-            val bytes = DaemonProtocol.cbor.encodeToByteArray(DaemonResponse.serializer(), response)
-            DaemonProtocol.cbor.decodeFromByteArray(DaemonResponse.serializer(), bytes)
-        }
+        val decoded = responses.map(::roundTripResponse)
 
         assertEquals(responses, decoded)
+    }
+
+    private fun roundTripRequest(request: DaemonRequest): DaemonRequest {
+        val bytes = DaemonProtocol.cbor.encodeToByteArray(DaemonRequest.serializer(), request)
+        return DaemonProtocol.cbor.decodeFromByteArray(DaemonRequest.serializer(), bytes)
+    }
+
+    private fun roundTripResponse(response: DaemonResponse): DaemonResponse {
+        val bytes = DaemonProtocol.cbor.encodeToByteArray(DaemonResponse.serializer(), response)
+        return DaemonProtocol.cbor.decodeFromByteArray(DaemonResponse.serializer(), bytes)
     }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import java.nio.channels.Channels
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
@@ -15,12 +16,15 @@ import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalSpectreAgentApi::class)
 class DaemonServerTest {
     @Test
     fun `close detaches all owned agent sessions`() {
         val socketPath = temporarySocketPath()
         var closes = 0
-        val registry = DaemonSessionRegistry { AutoCloseable { closes++ } }
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(closeAction = { closes++ })
+        }
         val server = DaemonServer(socketPath, registry = registry)
 
         try {
@@ -341,7 +345,11 @@ class DaemonServerTest {
     @Test
     fun `serves lifecycle requests over a unix domain socket and removes it on shutdown`() {
         val socketPath = temporarySocketPath()
-        val server = DaemonServer(socketPath, registry = DaemonSessionRegistry { AutoCloseable {} })
+        val server =
+            DaemonServer(
+                socketPath,
+                registry = DaemonSessionRegistry { TestDaemonSessionAutomator() },
+            )
 
         try {
             SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
@@ -2,12 +2,95 @@ package dev.sebastiano.spectre.cli.daemon
 
 import dev.sebastiano.spectre.agent.AttachUnsupportedException
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.RectDto
+import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
+import java.io.IOException
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalSpectreAgentApi::class)
 class DaemonSessionRegistryTest {
+    @OptIn(ExperimentalSpectreAgentApi::class)
+    @Test
+    fun `dispatches every automator operation through the attached session`() {
+        val window =
+            WindowSummaryDto(
+                index = 0,
+                surfaceId = "main",
+                title = "Fixture",
+                isPopup = false,
+                bounds = RectDto(x = 0, y = 0, width = 100, height = 100),
+            )
+        val node =
+            NodeSnapshotDto(
+                key = "main:0:1",
+                testTag = "submit",
+                texts = listOf("Submit"),
+                role = "Button",
+                contentDescription = null,
+                isVisible = true,
+                bounds = RectDto(x = 1, y = 2, width = 3, height = 4),
+            )
+        var clicked: String? = null
+        var typed: String? = null
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(
+                windowsResult = { listOf(window) },
+                nodesResult = { listOf(node) },
+                findByTestTagResult = { tag -> if (tag == "submit") listOf(node) else emptyList() },
+                clickAction = { nodeKey -> clicked = nodeKey },
+                typeTextAction = { text -> typed = text },
+                screenshotResult = { byteArrayOf(1, 2, 3) },
+            )
+        }
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(1234))).sessionId
+
+        assertEquals(
+            DaemonResponse.Windows(sessionId, listOf(window)),
+            registry.handle(DaemonRequest.Windows(sessionId)),
+        )
+        assertEquals(
+            DaemonResponse.Nodes(sessionId, listOf(node)),
+            registry.handle(DaemonRequest.AllNodes(sessionId)),
+        )
+        assertEquals(
+            DaemonResponse.Nodes(sessionId, listOf(node)),
+            registry.handle(DaemonRequest.FindByTestTag(sessionId, "submit")),
+        )
+        assertEquals(
+            DaemonResponse.Completed(sessionId),
+            registry.handle(DaemonRequest.Click(sessionId, node.key)),
+        )
+        assertEquals(node.key, clicked)
+        assertEquals(
+            DaemonResponse.Completed(sessionId),
+            registry.handle(DaemonRequest.TypeText(sessionId, "hello")),
+        )
+        assertEquals("hello", typed)
+        assertEquals(
+            DaemonResponse.Screenshot(sessionId, byteArrayOf(1, 2, 3)),
+            registry.handle(DaemonRequest.Screenshot(sessionId)),
+        )
+    }
+
+    @Test
+    fun `maps automator operation failures to protocol errors`() {
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(windowsResult = { throw IOException("target disconnected") })
+        }
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(1234))).sessionId
+
+        val response =
+            assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Windows(sessionId)))
+
+        assertEquals(DaemonErrorCode.OperationFailed, response.code)
+    }
+
     @OptIn(ExperimentalSpectreAgentApi::class)
     @Test
     fun `maps agent attach failures to protocol errors`() {
@@ -21,7 +104,9 @@ class DaemonSessionRegistryTest {
     @Test
     fun `closes the attached session when detached`() {
         var closes = 0
-        val registry = DaemonSessionRegistry { AutoCloseable { closes++ } }
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(closeAction = { closes++ })
+        }
 
         registry.handle(DaemonRequest.Attach(1234))
         registry.handle(DaemonRequest.Detach("pid-1234"))
@@ -32,7 +117,9 @@ class DaemonSessionRegistryTest {
     @Test
     fun `closes every attached session when shutting down`() {
         var closes = 0
-        val registry = DaemonSessionRegistry { AutoCloseable { closes++ } }
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(closeAction = { closes++ })
+        }
 
         registry.handle(DaemonRequest.Attach(1234))
         registry.handle(DaemonRequest.Attach(5678))
@@ -106,4 +193,7 @@ class DaemonSessionRegistryTest {
     }
 }
 
-private fun testRegistry(): DaemonSessionRegistry = DaemonSessionRegistry { AutoCloseable {} }
+@OptIn(ExperimentalSpectreAgentApi::class)
+private fun testRegistry(): DaemonSessionRegistry = DaemonSessionRegistry {
+    TestDaemonSessionAutomator()
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
@@ -1,0 +1,30 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal class TestDaemonSessionAutomator(
+    private val windowsResult: () -> List<WindowSummaryDto> = { emptyList() },
+    private val nodesResult: () -> List<NodeSnapshotDto> = { emptyList() },
+    private val findByTestTagResult: (String) -> List<NodeSnapshotDto> = { emptyList() },
+    private val clickAction: (String) -> Unit = {},
+    private val typeTextAction: (String) -> Unit = {},
+    private val screenshotResult: () -> ByteArray = { ByteArray(0) },
+    private val closeAction: () -> Unit = {},
+) : DaemonSessionAutomator {
+    override fun windows(): List<WindowSummaryDto> = windowsResult()
+
+    override fun allNodes(): List<NodeSnapshotDto> = nodesResult()
+
+    override fun findByTestTag(tag: String): List<NodeSnapshotDto> = findByTestTagResult(tag)
+
+    override fun click(nodeKey: String): Unit = clickAction(nodeKey)
+
+    override fun typeText(text: String): Unit = typeTextAction(text)
+
+    override fun screenshot(): ByteArray = screenshotResult()
+
+    override fun close(): Unit = closeAction()
+}


### PR DESCRIPTION
## Summary
- add daemon protocol operations for windows, nodes, selectors, input, and screenshots
- retain and dispatch through live AttachedAutomator sessions
- add CBOR contract and session dispatch coverage

## Verification
- ./gradlew check