### PR TITLE
Explain disabled dynamic agent loading

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -156,7 +156,9 @@ public object AgentAttach {
         } catch (ex: ReflectiveOperationException) {
             val cause = ex.cause ?: ex
             throw SpectreAttachExceptionImpl(
-                "VirtualMachine.loadAgent($jarPath) failed: ${cause.javaClass.simpleName}: ${cause.message}",
+                dynamicAgentLoadingGuidance(cause.message)
+                    ?: "VirtualMachine.loadAgent($jarPath) failed: " +
+                        "${cause.javaClass.simpleName}: ${cause.message}",
                 cause,
             )
         }
@@ -195,3 +197,14 @@ public object AgentAttach {
 @OptIn(ExperimentalSpectreAgentApi::class)
 private class SpectreAttachExceptionImpl(message: String, cause: Throwable?) :
     SpectreAttachException(message, cause)
+
+internal fun dynamicAgentLoadingGuidance(message: String?): String? =
+    if (
+        message?.contains("Dynamic agent loading is not enabled") == true &&
+            message.contains("EnableDynamicAgentLoading")
+    ) {
+        "The target JVM does not allow dynamic agent loading. Restart it with " +
+            "`-XX:+EnableDynamicAgentLoading` and retry the attach."
+    } else {
+        null
+    }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.condition.EnabledOnOs
@@ -92,6 +93,34 @@ class AgentAttachIntegrationTest {
             repeat(REPEAT_CYCLES) { iteration ->
                 attachExerciseDetach(fixture, agentJar, iteration = iteration)
             }
+        }
+    }
+
+    @Test
+    fun `attach explains when the target JVM disables dynamic agent loading`() {
+        assumeFalse(
+            GraphicsEnvironment.isHeadless(),
+            "Requires non-headless JVM for the Compose Desktop fixture",
+        )
+        val agentJar = locateAgentJarOrSkip()
+
+        spawnComposeFixture(dynamicAgentLoadingEnabled = false).use { fixture ->
+            val udsPath = AttachOptions.defaultUdsPath(fixture.pid)
+            orphanUdsFiles.add(udsPath)
+
+            val exception =
+                assertFailsWith<SpectreAttachException> {
+                    AgentAttach.attach(
+                        fixture.pid,
+                        AttachOptions(agentJarPath = agentJar, udsPath = udsPath),
+                    )
+                }
+
+            assertEquals(
+                "The target JVM does not allow dynamic agent loading. Restart it with " +
+                    "`-XX:+EnableDynamicAgentLoading` and retry the attach.",
+                exception.message,
+            )
         }
     }
 
@@ -187,7 +216,7 @@ class AgentAttachIntegrationTest {
         )
     }
 
-    private fun spawnComposeFixture(): FixtureProcess {
+    private fun spawnComposeFixture(dynamicAgentLoadingEnabled: Boolean = true): FixtureProcess {
         // ProcessBuilder does not append `.exe` for an absolute path on Windows, so pick the
         // launcher name explicitly.
         val javaExe =
@@ -201,7 +230,7 @@ class AgentAttachIntegrationTest {
                     javaBin,
                     "-cp",
                     classpath,
-                    "-XX:+EnableDynamicAgentLoading",
+                    "-XX:${if (dynamicAgentLoadingEnabled) "+" else "-"}EnableDynamicAgentLoading",
                     "-Djava.awt.headless=false",
                     "-Dcompose.application.configure.swing.globals=true",
                     // This test exercises real Robot-backed focus and keyboard input. A macOS

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt
@@ -1,10 +1,23 @@
 package dev.sebastiano.spectre.agent
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class AttachRuntimePreflightTest {
+    @Test
+    fun `explains how to enable dynamic agent loading on the target JVM`() {
+        assertEquals(
+            "The target JVM does not allow dynamic agent loading. Restart it with " +
+                "`-XX:+EnableDynamicAgentLoading` and retry the attach.",
+            dynamicAgentLoadingGuidance(
+                "Failed to load agent library: Dynamic agent loading is not enabled. " +
+                    "Use -XX:+EnableDynamicAgentLoading to launch target VM."
+            ),
+        )
+    }
+
     @Test
     fun `rejects JVMs older than Java 21 with actionable guidance`() {
         val exception =


### PR DESCRIPTION
Maps the documented Attach API rejection for disabled dynamic agent loading to an actionable target-JVM restart instruction. Adds both unit coverage and a real Compose fixture attach test launched with -XX:-EnableDynamicAgentLoading.