### PR TITLE
Add cross-target Roast CLI bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,7 @@ name: Release
 #                            `-PprebuiltWindowsHelpersDir=...`, runs the publication-shape
 #                            verification, then `publish` against the Sonatype Central
 #                            Portal staging endpoint. Finally it uploads the Linux x86_64
-#                            self-contained CLI bundle to the draft GitHub release. Other
-#                            platform bundles are added by the cross-targeted runtime phase.
+#                            cross-targeted Roast CLI bundles to the draft GitHub release.
 #
 # Secrets used (all from repo settings):
 #   APPLE_DEVELOPER_ID_P12 / _PASSWORD                  → keychain import (mac-helper)
@@ -400,9 +399,14 @@ jobs:
             -PprebuiltLinuxHelpersDir="$RUNNER_TEMP/linux-helpers" \
             -PprebuiltWindowsHelpersDir="$RUNNER_TEMP/windows-helper"
 
-      - name: Build version-stamped Linux x86_64 CLI distribution
+      - name: Build version-stamped cross-targeted CLI distributions
         run: |
-          ./gradlew :cli:shadowDistZip \
+          ./gradlew \
+            :cli:packageLinuxX64 \
+            :cli:packageLinuxArm64 \
+            :cli:packageMacosX64 \
+            :cli:packageMacosArm64 \
+            :cli:packageWindowsX64 \
             -PVERSION_NAME="$RELEASE_VERSION" \
             -PprebuiltMacHelperPath="$RUNNER_TEMP/mac-helper/spectre-screencapture" \
             -PprebuiltLinuxHelpersDir="$RUNNER_TEMP/linux-helpers" \
@@ -441,5 +445,9 @@ jobs:
           gh release view "$GITHUB_REF_NAME" \
             || gh release create "$GITHUB_REF_NAME" --draft --title "$GITHUB_REF_NAME"
           gh release upload "$GITHUB_REF_NAME" \
-            "cli/build/distributions/spectre-cli-$RELEASE_VERSION-linux-x86_64.zip" \
+            "cli/build/construo/distributions/spectre-linuxX64.zip" \
+            "cli/build/construo/distributions/spectre-linuxArm64.zip" \
+            "cli/build/construo/distributions/spectre-macosX64.zip" \
+            "cli/build/construo/distributions/spectre-macosArm64.zip" \
+            "cli/build/construo/distributions/spectre-windowsX64.zip" \
             --clobber

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
@@ -95,7 +95,9 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
         }
         val output = process.inputStream.bufferedReader().readText()
         check(process.exitValue() == 0) { "Bundled launcher failed: $output" }
-        check("Usage: spectre" in output) { "Bundled launcher did not run the Spectre CLI: $output" }
+        check("Usage: spectre" in output.withoutAnsiSequences()) {
+            "Bundled launcher did not run the Spectre CLI: $output"
+        }
     }
 
     private fun verifyRuntimeJava(java: File) {
@@ -114,7 +116,10 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
     private companion object {
         const val EXTRACTION_TIMEOUT_SECONDS = 30L
         const val LAUNCH_TIMEOUT_SECONDS = 20L
+        val ANSI_ESCAPE_SEQUENCE = Regex("\\u001B\\[[0-?]*[ -/]*[@-~]")
     }
 
     private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
+
+    private fun String.withoutAnsiSequences(): String = replace(ANSI_ESCAPE_SEQUENCE, "")
 }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
@@ -1,0 +1,66 @@
+package dev.sebastiano.spectre.build
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.zip.ZipFile
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+/** Verifies a host-platform Roast bundle carries and starts the JVM it packages. */
+abstract class VerifyRoastCliDistribution : DefaultTask() {
+    @get:InputFile abstract val artifact: RegularFileProperty
+
+    @get:Input abstract val launcherPath: Property<String>
+
+    @TaskAction
+    fun verify() {
+        val archive = artifact.get().asFile
+        val launcher = launcherPath.get()
+        ZipFile(archive).use { zip ->
+            check(zip.getEntry(launcher) != null) { "${archive.name} does not contain $launcher" }
+            val applicationRoot = launcher.substringBeforeLast('/')
+            check(zip.getEntry("$applicationRoot/runtime/release") != null) {
+                "${archive.name} does not contain a bundled JVM release file"
+            }
+            check(zip.getEntry("$applicationRoot/app/spectre.json") != null) {
+                "${archive.name} does not contain Roast's application configuration"
+            }
+        }
+        extract(archive)
+        verifyLauncher(File(temporaryDir, launcher))
+    }
+
+    private fun extract(archive: File) {
+        val result =
+            ProcessBuilder("unzip", "-o", "-q", archive.absolutePath, "-d", temporaryDir.absolutePath)
+                .redirectErrorStream(true)
+                .start()
+        check(result.waitFor(EXTRACTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            "Timed out extracting ${archive.name}"
+        }
+        check(result.exitValue() == 0) { "Could not extract ${archive.name}" }
+    }
+
+    private fun verifyLauncher(launcher: File) {
+        val process =
+            ProcessBuilder(launcher.absolutePath, "--help")
+                .directory(launcher.parentFile)
+                .redirectErrorStream(true)
+                .start()
+        check(process.waitFor(LAUNCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            "Timed out running bundled launcher ${launcher.name}"
+        }
+        val output = process.inputStream.bufferedReader().readText()
+        check(process.exitValue() == 0) { "Bundled launcher failed: $output" }
+        check("Usage: spectre" in output) { "Bundled launcher did not run the Spectre CLI: $output" }
+    }
+
+    private companion object {
+        const val EXTRACTION_TIMEOUT_SECONDS = 30L
+        const val LAUNCH_TIMEOUT_SECONDS = 20L
+    }
+}

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.build
 
 import java.io.File
+import java.nio.file.Files
 import java.util.concurrent.TimeUnit
 import java.util.zip.ZipFile
 import org.gradle.api.DefaultTask
@@ -29,20 +30,51 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
             check(zip.getEntry("$applicationRoot/app/spectre.json") != null) {
                 "${archive.name} does not contain Roast's application configuration"
             }
+            validateEntries(zip)
+            extract(archive, zip)
         }
-        extract(archive)
         verifyLauncher(File(temporaryDir, launcher))
     }
 
