### PR TITLE
Smoke Windows Roast MCP bundle

### DIFF
--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -267,10 +267,10 @@ jobs:
         if: always()
         run: |
           ./gradlew :cli:packageWindowsX64
-          archive="$PWD/cli/build/construo/distributions/spectre-windowsX64.zip"
+          archive="cli/build/construo/distributions/spectre-windowsX64.zip"
           distribution="$RUNNER_TEMP/spectre-cli"
           rm -rf "$distribution"
-          powershell -NoProfile -Command "Expand-Archive -LiteralPath '$archive' -DestinationPath '$distribution'"
+          unzip -q "$archive" -d "$distribution"
           launcher="$(find "$distribution" -name spectre.exe -type f -print -quit)"
           test -n "$launcher"
           ./gradlew :cli:test \

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -41,6 +41,8 @@ on:
       - "agent/**"
       - "agent-runtime/**"
       - "agent-test-fixture/**"
+      - "cli/**"
+      - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"
@@ -63,6 +65,8 @@ on:
       - "agent/**"
       - "agent-runtime/**"
       - "agent-test-fixture/**"
+      - "cli/**"
+      - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"
@@ -254,6 +258,27 @@ jobs:
           echo "All required classes present; ${#all_xml[@]} discovered XML report(s) clean (Gradle exit ignored due to known executor-protocol flake)."
         shell: bash
 
+      - name: Smoke Roast MCP stdio through the unpacked Windows CLI bundle
+        # Windows does not yet support the daemon's Unix-domain-socket attach transport (the
+        # explicit #173 non-goal), so this validates the Windows-specific release boundary we
+        # can exercise today: the console-subsystem Roast launcher must preserve MCP stdio.
+        # It intentionally runs the existing official-MCP-client integration suite through the
+        # unpacked .exe rather than the test classpath.
+        if: always()
+        run: |
+          ./gradlew :cli:packageWindowsX64
+          archive="$PWD/cli/build/construo/distributions/spectre-windowsX64.zip"
+          distribution="$RUNNER_TEMP/spectre-cli"
+          rm -rf "$distribution"
+          powershell -NoProfile -Command "Expand-Archive -LiteralPath '$archive' -DestinationPath '$distribution'"
+          launcher="$(find "$distribution" -name spectre.exe -type f -print -quit)"
+          test -n "$launcher"
+          ./gradlew :cli:test \
+            --tests "*SpectreMcpStdioIntegrationTest*" \
+            --rerun-tasks \
+            -Dspectre.cli.distributionExecutable="$launcher"
+        shell: bash
+
       - name: Upload validation artefacts
         # Always upload — useful both for diagnosing flakes and for confirming what ran on
         # green builds. The fail-tolerant Gradle step + XML-based verification means an absent
@@ -266,5 +291,8 @@ jobs:
             sample-desktop/build/reports/tests/
             sample-desktop/build/test-results/
             sample-desktop/hs_err_*.log
+            cli/build/reports/tests/
+            cli/build/test-results/
+            cli/hs_err_*.log
           if-no-files-found: ignore
           retention-days: 14


### PR DESCRIPTION
## Summary
- exercise the unpacked Windows Roast console launcher through the official MCP stdio integration suite
- trigger Windows validation for CLI and build tooling changes
- retain CLI test reports with existing Windows validation artifacts

