### PR TITLE
Add daemon-backed CLI tree command

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -9,6 +9,7 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.long
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import dev.sebastiano.spectre.cli.daemon.DaemonClient
 import dev.sebastiano.spectre.cli.daemon.DaemonEndpoint
@@ -74,12 +75,35 @@ private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Ap
             AttachCommand(request, output),
             DetachCommand(request, output),
             WindowsCommand(request, output),
+            TreeCommand(request, output),
             PsCommand(request, output),
             DaemonCommand(request, output),
         )
     }
 
     override fun run(): Unit = Unit
+}
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+private class TreeCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "tree") {
+    private val sessionId: String by argument()
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val nodes =
+            when (val response = request(DaemonRequest.AllNodes(sessionId))) {
+                is DaemonResponse.Nodes -> response.nodes
+                is DaemonResponse.Error -> throw IOException(response.message)
+                else -> error("Daemon returned an unexpected response to tree")
+            }
+        if (json) output.append(CLI_JSON.encodeToString(TreeJson(nodes = nodes.map(::NodeJson))))
+        else
+            output.append(nodes.joinToString("\n") { node -> "${node.key} ${node.role ?: "Node"}" })
+        output.appendLine()
+    }
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)
@@ -240,6 +264,22 @@ private data class AttachJson(val version: Int = JSON_VERSION, val id: String, v
 private data class WindowsJson(val version: Int = JSON_VERSION, val windows: List<WindowJson>)
 
 @Serializable
+private data class TreeJson(val version: Int = JSON_VERSION, val nodes: List<NodeJson>)
+
+@Serializable
+private data class NodeJson(
+    val key: String,
+    val testTag: String?,
+    val texts: List<String>,
+    val editableText: String?,
+    val role: String?,
+    val contentDescription: String?,
+    val isFocused: Boolean,
+    val isVisible: Boolean,
+    val bounds: RectJson,
+)
+
+@Serializable
 private data class WindowJson(
     val index: Int,
     val surfaceId: String,
@@ -276,6 +316,20 @@ private fun WindowJson(window: WindowSummaryDto): WindowJson =
         isPopup = window.isPopup,
         bounds =
             RectJson(window.bounds.x, window.bounds.y, window.bounds.width, window.bounds.height),
+    )
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+private fun NodeJson(node: NodeSnapshotDto): NodeJson =
+    NodeJson(
+        key = node.key,
+        testTag = node.testTag,
+        texts = node.texts,
+        editableText = node.editableText,
+        role = node.role,
+        contentDescription = node.contentDescription,
+        isFocused = node.isFocused,
+        isVisible = node.isVisible,
+        bounds = RectJson(node.bounds.x, node.bounds.y, node.bounds.width, node.bounds.height),
     )
 
 private fun daemonRequest(socketPath: Path?): (DaemonRequest) -> DaemonResponse =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.cli
 
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.RectDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import dev.sebastiano.spectre.cli.daemon.DaemonJvmProcessSummary
@@ -13,6 +14,31 @@ import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class SpectreCliTest {
+    @Test
+    fun `tree prints stable JSON node output`() {
+        val output = StringBuilder()
+        val node =
+            NodeSnapshotDto(
+                key = "main:0:1",
+                testTag = "submit",
+                texts = listOf("Submit"),
+                role = "Button",
+                contentDescription = null,
+                isVisible = true,
+                bounds = RectDto(1, 2, 3, 4),
+            )
+        val cli =
+            SpectreCli(request = { DaemonResponse.Nodes("pid-42", listOf(node)) }, output = output)
+
+        assertEquals(0, cli.run(listOf("tree", "pid-42", "--json")))
+        assertEquals(
+            "{\"version\":1,\"nodes\":[{\"key\":\"main:0:1\",\"testTag\":\"submit\",\"texts\":[\"Submit\"]," +
+                "\"editableText\":null,\"role\":\"Button\",\"contentDescription\":null,\"isFocused\":false," +
+                "\"isVisible\":true,\"bounds\":{\"x\":1,\"y\":2,\"width\":3,\"height\":4}}]}\n",
+            output.toString(),
+        )
+    }
+
     @Test
     fun `windows prints stable JSON output`() {
         val output = StringBuilder()


### PR DESCRIPTION
Part of #175.

Adds `spectre tree <session-id>` over the existing all-nodes daemon operation, with stable mapped JSON output.

Tests:
- `./gradlew :cli:test --tests "*SpectreCliTest"`
- `./gradlew check`