### PR TITLE
Add daemon-backed CLI find command

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -76,12 +76,36 @@ private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Ap
             DetachCommand(request, output),
             WindowsCommand(request, output),
             TreeCommand(request, output),
+            FindCommand(request, output),
             PsCommand(request, output),
             DaemonCommand(request, output),
         )
     }
 
     override fun run(): Unit = Unit
+}
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+private class FindCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "find") {
+    private val sessionId: String by argument()
+    private val testTag: String by argument()
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val nodes =
+            when (val response = request(DaemonRequest.FindByTestTag(sessionId, testTag))) {
+                is DaemonResponse.Nodes -> response.nodes
+                is DaemonResponse.Error -> throw IOException(response.message)
+                else -> error("Daemon returned an unexpected response to find")
+            }
+        if (json) output.append(CLI_JSON.encodeToString(TreeJson(nodes = nodes.map(::NodeJson))))
+        else
+            output.append(nodes.joinToString("\n") { node -> "${node.key} ${node.role ?: "Node"}" })
+        output.appendLine()
+    }
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -15,6 +15,37 @@ import kotlin.test.assertTrue
 
 class SpectreCliTest {
     @Test
+    fun `find prints stable JSON node output`() {
+        val output = StringBuilder()
+        val node =
+            NodeSnapshotDto(
+                key = "main:0:1",
+                testTag = "submit",
+                texts = listOf("Submit"),
+                role = "Button",
+                contentDescription = null,
+                isVisible = true,
+                bounds = RectDto(1, 2, 3, 4),
+            )
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(DaemonRequest.FindByTestTag("pid-42", "submit"), request)
+                    DaemonResponse.Nodes("pid-42", listOf(node))
+                },
+                output = output,
+            )
+
+        assertEquals(0, cli.run(listOf("find", "pid-42", "submit", "--json")))
+        assertEquals(
+            "{\"version\":1,\"nodes\":[{\"key\":\"main:0:1\",\"testTag\":\"submit\",\"texts\":[\"Submit\"]," +
+                "\"editableText\":null,\"role\":\"Button\",\"contentDescription\":null,\"isFocused\":false," +
+                "\"isVisible\":true,\"bounds\":{\"x\":1,\"y\":2,\"width\":3,\"height\":4}}]}\n",
+            output.toString(),
+        )
+    }
+
+    @Test
     fun `tree prints stable JSON node output`() {
         val output = StringBuilder()
         val node =


### PR DESCRIPTION
Part of #175.

Adds `spectre find <session-id> <test-tag>` over the existing daemon selector operation, with stable mapped JSON output.

Tests:
- `./gradlew :cli:test --tests "*SpectreCliTest"`
- `./gradlew check`