### PR TITLE
Add daemon-backed CLI type command

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -87,6 +87,7 @@ private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Ap
             TreeCommand(request, output),
             FindCommand(request, output),
             ClickCommand(request, output),
+            TypeCommand(request, output),
             ScreenshotCommand(request, output),
             PsCommand(request, output),
             DaemonCommand(request, output),
@@ -94,6 +95,28 @@ private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Ap
     }
 
     override fun run(): Unit = Unit
+}
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+private class TypeCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "type") {
+    private val sessionId: String by argument()
+    private val text: String by argument()
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val completedSessionId =
+            when (val response = request(DaemonRequest.TypeText(sessionId, text))) {
+                is DaemonResponse.Completed -> response.sessionId
+                is DaemonResponse.Error -> throw IOException(response.message)
+                else -> error("Daemon returned an unexpected response to type")
+            }
+        if (json) output.append(CLI_JSON.encodeToString(CompletionJson(id = completedSessionId)))
+        else output.append("Typed text.")
+        output.appendLine()
+    }
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -19,6 +19,22 @@ import kotlinx.serialization.json.jsonPrimitive
 
 class SpectreCliTest {
     @Test
+    fun `type prints stable JSON completion output`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(DaemonRequest.TypeText("pid-42", "hello"), request)
+                    DaemonResponse.Completed("pid-42")
+                },
+                output = output,
+            )
+
+        assertEquals(0, cli.run(listOf("type", "pid-42", "hello", "--json")))
+        assertEquals("{\"version\":1,\"id\":\"pid-42\"}\n", output.toString())
+    }
+
+    @Test
     fun `screenshot writes PNG output and reports its stable JSON path`() {
         val output = StringBuilder()
         val imagePath = Files.createTempFile("spectre-cli-test", ".png")


### PR DESCRIPTION
Part of #175.

Adds `spectre type <session-id> <text>` over the existing daemon input operation, with stable JSON completion output.

Tests:
- `./gradlew :cli:test --tests "*SpectreCliTest"`
- `./gradlew check`