### PR TITLE
Add daemon-backed CLI attach command

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -4,8 +4,10 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.parse
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.long
 import dev.sebastiano.spectre.cli.daemon.DaemonClient
 import dev.sebastiano.spectre.cli.daemon.DaemonEndpoint
 import dev.sebastiano.spectre.cli.daemon.DaemonJvmProcessSummary
@@ -66,10 +68,39 @@ public fun main(arguments: Array<String>): Unit = exitProcess(SpectreCli().run(a
 private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Appendable) :
     CliktCommand(name = "spectre") {
     init {
-        subcommands(PsCommand(request, output), DaemonCommand(request, output))
+        subcommands(
+            AttachCommand(request, output),
+            PsCommand(request, output),
+            DaemonCommand(request, output),
+        )
     }
 
     override fun run(): Unit = Unit
+}
+
+private class AttachCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "attach") {
+    private val targetPid: Long by argument().long()
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val session =
+            when (val response = request(DaemonRequest.Attach(targetPid))) {
+                is DaemonResponse.Attached -> response
+                is DaemonResponse.Error -> throw IOException(response.message)
+                else -> error("Daemon returned an unexpected response to attach")
+            }
+        if (json) {
+            output.append(
+                CLI_JSON.encodeToString(AttachJson(id = session.sessionId, pid = session.targetPid))
+            )
+        } else {
+            output.append(humanSession(DaemonSessionSummary(session.sessionId, session.targetPid)))
+        }
+        output.appendLine()
+    }
 }
 
 private class PsCommand(
@@ -145,6 +176,9 @@ private data class DaemonStatusJson(
 )
 
 @Serializable private data class DaemonSessionJson(val id: String, val pid: Long)
+
+@Serializable
+private data class AttachJson(val version: Int = JSON_VERSION, val id: String, val pid: Long)
 
 @Serializable
 private data class PsJson(val version: Int = JSON_VERSION, val processes: List<PsProcessJson>)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -12,6 +12,35 @@ import kotlin.test.assertTrue
 
 class SpectreCliTest {
     @Test
+    fun `attach prints stable JSON session output`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(DaemonRequest.Attach(targetPid = 42), request)
+                    DaemonResponse.Attached(sessionId = "pid-42", targetPid = 42)
+                },
+                output = output,
+            )
+
+        assertEquals(0, cli.run(listOf("attach", "42", "--json")))
+        assertEquals("{\"version\":1,\"id\":\"pid-42\",\"pid\":42}\n", output.toString())
+    }
+
+    @Test
+    fun `attach prints human-readable session output`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { DaemonResponse.Attached(sessionId = "pid-42", targetPid = 42) },
+                output = output,
+            )
+
+        assertEquals(0, cli.run(listOf("attach", "42")))
+        assertEquals("pid-42 (pid 42)\n", output.toString())
+    }
+
+    @Test
     fun `ps prints stable JSON JVM process output`() {
         val output = StringBuilder()
         val cli =


### PR DESCRIPTION
Part of #175.

Adds `spectre attach <pid>` as a protocol-only daemon client command with stable human-readable and versioned JSON output.

Tests:
- `./gradlew :cli:test --tests "*SpectreCliTest"`
- `./gradlew check`