## Validation
- Reusing configuration cache.
> Task :agent-runtime:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :cli:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :cli:processResources NO-SOURCE
> Task :agent-test-fixture:generateComposeResClass SKIPPED
> Task :agent-test-fixture:convertXmlValueResourcesForMain NO-SOURCE
> Task :agent:processResources NO-SOURCE
> Task :agent-runtime:processResources NO-SOURCE
> Task :recording:processResources NO-SOURCE
> Task :agent-test-fixture:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :recording-linux:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :core:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :core:processResources NO-SOURCE
> Task :recording:buildScreenCaptureKitHelper UP-TO-DATE
> Task :recording-macos:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording-linux:processResources NO-SOURCE
> Task :recording-windows:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :recording-macos:compileKotlin NO-SOURCE
> Task :agent-test-fixture:generateResourceAccessorsForMain SKIPPED
> Task :cli:downloadJdkWindowsX64 UP-TO-DATE
> Task :recording-windows:compileKotlin NO-SOURCE
> Task :recording:compileKotlin UP-TO-DATE
> Task :recording-linux:compileKotlin NO-SOURCE
> Task :agent-test-fixture:generateActualResourceCollectorsForMain SKIPPED
> Task :recording:assembleScreenCaptureKitHelper UP-TO-DATE
> Task :recording-windows:processResources NO-SOURCE
> Task :agent-test-fixture:assembleMainResources UP-TO-DATE
> Task :agent:compileKotlin UP-TO-DATE
> Task :recording-macos:compileJava NO-SOURCE
> Task :recording-macos:processResources UP-TO-DATE
> Task :core:compileKotlin UP-TO-DATE
> Task :recording:compileJava NO-SOURCE
> Task :recording:classes UP-TO-DATE
> Task :recording-macos:classes UP-TO-DATE
> Task :agent-test-fixture:processResources UP-TO-DATE
> Task :agent:compileJava NO-SOURCE
> Task :agent:classes UP-TO-DATE
> Task :recording-linux:compileJava NO-SOURCE
> Task :recording-linux:classes UP-TO-DATE
> Task :recording-windows:compileJava NO-SOURCE
> Task :recording-windows:classes UP-TO-DATE
> Task :core:compileJava NO-SOURCE
> Task :core:classes UP-TO-DATE
> Task :recording-macos:jar UP-TO-DATE
> Task :recording:jar UP-TO-DATE
> Task :cli:downloadRoastWindowsX64 UP-TO-DATE
> Task :recording-linux:jar UP-TO-DATE
> Task :recording-windows:jar UP-TO-DATE
> Task :agent:jar UP-TO-DATE
> Task :core:jar UP-TO-DATE
> Task :cli:unzipRoastWindowsX64 UP-TO-DATE
> Task :agent-runtime:compileKotlin NO-SOURCE
> Task :agent-runtime:compileJava NO-SOURCE
> Task :cli:replaceIconWindowsX64 UP-TO-DATE
> Task :agent-runtime:classes UP-TO-DATE
> Task :cli:compileKotlin UP-TO-DATE
> Task :agent-runtime:jar UP-TO-DATE
> Task :agent-test-fixture:compileKotlin UP-TO-DATE
> Task :cli:compileJava NO-SOURCE
> Task :cli:classes UP-TO-DATE
> Task :agent-test-fixture:compileJava NO-SOURCE
> Task :agent-test-fixture:classes UP-TO-DATE
> Task :agent-test-fixture:jar UP-TO-DATE
> Task :cli:jar UP-TO-DATE
> Task :cli:compileTestKotlin UP-TO-DATE
> Task :cli:compileTestJava NO-SOURCE
> Task :cli:shadowJar UP-TO-DATE
> Task :cli:unzipJdkWindowsX64 UP-TO-DATE
> Task :cli:createRuntimeImageWindowsX64 UP-TO-DATE
> Task :cli:preserveRuntimeJavaLauncherWindowsX64 UP-TO-DATE
> Task :cli:roastWindowsX64 UP-TO-DATE
> Task :cli:packageWindowsX64 UP-TO-DATE

