### PR TITLE
Stop idle daemon processes

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -1,6 +1,8 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import java.io.EOFException
 import java.io.IOException
+import java.net.SocketException
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
@@ -21,7 +23,13 @@ public class DaemonClient(public val socketPath: Path) : AutoCloseable {
             channel.connect(UnixDomainSocketAddress.of(socketPath))
             val input = Channels.newInputStream(channel)
             val output = Channels.newOutputStream(channel)
-            requireCompatibleDaemon(output, input)
+            try {
+                requireCompatibleDaemon(output, input)
+            } catch (exception: EOFException) {
+                throw DaemonConnectionClosedException(exception)
+            } catch (exception: SocketException) {
+                throw DaemonConnectionClosedException(exception)
+            }
             DaemonWireCodec.writeRequest(output, request)
             DaemonWireCodec.readResponse(input)
                 ?: throw IOException("Daemon closed the connection before responding")
@@ -41,11 +49,13 @@ public class DaemonClient(public val socketPath: Path) : AutoCloseable {
                 }
             is DaemonResponse.Error ->
                 throw IOException("Daemon handshake failed: ${response.message}")
-            null ->
-                throw IOException("Daemon closed the connection before completing the handshake")
+            null -> throw DaemonConnectionClosedException()
             else -> throw IOException("Daemon returned an unexpected handshake response")
         }
     }
 
     override fun close(): Unit = Unit
 }
