### PR TITLE
Package the Spectre CLI release distribution

### DIFF
--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -26,6 +26,8 @@ on:
       - "agent/**"
       - "agent-runtime/**"
       - "agent-test-fixture/**"
+      - "cli/**"
+      - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"
@@ -45,6 +47,8 @@ on:
       - "agent/**"
       - "agent-runtime/**"
       - "agent-test-fixture/**"
+      - "cli/**"
+      - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"
@@ -80,3 +84,15 @@ jobs:
 
       - name: Run checks
         run: ./gradlew check
+
+      - name: Smoke the unpacked CLI distribution against the Compose fixture
+        run: |
+          ./gradlew :cli:shadowDistZip
+          archive="$(find cli/build/distributions -name 'spectre-cli-*.zip' -print -quit)"
+          distribution="$RUNNER_TEMP/spectre-cli"
+          unzip -q "$archive" -d "$distribution"
+          launcher="$(find "$distribution" -path '*/bin/spectre' -type f -print -quit)"
+          ./gradlew :cli:test \
+            --tests "*DaemonFixtureIntegrationTest.CLI binary drives a Compose fixture through ps attach find click and screenshot" \
+            --rerun-tasks \
+            -Dspectre.cli.distributionExecutable="$launcher"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -400,6 +400,14 @@ jobs:
             -PprebuiltLinuxHelpersDir="$RUNNER_TEMP/linux-helpers" \
             -PprebuiltWindowsHelpersDir="$RUNNER_TEMP/windows-helper"
 
+      - name: Build version-stamped CLI distribution
+        run: |
+          ./gradlew :cli:shadowDistZip \
+            -PVERSION_NAME="$RELEASE_VERSION" \
+            -PprebuiltMacHelperPath="$RUNNER_TEMP/mac-helper/spectre-screencapture" \
+            -PprebuiltLinuxHelpersDir="$RUNNER_TEMP/linux-helpers" \
+            -PprebuiltWindowsHelpersDir="$RUNNER_TEMP/windows-helper"
+
       - name: Publish signed artefacts to Sonatype Central Portal
         env:
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
@@ -432,3 +440,6 @@ jobs:
         run: |
           gh release view "$GITHUB_REF_NAME" \
             || gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME"
+          gh release upload "$GITHUB_REF_NAME" \
+            "cli/build/distributions/spectre-cli-$RELEASE_VERSION.zip" \
+            --clobber

--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -44,6 +44,8 @@ on:
       - "agent/**"
       - "agent-runtime/**"
       - "agent-test-fixture/**"
+      - "cli/**"
+      - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"
@@ -65,6 +67,8 @@ on:
       - "agent/**"
       - "agent-runtime/**"
       - "agent-test-fixture/**"
+      - "cli/**"
+      - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"
@@ -204,6 +208,23 @@ jobs:
         if: always()
         run: |
           xvfb-run -a ./gradlew :agent:test --tests "*AgentAttachIntegrationTest*" --rerun-tasks
