### PR TITLE
Add #179 acceptance tests: live capture + lifecycle crash/concurrency

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -249,7 +249,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -164,7 +164,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureArtifactStore.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureArtifactStore.kt
@@ -25,7 +25,12 @@ internal object CaptureArtifactStore {
         retentionKeep: Int = CaptureRetention.DEFAULT_KEEP,
     ): DaemonResponse.Capture {
         val explicitOutDir = outDir != null
-        val directory = CaptureLifecycle.allocateDirectory(outDir, clock)
+        val directory =
+            CaptureLifecycle.allocateDirectory(
+                outDir = outDir,
+                clock = clock,
+                defaultRoot = defaultRoot,
+            )
         val captureJsonPath = directory.resolve("capture.json")
         val screenshotPngPath = directory.resolve("screenshot.png")
         Files.writeString(captureJsonPath, result.captureJson)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLifecycle.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLifecycle.kt
@@ -14,12 +14,16 @@ internal object CaptureLifecycle {
 
     fun ledger(ledgerFile: Path = defaultLedgerFile()): CaptureLedger = CaptureLedger(ledgerFile)
 
-    fun allocateDirectory(outDir: String?, clock: Clock = Clock.systemUTC()): Path {
+    fun allocateDirectory(
+        outDir: String?,
+        clock: Clock = Clock.systemUTC(),
+        defaultRoot: Path = defaultCapturesRoot(),
+    ): Path {
         val root =
             if (outDir != null) {
                 Path.of(outDir)
             } else {
-                defaultCapturesRoot()
+                defaultRoot
             }
         return CaptureDirectoryAllocator.allocate(root, clock)
     }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLifecycleAcceptanceTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureLifecycleAcceptanceTest.kt
@@ -1,0 +1,167 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.AtomicCaptureResult
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Files
+import java.time.Clock
+import java.time.Instant
+import java.time.ZoneOffset
+import java.util.concurrent.Callable
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Acceptance coverage for #181: crash-proof ledger survival and two-session concurrency/prune
+ * guards that the thinner unit tests do not fully exercise.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+class CaptureLifecycleAcceptanceTest {
+
+    @Test
+    fun `ledger survives process restart after mid-session captures`() {
+        val root = Files.createTempDirectory("spectre-crash-root")
+        val ledgerFile = root.resolve("capture-ledger.jsonl")
+        val firstProcessLedger = CaptureLedger(ledgerFile)
+        val clock = Clock.fixed(Instant.parse("2026-07-21T00:00:00Z"), ZoneOffset.UTC)
+
+        // Session writes two captures, then "dies" (drop the ledger instance; keep files).
+        CaptureArtifactStore.write(
+            sessionId = "pid-dead",
+            result = sampleResult(png = byteArrayOf(9, 9, 9)),
+            outDir = null,
+            liveSessionIds = setOf("pid-dead"),
+            clock = clock,
+            ledger = firstProcessLedger,
+            defaultRoot = root,
+            retentionKeep = 50,
+        )
+        CaptureArtifactStore.write(
+            sessionId = "pid-dead",
+            result = sampleResult(png = byteArrayOf(8, 8, 8, 8)),
+            outDir = null,
+            liveSessionIds = setOf("pid-dead"),
+            clock = clock,
+            ledger = firstProcessLedger,
+            defaultRoot = root,
+            retentionKeep = 50,
+        )
+
+        // New process: construct a fresh ledger on the same file — no in-memory state.
+        val restarted = CaptureLedger(ledgerFile)
+        val surviving = restarted.listExisting()
+        assertEquals(2, surviving.size, "both captures must still be listed after restart")
+        surviving.forEach { entry ->
+            assertEquals("pid-dead", entry.sessionId)
+            assertTrue(Files.isDirectory(java.nio.file.Path.of(entry.path)))
+            assertTrue(Files.isRegularFile(java.nio.file.Path.of(entry.path, "capture.json")))
+            assertTrue(Files.isRegularFile(java.nio.file.Path.of(entry.path, "screenshot.png")))
+            assertFalse(entry.explicitOutDir, "default-root captures must not be marked out-dir")
+        }
+        assertEquals(
+            listOf("0001-", "0002-"),
+            surviving.map { java.nio.file.Path.of(it.path).fileName.toString().take(5) }.sorted(),
+        )
+    }
+
+    @Test
+    fun `two sessions capture concurrently without colliding and cannot prune each others live dirs`() {
+        val root = Files.createTempDirectory("spectre-two-session")
+        val ledgerFile = root.resolve("capture-ledger.jsonl")
+        val ledger = CaptureLedger(ledgerFile)
+        val clock = Clock.systemUTC()
+        val pool = Executors.newFixedThreadPool(4)
+        try {
+            val jobs =
+                listOf("session-A", "session-B").flatMap { sessionId ->
+                    (1..8).map { index ->
+                        pool.submit(
+                            Callable {
+                                CaptureArtifactStore.write(
+                                    sessionId = sessionId,
+                                    result =
+                                        sampleResult(
+                                            png =
+                                                byteArrayOf(
+                                                    index.toByte(),
+                                                    sessionId.hashCode().toByte(),
+                                                )
+                                        ),
+                                    outDir = null,
+                                    liveSessionIds = setOf("session-A", "session-B"),
+                                    clock = clock,
+                                    ledger = ledger,
+                                    defaultRoot = root,
+                                    retentionKeep = 50,
+                                )
+                            }
+                        )
+                    }
+                }
+            val results = jobs.map { it.get(30, TimeUnit.SECONDS) }
+            assertEquals(16, results.size)
+            val dirs = results.map { it.directory }.toSet()
+            assertEquals(16, dirs.size, "every capture must get a unique directory")
+
+            val bySession = ledger.listExisting().groupBy { it.sessionId }
+            assertEquals(8, bySession["session-A"]?.size)
+            assertEquals(8, bySession["session-B"]?.size)
+
+            // Live guard: both sessions still attached — prune --all must skip every path.
+            val prunedWhileLive =
+                CapturePruner.prune(
+                    request = CapturePruner.Request(all = true),
+                    ledger = ledger,
+                    liveSessionIds = setOf("session-A", "session-B"),
+                )
+            assertTrue(prunedWhileLive.deletedPaths.isEmpty())
+            assertEquals(16, prunedWhileLive.skippedLive.size)
+            assertEquals(16, ledger.listExisting().size)
+
+            // Retention must also refuse to delete live sessions' dirs.
+            val retentionDeleted =
+                CaptureRetention.enforce(
+                    defaultRoot = root,
+                    ledger = ledger,
+                    keep = 1,
+                    liveSessionIds = setOf("session-A", "session-B"),
+                )
+            assertTrue(retentionDeleted.isEmpty())
+            assertEquals(16, ledger.listExisting().size)
+
+            // After A detaches, prune may remove only A's captures while B stays live.
+            val prunedAfterA =
+                CapturePruner.prune(
+                    request = CapturePruner.Request(sessionId = "session-A"),
+                    ledger = ledger,
+                    liveSessionIds = setOf("session-B"),
+                )
+            assertEquals(8, prunedAfterA.deletedPaths.size)
+            val remaining = ledger.listExisting()
+            assertEquals(8, remaining.size)
+            assertTrue(remaining.all { it.sessionId == "session-B" })
+            remaining.forEach { entry ->
+                assertTrue(Files.isDirectory(java.nio.file.Path.of(entry.path)))
+            }
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    private fun sampleResult(png: ByteArray): AtomicCaptureResult =
+        AtomicCaptureResult(
+            captureJson = """{"schemaVersion":1,"nodes":[]}""",
+            pngBytes = png,
+            schemaVersion = 1,
+            windowIndex = 0,
+            nodeCount = 0,
+            taggedNodeCount = 0,
+            textedNodeCount = 0,
+            imageWidth = 4,
+            imageHeight = 4,
+            captureDurationMs = 1,
+        )
+}

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/AtomicCaptureValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/AtomicCaptureValidationTest.kt
@@ -1,0 +1,189 @@
+package dev.sebastiano.spectre.sample.validation
+
+import dev.sebastiano.spectre.core.capture.CaptureArtifactsWriter
+import dev.sebastiano.spectre.core.capture.CaptureRect
+import dev.sebastiano.spectre.core.capture.screenRectToImageRect
+import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import java.nio.file.Files
+import javax.imageio.ImageIO
+import kotlin.math.abs
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Live acceptance for #180: [dev.sebastiano.spectre.core.ComposeAutomator.capture] on a real
+ * Compose Desktop sample UI.
+ *
+ * Asserts that `capture.json` image-space bounds for a known tagged node correlate with the PNG
+ * pixels, and that HiDPI density reported by the capture is applied consistently (the sample's
+ * hidpi scenario exercises fixed-dp targets whose screen/image geometry must scale together).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class AtomicCaptureValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre atomic capture validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `capture boundsImage matches PNG pixels for a tagged HiDPI target`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.hidpi")
+            // Semantics settle is enough here; waitForVisualIdle can hang under the synthetic
+            // driver when the host display is busy (same pattern as Issue8FidelityValidationTest).
+            waitForTestTag("hidpi.target.40x0")
+            waitForIdle()
+
+            val capture = capture(windowIndex = 0)
+            assertTrue(capture.pngBytes.isNotEmpty(), "PNG payload must be non-empty")
+            assertTrue(capture.document.nodes.isNotEmpty(), "semantics tree must be non-empty")
+            assertEquals(1, capture.document.schemaVersion)
+
+            val node = capture.document.nodes.firstOrNull { it.testTag == "hidpi.target.40x0" }
+            assertNotNull(node, "capture.json must include hidpi.target.40x0")
+            assertTrue(
+                node.clickable || node.enabled,
+                "target node should be interactive or enabled",
+            )
+
+            val window = capture.document.window
+            assertEquals(capture.image.width, window.imageWidth)
+            assertEquals(capture.image.height, window.imageHeight)
+            assertTrue(window.densityScaleX > 0.0 && window.densityScaleY > 0.0)
+
+            // Image-space bounds must be the pure transform of screen bounds through the
+            // capture region and PNG size — same math production uses.
+            val expectedImage =
+                screenRectToImageRect(
+                    screen =
+                        Rectangle(
+                            node.boundsScreen.x,
+                            node.boundsScreen.y,
+                            node.boundsScreen.width,
+                            node.boundsScreen.height,
+                        ),
+                    captureOriginX = window.boundsScreen.x,
+                    captureOriginY = window.boundsScreen.y,
+                    captureAwtWidth = window.boundsScreen.width,
+                    captureAwtHeight = window.boundsScreen.height,
+                    imageWidth = window.imageWidth,
+                    imageHeight = window.imageHeight,
+                )
+            assertEquals(
+                expectedImage,
+                node.boundsImage,
+                "boundsImage must match screen→image mapping for this capture",
+            )
+            assertTrue(node.boundsImage.width > 0 && node.boundsImage.height > 0)
+            assertTrue(
+                node.boundsImage.x >= 0 &&
+                    node.boundsImage.y >= 0 &&
+                    node.boundsImage.x + node.boundsImage.width <= window.imageWidth &&
+                    node.boundsImage.y + node.boundsImage.height <= window.imageHeight,
+                "boundsImage must lie inside the PNG: ${node.boundsImage} vs ${window.imageWidth}x${window.imageHeight}",
+            )
+
+            // PNG must actually contain non-background pixels inside the node's image box.
+            // HiDPI targets are solid primary-colored squares — sample the centre and a few
+            // interior points so we prove boundsImage points at the painted widget, not chrome.
+            val png = ImageIO.read(ByteArrayInputStream(capture.pngBytes))
+            assertNotNull(png)
+            assertEquals(window.imageWidth, png.width)
+            assertEquals(window.imageHeight, png.height)
+            assertTargetPixelsPresent(png, node.boundsImage)
+
+            // Density is recorded from the graphics transform; PNG scale may differ (synthetic
+            // screenshots often yield 1:1 AWT↔image while densityScale reports Retina 2.0). The
+            // image-space transform must still reconcile boundsScreen with the actual PNG size.
+            assertTrue(window.densityScaleX > 0.0 && window.densityScaleY > 0.0)
+            val scaleFromPixelsX =
+                window.imageWidth.toDouble() / window.boundsScreen.width.toDouble()
+            val scaleFromPixelsY =
+                window.imageHeight.toDouble() / window.boundsScreen.height.toDouble()
+            assertTrue(scaleFromPixelsX > 0.0 && scaleFromPixelsY > 0.0)
+
+            // Second target: relative geometry in image space must preserve the 2:1 dp ratio
+            // (160dp x, 80dp y) regardless of absolute density — HiDPI-scaled config coverage.
+            val node2 = capture.document.nodes.firstOrNull { it.testTag == "hidpi.target.200x80" }
+            assertNotNull(node2)
+            val dxImage = node2.boundsImage.x - node.boundsImage.x
+            val dyImage = node2.boundsImage.y - node.boundsImage.y
+            assertTrue(dxImage > 0 && dyImage > 0)
+            val ratio = dxImage.toDouble() / dyImage.toDouble()
+            assertTrue(
+                abs(ratio - 2.0) < 0.12,
+                "image-space delta ratio should stay ~2.0 (160dp/80dp), was $ratio " +
+                    "(dx=$dxImage dy=$dyImage density=${window.densityScaleX} " +
+                    "pngScale=$scaleFromPixelsX)",
+            )
+
+            // Files on disk must match the in-memory document/PNG.
+            val outDir = Files.createTempDirectory("spectre-atomic-capture-validation")
+            val written =
+                CaptureArtifactsWriter.write(
+                    directory = outDir,
+                    document = capture.document,
+                    pngBytes = capture.pngBytes,
+                )
+            assertTrue(Files.isRegularFile(written.captureJsonPath))
+            assertTrue(Files.isRegularFile(written.screenshotPngPath))
+            val diskPng = ImageIO.read(written.screenshotPngPath.toFile())
+            assertNotNull(diskPng)
+            assertEquals(png.width, diskPng.width)
+            assertEquals(png.height, diskPng.height)
+            val diskJson = Files.readString(written.captureJsonPath)
+            assertTrue(
+                diskJson.contains("\"schemaVersion\": 1") ||
+                    diskJson.contains("\"schemaVersion\":1")
+            )
+            assertTrue(diskJson.contains("hidpi.target.40x0"))
+        }
+    }
+
+    private fun assertTargetPixelsPresent(image: BufferedImage, box: CaptureRect) {
+        val samples = mutableListOf<Int>()
+        val cx = box.x + box.width / 2
+        val cy = box.y + box.height / 2
+        samples += image.getRGB(cx.coerceIn(0, image.width - 1), cy.coerceIn(0, image.height - 1))
+        // Interior offsets avoid anti-aliased edges.
+        val insetX = (box.width / 4).coerceAtLeast(1)
+        val insetY = (box.height / 4).coerceAtLeast(1)
+        samples +=
+            image.getRGB(
+                (box.x + insetX).coerceIn(0, image.width - 1),
+                (box.y + insetY).coerceIn(0, image.height - 1),
+            )
+        samples +=
+            image.getRGB(
+                (box.x + box.width - insetX - 1).coerceIn(0, image.width - 1),
+                (box.y + box.height - insetY - 1).coerceIn(0, image.height - 1),
+            )
+        // At least one interior sample must be far from pure black — solid primary fill.
+        val nonBlack = samples.any { rgb ->
+            val r = (rgb shr 16) and 0xFF
+            val g = (rgb shr 8) and 0xFF
+            val b = rgb and 0xFF
+            r + g + b > 40
+        }
+        assertTrue(
+            nonBlack,
+            "expected non-black pixels inside boundsImage $box (samples=${samples.map { Integer.toHexString(it) }})",
+        )
+    }
+}


### PR DESCRIPTION
Closes remaining verifier gaps for epic #179.

## #180 live capture
- `AtomicCaptureValidationTest` drives real `ComposeAutomator.capture()` against the sample-desktop HiDPI scenario
- Asserts `boundsImage` == `screenRectToImageRect(...)`, non-black PNG pixels inside the box, dual-target image-space ratio ~2.0
- Registered in validation-linux / validation-windows required classes

## #181 lifecycle acceptance
- Crash/restart: captures written then re-listed via a fresh `CaptureLedger` on the same file
- Two sessions: concurrent non-colliding dirs; live prune/retention cannot delete either session; after A detaches only A is pruneable

## Small production fix
- `CaptureLifecycle.allocateDirectory` / `CaptureArtifactStore` honour injected `defaultRoot` when `outDir` is null (needed for honest default-root tests)