### PR TITLE
Sign and notarize macOS CLI bundles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ name: Release
 # `-PVERSION_NAME=...`, and `vanniktech-maven-publish`'s POMs pick up the override
 # automatically.
 #
-# Four-stage fan-out:
+# Release job graph:
 #
 #   1. `release-gate`     — Linux runner. Rejects non-SemVer `v*` tags, runs the
 #                            full Gradle `check`, and runs `mkdocs build --strict`
@@ -21,17 +21,22 @@ name: Release
 #                            Uploads the notarised binary as a GitHub Actions
 #                            artifact.
 #
-#   3. `linux-helpers`    — Linux runner. Cross-builds the Wayland Rust helper for
+#   3. `mac-cli-bundles`  — macOS runner. Packages both Roast `.app` bundles,
+#                            signs every Mach-O nested in their jlink runtimes,
+#                            notarizes the archives, staples the tickets, and uploads
+#                            the resulting release-ready archives.
+#
+#   4. `linux-helpers`    — Linux runner. Cross-builds the Wayland Rust helper for
 #                            both x86_64 and aarch64 using the same toolchain dance
 #                            `ci.yml` documents (dpkg multi-arch + per-arch libdbus
 #                            sysroot + cross-linker). Uploads the per-arch binaries
 #                            as a GitHub Actions artifact.
 #
-#   4. `windows-helper`   — Windows runner. Builds the .NET Graphics Capture helper for
+#   5. `windows-helper`   — Windows runner. Builds the .NET Graphics Capture helper for
 #                            x64 and arm64 and uploads both helper directories as a
 #                            GitHub Actions artifact.
 #
-#   5. `publish`          — Linux runner. Depends on the gate and all helper jobs. Downloads
+#   6. `publish`          — Linux runner. Depends on the gate and all helper jobs. Downloads
 #                            the artefacts, stages them into the platform helper
 #                            resource jars via `-PprebuiltMacHelperPath=...` and
 #                            `-PprebuiltLinuxHelpersDir=...` and
@@ -223,6 +228,149 @@ jobs:
             rm -f "$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
           fi
 
