### PR TITLE
Test MCP stdio through Roast bundles

### DIFF
--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -87,12 +87,17 @@ jobs:
 
       - name: Smoke the unpacked CLI distribution against the Compose fixture
         run: |
-          ./gradlew :cli:shadowDistZip
-          archive="$(find cli/build/distributions -name 'spectre-cli-*.zip' -print -quit)"
+          case "$(uname -m)" in
+            arm64) target="MacosArm64"; archive="cli/build/construo/distributions/spectre-macosArm64.zip" ;;
+            x86_64) target="MacosX64"; archive="cli/build/construo/distributions/spectre-macosX64.zip" ;;
+            *) echo "Unsupported macOS architecture: $(uname -m)" >&2; exit 1 ;;
+          esac
+          ./gradlew ":cli:package$target"
           distribution="$RUNNER_TEMP/spectre-cli"
           unzip -q "$archive" -d "$distribution"
-          launcher="$(find "$distribution" -path '*/bin/spectre' -type f -print -quit)"
+          launcher="$(find "$distribution" -path '*/Contents/MacOS/spectre' -type f -print -quit)"
           ./gradlew :cli:test \
             --tests "*DaemonFixtureIntegrationTest.CLI binary drives a Compose fixture through ps attach find click and screenshot" \
+            --tests "*SpectreMcpStdioIntegrationTest*" \
             --rerun-tasks \
             -Dspectre.cli.distributionExecutable="$launcher"

--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -101,3 +101,15 @@ jobs:
             --tests "*SpectreMcpStdioIntegrationTest*" \
             --rerun-tasks \
             -Dspectre.cli.distributionExecutable="$launcher"
+
+      - name: Upload CLI smoke test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-cli-smoke-test-reports
+          path: |
+            cli/build/reports/tests/
+            cli/build/test-results/
+            cli/hs_err_*.log
+          if-no-files-found: ignore
+          retention-days: 14

--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -216,13 +216,14 @@ jobs:
         # together after a user unpacks the published artifact.
         if: always()
         run: |
-          ./gradlew :cli:shadowDistZip
-          archive="$(find cli/build/distributions -name 'spectre-cli-*.zip' -print -quit)"
+          ./gradlew :cli:packageLinuxX64
+          archive="cli/build/construo/distributions/spectre-linuxX64.zip"
           distribution="$RUNNER_TEMP/spectre-cli"
           unzip -q "$archive" -d "$distribution"
-          launcher="$(find "$distribution" -path '*/bin/spectre' -type f -print -quit)"
+          launcher="$(find "$distribution" -name spectre -type f -print -quit)"
           xvfb-run -a ./gradlew :cli:test \
             --tests "*DaemonFixtureIntegrationTest.CLI binary drives a Compose fixture through ps attach find click and screenshot" \
+            --tests "*SpectreMcpStdioIntegrationTest*" \
             --rerun-tasks \
             -Dspectre.cli.distributionExecutable="$launcher"
         shell: bash

--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -374,5 +374,8 @@ jobs:
             agent/build/reports/tests/
             agent/build/test-results/
             agent/hs_err_*.log
