### PR TITLE
Ship spectre-capture agent skill for capture.json workflows (#182)

### DIFF
--- a/.agents/skills/spectre-release/SKILL.md
+++ b/.agents/skills/spectre-release/SKILL.md
@@ -58,6 +58,12 @@ publish <deployment-id> <version>
 Do not pass `--yes` unless the user explicitly asks for non-interactive publishing in the
 current task.
 
+## Capture schema skill
+
+If the release changes `CaptureDocument.SCHEMA_VERSION` / `capture.json`, bump the
+**`spectre-capture`** skill (`skills/spectre-capture/SKILL.md` + `package.json`) and the
+user-guide page `docs/guide/capture.md` in the same release.
+
 ## Finish
 
 After Central reports `PUBLISHED`, undraft the GitHub release:

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -14,6 +14,7 @@ import com.github.ajalt.clikt.parameters.types.path
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
+import dev.sebastiano.spectre.cli.daemon.CaptureSessionReport
 import dev.sebastiano.spectre.cli.daemon.DaemonClient
 import dev.sebastiano.spectre.cli.daemon.DaemonEndpoint
 import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
@@ -241,11 +242,16 @@ private class CaptureCommand(
                         imageWidth = capture.imageWidth,
                         imageHeight = capture.imageHeight,
                         captureDurationMs = capture.captureDurationMs,
+                        skillHint = CaptureSessionReport.CAPTURE_SKILL_NAME,
                     )
                 )
             )
         } else {
             output.append("Captured ${capture.nodeCount} nodes → ${capture.directory}")
+            output.appendLine()
+            output.append(
+                "See agent skill `${CaptureSessionReport.CAPTURE_SKILL_NAME}` for capture.json / jq workflows."
+            )
         }
         output.appendLine()
     }
@@ -433,6 +439,7 @@ private class DetachCommand(
                         captureBytes = detached.captureBytes,
                         capturePaths = detached.capturePaths,
                         pruneCommand = detached.pruneCommand,
+                        skillHint = detached.skillHint,
                     )
                 )
             )
@@ -452,6 +459,10 @@ private class DetachCommand(
                 detached.pruneCommand?.let { command ->
                     output.appendLine()
                     output.append("Prune with: $command")
+                }
+                detached.skillHint?.let { skill ->
+                    output.appendLine()
+                    output.append("See agent skill `$skill` for capture.json / jq workflows.")
                 }
             }
         }
@@ -596,6 +607,7 @@ private data class DetachJson(
     val captureBytes: Long = 0L,
     val capturePaths: List<String> = emptyList(),
     val pruneCommand: String? = null,
+    val skillHint: String? = null,
 )
 
 @Serializable private data class CompletionJson(val version: Int = JSON_VERSION, val id: String)
@@ -616,6 +628,7 @@ private data class CaptureJson(
     val imageWidth: Int,
     val imageHeight: Int,
     val captureDurationMs: Long,
+    val skillHint: String = CaptureSessionReport.CAPTURE_SKILL_NAME,
 )
 
 @Serializable

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureSessionReport.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureSessionReport.kt
@@ -20,6 +20,14 @@ internal object CaptureSessionReport {
                 } else {
                     "spectre captures prune --session $sessionId"
                 },
+            skillHint =
+                if (entries.isEmpty()) {
+                    null
+                } else {
+                    CAPTURE_SKILL_NAME
+                },
         )
     }
+
+    internal const val CAPTURE_SKILL_NAME: String = "spectre-capture"
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -154,6 +154,8 @@ public sealed interface DaemonResponse {
         public val capturePaths: List<String> = emptyList(),
         /** Exact CLI command to prune only this session's leftover captures. */
         public val pruneCommand: String? = null,
+        /** Agent skill name that documents capture.json + jq workflows. */
+        public val skillHint: String? = null,
     ) : DaemonResponse
 
     @Serializable

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -88,6 +88,11 @@ sanity-checked the artefacts side-by-side.
 
 Manual promotion checklist:
 