+  mac-cli-bundles:
+    name: Build, sign, and notarise macOS CLI bundles
+    runs-on: macos-latest
+    needs:
+      - release-gate
+      - mac-helper
+    env:
+      RELEASE_VERSION: ${{ needs.release-gate.outputs.version }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Download notarised mac helper artefact
+        uses: actions/download-artifact@v4
+        with:
+          name: mac-helper
+          path: ${{ runner.temp }}/mac-helper
+
+      - name: Import Developer ID certificate
+        env:
+          APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_SIGNING_KEYCHAIN_PASSWORD }}
+        run: |
+          test -n "$APPLE_DEVELOPER_ID_P12"
+          test -n "$APPLE_DEVELOPER_ID_P12_PASSWORD"
+          test -n "$KEYCHAIN_PASSWORD"
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
+
+          echo "$APPLE_DEVELOPER_ID_P12" | base64 --decode > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Build, sign, and notarise macOS CLI bundles
+        env:
+          APPLE_DEVELOPER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
+          APPLE_NOTARY_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY }}
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_NOTARY_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          test -n "$APPLE_DEVELOPER_IDENTITY"
+          test -n "$APPLE_NOTARY_API_KEY"
+          test -n "$APPLE_NOTARY_API_KEY_ID"
+          test -n "$APPLE_NOTARY_API_ISSUER"
+
+          API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
+          echo "$APPLE_NOTARY_API_KEY" | base64 --decode > "$API_KEY_PATH"
+
+          ./gradlew \
+            :cli:packageMacosX64 \
+            :cli:packageMacosArm64 \
+            -PVERSION_NAME="$RELEASE_VERSION" \
+            -PprebuiltMacHelperPath="$RUNNER_TEMP/mac-helper/spectre-screencapture"
+
+          for target in macosX64 macosArm64; do
+            archive="cli/build/construo/distributions/spectre-${target}.zip"
+            workspace="$RUNNER_TEMP/spectre-${target}"
+            root="$workspace/spectre-cli-$RELEASE_VERSION"
+            app="$root/Spectre.app"
+            rm -rf "$workspace"
+            mkdir -p "$workspace"
+            ditto -x -k "$archive" "$workspace"
+            test -d "$app"
+
+            # jlink carries its own Java launchers and dylibs. Sign all nested Mach-O files
+            # first, then the outer app bundle, so Gatekeeper sees one coherent signature.
+            while IFS= read -r -d '' file; do
+              if file -b "$file" | grep -q 'Mach-O'; then
+                codesign --force --options runtime --timestamp \
+                  --sign "$APPLE_DEVELOPER_IDENTITY" "$file"
+              fi
+            done < <(find "$app" -type f -print0)
+            codesign --force --deep --options runtime --timestamp \
+              --sign "$APPLE_DEVELOPER_IDENTITY" "$app"
+            codesign --verify --deep --strict --verbose=4 "$app"
+
+            # Notarytool receives an app-root archive; the published archive keeps the outer
+            # version directory that the other platform bundles use. Staple first, then rebuild
+            # that published archive so users receive an offline-verifiable ticket.
+            notarization_archive="$workspace/Spectre.app.zip"
+            ditto -c -k --sequesterRsrc --keepParent "$app" "$notarization_archive"
+            xcrun notarytool submit "$notarization_archive" \
+              --key "$API_KEY_PATH" \
+              --key-id "$APPLE_NOTARY_API_KEY_ID" \
+              --issuer "$APPLE_NOTARY_API_ISSUER" \
+              --wait
+            xcrun stapler staple "$app"
+            xcrun stapler validate "$app"
+            codesign --verify --deep --strict --verbose=4 "$app"
+            ditto -c -k --sequesterRsrc --keepParent "$root" "$archive"
+          done
+
+      - name: Upload signed and notarised macOS CLI bundles
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-cli-bundles
+          path: |
+            cli/build/construo/distributions/spectre-macosX64.zip
+            cli/build/construo/distributions/spectre-macosArm64.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Clean up Apple credentials + signing keychain
+        if: always()
+        env:
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
+          if [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+          rm -f "$RUNNER_TEMP/developer-id.p12"
+          if [ -n "${APPLE_NOTARY_API_KEY_ID:-}" ]; then
+            rm -f "$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
+          fi
+
   linux-helpers:
     name: Build cross-arch Linux helpers
     runs-on: ubuntu-latest
@@ -339,6 +487,7 @@ jobs:
     needs:
       - release-gate
       - mac-helper
+      - mac-cli-bundles
       - linux-helpers
       - windows-helper
     # `contents: write` needed for `gh release create / upload`; nothing else opted up.
@@ -373,6 +522,12 @@ jobs:
           name: mac-helper
           path: ${{ runner.temp }}/mac-helper
 
+      - name: Download signed and notarised macOS CLI bundles
+        uses: actions/download-artifact@v4
+        with:
+          name: mac-cli-bundles
+          path: cli/build/construo/distributions
+
       - name: Download cross-arch Linux helpers artefact
         uses: actions/download-artifact@v4
         with:
@@ -404,8 +559,6 @@ jobs:
           ./gradlew \
             :cli:packageLinuxX64 \
             :cli:packageLinuxArm64 \
-            :cli:packageMacosX64 \
-            :cli:packageMacosArm64 \
             :cli:packageWindowsX64 \
             -PVERSION_NAME="$RELEASE_VERSION" \
             -PprebuiltMacHelperPath="$RUNNER_TEMP/mac-helper/spectre-screencapture" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -314,20 +314,25 @@ jobs:
             workspace="$RUNNER_TEMP/spectre-${target}"
             root="$workspace/spectre-cli-$RELEASE_VERSION"
             app="$root/Spectre.app"
+            entitlements="cli/packaging/macos/jvm-entitlements.plist"
             rm -rf "$workspace"
             mkdir -p "$workspace"
             ditto -x -k "$archive" "$workspace"
             test -d "$app"
 
-            # jlink carries its own Java launchers and dylibs. Sign all nested Mach-O files
-            # first, then the outer app bundle, so Gatekeeper sees one coherent signature.
+            # jlink carries its own Java launchers and dylibs. The JVM needs these hardened
+            # runtime entitlements for JIT code, native-library loading, and jdk.attach. Sign
+            # all nested Mach-O files first, then the outer app bundle, so Gatekeeper sees one
+            # coherent signature.
             while IFS= read -r -d '' file; do
               if file -b "$file" | grep -q 'Mach-O'; then
                 codesign --force --options runtime --timestamp \
+                  --entitlements "$entitlements" \
                   --sign "$APPLE_DEVELOPER_IDENTITY" "$file"
               fi
             done < <(find "$app" -type f -print0)
             codesign --force --deep --options runtime --timestamp \
+              --entitlements "$entitlements" \
               --sign "$APPLE_DEVELOPER_IDENTITY" "$app"
             codesign --verify --deep --strict --verbose=4 "$app"
 
@@ -340,6 +345,7 @@ jobs:
               --key "$API_KEY_PATH" \
               --key-id "$APPLE_NOTARY_API_KEY_ID" \
               --issuer "$APPLE_NOTARY_API_ISSUER" \
+              --timeout 30m \
               --wait
             xcrun stapler staple "$app"
             xcrun stapler validate "$app"

--- a/cli/packaging/macos/jvm-entitlements.plist
+++ b/cli/packaging/macos/jvm-entitlements.plist
@@ -2,14 +2,12 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-    <!-- The bundled Temurin JVM uses JIT-generated code and loads its own native libraries. -->
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
     <key>com.apple.security.cs.disable-library-validation</key>
     <true/>
-    <!-- The daemon's jdk.attach workflow must be allowed to inspect a target JVM. -->
     <key>com.apple.security.cs.debugger</key>
     <true/>
 </dict>

--- a/cli/packaging/macos/jvm-entitlements.plist
+++ b/cli/packaging/macos/jvm-entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- The bundled Temurin JVM uses JIT-generated code and loads its own native libraries. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <!-- The daemon's jdk.attach workflow must be allowed to inspect a target JVM. -->
+    <key>com.apple.security.cs.debugger</key>
+    <true/>
+</dict>
+</plist>

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -38,14 +38,18 @@ Five jobs run on tag push:
 4. **`windows-helper`** (Windows runner, depends on `release-gate`) — builds the
    .NET Windows Graphics Capture helper for `x64` and `arm64`, then uploads the
    per-arch helper directories as a GitHub Actions artefact.
-5. **`publish`** (Linux runner, depends on the gate and all helper jobs) — downloads the
-   helper artefacts, runs `:verifyMavenLocalPublication` to assert the publication shape, then
-   builds the version-stamped `spectre-cli-<version>-linux-x86_64.zip` Shadow distribution and
-   runs `publishToMavenCentral` against the [Sonatype Central Portal][central-portal]. Finally it
-   creates a draft GitHub release and uploads that self-contained Linux x86_64 CLI archive.
-   Maven Central remains the canonical host for library modules; do not attach a partial library
-   jar set to the GitHub release. Cross-targeted macOS, Windows, and Linux arm64 bundles remain
-   part of [#178](https://github.com/rock3r/spectre/issues/178).
+5. **`mac-cli-bundles`** (macOS runner, depends on the gate and `mac-helper`) — builds the
+   x64 and arm64 Roast `.app` CLI bundles with the notarised screen-capture helper, signs every
+   Mach-O component in their jlink runtimes with the Developer ID, submits each archive to
+   `notarytool`, staples the resulting ticket, verifies the signature, and uploads the finished
+   archives as workflow artefacts.
+6. **`publish`** (Linux runner, depends on the gate and all helper/bundle jobs) — downloads the
+   helper and signed macOS CLI artefacts, runs `:verifyMavenLocalPublication` to assert the
+   publication shape, builds the Linux x64/Linux arm64/Windows x64 Roast CLI bundles, and runs
+   `publishToMavenCentral` against the [Sonatype Central Portal][central-portal]. Finally it
+   creates a draft GitHub release and uploads all five self-contained CLI bundles. Maven Central
+   remains the canonical host for library modules; do not attach a partial library jar set to the
+   GitHub release.
 
 [ci-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/ci.yml
 [central-portal]: https://central.sonatype.com/
@@ -76,8 +80,8 @@ Manual promotion checklist:
   `scripts/central_portal_check.py validate --deployment-id <id> --version <version>`.
 - Promote the Central staging deployment from the Central Portal UI.
 - Confirm the GitHub release notes link to Maven Central for artifacts instead
-  of attaching a partial library jar set, and that it includes
-  `spectre-cli-<version>-linux-x86_64.zip`.
+  of attaching a partial library jar set, and that it includes the Linux x64/Linux arm64,
+  macOS x64/macOS arm64 (signed and stapled), and Windows x64 CLI bundles.
 - Undraft the GitHub release with `gh release edit <tag> --draft=false`.
 
 ## Required secrets

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -40,9 +40,10 @@ Five jobs run on tag push:
    per-arch helper directories as a GitHub Actions artefact.
 5. **`mac-cli-bundles`** (macOS runner, depends on the gate and `mac-helper`) — builds the
    x64 and arm64 Roast `.app` CLI bundles with the notarised screen-capture helper, signs every
-   Mach-O component in their jlink runtimes with the Developer ID, submits each archive to
-   `notarytool`, staples the resulting ticket, verifies the signature, and uploads the finished
-   archives as workflow artefacts.
+   Mach-O component in their jlink runtimes with the Developer ID and JVM hardened-runtime
+   entitlements, submits each archive to `notarytool` with a 30-minute bound, staples the
+   resulting ticket, verifies the signature, and uploads the finished archives as workflow
+   artefacts.
 6. **`publish`** (Linux runner, depends on the gate and all helper/bundle jobs) — downloads the
    helper and signed macOS CLI artefacts, runs `:verifyMavenLocalPublication` to assert the
    publication shape, builds the Linux x64/Linux arm64/Windows x64 Roast CLI bundles, and runs


### PR DESCRIPTION
## Summary
- add a macOS release job that builds both Roast CLI app bundles with the notarized capture helper
- sign nested jlink Mach-O binaries, notarize app-root archives, staple the accepted ticket, and publish the signed bundle artifacts
- make the release job consume signed macOS bundles rather than rebuilding unsigned ones on Linux
- update publishing documentation with the real five-bundle release flow

Part of #173.

## Validation
- release workflow YAML parsed successfully with Ruby
- git diff --check
- ./gradlew check
- mkdocs build --strict is unavailable locally because mkdocs is not installed; it remains a release-gate CI check.