### PR TITLE
Ignore skipped deploy checks when babysitting

### DIFF
--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -417,13 +417,16 @@ def summarize_checks(checks):
     skipping_count = 0
     for check in checks:
         bucket = str(check.get("bucket") or "").lower()
+        name = str(check.get("name") or "").lower()
         if is_pending_check(check):
             pending_count += 1
         elif bucket == "fail":
             failed_count += 1
         elif bucket == "pass":
             passed_count += 1
-        elif bucket in ("neutral", "skipping"):
+        elif bucket in ("neutral", "skipping") and not (
+            bucket == "skipping" and name == "deploy"
+        ):
             skipping_count += 1
     return {
         "pending_count": pending_count,

--- a/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
@@ -1232,6 +1232,17 @@ class SkippingChecksTests(unittest.TestCase):
         self.assertEqual(summary["skipping_count"], 2)
         self.assertTrue(summary["all_terminal"])
 
+    def test_summarize_checks_ignores_a_skipped_deploy_job(self):
+        checks = [
+            {"name": "deploy", "bucket": "skipping", "state": "SKIPPING"},
+            {"name": "other", "bucket": "skipping", "state": "SKIPPING"},
+            {"name": "deploy", "bucket": "neutral", "state": "NEUTRAL"},
+        ]
+
+        summary = watch.summarize_checks(checks)
+
+        self.assertEqual(summary["skipping_count"], 2)
+
     def test_should_stop_watching_on_skipping_checks(self):
         self.assertTrue(watch.should_stop_watching(["diagnose_skipping_checks"]))
 


### PR DESCRIPTION
## Summary
- treat a skipped `deploy` check as expected in the repo-local PR watcher
- retain blocking behavior for every other skipped or neutral check
- add watcher regression coverage

## Validation
- `python3 .agents/skills/babysit-pr/scripts/test_gh_pr_watch.py`
- `python3 -m py_compile .agents/skills/babysit-pr/scripts/gh_pr_watch.py`
- `./gradlew check`