### PR TITLE
Add daemon-backed CLI click command

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -77,12 +77,35 @@ private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Ap
             WindowsCommand(request, output),
             TreeCommand(request, output),
             FindCommand(request, output),
+            ClickCommand(request, output),
             PsCommand(request, output),
             DaemonCommand(request, output),
         )
     }
 
     override fun run(): Unit = Unit
+}
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+private class ClickCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "click") {
+    private val sessionId: String by argument()
+    private val nodeKey: String by argument()
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val completedSessionId =
+            when (val response = request(DaemonRequest.Click(sessionId, nodeKey))) {
+                is DaemonResponse.Completed -> response.sessionId
+                is DaemonResponse.Error -> throw IOException(response.message)
+                else -> error("Daemon returned an unexpected response to click")
+            }
+        if (json) output.append(CLI_JSON.encodeToString(CompletionJson(id = completedSessionId)))
+        else output.append("Clicked $nodeKey.")
+        output.appendLine()
+    }
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)
@@ -283,6 +306,8 @@ private data class DaemonStatusJson(
 private data class AttachJson(val version: Int = JSON_VERSION, val id: String, val pid: Long)
 
 @Serializable private data class DetachJson(val version: Int = JSON_VERSION, val id: String)
+
+@Serializable private data class CompletionJson(val version: Int = JSON_VERSION, val id: String)
 
 @Serializable
 private data class WindowsJson(val version: Int = JSON_VERSION, val windows: List<WindowJson>)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -15,6 +15,22 @@ import kotlin.test.assertTrue
 
 class SpectreCliTest {
     @Test
+    fun `click prints stable JSON completion output`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(DaemonRequest.Click("pid-42", "main:0:1"), request)
+                    DaemonResponse.Completed("pid-42")
+                },
+                output = output,
+            )
+
+        assertEquals(0, cli.run(listOf("click", "pid-42", "main:0:1", "--json")))
+        assertEquals("{\"version\":1,\"id\":\"pid-42\"}\n", output.toString())
+    }
+
+    @Test
     fun `find prints stable JSON node output`() {
         val output = StringBuilder()
         val node =


### PR DESCRIPTION
Part of #175.

Adds `spectre click <session-id> <node-key>` over the existing daemon action, with stable JSON completion output.

Tests:
- `./gradlew :cli:test --tests "*SpectreCliTest"`
- `./gradlew check`