### PR TITLE
Add daemon-backed CLI windows command

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -97,10 +97,13 @@ private class WindowsCommand(
                 is DaemonResponse.Error -> throw IOException(response.message)
                 else -> error("Daemon returned an unexpected response to windows")
             }
-        if (json) output.append(CLI_JSON.encodeToString(WindowsJson(windows = windows)))
-        else
+        if (json) {
+            output.append(CLI_JSON.encodeToString(WindowsJson(windows = windows.map(::WindowJson))))
+        } else
             output.append(
-                windows.joinToString("\n") { window -> "${window.index} ${window.title}" }
+                windows.joinToString("\n") { window ->
+                    "${window.index} ${window.title ?: "(untitled)"}"
+                }
             )
         output.appendLine()
     }
@@ -233,9 +236,19 @@ private data class AttachJson(val version: Int = JSON_VERSION, val id: String, v
 
 @Serializable private data class DetachJson(val version: Int = JSON_VERSION, val id: String)
 
-@OptIn(ExperimentalSpectreAgentApi::class)
 @Serializable
-private data class WindowsJson(val version: Int = JSON_VERSION, val windows: List<WindowSummaryDto>)
+private data class WindowsJson(val version: Int = JSON_VERSION, val windows: List<WindowJson>)
+
+@Serializable
+private data class WindowJson(
+    val index: Int,
+    val surfaceId: String,
+    val title: String?,
+    val isPopup: Boolean,
+    val bounds: RectJson,
+)
+
+@Serializable private data class RectJson(val x: Int, val y: Int, val width: Int, val height: Int)
 
 @Serializable
 private data class PsJson(val version: Int = JSON_VERSION, val processes: List<PsProcessJson>)
@@ -253,6 +266,17 @@ private fun PsProcessJson(summary: DaemonJvmProcessSummary): PsProcessJson =
 
 private fun humanProcess(summary: DaemonJvmProcessSummary): String =
     "${summary.pid} ${summary.displayName}"
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+private fun WindowJson(window: WindowSummaryDto): WindowJson =
+    WindowJson(
+        index = window.index,
+        surfaceId = window.surfaceId,
+        title = window.title,
+        isPopup = window.isPopup,
+        bounds =
+            RectJson(window.bounds.x, window.bounds.y, window.bounds.width, window.bounds.height),
+    )
 
 private fun daemonRequest(socketPath: Path?): (DaemonRequest) -> DaemonResponse =
     daemonRequest@{ request ->

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -8,6 +8,8 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.long
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import dev.sebastiano.spectre.cli.daemon.DaemonClient
 import dev.sebastiano.spectre.cli.daemon.DaemonEndpoint
 import dev.sebastiano.spectre.cli.daemon.DaemonJvmProcessSummary
@@ -71,12 +73,37 @@ private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Ap
         subcommands(
             AttachCommand(request, output),
             DetachCommand(request, output),
+            WindowsCommand(request, output),
             PsCommand(request, output),
             DaemonCommand(request, output),
         )
     }
 
     override fun run(): Unit = Unit
+}
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+private class WindowsCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "windows") {
+    private val sessionId: String by argument()
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val windows =
+            when (val response = request(DaemonRequest.Windows(sessionId))) {
+                is DaemonResponse.Windows -> response.windows
+                is DaemonResponse.Error -> throw IOException(response.message)
+                else -> error("Daemon returned an unexpected response to windows")
+            }
+        if (json) output.append(CLI_JSON.encodeToString(WindowsJson(windows = windows)))
+        else
+            output.append(
+                windows.joinToString("\n") { window -> "${window.index} ${window.title}" }
+            )
+        output.appendLine()
+    }
 }
 
 private class DetachCommand(
@@ -205,6 +232,10 @@ private data class DaemonStatusJson(
 private data class AttachJson(val version: Int = JSON_VERSION, val id: String, val pid: Long)
 
 @Serializable private data class DetachJson(val version: Int = JSON_VERSION, val id: String)
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+@Serializable
+private data class WindowsJson(val version: Int = JSON_VERSION, val windows: List<WindowSummaryDto>)
 
 @Serializable
 private data class PsJson(val version: Int = JSON_VERSION, val processes: List<PsProcessJson>)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -1,5 +1,7 @@
 package dev.sebastiano.spectre.cli
 
+import dev.sebastiano.spectre.agent.transport.RectDto
+import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import dev.sebastiano.spectre.cli.daemon.DaemonJvmProcessSummary
 import dev.sebastiano.spectre.cli.daemon.DaemonRequest
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
@@ -11,6 +13,24 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class SpectreCliTest {
+    @Test
+    fun `windows prints stable JSON output`() {
+        val output = StringBuilder()
+        val window = WindowSummaryDto(0, "main", "Fixture", false, RectDto(1, 2, 3, 4))
+        val cli =
+            SpectreCli(
+                request = { DaemonResponse.Windows("pid-42", listOf(window)) },
+                output = output,
+            )
+
+        assertEquals(0, cli.run(listOf("windows", "pid-42", "--json")))
+        assertEquals(
+            "{\"version\":1,\"windows\":[{\"index\":0,\"surfaceId\":\"main\",\"title\":\"Fixture\",\"isPopup\":false," +
+                "\"bounds\":{\"x\":1,\"y\":2,\"width\":3,\"height\":4}}]}\n",
+            output.toString(),
+        )
+    }
+
     @Test
     fun `detach prints stable JSON session output`() {
         val output = StringBuilder()

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -32,6 +32,20 @@ class SpectreCliTest {
     }
 
     @Test
+    fun `windows uses a readable label for untitled windows`() {
+        val output = StringBuilder()
+        val window = WindowSummaryDto(0, "popup", null, true, RectDto(1, 2, 3, 4))
+        val cli =
+            SpectreCli(
+                request = { DaemonResponse.Windows("pid-42", listOf(window)) },
+                output = output,
+            )
+
+        assertEquals(0, cli.run(listOf("windows", "pid-42")))
+        assertEquals("0 (untitled)\n", output.toString())
+    }
+
+    @Test
     fun `detach prints stable JSON session output`() {
         val output = StringBuilder()
         val cli =


### PR DESCRIPTION
Part of #175.

Adds `spectre windows <session-id>` with stable versioned JSON output over the existing daemon protocol.

Tests:
- `./gradlew :cli:test --tests "*SpectreCliTest"`
- `./gradlew check`