### PR TITLE
Test CLI binary against Compose fixture

### DIFF
--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -20,6 +20,10 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
@@ -27,6 +31,72 @@ import org.junit.jupiter.api.condition.OS
 /** Verifies the daemon owns a real attached agent session across client connections. */
 @EnabledOnOs(OS.LINUX, OS.MAC)
 class DaemonFixtureIntegrationTest {
+    @Test
+    fun `CLI binary drives a Compose fixture through ps attach find click and screenshot`() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
+        val daemonUser = "spectre-cli-e2e-${UUID.randomUUID()}"
+        val screenshot = Files.createTempFile("spectre-cli-e2e-", ".png")
+
+        try {
+            spawnComposeFixture().use { fixture ->
+                val processes = runCliBinary(daemonUser, "ps", "--json")
+                assertEquals(0, processes.exitCode)
+                assertTrue(
+                    Json.parseToJsonElement(processes.output)
+                        .jsonObject
+                        .getValue("processes")
+                        .jsonArray
+                        .any { process ->
+                            process.jsonObject.getValue("pid").jsonPrimitive.content.toLong() ==
+                                fixture.pid
+                        }
+                )
+
+                val attached = runCliBinary(daemonUser, "attach", fixture.pid.toString(), "--json")
+                assertEquals(0, attached.exitCode)
+                val sessionId =
+                    Json.parseToJsonElement(attached.output)
+                        .jsonObject
+                        .getValue("id")
+                        .jsonPrimitive
+                        .content
+
+                val found = runCliBinary(daemonUser, "find", sessionId, TAG_BUTTON, "--json")
+                assertEquals(0, found.exitCode)
+                val buttonKey =
+                    Json.parseToJsonElement(found.output)
+                        .jsonObject
+                        .getValue("nodes")
+                        .jsonArray
+                        .single { node ->
+                            node.jsonObject.getValue("testTag").jsonPrimitive.content == TAG_BUTTON
+                        }
+                        .jsonObject
+                        .getValue("key")
+                        .jsonPrimitive
+                        .content
+
+                assertEquals(0, runCliBinary(daemonUser, "click", sessionId, buttonKey).exitCode)
+                assertEquals(
+                    0,
+                    runCliBinary(
+                            daemonUser,
+                            "screenshot",
+                            sessionId,
+                            "--output",
+                            screenshot.toString(),
+                        )
+                        .exitCode,
+                )
+                assertTrue(Files.readAllBytes(screenshot).startsWith(PNG_MAGIC))
+            }
+        } finally {
+            runCatching { runCliBinary(daemonUser, "daemon", "kill") }
+            Files.deleteIfExists(screenshot)
+            deleteDaemonSocketAndParent(DaemonEndpoint.defaultSocketPath(userName = daemonUser))
+        }
+    }
+
     @Test
     fun `daemon attaches to a real Compose fixture and dispatches operations`() {
         assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
@@ -109,6 +179,11 @@ private fun deleteTemporaryDaemonFixtureSocketPath(socketPath: Path) {
     Files.deleteIfExists(socketPath.parent.parent)
 }
 
+private fun deleteDaemonSocketAndParent(socketPath: Path) {
+    Files.deleteIfExists(socketPath)
+    Files.deleteIfExists(socketPath.parent)
+}
+
 private fun spawnComposeFixture(): FixtureProcess {
     val javaExe =
         if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) "java.exe"
@@ -148,6 +223,33 @@ private fun spawnComposeFixture(): FixtureProcess {
     return FixtureProcess(process, reader, drainer)
 }
 
+private fun runCliBinary(daemonUser: String, vararg arguments: String): CliBinaryResult {
+    val javaExe =
+        if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) "java.exe"
+        else "java"
+    val javaBin = Paths.get(System.getProperty("java.home"), "bin", javaExe).toString()
+    val process =
+        ProcessBuilder(
+                javaBin,
+                "-Duser.name=$daemonUser",
+                "-Djava.awt.headless=false",
+                "-cp",
+                daemonFixtureRuntimeClassPath(),
+                "dev.sebastiano.spectre.cli.SpectreCliKt",
+                *arguments,
+            )
+            .redirectErrorStream(true)
+            .start()
+    check(process.waitFor(CLI_PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+        process.destroyForcibly()
+        "CLI binary did not exit within $CLI_PROCESS_TIMEOUT_SECONDS seconds: ${arguments.joinToString()}"
+    }
+    val output = process.inputStream.bufferedReader().use { reader -> reader.readText() }
+    return CliBinaryResult(exitCode = process.exitValue(), output = output)
+}
+
+private data class CliBinaryResult(val exitCode: Int, val output: String)
+
 private class FixtureProcess(
     private val process: Process,
     private val reader: BufferedReader,
@@ -170,6 +272,7 @@ private fun ByteArray.startsWith(prefix: ByteArray): Boolean =
 private const val FIXTURE_READY_TIMEOUT_SECONDS: Long = 30
 private const val FIXTURE_STOP_TIMEOUT_SECONDS: Long = 2
 private const val DRAINER_JOIN_TIMEOUT_MILLIS: Long = 500
+private const val CLI_PROCESS_TIMEOUT_SECONDS: Long = 30
 private const val MIN_PNG_BYTES: Int = 100
 private val PNG_MAGIC: ByteArray =
     byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -240,12 +240,28 @@ private fun runCliBinary(daemonUser: String, vararg arguments: String): CliBinar
             )
             .redirectErrorStream(true)
             .start()
-    check(process.waitFor(CLI_PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+    val output = StringBuilder()
+    val drainer =
+        Thread({
+                process.inputStream.bufferedReader().use { reader ->
+                    output.append(reader.readText())
+                }
+            })
+            .apply {
+                isDaemon = true
+                start()
+            }
+    if (!process.waitFor(CLI_PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
         process.destroyForcibly()
-        "CLI binary did not exit within $CLI_PROCESS_TIMEOUT_SECONDS seconds: ${arguments.joinToString()}"
+        process.waitFor()
+        drainer.join()
+        error(
+            "CLI binary did not exit within $CLI_PROCESS_TIMEOUT_SECONDS seconds: " +
+                arguments.joinToString()
+        )
     }
-    val output = process.inputStream.bufferedReader().use { reader -> reader.readText() }
-    return CliBinaryResult(exitCode = process.exitValue(), output = output)
+    drainer.join()
+    return CliBinaryResult(exitCode = process.exitValue(), output = output.toString())
 }
 
 private data class CliBinaryResult(val exitCode: Int, val output: String)


### PR DESCRIPTION
Adds the #175 acceptance test that runs the real CLI entrypoint in separate processes against agent-test-fixture: ps, attach, find, click, and screenshot. The test uses a unique daemon socket identity and cleans up the daemon after each run.