-    private fun extract(archive: File) {
+    private fun validateEntries(zip: ZipFile) {
+        val root = temporaryDir.toPath()
+        zip.entries().asSequence().forEach { entry ->
+            val destination = root.resolve(entry.name).normalize()
+            check(destination.startsWith(root)) { "ZIP entry escapes the verification directory: ${entry.name}" }
+        }
+    }
+
+    private fun extract(archive: File, zip: ZipFile) {
+        if (isWindows()) {
+            extractWindows(zip)
+        } else {
+            extractUnix(archive)
+        }
+    }
+
+    private fun extractUnix(archive: File) {
         val result =
             ProcessBuilder("unzip", "-o", "-q", archive.absolutePath, "-d", temporaryDir.absolutePath)
                 .redirectErrorStream(true)
                 .start()
         check(result.waitFor(EXTRACTION_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            result.destroyForcibly()
             "Timed out extracting ${archive.name}"
         }
         check(result.exitValue() == 0) { "Could not extract ${archive.name}" }
+    }
+
+    private fun extractWindows(zip: ZipFile) {
+        val root = temporaryDir.toPath()
+        zip.entries().asSequence().forEach { entry ->
+            val destination = root.resolve(entry.name).normalize()
+            if (entry.isDirectory) {
+                Files.createDirectories(destination)
+            } else {
+                Files.createDirectories(destination.parent)
+                zip.getInputStream(entry).use { input -> Files.newOutputStream(destination).use(input::copyTo) }
+            }
+        }
     }
 
     private fun verifyLauncher(launcher: File) {
@@ -52,6 +84,7 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
                 .redirectErrorStream(true)
                 .start()
         check(process.waitFor(LAUNCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
             "Timed out running bundled launcher ${launcher.name}"
         }
         val output = process.inputStream.bufferedReader().readText()
@@ -63,4 +96,6 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
         const val EXTRACTION_TIMEOUT_SECONDS = 30L
         const val LAUNCH_TIMEOUT_SECONDS = 20L
     }
+
+    private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
 }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
@@ -17,6 +17,8 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
 
     @get:Input abstract val launcherPath: Property<String>
 
+    @get:Input abstract val runtimeJavaPath: Property<String>
+
     @TaskAction
     fun verify() {
         val archive = artifact.get().asFile
@@ -27,6 +29,9 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
             check(zip.getEntry("$applicationRoot/runtime/release") != null) {
                 "${archive.name} does not contain a bundled JVM release file"
             }
+            check(zip.getEntry(runtimeJavaPath.get()) != null) {
+                "${archive.name} does not contain the JVM launcher required to start the daemon"
+            }
             check(zip.getEntry("$applicationRoot/app/spectre.json") != null) {
                 "${archive.name} does not contain Roast's application configuration"
             }
@@ -34,6 +39,7 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
             extract(archive, zip)
         }
         verifyLauncher(File(temporaryDir, launcher))
+        verifyRuntimeJava(File(temporaryDir, runtimeJavaPath.get()))
     }
 
     private fun validateEntries(zip: ZipFile) {
@@ -90,6 +96,19 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
         val output = process.inputStream.bufferedReader().readText()
         check(process.exitValue() == 0) { "Bundled launcher failed: $output" }
         check("Usage: spectre" in output) { "Bundled launcher did not run the Spectre CLI: $output" }
+    }
+
+    private fun verifyRuntimeJava(java: File) {
+        // ZIP extraction does not reliably retain the executable bit on every host. The daemon
+        // launcher restores it before spawning this bundled JVM; mirror that contract here.
+        java.setExecutable(true, false)
+        val process = ProcessBuilder(java.absolutePath, "-version").redirectErrorStream(true).start()
+        check(process.waitFor(LAUNCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            "Timed out running bundled JVM launcher ${java.name}"
+        }
+        val output = process.inputStream.bufferedReader().readText()
+        check(process.exitValue() == 0) { "Bundled JVM launcher failed: $output" }
     }
 
     private companion object {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -306,7 +306,16 @@ private data class RoastTarget(
     fun launcherPath(version: String): String = "spectre-cli-$version/$launcherRelativePath"
 
     fun runtimeJavaPath(version: String): String =
-        "spectre-cli-$version/${launcherRelativePath.substringBeforeLast('/')}/runtime/bin/$javaExecutable"
+        listOfNotNull(
+                "spectre-cli-$version",
+                launcherRelativePath.substringBeforeLast('/', missingDelimiterValue = "").ifBlank {
+                    null
+                },
+                "runtime",
+                "bin",
+                javaExecutable,
+            )
+            .joinToString("/")
 }
 
 private fun hostRoastTarget(): RoastTarget =

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -3,6 +3,9 @@ import dev.sebastiano.spectre.build.PatchStartScripts
 import dev.sebastiano.spectre.build.VerifyCliDistributionZip
 import dev.sebastiano.spectre.build.VerifyCliRuntimeImage
 import dev.sebastiano.spectre.build.VerifyCliShadowJar
+import dev.sebastiano.spectre.build.VerifyRoastCliDistribution
+import io.github.fourlastor.construo.Target
+import io.github.fourlastor.construo.task.jvm.CreateRuntimeImageTask as ConstruoCreateRuntimeImageTask
 import org.gradle.api.tasks.application.CreateStartScripts
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.jvm.toolchain.JavaLanguageVersion
@@ -10,6 +13,7 @@ import org.gradle.jvm.toolchain.JavaToolchainService
 
 plugins {
     application
+    id("io.github.fourlastor.construo") version "2.1.0"
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktfmt)
     alias(libs.plugins.kotlinJvm)
@@ -20,6 +24,80 @@ plugins {
 application {
     applicationName = "spectre"
     mainClass = "dev.sebastiano.spectre.cli.SpectreCliKt"
+}
+
+val javaToolchains = extensions.getByType<JavaToolchainService>()
+val cliJlinkToolchain =
+    javaToolchains
+        .launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
+        .map { launcher -> launcher.metadata.installationPath }
+
+// Construo runs the host jlink against each downloaded target JDK's jmods and then packages
+// Roast with that real target JVM. That preserves Spectre's attach/instrumentation support,
+// which a GraalVM native image cannot provide.
+construo {
+    name.set("spectre")
+    humanName.set("Spectre")
+    mainClass.set(application.mainClass)
+    jarTask.set("shadowJar")
+    outputDir.set(layout.buildDirectory.dir("construo/distributions"))
+    zipFolder.set("spectre-cli-${project.version}")
+    jdkRoot.set(cliJlinkToolchain)
+
+    jlink { modules.addAll("jdk.attach", "jdk.unsupported") }
+
+    targets {
+        create<Target.Linux>("linuxX64") {
+            architecture.set(Target.Architecture.X86_64)
+            jdkUrl.set(temurinJdkUrl("x64", "linux", "tar.gz"))
+        }
+        create<Target.Linux>("linuxArm64") {
+            architecture.set(Target.Architecture.AARCH64)
+            jdkUrl.set(temurinJdkUrl("aarch64", "linux", "tar.gz"))
+        }
+        create<Target.MacOs>("macosX64") {
+            architecture.set(Target.Architecture.X86_64)
+            jdkUrl.set(temurinJdkUrl("x64", "mac", "tar.gz"))
+            identifier.set("dev.sebastiano.spectre")
+            buildNumber.set(project.version.toString())
+            versionNumber.set(project.version.toString())
+        }
+        create<Target.MacOs>("macosArm64") {
+            architecture.set(Target.Architecture.AARCH64)
+            jdkUrl.set(temurinJdkUrl("aarch64", "mac", "tar.gz"))
+            identifier.set("dev.sebastiano.spectre")
+            buildNumber.set(project.version.toString())
+            versionNumber.set(project.version.toString())
+        }
+        create<Target.Windows>("windowsX64") {
+            architecture.set(Target.Architecture.X86_64)
+            jdkUrl.set(temurinJdkUrl("x64", "windows", "zip"))
+            useConsole.set(true)
+        }
+    }
+}
+
+// Construo 2.1.0 scans the unzipped JDK when serializing the configuration cache. The archive
+// root is stable for our pinned Temurin release, so use a static input directory that Gradle can
+// serialize and that the unzip task creates before jlink runs.
+tasks.named<ConstruoCreateRuntimeImageTask>("createRuntimeImageLinuxX64") {
+    targetJdkRoot.set(targetJdkHome("linuxX64"))
+}
+
+tasks.named<ConstruoCreateRuntimeImageTask>("createRuntimeImageLinuxArm64") {
+    targetJdkRoot.set(targetJdkHome("linuxArm64"))
+}
+
+tasks.named<ConstruoCreateRuntimeImageTask>("createRuntimeImageMacosX64") {
+    targetJdkRoot.set(targetJdkHome("macosX64", macBundle = true))
+}
+
+tasks.named<ConstruoCreateRuntimeImageTask>("createRuntimeImageMacosArm64") {
+    targetJdkRoot.set(targetJdkHome("macosArm64", macBundle = true))
+}
+
+tasks.named<ConstruoCreateRuntimeImageTask>("createRuntimeImageWindowsX64") {
+    targetJdkRoot.set(targetJdkHome("windowsX64"))
 }
 
 tasks.shadowJar {
@@ -79,7 +157,6 @@ val verifyCliShadowJar =
     }
 
 val cliRuntimeImage = layout.buildDirectory.dir("runtime/cli")
-val javaToolchains = extensions.getByType<JavaToolchainService>()
 val jlinkBinary =
     javaToolchains
         .launcherFor { languageVersion.set(JavaLanguageVersion.of(21)) }
@@ -125,9 +202,26 @@ val verifyCliDistributionZip =
         artifact.set(tasks.named<Zip>("shadowDistZip").flatMap { it.archiveFile })
     }
 
+val verifyRoastCliDistribution =
+    tasks.register<VerifyRoastCliDistribution>("verifyRoastCliDistribution") {
+        val hostTarget = hostRoastTarget()
+        dependsOn(tasks.named("package${hostTarget.taskSuffix}"))
+        artifact.set(
+            layout.buildDirectory.file("construo/distributions/spectre-${hostTarget.name}.zip")
+        )
+        launcherPath.set(hostTarget.launcherPath(project.version.toString()))
+    }
+
 tasks.assemble { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage) }
 
-tasks.check { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage, verifyCliDistributionZip) }
+tasks.check {
+    dependsOn(
+        verifyCliShadowJar,
+        verifyCliRuntimeImage,
+        verifyCliDistributionZip,
+        verifyRoastCliDistribution,
+    )
+}
 
 private fun isWindows(): Boolean = System.getProperty("os.name").startsWith("Windows")
 
@@ -157,6 +251,40 @@ private fun runtimeArchiveOperatingSystem(): String =
         "Windows" -> "windows"
         "Linux" -> "linux"
         else -> error("Unsupported CLI runtime operating system: ${runtimeOperatingSystem()}")
+    }
+
+private fun temurinJdkUrl(
+    architecture: String,
+    operatingSystem: String,
+    extension: String,
+): String {
+    val version = "21.0.11_10"
+    return ("https://github.com/adoptium/temurin21-binaries/releases/download/" +
+        "jdk-21.0.11%2B10/OpenJDK21U-jdk_${architecture}_${operatingSystem}_hotspot_${version}.${extension}")
+}
+
+private fun targetJdkHome(target: String, macBundle: Boolean = false) =
+    layout.buildDirectory.dir(
+        "construo/jdk/$target/jdk-21.0.11+10" + if (macBundle) "/Contents/Home" else ""
+    )
+
+private data class RoastTarget(
+    val name: String,
+    val taskSuffix: String,
+    val launcherRelativePath: String,
+) {
+    fun launcherPath(version: String): String = "spectre-cli-$version/$launcherRelativePath"
+}
+
+private fun hostRoastTarget(): RoastTarget =
+    when (runtimeArchivePlatform()) {
+        "linux-x86_64" -> RoastTarget("linuxX64", "LinuxX64", "spectre")
+        "linux-aarch64" -> RoastTarget("linuxArm64", "LinuxArm64", "spectre")
+        "macos-x86_64" -> RoastTarget("macosX64", "MacosX64", "Spectre.app/Contents/MacOS/spectre")
+        "macos-aarch64" ->
+            RoastTarget("macosArm64", "MacosArm64", "Spectre.app/Contents/MacOS/spectre")
+        "windows-x86_64" -> RoastTarget("windowsX64", "WindowsX64", "spectre.exe")
+        else -> error("Unsupported Roast target: ${runtimeArchivePlatform()}")
     }
 
 kotlin {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -6,6 +6,7 @@ import dev.sebastiano.spectre.build.VerifyCliShadowJar
 import dev.sebastiano.spectre.build.VerifyRoastCliDistribution
 import io.github.fourlastor.construo.Target
 import io.github.fourlastor.construo.task.jvm.CreateRuntimeImageTask as ConstruoCreateRuntimeImageTask
+import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.application.CreateStartScripts
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.jvm.toolchain.JavaLanguageVersion
@@ -99,6 +100,18 @@ tasks.named<ConstruoCreateRuntimeImageTask>("createRuntimeImageMacosArm64") {
 tasks.named<ConstruoCreateRuntimeImageTask>("createRuntimeImageWindowsX64") {
     targetJdkRoot.set(targetJdkHome("windowsX64"))
 }
+
+// Construo strips native commands from its jlink image. Spectre must retain the `java` launcher:
+// the foreground Roast process starts a separate daemon JVM for attach-capable commands.
+preserveRuntimeJavaLauncher("linuxX64")
+
+preserveRuntimeJavaLauncher("linuxArm64")
+
+preserveRuntimeJavaLauncher("macosX64", macBundle = true)
+
+preserveRuntimeJavaLauncher("macosArm64", macBundle = true)
+
+preserveRuntimeJavaLauncher("windowsX64")
 
 tasks.shadowJar {
     val agentRuntimeJar = project(":agent-runtime").tasks.named<Jar>("jar")
@@ -210,6 +223,7 @@ val verifyRoastCliDistribution =
             layout.buildDirectory.file("construo/distributions/spectre-${hostTarget.name}.zip")
         )
         launcherPath.set(hostTarget.launcherPath(project.version.toString()))
+        runtimeJavaPath.set(hostTarget.runtimeJavaPath(project.version.toString()))
     }
 
 tasks.assemble { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage) }
