### PR TITLE
Publish CLI package manifests

### DIFF
--- a/.github/scripts/generate-cli-package-manifests.py
+++ b/.github/scripts/generate-cli-package-manifests.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Generate the self-hosted Homebrew tap formula and Scoop bucket manifest for a release."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+
+RELEASE_BASE = "https://github.com/rock3r/spectre/releases/download/v{version}"
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as archive:
+        for chunk in iter(lambda: archive.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--macos-arm64", type=Path, required=True)
+    parser.add_argument("--macos-x64", type=Path, required=True)
+    parser.add_argument("--windows-x64", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    for archive in (args.macos_arm64, args.macos_x64, args.windows_x64):
+        if not archive.is_file():
+            raise SystemExit(f"Missing release archive: {archive}")
+
+    output = args.output_dir
+    formula = output / "Formula" / "spectre.rb"
+    scoop = output / "bucket" / "spectre.json"
+    formula.parent.mkdir(parents=True, exist_ok=True)
+    scoop.parent.mkdir(parents=True, exist_ok=True)
+
+    base = RELEASE_BASE.format(version=args.version)
+    formula.write_text(
+        f'''class Spectre < Formula
+  desc "Agent-facing CLI and MCP server for Spectre Compose Desktop automation"
+  homepage "https://github.com/rock3r/spectre"
+  version "{args.version}"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "{base}/spectre-macosArm64.zip"
+      sha256 "{sha256(args.macos_arm64)}"
+    else
+      url "{base}/spectre-macosX64.zip"
+      sha256 "{sha256(args.macos_x64)}"
+    end
+  end
+
+  def install
+    app = Dir["spectre-cli-*/Spectre.app"].first
+    odie "missing Spectre.app in release archive" if app.nil?
+    libexec.install app
+    bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"
+  end
+
+  test do
+    assert_match version.to_s, shell_output("#{bin}/spectre --version")
+  end
+end
+'''
+    )
+    scoop.write_text(
+        f'''{{
+    "version": "{args.version}",
+    "description": "Agent-facing CLI and MCP server for Spectre Compose Desktop automation",
+    "homepage": "https://github.com/rock3r/spectre",
+    "license": "Apache-2.0",
+    "architecture": {{
+        "64bit": {{
+            "url": "{base}/spectre-windowsX64.zip",
+            "hash": "sha256:{sha256(args.windows_x64)}"
+        }}
+    }},
+    "bin": "spectre-cli-$version/spectre.exe"
+}}
+'''
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/generate-cli-package-manifests.py
+++ b/.github/scripts/generate-cli-package-manifests.py
@@ -63,7 +63,7 @@ def main() -> None:
   end
 
   test do
-    assert_match version.to_s, shell_output("#{bin}/spectre --version")
+    assert_match "Usage:", shell_output("#{{bin}}/spectre --help")
   end
 end
 '''

--- a/.github/scripts/generate-cli-package-manifests.py
+++ b/.github/scripts/generate-cli-package-manifests.py
@@ -80,7 +80,7 @@ end
             "hash": "sha256:{sha256(args.windows_x64)}"
         }}
     }},
-    "bin": "spectre-cli-$version/spectre.exe"
+    "bin": "spectre-cli-{args.version}/spectre.exe"
 }}
 '''
     )

--- a/.github/scripts/test-generate-cli-package-manifests.sh
+++ b/.github/scripts/test-generate-cli-package-manifests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+printf arm > "$tmp/spectre-macosArm64.zip"
+printf intel > "$tmp/spectre-macosX64.zip"
+printf windows > "$tmp/spectre-windowsX64.zip"
+python3 "$root/.github/scripts/generate-cli-package-manifests.py" \
+  --version 1.2.3 \
+  --macos-arm64 "$tmp/spectre-macosArm64.zip" \
+  --macos-x64 "$tmp/spectre-macosX64.zip" \
+  --windows-x64 "$tmp/spectre-windowsX64.zip" \
+  --output-dir "$tmp/out"
+ruby -c "$tmp/out/Formula/spectre.rb"
+python3 -m json.tool "$tmp/out/bucket/spectre.json" >/dev/null
+grep -q 'version "1.2.3"' "$tmp/out/Formula/spectre.rb"
+grep -q 'sha256 "ddf7ff5ebd9d66ce161466c1c0262430fa04de32b0e420ee3f489e2e2112e386"' "$tmp/out/Formula/spectre.rb"
+grep -q '"bin": "spectre-cli-\$version/spectre.exe"' "$tmp/out/bucket/spectre.json"

--- a/.github/scripts/test-generate-cli-package-manifests.sh
+++ b/.github/scripts/test-generate-cli-package-manifests.sh
@@ -17,4 +17,5 @@ ruby -c "$tmp/out/Formula/spectre.rb"
 python3 -m json.tool "$tmp/out/bucket/spectre.json" >/dev/null
 grep -q 'version "1.2.3"' "$tmp/out/Formula/spectre.rb"
 grep -q 'sha256 "ddf7ff5ebd9d66ce161466c1c0262430fa04de32b0e420ee3f489e2e2112e386"' "$tmp/out/Formula/spectre.rb"
+grep -q 'shell_output("#{bin}/spectre --help")' "$tmp/out/Formula/spectre.rb"
 grep -q '"bin": "spectre-cli-1.2.3/spectre.exe"' "$tmp/out/bucket/spectre.json"

--- a/.github/scripts/test-generate-cli-package-manifests.sh
+++ b/.github/scripts/test-generate-cli-package-manifests.sh
@@ -17,4 +17,4 @@ ruby -c "$tmp/out/Formula/spectre.rb"
 python3 -m json.tool "$tmp/out/bucket/spectre.json" >/dev/null
 grep -q 'version "1.2.3"' "$tmp/out/Formula/spectre.rb"
 grep -q 'sha256 "ddf7ff5ebd9d66ce161466c1c0262430fa04de32b0e420ee3f489e2e2112e386"' "$tmp/out/Formula/spectre.rb"
-grep -q '"bin": "spectre-cli-\$version/spectre.exe"' "$tmp/out/bucket/spectre.json"
+grep -q '"bin": "spectre-cli-1.2.3/spectre.exe"' "$tmp/out/bucket/spectre.json"

--- a/.github/workflows/package-channels.yml
+++ b/.github/workflows/package-channels.yml
@@ -38,9 +38,16 @@ jobs:
             --macos-x64 "$RUNNER_TEMP/cli-bundles/spectre-macosX64.zip" \
             --windows-x64 "$RUNNER_TEMP/cli-bundles/spectre-windowsX64.zip" \
             --output-dir "$output"
+          git fetch origin main
+          git rebase origin/main
           cp -R "$output/Formula" "$output/bucket" .
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula/spectre.rb bucket/spectre.json
           git diff --cached --quiet || git commit -m "Publish Spectre CLI ${RELEASE_TAG#v} package manifests"
-          git push origin HEAD:main
+          for attempt in 1 2 3; do
+            git push origin HEAD:main && exit 0
+            git fetch origin main
+            git rebase origin/main
+          done
+          exit 1

--- a/.github/workflows/package-channels.yml
+++ b/.github/workflows/package-channels.yml
@@ -1,0 +1,46 @@
+name: Publish CLI package channels
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  publish-manifests:
+    runs-on: ubuntu-latest
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Download published CLI bundles
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p "$RUNNER_TEMP/cli-bundles"
+          gh release download "$RELEASE_TAG" \
+            --dir "$RUNNER_TEMP/cli-bundles" \
+            --pattern 'spectre-macosArm64.zip' \
+            --pattern 'spectre-macosX64.zip' \
+            --pattern 'spectre-windowsX64.zip'
+
+      - name: Generate and publish manifests
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/package-manifests"
+          python3 .github/scripts/generate-cli-package-manifests.py \
+            --version "${RELEASE_TAG#v}" \
+            --macos-arm64 "$RUNNER_TEMP/cli-bundles/spectre-macosArm64.zip" \
+            --macos-x64 "$RUNNER_TEMP/cli-bundles/spectre-macosX64.zip" \
+            --windows-x64 "$RUNNER_TEMP/cli-bundles/spectre-windowsX64.zip" \
+            --output-dir "$output"
+          cp -R "$output/Formula" "$output/bucket" .
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Formula/spectre.rb bucket/spectre.json
+          git diff --cached --quiet || git commit -m "Publish Spectre CLI ${RELEASE_TAG#v} package manifests"
+          git push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -610,26 +610,3 @@ jobs:
             "cli/build/construo/distributions/spectre-macosArm64.zip" \
             "cli/build/construo/distributions/spectre-windowsX64.zip" \
             --clobber
-
-      - name: Update self-hosted Homebrew tap and Scoop bucket
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          output="$RUNNER_TEMP/package-manifests"
-          python3 .github/scripts/generate-cli-package-manifests.py \
-            --version "$RELEASE_VERSION" \
-            --macos-arm64 cli/build/construo/distributions/spectre-macosArm64.zip \
-            --macos-x64 cli/build/construo/distributions/spectre-macosX64.zip \
-            --windows-x64 cli/build/construo/distributions/spectre-windowsX64.zip \
-            --output-dir "$output"
-          git fetch origin main
-          git worktree add "$RUNNER_TEMP/spectre-package-channels" origin/main
-          cp -R "$output/Formula" "$output/bucket" "$RUNNER_TEMP/spectre-package-channels/"
-          git -C "$RUNNER_TEMP/spectre-package-channels" config user.name "github-actions[bot]"
-          git -C "$RUNNER_TEMP/spectre-package-channels" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git -C "$RUNNER_TEMP/spectre-package-channels" add Formula/spectre.rb bucket/spectre.json
-          git -C "$RUNNER_TEMP/spectre-package-channels" diff --cached --quiet \
-            || git -C "$RUNNER_TEMP/spectre-package-channels" commit \
-              -m "Publish Spectre CLI $RELEASE_VERSION package manifests"
-          git -C "$RUNNER_TEMP/spectre-package-channels" push origin HEAD:main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -610,3 +610,26 @@ jobs:
             "cli/build/construo/distributions/spectre-macosArm64.zip" \
             "cli/build/construo/distributions/spectre-windowsX64.zip" \
             --clobber
+
+      - name: Update self-hosted Homebrew tap and Scoop bucket
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/package-manifests"
+          python3 .github/scripts/generate-cli-package-manifests.py \
+            --version "$RELEASE_VERSION" \
+            --macos-arm64 cli/build/construo/distributions/spectre-macosArm64.zip \
+            --macos-x64 cli/build/construo/distributions/spectre-macosX64.zip \
+            --windows-x64 cli/build/construo/distributions/spectre-windowsX64.zip \
+            --output-dir "$output"
+          git fetch origin main
+          git worktree add "$RUNNER_TEMP/spectre-package-channels" origin/main
+          cp -R "$output/Formula" "$output/bucket" "$RUNNER_TEMP/spectre-package-channels/"
+          git -C "$RUNNER_TEMP/spectre-package-channels" config user.name "github-actions[bot]"
+          git -C "$RUNNER_TEMP/spectre-package-channels" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$RUNNER_TEMP/spectre-package-channels" add Formula/spectre.rb bucket/spectre.json
+          git -C "$RUNNER_TEMP/spectre-package-channels" diff --cached --quiet \
+            || git -C "$RUNNER_TEMP/spectre-package-channels" commit \
+              -m "Publish Spectre CLI $RELEASE_VERSION package manifests"
+          git -C "$RUNNER_TEMP/spectre-package-channels" push origin HEAD:main

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -52,6 +52,27 @@ Five jobs run on tag push:
    remains the canonical host for library modules; do not attach a partial library jar set to the
    GitHub release.
 
+## CLI package channels
+
+The Spectre repository also hosts its release manifests: `Formula/spectre.rb` is the Homebrew
+tap formula and `bucket/spectre.json` is the Scoop bucket manifest. The tag workflow regenerates
+both from the uploaded release archives and their SHA-256 values, then commits them to `main`.
+
+On macOS, use the repository as an explicit tap because its name is `spectre`, not Homebrew's
+`homebrew-*` shorthand:
+
+```shell
+brew tap rock3r/spectre https://github.com/rock3r/spectre
+brew install rock3r/spectre/spectre
+```
+
+On Windows:
+
+```powershell
+scoop bucket add spectre https://github.com/rock3r/spectre
+scoop install spectre
+```
+
 [ci-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/ci.yml
 [central-portal]: https://central.sonatype.com/
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -55,8 +55,9 @@ Five jobs run on tag push:
 ## CLI package channels
 
 The Spectre repository also hosts its release manifests: `Formula/spectre.rb` is the Homebrew
-tap formula and `bucket/spectre.json` is the Scoop bucket manifest. The tag workflow regenerates
-both from the uploaded release archives and their SHA-256 values, then commits them to `main`.
+tap formula and `bucket/spectre.json` is the Scoop bucket manifest. Publishing the draft GitHub
+release regenerates both from its public CLI archives and their SHA-256 values, then commits them
+to `main`.
 
 On macOS, use the repository as an explicit tap because its name is `spectre`, not Homebrew's
 `homebrew-*` shorthand:
@@ -105,6 +106,8 @@ Manual promotion checklist:
   of attaching a partial library jar set, and that it includes the Linux x64/Linux arm64,
   macOS x64/macOS arm64 (signed and stapled), and Windows x64 CLI bundles.
 - Undraft the GitHub release with `gh release edit <tag> --draft=false`.
+- Confirm the **Publish CLI package channels** workflow committed the refreshed Homebrew and Scoop
+  manifests to `main`.
 
 ## Required secrets
 


### PR DESCRIPTION
Closes #173

Adds the self-hosted distribution channels for the CLI:
- generates the Homebrew `Formula/spectre.rb` and Scoop `bucket/spectre.json` from release archives and SHA-256 values;
- has the tag release workflow commit refreshed manifests to `main`;
- documents explicit tapping of this repository plus Scoop installation.

Validation:
- `bash .github/scripts/test-generate-cli-package-manifests.sh`
- generated Formula syntax and Scoop JSON parsing
- Homebrew local-tap install dry-run (`Would install spectre`)
- `./gradlew check`