### PR TITLE
Add daemon-backed CLI screenshot command

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -8,6 +8,7 @@ import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.long
+import com.github.ajalt.clikt.parameters.types.path
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
@@ -78,12 +79,37 @@ private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Ap
             TreeCommand(request, output),
             FindCommand(request, output),
             ClickCommand(request, output),
+            ScreenshotCommand(request, output),
             PsCommand(request, output),
             DaemonCommand(request, output),
         )
     }
 
     override fun run(): Unit = Unit
+}
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+private class ScreenshotCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "screenshot") {
+    private val sessionId: String by argument()
+    private val outputPath: Path? by option("--output").path()
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val pngBytes =
+            when (val response = request(DaemonRequest.Screenshot(sessionId))) {
+                is DaemonResponse.Screenshot -> response.pngBytes
+                is DaemonResponse.Error -> throw IOException(response.message)
+                else -> error("Daemon returned an unexpected response to screenshot")
+            }
+        val path = outputPath ?: Files.createTempFile("spectre-screenshot-", ".png")
+        Files.write(path, pngBytes)
+        if (json) output.append(CLI_JSON.encodeToString(ScreenshotJson(path = path.toString())))
+        else output.append(path.toString())
+        output.appendLine()
+    }
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)
@@ -308,6 +334,8 @@ private data class AttachJson(val version: Int = JSON_VERSION, val id: String, v
 @Serializable private data class DetachJson(val version: Int = JSON_VERSION, val id: String)
 
 @Serializable private data class CompletionJson(val version: Int = JSON_VERSION, val id: String)
+
+@Serializable private data class ScreenshotJson(val version: Int = JSON_VERSION, val path: String)
 
 @Serializable
 private data class WindowsJson(val version: Int = JSON_VERSION, val windows: List<WindowJson>)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -52,6 +52,8 @@ public class SpectreCli(
             destination.append(command.getFormattedHelp(exception))
             destination.appendLine()
             exception.statusCode
+        } catch (exception: CliOutputException) {
+            outputFailure(exception.message ?: "failed to write command output")
         } catch (exception: IOException) {
             daemonFailure(exception.message ?: "I/O failure")
         } catch (exception: IllegalArgumentException) {
@@ -61,6 +63,12 @@ public class SpectreCli(
 
     private fun daemonFailure(message: String): Int {
         errorOutput.append("Spectre daemon error: $message")
+        errorOutput.appendLine()
+        return EXIT_FAILURE
+    }
+
+    private fun outputFailure(message: String): Int {
+        errorOutput.append("Spectre output error: $message")
         errorOutput.appendLine()
         return EXIT_FAILURE
     }
@@ -104,8 +112,14 @@ private class ScreenshotCommand(
                 is DaemonResponse.Error -> throw IOException(response.message)
                 else -> error("Daemon returned an unexpected response to screenshot")
             }
-        val path = outputPath ?: Files.createTempFile("spectre-screenshot-", ".png")
-        Files.write(path, pngBytes)
+        val path =
+            try {
+                val destination = outputPath ?: Files.createTempFile("spectre-screenshot-", ".png")
+                Files.write(destination, pngBytes)
+                destination
+            } catch (exception: IOException) {
+                throw CliOutputException(exception)
+            }
         if (json) output.append(CLI_JSON.encodeToString(ScreenshotJson(path = path.toString())))
         else output.append(path.toString())
         output.appendLine()
@@ -438,3 +452,5 @@ private const val EXIT_SUCCESS: Int = 0
 private const val EXIT_FAILURE: Int = 1
 private const val JSON_VERSION: Int = 1
 private val CLI_JSON: Json = Json { encodeDefaults = true }
+
+private class CliOutputException(cause: IOException) : IOException(cause.message, cause)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -13,6 +13,9 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 class SpectreCliTest {
     @Test
@@ -35,10 +38,33 @@ class SpectreCliTest {
                 cli.run(listOf("screenshot", "pid-42", "--output", imagePath.toString(), "--json")),
             )
             assertEquals(byteArrayOf(1, 2, 3).toList(), Files.readAllBytes(imagePath).toList())
-            assertEquals("{\"version\":1,\"path\":\"${imagePath}\"}\n", output.toString())
+            val json = Json.parseToJsonElement(output.toString())
+            assertEquals(1, json.jsonObject.getValue("version").jsonPrimitive.content.toInt())
+            assertEquals(
+                imagePath.toString(),
+                json.jsonObject.getValue("path").jsonPrimitive.content,
+            )
         } finally {
             Files.deleteIfExists(imagePath)
         }
+    }
+
+    @Test
+    fun `screenshot reports local output errors separately from daemon errors`() {
+        val output = StringBuilder()
+        val errorOutput = StringBuilder()
+        val missingDirectory = Files.createTempDirectory("spectre-cli-test").resolve("missing")
+        val imagePath = missingDirectory.resolve("capture.png")
+        val cli =
+            SpectreCli(
+                request = { DaemonResponse.Screenshot("pid-42", byteArrayOf(1, 2, 3)) },
+                output = output,
+                errorOutput = errorOutput,
+            )
+
+        assertEquals(1, cli.run(listOf("screenshot", "pid-42", "--output", imagePath.toString())))
+        assertEquals("", output.toString())
+        assertTrue(errorOutput.startsWith("Spectre output error:"))
     }
 
     @Test

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -8,12 +8,39 @@ import dev.sebastiano.spectre.cli.daemon.DaemonRequest
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
 import dev.sebastiano.spectre.cli.daemon.DaemonSessionSummary
 import java.io.IOException
+import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 
 class SpectreCliTest {
+    @Test
+    fun `screenshot writes PNG output and reports its stable JSON path`() {
+        val output = StringBuilder()
+        val imagePath = Files.createTempFile("spectre-cli-test", ".png")
+        Files.deleteIfExists(imagePath)
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(DaemonRequest.Screenshot("pid-42"), request)
+                    DaemonResponse.Screenshot("pid-42", byteArrayOf(1, 2, 3))
+                },
+                output = output,
+            )
+
+        try {
+            assertEquals(
+                0,
+                cli.run(listOf("screenshot", "pid-42", "--output", imagePath.toString(), "--json")),
+            )
+            assertEquals(byteArrayOf(1, 2, 3).toList(), Files.readAllBytes(imagePath).toList())
+            assertEquals("{\"version\":1,\"path\":\"${imagePath}\"}\n", output.toString())
+        } finally {
+            Files.deleteIfExists(imagePath)
+        }
+    }
+
     @Test
     fun `click prints stable JSON completion output`() {
         val output = StringBuilder()


### PR DESCRIPTION
Part of #175.

Adds `spectre screenshot <session-id> --output <path>` with a temp-file fallback and stable JSON path output.

Tests:
- `./gradlew :cli:test --tests "*SpectreCliTest"`
- `./gradlew check`