@@ -268,12 +282,31 @@ private fun targetJdkHome(target: String, macBundle: Boolean = false) =
         "construo/jdk/$target/jdk-21.0.11+10" + if (macBundle) "/Contents/Home" else ""
     )
 
+private fun preserveRuntimeJavaLauncher(target: String, macBundle: Boolean = false) {
+    val taskSuffix = target.replaceFirstChar(Char::uppercase)
+    val javaExecutable = if (target.startsWith("windows")) "java.exe" else "java"
+    val createRuntimeImage =
+        tasks.named<ConstruoCreateRuntimeImageTask>("createRuntimeImage$taskSuffix")
+    val preserveLauncher =
+        tasks.register<Copy>("preserveRuntimeJavaLauncher$taskSuffix") {
+            dependsOn(createRuntimeImage)
+            from(targetJdkHome(target, macBundle).map { it.file("bin/$javaExecutable") })
+            into(layout.buildDirectory.dir("construo/runtime-image/cli-$target/bin"))
+            filePermissions { unix("rwxr-xr-x") }
+        }
+    tasks.named("roast$taskSuffix") { dependsOn(preserveLauncher) }
+}
+
 private data class RoastTarget(
     val name: String,
     val taskSuffix: String,
     val launcherRelativePath: String,
+    val javaExecutable: String = "java",
 ) {
     fun launcherPath(version: String): String = "spectre-cli-$version/$launcherRelativePath"
+
+    fun runtimeJavaPath(version: String): String =
+        "spectre-cli-$version/${launcherRelativePath.substringBeforeLast('/')}/runtime/bin/$javaExecutable"
 }
 
 private fun hostRoastTarget(): RoastTarget =