+            cli/build/reports/tests/
+            cli/build/test-results/
+            cli/hs_err_*.log
           if-no-files-found: ignore
           retention-days: 14

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -47,6 +47,10 @@ construo {
 
     jlink { modules.addAll("jdk.attach", "jdk.unsupported") }
 
+    // Spectre's Roast bundle is a command-line tool, not a macOS UI application. Running its
+    // JVM on the first thread blocks command invocation before the CLI can process its args.
+    roast { runOnFirstThread.set(false) }
+
     targets {
         create<Target.Linux>("linuxX64") {
             architecture.set(Target.Architecture.X86_64)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -631,24 +631,35 @@ internal fun daemonRequest(
                 DaemonResponse.Sessions(emptyList())
             }
         } else {
-            val launcher = DaemonProcessLauncher(resolvedSocketPath)
-            try {
-                client.requestOrStart(
-                    request = request,
-                    start = { launcher.start() },
-                    onAbsent = {
-                        attachPreflight(request)?.let { message ->
-                            DaemonResponse.Error(DaemonErrorCode.AttachFailed, message)
-                        }
-                    },
-                )
-            } catch (exception: IOException) {
-                launcher.consumeStartupError()?.let { diagnostic ->
-                    throw IOException("Daemon startup failed: $diagnostic", exception)
-                }
-                throw exception
-            }
+            daemonRequestWithLifecycle(client, resolvedSocketPath, request, attachPreflight)
         }
+    }
+}
+
+private fun daemonRequestWithLifecycle(
+    client: DaemonClient,
+    socketPath: Path,
+    request: DaemonRequest,
+    attachPreflight: (DaemonRequest) -> String?,
+): DaemonResponse {
+    val launcher = DaemonProcessLauncher(socketPath)
+    try {
+        return client
+            .requestOrStart(
+                request = request,
+                start = { launcher.start() },
+                onAbsent = {
+                    attachPreflight(request)?.let { message ->
+                        DaemonResponse.Error(DaemonErrorCode.AttachFailed, message)
+                    }
+                },
+            )
+            .also { launcher.discardStartupError() }
+    } catch (exception: IOException) {
+        launcher.consumeStartupError()?.let { diagnostic ->
+            throw IOException("Daemon startup failed: $diagnostic", exception)
+        }
+        throw exception
     }
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -631,15 +631,23 @@ internal fun daemonRequest(
                 DaemonResponse.Sessions(emptyList())
             }
         } else {
-            client.requestOrStart(
-                request = request,
-                start = { DaemonProcessLauncher(resolvedSocketPath).start() },
-                onAbsent = {
-                    attachPreflight(request)?.let { message ->
-                        DaemonResponse.Error(DaemonErrorCode.AttachFailed, message)
-                    }
-                },
-            )
+            val launcher = DaemonProcessLauncher(resolvedSocketPath)
+            try {
+                client.requestOrStart(
+                    request = request,
+                    start = { launcher.start() },
+                    onAbsent = {
+                        attachPreflight(request)?.let { message ->
+                            DaemonResponse.Error(DaemonErrorCode.AttachFailed, message)
+                        }
+                    },
+                )
+            } catch (exception: IOException) {
+                launcher.consumeStartupError()?.let { diagnostic ->
+                    throw IOException("Daemon startup failed: $diagnostic", exception)
+                }
+                throw exception
+            }
         }
     }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import java.io.IOException
+import java.nio.file.Files
 import java.nio.file.Path
 
 /** Starts a detached JVM hosting [DaemonMain] for one local socket endpoint. */