BUILD SUCCESSFUL in 406ms
30 actionable tasks: 30 up-to-date
Configuration cache entry reused.
- Reusing configuration cache.
> Task :agent-runtime:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:processResources NO-SOURCE
> Task :agent-test-fixture:generateComposeResClass SKIPPED
> Task :core:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :cli:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :cli:processResources NO-SOURCE
> Task :agent-test-fixture:convertXmlValueResourcesForMain NO-SOURCE
> Task :core:processResources NO-SOURCE
> Task :recording:processResources NO-SOURCE
> Task :agent-runtime:processResources NO-SOURCE
> Task :cli:processTestResources NO-SOURCE
> Task :recording-linux:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :recording-linux:processResources NO-SOURCE
> Task :recording-linux:compileKotlin NO-SOURCE
> Task :agent-test-fixture:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :recording:buildScreenCaptureKitHelper UP-TO-DATE
> Task :recording-windows:processResources NO-SOURCE
> Task :recording-windows:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:generateResourceAccessorsForMain SKIPPED
> Task :recording-linux:compileJava NO-SOURCE
> Task :recording:compileKotlin UP-TO-DATE
> Task :recording-macos:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:compileKotlin UP-TO-DATE
> Task :agent-test-fixture:generateActualResourceCollectorsForMain SKIPPED
> Task :recording:assembleScreenCaptureKitHelper UP-TO-DATE
> Task :core:compileKotlin UP-TO-DATE
> Task :agent-test-fixture:assembleMainResources UP-TO-DATE
> Task :recording-linux:classes UP-TO-DATE
> Task :recording-macos:compileKotlin NO-SOURCE
> Task :recording-windows:compileKotlin NO-SOURCE
> Task :core:compileJava NO-SOURCE
> Task :recording:compileJava NO-SOURCE
> Task :agent-test-fixture:processResources UP-TO-DATE
> Task :core:classes UP-TO-DATE
> Task :agent:compileJava NO-SOURCE
> Task :recording-macos:processResources UP-TO-DATE
> Task :recording-windows:compileJava NO-SOURCE
> Task :agent:classes UP-TO-DATE
> Task :recording:classes UP-TO-DATE
> Task :recording-macos:compileJava NO-SOURCE
> Task :recording-linux:jar UP-TO-DATE
> Task :core:jar UP-TO-DATE
> Task :agent:jar UP-TO-DATE
> Task :recording-windows:classes UP-TO-DATE
> Task :recording-macos:classes UP-TO-DATE
> Task :recording:jar UP-TO-DATE
> Task :recording-windows:jar UP-TO-DATE
> Task :agent-runtime:compileKotlin NO-SOURCE
> Task :recording-macos:jar UP-TO-DATE
> Task :agent-runtime:compileJava NO-SOURCE
> Task :agent-runtime:classes UP-TO-DATE
> Task :agent-runtime:jar UP-TO-DATE
> Task :agent-test-fixture:compileKotlin UP-TO-DATE
> Task :cli:compileKotlin UP-TO-DATE
> Task :agent-test-fixture:compileJava NO-SOURCE
> Task :cli:compileJava NO-SOURCE
> Task :agent-test-fixture:classes UP-TO-DATE
> Task :cli:classes UP-TO-DATE
> Task :agent-test-fixture:jar UP-TO-DATE
> Task :cli:jar UP-TO-DATE
> Task :cli:compileTestKotlin UP-TO-DATE
> Task :cli:compileTestJava NO-SOURCE
> Task :cli:testClasses UP-TO-DATE
> Task :cli:test FROM-CACHE

BUILD SUCCESSFUL in 400ms
21 actionable tasks: 1 from cache, 20 up-to-date
Configuration cache entry reused.
- Reusing configuration cache.
> Task :agent-test-fixture:generateComposeResClass SKIPPED
> Task :agent-runtime:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :core:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:convertXmlValueResourcesForMain NO-SOURCE
> Task :agent:processResources NO-SOURCE
> Task :agent:processTestResources NO-SOURCE
> Task :agent-runtime:processResources NO-SOURCE
> Task :core:processResources NO-SOURCE
> Task :agent-test-fixture:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :agent-test-fixture:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :agent-test-fixture:generateResourceAccessorsForMain SKIPPED
> Task :agent-test-fixture:generateActualResourceCollectorsForMain SKIPPED
> Task :agent-test-fixture:assembleMainResources
> Task :agent-test-fixture:processResources

> Task :agent:compileKotlin
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt:53:9 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt:53:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt:55:13 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt:55:21 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt:152:28 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt:152:36 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt:157:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt:157:25 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt:192:13 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt:192:21 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).

> Task :agent:compileJava NO-SOURCE
> Task :agent:classes UP-TO-DATE
> Task :agent:jar
> Task :agent-runtime:compileKotlin NO-SOURCE
> Task :agent-runtime:compileJava NO-SOURCE
> Task :agent-runtime:classes UP-TO-DATE
> Task :agent-runtime:jar
> Task :core:compileKotlin
> Task :core:compileJava NO-SOURCE
> Task :core:classes UP-TO-DATE
> Task :core:jar
> Task :agent-test-fixture:compileKotlin
> Task :agent-test-fixture:compileJava NO-SOURCE
> Task :agent-test-fixture:classes
> Task :agent-test-fixture:jar

> Task :agent:compileTestKotlin
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt:24:13 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt:24:29 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt:25:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt:25:40 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt:28:20 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachRuntimePreflightTest.kt:28:30 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:25:9 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:25:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:26:24 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:26:32 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:34:9 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:34:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:36:24 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:36:32 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:44:9 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:44:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:45:9 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:45:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:46:9 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:46:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:49:45 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:49:53 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:50:48 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:50:56 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:51:51 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:51:59 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:53:20 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:53:28 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:59:20 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:59:28 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:66:41 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:66:49 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:73:41 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:73:49 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:83:50 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:83:58 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:90:50 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:90:58 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:95:35 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:97:13 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:97:21 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:108:9 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:108:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:109:24 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:109:32 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:119:9 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:119:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:120:9 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:120:17 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:123:26 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:123:34 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:127:27 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).
w: file:///Users/seb/src/spectre/.worktrees/windows-roast-smoke/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt:127:35 The Spectre agent attach API is experimental and may change in any release. Opt in with @OptIn(ExperimentalSpectreAgentApi::class).