+        shell: bash
+
+      - name: Smoke the unpacked CLI distribution against the Compose fixture
+        # This is deliberately separate from the classpath-based integration test above: it
+        # proves the archive's generated launcher, embedded agent runtime, and fat JAR work
+        # together after a user unpacks the published artifact.
+        if: always()
+        run: |
+          ./gradlew :cli:shadowDistZip
+          archive="$(find cli/build/distributions -name 'spectre-cli-*.zip' -print -quit)"
+          distribution="$RUNNER_TEMP/spectre-cli"
+          unzip -q "$archive" -d "$distribution"
+          launcher="$(find "$distribution" -path '*/bin/spectre' -type f -print -quit)"
+          xvfb-run -a ./gradlew :cli:test \
+            --tests "*DaemonFixtureIntegrationTest.CLI binary drives a Compose fixture through ps attach find click and screenshot" \
+            --rerun-tasks \
+            -Dspectre.cli.distributionExecutable="$launcher"
         shell: bash
 
       - name: Verify validation tests passed via JUnit XML

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,3 @@
+plugins { `kotlin-dsl` }
+
+repositories { gradlePluginPortal() }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "spectre-build-src"

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -88,7 +88,8 @@ abstract class PatchStartScripts : DefaultTask() {
             """
             :execute
             @rem Spectre attaches an agent, so it requires a full JDK rather than a JRE.
-            for /f "tokens=2 delims=\"" %%v in ('"%JAVA_EXE%" -version 2^>^&1 ^| findstr /c:"version"') do set SPECTRE_JAVA_VERSION=%%v
+            for /f "tokens=3" %%v in ('"%JAVA_EXE%" -version 2^>^&1 ^| findstr /c:"version"') do set SPECTRE_JAVA_VERSION=%%v
+            set SPECTRE_JAVA_VERSION=%SPECTRE_JAVA_VERSION:"=%
             for /f "tokens=1 delims=." %%v in ("%SPECTRE_JAVA_VERSION%") do set SPECTRE_JAVA_FEATURE=%%v
             if not defined SPECTRE_JAVA_FEATURE goto invalidJavaVersion
             if %SPECTRE_JAVA_FEATURE% LSS 21 goto oldJavaVersion

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -55,23 +55,31 @@ abstract class PatchStartScripts : DefaultTask() {
                 if [ -x /usr/libexec/java_home ]; then
                     JAVA_HOME=${'$'}(/usr/libexec/java_home -v 21+ 2>/dev/null || true)
                 fi
-                for spectre_java_home in "${'$'}{HOME:-}/.sdkman/candidates/java/current" /usr/lib/jvm/* /Library/Java/JavaVirtualMachines/*/Contents/Home; do
-                    if [ -x "${'$'}spectre_java_home/bin/java" ]; then
-                        spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
-                        spectre_java_feature=${'$'}{spectre_java_version%%.*}
-                        case "${'$'}spectre_java_feature" in
-                            '' | *[!0-9]*) continue ;;
-                        esac
-                        if [ "${'$'}spectre_java_feature" -ge 21 ] && "${'$'}spectre_java_home/bin/java" --list-modules 2>/dev/null | grep -q '^jdk.attach@'; then
-                            JAVA_HOME=${'$'}spectre_java_home
-                            break
-                        elif [ -z "${'$'}spectre_java_fallback_home" ] && [ "${'$'}spectre_java_feature" -ge 21 ]; then
-                            spectre_java_fallback_home=${'$'}spectre_java_home
-                        fi
+                if [ -n "${'$'}{JAVA_HOME:-}" ] && "${'$'}JAVA_HOME/bin/java" --list-modules 2>/dev/null | grep -q '^jdk.attach@'; then
+                    : # Preserve the OS-selected JDK.
+                else
+                    if [ -n "${'$'}{JAVA_HOME:-}" ]; then
+                        spectre_java_fallback_home=${'$'}JAVA_HOME
+                        JAVA_HOME=
                     fi
-                done
-                if [ -z "${'$'}{JAVA_HOME:-}" ]; then
-                    JAVA_HOME=${'$'}spectre_java_fallback_home
+                    for spectre_java_home in "${'$'}{HOME:-}/.sdkman/candidates/java/current" /usr/lib/jvm/* /Library/Java/JavaVirtualMachines/*/Contents/Home; do
+                        if [ -x "${'$'}spectre_java_home/bin/java" ]; then
+                            spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
+                            spectre_java_feature=${'$'}{spectre_java_version%%.*}
+                            case "${'$'}spectre_java_feature" in
+                                '' | *[!0-9]*) continue ;;
+                            esac
+                            if [ "${'$'}spectre_java_feature" -ge 21 ] && "${'$'}spectre_java_home/bin/java" --list-modules 2>/dev/null | grep -q '^jdk.attach@'; then
+                                JAVA_HOME=${'$'}spectre_java_home
+                                break
+                            elif [ -z "${'$'}spectre_java_fallback_home" ] && [ "${'$'}spectre_java_feature" -ge 21 ]; then
+                                spectre_java_fallback_home=${'$'}spectre_java_home
+                            fi
+                        fi
+                    done
+                    if [ -z "${'$'}{JAVA_HOME:-}" ]; then
+                        JAVA_HOME=${'$'}spectre_java_fallback_home
+                    fi
                 fi
             fi
 

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -51,21 +51,28 @@ abstract class PatchStartScripts : DefaultTask() {
             """
             # Find a locally installed JDK when JAVA_HOME and PATH are unset.
             if [ -z "${'$'}{JAVA_HOME:-}" ] && ! command -v java >/dev/null 2>&1; then
+                spectre_java_fallback_home=
                 if [ -x /usr/libexec/java_home ]; then
                     JAVA_HOME=${'$'}(/usr/libexec/java_home -v 21+ 2>/dev/null || true)
                 fi
                 for spectre_java_home in "${'$'}{HOME:-}/.sdkman/candidates/java/current" /usr/lib/jvm/* /Library/Java/JavaVirtualMachines/*/Contents/Home; do
-                    if [ -z "${'$'}{JAVA_HOME:-}" ] && [ -x "${'$'}spectre_java_home/bin/java" ]; then
+                    if [ -x "${'$'}spectre_java_home/bin/java" ]; then
                         spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
                         spectre_java_feature=${'$'}{spectre_java_version%%.*}
                         case "${'$'}spectre_java_feature" in
                             '' | *[!0-9]*) continue ;;
                         esac
-                        if [ "${'$'}spectre_java_feature" -ge 21 ]; then
+                        if [ "${'$'}spectre_java_feature" -ge 21 ] && "${'$'}spectre_java_home/bin/java" --list-modules 2>/dev/null | grep -q '^jdk.attach@'; then
                             JAVA_HOME=${'$'}spectre_java_home
