### PR TITLE
Build a jlink runtime for the CLI bundle

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,9 @@ name: Release
 #                            `-PprebuiltLinuxHelpersDir=...` and
 #                            `-PprebuiltWindowsHelpersDir=...`, runs the publication-shape
 #                            verification, then `publish` against the Sonatype Central
-#                            Portal staging endpoint. Finally creates the draft GitHub
-#                            release notes so the maintainer can sanity-check Central +
-#                            GitHub side-by-side before promoting.
+#                            Portal staging endpoint. Finally it uploads the Linux x86_64
+#                            self-contained CLI bundle to the draft GitHub release. Other
+#                            platform bundles are added by the cross-targeted runtime phase.
 #
 # Secrets used (all from repo settings):
 #   APPLE_DEVELOPER_ID_P12 / _PASSWORD                  → keychain import (mac-helper)
@@ -400,7 +400,7 @@ jobs:
             -PprebuiltLinuxHelpersDir="$RUNNER_TEMP/linux-helpers" \
             -PprebuiltWindowsHelpersDir="$RUNNER_TEMP/windows-helper"
 
-      - name: Build version-stamped CLI distribution
+      - name: Build version-stamped Linux x86_64 CLI distribution
         run: |
           ./gradlew :cli:shadowDistZip \
             -PVERSION_NAME="$RELEASE_VERSION" \
@@ -441,5 +441,5 @@ jobs:
           gh release view "$GITHUB_REF_NAME" \
             || gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME"
           gh release upload "$GITHUB_REF_NAME" \
-            "cli/build/distributions/spectre-cli-$RELEASE_VERSION.zip" \
+            "cli/build/distributions/spectre-cli-$RELEASE_VERSION-linux-x86_64.zip" \
             --clobber

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/CreateCliRuntimeImage.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/CreateCliRuntimeImage.kt
@@ -1,0 +1,42 @@
+package dev.sebastiano.spectre.build
+
+import javax.inject.Inject
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import org.gradle.process.ExecOperations
+
+/** Creates a compact host JRE for the CLI bundle with dynamic agent attachment support. */
+abstract class CreateCliRuntimeImage
+    @Inject
+    constructor(
+        private val execOperations: ExecOperations,
+        private val fileSystemOperations: FileSystemOperations,
+    ) : DefaultTask() {
+        @get:InputFile abstract val jlinkExecutable: RegularFileProperty
+
+        @get:OutputDirectory abstract val runtimeImage: DirectoryProperty
+
+        @TaskAction
+        fun create() {
+            val output = runtimeImage.get().asFile
+            fileSystemOperations.delete { delete(output) }
+            execOperations.exec {
+                commandLine(
+                    jlinkExecutable.get().asFile.path,
+                    "--add-modules",
+                    "java.se,jdk.attach,jdk.unsupported",
+                    "--output",
+                    output.path,
+                    "--strip-debug",
+                    "--no-man-pages",
+                    "--no-header-files",
+                    "--compress=zip-6",
+                )
+            }
+        }
+    }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/CreateCliRuntimeImage.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/CreateCliRuntimeImage.kt
@@ -1,10 +1,12 @@
 package dev.sebastiano.spectre.build
 
 import javax.inject.Inject
+import java.nio.file.Files
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
@@ -20,6 +22,10 @@ abstract class CreateCliRuntimeImage
         @get:InputFile abstract val jlinkExecutable: RegularFileProperty
 
         @get:OutputDirectory abstract val runtimeImage: DirectoryProperty
+
+        @get:org.gradle.api.tasks.Input abstract val targetOperatingSystem: Property<String>
+
+        @get:org.gradle.api.tasks.Input abstract val targetArchitecture: Property<String>
 
         @TaskAction
         fun create() {
@@ -38,5 +44,9 @@ abstract class CreateCliRuntimeImage
                     "--compress=zip-6",
                 )
             }