> Task :agent:compileTestJava NO-SOURCE
> Task :agent:testClasses UP-TO-DATE
> Task :agent:test

BUILD SUCCESSFUL in 17s
11 actionable tasks: 11 executed
Configuration cache entry reused.
- Reusing configuration cache.
> Task :detekt NO-SOURCE
> Task :agent-test-fixture:ktfmtCheckMain UP-TO-DATE
> Task :agent-test-fixture:ktfmtCheckDev NO-SOURCE
> Task :agent:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent:ktfmtCheckTest UP-TO-DATE
> Task :agent-test-fixture:ktfmtCheckTest NO-SOURCE
> Task :agent:ktfmtCheckMain UP-TO-DATE
> Task :agent:ktfmtCheckSpike NO-SOURCE
> Task :agent-test-fixture:generateComposeResClass SKIPPED
> Task :agent-test-fixture:convertXmlValueResourcesForMain NO-SOURCE
> Task :agent:processResources NO-SOURCE
> Task :core:ktfmtCheckMain UP-TO-DATE
> Task :agent-test-fixture:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :core:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :core:ktfmtCheckTest UP-TO-DATE
> Task :core:processResources NO-SOURCE
> Task :agent-runtime:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-runtime:ktfmtCheckMain NO-SOURCE
> Task :agent-runtime:ktfmtCheckScripts UP-TO-DATE
> Task :agent:processTestResources NO-SOURCE
> Task :agent-test-fixture:ktfmtCheckScripts UP-TO-DATE
> Task :agent-test-fixture:ktfmtCheck UP-TO-DATE
> Task :agent-test-fixture:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :agent-test-fixture:generateResourceAccessorsForMain SKIPPED
> Task :agent-test-fixture:generateActualResourceCollectorsForMain SKIPPED
> Task :agent-runtime:ktfmtCheckTest NO-SOURCE
> Task :cli:ktfmtCheckMain UP-TO-DATE
> Task :agent-runtime:processResources NO-SOURCE
> Task :agent-test-fixture:convertXmlValueResourcesForTest NO-SOURCE
> Task :agent-test-fixture:assembleMainResources UP-TO-DATE
> Task :cli:ktfmtCheckTest UP-TO-DATE
> Task :agent-runtime:ktfmtCheck UP-TO-DATE
> Task :agent-runtime:processTestResources NO-SOURCE
> Task :cli:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :agent-test-fixture:processResources UP-TO-DATE
> Task :agent-test-fixture:copyNonXmlValueResourcesForTest NO-SOURCE
> Task :recording:ktfmtCheckMain UP-TO-DATE
> Task :agent-test-fixture:prepareComposeResourcesTaskForTest NO-SOURCE
> Task :agent-test-fixture:generateResourceAccessorsForTest SKIPPED
> Task :recording:processResources NO-SOURCE
> Task :cli:processResources NO-SOURCE
> Task :agent-test-fixture:assembleTestResources UP-TO-DATE
> Task :recording-linux:ktfmtCheckMain NO-SOURCE
> Task :agent-test-fixture:processTestResources UP-TO-DATE
> Task :recording:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording-linux:ktfmtCheckTest NO-SOURCE
> Task :recording:ktfmtCheckTest UP-TO-DATE
> Task :recording-linux:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording-linux:processResources NO-SOURCE
> Task :recording-macos:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording:buildScreenCaptureKitHelper UP-TO-DATE
> Task :recording-macos:ktfmtCheckTest NO-SOURCE
> Task :recording-macos:ktfmtCheckScripts UP-TO-DATE
> Task :recording-macos:ktfmtCheckMain NO-SOURCE
> Task :recording:assembleScreenCaptureKitHelper UP-TO-DATE
> Task :recording-windows:ktfmtCheckMain NO-SOURCE
> Task :recording-macos:compileKotlin NO-SOURCE
> Task :recording-linux:ktfmtCheckScripts UP-TO-DATE
> Task :recording-windows:ktfmtCheckTest NO-SOURCE
> Task :agent:ktfmtCheckScripts UP-TO-DATE
> Task :agent:ktfmtCheck UP-TO-DATE
> Task :recording-windows:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording-macos:compileJava NO-SOURCE
> Task :recording-macos:processResources UP-TO-DATE
> Task :recording-macos:classes UP-TO-DATE
> Task :core:ktfmtCheckScripts UP-TO-DATE
> Task :recording-windows:processResources NO-SOURCE
> Task :cli:processTestResources NO-SOURCE
> Task :recording-windows:ktfmtCheckScripts UP-TO-DATE
> Task :recording-linux:compileKotlin NO-SOURCE
> Task :recording-macos:jar UP-TO-DATE
> Task :recording-windows:compileKotlin NO-SOURCE
> Task :recording-linux:compileJava NO-SOURCE
> Task :recording-linux:classes UP-TO-DATE
> Task :cli:downloadJdkMacosArm64 UP-TO-DATE
> Task :recording-windows:compileJava NO-SOURCE
> Task :recording-windows:classes UP-TO-DATE
> Task :recording-linux:jar UP-TO-DATE
> Task :cli:generatePListMacosArm64 UP-TO-DATE
> Task :cli:unzipJdkMacosArm64 UP-TO-DATE
> Task :agent:compileKotlin UP-TO-DATE
> Task :recording-windows:jar UP-TO-DATE
> Task :core:compileKotlin UP-TO-DATE
> Task :core:ktfmtCheck UP-TO-DATE
> Task :cli:createCliRuntimeImage UP-TO-DATE
> Task :recording:processTestResources UP-TO-DATE
> Task :core:processTestResources NO-SOURCE
> Task :recording-linux:ktfmtCheck UP-TO-DATE
> Task :cli:downloadRoastMacosArm64 UP-TO-DATE
> Task :recording-linux:verifyRecordingLinuxHelpers SKIPPED
> Task :recording-linux:detektMain NO-SOURCE
> Task :cli:unzipRoastMacosArm64 UP-TO-DATE
> Task :recording-macos:ktfmtCheck UP-TO-DATE
> Task :recording-linux:processTestResources NO-SOURCE
> Task :core:compileJava NO-SOURCE
> Task :recording-macos:verifyRecordingMacosHelpers
> Task :core:classes UP-TO-DATE
> Task :agent:compileJava NO-SOURCE
> Task :core:internalDumpKotlinAbi UP-TO-DATE
> Task :recording-macos:detektMain NO-SOURCE
> Task :agent:classes UP-TO-DATE
> Task :recording-macos:compileTestKotlin NO-SOURCE
> Task :core:jar UP-TO-DATE
> Task :recording-macos:processTestResources NO-SOURCE
> Task :core:checkKotlinAbi
> Task :agent:internalDumpKotlinAbi UP-TO-DATE
> Task :recording-linux:compileTestKotlin NO-SOURCE
> Task :recording-linux:compileTestJava NO-SOURCE
> Task :agent:jar UP-TO-DATE
> Task :recording-linux:detektTest NO-SOURCE
> Task :agent:checkKotlinAbi
> Task :recording-linux:testClasses UP-TO-DATE
> Task :agent-runtime:compileKotlin NO-SOURCE
> Task :recording-macos:compileTestJava NO-SOURCE
> Task :recording-linux:detekt NO-SOURCE
> Task :recording-macos:testClasses UP-TO-DATE
> Task :agent-runtime:compileJava NO-SOURCE
> Task :agent-runtime:classes UP-TO-DATE
> Task :agent-test-fixture:compileKotlin UP-TO-DATE
> Task :agent:detektMain UP-TO-DATE
> Task :core:detektMain UP-TO-DATE
> Task :core:compileTestKotlin UP-TO-DATE
> Task :agent-runtime:jar UP-TO-DATE
> Task :recording:ktfmtCheckScripts UP-TO-DATE
> Task :recording-windows:detektMain NO-SOURCE
> Task :agent-runtime:detektMain NO-SOURCE
> Task :recording-macos:detektTest NO-SOURCE
> Task :agent-test-fixture:compileJava NO-SOURCE
> Task :agent-runtime:compileTestKotlin NO-SOURCE
> Task :recording-windows:compileTestKotlin NO-SOURCE
> Task :core:compileTestJava NO-SOURCE
> Task :recording:ktfmtCheck UP-TO-DATE
> Task :recording-macos:detekt NO-SOURCE
> Task :agent-test-fixture:classes UP-TO-DATE
> Task :core:testClasses UP-TO-DATE
> Task :agent-runtime:compileTestJava NO-SOURCE
> Task :recording-windows:compileTestJava NO-SOURCE
> Task :agent-runtime:detektTest NO-SOURCE
> Task :agent-runtime:testClasses UP-TO-DATE
> Task :agent-runtime:detekt NO-SOURCE
> Task :agent-runtime:test NO-SOURCE
> Task :agent-test-fixture:jar UP-TO-DATE
> Task :recording-windows:detektTest NO-SOURCE
> Task :agent-runtime:verifyAgentRuntimeJarContents
> Task :agent-test-fixture:detektMain UP-TO-DATE
> Task :agent-runtime:check
> Task :core:test UP-TO-DATE
> Task :recording-windows:ktfmtCheck UP-TO-DATE
> Task :recording-windows:verifyRecordingWindowsHelper SKIPPED
> Task :recording-windows:processTestResources NO-SOURCE
> Task :recording-windows:testClasses UP-TO-DATE
> Task :recording-windows:detekt NO-SOURCE
> Task :agent-test-fixture:compileTestKotlin NO-SOURCE
> Task :sample-desktop:ktfmtCheckDev NO-SOURCE
> Task :core:detektTest UP-TO-DATE
> Task :agent-test-fixture:compileTestJava NO-SOURCE
> Task :agent-test-fixture:detektTest NO-SOURCE
> Task :recording:compileKotlin UP-TO-DATE
> Task :agent-test-fixture:testClasses UP-TO-DATE
> Task :sample-desktop:ktfmtCheckMain UP-TO-DATE
> Task :agent-test-fixture:test NO-SOURCE
> Task :agent:compileTestKotlin UP-TO-DATE
> Task :sample-desktop:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :recording:compileJava NO-SOURCE
> Task :agent:compileTestJava NO-SOURCE
> Task :recording:classes UP-TO-DATE
> Task :sample-desktop:convertXmlValueResourcesForMain NO-SOURCE
> Task :sample-desktop:ktfmtCheckValidation UP-TO-DATE
> Task :agent:testClasses UP-TO-DATE
> Task :sample-desktop:ktfmtCheckTest UP-TO-DATE
> Task :recording:jar UP-TO-DATE
> Task :recording:internalDumpKotlinAbi UP-TO-DATE
> Task :core:detekt UP-TO-DATE
> Task :core:check
> Task :agent-test-fixture:detekt UP-TO-DATE
> Task :agent-test-fixture:check UP-TO-DATE
> Task :agent:detektTest UP-TO-DATE
> Task :recording-linux:test NO-SOURCE
> Task :recording-linux:check UP-TO-DATE
> Task :recording:checkKotlinAbi
> Task :recording:detektMain UP-TO-DATE
> Task :sample-desktop:generateComposeResClass SKIPPED
> Task :sample-desktop:ktfmtCheckScripts UP-TO-DATE
> Task :recording-macos:test NO-SOURCE
> Task :agent:detekt UP-TO-DATE
> Task :sample-desktop:ktfmtCheck UP-TO-DATE
> Task :recording-windows:test NO-SOURCE
> Task :sample-desktop:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :recording-macos:check
> Task :recording:compileTestKotlin UP-TO-DATE
> Task :sample-desktop:convertXmlValueResourcesForTest NO-SOURCE
> Task :sample-desktop:copyNonXmlValueResourcesForTest NO-SOURCE
> Task :recording:compileTestJava NO-SOURCE
> Task :sample-desktop:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :recording-windows:check UP-TO-DATE
> Task :recording:testClasses UP-TO-DATE
> Task :sample-desktop:generateResourceAccessorsForMain SKIPPED
> Task :sample-desktop:generateActualResourceCollectorsForMain SKIPPED
> Task :sample-intellij-plugin:ktfmtCheckDev NO-SOURCE
> Task :sample-desktop:assembleMainResources UP-TO-DATE
> Task :sample-desktop:prepareComposeResourcesTaskForTest NO-SOURCE
> Task :sample-desktop:generateResourceAccessorsForTest SKIPPED
> Task :sample-intellij-plugin:ktfmtCheckMain UP-TO-DATE
> Task :sample-intellij-plugin:ktfmtCheckTest NO-SOURCE
> Task :sample-desktop:processResources UP-TO-DATE
> Task :sample-intellij-plugin:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :sample-intellij-plugin:convertXmlValueResourcesForMain NO-SOURCE
> Task :sample-intellij-plugin:copyNonXmlValueResourcesForMain NO-SOURCE
> Task :sample-desktop:assembleTestResources UP-TO-DATE
> Task :sample-intellij-plugin:prepareComposeResourcesTaskForMain NO-SOURCE
> Task :sample-intellij-plugin:generateResourceAccessorsForMain SKIPPED
> Task :sample-intellij-plugin:generateActualResourceCollectorsForMain SKIPPED
> Task :sample-intellij-plugin:generateComposeResClass SKIPPED
> Task :sample-intellij-plugin:ktfmtCheckUiTest UP-TO-DATE
> Task :sample-desktop:processTestResources UP-TO-DATE
> Task :sample-intellij-plugin:convertXmlValueResourcesForTest NO-SOURCE
> Task :recording:test UP-TO-DATE
> Task :sample-intellij-plugin:convertXmlValueResourcesForUiTest NO-SOURCE
> Task :sample-intellij-plugin:assembleMainResources UP-TO-DATE
> Task :sample-intellij-plugin:copyNonXmlValueResourcesForTest NO-SOURCE
> Task :sample-desktop:compileKotlin UP-TO-DATE
> Task :sample-intellij-plugin:copyNonXmlValueResourcesForUiTest NO-SOURCE
> Task :cli:ktfmtCheckScripts UP-TO-DATE
> Task :sample-intellij-plugin:prepareComposeResourcesTaskForTest NO-SOURCE
> Task :cli:ktfmtCheck UP-TO-DATE
> Task :sample-intellij-plugin:generateResourceAccessorsForTest SKIPPED
> Task :recording:detektTest UP-TO-DATE
> Task :sample-intellij-plugin:prepareComposeResourcesTaskForUiTest NO-SOURCE
> Task :sample-intellij-plugin:generateResourceAccessorsForUiTest SKIPPED
> Task :server:ktfmtCheckMain UP-TO-DATE
> Task :sample-desktop:compileJava NO-SOURCE
> Task :sample-intellij-plugin:assembleTestResources UP-TO-DATE
> Task :sample-desktop:classes UP-TO-DATE
> Task :sample-desktop:jar UP-TO-DATE
> Task :cli:compileKotlin UP-TO-DATE
> Task :cli:compileJava NO-SOURCE
> Task :sample-intellij-plugin:ktfmtCheckScripts UP-TO-DATE
> Task :cli:classes UP-TO-DATE
> Task :sample-intellij-plugin:initializeIntellijPlatformPlugin
> Task :server:ktfmtCheckTest UP-TO-DATE
> Task :cli:jar UP-TO-DATE
> Task :sample-intellij-plugin:patchPluginXml UP-TO-DATE
> Task :recording:detekt UP-TO-DATE
> Task :recording:check
> Task :sample-desktop:detektMain UP-TO-DATE
> Task :sample-intellij-plugin:ktfmtCheck UP-TO-DATE
> Task :sample-intellij-plugin:processResources UP-TO-DATE
> Task :server:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :server:processResources NO-SOURCE
> Task :sample-intellij-plugin:processTestResources UP-TO-DATE
> Task :server:processTestResources NO-SOURCE
> Task :server:ktfmtCheckScripts UP-TO-DATE
> Task :sample-intellij-plugin:generateManifest UP-TO-DATE
> Task :server:ktfmtCheck UP-TO-DATE
> Task :cli:detektMain UP-TO-DATE
> Task :testing:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :testing:processResources NO-SOURCE
> Task :sample-desktop:compileTestKotlin UP-TO-DATE
> Task :testing:processTestResources NO-SOURCE
> Task :cli:compileTestKotlin UP-TO-DATE
> Task :agent:test FROM-CACHE
> Task :agent:check
> Task :sample-desktop:compileTestJava NO-SOURCE
> Task :cli:compileTestJava NO-SOURCE
> Task :testing:ktfmtCheckMain UP-TO-DATE
> Task :testing:ktfmtCheckTest UP-TO-DATE
> Task :cli:testClasses UP-TO-DATE
> Task :cli:detektTest UP-TO-DATE
> Task :sample-desktop:detektTest UP-TO-DATE
> Task :testing:ktfmtCheckScripts UP-TO-DATE
> Task :sample-desktop:testClasses UP-TO-DATE
> Task :cli:shadowJar UP-TO-DATE
> Task :cli:detekt UP-TO-DATE
> Task :sample-desktop:detekt UP-TO-DATE
> Task :cli:createRuntimeImageMacosArm64 UP-TO-DATE
> Task :cli:preserveRuntimeJavaLauncherMacosArm64 UP-TO-DATE
> Task :cli:roastMacosArm64 UP-TO-DATE
> Task :cli:test FROM-CACHE
> Task :cli:buildMacAppBundleMacosArm64 UP-TO-DATE
> Task :cli:packageMacosArm64 UP-TO-DATE
> Task :sample-desktop:test UP-TO-DATE
> Task :sample-desktop:check UP-TO-DATE
> Task :testing:compileKotlin UP-TO-DATE
> Task :testing:compileJava NO-SOURCE
> Task :testing:internalDumpKotlinAbi UP-TO-DATE
> Task :testing:checkKotlinAbi
> Task :testing:detektMain UP-TO-DATE
> Task :testing:classes UP-TO-DATE
> Task :testing:jar UP-TO-DATE
> Task :ktfmtCheckScripts UP-TO-DATE
> Task :ktfmtCheck UP-TO-DATE
> Task :check UP-TO-DATE
> Task :testing:ktfmtCheck UP-TO-DATE
> Task :server:compileKotlin UP-TO-DATE
> Task :server:compileJava NO-SOURCE
> Task :server:classes UP-TO-DATE
> Task :server:internalDumpKotlinAbi UP-TO-DATE
> Task :server:checkKotlinAbi
> Task :server:jar UP-TO-DATE
> Task :testing:compileTestKotlin UP-TO-DATE
> Task :testing:compileTestJava NO-SOURCE
> Task :testing:testClasses UP-TO-DATE
> Task :sample-intellij-plugin:compileKotlin UP-TO-DATE
> Task :server:detektMain UP-TO-DATE
> Task :testing:detektTest UP-TO-DATE
> Task :sample-intellij-plugin:compileJava NO-SOURCE
> Task :testing:detekt UP-TO-DATE
> Task :sample-intellij-plugin:classes UP-TO-DATE
> Task :cli:startShadowScripts
> Task :sample-intellij-plugin:instrumentCode UP-TO-DATE
> Task :cli:patchShadowStartScripts
> Task :sample-intellij-plugin:jar UP-TO-DATE
> Task :sample-intellij-plugin:compileTestKotlin NO-SOURCE
> Task :sample-intellij-plugin:compileTestJava NO-SOURCE
> Task :sample-intellij-plugin:detektTest NO-SOURCE
> Task :sample-intellij-plugin:testClasses UP-TO-DATE
> Task :sample-intellij-plugin:instrumentedJar UP-TO-DATE
> Task :server:compileTestKotlin UP-TO-DATE
> Task :sample-intellij-plugin:detektMain UP-TO-DATE
> Task :server:compileTestJava NO-SOURCE
> Task :sample-intellij-plugin:instrumentTestCode UP-TO-DATE
> Task :server:testClasses UP-TO-DATE
> Task :sample-intellij-plugin:composedJar UP-TO-DATE
> Task :sample-intellij-plugin:prepareTestSandbox UP-TO-DATE
> Task :sample-intellij-plugin:prepareTest
> Task :sample-intellij-plugin:test NO-SOURCE
> Task :sample-intellij-plugin:prepareSandbox UP-TO-DATE
> Task :sample-intellij-plugin:detekt UP-TO-DATE
> Task :server:detektTest UP-TO-DATE
> Task :server:detekt UP-TO-DATE
> Task :testing:test UP-TO-DATE
> Task :testing:check
> Task :server:test UP-TO-DATE
> Task :server:check
> Task :sample-intellij-plugin:compileUiTestKotlin UP-TO-DATE
> Task :sample-intellij-plugin:compileUiTestJava NO-SOURCE
> Task :sample-intellij-plugin:verifyPluginStructure
> Task :sample-intellij-plugin:detektUiTest UP-TO-DATE
> Task :sample-intellij-plugin:check
> Task :cli:verifyCliRuntimeImage
> Task :cli:verifyCliShadowJar
> Task :cli:verifyRoastCliDistribution
> Task :cli:shadowDistZip
> Task :cli:verifyCliDistributionZip
> Task :cli:check

BUILD SUCCESSFUL in 4s
152 actionable tasks: 16 executed, 2 from cache, 134 up-to-date
Configuration cache entry reused.

Closes #178