### PR TITLE
Require JDK 21 for agent attach

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -68,6 +68,10 @@ public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/Au
 public abstract interface annotation class dev/sebastiano/spectre/agent/ExperimentalSpectreAgentApi : java/lang/annotation/Annotation {
 }
 
+public final class dev/sebastiano/spectre/agent/JavaVersionUnsupportedException : dev/sebastiano/spectre/agent/SpectreAttachException {
+	public fun <init> (I)V
+}
+
 public final class dev/sebastiano/spectre/agent/JvmProcessInfo {
 	public fun <init> (JLjava/lang/String;)V
 	public final fun component1 ()J

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -28,6 +28,7 @@ public object AgentAttach {
     /** Attach to the JVM identified by [pid] and return a connected [AttachedAutomator]. */
     @Throws(SpectreAttachException::class)
     public fun attach(pid: Long, options: AttachOptions = AttachOptions()): AttachedAutomator {
+        AttachRuntimePreflight.requireSupported()
         AgentPlatformPreflight.requireSupported()
         val agentJar = resolveAgentJar(options)
         val udsPath = options.udsPath ?: AttachOptions.defaultUdsPath(pid)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
@@ -18,6 +18,14 @@ public class AttachUnsupportedException(cause: Throwable? = null) :
         cause,
     )
 
+/** Thrown when the attaching JVM is older than Spectre's minimum supported Java version. */
+@ExperimentalSpectreAgentApi
+public class JavaVersionUnsupportedException(javaFeature: Int) :
+    SpectreAttachException(
+        "Spectre's agent attach requires JDK 21 or newer, but this JVM reports Java $javaFeature. " +
+            "Run the CLI with a JDK 21+ distribution."
+    )
+
 /** Thrown when the current operating system does not support the agent transport. */
 @ExperimentalSpectreAgentApi
 public class AttachPlatformUnsupportedException(public val osName: String) :

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflight.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflight.kt
@@ -1,0 +1,13 @@
+package dev.sebastiano.spectre.agent
+
+/** Runtime prerequisites shared by all JDK Attach API entrypoints. */
+@ExperimentalSpectreAgentApi
+internal object AttachRuntimePreflight {
+    fun requireSupported(javaFeature: Int = Runtime.version().feature()) {
+        if (javaFeature < MINIMUM_JAVA_FEATURE) {
+            throw JavaVersionUnsupportedException(javaFeature)
+        }
+    }
+
+    private const val MINIMUM_JAVA_FEATURE: Int = 21
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt
@@ -1,0 +1,17 @@
+package dev.sebastiano.spectre.agent
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class AttachRuntimePreflightTest {
+    @Test
+    fun `rejects JVMs older than Java 21 with actionable guidance`() {
+        val exception =
+            assertFailsWith<JavaVersionUnsupportedException> {
+                AttachRuntimePreflight.requireSupported(javaFeature = 20)
+            }
+
+        assertTrue(exception.message.orEmpty().contains("JDK 21"))
+    }
+}


### PR DESCRIPTION
Adds an actionable Java 21 runtime preflight before agent-attach side effects, with contract coverage and an updated public API baseline.