### PR TITLE
Add MCP stdio facade

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -20,10 +20,12 @@ dependencies {
     implementation(libs.clikt)
     implementation(libs.kotlinx.serialization.cbor)
     implementation(libs.kotlinx.serialization.json)
+    implementation(libs.mcp.kotlin.sdk.server)
 
     detektPlugins(libs.compose.rules.detekt)
 
     testImplementation(libs.kotlin.testJunit5)
+    testImplementation(libs.mcp.kotlin.sdk.client)
     testImplementation(projects.agentTestFixture)
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -114,7 +114,7 @@ private class RootCommand(
 
 private class McpCommand(private val request: (DaemonRequest) -> DaemonResponse) :
     CliktCommand(name = "mcp") {
-    override fun run(): Nothing = SpectreMcpServer.run(request)
+    override fun run(): Unit = SpectreMcpServer.run(request)
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -21,6 +21,7 @@ import dev.sebastiano.spectre.cli.daemon.DaemonProtocol
 import dev.sebastiano.spectre.cli.daemon.DaemonRequest
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
 import dev.sebastiano.spectre.cli.daemon.DaemonSessionSummary
+import dev.sebastiano.spectre.cli.mcp.SpectreMcpServer
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
@@ -104,10 +105,16 @@ private class RootCommand(
             RecordCommand(request, output),
             PsCommand(request, output),
             DaemonCommand(request, shutdownRequest, output),
+            McpCommand(request),
         )
     }
 
     override fun run(): Unit = Unit
+}
+
+private class McpCommand(private val request: (DaemonRequest) -> DaemonResponse) :
+    CliktCommand(name = "mcp") {
+    override fun run(): Nothing = SpectreMcpServer.run(request)
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -13,7 +13,7 @@ import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
 import java.util.Base64
-import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.Sink
 import kotlinx.io.Source
@@ -44,9 +44,13 @@ public object SpectreMcpServer {
         request: (DaemonRequest) -> DaemonResponse,
         input: Source = System.`in`.asSource().buffered(),
         output: Sink = System.out.asSink().buffered(),
-    ): Nothing = runBlocking {
-        create(request).createSession(StdioServerTransport(input, output) {})
-        awaitCancellation()
+    ): Unit = runBlocking {
+        val transportClosed = CompletableDeferred<Unit>()
+        val transport = StdioServerTransport(input, output) {}
+        transport.onClose { transportClosed.complete(Unit) }
+
+        create(request).createSession(transport)
+        transportClosed.await()
     }
 
     private fun registerTools(server: Server, request: (DaemonRequest) -> DaemonResponse) {
@@ -158,7 +162,7 @@ public object SpectreMcpServer {
             request(
                     DaemonRequest.StartRecording(
                         call.requiredString("session_id"),
-                        call.requiredString("output_path"),
+                        normalizeRecordingOutputPath(call.requiredString("output_path")),
                     )
                 )
                 .asResult { it is DaemonResponse.RecordingStarted }
@@ -212,6 +216,9 @@ public object SpectreMcpServer {
     private const val MCP_VERSION: String = "0.1.0"
     private val MCP_JSON: Json = Json { encodeDefaults = true }
 }
+
+internal fun normalizeRecordingOutputPath(outputPath: String): String =
+    java.nio.file.Path.of(outputPath).toAbsolutePath().normalize().toString()
 
 internal fun DaemonResponse.screenshotResult(): CallToolResult =
     when (this) {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -1,0 +1,233 @@
+package dev.sebastiano.spectre.cli.mcp
+
+import dev.sebastiano.spectre.cli.daemon.DaemonRequest
+import dev.sebastiano.spectre.cli.daemon.DaemonResponse
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.server.StdioServerTransport
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import java.util.Base64
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.Sink
+import kotlinx.io.Source
+import kotlinx.io.asSink
+import kotlinx.io.asSource
+import kotlinx.io.buffered
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+
+/** MCP stdio facade over the local Spectre session daemon. */
+public object SpectreMcpServer {
+    /** Creates the MCP server and registers the agent-facing daemon tools. */
+    public fun create(request: (DaemonRequest) -> DaemonResponse): Server =
+        Server(
+                serverInfo = Implementation(name = "spectre", version = MCP_VERSION),
+                options =
+                    ServerOptions(
+                        capabilities = ServerCapabilities(tools = ServerCapabilities.Tools())
+                    ),
+            )
+            .also { server -> registerTools(server, request) }
+
+    /** Runs one long-lived MCP stdio server without writing non-protocol data to stdout. */
+    public fun run(
+        request: (DaemonRequest) -> DaemonResponse,
+        input: Source = System.`in`.asSource().buffered(),
+        output: Sink = System.out.asSink().buffered(),
+    ): Nothing = runBlocking {
+        create(request).createSession(StdioServerTransport(input, output) {})
+        awaitCancellation()
+    }
+
+    private fun registerTools(server: Server, request: (DaemonRequest) -> DaemonResponse) {
+        registerDiscoveryTools(server, request)
+        registerSessionTools(server, request)
+        registerRecordingTools(server, request)
+    }
+
+    private fun registerDiscoveryTools(server: Server, request: (DaemonRequest) -> DaemonResponse) {
+        server.addTool(
+            name = "list_processes",
+            description = "List JVM processes that expose a Spectre agent and can be attached.",
+        ) {
+            val response = request(DaemonRequest.ListJvmProcesses(ProcessHandle.current().pid()))
+            response.asResult { daemonResponse -> daemonResponse is DaemonResponse.JvmProcesses }
+        }
+        server.addTool(
+            name = "attach",
+            description =
+                "Attach the shared Spectre daemon to a target JVM process and return its session id.",
+            inputSchema = schema("pid" to "integer"),
+        ) { call ->
+            request(DaemonRequest.Attach(call.requiredLong("pid"))).asResult { daemonResponse ->
+                daemonResponse is DaemonResponse.Attached
+            }
+        }
+    }
+
+    private fun registerSessionTools(server: Server, request: (DaemonRequest) -> DaemonResponse) {
+        server.addTool(
+            name = "windows",
+            description = "List top-level windows and popup roots for an attached session.",
+            inputSchema = sessionSchema(),
+        ) { call ->
+            request(DaemonRequest.Windows(call.requiredString("session_id"))).asResult {
+                it is DaemonResponse.Windows
+            }
+        }
+        server.addTool(
+            name = "tree",
+            description =
+                "Dump the current semantics tree. Node keys are valid only until the UI changes.",
+            inputSchema = sessionSchema(),
+        ) { call ->
+            request(DaemonRequest.AllNodes(call.requiredString("session_id"))).asResult {
+                it is DaemonResponse.Nodes
+            }
+        }
+        server.addTool(
+            name = "find",
+            description =
+                "Find semantics nodes by exact Compose test tag. Returned node keys are ephemeral.",
+            inputSchema = schema("session_id" to "string", "test_tag" to "string"),
+        ) { call ->
+            request(
+                    DaemonRequest.FindByTestTag(
+                        call.requiredString("session_id"),
+                        call.requiredString("test_tag"),
+                    )
+                )
+                .asResult { it is DaemonResponse.Nodes }
+        }
+        server.addTool(
+            name = "click",
+            description =
+                "Click a visible semantics node by its node key. Refresh the tree after UI changes.",
+            inputSchema = schema("session_id" to "string", "node_key" to "string"),
+        ) { call ->
+            request(
+                    DaemonRequest.Click(
+                        call.requiredString("session_id"),
+                        call.requiredString("node_key"),
+                    )
+                )
+                .asResult { it is DaemonResponse.Completed }
+        }
+        server.addTool(
+            name = "type_text",
+            description =
+                "Type text through the real operating-system input path into the focused target UI.",
+            inputSchema = schema("session_id" to "string", "text" to "string"),
+        ) { call ->
+            request(
+                    DaemonRequest.TypeText(
+                        call.requiredString("session_id"),
+                        call.requiredString("text"),
+                    )
+                )
+                .asResult { it is DaemonResponse.Completed }
+        }
+        server.addTool(
+            name = "screenshot",
+            description =
+                "Capture the attached UI and return a PNG inline as MCP image content, never as a file path.",
+            inputSchema = sessionSchema(),
+        ) { call ->
+            val response = request(DaemonRequest.Screenshot(call.requiredString("session_id")))
+            response.screenshotResult()
+        }
+    }
+
+    private fun registerRecordingTools(server: Server, request: (DaemonRequest) -> DaemonResponse) {
+        server.addTool(
+            name = "record_start",
+            description =
+                "Start recording an attached session to the supplied absolute output path.",
+            inputSchema = schema("session_id" to "string", "output_path" to "string"),
+        ) { call ->
+            request(
+                    DaemonRequest.StartRecording(
+                        call.requiredString("session_id"),
+                        call.requiredString("output_path"),
+                    )
+                )
+                .asResult { it is DaemonResponse.RecordingStarted }
+        }
+        server.addTool(
+            name = "record_stop",
+            description = "Stop the active recording and return its final output path.",
+            inputSchema = sessionSchema(),
+        ) { call ->
+            request(DaemonRequest.StopRecording(call.requiredString("session_id"))).asResult {
+                it is DaemonResponse.RecordingStopped
+            }
+        }
+    }
+
+    private fun schema(vararg properties: Pair<String, String>): ToolSchema =
+        ToolSchema(
+            properties =
+                buildJsonObject {
+                    properties.forEach { (name, type) ->
+                        put(name, buildJsonObject { put("type", type) })
+                    }
+                },
+            required = properties.map(Pair<String, String>::first),
+        )
+
+    private fun sessionSchema(): ToolSchema = schema("session_id" to "string")
+
+    private fun CallToolRequest.callString(name: String): String =
+        arguments?.get(name)?.jsonPrimitive?.content
+            ?: throw IllegalArgumentException("MCP tool requires a non-empty '$name' argument")
+
+    private fun CallToolRequest.requiredString(name: String): String = callString(name)
+
+    private fun CallToolRequest.requiredLong(name: String): Long =
+        requiredString(name).toLongOrNull()
+            ?: throw IllegalArgumentException("MCP tool argument '$name' must be an integer")
+
+    private fun DaemonResponse.asResult(expected: (DaemonResponse) -> Boolean): CallToolResult =
+        when {
+            this is DaemonResponse.Error ->
+                CallToolResult(listOf(TextContent(message)), isError = true)
+            expected(this) -> CallToolResult(listOf(TextContent(MCP_JSON.encodeToString(this))))
+            else ->
+                CallToolResult(
+                    listOf(TextContent("Spectre daemon returned an unexpected response.")),
+                    isError = true,
+                )
+        }
+
+    private const val MCP_VERSION: String = "0.1.0"
+    private val MCP_JSON: Json = Json { encodeDefaults = true }
+}
+
+internal fun DaemonResponse.screenshotResult(): CallToolResult =
+    when (this) {
+        is DaemonResponse.Screenshot ->
+            CallToolResult(
+                content =
+                    listOf(
+                        ImageContent(
+                            data = Base64.getEncoder().encodeToString(pngBytes),
+                            mimeType = "image/png",
+                        )
+                    )
+            )
+        else ->
+            CallToolResult(
+                listOf(TextContent("Spectre daemon did not return a screenshot.")),
+                isError = true,
+            )
+    }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -225,6 +225,7 @@ internal fun DaemonResponse.screenshotResult(): CallToolResult =
                         )
                     )
             )
+        is DaemonResponse.Error -> CallToolResult(listOf(TextContent(message)), isError = true)
         else ->
             CallToolResult(
                 listOf(TextContent("Spectre daemon did not return a screenshot.")),

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
@@ -1,7 +1,9 @@
 package dev.sebastiano.spectre.cli.mcp
 
+import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -50,5 +52,21 @@ class SpectreMcpServerTest {
         val image = result.content.single() as ImageContent
         assertEquals("image/png", image.mimeType)
         assertEquals("AQID", image.data)
+    }
+
+    @Test
+    fun `screenshot tool preserves daemon error messages`() {
+        val result =
+            DaemonResponse.Error(
+                    DaemonErrorCode.SessionNotFound,
+                    "session session-42 was not found",
+                )
+                .screenshotResult()
+
+        assertTrue(result.isError == true)
+        assertEquals(
+            "session session-42 was not found",
+            (result.content.single() as TextContent).text,
+        )
     }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
@@ -4,11 +4,22 @@ import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class SpectreMcpServerTest {
+    @Test
+    fun `normalizes recording output paths before sending them to the daemon`() {
+        val outputPath = "captures/../captures/session.mp4"
+
+        assertEquals(
+            Path.of(outputPath).toAbsolutePath().normalize().toString(),
+            normalizeRecordingOutputPath(outputPath),
+        )
+    }
+
     @Test
     fun `advertises agent-oriented schemas for the initial daemon tool set`() {
         val server =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
@@ -1,0 +1,54 @@
+package dev.sebastiano.spectre.cli.mcp
+
+import dev.sebastiano.spectre.cli.daemon.DaemonResponse
+import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SpectreMcpServerTest {
+    @Test
+    fun `advertises agent-oriented schemas for the initial daemon tool set`() {
+        val server =
+            SpectreMcpServer.create(request = { error("tools must not run while being listed") })
+
+        assertEquals(
+            setOf(
+                "list_processes",
+                "attach",
+                "windows",
+                "tree",
+                "find",
+                "click",
+                "type_text",
+                "screenshot",
+                "record_start",
+                "record_stop",
+            ),
+            server.tools.keys,
+        )
+        assertTrue(server.tools.getValue("click").tool.description.orEmpty().contains("node key"))
+        assertEquals(
+            listOf("session_id", "node_key"),
+            server.tools.getValue("click").tool.inputSchema.required,
+        )
+        assertTrue(
+            server.tools
+                .getValue("screenshot")
+                .tool
+                .description
+                .orEmpty()
+                .contains("inline", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `screenshot tool returns daemon PNG bytes as inline MCP image content`() {
+        val result =
+            DaemonResponse.Screenshot("session-42", byteArrayOf(1, 2, 3)).screenshotResult()
+
+        val image = result.content.single() as ImageContent
+        assertEquals("image/png", image.mimeType)
+        assertEquals("AQID", image.data)
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -1,0 +1,63 @@
+package dev.sebastiano.spectre.cli.mcp
+
+import io.modelcontextprotocol.kotlin.sdk.client.Client
+import io.modelcontextprotocol.kotlin.sdk.client.StdioClientTransport
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.io.asSink
+import kotlinx.io.asSource
+import kotlinx.io.buffered
+
+class SpectreMcpStdioIntegrationTest {
+    @Test
+    fun `spectre mcp serves tools through official stdio client`() = runBlocking {
+        val process = ProcessBuilder(mcpCommand()).start()
+        val transport =
+            StdioClientTransport(
+                input = process.inputStream.asSource().buffered(),
+                output = process.outputStream.asSink().buffered(),
+            )
+        try {
+            val client = Client(clientInfo = Implementation(name = "spectre-test", version = "1"))
+            withTimeout(CONNECTION_TIMEOUT_MILLIS) {
+                client.connect(transport)
+                assertEquals(
+                    setOf(
+                        "attach",
+                        "click",
+                        "find",
+                        "list_processes",
+                        "record_start",
+                        "record_stop",
+                        "screenshot",
+                        "tree",
+                        "type_text",
+                        "windows",
+                    ),
+                    client.listTools().tools.map { it.name }.toSet(),
+                )
+            }
+        } finally {
+            transport.close()
+            process.destroyForcibly()
+            process.waitFor()
+        }
+    }
+
+    private fun mcpCommand(): List<String> =
+        listOf(
+            Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+            "-cp",
+            System.getProperty("spectre.cli.testRuntimeClasspath"),
+            "dev.sebastiano.spectre.cli.SpectreCliKt",
+            "mcp",
+        )
+
+    private companion object {
+        private const val CONNECTION_TIMEOUT_MILLIS: Long = 10_000
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -4,8 +4,10 @@ import io.modelcontextprotocol.kotlin.sdk.client.Client
 import io.modelcontextprotocol.kotlin.sdk.client.StdioClientTransport
 import io.modelcontextprotocol.kotlin.sdk.types.Implementation
 import java.nio.file.Path
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.asSink
@@ -13,6 +15,20 @@ import kotlinx.io.asSource
 import kotlinx.io.buffered
 
 class SpectreMcpStdioIntegrationTest {
+    @Test
+    fun `spectre mcp exits when its stdio input closes`() {
+        val process = ProcessBuilder(mcpCommand()).start()
+
+        try {
+            process.outputStream.close()
+
+            assertTrue(process.waitFor(PROCESS_EXIT_TIMEOUT_SECONDS, TimeUnit.SECONDS))
+        } finally {
+            process.destroyForcibly()
+            process.waitFor()
+        }
+    }
+
     @Test
     fun `spectre mcp serves tools through official stdio client`() = runBlocking {
         val process = ProcessBuilder(mcpCommand()).start()
@@ -59,5 +75,6 @@ class SpectreMcpStdioIntegrationTest {
 
     private companion object {
         private const val CONNECTION_TIMEOUT_MILLIS: Long = 10_000
+        private const val PROCESS_EXIT_TIMEOUT_SECONDS: Long = 5
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,10 +19,11 @@ kotlin = "2.3.20"
 # POM defaults, sources + javadoc jars, signing, and the Central upload in one place. See
 # `docs/PUBLISHING.md` for the release flow.
 mavenPublish = "0.36.0"
+mcpKotlinSdk = "0.14.0"
 junit4 = "4.13.2"
 junit5 = "5.11.4"
 kotlinx-coroutines = "1.10.2"
-kotlinx-serialization = "1.7.3"
+kotlinx-serialization = "1.11.0"
 ktor = "3.0.3"
 material3 = "1.10.0-alpha05"
 # GradleUp Shadow — maintained successor to johnrengelman/shadow. Used by `:agent` to
@@ -57,6 +58,8 @@ junit5-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref
 junit5-vintageEngine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "junit5" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-cbor = { module = "org.jetbrains.kotlinx:kotlinx-serialization-cbor", version.ref = "kotlinx-serialization" }
+mcp-kotlin-sdk-server = { module = "io.modelcontextprotocol:kotlin-sdk-server", version.ref = "mcpKotlinSdk" }
+mcp-kotlin-sdk-client = { module = "io.modelcontextprotocol:kotlin-sdk-client", version.ref = "mcpKotlinSdk" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 ktor-client-contentNegotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- add the official MCP Kotlin SDK-backed mcp subcommand using stdio
- expose daemon-backed process, session, input, screenshot, and recording tools with agent-oriented schemas
- return screenshots as inline MCP PNG image content and verify a real official-client stdio handshake
- align Kotlin serialization runtime with the official SDK requirement

## Verification
- ./gradlew :cli:test --tests MCP server tests
- ./gradlew :cli:test --tests MCP stdio integration test
- ./gradlew check --console=plain --quiet