### PR TITLE
Capture directory lifecycle: sequencing, ledger, prune, detach report (#181)

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/CaptureCliCommands.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/CaptureCliCommands.kt
@@ -1,0 +1,182 @@
+package dev.sebastiano.spectre.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.int
+import dev.sebastiano.spectre.cli.daemon.CaptureLifecycle
+import dev.sebastiano.spectre.cli.daemon.CapturePruner
+import dev.sebastiano.spectre.cli.daemon.DaemonRequest
+import dev.sebastiano.spectre.cli.daemon.DaemonResponse
+import java.time.Duration
+import java.util.Locale
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal class CapturesCommand(request: (DaemonRequest) -> DaemonResponse, output: Appendable) :
+    CliktCommand(name = "captures") {
+    init {
+        subcommands(CapturesListCommand(request, output), CapturesPruneCommand(request, output))
+    }
+
+    override fun run(): Unit = Unit
+}
+
+private class CapturesListCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "list") {
+    private val all: Boolean by option("--all").flag(default = false)
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val liveIds = liveSessionIdsOrEmpty(request)
+        val entries = CaptureLifecycle.ledger().listExisting()
+        val rows =
+            entries
+                .filter { all || !it.explicitOutDir }
+                .sortedByDescending { it.createdAtEpochMs }
+                .map { entry ->
+                    CaptureListRowJson(
+                        path = entry.path,
+                        sessionId = entry.sessionId,
+                        sizeBytes = entry.sizeBytes,
+                        createdAtEpochMs = entry.createdAtEpochMs,
+                        explicitOutDir = entry.explicitOutDir,
+                        live = entry.sessionId in liveIds,
+                    )
+                }
+        if (json) {
+            output.append(CAPTURE_JSON.encodeToString(CaptureListJson(captures = rows)))
+        } else if (rows.isEmpty()) {
+            output.append("No captures.")
+            output.appendLine()
+        } else {
+            rows.forEach { row ->
+                val status = if (row.live) "live" else "closed"
+                val out = if (row.explicitOutDir) " out-dir" else ""
+                output.append(
+                    "${row.path}  session=${row.sessionId}  ${row.sizeBytes}B  $status$out"
+                )
+                output.appendLine()
+            }
+        }
+    }
+}
+
+private class CapturesPruneCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "prune") {
+    private val keep: Int? by option("--keep").int()
+    private val olderThan: String? by option("--older-than")
+    private val all: Boolean by option("--all").flag(default = false)
+    private val sessionId: String? by option("--session")
+    private val force: Boolean by option("--force").flag(default = false)
+    private val includeOutDir: Boolean by
+        option(
+                "--include-out-dir",
+                help = "Also delete captures written under client-supplied --out-dir roots",
+            )
+            .flag(default = false)
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val older = olderThan?.let { raw ->
+            parseOlderThan(raw)
+                ?: throw CliktError("Invalid --older-than value: $raw (use e.g. 7d, 24h, 30m)")
+        }
+        val result =
+            CapturePruner.prune(
+                request =
+                    CapturePruner.Request(
+                        keep = keep,
+                        olderThan = older,
+                        all = all,
+                        sessionId = sessionId,
+                        force = force,
+                        allowExplicitOutDir = includeOutDir,
+                    ),
+                liveSessionIds = liveSessionIdsOrEmpty(request),
+            )
+        if (json) {
+            output.append(
+                CAPTURE_JSON.encodeToString(
+                    CapturePruneJson(
+                        deleted = result.deletedPaths,
+                        skippedLive = result.skippedLive,
+                        skippedExplicitOutDir = result.skippedExplicitOutDir,
+                    )
+                )
+            )
+        } else {
+            output.append("Deleted ${result.deletedPaths.size} capture(s).")
+            if (result.skippedLive.isNotEmpty()) {
+                output.appendLine()
+                output.append(
+                    "Skipped ${result.skippedLive.size} live-session capture(s) (use --force)."
+                )
+            }
+            if (result.skippedExplicitOutDir.isNotEmpty()) {
+                output.appendLine()
+                output.append(
+                    "Skipped ${result.skippedExplicitOutDir.size} out-dir capture(s) " +
+                        "(use --include-out-dir)."
+                )
+            }
+        }
+        output.appendLine()
+    }
+}
+
+internal fun liveSessionIdsOrEmpty(request: (DaemonRequest) -> DaemonResponse): Set<String> =
+    runCatching {
+            when (val response = request(DaemonRequest.ListSessions)) {
+                is DaemonResponse.Sessions -> response.sessions.map { it.sessionId }.toSet()
+                else -> emptySet()
+            }
+        }
+        .getOrDefault(emptySet())
+
+internal fun parseOlderThan(raw: String): Duration? {
+    val match = Regex("^(\\d+)([smhd])$").matchEntire(raw.trim()) ?: return null
+    val amount = match.groupValues[1].toLong()
+    return when (match.groupValues[2]) {
+        "s" -> Duration.ofSeconds(amount)
+        "m" -> Duration.ofMinutes(amount)
+        "h" -> Duration.ofHours(amount)
+        "d" -> Duration.ofDays(amount)
+        else -> null
+    }
+}
+
+internal fun formatCaptureMegabytes(bytes: Long): String =
+    String.format(Locale.ROOT, "%.2f", bytes / BYTES_PER_MEBIBYTE)
+
+private const val BYTES_PER_MEBIBYTE: Double = 1024.0 * 1024.0
+
+@Serializable
+internal data class CaptureListJson(val version: Int = 1, val captures: List<CaptureListRowJson>)
+
+@Serializable
+internal data class CaptureListRowJson(
+    val path: String,
+    val sessionId: String,
+    val sizeBytes: Long,
+    val createdAtEpochMs: Long,
+    val explicitOutDir: Boolean,
+    val live: Boolean,
+)
+
+@Serializable
+internal data class CapturePruneJson(
+    val version: Int = 1,
+    val deleted: List<String>,
+    val skippedLive: List<String>,
+    val skippedExplicitOutDir: List<String>,
+)
+
+private val CAPTURE_JSON: Json = Json { encodeDefaults = true }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/CaptureCliCommands.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/CaptureCliCommands.kt
@@ -33,6 +33,7 @@ private class CapturesListCommand(
     private val json: Boolean by option("--json").flag(default = false)
 
     override fun run() {
+        // Listing is best-effort for live status; a down daemon marks everything closed.
         val liveIds = liveSessionIdsOrEmpty(request)
         val entries = CaptureLifecycle.ledger().listExisting()
         val rows =
@@ -89,6 +90,13 @@ private class CapturesPruneCommand(
             parseOlderThan(raw)
                 ?: throw CliktError("Invalid --older-than value: $raw (use e.g. 7d, 24h, 30m)")
         }
+        val keepValue = keep
+        if (keepValue != null && keepValue < 0) {
+            throw CliktError("--keep must be zero or a positive integer")
+        }
+        // Fail closed: if we cannot learn live sessions, refuse to prune so we never delete
+        // attached sessions' captures by treating the live set as empty.
+        val liveIds = requireLiveSessionIds(request)
         val result =
             CapturePruner.prune(
                 request =
@@ -100,7 +108,7 @@ private class CapturesPruneCommand(
                         force = force,
                         allowExplicitOutDir = includeOutDir,
                     ),
-                liveSessionIds = liveSessionIdsOrEmpty(request),
+                liveSessionIds = liveIds,
             )
         if (json) {
             output.append(
@@ -140,6 +148,21 @@ internal fun liveSessionIdsOrEmpty(request: (DaemonRequest) -> DaemonResponse): 
             }
         }
         .getOrDefault(emptySet())
+
+internal fun requireLiveSessionIds(request: (DaemonRequest) -> DaemonResponse): Set<String> =
+    when (val response = request(DaemonRequest.ListSessions)) {
+        is DaemonResponse.Sessions -> response.sessions.map { it.sessionId }.toSet()
+        is DaemonResponse.Error ->
+            throw CliktError(
+                "Cannot determine live sessions (${response.message}); " +
+                    "refusing to prune without a live-session list"
+            )
+        else ->
+            throw CliktError(
+                "Cannot determine live sessions from the daemon; " +
+                    "refusing to prune without a live-session list"
+            )
+    }
 
 internal fun parseOlderThan(raw: String): Duration? {
     val match = Regex("^(\\d+)([smhd])$").matchEntire(raw.trim()) ?: return null

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -133,6 +133,7 @@ private class RootCommand(
             TypeCommand(request, output),
             ScreenshotCommand(request, output),
             CaptureCommand(request, output),
+            CapturesCommand(request, output),
             RecordCommand(request, output),
             PsCommand(request, output),
             DaemonCommand(request, shutdownRequest, output),
@@ -417,16 +418,42 @@ private class DetachCommand(
     private val json: Boolean by option("--json").flag(default = false)
 
     override fun run() {
-        val detachedSessionId =
+        val detached =
             when (val response = request(DaemonRequest.Detach(sessionId))) {
-                is DaemonResponse.Detached -> response.sessionId
+                is DaemonResponse.Detached -> response
                 is DaemonResponse.Error -> throw DaemonCommandException(response)
                 else -> error("Daemon returned an unexpected response to detach")
             }
         if (json) {
-            output.append(CLI_JSON.encodeToString(DetachJson(id = detachedSessionId)))
+            output.append(
+                CLI_JSON.encodeToString(
+                    DetachJson(
+                        id = detached.sessionId,
+                        captureCount = detached.captureCount,
+                        captureBytes = detached.captureBytes,
+                        capturePaths = detached.capturePaths,
+                        pruneCommand = detached.pruneCommand,
+                    )
+                )
+            )
         } else {
-            output.append("Detached $detachedSessionId.")
+            output.append("Detached ${detached.sessionId}.")
+            if (detached.captureCount > 0) {
+                output.appendLine()
+                output.append(
+                    "This session wrote ${detached.captureCount} captures, " +
+                        formatCaptureMegabytes(detached.captureBytes) +
+                        " MB:"
+                )
+                detached.capturePaths.forEach { path ->
+                    output.appendLine()
+                    output.append("  $path")
+                }
+                detached.pruneCommand?.let { command ->
+                    output.appendLine()
+                    output.append("Prune with: $command")
+                }
+            }
         }
         output.appendLine()
     }
@@ -561,7 +588,15 @@ private data class DaemonKillJson(val version: Int = JSON_VERSION, val stopped: 
 @Serializable
 private data class AttachJson(val version: Int = JSON_VERSION, val id: String, val pid: Long)
 
-@Serializable private data class DetachJson(val version: Int = JSON_VERSION, val id: String)
+@Serializable
+private data class DetachJson(
+    val version: Int = JSON_VERSION,
+    val id: String,
+    val captureCount: Int = 0,
+    val captureBytes: Long = 0L,
+    val capturePaths: List<String> = emptyList(),
+    val pruneCommand: String? = null,
+)
 
 @Serializable private data class CompletionJson(val version: Int = JSON_VERSION, val id: String)
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureArtifactStore.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureArtifactStore.kt
@@ -4,15 +4,12 @@ import dev.sebastiano.spectre.agent.AtomicCaptureResult
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import java.nio.file.Files
 import java.nio.file.Path
-import java.time.Instant
-import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
+import java.time.Clock
 
 /**
- * Writes atomic-capture artifacts for the #180 thin surface.
+ * Writes atomic-capture artifacts and records them in the append-only ledger.
  *
- * Full sequencing, retention, and ledger ownership land in #181; this store only guarantees a
- * unique writable directory and dumps `capture.json` + `screenshot.png`.
+ * Sequencing, retention, and session-aware lifecycle ownership for #181 live here.
  */
 @OptIn(ExperimentalSpectreAgentApi::class)
 internal object CaptureArtifactStore {
@@ -21,12 +18,36 @@ internal object CaptureArtifactStore {
         sessionId: String,
         result: AtomicCaptureResult,
         outDir: String?,
+        liveSessionIds: Set<String> = emptySet(),
+        clock: Clock = Clock.systemUTC(),
+        ledger: CaptureLedger = CaptureLifecycle.ledger(),
+        defaultRoot: Path = CaptureLifecycle.defaultCapturesRoot(),
+        retentionKeep: Int = CaptureRetention.DEFAULT_KEEP,
     ): DaemonResponse.Capture {
-        val directory = allocateDirectory(outDir)
+        val explicitOutDir = outDir != null
+        val directory = CaptureLifecycle.allocateDirectory(outDir, clock)
         val captureJsonPath = directory.resolve("capture.json")
         val screenshotPngPath = directory.resolve("screenshot.png")
         Files.writeString(captureJsonPath, result.captureJson)
         Files.write(screenshotPngPath, result.pngBytes)
+        val sizeBytes = CaptureLifecycle.directorySizeBytes(directory)
+        ledger.append(
+            CaptureLedgerEntry(
+                sessionId = sessionId,
+                path = directory.toAbsolutePath().normalize().toString(),
+                createdAtEpochMs = clock.millis(),
+                sizeBytes = sizeBytes,
+                explicitOutDir = explicitOutDir,
+            )
+        )
+        if (!explicitOutDir) {
+            CaptureRetention.enforce(
+                defaultRoot = defaultRoot,
+                ledger = ledger,
+                keep = retentionKeep,
+                liveSessionIds = liveSessionIds + sessionId,
+            )
+        }
         return DaemonResponse.Capture(
             sessionId = sessionId,
             directory = directory.toString(),
@@ -41,20 +62,5 @@ internal object CaptureArtifactStore {
             imageHeight = result.imageHeight,
             captureDurationMs = result.captureDurationMs,
         )
-    }
-
-    private fun allocateDirectory(outDir: String?): Path {
-        val root =
-            if (outDir != null) {
-                Path.of(outDir)
-            } else {
-                Path.of(System.getProperty("java.io.tmpdir"), "spectre", "captures")
-            }
-        Files.createDirectories(root)
-        val stamp =
-            DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSS")
-                .withZone(ZoneOffset.UTC)
-                .format(Instant.now())
-        return Files.createTempDirectory(root, "0000-$stamp-")
     }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureDirectoryAllocator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureDirectoryAllocator.kt
@@ -1,0 +1,73 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.FileAlreadyExistsException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+/** Allocates `NNNN-<timestamp>/` capture directories under a root without shared counters. */
+internal object CaptureDirectoryAllocator {
+    private val SEQUENCE_PREFIX = Regex("^(\\d{4})-")
+    private val TIMESTAMP =
+        DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssSSS'Z'").withZone(ZoneOffset.UTC)
+
+    fun allocate(root: Path, clock: Clock = Clock.systemUTC()): Path {
+        Files.createDirectories(root)
+        hardenDirectoryPermissions(root)
+        var nextSequence = nextSequenceNumber(root)
+        repeat(MAX_ALLOCATION_ATTEMPTS) {
+            val name =
+                String.format(
+                    Locale.ROOT,
+                    "%04d-%s",
+                    nextSequence,
+                    TIMESTAMP.format(Instant.now(clock)),
+                )
+            val candidate = root.resolve(name)
+            try {
+                Files.createDirectory(candidate)
+                hardenDirectoryPermissions(candidate)
+                return candidate
+            } catch (_: FileAlreadyExistsException) {
+                nextSequence = maxOf(nextSequence + 1, nextSequenceNumber(root))
+            }
+        }
+        error(
+            "Could not allocate a capture directory under $root after $MAX_ALLOCATION_ATTEMPTS attempts"
+        )
+    }
+
+    fun nextSequenceNumber(root: Path): Int {
+        if (!Files.isDirectory(root)) return 1
+        var max = 0
+        Files.list(root).use { stream ->
+            stream.forEach { path ->
+                val match = SEQUENCE_PREFIX.find(path.fileName.toString()) ?: return@forEach
+                max = maxOf(max, match.groupValues[1].toInt())
+            }
+        }
+        return max + 1
+    }
+
+    private fun hardenDirectoryPermissions(directory: Path) {
+        try {
+            Files.setPosixFilePermissions(
+                directory,
+                setOf(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE,
+                ),
+            )
+        } catch (_: UnsupportedOperationException) {
+            // Windows and other non-POSIX filesystems ignore mode 0700.
+        }
+    }
+
+    private const val MAX_ALLOCATION_ATTEMPTS: Int = 64
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLedger.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLedger.kt
@@ -2,8 +2,10 @@ package dev.sebastiano.spectre.cli.daemon
 
 import java.nio.channels.FileChannel
 import java.nio.charset.StandardCharsets
+import java.nio.file.AtomicMoveNotSupportedException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.StandardCopyOption
 import java.nio.file.StandardOpenOption
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.encodeToString
@@ -12,36 +14,42 @@ import kotlinx.serialization.json.Json
 /** Append-only capture ledger. Crash-proof index covering default-root and out-dir captures. */
 internal class CaptureLedger(private val ledgerFile: Path) {
     fun append(entry: CaptureLedgerEntry) {
-        Files.createDirectories(ledgerFile.parent)
-        val line = JSON.encodeToString(entry) + "\n"
-        FileChannel.open(
-                ledgerFile,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.WRITE,
-                StandardOpenOption.APPEND,
-            )
-            .use { channel ->
-                val buffer = StandardCharsets.UTF_8.encode(line)
-                while (buffer.hasRemaining()) {
-                    channel.write(buffer)
+        withLedgerLock {
+            Files.createDirectories(ledgerFile.parent)
+            val line = JSON.encodeToString(entry) + "\n"
+            FileChannel.open(
+                    ledgerFile,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.APPEND,
+                )
+                .use { channel ->
+                    val buffer = StandardCharsets.UTF_8.encode(line)
+                    while (buffer.hasRemaining()) {
+                        channel.write(buffer)
+                    }
+                    channel.force(true)
                 }
-                channel.force(true)
-            }
+        }
     }
 
-    fun listExisting(): List<CaptureLedgerEntry> =
-        readAll().filter { entry -> Files.isDirectory(Path.of(entry.path)) }
+    fun listExisting(): List<CaptureLedgerEntry> = withLedgerLock {
+        readAllUnlocked().filter { entry -> Files.isDirectory(Path.of(entry.path)) }
+    }
 
     fun entriesForSession(sessionId: String): List<CaptureLedgerEntry> =
         listExisting().filter { it.sessionId == sessionId }
 
     fun removePaths(paths: Set<String>) {
-        if (paths.isEmpty() || !Files.isRegularFile(ledgerFile)) return
-        val remaining = readAll().filterNot { it.path in paths }
-        rewrite(remaining)
+        if (paths.isEmpty()) return
+        withLedgerLock {
+            if (!Files.isRegularFile(ledgerFile)) return@withLedgerLock
+            val remaining = readAllUnlocked().filterNot { it.path in paths }
+            rewriteUnlocked(remaining)
+        }
     }
 
-    private fun readAll(): List<CaptureLedgerEntry> {
+    private fun readAllUnlocked(): List<CaptureLedgerEntry> {
         if (!Files.isRegularFile(ledgerFile)) return emptyList()
         return Files.readAllLines(ledgerFile, StandardCharsets.UTF_8).mapNotNull { line ->
             val trimmed = line.trim()
@@ -51,7 +59,7 @@ internal class CaptureLedger(private val ledgerFile: Path) {
         }
     }
 
-    private fun rewrite(entries: List<CaptureLedgerEntry>) {
+    private fun rewriteUnlocked(entries: List<CaptureLedgerEntry>) {
         Files.createDirectories(ledgerFile.parent)
         val content = buildString {
             entries.forEach { entry ->
@@ -65,11 +73,28 @@ internal class CaptureLedger(private val ledgerFile: Path) {
             Files.move(
                 tmp,
                 ledgerFile,
-                java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-                java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+                StandardCopyOption.REPLACE_EXISTING,
+                StandardCopyOption.ATOMIC_MOVE,
             )
-        } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
-            Files.move(tmp, ledgerFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(tmp, ledgerFile, StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    private fun <T> withLedgerLock(block: () -> T): T {
+        val key = ledgerFile.toAbsolutePath().normalize().toString()
+        val monitor = JVM_LOCKS.computeIfAbsent(key) { Any() }
+        // Same-JVM writers cannot overlap FileChannel locks; serialize in-process first, then
+        // take an exclusive file lock so CLI prune and the daemon cannot race across processes.
+        synchronized(monitor) {
+            Files.createDirectories(ledgerFile.parent)
+            val lockPath = ledgerFile.resolveSibling(ledgerFile.fileName.toString() + ".lock")
+            FileChannel.open(lockPath, StandardOpenOption.CREATE, StandardOpenOption.WRITE).use {
+                channel ->
+                channel.lock().use {
+                    return block()
+                }
+            }
         }
     }
 
@@ -78,6 +103,7 @@ internal class CaptureLedger(private val ledgerFile: Path) {
             ignoreUnknownKeys = true
             encodeDefaults = true
         }
+        private val JVM_LOCKS = java.util.concurrent.ConcurrentHashMap<String, Any>()
     }
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLedger.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLedger.kt
@@ -1,0 +1,91 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.channels.FileChannel
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/** Append-only capture ledger. Crash-proof index covering default-root and out-dir captures. */
+internal class CaptureLedger(private val ledgerFile: Path) {
+    fun append(entry: CaptureLedgerEntry) {
+        Files.createDirectories(ledgerFile.parent)
+        val line = JSON.encodeToString(entry) + "\n"
+        FileChannel.open(
+                ledgerFile,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.WRITE,
+                StandardOpenOption.APPEND,
+            )
+            .use { channel ->
+                val buffer = StandardCharsets.UTF_8.encode(line)
+                while (buffer.hasRemaining()) {
+                    channel.write(buffer)
+                }
+                channel.force(true)
+            }
+    }
+
+    fun listExisting(): List<CaptureLedgerEntry> =
+        readAll().filter { entry -> Files.isDirectory(Path.of(entry.path)) }
+
+    fun entriesForSession(sessionId: String): List<CaptureLedgerEntry> =
+        listExisting().filter { it.sessionId == sessionId }
+
+    fun removePaths(paths: Set<String>) {
+        if (paths.isEmpty() || !Files.isRegularFile(ledgerFile)) return
+        val remaining = readAll().filterNot { it.path in paths }
+        rewrite(remaining)
+    }
+
+    private fun readAll(): List<CaptureLedgerEntry> {
+        if (!Files.isRegularFile(ledgerFile)) return emptyList()
+        return Files.readAllLines(ledgerFile, StandardCharsets.UTF_8).mapNotNull { line ->
+            val trimmed = line.trim()
+            if (trimmed.isEmpty()) return@mapNotNull null
+            runCatching { JSON.decodeFromString(CaptureLedgerEntry.serializer(), trimmed) }
+                .getOrNull()
+        }
+    }
+
+    private fun rewrite(entries: List<CaptureLedgerEntry>) {
+        Files.createDirectories(ledgerFile.parent)
+        val content = buildString {
+            entries.forEach { entry ->
+                append(JSON.encodeToString(entry))
+                append('\n')
+            }
+        }
+        val tmp = ledgerFile.resolveSibling(ledgerFile.fileName.toString() + ".tmp")
+        Files.writeString(tmp, content, StandardCharsets.UTF_8)
+        try {
+            Files.move(
+                tmp,
+                ledgerFile,
+                java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+            )
+        } catch (_: java.nio.file.AtomicMoveNotSupportedException) {
+            Files.move(tmp, ledgerFile, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        }
+    }
+
+    private companion object {
+        private val JSON = Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+        }
+    }
+}
+
+@Serializable
+internal data class CaptureLedgerEntry(
+    val sessionId: String,
+    val path: String,
+    val createdAtEpochMs: Long,
+    val sizeBytes: Long,
+    val explicitOutDir: Boolean,
+)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLifecycle.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLifecycle.kt
@@ -1,0 +1,35 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+
+/** Shared capture roots, ledger, and lifecycle helpers for the daemon and CLI. */
+internal object CaptureLifecycle {
+    fun defaultCapturesRoot(): Path =
+        Path.of(System.getProperty("java.io.tmpdir"), "spectre", "captures")
+
+    fun defaultLedgerFile(): Path =
+        Path.of(System.getProperty("java.io.tmpdir"), "spectre", "capture-ledger.jsonl")
+
+    fun ledger(ledgerFile: Path = defaultLedgerFile()): CaptureLedger = CaptureLedger(ledgerFile)
+
+    fun allocateDirectory(outDir: String?, clock: Clock = Clock.systemUTC()): Path {
+        val root =
+            if (outDir != null) {
+                Path.of(outDir)
+            } else {
+                defaultCapturesRoot()
+            }
+        return CaptureDirectoryAllocator.allocate(root, clock)
+    }
+
+    fun directorySizeBytes(directory: Path): Long {
+        if (!Files.isDirectory(directory)) return 0L
+        var total = 0L
+        Files.walk(directory).use { stream ->
+            stream.filter { Files.isRegularFile(it) }.forEach { total += Files.size(it) }
+        }
+        return total
+    }
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CapturePruner.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CapturePruner.kt
@@ -35,6 +35,9 @@ internal object CapturePruner {
         ) {
             "prune requires --keep, --older-than, --all, or --session"
         }
+        require(request.keep == null || request.keep >= 0) {
+            "--keep must be zero or a positive integer"
+        }
         val candidates = candidatesFor(request, ledger)
         val classified = classify(candidates, request, liveSessionIds)
         val toDelete = selectForDeletion(classified.selected, request, clock.millis())

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CapturePruner.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CapturePruner.kt
@@ -1,0 +1,115 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Path
+import java.time.Clock
+import java.time.Duration
+
+/** Explicit prune for `spectre captures prune` — all deletion flows through here. */
+internal object CapturePruner {
+    data class Request(
+        val keep: Int? = null,
+        val olderThan: Duration? = null,
+        val all: Boolean = false,
+        val sessionId: String? = null,
+        val force: Boolean = false,
+        val allowExplicitOutDir: Boolean = false,
+    )
+
+    data class Result(
+        val deletedPaths: List<String>,
+        val skippedLive: List<String>,
+        val skippedExplicitOutDir: List<String>,
+    )
+
+    fun prune(
+        request: Request,
+        ledger: CaptureLedger = CaptureLifecycle.ledger(),
+        liveSessionIds: Set<String>,
+        clock: Clock = Clock.systemUTC(),
+    ): Result {
+        require(
+            request.keep != null ||
+                request.olderThan != null ||
+                request.all ||
+                request.sessionId != null
+        ) {
+            "prune requires --keep, --older-than, --all, or --session"
+        }
+        val candidates = candidatesFor(request, ledger)
+        val classified = classify(candidates, request, liveSessionIds)
+        val toDelete = selectForDeletion(classified.selected, request, clock.millis())
+        val deleted = deleteEntries(toDelete, ledger)
+        return Result(
+            deletedPaths = deleted,
+            skippedLive = classified.skippedLive,
+            skippedExplicitOutDir = classified.skippedExplicit,
+        )
+    }
+
+    private fun candidatesFor(request: Request, ledger: CaptureLedger): List<CaptureLedgerEntry> =
+        ledger.listExisting().filter { entry ->
+            request.sessionId == null || entry.sessionId == request.sessionId
+        }
+
+    private data class Classified(
+        val selected: List<CaptureLedgerEntry>,
+        val skippedLive: List<String>,
+        val skippedExplicit: List<String>,
+    )
+
+    private fun classify(
+        candidates: List<CaptureLedgerEntry>,
+        request: Request,
+        liveSessionIds: Set<String>,
+    ): Classified {
+        val selected = ArrayList<CaptureLedgerEntry>()
+        val skippedLive = ArrayList<String>()
+        val skippedExplicit = ArrayList<String>()
+        for (entry in candidates) {
+            when {
+                !request.force && entry.sessionId in liveSessionIds -> skippedLive.add(entry.path)
+                entry.explicitOutDir && !request.allowExplicitOutDir ->
+                    skippedExplicit.add(entry.path)
+                else -> selected.add(entry)
+            }
+        }
+        return Classified(selected, skippedLive, skippedExplicit)
+    }
+
+    private fun selectForDeletion(
+        selected: List<CaptureLedgerEntry>,
+        request: Request,
+        nowEpochMs: Long,
+    ): List<CaptureLedgerEntry> {
+        val sorted = selected.sortedBy { it.createdAtEpochMs }
+        if (request.all) return sorted
+        if (request.sessionId != null && request.keep == null && request.olderThan == null) {
+            return sorted
+        }
+        var remaining = sorted
+        request.olderThan?.let { age ->
+            val cutoff = nowEpochMs - age.toMillis()
+            remaining = remaining.filter { it.createdAtEpochMs < cutoff }
+        }
+        request.keep?.let { keep ->
+            remaining = if (remaining.size > keep) remaining.dropLast(keep) else emptyList()
+        }
+        return remaining
+    }
+
+    private fun deleteEntries(
+        entries: List<CaptureLedgerEntry>,
+        ledger: CaptureLedger,
+    ): List<String> {
+        val deleted = ArrayList<String>()
+        for (entry in entries) {
+            if (CaptureRetention.deleteCaptureDirectory(Path.of(entry.path))) {
+                deleted.add(entry.path)
+            }
+        }
+        if (deleted.isNotEmpty()) {
+            ledger.removePaths(deleted.toSet())
+        }
+        return deleted
+    }
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureRetention.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureRetention.kt
@@ -1,0 +1,62 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.isDirectory
+
+/**
+ * Lazy retention for the default capture root only.
+ *
+ * Never deletes captures owned by currently-attached sessions, and never auto-touches
+ * client-supplied out-dir captures (those are only removed via explicit prune).
+ */
+internal object CaptureRetention {
+    const val DEFAULT_KEEP: Int = 50
+
+    fun enforce(
+        defaultRoot: Path,
+        ledger: CaptureLedger,
+        keep: Int = DEFAULT_KEEP,
+        liveSessionIds: Set<String>,
+    ): List<Path> {
+        if (keep < 0) return emptyList()
+        val defaultEntries =
+            ledger
+                .listExisting()
+                .filter { !it.explicitOutDir }
+                .filter { isUnder(Path.of(it.path), defaultRoot) }
+                .sortedBy { it.createdAtEpochMs }
+
+        val deletable = defaultEntries.filter { entry -> entry.sessionId !in liveSessionIds }
+        if (deletable.size <= keep) return emptyList()
+
+        val toDelete = deletable.dropLast(keep)
+        val deleted = ArrayList<Path>()
+        for (entry in toDelete) {
+            val path = Path.of(entry.path)
+            if (deleteRecursively(path)) {
+                deleted.add(path)
+            }
+        }
+        if (deleted.isNotEmpty()) {
+            ledger.removePaths(deleted.map { it.toString() }.toSet())
+        }
+        return deleted
+    }
+
+    fun deleteCaptureDirectory(path: Path): Boolean = deleteRecursively(path)
+
+    private fun isUnder(path: Path, root: Path): Boolean {
+        val normalizedPath = path.toAbsolutePath().normalize()
+        val normalizedRoot = root.toAbsolutePath().normalize()
+        return normalizedPath.startsWith(normalizedRoot)
+    }
+
+    private fun deleteRecursively(path: Path): Boolean {
+        if (!Files.exists(path)) return false
+        if (path.isDirectory()) {
+            Files.list(path).use { stream -> stream.forEach { child -> deleteRecursively(child) } }
+        }
+        return runCatching { Files.deleteIfExists(path) }.getOrDefault(false)
+    }
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureSessionReport.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureSessionReport.kt
@@ -1,0 +1,25 @@
+package dev.sebastiano.spectre.cli.daemon
+
+/** Session-scoped leftover capture reporting for detach. */
+internal object CaptureSessionReport {
+    fun forDetach(
+        sessionId: String,
+        ledger: CaptureLedger = CaptureLifecycle.ledger(),
+    ): DaemonResponse.Detached {
+        val entries = ledger.entriesForSession(sessionId)
+        val bytes = entries.sumOf { it.sizeBytes }
+        val paths = entries.map { it.path }
+        return DaemonResponse.Detached(
+            sessionId = sessionId,
+            captureCount = entries.size,
+            captureBytes = bytes,
+            capturePaths = paths,
+            pruneCommand =
+                if (entries.isEmpty()) {
+                    null
+                } else {
+                    "spectre captures prune --session $sessionId"
+                },
+        )
+    }
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -146,7 +146,15 @@ public sealed interface DaemonResponse {
 
     @Serializable
     @SerialName("detached")
-    public data class Detached(public val sessionId: String) : DaemonResponse
+    public data class Detached(
+        public val sessionId: String,
+        /** Captures this session left on disk (existing directories only). */
+        public val captureCount: Int = 0,
+        public val captureBytes: Long = 0L,
+        public val capturePaths: List<String> = emptyList(),
+        /** Exact CLI command to prune only this session's leftover captures. */
+        public val pruneCommand: String? = null,
+    ) : DaemonResponse
 
     @Serializable
     @SerialName("sessions")

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -79,9 +79,10 @@ internal constructor(
             is DaemonRequest.Capture ->
                 invoke(request.sessionId) { automator ->
                     CaptureArtifactStore.write(
-                        request.sessionId,
-                        automator.capture(request.windowIndex),
-                        request.outDir,
+                        sessionId = request.sessionId,
+                        result = automator.capture(request.windowIndex),
+                        outDir = request.outDir,
+                        liveSessionIds = liveSessionIds(),
                     )
                 }
             is DaemonRequest.StartRecording ->
@@ -147,8 +148,10 @@ internal constructor(
                     message = "session not found: $sessionId",
                 )
         sessionsByPid.remove(removed.key)?.automator?.close()
-        return DaemonResponse.Detached(sessionId = sessionId)
+        return CaptureSessionReport.forDetach(sessionId)
     }
+
+    private fun liveSessionIds(): Set<String> = sessionsByPid.values.map { it.sessionId }.toSet()
 
     private fun listSessions(): DaemonResponse =
         DaemonResponse.Sessions(

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -290,7 +290,8 @@ class SpectreCliTest {
             )
 
         assertEquals(0, cli.run(listOf("detach", "pid-42", "--json")))
-        assertEquals("{\"version\":1,\"id\":\"pid-42\"}\n", output.toString())
+        assertTrue(output.toString().contains("\"id\":\"pid-42\""))
+        assertTrue(output.toString().contains("\"captureCount\":0"))
     }
 
     @Test

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureArtifactStoreTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureArtifactStoreTest.kt
@@ -1,0 +1,66 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.AtomicCaptureResult
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Files
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+class CaptureArtifactStoreTest {
+    @Test
+    fun `writes artifacts ledger entry and uses sequenced directory names`() {
+        val root = Files.createTempDirectory("spectre-store-root")
+        val ledgerFile = root.resolve("ledger.jsonl")
+        val ledger = CaptureLedger(ledgerFile)
+        val clock = Clock.fixed(Instant.parse("2026-07-20T12:00:00Z"), ZoneOffset.UTC)
+
+        val first =
+            CaptureArtifactStore.write(
+                sessionId = "pid-1",
+                result = sampleResult(),
+                outDir = root.toString(),
+                liveSessionIds = setOf("pid-1"),
+                clock = clock,
+                ledger = ledger,
+                defaultRoot = root,
+                retentionKeep = 50,
+            )
+        val second =
+            CaptureArtifactStore.write(
+                sessionId = "pid-1",
+                result = sampleResult(),
+                outDir = root.toString(),
+                liveSessionIds = setOf("pid-1"),
+                clock = clock,
+                ledger = ledger,
+                defaultRoot = root,
+                retentionKeep = 50,
+            )
+
+        assertTrue(Files.isRegularFile(java.nio.file.Path.of(first.captureJsonPath)))
+        assertTrue(Files.isRegularFile(java.nio.file.Path.of(first.screenshotPngPath)))
+        assertTrue(first.directory.contains("0001-"))
+        assertTrue(second.directory.contains("0002-"))
+        assertEquals(2, ledger.listExisting().size)
+        assertEquals("pid-1", ledger.listExisting().first().sessionId)
+    }
+
+    private fun sampleResult(): AtomicCaptureResult =
+        AtomicCaptureResult(
+            captureJson = """{"schemaVersion":1}""",
+            pngBytes = byteArrayOf(1, 2, 3, 4),
+            schemaVersion = 1,
+            windowIndex = 0,
+            nodeCount = 1,
+            taggedNodeCount = 0,
+            textedNodeCount = 0,
+            imageWidth = 10,
+            imageHeight = 10,
+            captureDurationMs = 5,
+        )
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureDirectoryAllocatorTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureDirectoryAllocatorTest.kt
@@ -1,0 +1,54 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Files
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CaptureDirectoryAllocatorTest {
+    @Test
+    fun `allocates sequential NNNN-timestamp directories under the root`() {
+        val root = Files.createTempDirectory("spectre-capture-root")
+        val first = CaptureDirectoryAllocator.allocate(root)
+        val second = CaptureDirectoryAllocator.allocate(root)
+
+        assertTrue(first.fileName.toString().startsWith("0001-"))
+        assertTrue(second.fileName.toString().startsWith("0002-"))
+        assertTrue(Files.isDirectory(first))
+        assertTrue(Files.isDirectory(second))
+        assertEquals(root, first.parent)
+        assertEquals(root, second.parent)
+    }
+
+    @Test
+    fun `continues sequence after existing directories`() {
+        val root = Files.createTempDirectory("spectre-capture-root")
+        Files.createDirectory(root.resolve("0007-already-there"))
+        Files.createDirectory(root.resolve("not-a-capture"))
+
+        val next = CaptureDirectoryAllocator.allocate(root)
+        assertTrue(next.fileName.toString().startsWith("0008-"))
+    }
+
+    @Test
+    fun `concurrent allocators never collide on the same root`() {
+        val root = Files.createTempDirectory("spectre-capture-root")
+        val pool = Executors.newFixedThreadPool(8)
+        try {
+            val futures =
+                (1..40).map {
+                    pool.submit(
+                        Callable { CaptureDirectoryAllocator.allocate(root).fileName.toString() }
+                    )
+                }
+            val names = futures.map { it.get(10, TimeUnit.SECONDS) }.toSet()
+            assertEquals(40, names.size)
+            assertEquals(40, Files.list(root).use { it.count() })
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLedgerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLedgerTest.kt
@@ -67,4 +67,41 @@ class CaptureLedgerTest {
         assertEquals(listOf(keep.toString()), ledger.listExisting().map { it.path })
         assertTrue(Files.exists(keep))
     }
+
+    @Test
+    fun `concurrent append and removePaths does not drop surviving entries`() {
+        val root = Files.createTempDirectory("spectre-ledger-race")
+        val ledger = CaptureLedger(root.resolve("ledger.jsonl"))
+        val keepers =
+            (1..20).map { index ->
+                val dir = Files.createDirectory(root.resolve("k$index"))
+                ledger.append(CaptureLedgerEntry("s", dir.toString(), index.toLong(), 1, false))
+                dir
+            }
+        val doomed = Files.createDirectory(root.resolve("doomed"))
+        ledger.append(CaptureLedgerEntry("s", doomed.toString(), 100, 1, false))
+
+        val pool = java.util.concurrent.Executors.newFixedThreadPool(4)
+        try {
+            val appends =
+                (1..30).map { index ->
+                    pool.submit {
+                        val dir = Files.createDirectory(root.resolve("a$index"))
+                        ledger.append(
+                            CaptureLedgerEntry("s", dir.toString(), 200L + index, 1, false)
+                        )
+                    }
+                }
+            val removals =
+                (1..10).map { pool.submit { ledger.removePaths(setOf(doomed.toString())) } }
+            (appends + removals).forEach { it.get(10, java.util.concurrent.TimeUnit.SECONDS) }
+        } finally {
+            pool.shutdownNow()
+        }
+
+        val paths = ledger.listExisting().map { it.path }.toSet()
+        keepers.forEach { assertTrue(paths.contains(it.toString()), "missing ${it.fileName}") }
+        assertTrue(paths.none { it.endsWith("doomed") })
+        assertTrue(paths.size >= keepers.size + 20)
+    }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLedgerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLedgerTest.kt
@@ -1,0 +1,70 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CaptureLedgerTest {
+    @Test
+    fun `append and list drops entries whose directories no longer exist`() {
+        val root = Files.createTempDirectory("spectre-ledger")
+        val ledgerFile = root.resolve("ledger.jsonl")
+        val alive = Files.createDirectory(root.resolve("alive"))
+        val gone = root.resolve("gone")
+        Files.createDirectory(gone)
+
+        val ledger = CaptureLedger(ledgerFile)
+        ledger.append(
+            CaptureLedgerEntry(
+                sessionId = "pid-1",
+                path = alive.toString(),
+                createdAtEpochMs = 10,
+                sizeBytes = 11,
+                explicitOutDir = false,
+            )
+        )
+        ledger.append(
+            CaptureLedgerEntry(
+                sessionId = "pid-1",
+                path = gone.toString(),
+                createdAtEpochMs = 20,
+                sizeBytes = 22,
+                explicitOutDir = true,
+            )
+        )
+        Files.delete(gone)
+
+        val listed = ledger.listExisting()
+        assertEquals(1, listed.size)
+        assertEquals(alive.toString(), listed.single().path)
+        assertEquals("pid-1", listed.single().sessionId)
+    }
+
+    @Test
+    fun `entriesForSession returns only that session's existing dirs`() {
+        val root = Files.createTempDirectory("spectre-ledger")
+        val ledger = CaptureLedger(root.resolve("ledger.jsonl"))
+        val a = Files.createDirectory(root.resolve("a"))
+        val b = Files.createDirectory(root.resolve("b"))
+        ledger.append(CaptureLedgerEntry("pid-1", a.toString(), 1, 1, explicitOutDir = false))
+        ledger.append(CaptureLedgerEntry("pid-2", b.toString(), 2, 2, explicitOutDir = false))
+
+        assertEquals(listOf(a.toString()), ledger.entriesForSession("pid-1").map { it.path })
+        assertEquals(listOf(b.toString()), ledger.entriesForSession("pid-2").map { it.path })
+    }
+
+    @Test
+    fun `removePaths drops matching ledger lines`() {
+        val root = Files.createTempDirectory("spectre-ledger")
+        val ledger = CaptureLedger(root.resolve("ledger.jsonl"))
+        val keep = Files.createDirectory(root.resolve("keep"))
+        val drop = Files.createDirectory(root.resolve("drop"))
+        ledger.append(CaptureLedgerEntry("s", keep.toString(), 1, 1, false))
+        ledger.append(CaptureLedgerEntry("s", drop.toString(), 2, 2, false))
+
+        ledger.removePaths(setOf(drop.toString()))
+        assertEquals(listOf(keep.toString()), ledger.listExisting().map { it.path })
+        assertTrue(Files.exists(keep))
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CapturePrunerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CapturePrunerTest.kt
@@ -1,0 +1,38 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class CapturePrunerTest {
+    @Test
+    fun `negative keep is rejected`() {
+        val root = Files.createTempDirectory("spectre-prune")
+        val ledger = CaptureLedger(root.resolve("ledger.jsonl"))
+        assertFailsWith<IllegalArgumentException> {
+            CapturePruner.prune(
+                request = CapturePruner.Request(keep = -1),
+                ledger = ledger,
+                liveSessionIds = emptySet(),
+            )
+        }
+    }
+
+    @Test
+    fun `live sessions are skipped without force`() {
+        val root = Files.createTempDirectory("spectre-prune")
+        val ledger = CaptureLedger(root.resolve("ledger.jsonl"))
+        val liveDir = Files.createDirectory(root.resolve("live"))
+        ledger.append(CaptureLedgerEntry("live", liveDir.toString(), 1, 1, false))
+        val result =
+            CapturePruner.prune(
+                request = CapturePruner.Request(all = true),
+                ledger = ledger,
+                liveSessionIds = setOf("live"),
+            )
+        assertTrue(result.deletedPaths.isEmpty())
+        assertTrue(result.skippedLive.contains(liveDir.toString()))
+        assertTrue(Files.isDirectory(liveDir))
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureRetentionTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureRetentionTest.kt
@@ -1,0 +1,76 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CaptureRetentionTest {
+    @Test
+    fun `keeps newest captures on default root and never touches live sessions`() {
+        val root = Files.createTempDirectory("spectre-retention")
+        val ledger = CaptureLedger(root.resolve("ledger.jsonl"))
+        val dirs =
+            (1..5).map { index ->
+                val dir =
+                    Files.createDirectory(
+                        root.resolve(String.format(java.util.Locale.ROOT, "%04d-ts", index))
+                    )
+                Files.writeString(dir.resolve("marker"), "x".repeat(index))
+                ledger.append(
+                    CaptureLedgerEntry(
+                        sessionId = if (index == 2) "live" else "closed",
+                        path = dir.toString(),
+                        createdAtEpochMs = index.toLong(),
+                        sizeBytes = index.toLong(),
+                        explicitOutDir = false,
+                    )
+                )
+                dir
+            }
+
+        val deleted =
+            CaptureRetention.enforce(
+                defaultRoot = root,
+                ledger = ledger,
+                keep = 2,
+                liveSessionIds = setOf("live"),
+            )
+
+        // Live session capture (0002) must remain even if old; keep last 2 closed plus live.
+        assertTrue(Files.isDirectory(dirs[1])) // live 0002
+        assertTrue(deleted.isNotEmpty())
+        assertFalse(Files.exists(dirs[0])) // oldest closed deleted
+        val remaining = ledger.listExisting().map { it.path }.toSet()
+        assertTrue(remaining.contains(dirs[1].toString()))
+        assertEquals(3, remaining.size) // live + 2 newest closed (0004, 0005) — or similar
+    }
+
+    @Test
+    fun `never auto-prunes explicit out-dir captures`() {
+        val defaultRoot = Files.createTempDirectory("spectre-default")
+        val outRoot = Files.createTempDirectory("spectre-out")
+        val ledger = CaptureLedger(defaultRoot.resolve("ledger.jsonl"))
+        val outCapture = Files.createDirectory(outRoot.resolve("0001-x"))
+        ledger.append(CaptureLedgerEntry("s", outCapture.toString(), 1, 10, explicitOutDir = true))
+        repeat(3) { index ->
+            val dir =
+                Files.createDirectory(
+                    defaultRoot.resolve(String.format(java.util.Locale.ROOT, "%04d-d", index + 1))
+                )
+            ledger.append(
+                CaptureLedgerEntry("s", dir.toString(), index + 2L, 1, explicitOutDir = false)
+            )
+        }
+
+        CaptureRetention.enforce(
+            defaultRoot = defaultRoot,
+            ledger = ledger,
+            keep = 1,
+            liveSessionIds = emptySet(),
+        )
+
+        assertTrue(Files.isDirectory(outCapture))
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
@@ -309,10 +309,10 @@ class DaemonSessionRegistryTest {
         val registry = testRegistry()
         registry.handle(DaemonRequest.Attach(1234))
 
-        assertEquals(
-            DaemonResponse.Detached("pid-1234"),
-            registry.handle(DaemonRequest.Detach("pid-1234")),
-        )
+        val detached =
+            assertIs<DaemonResponse.Detached>(registry.handle(DaemonRequest.Detach("pid-1234")))
+        assertEquals("pid-1234", detached.sessionId)
+        assertEquals(0, detached.captureCount)
         assertEquals(
             DaemonResponse.Sessions(emptyList()),
             registry.handle(DaemonRequest.ListSessions),

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -60,6 +60,10 @@ spectre type <session-id> "A short note"
 spectre screenshot <session-id> --output ./after-save.png
 # Atomic capture: window PNG + full semantics tree on disk (summary only on stdout).
 spectre capture <session-id> --json
+# List leftover capture dirs (sizes + live/closed status).
+spectre captures list
+# Prune closed-session captures on the default root (never touches live sessions without --force).
+spectre captures prune --keep 20
 spectre record start <session-id> --output ./interaction.mp4
 spectre record stop <session-id>
 ```
@@ -67,12 +71,22 @@ spectre record stop <session-id>
 `tree` lists the current semantics nodes. `find` performs an exact match on a Compose test tag.
 `windows` includes top-level windows and popup roots. `screenshot` writes a PNG to `--output`, or
 creates a temporary PNG and prints its path. `capture` takes a window screenshot and the semantics
-tree under the same tick, writes `capture.json` + `screenshot.png` under a capture directory
-(default `$TMPDIR/spectre/captures/…`, or `--out-dir`), and returns only a decision-grade summary
-(paths, node counts, image size). `record start` behaves similarly for an MP4.
+tree under the same tick, writes `capture.json` + `screenshot.png` under a sequenced capture
+directory (`NNNN-<timestamp>/` under `$TMPDIR/spectre/captures` by default, mode `0700`, or under
+`--out-dir`), appends a crash-proof ledger entry, and returns only a decision-grade summary
+(paths, node counts, image size). Default-root captures are lazily capped (keep last 50 closed
+sessions' captures); client `--out-dir` captures are never auto-deleted. `record start` behaves
+similarly for an MP4.
 
-Use `spectre detach <session-id>` when the session is no longer useful. `spectre daemon status`
-lists the daemon's sessions, and `spectre daemon kill` stops the daemon and discards all of them.
+`spectre captures list [--all] [--json]` lists ledger-backed capture directories with size and
+live/closed status. `spectre captures prune` supports `--keep N`, `--older-than 7d`, `--all`,
+`--session <id>`, and `--force` (override the live-session guard). Out-dir captures are skipped
+unless you pass `--include-out-dir`.
+
+Use `spectre detach <session-id>` when the session is no longer useful; the detach report lists
+that session's leftover captures and the exact `captures prune --session` command. `spectre daemon
+status` lists the daemon's sessions, and `spectre daemon kill` stops the daemon and discards all of
+them.
 
 ## MCP
 


### PR DESCRIPTION
Closes #181 (part of #179).

## Summary
- Sequenced capture dirs `NNNN-<timestamp>/` under `$TMPDIR/spectre/captures` (0700) or client `--out-dir`
- Append-only crash-proof ledger (`$TMPDIR/spectre/capture-ledger.jsonl`) covering default-root and out-dir captures
- Lazy default-root retention (keep last 50 closed captures); never auto-delete live sessions or out-dir captures
- CLI: `spectre captures list [--all] [--json]`, `spectre captures prune [--keep N | --older-than D | --all | --session id] [--force] [--include-out-dir]`
- Detach reports this session’s leftover captures + exact scoped prune command

## Tests
- Concurrent allocator no-collision test
- Ledger append/list/remove + gone-dir drop
- Retention live-session and out-dir guards
- CaptureArtifactStore sequencing + ledger wiring
- Registry/CLI detach field updates

## Validation
- `./gradlew check -x :agent:test` green locally (agent attach integration remains flaky under local GUI focus)