+
+internal class DaemonConnectionClosedException(cause: Throwable? = null) :
+    IOException("Daemon closed the connection during handshake", cause)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcess.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcess.kt
@@ -25,9 +25,7 @@ public constructor(
                 server ?: serverFactory(socketPath).also { server = it }
             }
         while (!activeServer.awaitTermination(IDLE_POLL_INTERVAL_MILLIS)) {
-            if (activeServer.idleMillis() >= idleTimeoutMillis) {
-                activeServer.close()
-            }
+            activeServer.closeIfIdle(idleTimeoutMillis)
         }
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcess.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcess.kt
@@ -9,6 +9,7 @@ public class DaemonProcess
 public constructor(
     private val socketPath: Path,
     private val serverFactory: (Path) -> DaemonServer = ::DaemonServer,
+    private val idleTimeoutMillis: Long = DEFAULT_IDLE_TIMEOUT_MILLIS,
 ) : AutoCloseable {
     private val lifecycleLock: Any = Any()
     private var server: DaemonServer? = null
@@ -17,12 +18,17 @@ public constructor(
     /** Blocks until the daemon receives a shutdown request or [close] is called. */
     @Throws(IOException::class, InterruptedException::class)
     public fun runUntilShutdown() {
+        require(idleTimeoutMillis > 0) { "idleTimeoutMillis must be positive" }
         val activeServer =
             synchronized(lifecycleLock) {
                 check(!closed) { "Daemon process is closed" }
                 server ?: serverFactory(socketPath).also { server = it }
             }
-        activeServer.awaitTermination(TERMINATION_WAIT_MILLIS)
+        while (!activeServer.awaitTermination(IDLE_POLL_INTERVAL_MILLIS)) {
+            if (activeServer.idleMillis() >= idleTimeoutMillis) {
+                activeServer.close()
+            }
+        }
     }
 
     /** Stops the daemon when the hosting process is asked to exit. */
@@ -35,6 +41,7 @@ public constructor(
     }
 
     private companion object {
-        private const val TERMINATION_WAIT_MILLIS: Long = Long.MAX_VALUE
+        private const val DEFAULT_IDLE_TIMEOUT_MILLIS: Long = 5 * 60 * 1_000
+        private const val IDLE_POLL_INTERVAL_MILLIS: Long = 100
     }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -131,7 +131,19 @@ public constructor(
                     if (running.get()) logConnectionFailure(exception)
                     return
                 }
-            activeClient.set(client)
+            val accepted =
+                synchronized(activityLock) {
+                    if (!running.get()) {
+                        false
+                    } else {
+                        activeClient.set(client)
+                        true
+                    }
+                }
+            if (!accepted) {
+                client.close()
+                return
+            }
             @Suppress("TooGenericExceptionCaught")
             try {
                 handleConnection(client)
@@ -166,7 +178,7 @@ public constructor(
                 }
             }
         } finally {
-            activeClient.compareAndSet(client, null)
+            synchronized(activityLock) { activeClient.compareAndSet(client, null) }
         }
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -26,7 +26,6 @@ import java.util.EnumSet
 import java.util.HexFormat
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -46,7 +45,8 @@ public constructor(
     }
     private val running: AtomicBoolean = AtomicBoolean(true)
     private val closed: AtomicBoolean = AtomicBoolean(false)
-    private val lastActivityNanos: AtomicLong = AtomicLong(System.nanoTime())
+    private val activityLock: Any = Any()
+    private var lastActivityNanos: Long = System.nanoTime()
     private val activeClient: AtomicReference<SocketChannel?> = AtomicReference(null)
     private val socketProtection: DaemonSocketProtection =
         DaemonSocketProtection.forPath(socketPath)
@@ -99,10 +99,20 @@ public constructor(
     }
 
     /** Milliseconds elapsed since the most recently received daemon request. */
-    public fun idleMillis(): Long =
-        java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
-            System.nanoTime() - lastActivityNanos.get()
-        )
+    public fun idleMillis(): Long = synchronized(activityLock) { idleMillisLocked() }
+
+    /** Stops this server only when it remains inactive for at least [timeoutMillis]. */
+    public fun closeIfIdle(timeoutMillis: Long): Boolean {
+        require(timeoutMillis > 0) { "timeoutMillis must be positive" }
+        synchronized(activityLock) {
+            if (registry.hasSessions || idleMillisLocked() < timeoutMillis) return false
+            close()
+            return true
+        }
+    }
+
+    private fun idleMillisLocked(): Long =
+        java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - lastActivityNanos)
 
     private fun acceptLoop() {
         while (running.get()) {
@@ -133,7 +143,7 @@ public constructor(
                 var handshakeComplete = false
                 while (running.get()) {
                     val request = DaemonWireCodec.readRequest(input) ?: return
-                    lastActivityNanos.set(System.nanoTime())
+                    synchronized(activityLock) { lastActivityNanos = System.nanoTime() }
                     val response = handleRequest(request, handshakeComplete)
                     if (request is DaemonRequest.Hello) {
                         handshakeComplete = response is DaemonResponse.Hello

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -26,6 +26,7 @@ import java.util.EnumSet
 import java.util.HexFormat
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -45,6 +46,7 @@ public constructor(
     }
     private val running: AtomicBoolean = AtomicBoolean(true)
     private val closed: AtomicBoolean = AtomicBoolean(false)
+    private val lastActivityNanos: AtomicLong = AtomicLong(System.nanoTime())
     private val activeClient: AtomicReference<SocketChannel?> = AtomicReference(null)
     private val socketProtection: DaemonSocketProtection =
         DaemonSocketProtection.forPath(socketPath)
@@ -96,6 +98,12 @@ public constructor(
         return !acceptThread.isAlive
     }
 
+    /** Milliseconds elapsed since the most recently received daemon request. */
+    public fun idleMillis(): Long =
+        java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
+            System.nanoTime() - lastActivityNanos.get()
+        )
+
     private fun acceptLoop() {
         while (running.get()) {
             val client =
@@ -125,6 +133,7 @@ public constructor(
                 var handshakeComplete = false
                 while (running.get()) {
                     val request = DaemonWireCodec.readRequest(input) ?: return
+                    lastActivityNanos.set(System.nanoTime())
                     val response = handleRequest(request, handshakeComplete)
                     if (request is DaemonRequest.Hello) {
                         handshakeComplete = response is DaemonResponse.Hello

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -105,7 +105,13 @@ public constructor(
     public fun closeIfIdle(timeoutMillis: Long): Boolean {
         require(timeoutMillis > 0) { "timeoutMillis must be positive" }
         synchronized(activityLock) {
-            if (registry.hasSessions || idleMillisLocked() < timeoutMillis) return false
+            if (
+                activeClient.get() != null ||
+                    registry.hasSessions ||
+                    idleMillisLocked() < timeoutMillis
+            ) {
+                return false
+            }
             close()
             return true
         }
@@ -125,6 +131,7 @@ public constructor(
                     if (running.get()) logConnectionFailure(exception)
                     return
                 }
+            activeClient.set(client)
             @Suppress("TooGenericExceptionCaught")
             try {
                 handleConnection(client)
@@ -135,7 +142,6 @@ public constructor(
     }
 
     private fun handleConnection(client: SocketChannel) {
-        activeClient.set(client)
         try {
             client.use { channel ->
                 val input = Channels.newInputStream(channel)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -18,6 +18,9 @@ internal constructor(
     public val isShutdown: Boolean
         get() = shutdown
 
+    public val hasSessions: Boolean
+        @Synchronized get() = sessionsByPid.isNotEmpty()
+
     private var shutdown: Boolean = false
 
     @Synchronized

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinator.kt
@@ -60,6 +60,7 @@ public class DaemonStartupCoordinator<T>(
     private fun isAbsentEndpoint(exception: IOException): Boolean =
         exception is ConnectException ||
             exception is NoSuchFileException ||
+            exception is DaemonConnectionClosedException ||
             (exception is SocketException && exception.message == MISSING_UNIX_SOCKET_MESSAGE)
 
     private companion object {

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
@@ -38,13 +38,13 @@ class DaemonProcessTest {
     @Test
     fun `resets the idle timeout after a daemon request`() {
         val socketPath = temporarySocketPath()
-        val daemon = DaemonProcess(socketPath, idleTimeoutMillis = 300)
+        val daemon = DaemonProcess(socketPath, idleTimeoutMillis = 2_000)
         val runner = Thread(daemon::runUntilShutdown)
 
         try {
             runner.start()
             awaitSocket(socketPath)
-            Thread.sleep(150)
+            Thread.sleep(500)
 
             SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
                 channel.connect(UnixDomainSocketAddress.of(socketPath))
@@ -60,7 +60,7 @@ class DaemonProcessTest {
                 )
             }
 
-            Thread.sleep(200)
+            Thread.sleep(500)
             assertTrue(runner.isAlive)
             runner.join(2_000)
             assertFalse(runner.isAlive)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
@@ -11,8 +11,66 @@ import java.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class DaemonProcessTest {
+    @Test
+    fun `closes after the idle timeout`() {
+        val socketPath = temporarySocketPath()
+        val daemon = DaemonProcess(socketPath, idleTimeoutMillis = 100)
+        val runner = Thread(daemon::runUntilShutdown)
+
+        try {
+            runner.start()
+            awaitSocket(socketPath)
+
+            runner.join(2_000)
+
+            assertFalse(runner.isAlive)
+            assertFalse(Files.exists(socketPath))
+        } finally {
+            daemon.close()
+            runner.join(2_000)
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
+    fun `resets the idle timeout after a daemon request`() {
+        val socketPath = temporarySocketPath()
+        val daemon = DaemonProcess(socketPath, idleTimeoutMillis = 300)
+        val runner = Thread(daemon::runUntilShutdown)
+
+        try {
+            runner.start()
+            awaitSocket(socketPath)
+            Thread.sleep(150)
+
+            SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(UnixDomainSocketAddress.of(socketPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+                DaemonWireCodec.writeRequest(
+                    output,
+                    DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
+                )
+                assertEquals(
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonWireCodec.readResponse(input),
+                )
+            }
+
+            Thread.sleep(200)
+            assertTrue(runner.isAlive)
+            runner.join(2_000)
+            assertFalse(runner.isAlive)
+        } finally {
+            daemon.close()
+            runner.join(2_000)
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
     @Test
     fun `close before run prevents starting a daemon`() {
         val socketPath = temporarySocketPath()

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -19,6 +19,25 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalSpectreAgentApi::class)
 class DaemonServerTest {
     @Test
+    fun `idle cleanup keeps an accepted client alive through its first request`() {
+        val socketPath = temporarySocketPath()
+        val server = DaemonServer(socketPath)
+        val client = SocketChannel.open(java.net.StandardProtocolFamily.UNIX)
+
+        try {
+            client.connect(java.net.UnixDomainSocketAddress.of(socketPath))
+            Thread.sleep(10)
+
+            assertFalse(server.closeIfIdle(timeoutMillis = 1))
+            assertTrue(Files.exists(socketPath))
+        } finally {
+            client.close()
+            server.close()
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
     fun `idle cleanup keeps servers with active sessions alive`() {
         val socketPath = temporarySocketPath()
         val registry = DaemonSessionRegistry { TestDaemonSessionAutomator() }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -19,6 +19,24 @@ import kotlin.test.assertTrue
 @OptIn(ExperimentalSpectreAgentApi::class)
 class DaemonServerTest {
     @Test
+    fun `idle cleanup keeps servers with active sessions alive`() {
+        val socketPath = temporarySocketPath()
+        val registry = DaemonSessionRegistry { TestDaemonSessionAutomator() }
+        val server = DaemonServer(socketPath, registry = registry)
+
+        try {
+            registry.handle(DaemonRequest.Attach(1234))
+            Thread.sleep(10)
+
+            assertFalse(server.closeIfIdle(timeoutMillis = 1))
+            assertTrue(Files.exists(socketPath))
+        } finally {
+            server.close()
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
     fun `close detaches all owned agent sessions`() {
         val socketPath = temporarySocketPath()
         var closes = 0

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonStartupCoordinatorTest.kt
@@ -11,6 +11,24 @@ import kotlin.test.assertTrue
 
 class DaemonStartupCoordinatorTest {
     @Test
+    fun `starts once when the daemon closes during handshake`() {
+        var attempts = 0
+        var starts = 0
+
+        DaemonStartupCoordinator(
+                connect = {
+                    attempts++
+                    if (attempts == 1) throw DaemonConnectionClosedException()
+                },
+                start = { starts++ },
+            )
+            .connectOrStart()
+
+        assertEquals(2, attempts)
+        assertEquals(1, starts)
+    }
+
+    @Test
     fun `starts once and retries when the daemon is absent`() {
         var attempts = 0
         var starts = 0


### PR DESCRIPTION
## Summary
- track daemon request activity
- stop daemon processes after a resettable idle timeout
- cover idle expiration and request activity reset

## Verification
- ./gradlew check