### PR TITLE
Add daemon kill CLI command

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -324,10 +324,28 @@ private class PsCommand(
 private class DaemonCommand(request: (DaemonRequest) -> DaemonResponse, output: Appendable) :
     CliktCommand(name = "daemon") {
     init {
-        subcommands(DaemonStatusCommand(request, output))
+        subcommands(DaemonStatusCommand(request, output), DaemonKillCommand(request, output))
     }
 
     override fun run(): Unit = Unit
+}
+
+private class DaemonKillCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "kill") {
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        when (val response = request(DaemonRequest.Shutdown)) {
+            DaemonResponse.ShuttingDown -> Unit
+            is DaemonResponse.Error -> throw IOException(response.message)
+            else -> error("Daemon returned an unexpected response to shutdown")
+        }
+        if (json) output.append(CLI_JSON.encodeToString(DaemonKillJson()))
+        else output.append("Daemon stopped.")
+        output.appendLine()
+    }
 }
 
 private class DaemonStatusCommand(
@@ -362,6 +380,9 @@ private data class DaemonStatusJson(
     val version: Int = JSON_VERSION,
     val sessions: List<DaemonSessionJson>,
 )
+
+@Serializable
+private data class DaemonKillJson(val version: Int = JSON_VERSION, val stopped: Boolean = true)
 
 @Serializable private data class DaemonSessionJson(val id: String, val pid: Long)
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -31,6 +31,7 @@ import kotlinx.serialization.json.Json
 /** Protocol-only command-line facade over the local Spectre daemon. */
 public class SpectreCli(
     private val request: (DaemonRequest) -> DaemonResponse,
+    private val shutdownRequest: () -> DaemonResponse = { request(DaemonRequest.Shutdown) },
     private val output: Appendable = System.out,
     private val errorOutput: Appendable = System.err,
 ) {
@@ -39,11 +40,16 @@ public class SpectreCli(
         output: Appendable = System.out,
         errorOutput: Appendable = System.err,
         socketPath: Path? = null,
-    ) : this(request = daemonRequest(socketPath), output = output, errorOutput = errorOutput)
+    ) : this(
+        request = daemonRequest(socketPath),
+        shutdownRequest = daemonShutdownRequest(socketPath),
+        output = output,
+        errorOutput = errorOutput,
+    )
 
     /** Parses and executes one CLI invocation, returning zero when it succeeds. */
     public fun run(arguments: List<String>): Int {
-        val command = RootCommand(request, output)
+        val command = RootCommand(request, shutdownRequest, output)
         return try {
             command.parse(arguments)
             EXIT_SUCCESS
@@ -77,8 +83,11 @@ public class SpectreCli(
 /** Runs the Spectre CLI with its default per-user daemon endpoint. */
 public fun main(arguments: Array<String>): Unit = exitProcess(SpectreCli().run(arguments.asList()))
 
-private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Appendable) :
-    CliktCommand(name = "spectre") {
+private class RootCommand(
+    request: (DaemonRequest) -> DaemonResponse,
+    shutdownRequest: () -> DaemonResponse,
+    output: Appendable,
+) : CliktCommand(name = "spectre") {
     init {
         subcommands(
             AttachCommand(request, output),
@@ -90,7 +99,7 @@ private class RootCommand(request: (DaemonRequest) -> DaemonResponse, output: Ap
             TypeCommand(request, output),
             ScreenshotCommand(request, output),
             PsCommand(request, output),
-            DaemonCommand(request, output),
+            DaemonCommand(request, shutdownRequest, output),
         )
     }
 
@@ -321,23 +330,29 @@ private class PsCommand(
     }
 }
 
-private class DaemonCommand(request: (DaemonRequest) -> DaemonResponse, output: Appendable) :
-    CliktCommand(name = "daemon") {
+private class DaemonCommand(
+    request: (DaemonRequest) -> DaemonResponse,
+    shutdownRequest: () -> DaemonResponse,
+    output: Appendable,
+) : CliktCommand(name = "daemon") {
     init {
-        subcommands(DaemonStatusCommand(request, output), DaemonKillCommand(request, output))
+        subcommands(
+            DaemonStatusCommand(request, output),
+            DaemonKillCommand(shutdownRequest, output),
+        )
     }
 
     override fun run(): Unit = Unit
 }
 
 private class DaemonKillCommand(
-    private val request: (DaemonRequest) -> DaemonResponse,
+    private val shutdownRequest: () -> DaemonResponse,
     private val output: Appendable,
 ) : CliktCommand(name = "kill") {
     private val json: Boolean by option("--json").flag(default = false)
 
     override fun run() {
-        when (val response = request(DaemonRequest.Shutdown)) {
+        when (val response = shutdownRequest()) {
             DaemonResponse.ShuttingDown -> Unit
             is DaemonResponse.Error -> throw IOException(response.message)
             else -> error("Daemon returned an unexpected response to shutdown")
@@ -491,6 +506,12 @@ private fun daemonRequest(socketPath: Path?): (DaemonRequest) -> DaemonResponse 
             client.requestOrStart(request) { DaemonProcessLauncher(resolvedSocketPath).start() }
         }
     }
+
+private fun daemonShutdownRequest(socketPath: Path?): () -> DaemonResponse = {
+    DaemonClient(socketPath ?: DaemonEndpoint.defaultSocketPath()).use { client ->
+        client.request(DaemonRequest.Shutdown)
+    }
+}
 
 private const val EXIT_SUCCESS: Int = 0
 private const val EXIT_FAILURE: Int = 1

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -507,10 +507,25 @@ private fun daemonRequest(socketPath: Path?): (DaemonRequest) -> DaemonResponse 
         }
     }
 
-private fun daemonShutdownRequest(socketPath: Path?): () -> DaemonResponse = {
-    DaemonClient(socketPath ?: DaemonEndpoint.defaultSocketPath()).use { client ->
-        client.request(DaemonRequest.Shutdown)
+private fun daemonShutdownRequest(socketPath: Path?): () -> DaemonResponse = daemonShutdownRequest@{
+    val resolvedSocketPath = socketPath ?: DaemonEndpoint.defaultSocketPath()
+    if (
+        socketPath == null &&
+            DaemonProtocol.minimumDaemonVersion(DaemonRequest.Shutdown).minor <
+                DaemonProtocol.CurrentVersion.minor
+    ) {
+        for (legacySocketPath in DaemonEndpoint.legacySocketPaths()) {
+            if (!Files.exists(legacySocketPath)) continue
+            try {
+                return@daemonShutdownRequest DaemonClient(legacySocketPath).use { client ->
+                    client.request(DaemonRequest.Shutdown)
+                }
+            } catch (_: IOException) {
+                // A stale legacy socket must not prevent probing another endpoint.
+            }
+        }
     }
+    DaemonClient(resolvedSocketPath).use { client -> client.request(DaemonRequest.Shutdown) }
 }
 
 private const val EXIT_SUCCESS: Int = 0

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -325,10 +325,8 @@ class SpectreCliTest {
         val output = StringBuilder()
         val cli =
             SpectreCli(
-                request = { request ->
-                    assertEquals(DaemonRequest.Shutdown, request)
-                    DaemonResponse.ShuttingDown
-                },
+                request = { error("Kill must not use the auto-starting daemon request path") },
+                shutdownRequest = { DaemonResponse.ShuttingDown },
                 output = output,
             )
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -321,6 +321,22 @@ class SpectreCliTest {
     }
 
     @Test
+    fun `daemon kill prints stable JSON confirmation`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(DaemonRequest.Shutdown, request)
+                    DaemonResponse.ShuttingDown
+                },
+                output = output,
+            )
+
+        assertEquals(0, cli.run(listOf("daemon", "kill", "--json")))
+        assertEquals("{\"version\":1,\"stopped\":true}\n", output.toString())
+    }
+
+    @Test
     fun `usage errors are printed and returned as a nonzero exit code`() {
         val output = StringBuilder()
         val errorOutput = StringBuilder()


### PR DESCRIPTION
Adds `spectre daemon kill` with stable versioned JSON output, backed by the existing daemon shutdown protocol. Includes a TDD contract test.