@@ -283,7 +316,7 @@ private fun hostRoastTarget(): RoastTarget =
         "macos-x86_64" -> RoastTarget("macosX64", "MacosX64", "Spectre.app/Contents/MacOS/spectre")
         "macos-aarch64" ->
             RoastTarget("macosArm64", "MacosArm64", "Spectre.app/Contents/MacOS/spectre")
-        "windows-x86_64" -> RoastTarget("windowsX64", "WindowsX64", "spectre.exe")
+        "windows-x86_64" -> RoastTarget("windowsX64", "WindowsX64", "spectre.exe", "java.exe")
         else -> error("Unsupported Roast target: ${runtimeArchivePlatform()}")
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -13,6 +13,7 @@ public class DaemonProcessLauncher(
     @Throws(IOException::class)
     public fun start(): Process =
         ProcessBuilder(command())
+            .also { restoreBundledJavaExecutePermission() }
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
             .redirectError(ProcessBuilder.Redirect.DISCARD)
             .start()
@@ -32,6 +33,11 @@ public class DaemonProcessLauncher(
         System.getProperty("dev.sebastiano.spectre.agent.runtimeJar")
             ?.let { listOf("-Ddev.sebastiano.spectre.agent.runtimeJar=$it") }
             .orEmpty()
+
+    private fun restoreBundledJavaExecutePermission() {
+        if (javaExecutable != defaultJavaExecutable()) return
+        Path.of(javaExecutable).toFile().setExecutable(true, false)
+    }
 
     private companion object {
         private const val DAEMON_MAIN_CLASS: String =


### PR DESCRIPTION
## Summary
- configure Construo target JDKs for Linux x86_64/aarch64, macOS x86_64/aarch64, and Windows x86_64
- build each target with the JDK 21 toolchain, foreign jmods, and Roast; keep Windows console-subsystem enabled
- add a host-platform archive verifier that runs the bundled Roast launcher from its embedded runtime
- make Construo's pinned JDK roots configuration-cache-safe

## Verification
- Calculating task graph as configuration cache cannot be reused because file 'cli/build.gradle.kts' has changed.
Type-safe project accessors is an incubating feature.
Kotlin does not yet support 26 JDK target, falling back to Kotlin JVM_25 JVM target
> Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED

> Task :buildSrc:compileKotlin UP-TO-DATE
Kotlin does not yet support 26 JDK target, falling back to Kotlin JVM_25 JVM target

> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources NO-SOURCE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE
:agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
:agent:compileKotlin SKIPPED
:agent:compileJava SKIPPED
:agent:processResources SKIPPED
:agent:classes SKIPPED
:agent:jar SKIPPED
:agent-runtime:checkKotlinGradlePluginConfigurationErrors SKIPPED
:agent-runtime:compileKotlin SKIPPED
:agent-runtime:compileJava SKIPPED
:agent-runtime:processResources SKIPPED
:agent-runtime:classes SKIPPED
:agent-runtime:jar SKIPPED
:cli:checkKotlinGradlePluginConfigurationErrors SKIPPED
:recording:checkKotlinGradlePluginConfigurationErrors SKIPPED
:recording:compileKotlin SKIPPED
:recording:compileJava SKIPPED
:recording:processResources SKIPPED
:recording:classes SKIPPED
:recording:jar SKIPPED
:cli:compileKotlin SKIPPED
:cli:compileJava SKIPPED
:cli:processResources SKIPPED
:cli:classes SKIPPED
:agent-test-fixture:checkKotlinGradlePluginConfigurationErrors SKIPPED
:agent-test-fixture:convertXmlValueResourcesForMain SKIPPED
:agent-test-fixture:copyNonXmlValueResourcesForMain SKIPPED
:agent-test-fixture:prepareComposeResourcesTaskForMain SKIPPED
:agent-test-fixture:generateResourceAccessorsForMain SKIPPED
:agent-test-fixture:generateActualResourceCollectorsForMain SKIPPED
:agent-test-fixture:generateComposeResClass SKIPPED
:core:checkKotlinGradlePluginConfigurationErrors SKIPPED
:core:compileKotlin SKIPPED
:core:compileJava SKIPPED
:core:processResources SKIPPED
:core:classes SKIPPED
:core:jar SKIPPED
:agent-test-fixture:compileKotlin SKIPPED
:agent-test-fixture:compileJava SKIPPED
:agent-test-fixture:assembleMainResources SKIPPED
:agent-test-fixture:processResources SKIPPED
:agent-test-fixture:classes SKIPPED
:agent-test-fixture:jar SKIPPED
:cli:jar SKIPPED
:cli:compileTestKotlin SKIPPED
:cli:compileTestJava SKIPPED
:recording-linux:checkKotlinGradlePluginConfigurationErrors SKIPPED
:recording-linux:compileKotlin SKIPPED
:recording-linux:compileJava SKIPPED
:recording-linux:processResources SKIPPED
:recording-linux:classes SKIPPED
:recording-linux:jar SKIPPED
:recording-macos:checkKotlinGradlePluginConfigurationErrors SKIPPED
:recording-macos:compileKotlin SKIPPED
:recording-macos:compileJava SKIPPED
:recording:buildScreenCaptureKitHelper SKIPPED
:recording:assembleScreenCaptureKitHelper SKIPPED
:recording-macos:processResources SKIPPED
:recording-macos:classes SKIPPED
:recording-macos:jar SKIPPED
:recording-windows:checkKotlinGradlePluginConfigurationErrors SKIPPED
:recording-windows:compileKotlin SKIPPED
:recording-windows:compileJava SKIPPED
:recording-windows:processResources SKIPPED
:recording-windows:classes SKIPPED
:recording-windows:jar SKIPPED
:cli:shadowJar SKIPPED
:cli:downloadJdkLinuxX64 SKIPPED
:cli:unzipJdkLinuxX64 SKIPPED
:cli:createRuntimeImageLinuxX64 SKIPPED
:cli:downloadRoastLinuxX64 SKIPPED
:cli:unzipRoastLinuxX64 SKIPPED
:cli:roastLinuxX64 SKIPPED
:cli:packageLinuxX64 SKIPPED

BUILD SUCCESSFUL in 821ms
3 actionable tasks: 3 up-to-date
Configuration cache entry stored.
- Calculating task graph as configuration cache cannot be reused because file 'cli/build.gradle.kts' has changed.
Type-safe project accessors is an incubating feature.
Kotlin does not yet support 26 JDK target, falling back to Kotlin JVM_25 JVM target
> Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED

> Task :buildSrc:compileKotlin UP-TO-DATE
Kotlin does not yet support 26 JDK target, falling back to Kotlin JVM_25 JVM target

> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources NO-SOURCE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE
> Task :recording:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :cli:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-runtime:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:processResources NO-SOURCE
> Task :agent-test-fixture:generateComposeResClass SKIPPED
> Task :agent-test-fixture:convertXmlValueResourcesForMain NO-SOURCE
> Task :core:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording-linux:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording:processResources NO-SOURCE
> Task :cli:processResources NO-SOURCE
> Task :agent-runtime:processResources NO-SOURCE
> Task :recording-macos:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :cli:generatePListMacosArm64 UP-TO-DATE
> Task :core:processResources NO-SOURCE
> Task :recording:compileKotlin UP-TO-DATE
> Task :recording-windows:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :recording-linux:processResources NO-SOURCE
> Task :recording-linux:compileKotlin NO-SOURCE
> Task :recording:buildScreenCaptureKitHelper UP-TO-DATE
> Task :recording:compileJava NO-SOURCE
> Task :recording-macos:compileKotlin NO-SOURCE
> Task :agent:compileKotlin UP-TO-DATE
> Task :recording-windows:compileKotlin NO-SOURCE
> Task :recording:assembleScreenCaptureKitHelper UP-TO-DATE
> Task :agent-test-fixture:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :recording-windows:processResources NO-SOURCE
> Task :cli:downloadJdkMacosArm64 UP-TO-DATE
> Task :recording:classes UP-TO-DATE
> Task :recording-linux:compileJava NO-SOURCE
> Task :agent-test-fixture:generateResourceAccessorsForMain SKIPPED
> Task :recording-linux:classes UP-TO-DATE
> Task :core:compileKotlin UP-TO-DATE
> Task :agent-test-fixture:generateActualResourceCollectorsForMain SKIPPED
> Task :recording-macos:processResources UP-TO-DATE
> Task :recording-macos:compileJava NO-SOURCE
> Task :recording-windows:compileJava NO-SOURCE
> Task :recording:jar UP-TO-DATE
> Task :recording-macos:classes UP-TO-DATE
> Task :recording-windows:classes UP-TO-DATE
> Task :agent-test-fixture:assembleMainResources UP-TO-DATE
> Task :agent:compileJava NO-SOURCE
> Task :agent:classes UP-TO-DATE
> Task :recording-linux:jar UP-TO-DATE
> Task :cli:unzipJdkMacosArm64 UP-TO-DATE
> Task :agent-test-fixture:processResources UP-TO-DATE
> Task :cli:downloadRoastMacosArm64 UP-TO-DATE
> Task :recording-windows:jar UP-TO-DATE
> Task :recording-macos:jar UP-TO-DATE
> Task :core:compileJava NO-SOURCE
> Task :core:classes UP-TO-DATE
> Task :agent:jar UP-TO-DATE
> Task :cli:unzipRoastMacosArm64 UP-TO-DATE
> Task :core:jar UP-TO-DATE
> Task :agent-runtime:compileKotlin NO-SOURCE
> Task :agent-runtime:compileJava NO-SOURCE
> Task :agent-runtime:classes UP-TO-DATE
> Task :agent-runtime:jar UP-TO-DATE
> Task :cli:compileKotlin UP-TO-DATE
> Task :agent-test-fixture:compileKotlin UP-TO-DATE
> Task :cli:compileJava NO-SOURCE
> Task :cli:classes UP-TO-DATE
> Task :agent-test-fixture:compileJava NO-SOURCE
> Task :agent-test-fixture:classes UP-TO-DATE
> Task :cli:jar UP-TO-DATE
> Task :agent-test-fixture:jar UP-TO-DATE
> Task :cli:compileTestKotlin UP-TO-DATE
> Task :cli:compileTestJava NO-SOURCE
> Task :cli:shadowJar UP-TO-DATE
> Task :cli:createRuntimeImageMacosArm64 UP-TO-DATE
> Task :cli:roastMacosArm64 UP-TO-DATE
> Task :cli:buildMacAppBundleMacosArm64 UP-TO-DATE
> Task :cli:packageMacosArm64 UP-TO-DATE
> Task :cli:verifyRoastCliDistribution

BUILD SUCCESSFUL in 2s
34 actionable tasks: 1 executed, 33 up-to-date
Configuration cache entry stored.
- Calculating task graph as configuration cache cannot be reused because a build logic input of type 'JavaRuntimeMetadataValueSource' has changed.
Type-safe project accessors is an incubating feature.
Kotlin does not yet support 26 JDK target, falling back to Kotlin JVM_25 JVM target
> Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED

> Task :buildSrc:compileKotlin UP-TO-DATE
Kotlin does not yet support 26 JDK target, falling back to Kotlin JVM_25 JVM target

> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources NO-SOURCE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE
> Task :agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:processResources NO-SOURCE
> Task :agent-test-fixture:ktfmtCheckMain UP-TO-DATE
> Task :agent-test-fixture:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:ktfmtCheckTest UP-TO-DATE
> Task :agent-test-fixture:ktfmtCheckDev NO-SOURCE
> Task :agent:ktfmtCheckMain UP-TO-DATE
> Task :agent-test-fixture:generateComposeResClass SKIPPED
> Task :agent-test-fixture:ktfmtCheckTest NO-SOURCE
> Task :detekt NO-SOURCE
> Task :agent-test-fixture:convertXmlValueResourcesForMain NO-SOURCE
> Task :agent:ktfmtCheckSpike NO-SOURCE
> Task :agent-test-fixture:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :core:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:processTestResources NO-SOURCE
> Task :core:ktfmtCheckMain UP-TO-DATE
> Task :agent-test-fixture:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :agent-test-fixture:generateResourceAccessorsForMain SKIPPED
> Task :agent-test-fixture:generateActualResourceCollectorsForMain SKIPPED
> Task :core:ktfmtCheckTest UP-TO-DATE
> Task :agent-runtime:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :core:processResources NO-SOURCE
> Task :agent-test-fixture:assembleMainResources UP-TO-DATE
> Task :agent-runtime:ktfmtCheckMain NO-SOURCE
> Task :agent-runtime:processResources NO-SOURCE
> Task :agent-test-fixture:processResources UP-TO-DATE
> Task :agent-runtime:ktfmtCheckTest NO-SOURCE
> Task :agent-runtime:processTestResources NO-SOURCE
> Task :agent-test-fixture:convertXmlValueResourcesForTest NO-SOURCE
> Task :agent-test-fixture:copyNonXmlValueResourcesForTest NO-SOURCE
> Task :cli:ktfmtCheckTest UP-TO-DATE
> Task :cli:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:prepareComposeResourcesTaskForTest NO-SOURCE
> Task :agent-test-fixture:ktfmtCheckScripts UP-TO-DATE
> Task :agent-test-fixture:generateResourceAccessorsForTest SKIPPED
> Task :cli:ktfmtCheckMain UP-TO-DATE
> Task :agent-test-fixture:ktfmtCheck UP-TO-DATE
> Task :recording:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording:ktfmtCheckMain UP-TO-DATE
> Task :recording:processResources NO-SOURCE
> Task :agent-runtime:ktfmtCheckScripts UP-TO-DATE
> Task :cli:processResources NO-SOURCE
> Task :agent-runtime:ktfmtCheck UP-TO-DATE
> Task :agent-test-fixture:assembleTestResources UP-TO-DATE
> Task :recording:ktfmtCheckTest UP-TO-DATE
> Task :recording-linux:ktfmtCheckMain NO-SOURCE
> Task :recording-linux:ktfmtCheckTest NO-SOURCE
> Task :recording-linux:processResources NO-SOURCE
> Task :recording-linux:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:processTestResources UP-TO-DATE
> Task :recording-linux:ktfmtCheckScripts UP-TO-DATE
> Task :recording-macos:ktfmtCheckMain NO-SOURCE
> Task :recording-macos:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording-macos:ktfmtCheckTest NO-SOURCE
> Task :recording-linux:compileKotlin NO-SOURCE
> Task :recording:buildScreenCaptureKitHelper UP-TO-DATE
> Task :recording-linux:compileJava NO-SOURCE
> Task :recording-linux:classes UP-TO-DATE
> Task :recording-macos:ktfmtCheckScripts UP-TO-DATE
> Task :recording:assembleScreenCaptureKitHelper UP-TO-DATE
> Task :recording-windows:ktfmtCheckMain NO-SOURCE
> Task :recording-windows:ktfmtCheckScripts UP-TO-DATE
> Task :recording-macos:compileKotlin NO-SOURCE
> Task :recording-windows:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording-linux:jar UP-TO-DATE
> Task :recording-windows:ktfmtCheckTest NO-SOURCE
> Task :recording-macos:processResources UP-TO-DATE
> Task :recording-macos:compileJava NO-SOURCE
> Task :recording-macos:classes UP-TO-DATE
> Task :recording-windows:processResources NO-SOURCE
> Task :recording-macos:jar UP-TO-DATE
> Task :cli:processTestResources NO-SOURCE
> Task :cli:downloadJdkMacosArm64 UP-TO-DATE
> Task :recording-windows:compileKotlin NO-SOURCE
> Task :cli:generatePListMacosArm64 UP-TO-DATE
> Task :cli:downloadRoastMacosArm64 UP-TO-DATE
> Task :core:processTestResources NO-SOURCE
> Task :agent:ktfmtCheckScripts UP-TO-DATE
> Task :recording-windows:compileJava NO-SOURCE
> Task :cli:unzipJdkMacosArm64 UP-TO-DATE
> Task :agent:ktfmtCheck UP-TO-DATE
> Task :recording-windows:classes UP-TO-DATE
> Task :cli:unzipRoastMacosArm64 UP-TO-DATE
> Task :core:ktfmtCheckScripts UP-TO-DATE
> Task :recording:processTestResources UP-TO-DATE
> Task :recording-linux:detektMain NO-SOURCE
> Task :core:ktfmtCheck UP-TO-DATE
> Task :recording-linux:ktfmtCheck UP-TO-DATE
> Task :recording-windows:jar UP-TO-DATE
> Task :recording-linux:verifyRecordingLinuxHelpers SKIPPED
> Task :cli:createCliRuntimeImage UP-TO-DATE
> Task :recording-linux:compileTestKotlin NO-SOURCE
> Task :agent:compileKotlin UP-TO-DATE
> Task :recording-linux:processTestResources NO-SOURCE
> Task :recording-macos:ktfmtCheck UP-TO-DATE
> Task :recording-linux:compileTestJava NO-SOURCE
> Task :agent:compileJava NO-SOURCE
> Task :agent:classes UP-TO-DATE
> Task :recording-macos:compileTestKotlin NO-SOURCE
> Task :agent:internalDumpKotlinAbi UP-TO-DATE
> Task :recording-macos:processTestResources NO-SOURCE
> Task :recording-linux:testClasses UP-TO-DATE
> Task :recording-macos:detektMain NO-SOURCE
> Task :recording-linux:detektTest NO-SOURCE
> Task :agent:jar UP-TO-DATE
> Task :recording-macos:compileTestJava NO-SOURCE
> Task :agent:detektMain UP-TO-DATE
> Task :recording-macos:testClasses UP-TO-DATE
> Task :recording-macos:verifyRecordingMacosHelpers
> Task :agent-runtime:compileKotlin NO-SOURCE
> Task :agent:checkKotlinAbi
> Task :recording-windows:ktfmtCheck UP-TO-DATE
> Task :core:compileKotlin UP-TO-DATE
> Task :recording-linux:detekt NO-SOURCE
> Task :recording-macos:detektTest NO-SOURCE
> Task :recording-windows:verifyRecordingWindowsHelper SKIPPED
> Task :recording-windows:processTestResources NO-SOURCE
> Task :agent-runtime:compileJava NO-SOURCE
> Task :agent-runtime:classes UP-TO-DATE
> Task :recording-windows:compileTestKotlin NO-SOURCE
> Task :recording-windows:detektMain NO-SOURCE
> Task :core:compileJava NO-SOURCE
> Task :sample-desktop:ktfmtCheckDev NO-SOURCE
> Task :recording-macos:detekt NO-SOURCE
> Task :core:classes UP-TO-DATE
> Task :agent-runtime:detektMain NO-SOURCE
> Task :sample-desktop:ktfmtCheckMain UP-TO-DATE
> Task :recording-windows:compileTestJava NO-SOURCE
> Task :core:jar UP-TO-DATE
> Task :recording-windows:testClasses UP-TO-DATE
> Task :agent-runtime:jar UP-TO-DATE
> Task :agent-runtime:compileTestKotlin NO-SOURCE
> Task :core:internalDumpKotlinAbi UP-TO-DATE
> Task :recording-windows:detektTest NO-SOURCE
> Task :core:detektMain UP-TO-DATE
> Task :core:checkKotlinAbi
> Task :agent-runtime:compileTestJava NO-SOURCE
> Task :recording-windows:detekt NO-SOURCE
> Task :agent-runtime:testClasses UP-TO-DATE
> Task :sample-desktop:ktfmtCheckTest UP-TO-DATE
> Task :agent-runtime:verifyAgentRuntimeJarContents
> Task :sample-desktop:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-runtime:detektTest NO-SOURCE
> Task :agent-runtime:test NO-SOURCE
> Task :sample-desktop:generateComposeResClass SKIPPED
> Task :sample-desktop:ktfmtCheckValidation UP-TO-DATE
> Task :sample-desktop:convertXmlValueResourcesForMain NO-SOURCE
> Task :agent-test-fixture:compileKotlin UP-TO-DATE
> Task :agent-runtime:detekt NO-SOURCE
> Task :agent-runtime:check
> Task :sample-desktop:convertXmlValueResourcesForTest NO-SOURCE
> Task :sample-desktop:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :sample-desktop:copyNonXmlValueResourcesForTest NO-SOURCE
> Task :sample-intellij-plugin:ktfmtCheckMain UP-TO-DATE
> Task :agent-test-fixture:compileJava NO-SOURCE
> Task :agent-test-fixture:classes UP-TO-DATE
> Task :core:compileTestKotlin UP-TO-DATE
> Task :sample-intellij-plugin:ktfmtCheckDev NO-SOURCE
> Task :sample-desktop:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :sample-desktop:generateResourceAccessorsForMain SKIPPED
> Task :sample-desktop:generateActualResourceCollectorsForMain SKIPPED
> Task :agent-test-fixture:jar UP-TO-DATE
> Task :sample-desktop:prepareComposeResourcesTaskForTest NO-SOURCE
> Task :recording:ktfmtCheckScripts UP-TO-DATE
> Task :core:compileTestJava NO-SOURCE
> Task :agent-test-fixture:compileTestKotlin NO-SOURCE
> Task :sample-desktop:assembleMainResources UP-TO-DATE
> Task :agent-test-fixture:compileTestJava NO-SOURCE
> Task :agent-test-fixture:detektTest NO-SOURCE
> Task :core:testClasses UP-TO-DATE
> Task :agent-test-fixture:testClasses UP-TO-DATE
> Task :agent-test-fixture:test NO-SOURCE
> Task :recording:ktfmtCheck UP-TO-DATE
> Task :agent-test-fixture:detektMain UP-TO-DATE
> Task :sample-desktop:ktfmtCheckScripts UP-TO-DATE
> Task :agent:compileTestKotlin UP-TO-DATE
> Task :sample-desktop:processResources UP-TO-DATE
> Task :sample-desktop:generateResourceAccessorsForTest SKIPPED
> Task :sample-desktop:ktfmtCheck UP-TO-DATE
> Task :core:detektTest UP-TO-DATE
> Task :agent:compileTestJava NO-SOURCE
> Task :core:test UP-TO-DATE
> Task :agent:testClasses UP-TO-DATE
> Task :sample-desktop:assembleTestResources UP-TO-DATE
> Task :recording:compileKotlin UP-TO-DATE
> Task :agent-test-fixture:detekt UP-TO-DATE
> Task :agent-test-fixture:check UP-TO-DATE
> Task :sample-desktop:processTestResources UP-TO-DATE
> Task :sample-intellij-plugin:ktfmtCheckTest NO-SOURCE
> Task :sample-intellij-plugin:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording:compileJava NO-SOURCE
> Task :recording:classes UP-TO-DATE
> Task :sample-intellij-plugin:ktfmtCheckUiTest UP-TO-DATE
> Task :sample-desktop:compileKotlin UP-TO-DATE
> Task :recording:internalDumpKotlinAbi UP-TO-DATE
> Task :recording:jar UP-TO-DATE
> Task :recording-linux:test NO-SOURCE
> Task :recording-linux:check UP-TO-DATE
> Task :agent:test UP-TO-DATE
> Task :core:detekt UP-TO-DATE
> Task :core:check
> Task :agent:detektTest UP-TO-DATE
> Task :recording:checkKotlinAbi
> Task :recording-macos:test NO-SOURCE
> Task :recording-windows:test NO-SOURCE
> Task :recording-windows:check UP-TO-DATE
> Task :recording-macos:check
> Task :sample-desktop:compileJava NO-SOURCE
> Task :sample-intellij-plugin:generateComposeResClass SKIPPED
> Task :sample-desktop:classes UP-TO-DATE
> Task :sample-intellij-plugin:ktfmtCheckScripts UP-TO-DATE
> Task :sample-intellij-plugin:initializeIntellijPlatformPlugin
> Task :sample-intellij-plugin:convertXmlValueResourcesForMain NO-SOURCE
> Task :sample-intellij-plugin:convertXmlValueResourcesForTest NO-SOURCE
> Task :sample-intellij-plugin:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :sample-desktop:jar UP-TO-DATE
> Task :sample-intellij-plugin:copyNonXmlValueResourcesForTest NO-SOURCE
> Task :sample-intellij-plugin:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :sample-intellij-plugin:prepareComposeResourcesTaskForTest NO-SOURCE
> Task :sample-intellij-plugin:patchPluginXml UP-TO-DATE
> Task :sample-intellij-plugin:generateResourceAccessorsForTest SKIPPED
> Task :sample-intellij-plugin:generateResourceAccessorsForMain SKIPPED
> Task :sample-intellij-plugin:generateActualResourceCollectorsForMain SKIPPED
> Task :recording:detektMain UP-TO-DATE
> Task :sample-intellij-plugin:convertXmlValueResourcesForUiTest NO-SOURCE
> Task :sample-intellij-plugin:copyNonXmlValueResourcesForUiTest NO-SOURCE
> Task :recording:compileTestKotlin UP-TO-DATE
> Task :sample-intellij-plugin:prepareComposeResourcesTaskForUiTest NO-SOURCE
> Task :sample-intellij-plugin:generateResourceAccessorsForUiTest SKIPPED
> Task :sample-intellij-plugin:ktfmtCheck UP-TO-DATE
> Task :sample-intellij-plugin:assembleMainResources UP-TO-DATE
> Task :recording:compileTestJava NO-SOURCE
> Task :agent:detekt UP-TO-DATE
> Task :sample-intellij-plugin:assembleTestResources UP-TO-DATE
> Task :recording:testClasses UP-TO-DATE
> Task :sample-desktop:detektMain UP-TO-DATE
> Task :sample-intellij-plugin:processResources UP-TO-DATE
> Task :agent:check
> Task :sample-intellij-plugin:generateManifest UP-TO-DATE
> Task :server:ktfmtCheckMain UP-TO-DATE
> Task :server:ktfmtCheckTest UP-TO-DATE
> Task :sample-intellij-plugin:processTestResources UP-TO-DATE
> Task :server:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :server:processResources NO-SOURCE
> Task :recording:test UP-TO-DATE
> Task :recording:detektTest UP-TO-DATE
> Task :server:processTestResources NO-SOURCE
> Task :testing:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :testing:processResources NO-SOURCE
> Task :sample-desktop:compileTestKotlin UP-TO-DATE
> Task :testing:ktfmtCheckMain UP-TO-DATE
> Task :sample-desktop:compileTestJava NO-SOURCE
> Task :testing:processTestResources NO-SOURCE
> Task :testing:ktfmtCheckTest UP-TO-DATE
> Task :sample-desktop:testClasses UP-TO-DATE
> Task :recording:detekt UP-TO-DATE
> Task :recording:check
> Task :sample-desktop:detektTest UP-TO-DATE
> Task :sample-desktop:test UP-TO-DATE
> Task :server:ktfmtCheckScripts UP-TO-DATE
> Task :testing:ktfmtCheckScripts UP-TO-DATE
> Task :server:ktfmtCheck UP-TO-DATE
> Task :cli:ktfmtCheckScripts UP-TO-DATE
> Task :cli:ktfmtCheck UP-TO-DATE
> Task :testing:ktfmtCheck UP-TO-DATE
> Task :sample-desktop:detekt UP-TO-DATE
> Task :sample-desktop:check UP-TO-DATE
> Task :cli:compileKotlin UP-TO-DATE
> Task :cli:compileJava NO-SOURCE
> Task :cli:classes UP-TO-DATE
> Task :cli:detektMain UP-TO-DATE
> Task :cli:jar UP-TO-DATE
> Task :cli:compileTestKotlin UP-TO-DATE
> Task :cli:compileTestJava NO-SOURCE
> Task :cli:detektTest UP-TO-DATE
> Task :cli:detekt UP-TO-DATE
> Task :cli:shadowJar UP-TO-DATE
> Task :cli:testClasses UP-TO-DATE
> Task :cli:test UP-TO-DATE
> Task :server:compileKotlin UP-TO-DATE
> Task :server:compileJava NO-SOURCE
> Task :server:internalDumpKotlinAbi UP-TO-DATE
> Task :server:checkKotlinAbi
> Task :server:classes UP-TO-DATE
> Task :server:jar UP-TO-DATE
> Task :server:compileTestKotlin UP-TO-DATE
> Task :testing:compileKotlin UP-TO-DATE
> Task :server:compileTestJava NO-SOURCE
> Task :server:detektMain UP-TO-DATE
> Task :server:testClasses UP-TO-DATE
> Task :testing:compileJava NO-SOURCE
> Task :cli:createRuntimeImageMacosArm64 UP-TO-DATE
> Task :sample-intellij-plugin:compileKotlin UP-TO-DATE
> Task :sample-intellij-plugin:compileJava NO-SOURCE
> Task :sample-intellij-plugin:classes UP-TO-DATE
> Task :cli:roastMacosArm64 UP-TO-DATE
> Task :testing:internalDumpKotlinAbi UP-TO-DATE
> Task :sample-intellij-plugin:instrumentCode UP-TO-DATE
> Task :server:test UP-TO-DATE
> Task :server:detektTest UP-TO-DATE
> Task :sample-intellij-plugin:detektMain UP-TO-DATE
> Task :testing:checkKotlinAbi
> Task :testing:classes UP-TO-DATE
> Task :sample-intellij-plugin:jar UP-TO-DATE
> Task :testing:jar UP-TO-DATE
> Task :sample-intellij-plugin:compileTestKotlin NO-SOURCE
> Task :sample-intellij-plugin:compileTestJava NO-SOURCE
> Task :cli:buildMacAppBundleMacosArm64 UP-TO-DATE
> Task :sample-intellij-plugin:instrumentedJar UP-TO-DATE
> Task :sample-intellij-plugin:detektTest NO-SOURCE
> Task :sample-intellij-plugin:testClasses UP-TO-DATE
> Task :sample-intellij-plugin:instrumentTestCode UP-TO-DATE
> Task :testing:detektMain UP-TO-DATE
> Task :cli:packageMacosArm64 UP-TO-DATE
> Task :server:detekt UP-TO-DATE
> Task :sample-intellij-plugin:composedJar UP-TO-DATE
> Task :server:check
> Task :sample-intellij-plugin:prepareTestSandbox UP-TO-DATE
> Task :sample-intellij-plugin:prepareTest
> Task :sample-intellij-plugin:test NO-SOURCE
> Task :sample-intellij-plugin:prepareSandbox UP-TO-DATE
> Task :sample-intellij-plugin:detekt UP-TO-DATE
> Task :testing:compileTestKotlin UP-TO-DATE
> Task :testing:compileTestJava NO-SOURCE
> Task :testing:detektTest UP-TO-DATE
> Task :testing:detekt UP-TO-DATE
> Task :testing:testClasses UP-TO-DATE
> Task :sample-intellij-plugin:verifyPluginStructure
> Task :testing:test UP-TO-DATE
> Task :testing:check
> Task :ktfmtCheckScripts UP-TO-DATE
> Task :ktfmtCheck UP-TO-DATE
> Task :check UP-TO-DATE
> Task :cli:startShadowScripts
> Task :cli:patchShadowStartScripts
> Task :sample-intellij-plugin:compileUiTestKotlin UP-TO-DATE
> Task :sample-intellij-plugin:compileUiTestJava NO-SOURCE
> Task :sample-intellij-plugin:detektUiTest UP-TO-DATE
> Task :sample-intellij-plugin:check
> Task :cli:verifyCliRuntimeImage
> Task :cli:verifyCliShadowJar
> Task :cli:verifyRoastCliDistribution
> Task :cli:shadowDistZip
> Task :cli:verifyCliDistributionZip
> Task :cli:check

BUILD SUCCESSFUL in 10s
154 actionable tasks: 16 executed, 138 up-to-date
Configuration cache entry stored.

Part of #178, #173.