### PR TITLE
Add daemon-backed CLI detach command

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -70,12 +70,36 @@ private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Ap
     init {
         subcommands(
             AttachCommand(request, output),
+            DetachCommand(request, output),
             PsCommand(request, output),
             DaemonCommand(request, output),
         )
     }
 
     override fun run(): Unit = Unit
+}
+
+private class DetachCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "detach") {
+    private val sessionId: String by argument()
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val detachedSessionId =
+            when (val response = request(DaemonRequest.Detach(sessionId))) {
+                is DaemonResponse.Detached -> response.sessionId
+                is DaemonResponse.Error -> throw IOException(response.message)
+                else -> error("Daemon returned an unexpected response to detach")
+            }
+        if (json) {
+            output.append(CLI_JSON.encodeToString(DetachJson(id = detachedSessionId)))
+        } else {
+            output.append("Detached $detachedSessionId.")
+        }
+        output.appendLine()
+    }
 }
 
 private class AttachCommand(
@@ -179,6 +203,8 @@ private data class DaemonStatusJson(
 
 @Serializable
 private data class AttachJson(val version: Int = JSON_VERSION, val id: String, val pid: Long)
+
+@Serializable private data class DetachJson(val version: Int = JSON_VERSION, val id: String)
 
 @Serializable
 private data class PsJson(val version: Int = JSON_VERSION, val processes: List<PsProcessJson>)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -12,6 +12,32 @@ import kotlin.test.assertTrue
 
 class SpectreCliTest {
     @Test
+    fun `detach prints stable JSON session output`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(DaemonRequest.Detach(sessionId = "pid-42"), request)
+                    DaemonResponse.Detached(sessionId = "pid-42")
+                },
+                output = output,
+            )
+
+        assertEquals(0, cli.run(listOf("detach", "pid-42", "--json")))
+        assertEquals("{\"version\":1,\"id\":\"pid-42\"}\n", output.toString())
+    }
+
+    @Test
+    fun `detach prints human-readable session output`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(request = { DaemonResponse.Detached(sessionId = "pid-42") }, output = output)
+
+        assertEquals(0, cli.run(listOf("detach", "pid-42")))
+        assertEquals("Detached pid-42.\n", output.toString())
+    }
+
+    @Test
     fun `attach prints stable JSON session output`() {
         val output = StringBuilder()
         val cli =


### PR DESCRIPTION
Part of #175.

Adds `spectre detach <session-id>` as a protocol-only daemon client command with stable human-readable and versioned JSON output.

Tests:
- `./gradlew :cli:test --tests "*SpectreCliTest"`
- `./gradlew check`