### PR TITLE
Shrink the CLI shadow jar with R8

### DIFF
--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.build
 
 import java.io.File
 import java.util.jar.JarFile
+import java.util.concurrent.ExecutionException
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.TimeUnit
@@ -83,7 +84,13 @@ abstract class VerifyCliShadowJar : DefaultTask() {
                 output.get(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             } catch (exception: TimeoutException) {
                 process.destroyForcibly()
-                output.get(PROCESS_KILL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                try {
+                    output.get(PROCESS_KILL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                } catch (_: TimeoutException) {
+                    // The process did not stop promptly, but report the original read timeout.
+                } catch (_: ExecutionException) {
+                    // Teardown can close the stream; report the original read timeout instead.
+                }
                 error("Timed out after $PROCESS_TIMEOUT_SECONDS seconds while reading ${process.info().command().orElse("the CLI")}")
             } finally {
                 if (!output.isDone) output.cancel(true)

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
@@ -1,0 +1,48 @@
+package dev.sebastiano.spectre.build
+
+import java.io.File
+import java.util.jar.JarFile
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+/** Verifies the shrink-only CLI JAR remains directly executable and retains dynamic resources. */
+abstract class VerifyCliShadowJar : DefaultTask() {
+    @get:InputFile abstract val artifact: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val jar = artifact.get().asFile
+        JarFile(jar).use { archive ->
+            check(archive.manifest.mainAttributes.getValue("Main-Class") == CLI_MAIN_CLASS) {
+                "${jar.name} does not declare $CLI_MAIN_CLASS as its Main-Class"
+            }
+            check(archive.getEntry(AGENT_RUNTIME_ENTRY) != null) {
+                "${jar.name} does not retain the embedded agent runtime at $AGENT_RUNTIME_ENTRY"
+            }
+            check(archive.getEntry(KTOR_SERVICE_ENTRY) != null) {
+                "${jar.name} does not retain Ktor's ServiceLoader entry at $KTOR_SERVICE_ENTRY"
+            }
+        }
+
+        val process =
+            ProcessBuilder(javaExecutable(), "-jar", jar.absolutePath, "--help")
+                .redirectErrorStream(true)
+                .start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        check(process.waitFor() == 0) { "${jar.name} --help failed:\n$output" }
+        check("mcp" in output) { "${jar.name} --help did not expose the mcp command:\n$output" }
+    }
+
+    private fun javaExecutable(): String =
+        File(System.getProperty("java.home"), "bin/java${if (isWindows()) ".exe" else ""}").path
+
+    private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
+
+    private companion object {
+        private const val CLI_MAIN_CLASS = "dev.sebastiano.spectre.cli.SpectreCliKt"
+        private const val AGENT_RUNTIME_ENTRY = "spectre/agent-runtime.jar"
+        private const val KTOR_SERVICE_ENTRY = "META-INF/services/io.ktor.server.config.ConfigLoader"
+    }
+}

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
@@ -2,6 +2,8 @@ package dev.sebastiano.spectre.build
 
 import java.io.File
 import java.util.jar.JarFile
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.tasks.InputFile
@@ -31,27 +33,58 @@ abstract class VerifyCliShadowJar : DefaultTask() {
     }
 
     private fun verifyHelp(jar: File) {
-        val process = ProcessBuilder(javaExecutable(), "-jar", jar.absolutePath, "--help").start()
-        val output = process.inputStream.bufferedReader().use { it.readText() }
-        val error = process.errorStream.bufferedReader().use { it.readText() }
-        check(process.waitFor() == 0) { "${jar.name} --help failed:\n$output$error" }
-        check("mcp" in output) { "${jar.name} --help did not expose the mcp command:\n$output" }
+        val process = ProcessBuilder(javaExecutable(), "-jar", jar.absolutePath, "--help").redirectErrorStream(true).start()
+        try {
+            val output = readUntil(process) { "mcp" in it }
+            check(process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS) && process.exitValue() == 0) {
+                "${jar.name} --help failed:\n$output"
+            }
+            check("mcp" in output) { "${jar.name} --help did not expose the mcp command:\n$output" }
+        } finally {
+            process.destroyForcibly()
+        }
     }
 
     private fun verifyMcpToolDiscovery(jar: File) {
-        val process = ProcessBuilder(javaExecutable(), "-jar", jar.absolutePath, "mcp").start()
-        process.outputStream.bufferedWriter().use { writer ->
+        val process = ProcessBuilder(javaExecutable(), "-jar", jar.absolutePath, "mcp").redirectErrorStream(true).start()
+        try {
+            val writer = process.outputStream.bufferedWriter()
             writer.appendLine(INITIALIZE_REQUEST)
             writer.appendLine(INITIALIZED_NOTIFICATION)
             writer.appendLine(TOOLS_LIST_REQUEST)
-        }
-        val output = process.inputStream.bufferedReader().use { it.readText() }
-        val error = process.errorStream.bufferedReader().use { it.readText() }
-        check(process.waitFor() == 0) { "${jar.name} mcp failed:\n$output$error" }
-        check("\"id\":2" in output && "\"type_text\"" in output) {
-            "${jar.name} mcp did not return its tool list:\n$output"
+            writer.flush()
+            val output = readUntil(process) { "\"id\":2" in it && "\"type_text\"" in it }
+            check("\"id\":2" in output && "\"type_text\"" in output) {
+                "${jar.name} mcp did not return its tool list:\n$output"
+            }
+            process.outputStream.close()
+            check(process.waitFor(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS) && process.exitValue() == 0) {
+                "${jar.name} mcp did not stop after its input closed:\n$output"
+            }
+        } finally {
+            process.destroyForcibly()
         }
     }
+
+    private fun readUntil(process: Process, complete: (String) -> Boolean): String =
+        Executors.newSingleThreadExecutor().use { executor ->
+            val output =
+                executor.submit<String> {
+                    buildString {
+                        process.inputStream.bufferedReader().useLines { lines ->
+                            for (line in lines) {
+                                appendLine(line)
+                                if (complete(toString())) return@useLines
+                            }
+                        }
+                    }
+                }
+            try {
+                output.get(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            } finally {
+                if (!output.isDone) output.cancel(true)
+            }
+        }
 
     private fun javaExecutable(): String =
         File(System.getProperty("java.home"), "bin/java${if (isWindows()) ".exe" else ""}").path
@@ -62,6 +95,7 @@ abstract class VerifyCliShadowJar : DefaultTask() {
         private const val CLI_MAIN_CLASS = "dev.sebastiano.spectre.cli.SpectreCliKt"
         private const val AGENT_RUNTIME_ENTRY = "spectre/agent-runtime.jar"
         private const val KTOR_SERVICE_ENTRY = "META-INF/services/io.ktor.server.config.ConfigLoader"
+        private const val PROCESS_TIMEOUT_SECONDS: Long = 10
         private const val INITIALIZE_REQUEST =
             "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"spectre-r8-smoke\",\"version\":\"1\"}}}"
         private const val INITIALIZED_NOTIFICATION =

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
@@ -26,13 +26,31 @@ abstract class VerifyCliShadowJar : DefaultTask() {
             }
         }
 
-        val process =
-            ProcessBuilder(javaExecutable(), "-jar", jar.absolutePath, "--help")
-                .redirectErrorStream(true)
-                .start()
+        verifyHelp(jar)
+        verifyMcpToolDiscovery(jar)
+    }
+
+    private fun verifyHelp(jar: File) {
+        val process = ProcessBuilder(javaExecutable(), "-jar", jar.absolutePath, "--help").start()
         val output = process.inputStream.bufferedReader().use { it.readText() }
-        check(process.waitFor() == 0) { "${jar.name} --help failed:\n$output" }
+        val error = process.errorStream.bufferedReader().use { it.readText() }
+        check(process.waitFor() == 0) { "${jar.name} --help failed:\n$output$error" }
         check("mcp" in output) { "${jar.name} --help did not expose the mcp command:\n$output" }
+    }
+
+    private fun verifyMcpToolDiscovery(jar: File) {
+        val process = ProcessBuilder(javaExecutable(), "-jar", jar.absolutePath, "mcp").start()
+        process.outputStream.bufferedWriter().use { writer ->
+            writer.appendLine(INITIALIZE_REQUEST)
+            writer.appendLine(INITIALIZED_NOTIFICATION)
+            writer.appendLine(TOOLS_LIST_REQUEST)
+        }
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        val error = process.errorStream.bufferedReader().use { it.readText() }
+        check(process.waitFor() == 0) { "${jar.name} mcp failed:\n$output$error" }
+        check("\"id\":2" in output && "\"type_text\"" in output) {
+            "${jar.name} mcp did not return its tool list:\n$output"
+        }
     }
 
     private fun javaExecutable(): String =
@@ -44,5 +62,11 @@ abstract class VerifyCliShadowJar : DefaultTask() {
         private const val CLI_MAIN_CLASS = "dev.sebastiano.spectre.cli.SpectreCliKt"
         private const val AGENT_RUNTIME_ENTRY = "spectre/agent-runtime.jar"
         private const val KTOR_SERVICE_ENTRY = "META-INF/services/io.ktor.server.config.ConfigLoader"
+        private const val INITIALIZE_REQUEST =
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"spectre-r8-smoke\",\"version\":\"1\"}}}"
+        private const val INITIALIZED_NOTIFICATION =
+            "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}"
+        private const val TOOLS_LIST_REQUEST =
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}"
     }
 }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliShadowJar.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.build
 import java.io.File
 import java.util.jar.JarFile
 import java.util.concurrent.Executors
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.TimeUnit
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
@@ -67,22 +68,26 @@ abstract class VerifyCliShadowJar : DefaultTask() {
     }
 
     private fun readUntil(process: Process, complete: (String) -> Boolean): String =
-        Executors.newSingleThreadExecutor().use { executor ->
-            val output =
-                executor.submit<String> {
-                    buildString {
-                        process.inputStream.bufferedReader().useLines { lines ->
-                            for (line in lines) {
-                                appendLine(line)
-                                if (complete(toString())) return@useLines
-                            }
+        Executors.newSingleThreadExecutor().let { executor ->
+            val output = executor.submit<String> {
+                buildString {
+                    process.inputStream.bufferedReader().useLines { lines ->
+                        for (line in lines) {
+                            appendLine(line)
+                            if (complete(toString())) return@useLines
                         }
                     }
                 }
+            }
             try {
                 output.get(PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            } catch (exception: TimeoutException) {
+                process.destroyForcibly()
+                output.get(PROCESS_KILL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                error("Timed out after $PROCESS_TIMEOUT_SECONDS seconds while reading ${process.info().command().orElse("the CLI")}")
             } finally {
                 if (!output.isDone) output.cancel(true)
+                executor.shutdownNow()
             }
         }
 
@@ -96,6 +101,7 @@ abstract class VerifyCliShadowJar : DefaultTask() {
         private const val AGENT_RUNTIME_ENTRY = "spectre/agent-runtime.jar"
         private const val KTOR_SERVICE_ENTRY = "META-INF/services/io.ktor.server.config.ConfigLoader"
         private const val PROCESS_TIMEOUT_SECONDS: Long = 10
+        private const val PROCESS_KILL_TIMEOUT_SECONDS: Long = 1
         private const val INITIALIZE_REQUEST =
             "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2025-03-26\",\"capabilities\":{},\"clientInfo\":{\"name\":\"spectre-r8-smoke\",\"version\":\"1\"}}}"
         private const val INITIALIZED_NOTIFICATION =

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,4 +1,5 @@
 import dev.sebastiano.spectre.build.PatchStartScripts
+import dev.sebastiano.spectre.build.VerifyCliShadowJar
 import org.gradle.api.tasks.application.CreateStartScripts
 import org.gradle.api.tasks.bundling.Zip
 
@@ -21,6 +22,23 @@ tasks.shadowJar {
     dependsOn(agentRuntimeJar)
     archiveClassifier = "all"
     manifest { attributes["Main-Class"] = application.mainClass.get() }
+    // Keep Spectre's entrypoints readable and callable by name while R8 removes dead code from
+    // the merged third-party runtime. The nested agent runtime is copied as an opaque resource
+    // below, so its reflection-based attach contract stays outside the shrinker's scope.
+    minimize {
+        r8 {
+            keepRules.addAll(
+                "-dontobfuscate",
+                "-dontoptimize",
+                // kotlin-logging ships adapters for optional logging backends. The CLI does not
+                // bundle Logback, so R8 must not treat those unused adapter references as an
+                // unresolved runtime dependency.
+                "-dontwarn ch.qos.logback.classic.**",
+                "-keepattributes SourceFile,LineNumberTable",
+                "-keep class dev.sebastiano.spectre.cli.** { *; }",
+            )
+        }
+    }
     from(agentRuntimeJar.flatMap { it.archiveFile }) {
         into("spectre")
         rename { "agent-runtime.jar" }
@@ -46,7 +64,15 @@ tasks.named<Zip>("shadowDistZip") {
     dependsOn(patchShadowStartScripts)
 }
 
-tasks.assemble { dependsOn(tasks.shadowJar) }
+val verifyCliShadowJar =
+    tasks.register<VerifyCliShadowJar>("verifyCliShadowJar") {
+        dependsOn(tasks.shadowJar)
+        artifact.set(tasks.shadowJar.flatMap { it.archiveFile })
+    }
+
+tasks.assemble { dependsOn(verifyCliShadowJar) }
+
+tasks.check { dependsOn(verifyCliShadowJar) }
 
 kotlin {
     jvmToolchain(21)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -75,6 +75,8 @@ class SpectreMcpStdioIntegrationTest {
 
     private companion object {
         private const val CONNECTION_TIMEOUT_MILLIS: Long = 10_000
-        private const val PROCESS_EXIT_TIMEOUT_SECONDS: Long = 5
+        // Windows hosted runners can take longer than the usual process startup window to
+        // initialize the JVM before observing closed stdin.
+        private const val PROCESS_EXIT_TIMEOUT_SECONDS: Long = 15
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ material3 = "1.10.0-alpha05"
 # See `.plans/2026-05-22-issue-153-agent-attach-workshop.md` for the agent packaging
 # rationale (thin agent: bundles only bootstrap + IPC + DTOs + serialization, NOT
 # Compose / Skiko / Kotlin stdlib).
-shadow = "9.4.1"
+shadow = "9.5.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

- upgrade Shadow to 9.5.1 and enable its R8 shrinker for the CLI fat JAR
- retain readable class names and source/line metadata while excluding optional Logback references
- keep the nested agent runtime outside R8 and add a CI verification task for the executable artifact and Ktor ServiceLoader entry

## Validation

- ./gradlew :cli:verifyCliShadowJar
- ./gradlew check

Part of #178.