+            Files.writeString(
+                output.toPath().resolve("spectre-runtime.properties"),
+                "spectre.runtime.os=${targetOperatingSystem.get()}\nspectre.runtime.arch=${targetArchitecture.get()}\n",
+            )
         }
     }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -49,9 +49,15 @@ abstract class PatchStartScripts : DefaultTask() {
     private companion object {
         private val UNIX_JAVA_SEARCH =
             """
-            # Prefer the jlink runtime packaged with this distribution.
-            if [ -x "${'$'}APP_HOME/runtime/bin/java" ]; then
-                JAVA_HOME=${'$'}APP_HOME/runtime
+            # Prefer a bundled runtime only when it matches this host.
+            if [ -x "${'$'}APP_HOME/runtime/bin/java" ] && [ -r "${'$'}APP_HOME/runtime/spectre-runtime.properties" ]; then
+                spectre_runtime_os=${'$'}(sed -n 's/^spectre\.runtime\.os=//p' "${'$'}APP_HOME/runtime/spectre-runtime.properties")
+                spectre_runtime_arch=${'$'}(sed -n 's/^spectre\.runtime\.arch=//p' "${'$'}APP_HOME/runtime/spectre-runtime.properties")
+                case "${'$'}(uname -s)" in Darwin) spectre_host_os='Mac OS X' ;; Linux) spectre_host_os=Linux ;; *) spectre_host_os= ;; esac
+                case "${'$'}(uname -m)" in arm64|aarch64) spectre_host_arch=aarch64 ;; x86_64|amd64) spectre_host_arch=x86_64 ;; *) spectre_host_arch= ;; esac
+                if [ "${'$'}spectre_runtime_os" = "${'$'}spectre_host_os" ] && [ "${'$'}spectre_runtime_arch" = "${'$'}spectre_host_arch" ]; then
+                    JAVA_HOME=${'$'}APP_HOME/runtime
+                fi
             fi
 
             # Find a locally installed JDK when JAVA_HOME and PATH are unset.
@@ -113,9 +119,14 @@ abstract class PatchStartScripts : DefaultTask() {
         private val WINDOWS_JAVA_SEARCH =
             """
             @rem Find java.exe
-            if exist "%APP_HOME%\runtime\bin\java.exe" (
-                set JAVA_HOME=%APP_HOME%\runtime
-                goto findJavaFromJavaHome
+            if exist "%APP_HOME%\runtime\bin\java.exe" if exist "%APP_HOME%\runtime\spectre-runtime.properties" (
+                for /f "tokens=1,* delims==" %%a in ('findstr /b "spectre.runtime.os=" "%APP_HOME%\runtime\spectre-runtime.properties"') do set SPECTRE_RUNTIME_OS=%%b
+                for /f "tokens=1,* delims==" %%a in ('findstr /b "spectre.runtime.arch=" "%APP_HOME%\runtime\spectre-runtime.properties"') do set SPECTRE_RUNTIME_ARCH=%%b
+                set SPECTRE_HOST_ARCH=%PROCESSOR_ARCHITECTURE%
+                if /I "%SPECTRE_HOST_ARCH%"=="AMD64" set SPECTRE_HOST_ARCH=x86_64
+                if /I "%SPECTRE_HOST_ARCH%"=="ARM64" set SPECTRE_HOST_ARCH=aarch64
+                if /I "%SPECTRE_RUNTIME_OS%"=="Windows" if /I "%SPECTRE_RUNTIME_ARCH%"=="%SPECTRE_HOST_ARCH%" set JAVA_HOME=%APP_HOME%\runtime
+                if defined JAVA_HOME goto findJavaFromJavaHome
             )
             """
                 .trimIndent()

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -49,6 +49,11 @@ abstract class PatchStartScripts : DefaultTask() {
     private companion object {
         private val UNIX_JAVA_SEARCH =
             """
+            # Prefer the jlink runtime packaged with this distribution.
+            if [ -x "${'$'}APP_HOME/runtime/bin/java" ]; then
+                JAVA_HOME=${'$'}APP_HOME/runtime
+            fi
+
             # Find a locally installed JDK when JAVA_HOME and PATH are unset.
             if [ -z "${'$'}{JAVA_HOME:-}" ] && ! command -v java >/dev/null 2>&1; then
                 spectre_java_fallback_home=
@@ -108,6 +113,10 @@ abstract class PatchStartScripts : DefaultTask() {
         private val WINDOWS_JAVA_SEARCH =
             """
             @rem Find java.exe
+            if exist "%APP_HOME%\runtime\bin\java.exe" (
+                set JAVA_HOME=%APP_HOME%\runtime
+                goto findJavaFromJavaHome
+            )
             """
                 .trimIndent()
 

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -120,12 +120,7 @@ abstract class PatchStartScripts : DefaultTask() {
             """
             @rem Find java.exe
             if exist "%APP_HOME%\runtime\bin\java.exe" if exist "%APP_HOME%\runtime\spectre-runtime.properties" (
-                for /f "tokens=1,* delims==" %%a in ('findstr /b "spectre.runtime.os=" "%APP_HOME%\runtime\spectre-runtime.properties"') do set SPECTRE_RUNTIME_OS=%%b
-                for /f "tokens=1,* delims==" %%a in ('findstr /b "spectre.runtime.arch=" "%APP_HOME%\runtime\spectre-runtime.properties"') do set SPECTRE_RUNTIME_ARCH=%%b
-                set SPECTRE_HOST_ARCH=%PROCESSOR_ARCHITECTURE%
-                if /I "%SPECTRE_HOST_ARCH%"=="AMD64" set SPECTRE_HOST_ARCH=x86_64
-                if /I "%SPECTRE_HOST_ARCH%"=="ARM64" set SPECTRE_HOST_ARCH=aarch64
-                if /I "%SPECTRE_RUNTIME_OS%"=="Windows" if /I "%SPECTRE_RUNTIME_ARCH%"=="%SPECTRE_HOST_ARCH%" set JAVA_HOME=%APP_HOME%\runtime
+                call :useBundledSpectreRuntime
                 if defined JAVA_HOME goto findJavaFromJavaHome
             )
             """
@@ -146,6 +141,17 @@ abstract class PatchStartScripts : DefaultTask() {
 
         private val WINDOWS_JDK_CANDIDATE_PROBE =
             """
+            :useBundledSpectreRuntime
+            set SPECTRE_RUNTIME_OS=
+            set SPECTRE_RUNTIME_ARCH=
+            for /f "tokens=1,* delims==" %%a in ('findstr /b "spectre.runtime.os=" "%APP_HOME%\runtime\spectre-runtime.properties"') do set SPECTRE_RUNTIME_OS=%%b
+            for /f "tokens=1,* delims==" %%a in ('findstr /b "spectre.runtime.arch=" "%APP_HOME%\runtime\spectre-runtime.properties"') do set SPECTRE_RUNTIME_ARCH=%%b
+            set SPECTRE_HOST_ARCH=%PROCESSOR_ARCHITECTURE%
+            if /I "%SPECTRE_HOST_ARCH%"=="AMD64" set SPECTRE_HOST_ARCH=x86_64
+            if /I "%SPECTRE_HOST_ARCH%"=="ARM64" set SPECTRE_HOST_ARCH=aarch64
+            if /I "%SPECTRE_RUNTIME_OS%"=="Windows" if /I "%SPECTRE_RUNTIME_ARCH%"=="%SPECTRE_HOST_ARCH%" set JAVA_HOME=%APP_HOME%\runtime
+            goto :eof
+
             :findCompatibleSpectreJdk
             if defined JAVA_HOME goto :eof
             if not exist "%~1\\bin\\java.exe" goto :eof

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
@@ -1,0 +1,26 @@
+package dev.sebastiano.spectre.build
+
+import java.util.zip.ZipFile
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+/** Verifies the CLI distribution ZIP carries the jlink runtime it requires to run. */
+abstract class VerifyCliDistributionZip : DefaultTask() {
+    @get:InputFile abstract val artifact: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val archive = artifact.get().asFile
+        ZipFile(archive).use { zip ->
+            check(zip.entries().asSequence().any { it.name.endsWith("/runtime/${javaPath()}") }) {
+                "${archive.name} does not contain its jlink runtime executable"
+            }
+        }
+    }
+
+    private fun javaPath(): String = if (isWindows()) "bin/java.exe" else "bin/java"
+
+    private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
+}

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
@@ -1,5 +1,8 @@
 package dev.sebastiano.spectre.build
 
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
@@ -14,13 +17,63 @@ abstract class VerifyCliDistributionZip : DefaultTask() {
     fun verify() {
         val archive = artifact.get().asFile
         ZipFile(archive).use { zip ->
-            check(zip.entries().asSequence().any { it.name.endsWith("/runtime/${javaPath()}") }) {
-                "${archive.name} does not contain its jlink runtime executable"
+            val runtimeEntry =
+                zip.entries().asSequence().firstOrNull { it.name.endsWith("/runtime/${javaPath()}") }
+                    ?: error("${archive.name} does not contain its jlink runtime executable")
+            val distributionRoot = runtimeEntry.name.substringBefore("/runtime/")
+            check(zip.getEntry("$distributionRoot/bin/${launcherName()}") != null) {
+                "${archive.name} does not contain its launcher in $distributionRoot"
             }
+            extract(zip)
+            verifyLauncher(File(temporaryDir, distributionRoot))
+        }
+    }
+
+    private fun extract(zip: ZipFile) {
+        val root = temporaryDir.toPath()
+        zip.entries().asSequence().forEach { entry ->
+            val destination = root.resolve(entry.name).normalize()
+            check(destination.startsWith(root)) { "ZIP entry escapes the verification directory: ${entry.name}" }
+            if (entry.isDirectory) {
+                Files.createDirectories(destination)
+            } else {
+                Files.createDirectories(destination.parent)
+                zip.getInputStream(entry).use { input -> Files.newOutputStream(destination).use(input::copyTo) }
+            }
+        }
+    }
+
+    private fun verifyLauncher(distributionRoot: File) {
+        val launcher = File(distributionRoot, "bin/${launcherName()}")
+        val runtimeJava = File(distributionRoot, "runtime/${javaPath()}")
+        launcher.setExecutable(true)
+        runtimeJava.setExecutable(true)
+        val command =
+            if (isWindows()) {
+                listOf("cmd", "/c", launcher.path, "--help")
+            } else {
+                listOf(launcher.path, "--help")
+            }
+        val processBuilder = ProcessBuilder(command).redirectErrorStream(true)
+        processBuilder.environment()["JAVA_HOME"] = File(temporaryDir, "missing-java-home").path
+        val process = processBuilder.start()
+        check(process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            "${launcher.name} did not finish within $COMMAND_TIMEOUT_SECONDS seconds"
+        }
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        check(process.exitValue() == 0) {
+            "${launcher.name} did not run with its bundled runtime:\n$output"
         }
     }
 
     private fun javaPath(): String = if (isWindows()) "bin/java.exe" else "bin/java"
 
+    private fun launcherName(): String = if (isWindows()) "spectre.bat" else "spectre"
+
     private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
+
+    private companion object {
+        private const val COMMAND_TIMEOUT_SECONDS: Long = 30
+    }
 }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
@@ -27,16 +27,41 @@ abstract class VerifyCliDistributionZip : DefaultTask() {
             check(zip.getEntry("$distributionRoot/runtime/spectre-runtime.properties") != null) {
                 "${archive.name} does not declare its bundled runtime platform"
             }
-            extract(zip)
+            validateEntries(zip)
+            extract(archive, zip)
             verifyLauncher(File(temporaryDir, distributionRoot))
         }
     }
 
-    private fun extract(zip: ZipFile) {
+    private fun validateEntries(zip: ZipFile) {
         val root = temporaryDir.toPath()
         zip.entries().asSequence().forEach { entry ->
             val destination = root.resolve(entry.name).normalize()
             check(destination.startsWith(root)) { "ZIP entry escapes the verification directory: ${entry.name}" }
+        }
+    }
+
+    private fun extract(archive: File, zip: ZipFile) {
+        if (isWindows()) {
+            extractWindows(zip)
+        } else {
+            extractUnix(archive)
+        }
+    }
+
+    private fun extractUnix(archive: File) {
+        val process = ProcessBuilder("unzip", "-o", "-q", archive.path, "-d", temporaryDir.path).start()
+        check(process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            "unzip did not finish within $COMMAND_TIMEOUT_SECONDS seconds"
+        }
+        check(process.exitValue() == 0) { "unzip failed: ${process.errorStream.bufferedReader().readText()}" }
+    }
+
+    private fun extractWindows(zip: ZipFile) {
+        val root = temporaryDir.toPath()
+        zip.entries().asSequence().forEach { entry ->
+            val destination = root.resolve(entry.name).normalize()
             if (entry.isDirectory) {
                 Files.createDirectories(destination)
             } else {
@@ -48,9 +73,6 @@ abstract class VerifyCliDistributionZip : DefaultTask() {
 
     private fun verifyLauncher(distributionRoot: File) {
         val launcher = File(distributionRoot, "bin/${launcherName()}")
-        val runtimeJava = File(distributionRoot, "runtime/${javaPath()}")
-        launcher.setExecutable(true)
-        runtimeJava.setExecutable(true)
         val command =
             if (isWindows()) {
                 listOf("cmd", "/c", launcher.path, "--help")

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.build
 import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
+import java.util.Properties
 import java.util.zip.ZipFile
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
@@ -26,6 +27,18 @@ abstract class VerifyCliDistributionZip : DefaultTask() {
             }
             check(zip.getEntry("$distributionRoot/runtime/spectre-runtime.properties") != null) {
                 "${archive.name} does not declare its bundled runtime platform"
+            }
+            val runtimePlatform =
+                zip
+                    .getInputStream(zip.getEntry("$distributionRoot/runtime/spectre-runtime.properties"))
+                    .use { input ->
+                        Properties().apply { load(input) }.let { properties ->
+                            "${archiveOperatingSystem(properties.getProperty("spectre.runtime.os"))}-" +
+                                properties.getProperty("spectre.runtime.arch")
+                        }
+                    }
+            check(archive.name.endsWith("-$runtimePlatform.zip")) {
+                "${archive.name} must name the platform of its bundled runtime ($runtimePlatform)"
             }
             validateEntries(zip)
             extract(archive, zip)
@@ -97,6 +110,14 @@ abstract class VerifyCliDistributionZip : DefaultTask() {
     private fun launcherName(): String = if (isWindows()) "spectre.bat" else "spectre"
 
     private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
+
+    private fun archiveOperatingSystem(value: String): String =
+        when (value) {
+            "Mac OS X" -> "macos"
+            "Windows" -> "windows"
+            "Linux" -> "linux"
+            else -> error("Unsupported bundled runtime operating system: $value")
+        }
 
     private companion object {
         private const val COMMAND_TIMEOUT_SECONDS: Long = 30

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
@@ -24,6 +24,9 @@ abstract class VerifyCliDistributionZip : DefaultTask() {
             check(zip.getEntry("$distributionRoot/bin/${launcherName()}") != null) {
                 "${archive.name} does not contain its launcher in $distributionRoot"
             }
+            check(zip.getEntry("$distributionRoot/runtime/spectre-runtime.properties") != null) {
+                "${archive.name} does not declare its bundled runtime platform"
+            }
             extract(zip)
             verifyLauncher(File(temporaryDir, distributionRoot))
         }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliRuntimeImage.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliRuntimeImage.kt
@@ -1,0 +1,59 @@
+package dev.sebastiano.spectre.build
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+/** Verifies the CLI runtime image includes attach support and can launch the shrunk CLI. */
+abstract class VerifyCliRuntimeImage : DefaultTask() {
+    @get:InputDirectory abstract val runtimeImage: DirectoryProperty
+
+    @get:InputFile abstract val artifact: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val java = runtimeImage.file(javaPath()).get().asFile
+        check(java.isFile) { "Runtime image does not contain ${java.path}" }
+
+        val modules = runCommand(java, "--list-modules")
+        check(modules.lineSequence().any { it.startsWith("jdk.attach@") }) {
+            "Runtime image does not include jdk.attach:\n$modules"
+        }
+
+        runCommand(java, "-jar", artifact.get().asFile.path, "--help")
+    }
+
+    private fun runCommand(executable: File, vararg arguments: String): String {
+        val process =
+            ProcessBuilder(executable.path, *arguments)
+                .redirectErrorStream(true)
+                .start()
+        if (!process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            process.waitFor(PROCESS_KILL_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            error(
+                "${executable.name} ${arguments.joinToString(" ")} did not finish within " +
+                    "$COMMAND_TIMEOUT_SECONDS seconds"
+            )
+        }
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        check(process.exitValue() == 0) {
+            "${executable.name} ${arguments.joinToString(" ")} failed:\n$output"
+        }
+        return output
+    }
+
+    private fun javaPath(): String = if (isWindows()) "bin/java.exe" else "bin/java"
+
+    private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
+
+    private companion object {
+        private const val COMMAND_TIMEOUT_SECONDS: Long = 30
+        private const val PROCESS_KILL_TIMEOUT_SECONDS: Long = 1
+    }
+}

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -67,6 +67,9 @@ tasks.named<CreateStartScripts>("startShadowScripts") {
 tasks.named<Zip>("shadowDistZip") {
     archiveFileName.set("spectre-cli-${project.version}.zip")
     dependsOn(patchShadowStartScripts)
+    // PatchStartScripts mutates the generated launcher after Shadow has assembled its copy spec.
+    // Recreate the archive so direct release builds cannot reuse an earlier unpatched ZIP.
+    outputs.upToDateWhen { false }
 }
 
 val verifyCliShadowJar =

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -101,7 +101,15 @@ val createCliRuntimeImage =
 
 tasks.named<Zip>("shadowDistZip") {
     dependsOn(createCliRuntimeImage)
-    from(cliRuntimeImage) { into("spectre-cli-${project.version}/runtime") }
+    from(cliRuntimeImage) {
+        include("bin/**", "lib/jspawnhelper")
+        into("spectre-cli-${project.version}/runtime")
+        filePermissions { unix("rwxr-xr-x") }
+    }
+    from(cliRuntimeImage) {
+        exclude("bin/**", "lib/jspawnhelper")
+        into("spectre-cli-${project.version}/runtime")
+    }
 }
 
 val verifyCliRuntimeImage =

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,7 +1,11 @@
+import dev.sebastiano.spectre.build.CreateCliRuntimeImage
 import dev.sebastiano.spectre.build.PatchStartScripts
+import dev.sebastiano.spectre.build.VerifyCliRuntimeImage
 import dev.sebastiano.spectre.build.VerifyCliShadowJar
 import org.gradle.api.tasks.application.CreateStartScripts
 import org.gradle.api.tasks.bundling.Zip
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
 
 plugins {
     application
@@ -70,9 +74,37 @@ val verifyCliShadowJar =
         artifact.set(tasks.shadowJar.flatMap { it.archiveFile })
     }
 
-tasks.assemble { dependsOn(verifyCliShadowJar) }
+val cliRuntimeImage = layout.buildDirectory.dir("runtime/cli")
+val javaToolchains = extensions.getByType<JavaToolchainService>()
+val jlinkBinary =
+    javaToolchains
+        .launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+        .map { launcher ->
+            launcher.metadata.installationPath.file(
+                if (isWindows()) "bin/jlink.exe" else "bin/jlink"
+            )
+        }
 
-tasks.check { dependsOn(verifyCliShadowJar) }
+val createCliRuntimeImage =
+    tasks.register<CreateCliRuntimeImage>("createCliRuntimeImage") {
+        description = "Creates the host jlink runtime image for the Spectre CLI bundle."
+        group = "distribution"
+        jlinkExecutable.set(jlinkBinary)
+        runtimeImage.set(cliRuntimeImage)
+    }
+
+val verifyCliRuntimeImage =
+    tasks.register<VerifyCliRuntimeImage>("verifyCliRuntimeImage") {
+        dependsOn(createCliRuntimeImage)
+        runtimeImage.set(cliRuntimeImage)
+        artifact.set(tasks.shadowJar.flatMap { it.archiveFile })
+    }
+
+tasks.assemble { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage) }
+
+tasks.check { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage) }
+
+private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
 
 kotlin {
     jvmToolchain(21)

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -65,7 +65,7 @@ tasks.named<CreateStartScripts>("startShadowScripts") {
 }
 
 tasks.named<Zip>("shadowDistZip") {
-    archiveFileName.set("spectre-cli-${project.version}.zip")
+    archiveFileName.set("spectre-cli-${project.version}-${runtimeArchivePlatform()}.zip")
     dependsOn(patchShadowStartScripts)
     // PatchStartScripts mutates the generated launcher after Shadow has assembled its copy spec.
     // Recreate the archive so direct release builds cannot reuse an earlier unpatched ZIP.
@@ -103,12 +103,12 @@ tasks.named<Zip>("shadowDistZip") {
     dependsOn(createCliRuntimeImage)
     from(cliRuntimeImage) {
         include("bin/**", "lib/jspawnhelper")
-        into("spectre-cli-${project.version}/runtime")
+        into("spectre-cli-${project.version}-${runtimeArchivePlatform()}/runtime")
         filePermissions { unix("rwxr-xr-x") }
     }
     from(cliRuntimeImage) {
         exclude("bin/**", "lib/jspawnhelper")
-        into("spectre-cli-${project.version}/runtime")
+        into("spectre-cli-${project.version}-${runtimeArchivePlatform()}/runtime")
     }
 }
 
@@ -146,6 +146,17 @@ private fun runtimeArchitecture(): String =
         "aarch64",
         "arm64" -> "aarch64"
         else -> System.getProperty("os.arch")
+    }
+
+private fun runtimeArchivePlatform(): String =
+    "${runtimeArchiveOperatingSystem()}-${runtimeArchitecture()}"
+
+private fun runtimeArchiveOperatingSystem(): String =
+    when (runtimeOperatingSystem()) {
+        "Mac OS X" -> "macos"
+        "Windows" -> "windows"
+        "Linux" -> "linux"
+        else -> error("Unsupported CLI runtime operating system: ${runtimeOperatingSystem()}")
     }
 
 kotlin {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -95,6 +95,8 @@ val createCliRuntimeImage =
         group = "distribution"
         jlinkExecutable.set(jlinkBinary)
         runtimeImage.set(cliRuntimeImage)
+        targetOperatingSystem.set(runtimeOperatingSystem())
+        targetArchitecture.set(runtimeArchitecture())
     }
 
 tasks.named<Zip>("shadowDistZip") {
@@ -120,6 +122,23 @@ tasks.assemble { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage) }
 tasks.check { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage, verifyCliDistributionZip) }
 
 private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
+
+private fun runtimeOperatingSystem(): String =
+    when {
+        isWindows() -> "Windows"
+        System.getProperty("os.name").startsWith("Mac") -> "Mac OS X"
+        System.getProperty("os.name").startsWith("Linux") -> "Linux"
+        else -> System.getProperty("os.name")
+    }
+
+private fun runtimeArchitecture(): String =
+    when (System.getProperty("os.arch")) {
+        "amd64",
+        "x86_64" -> "x86_64"
+        "aarch64",
+        "arm64" -> "aarch64"
+        else -> System.getProperty("os.arch")
+    }
 
 kotlin {
     jvmToolchain(21)

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,5 +1,6 @@
 import dev.sebastiano.spectre.build.CreateCliRuntimeImage
 import dev.sebastiano.spectre.build.PatchStartScripts
+import dev.sebastiano.spectre.build.VerifyCliDistributionZip
 import dev.sebastiano.spectre.build.VerifyCliRuntimeImage
 import dev.sebastiano.spectre.build.VerifyCliShadowJar
 import org.gradle.api.tasks.application.CreateStartScripts
@@ -93,6 +94,11 @@ val createCliRuntimeImage =
         runtimeImage.set(cliRuntimeImage)
     }
 
+tasks.named<Zip>("shadowDistZip") {
+    dependsOn(createCliRuntimeImage)
+    from(cliRuntimeImage) { into("spectre-cli-${project.version}/runtime") }
+}
+
 val verifyCliRuntimeImage =
     tasks.register<VerifyCliRuntimeImage>("verifyCliRuntimeImage") {
         dependsOn(createCliRuntimeImage)
@@ -100,9 +106,15 @@ val verifyCliRuntimeImage =
         artifact.set(tasks.shadowJar.flatMap { it.archiveFile })
     }
 
+val verifyCliDistributionZip =
+    tasks.register<VerifyCliDistributionZip>("verifyCliDistributionZip") {
+        dependsOn(tasks.named("shadowDistZip"))
+        artifact.set(tasks.named<Zip>("shadowDistZip").flatMap { it.archiveFile })
+    }
+
 tasks.assemble { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage) }
 
-tasks.check { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage) }
+tasks.check { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage, verifyCliDistributionZip) }
 
 private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -40,11 +40,12 @@ Five jobs run on tag push:
    per-arch helper directories as a GitHub Actions artefact.
 5. **`publish`** (Linux runner, depends on the gate and all helper jobs) — downloads the
    helper artefacts, runs `:verifyMavenLocalPublication` to assert the publication shape, then
-   builds the version-stamped `spectre-cli-<version>.zip` Shadow distribution and runs
-   `publishToMavenCentral` against the [Sonatype Central Portal][central-portal]. Finally it
-   creates a draft GitHub release and uploads that self-contained CLI archive. Maven Central
-   remains the canonical host for library modules; do not attach a partial library jar set to
-   the GitHub release.
+   builds the version-stamped `spectre-cli-<version>-linux-x86_64.zip` Shadow distribution and
+   runs `publishToMavenCentral` against the [Sonatype Central Portal][central-portal]. Finally it
+   creates a draft GitHub release and uploads that self-contained Linux x86_64 CLI archive.
+   Maven Central remains the canonical host for library modules; do not attach a partial library
+   jar set to the GitHub release. Cross-targeted macOS, Windows, and Linux arm64 bundles remain
+   part of [#178](https://github.com/rock3r/spectre/issues/178).
 
 [ci-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/ci.yml
 [central-portal]: https://central.sonatype.com/
@@ -76,7 +77,7 @@ Manual promotion checklist:
 - Promote the Central staging deployment from the Central Portal UI.
 - Confirm the GitHub release notes link to Maven Central for artifacts instead
   of attaching a partial library jar set, and that it includes
-  `spectre-cli-<version>.zip`.
+  `spectre-cli-<version>-linux-x86_64.zip`.
 - Undraft the GitHub release with `gh release edit <tag> --draft=false`.
 
 ## Required secrets


### PR DESCRIPTION
Part of #178 and #173.

Adds a host jlink runtime image for the CLI bundle with java.se, jdk.attach, and jdk.unsupported. The build verifies the generated image exposes jdk.attach and launches the R8-shrunk CLI jar, and wires that contract into assemble and check.

Validation: ./gradlew check