@@ -9,14 +10,22 @@ public class DaemonProcessLauncher(
     private val javaExecutable: String = defaultJavaExecutable(),
     private val classPath: String = System.getProperty("java.class.path"),
 ) {
+    private val startupErrorLog: Path = Files.createTempFile("spectre-daemon-startup-", ".log")
+
     /** Launches the daemon process without inheriting this client's standard streams. */
     @Throws(IOException::class)
     public fun start(): Process =
         ProcessBuilder(command())
             .also { restoreBundledRuntimeExecutePermissions() }
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(startupErrorLog.toFile())
             .start()
+
+    /** Returns and removes any diagnostic emitted before the daemon reached its socket. */
+    public fun consumeStartupError(): String? =
+        runCatching { Files.readString(startupErrorLog).trim().ifEmpty { null } }
+            .getOrNull()
+            .also { Files.deleteIfExists(startupErrorLog) }
 
     /** Returns the isolated daemon command without starting a process. */
     public fun command(): List<String> = buildList {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -15,7 +15,9 @@ public class DaemonProcessLauncher(
         ProcessBuilder(command())
             .also { restoreBundledRuntimeExecutePermissions() }
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            // Surface a daemon startup failure to the invoking CLI instead of reporting only
+            // the missing socket after its connection retry window expires.
+            .redirectError(ProcessBuilder.Redirect.INHERIT)
             .start()
 
     /** Returns the isolated daemon command without starting a process. */

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -13,7 +13,7 @@ public class DaemonProcessLauncher(
     @Throws(IOException::class)
     public fun start(): Process =
         ProcessBuilder(command())
-            .also { restoreBundledJavaExecutePermission() }
+            .also { restoreBundledRuntimeExecutePermissions() }
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
             .redirectError(ProcessBuilder.Redirect.DISCARD)
             .start()
@@ -34,9 +34,15 @@ public class DaemonProcessLauncher(
             ?.let { listOf("-Ddev.sebastiano.spectre.agent.runtimeJar=$it") }
             .orEmpty()
 
-    private fun restoreBundledJavaExecutePermission() {
+    private fun restoreBundledRuntimeExecutePermissions() {
         if (javaExecutable != defaultJavaExecutable()) return
-        Path.of(javaExecutable).toFile().setExecutable(true, false)
+        val javaPath = Path.of(javaExecutable)
+        javaPath.toFile().setExecutable(true, false)
+        javaPath.parent.parent
+            .resolve("lib")
+            .resolve("jspawnhelper")
+            .toFile()
+            .setExecutable(true, false)
     }
 
     private companion object {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -36,9 +36,15 @@ public class DaemonProcessLauncher(
                     .also { Files.deleteIfExists(errorLog) }
             }
 
-    /** Removes the empty startup diagnostic after the daemon accepts a request. */
+    /** Removes the startup diagnostic after a confirmed daemon exits. */
     public fun discardStartupError() {
-        startupErrorLog?.let(Files::deleteIfExists)
+        val errorLog = startupErrorLog ?: return
+        val process = daemonProcess
+        if (process?.isAlive == true) {
+            process.onExit().thenRun { Files.deleteIfExists(errorLog) }
+        } else {
+            Files.deleteIfExists(errorLog)
+        }
     }
 
     /** Returns the isolated daemon command without starting a process. */

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -10,22 +10,36 @@ public class DaemonProcessLauncher(
     private val javaExecutable: String = defaultJavaExecutable(),
     private val classPath: String = System.getProperty("java.class.path"),
 ) {
-    private val startupErrorLog: Path = Files.createTempFile("spectre-daemon-startup-", ".log")
+    private var startupErrorLog: Path? = null
+    private var daemonProcess: Process? = null
 
     /** Launches the daemon process without inheriting this client's standard streams. */
     @Throws(IOException::class)
-    public fun start(): Process =
-        ProcessBuilder(command())
+    public fun start(): Process {
+        val errorLog = Files.createTempFile("spectre-daemon-startup-", ".log")
+        startupErrorLog = errorLog
+        return ProcessBuilder(command())
             .also { restoreBundledRuntimeExecutePermissions() }
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-            .redirectError(startupErrorLog.toFile())
+            .redirectError(errorLog.toFile())
             .start()
+            .also { daemonProcess = it }
+    }
 
     /** Returns and removes any diagnostic emitted before the daemon reached its socket. */
     public fun consumeStartupError(): String? =
-        runCatching { Files.readString(startupErrorLog).trim().ifEmpty { null } }
-            .getOrNull()
-            .also { Files.deleteIfExists(startupErrorLog) }
+        startupErrorLog
+            ?.takeIf { daemonProcess?.isAlive != true }
+            ?.let { errorLog ->
+                runCatching { Files.readString(errorLog).trim().ifEmpty { null } }
+                    .getOrNull()
+                    .also { Files.deleteIfExists(errorLog) }
+            }
+
+    /** Removes the empty startup diagnostic after the daemon accepts a request. */
+    public fun discardStartupError() {
+        startupErrorLog?.let(Files::deleteIfExists)
+    }
 
     /** Returns the isolated daemon command without starting a process. */
     public fun command(): List<String> = buildList {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -15,9 +15,7 @@ public class DaemonProcessLauncher(
         ProcessBuilder(command())
             .also { restoreBundledRuntimeExecutePermissions() }
             .redirectOutput(ProcessBuilder.Redirect.DISCARD)
-            // Surface a daemon startup failure to the invoking CLI instead of reporting only
-            // the missing socket after its connection retry window expires.
-            .redirectError(ProcessBuilder.Redirect.INHERIT)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
             .start()
 
     /** Returns the isolated daemon command without starting a process. */

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -323,8 +323,9 @@ private fun runCliBinary(daemonUser: String, vararg arguments: String): CliBinar
                     // Roast launches the bundled JVM directly rather than through Gradle's
                     // generated start script, so it cannot consume SPECTRE_OPTS. The JVM
                     // itself consumes JAVA_TOOL_OPTIONS before application startup.
+                    val daemonHome = Path.of("/tmp", daemonUser)
                     environment()["JAVA_TOOL_OPTIONS"] =
-                        "-Duser.name=$daemonUser -Djava.awt.headless=false"
+                        "-Duser.name=$daemonUser -Duser.home=$daemonHome -Djava.awt.headless=false"
                 }
             }
             .start()

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -112,7 +112,7 @@ class DaemonFixtureIntegrationTest {
         try {
             spawnComposeFixture().use { fixture ->
                 val processes = runCliBinary(daemonUser, "ps", "--json")
-                assertEquals(0, processes.exitCode)
+                assertEquals(0, processes.exitCode, processes.output)
                 assertTrue(
                     Json.parseToJsonElement(processes.output)
                         .jsonObject

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -320,7 +320,10 @@ private fun runCliBinary(daemonUser: String, vararg arguments: String): CliBinar
         ProcessBuilder(command)
             .apply {
                 if (distributionExecutable != null) {
-                    environment()["SPECTRE_OPTS"] =
+                    // Roast launches the bundled JVM directly rather than through Gradle's
+                    // generated start script, so it cannot consume SPECTRE_OPTS. The JVM
+                    // itself consumes JAVA_TOOL_OPTIONS before application startup.
+                    environment()["JAVA_TOOL_OPTIONS"] =
                         "-Duser.name=$daemonUser -Djava.awt.headless=false"
                 }
             }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -112,7 +112,7 @@ class DaemonFixtureIntegrationTest {
         try {
             spawnComposeFixture().use { fixture ->
                 val processes = runCliBinary(daemonUser, "ps", "--json")
-                assertEquals(0, processes.exitCode, processes.output)
+                assertEquals(0, processes.exitCode, processes.output + processes.errorOutput)
                 assertTrue(
                     Json.parseToJsonElement(processes.output)
                         .jsonObject
@@ -327,10 +327,10 @@ private fun runCliBinary(daemonUser: String, vararg arguments: String): CliBinar
                         "-Duser.name=$daemonUser -Djava.awt.headless=false"
                 }
             }
-            .redirectErrorStream(true)
             .start()
     val output = StringBuilder()
-    val drainer =
+    val errorOutput = StringBuilder()
+    val outputDrainer =
         Thread({
                 process.inputStream.bufferedReader().use { reader ->
                     output.append(reader.readText())
@@ -340,17 +340,33 @@ private fun runCliBinary(daemonUser: String, vararg arguments: String): CliBinar
                 isDaemon = true
                 start()
             }
+    val errorDrainer =
+        Thread({
+                process.errorStream.bufferedReader().use { reader ->
+                    errorOutput.append(reader.readText())
+                }
+            })
+            .apply {
+                isDaemon = true
+                start()
+            }
     if (!process.waitFor(CLI_PROCESS_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
         process.destroyForcibly()
         process.waitFor()
-        drainer.join()
+        outputDrainer.join()
+        errorDrainer.join()
         error(
             "CLI binary did not exit within $CLI_PROCESS_TIMEOUT_SECONDS seconds: " +
                 arguments.joinToString()
         )
     }
-    drainer.join()
-    return CliBinaryResult(exitCode = process.exitValue(), output = output.toString())
+    outputDrainer.join()
+    errorDrainer.join()
+    return CliBinaryResult(
+        exitCode = process.exitValue(),
+        output = output.toString(),
+        errorOutput = errorOutput.toString(),
+    )
 }
 
 private fun startMcpBinary(daemonUser: String): Process {
@@ -375,7 +391,7 @@ private suspend fun mcpText(client: Client, tool: String, arguments: Map<String,
     return (result.content.single() as TextContent).text
 }
 
-private data class CliBinaryResult(val exitCode: Int, val output: String)
+private data class CliBinaryResult(val exitCode: Int, val output: String, val errorOutput: String)
 
 private class FixtureProcess(
     private val process: Process,

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -65,13 +65,16 @@ class SpectreMcpStdioIntegrationTest {
     }
 
     private fun mcpCommand(): List<String> =
-        listOf(
-            Path.of(System.getProperty("java.home"), "bin", "java").toString(),
-            "-cp",
-            System.getProperty("spectre.cli.testRuntimeClasspath"),
-            "dev.sebastiano.spectre.cli.SpectreCliKt",
-            "mcp",
-        )
+        System.getProperty("spectre.cli.distributionExecutable")?.let { executable ->
+            listOf(executable, "mcp")
+        }
+            ?: listOf(
+                Path.of(System.getProperty("java.home"), "bin", "java").toString(),
+                "-cp",
+                System.getProperty("spectre.cli.testRuntimeClasspath"),
+                "dev.sebastiano.spectre.cli.SpectreCliKt",
+                "mcp",
+            )
 
     private companion object {
         private const val CONNECTION_TIMEOUT_MILLIS: Long = 10_000


### PR DESCRIPTION
## Summary
- run MCP stdio integration tests through the unpacked Roast launcher
- smoke the host-native Roast bundle in Linux and macOS workflow lanes
- preserve the existing full CLI fixture smoke alongside MCP protocol validation

## Verification
- host Roast bundle MCP stdio test
- `CI=true ./gradlew check`

Part of #178, #173.