+                            break
+                        elif [ -z "${'$'}spectre_java_fallback_home" ] && [ "${'$'}spectre_java_feature" -ge 21 ]; then
+                            spectre_java_fallback_home=${'$'}spectre_java_home
                         fi
                     fi
                 done
+                if [ -z "${'$'}{JAVA_HOME:-}" ]; then
+                    JAVA_HOME=${'$'}spectre_java_fallback_home
+                fi
             fi
 
             # Determine the Java command to use to start the JVM.
@@ -102,7 +109,9 @@ abstract class PatchStartScripts : DefaultTask() {
         private val WINDOWS_JDK_FALLBACK =
             """
             @rem PATH did not provide Java; now try common local JDK installations.
+            set SPECTRE_JRE_HOME=
             for %%d in ("%ProgramFiles%\\Java\\*" "%ProgramFiles%\\Eclipse Adoptium\\*" "%ProgramFiles%\\Microsoft\\jdk-*") do call :findCompatibleSpectreJdk "%%~fd"
+            if not defined JAVA_HOME if defined SPECTRE_JRE_HOME set JAVA_HOME=%SPECTRE_JRE_HOME%
             if defined JAVA_HOME goto findJavaFromJavaHome
             """
                 .trimIndent()
@@ -119,7 +128,9 @@ abstract class PatchStartScripts : DefaultTask() {
             for /f "tokens=1 delims=." %%v in ("%SPECTRE_JAVA_VERSION%") do set SPECTRE_JAVA_FEATURE=%%v
             if "%SPECTRE_JAVA_FEATURE%"=="" goto :eof
             if %SPECTRE_JAVA_FEATURE% LSS 21 goto :eof
-            set JAVA_HOME=%~1
+            "%~1\\bin\\java.exe" --list-modules 2^>NUL | findstr /r /c:"^jdk.attach@" >NUL
+            if %ERRORLEVEL% equ 0 set JAVA_HOME=%~1
+            if not defined JAVA_HOME if not defined SPECTRE_JRE_HOME set SPECTRE_JRE_HOME=%~1
             goto :eof
             """
                 .trimIndent()

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -1,0 +1,116 @@
+package dev.sebastiano.spectre.build
+
+import java.io.File
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+/** Adds Spectre's JDK preflight to the generated application launchers. */
+abstract class PatchStartScripts : DefaultTask() {
+    @get:InputFile abstract val unixScript: RegularFileProperty
+
+    @get:InputFile abstract val windowsScript: RegularFileProperty
+
+    @TaskAction
+    fun patch() {
+        patchUnix(unixScript.get().asFile)
+        patchWindows(windowsScript.get().asFile)
+    }
+
+    private fun patchUnix(script: File) {
+        script.writeText(
+            script
+                .readText()
+                .replace("# Determine the Java command to use to start the JVM.", UNIX_JAVA_SEARCH)
+                .replace("# Increase the maximum file descriptors if we can.", UNIX_JDK_PREFLIGHT),
+        )
+    }
+
+    private fun patchWindows(script: File) {
+        script.writeText(
+            script
+                .readText()
+                .replace("@rem Find java.exe", WINDOWS_JAVA_SEARCH)
+                .replace(":execute\n@rem Setup the command line", WINDOWS_JDK_PREFLIGHT),
+        )
+    }
+
+    private companion object {
+        private val UNIX_JAVA_SEARCH =
+            """
+            # Find a locally installed JDK when JAVA_HOME and PATH are unset.
+            if [ -z "${'$'}{JAVA_HOME:-}" ] && ! command -v java >/dev/null 2>&1; then
+                if [ -x /usr/libexec/java_home ]; then
+                    JAVA_HOME=${'$'}(/usr/libexec/java_home -v 21+ 2>/dev/null || true)
+                fi
+                for spectre_java_home in "${'$'}{HOME:-}/.sdkman/candidates/java/current" /usr/lib/jvm/* /Library/Java/JavaVirtualMachines/*/Contents/Home; do
+                    if [ -z "${'$'}{JAVA_HOME:-}" ] && [ -x "${'$'}spectre_java_home/bin/java" ]; then
+                        JAVA_HOME=${'$'}spectre_java_home
+                    fi
+                done
+            fi
+
+            # Determine the Java command to use to start the JVM.
+            """
+                .trimIndent()
+
+        private val UNIX_JDK_PREFLIGHT =
+            """
+            # Spectre attaches an agent, so it requires a full JDK rather than a JRE.
+            spectre_java_version=${'$'}("${'$'}JAVACMD" -version 2>&1 | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
+            spectre_java_feature=${'$'}{spectre_java_version%%.*}
+            case "${'$'}spectre_java_feature" in
+                '' | *[!0-9]*) die "ERROR: Could not determine the Java version from ${'$'}JAVACMD." ;;
+            esac
+            if [ "${'$'}spectre_java_feature" -lt 21 ]; then
+                die "ERROR: Spectre requires JDK 21 or later; found Java ${'$'}spectre_java_version at ${'$'}JAVACMD."
+            fi
+            if ! "${'$'}JAVACMD" --list-modules 2>/dev/null | grep -q '^jdk.attach@'; then
+                die "ERROR: Spectre requires a full JDK with the jdk.attach module; found Java ${'$'}spectre_java_version at ${'$'}JAVACMD."
+            fi
+
+            # Increase the maximum file descriptors if we can.
+            """
+                .trimIndent()
+
+        private val WINDOWS_JAVA_SEARCH =
+            """
+            @rem Find a locally installed JDK when JAVA_HOME and PATH are unset.
+            if defined JAVA_HOME goto findJavaFromJavaHome
+            for %%d in ("%ProgramFiles%\\Java\\*" "%ProgramFiles%\\Eclipse Adoptium\\*" "%ProgramFiles%\\Microsoft\\jdk-*") do if not defined JAVA_HOME if exist "%%~fd\\bin\\java.exe" set JAVA_HOME=%%~fd
+
+            @rem Find java.exe
+            """
+                .trimIndent()
+
+        private val WINDOWS_JDK_PREFLIGHT =
+            """
+            :execute
+            @rem Spectre attaches an agent, so it requires a full JDK rather than a JRE.
+            for /f "tokens=2 delims=\"" %%v in ('"%JAVA_EXE%" -version 2^>^&1 ^| findstr /c:"version"') do set SPECTRE_JAVA_VERSION=%%v
+            for /f "tokens=1 delims=." %%v in ("%SPECTRE_JAVA_VERSION%") do set SPECTRE_JAVA_FEATURE=%%v
+            if not defined SPECTRE_JAVA_FEATURE goto invalidJavaVersion
+            if %SPECTRE_JAVA_FEATURE% LSS 21 goto oldJavaVersion
+            "%JAVA_EXE%" --list-modules 2^>NUL | findstr /r /c:"^jdk.attach@" >NUL
+            if %ERRORLEVEL% neq 0 goto missingAttachModule
+            goto setupCommandLine
+
+            :invalidJavaVersion
+            echo ERROR: Could not determine the Java version from %JAVA_EXE%. 1>&2
+            goto fail
+
+            :oldJavaVersion
+            echo ERROR: Spectre requires JDK 21 or later; found Java %SPECTRE_JAVA_VERSION% at %JAVA_EXE%. 1>&2
+            goto fail
+
+            :missingAttachModule
+            echo ERROR: Spectre requires a full JDK with the jdk.attach module; found Java %SPECTRE_JAVA_VERSION% at %JAVA_EXE%. 1>&2
+            goto fail
+
+            :setupCommandLine
+            @rem Setup the command line
+            """
+                .trimIndent()
+    }
+}

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -23,7 +23,7 @@ abstract class PatchStartScripts : DefaultTask() {
             script
                 .readText()
                 .replace("# Determine the Java command to use to start the JVM.", UNIX_JAVA_SEARCH)
-                .replace("# Increase the maximum file descriptors if we can.", UNIX_JDK_PREFLIGHT),
+                .replace("# Add default JVM options here.", UNIX_JDK_PREFLIGHT),
         )
     }
 
@@ -85,7 +85,7 @@ abstract class PatchStartScripts : DefaultTask() {
                 die "ERROR: Spectre requires a full JDK with the jdk.attach module; found Java ${'$'}spectre_java_version at ${'$'}JAVACMD."
             fi
 
-            # Increase the maximum file descriptors if we can.
+            # Add default JVM options here.
             """
                 .trimIndent()
 
@@ -111,6 +111,8 @@ abstract class PatchStartScripts : DefaultTask() {
             :findCompatibleSpectreJdk
             if defined JAVA_HOME goto :eof
             if not exist "%~1\\bin\\java.exe" goto :eof
+            set SPECTRE_JAVA_VERSION=
+            set SPECTRE_JAVA_FEATURE=
             for /f "tokens=3" %%v in ('"%~1\\bin\\java.exe" -version 2^>^&1 ^| findstr /c:"version"') do set SPECTRE_JAVA_VERSION=%%v
             set SPECTRE_JAVA_VERSION=%SPECTRE_JAVA_VERSION:"=%
             for /f "tokens=1 delims=." %%v in ("%SPECTRE_JAVA_VERSION%") do set SPECTRE_JAVA_FEATURE=%%v

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -61,7 +61,7 @@ abstract class PatchStartScripts : DefaultTask() {
                         case "${'$'}spectre_java_feature" in
                             '' | *[!0-9]*) continue ;;
                         esac
-                        if [ "${'$'}spectre_java_feature" -ge 21 ] && "${'$'}spectre_java_home/bin/java" --list-modules 2>/dev/null | grep -q '^jdk.attach@'; then
+                        if [ "${'$'}spectre_java_feature" -ge 21 ]; then
                             JAVA_HOME=${'$'}spectre_java_home
                         fi
                     fi
@@ -74,7 +74,7 @@ abstract class PatchStartScripts : DefaultTask() {
 
         private val UNIX_JDK_PREFLIGHT =
             """
-            # Spectre attaches an agent, so it requires a full JDK rather than a JRE.
+            # Spectre requires Java 21 or later. Attach operations validate jdk.attach themselves.
             spectre_java_version=${'$'}("${'$'}JAVACMD" -version 2>&1 | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
             spectre_java_feature=${'$'}{spectre_java_version%%.*}
             case "${'$'}spectre_java_feature" in
@@ -83,10 +83,6 @@ abstract class PatchStartScripts : DefaultTask() {
             if [ "${'$'}spectre_java_feature" -lt 21 ]; then
                 die "ERROR: Spectre requires JDK 21 or later; found Java ${'$'}spectre_java_version at ${'$'}JAVACMD."
             fi
-            if ! "${'$'}JAVACMD" --list-modules 2>/dev/null | grep -q '^jdk.attach@'; then
-                die "ERROR: Spectre requires a full JDK with the jdk.attach module; found Java ${'$'}spectre_java_version at ${'$'}JAVACMD."
-            fi
-
             $UNIX_DEFAULT_JVM_OPTIONS_COMMENT
             """
                 .trimIndent()
@@ -123,8 +119,6 @@ abstract class PatchStartScripts : DefaultTask() {
             for /f "tokens=1 delims=." %%v in ("%SPECTRE_JAVA_VERSION%") do set SPECTRE_JAVA_FEATURE=%%v
             if "%SPECTRE_JAVA_FEATURE%"=="" goto :eof
             if %SPECTRE_JAVA_FEATURE% LSS 21 goto :eof
-            "%~1\\bin\\java.exe" --list-modules 2^>NUL | findstr /r /c:"^jdk.attach@" >NUL
-            if %ERRORLEVEL% neq 0 goto :eof
             set JAVA_HOME=%~1
             goto :eof
             """
@@ -133,7 +127,7 @@ abstract class PatchStartScripts : DefaultTask() {
         private val WINDOWS_JDK_PREFLIGHT =
             """
             :execute
-            @rem Spectre attaches an agent, so it requires a full JDK rather than a JRE.
+            @rem Spectre requires Java 21 or later. Attach operations validate jdk.attach themselves.
             set SPECTRE_JAVA_VERSION=
             set SPECTRE_JAVA_FEATURE=
             for /f "tokens=3" %%v in ('"%JAVA_EXE%" -version 2^>^&1 ^| findstr /c:"version"') do set SPECTRE_JAVA_VERSION=%%v
@@ -141,8 +135,6 @@ abstract class PatchStartScripts : DefaultTask() {
             for /f "tokens=1 delims=." %%v in ("%SPECTRE_JAVA_VERSION%") do set SPECTRE_JAVA_FEATURE=%%v
             if "%SPECTRE_JAVA_FEATURE%"=="" goto invalidJavaVersion
             if %SPECTRE_JAVA_FEATURE% LSS 21 goto oldJavaVersion
-            "%JAVA_EXE%" --list-modules 2^>NUL | findstr /r /c:"^jdk.attach@" >NUL
-            if %ERRORLEVEL% neq 0 goto missingAttachModule
             goto setupCommandLine
 
             :invalidJavaVersion
@@ -151,10 +143,6 @@ abstract class PatchStartScripts : DefaultTask() {
 
             :oldJavaVersion
             echo ERROR: Spectre requires JDK 21 or later; found Java %SPECTRE_JAVA_VERSION% at %JAVA_EXE%. 1>&2
-            goto fail
-
-            :missingAttachModule
-            echo ERROR: Spectre requires a full JDK with the jdk.attach module; found Java %SPECTRE_JAVA_VERSION% at %JAVA_EXE%. 1>&2
             goto fail
 
             :setupCommandLine

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -32,6 +32,10 @@ abstract class PatchStartScripts : DefaultTask() {
             script
                 .readText()
                 .replace("@rem Find java.exe", WINDOWS_JAVA_SEARCH)
+                .replace(
+                    WINDOWS_PATH_PROBE,
+                    "$WINDOWS_PATH_PROBE\n\n$WINDOWS_JDK_FALLBACK",
+                )
                 .replace(":execute\n@rem Setup the command line", WINDOWS_JDK_PREFLIGHT),
         )
     }
@@ -76,11 +80,18 @@ abstract class PatchStartScripts : DefaultTask() {
 
         private val WINDOWS_JAVA_SEARCH =
             """
-            @rem Find a locally installed JDK when JAVA_HOME and PATH are unset.
-            if defined JAVA_HOME goto findJavaFromJavaHome
-            for %%d in ("%ProgramFiles%\\Java\\*" "%ProgramFiles%\\Eclipse Adoptium\\*" "%ProgramFiles%\\Microsoft\\jdk-*") do if not defined JAVA_HOME if exist "%%~fd\\bin\\java.exe" set JAVA_HOME=%%~fd
-
             @rem Find java.exe
+            """
+                .trimIndent()
+
+        private const val WINDOWS_PATH_PROBE =
+            """if %ERRORLEVEL% equ 0 goto execute"""
+
+        private val WINDOWS_JDK_FALLBACK =
+            """
+            @rem PATH did not provide Java; now try common local JDK installations.
+            for %%d in ("%ProgramFiles%\\Java\\*" "%ProgramFiles%\\Eclipse Adoptium\\*" "%ProgramFiles%\\Microsoft\\jdk-*") do if not defined JAVA_HOME if exist "%%~fd\\bin\\java.exe" set JAVA_HOME=%%~fd
+            if defined JAVA_HOME goto findJavaFromJavaHome
             """
                 .trimIndent()
 

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -36,6 +36,10 @@ abstract class PatchStartScripts : DefaultTask() {
                     WINDOWS_PATH_PROBE,
                     "$WINDOWS_PATH_PROBE\n\n$WINDOWS_JDK_FALLBACK",
                 )
+                .replace(
+                    ":findJavaFromJavaHome",
+                    "$WINDOWS_JDK_CANDIDATE_PROBE\n\n:findJavaFromJavaHome",
+                )
                 .replace(":execute\n@rem Setup the command line", WINDOWS_JDK_PREFLIGHT),
         )
     }
@@ -50,7 +54,14 @@ abstract class PatchStartScripts : DefaultTask() {
                 fi
                 for spectre_java_home in "${'$'}{HOME:-}/.sdkman/candidates/java/current" /usr/lib/jvm/* /Library/Java/JavaVirtualMachines/*/Contents/Home; do
                     if [ -z "${'$'}{JAVA_HOME:-}" ] && [ -x "${'$'}spectre_java_home/bin/java" ]; then
-                        JAVA_HOME=${'$'}spectre_java_home
+                        spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
+                        spectre_java_feature=${'$'}{spectre_java_version%%.*}
+                        case "${'$'}spectre_java_feature" in
+                            '' | *[!0-9]*) continue ;;
+                        esac
+                        if [ "${'$'}spectre_java_feature" -ge 21 ] && "${'$'}spectre_java_home/bin/java" --list-modules 2>/dev/null | grep -q '^jdk.attach@'; then
+                            JAVA_HOME=${'$'}spectre_java_home
+                        fi
                     fi
                 done
             fi
@@ -90,8 +101,25 @@ abstract class PatchStartScripts : DefaultTask() {
         private val WINDOWS_JDK_FALLBACK =
             """
             @rem PATH did not provide Java; now try common local JDK installations.
-            for %%d in ("%ProgramFiles%\\Java\\*" "%ProgramFiles%\\Eclipse Adoptium\\*" "%ProgramFiles%\\Microsoft\\jdk-*") do if not defined JAVA_HOME if exist "%%~fd\\bin\\java.exe" set JAVA_HOME=%%~fd
+            for %%d in ("%ProgramFiles%\\Java\\*" "%ProgramFiles%\\Eclipse Adoptium\\*" "%ProgramFiles%\\Microsoft\\jdk-*") do call :findCompatibleSpectreJdk "%%~fd"
             if defined JAVA_HOME goto findJavaFromJavaHome
+            """
+                .trimIndent()
+
+        private val WINDOWS_JDK_CANDIDATE_PROBE =
+            """
+            :findCompatibleSpectreJdk
+            if defined JAVA_HOME goto :eof
+            if not exist "%~1\\bin\\java.exe" goto :eof
+            for /f "tokens=3" %%v in ('"%~1\\bin\\java.exe" -version 2^>^&1 ^| findstr /c:"version"') do set SPECTRE_JAVA_VERSION=%%v
+            set SPECTRE_JAVA_VERSION=%SPECTRE_JAVA_VERSION:"=%
+            for /f "tokens=1 delims=." %%v in ("%SPECTRE_JAVA_VERSION%") do set SPECTRE_JAVA_FEATURE=%%v
+            if not defined SPECTRE_JAVA_FEATURE goto :eof
+            if %SPECTRE_JAVA_FEATURE% LSS 21 goto :eof
+            "%~1\\bin\\java.exe" --list-modules 2^>NUL | findstr /r /c:"^jdk.attach@" >NUL
+            if %ERRORLEVEL% neq 0 goto :eof
+            set JAVA_HOME=%~1
+            goto :eof
             """
                 .trimIndent()
 

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -23,14 +23,16 @@ abstract class PatchStartScripts : DefaultTask() {
             script
                 .readText()
                 .replace("# Determine the Java command to use to start the JVM.", UNIX_JAVA_SEARCH)
-                .replace("# Add default JVM options here.", UNIX_JDK_PREFLIGHT),
+                .replace(UNIX_DEFAULT_JVM_OPTIONS_COMMENT, UNIX_JDK_PREFLIGHT),
         )
     }
 
     private fun patchWindows(script: File) {
-        script.writeText(
-            script
-                .readText()
+        val originalScript = script.readText()
+        val lineSeparator = if ("\r\n" in originalScript) "\r\n" else "\n"
+        val patchedScript =
+            originalScript
+                .replace("\r\n", "\n")
                 .replace("@rem Find java.exe", WINDOWS_JAVA_SEARCH)
                 .replace(
                     WINDOWS_PATH_PROBE,
@@ -40,8 +42,8 @@ abstract class PatchStartScripts : DefaultTask() {
                     ":findJavaFromJavaHome",
                     "$WINDOWS_JDK_CANDIDATE_PROBE\n\n:findJavaFromJavaHome",
                 )
-                .replace(":execute\n@rem Setup the command line", WINDOWS_JDK_PREFLIGHT),
-        )
+                .replace(":execute\n@rem Setup the command line", WINDOWS_JDK_PREFLIGHT)
+        script.writeText(patchedScript.replace("\n", lineSeparator))
     }
 
     private companion object {
@@ -85,9 +87,12 @@ abstract class PatchStartScripts : DefaultTask() {
                 die "ERROR: Spectre requires a full JDK with the jdk.attach module; found Java ${'$'}spectre_java_version at ${'$'}JAVACMD."
             fi
 
-            # Add default JVM options here.
+            $UNIX_DEFAULT_JVM_OPTIONS_COMMENT
             """
                 .trimIndent()
+
+        private const val UNIX_DEFAULT_JVM_OPTIONS_COMMENT =
+            "# Add default JVM options here. You can also use JAVA_OPTS and SPECTRE_OPTS to pass JVM options to this script."
 
         private val WINDOWS_JAVA_SEARCH =
             """
@@ -116,7 +121,7 @@ abstract class PatchStartScripts : DefaultTask() {
             for /f "tokens=3" %%v in ('"%~1\\bin\\java.exe" -version 2^>^&1 ^| findstr /c:"version"') do set SPECTRE_JAVA_VERSION=%%v
             set SPECTRE_JAVA_VERSION=%SPECTRE_JAVA_VERSION:"=%
             for /f "tokens=1 delims=." %%v in ("%SPECTRE_JAVA_VERSION%") do set SPECTRE_JAVA_FEATURE=%%v
-            if not defined SPECTRE_JAVA_FEATURE goto :eof
+            if "%SPECTRE_JAVA_FEATURE%"=="" goto :eof
             if %SPECTRE_JAVA_FEATURE% LSS 21 goto :eof
             "%~1\\bin\\java.exe" --list-modules 2^>NUL | findstr /r /c:"^jdk.attach@" >NUL
             if %ERRORLEVEL% neq 0 goto :eof
@@ -129,10 +134,12 @@ abstract class PatchStartScripts : DefaultTask() {
             """
             :execute
             @rem Spectre attaches an agent, so it requires a full JDK rather than a JRE.
+            set SPECTRE_JAVA_VERSION=
+            set SPECTRE_JAVA_FEATURE=
             for /f "tokens=3" %%v in ('"%JAVA_EXE%" -version 2^>^&1 ^| findstr /c:"version"') do set SPECTRE_JAVA_VERSION=%%v
             set SPECTRE_JAVA_VERSION=%SPECTRE_JAVA_VERSION:"=%
             for /f "tokens=1 delims=." %%v in ("%SPECTRE_JAVA_VERSION%") do set SPECTRE_JAVA_FEATURE=%%v
-            if not defined SPECTRE_JAVA_FEATURE goto invalidJavaVersion
+            if "%SPECTRE_JAVA_FEATURE%"=="" goto invalidJavaVersion
             if %SPECTRE_JAVA_FEATURE% LSS 21 goto oldJavaVersion
             "%JAVA_EXE%" --list-modules 2^>NUL | findstr /r /c:"^jdk.attach@" >NUL
             if %ERRORLEVEL% neq 0 goto missingAttachModule

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,3 +1,7 @@
+import dev.sebastiano.spectre.build.PatchStartScripts
+import org.gradle.api.tasks.application.CreateStartScripts
+import org.gradle.api.tasks.bundling.Zip
+
 plugins {
     application
     alias(libs.plugins.detekt)
@@ -21,6 +25,25 @@ tasks.shadowJar {
         into("spectre")
         rename { "agent-runtime.jar" }
     }
+}
+
+val patchShadowStartScripts =
+    tasks.register<PatchStartScripts>("patchShadowStartScripts") {
+        dependsOn(tasks.named("startShadowScripts"))
+        unixScript.set(layout.buildDirectory.file("scriptsShadow/spectre"))
+        windowsScript.set(layout.buildDirectory.file("scriptsShadow/spectre.bat"))
+    }
+
+tasks.named<CreateStartScripts>("startShadowScripts") {
+    // The patch task intentionally modifies this task's generated output before it is zipped.
+    // Regenerate it on every distribution build so a changed preflight can never reuse stale
+    // launcher contents from a previous build.
+    outputs.upToDateWhen { false }
+}
+
+tasks.named<Zip>("shadowDistZip") {
+    archiveFileName.set("spectre-cli-${project.version}.zip")
+    dependsOn(patchShadowStartScripts)
 }
 
 tasks.assemble { dependsOn(tasks.shadowJar) }
@@ -55,4 +78,7 @@ tasks.withType<Test>().configureEach {
         "spectre.cli.testRuntimeClasspath",
         sourceSets.test.get().runtimeClasspath.asPath,
     )
+    providers.systemProperty("spectre.cli.distributionExecutable").orNull?.let { executable ->
+        systemProperty("spectre.cli.distributionExecutable", executable)
+    }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -296,20 +296,34 @@ private fun spawnComposeFixture(): FixtureProcess {
 }
 
 private fun runCliBinary(daemonUser: String, vararg arguments: String): CliBinaryResult {
-    val javaExe =
-        if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) "java.exe"
-        else "java"
-    val javaBin = Paths.get(System.getProperty("java.home"), "bin", javaExe).toString()
+    val distributionExecutable = System.getProperty("spectre.cli.distributionExecutable")
+    val command =
+        distributionExecutable?.let { executable -> listOf(executable, *arguments) }
+            ?: run {
+                val javaExe =
+                    if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+                        "java.exe"
+                    } else {
+                        "java"
+                    }
+                listOf(
+                    Paths.get(System.getProperty("java.home"), "bin", javaExe).toString(),
+                    "-Duser.name=$daemonUser",
+                    "-Djava.awt.headless=false",
+                    "-cp",
+                    daemonFixtureRuntimeClassPath(),
+                    "dev.sebastiano.spectre.cli.SpectreCliKt",
+                    *arguments,
+                )
+            }
     val process =
-        ProcessBuilder(
-                javaBin,
-                "-Duser.name=$daemonUser",
-                "-Djava.awt.headless=false",
-                "-cp",
-                daemonFixtureRuntimeClassPath(),
-                "dev.sebastiano.spectre.cli.SpectreCliKt",
-                *arguments,
-            )
+        ProcessBuilder(command)
+            .apply {
+                if (distributionExecutable != null) {
+                    environment()["SPECTRE_OPTS"] =
+                        "-Duser.name=$daemonUser -Djava.awt.headless=false"
+                }
+            }
             .redirectErrorStream(true)
             .start()
     val output = StringBuilder()

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -40,9 +40,11 @@ Five jobs run on tag push:
    per-arch helper directories as a GitHub Actions artefact.
 5. **`publish`** (Linux runner, depends on the gate and all helper jobs) — downloads the
    helper artefacts, runs `:verifyMavenLocalPublication` to assert the publication shape, then
-   runs `publishToMavenCentral` against the [Sonatype Central Portal][central-portal].
-   Finally creates a draft GitHub release. Maven Central is the canonical artifact host; do
-   not attach a partial jar set to the GitHub release.
+   builds the version-stamped `spectre-cli-<version>.zip` Shadow distribution and runs
+   `publishToMavenCentral` against the [Sonatype Central Portal][central-portal]. Finally it
+   creates a draft GitHub release and uploads that self-contained CLI archive. Maven Central
+   remains the canonical host for library modules; do not attach a partial library jar set to
+   the GitHub release.
 
 [ci-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/ci.yml
 [central-portal]: https://central.sonatype.com/
@@ -73,7 +75,8 @@ Manual promotion checklist:
   `scripts/central_portal_check.py validate --deployment-id <id> --version <version>`.
 - Promote the Central staging deployment from the Central Portal UI.
 - Confirm the GitHub release notes link to Maven Central for artifacts instead
-  of attaching a partial jar set.
+  of attaching a partial library jar set, and that it includes
+  `spectre-cli-<version>.zip`.
 - Undraft the GitHub release with `gh release edit <tag> --draft=false`.
 
 ## Required secrets


### PR DESCRIPTION
Closes #177\n\n- ships a version-stamped Shadow CLI archive with POSIX and Windows JDK 21/jdk.attach preflight launchers\n- uploads the archive to tag-driven draft releases\n- smoke-tests the unpacked wrapper against the Compose fixture on macOS and Linux\n\nValidation: ./gradlew check; unpacked distribution fixture smoke