+- If this release changes the atomic capture schema (`CaptureDocument.SCHEMA_VERSION` /
+  `capture.json`), bump the **`spectre-capture`** agent skill
+  (`skills/spectre-capture/SKILL.md` + `package.json`) and the capture user-guide page in the
+  same release.
+
 - Confirm the tag points at the intended, already-reviewed `main` SHA.
 - Inspect the Central Portal staging deployment for all nine modules, including
   POM metadata, sources jars, javadoc jars, and Gradle module metadata.

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -1,0 +1,60 @@
+# Atomic capture
+
+Atomic capture freezes one Compose window into a PNG plus a versioned semantics tree
+(`capture.json`) taken under the same EDT/intent tick. Agents and scripts get only a
+decision-grade summary back; the full tree stays on disk for `jq` and other tools.
+
+## CLI
+
+```shell
+spectre capture <session-id> [--window N] [--out-dir DIR] [--json]
+spectre captures list [--all] [--json]
+spectre captures prune --keep 20
+spectre captures prune --session <session-id>
+```
+
+Default layout:
+
+```text
+$TMPDIR/spectre/captures/NNNN-<timestamp>/
+  capture.json
+  screenshot.png
+```
+
+See [CLI](cli.md) for full flags, retention, and detach leftover reports.
+
+## Agent skill: `spectre-capture`
+
+Ship path in this repository: [`skills/spectre-capture/SKILL.md`](https://github.com/rock3r/spectre/blob/main/skills/spectre-capture/SKILL.md).
+
+Install or copy that skill into the locations your agent harness already loads (for example
+project `skills/`, Claude skill dirs, or the packaged `skill/` tree for the general automation
+skill). Capture summaries and detach reports name **`spectre-capture`** so agents can discover
+it in-band.
+
+The skill covers:
+
+- schemaVersion **1** field reference
+- ready-made `jq` recipes (clickable nodes by text, bounds by test tag, tree diffs)
+- capture → act → capture → diff workflow
+- node-key lifetime (re-capture after navigation / re-attach)
+- `spectre captures prune` cleanup guidance
+- a manual find-click-verify recipe against a live fixture
+
+## Schema versioning
+
+`capture.json` is stable API. When `schemaVersion` bumps:
+
+1. Update golden fixtures under `core/src/test/resources/capture/`.
+2. Bump the **`spectre-capture`** skill (content + `package.json` version).
+3. Update this page and [CLI](cli.md) examples.
+4. Note the skill bump on the release checklist in [PUBLISHING.md](https://github.com/rock3r/spectre/blob/main/docs/PUBLISHING.md).
+
+## In-process API
+
+```kotlin
+val result = automator.capture(windowIndex = 0)
+// result.captureJson + result.pngBytes; write via your own paths or the agent/CLI surfaces
+```
+
+Library details live in `:core` under `dev.sebastiano.spectre.core.capture`.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -75,8 +75,9 @@ tree under the same tick, writes `capture.json` + `screenshot.png` under a seque
 directory (`NNNN-<timestamp>/` under `$TMPDIR/spectre/captures` by default, mode `0700`, or under
 `--out-dir`), appends a crash-proof ledger entry, and returns only a decision-grade summary
 (paths, node counts, image size). Default-root captures are lazily capped (keep last 50 closed
-sessions' captures); client `--out-dir` captures are never auto-deleted. `record start` behaves
-similarly for an MP4.
+sessions' captures); client `--out-dir` captures are never auto-deleted. Summaries and detach
+reports point agents at the **`spectre-capture`** skill for `jq` recipes — see
+[Atomic capture](capture.md). `record start` behaves similarly for an MP4.
 
 `spectre captures list [--all] [--json]` lists ledger-backed capture directories with size and
 live/closed status. `spectre captures prune` supports `--keep N`, `--older-than 7d`, `--all`,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
       - Cross-JVM access: guide/cross-jvm.md
       - Agent attach: guide/agent.md
       - CLI: guide/cli.md
+      - Atomic capture: guide/capture.md
       - IntelliJ-hosted Compose: guide/intellij.md
       - Troubleshooting: guide/troubleshooting.md
   - Reference:

--- a/skills/spectre-capture/SKILL.md
+++ b/skills/spectre-capture/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: spectre-capture
+description: >
+  Use when working with Spectre atomic captures — capture.json + screenshot.png written by
+  `spectre capture`, the capture MCP tool, or ComposeAutomator.capture. Covers the versioned
+  capture schema, jq recipes over the tree, capture → act → capture → diff verification,
+  node-key lifetime, and captures prune cleanup.
+license: Apache-2.0
+compatibility: Requires the Spectre CLI (or in-process capture API) and schemaVersion 1 captures.
+---
+
+# Spectre capture output
+
+Atomic capture freezes one Compose window into:
+
+| File | Role |
+|---|---|
+| `screenshot.png` | Window pixels at capture time (primary visual evidence) |
+| `capture.json` | Versioned semantics tree + window metadata + summary |
+
+Only a **decision-grade summary** is returned to agents (paths, node counts, image size). The full
+tree stays on disk — query it with `jq` (or any JSON tool). This skill is the map.
+
+Skill name (for discovery): **`spectre-capture`**. Capture summaries and detach leftovers reports
+reference this name on purpose.
+
+## Where captures live
+
+Default root (mode `0700`):
+
+```text
+$TMPDIR/spectre/captures/NNNN-<timestamp>/
+  capture.json
+  screenshot.png
+```
+
+- Sequence numbers are allocated by scanning the root (no shared counter).
+- Client `--out-dir` / MCP `out_dir` overrides the root for that capture only.
+- Append-only ledger: `$TMPDIR/spectre/capture-ledger.jsonl`.
+
+List / prune:
+
+```shell
+spectre captures list [--all] [--json]
+spectre captures prune --keep 20
+spectre captures prune --session <session-id>
+spectre captures prune --older-than 7d
+# never touches live sessions without --force
+# never auto-touches --out-dir captures without --include-out-dir
+```
+
+On detach, Spectre reports that session’s leftover paths and the exact prune command.
+
+## capture.json schema (schemaVersion 1)
+
+Stable API surface — a schema bump is a skill bump (release checklist).
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "capturedAt": "ISO-8601 UTC",
+  "window": {
+    "index": 0,
+    "surfaceId": "…",
+    "title": "…",
+    "isPopup": false,
+    "boundsScreen": { "x": 0, "y": 0, "width": 0, "height": 0 },
+    "densityScaleX": 1.0,
+    "densityScaleY": 1.0,
+    "imageWidth": 800,
+    "imageHeight": 600
+  },
+  "nodes": [ /* flat DFS list; no parent/child edges in v1 */ ],
+  "summary": {
+    "nodeCount": 0,
+    "taggedNodeCount": 0,
+    "textedNodeCount": 0,
+    "imageWidth": 800,
+    "imageHeight": 600,
+    "captureDurationMs": 0
+  }
+}
+```
+
+### Node fields
+
+| Field | Meaning |
+|---|---|
+| `key` | Owner-scoped node key for `click` / friends **on the same attach session** |
+| `testTag` | Compose `Modifier.testTag` |
+| `text` / `texts` | Visible text |
+| `editableText` | Text field contents when present |
+| `contentDescription` | A11y description |
+| `role` | Semantics role string when present |
+| `enabled` / `clickable` / `focused` / `selected` | Flags |
+| `boundsImage` | **Primary** — pixels of `screenshot.png` |
+| `boundsScreen` | Secondary — screen-space for input targeting |
+
+`summary.textedNodeCount` counts nodes with non-empty `text` **or** `editableText`.
+
+## jq recipes
+
+Assume `CAP=…/capture.json`.
+
+```shell
+# All clickable nodes with text matching a substring (case-insensitive)
+jq -r --arg q 'save' '
+  .nodes[]
+  | select(.clickable and .enabled)
+  | select((.text // "" | ascii_downcase | contains($q))
+        or (.editableText // "" | ascii_downcase | contains($q)))
+  | "\(.key)\t\(.testTag // "-")\t\(.text // .editableText // "")"
+' "$CAP"
+
+# Bounds of a test tag (image pixels)
+jq -r --arg tag 'submit' '
+  .nodes[] | select(.testTag == $tag)
+  | "\(.key) image=\(.boundsImage) screen=\(.boundsScreen)"
+' "$CAP"
+
+# Node key for click after finding by tag
+KEY=$(jq -r --arg tag 'submit' '
+  .nodes[] | select(.testTag == $tag and .clickable) | .key
+' "$CAP" | head -n1)
+
+# Diff two captures' node keys + tags + text (structural smoke)
+jq -r '.nodes[] | "\(.key)\t\(.testTag // "")\t\(.text // .editableText // "")"' "$CAP_BEFORE" \
+  | sort > /tmp/before.txt
+jq -r '.nodes[] | "\(.key)\t\(.testTag // "")\t\(.text // .editableText // "")"' "$CAP_AFTER" \
+  | sort > /tmp/after.txt
+diff -u /tmp/before.txt /tmp/after.txt || true
+
+# Summary only
+jq '.summary' "$CAP"
+```
+
+## Workflow: capture → act → capture → diff
+
+1. **Settle the UI** yourself (`waitForIdle` / `waitForVisualIdle` in-process, or wait in the
+   target app). Capture does **not** auto-idle.
+2. **Capture before**:
+   ```shell
+   spectre capture <session-id> --json
+   # note directory / captureJson from the summary
+   ```
+3. **Find a target** with `jq` on `capture.json` (prefer `testTag`, then text).
+4. **Act** using the node **key** from that same capture while the session stays attached:
+   ```shell
+   spectre click <session-id> "$KEY"
+   ```
+5. **Capture after** and **diff** trees (or re-query for the expected text/tag).
+6. **Prune** when done:
+   ```shell
+   spectre captures prune --session <session-id>
+   ```
+
+### Node-key lifetime (critical)
+
+- Keys are valid for the **current attach session** and the tree they came from.
+- After navigation, re-composition, or re-attach, **re-capture** and re-resolve keys.
+- Do not cache keys across detach/attach cycles.
+
+## Capture from MCP / CLI / library
+
+| Surface | How |
+|---|---|
+| CLI | `spectre capture <session-id> [--window N] [--out-dir DIR] [--json]` |
+| MCP | `capture` tool (`session_id`, optional `window_index`, `out_dir`, `include_image`) |
+| In-process | `ComposeAutomator.capture(windowIndex)` → files via your own writer, or agent `AttachedAutomator.capture` |
+
+Prefer **files over inlining** the tree. Return summary fields to the agent; read `capture.json` on demand.
+
+## Cleanup guidance
+
+- Default root is lazy-capped (keep last 50 **closed** captures). Live sessions are never auto-pruned.
+- Explicit `--out-dir` captures are **never** auto-deleted; only `captures prune --include-out-dir`.
+- Prefer session-scoped prune from the detach report over blanket `--all`.
+
+## Manual validation recipe
+
+With only this skill + the Spectre CLI (no source reading):
+
+1. Start `agent-test-fixture` (or any tagged Compose Desktop fixture).
+2. `spectre ps --json` → `spectre attach <pid> --json`.
+3. `spectre capture <session-id> --json` → open `capture.json` with `jq`.
+4. Resolve a clickable node by `testTag` or text; `spectre click <session-id> <key>`.
+5. Capture again; confirm the expected text/tag change with `jq` or `diff`.
+6. `spectre detach <session-id>`; run the printed prune command.
+
+## Related
+
+- User guide CLI: <https://spectre.sebastiano.dev/guide/cli/>
+- Capture skill page: <https://spectre.sebastiano.dev/guide/capture/>
+- General UI automation skill: `spectre-ui-automation` / `spectre`

--- a/skills/spectre-capture/package.json
+++ b/skills/spectre-capture/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "spectre-capture",
+  "version": "1.0.0",
+  "description": "Agent skill for querying Spectre atomic capture output (capture.json schema v1)",
+  "keywords": ["claude-skill", "spectre", "capture", "compose-desktop", "jq", "ui-automation"],
+  "author": "Sebastiano Poggi <poggos@gmail.com>",
+  "license": "Apache-2.0",
+  "files": ["SKILL.md"]
+}


### PR DESCRIPTION
Closes #182 (part of #179).

## Summary
- New agent skill **`spectre-capture`** at `skills/spectre-capture/` (schema v1, jq recipes, capture→act→diff, node-key lifetime, prune guidance, manual validation recipe)
- User-guide page [Atomic capture](docs/guide/capture.md) + mkdocs nav
- Release checklist: schema bump ⇒ skill bump (`docs/PUBLISHING.md`, `spectre-release` skill)
- In-band discovery: capture CLI summary + detach leftovers report name the skill; MCP capture tool already references it

## Validation
- Targeted CLI tests green
- Docs links relative under `docs/` for mkdocs strict