### PR TITLE
Add window-identity read op for daemon-owned recording (#184)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -224,10 +224,13 @@ public final class dev/sebastiano/spectre/agent/transport/RectDto$Companion {
 
 public final class dev/sebastiano/spectre/agent/transport/WindowIdentityDto {
 	public static final field Companion Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto$Companion;
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DD)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DDDD)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DDDDILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()D
 	public final fun component11 ()D
+	public final fun component12 ()D
+	public final fun component13 ()D
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
@@ -236,8 +239,8 @@ public final class dev/sebastiano/spectre/agent/transport/WindowIdentityDto {
 	public final fun component7 ()Ldev/sebastiano/spectre/agent/transport/RectDto;
 	public final fun component8 ()Ldev/sebastiano/spectre/agent/transport/RectDto;
 	public final fun component9 ()Ldev/sebastiano/spectre/agent/transport/RectDto;
-	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DD)Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;
-	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DDILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DDDD)Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DDDDILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCropRequired ()Z
 	public final fun getIndex ()I
@@ -248,6 +251,8 @@ public final class dev/sebastiano/spectre/agent/transport/WindowIdentityDto {
 	public final fun getSurfaceBoundsOnScreen ()Ldev/sebastiano/spectre/agent/transport/RectDto;
 	public final fun getSurfaceId ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTranslateX ()D
+	public final fun getTranslateY ()D
 	public final fun getWindowBoundsOnScreen ()Ldev/sebastiano/spectre/agent/transport/RectDto;
 	public fun hashCode ()I
 	public final fun isPopup ()Z

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -93,6 +93,8 @@ public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/Au
 	public final fun getPid ()J
 	public final fun screenshot ()[B
 	public final fun typeText (Ljava/lang/String;)V
+	public final fun windowIdentities (Ljava/lang/Integer;)Ljava/util/List;
+	public static synthetic fun windowIdentities$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/Integer;ILjava/lang/Object;)Ljava/util/List;
 	public final fun windows ()Ljava/util/List;
 }
 
@@ -217,6 +219,53 @@ public final synthetic class dev/sebastiano/spectre/agent/transport/RectDto$$ser
 }
 
 public final class dev/sebastiano/spectre/agent/transport/RectDto$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/agent/transport/WindowIdentityDto {
+	public static final field Companion Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto$Companion;
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DD)V
+	public final fun component1 ()I
+	public final fun component10 ()D
+	public final fun component11 ()D
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Z
+	public final fun component7 ()Ldev/sebastiano/spectre/agent/transport/RectDto;
+	public final fun component8 ()Ldev/sebastiano/spectre/agent/transport/RectDto;
+	public final fun component9 ()Ldev/sebastiano/spectre/agent/transport/RectDto;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DD)Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLdev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;Ldev/sebastiano/spectre/agent/transport/RectDto;DDILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCropRequired ()Z
+	public final fun getIndex ()I
+	public final fun getNativeHandle ()Ljava/lang/Long;
+	public final fun getScaleX ()D
+	public final fun getScaleY ()D
+	public final fun getSurfaceBoundsInWindow ()Ldev/sebastiano/spectre/agent/transport/RectDto;
+	public final fun getSurfaceBoundsOnScreen ()Ldev/sebastiano/spectre/agent/transport/RectDto;
+	public final fun getSurfaceId ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getWindowBoundsOnScreen ()Ldev/sebastiano/spectre/agent/transport/RectDto;
+	public fun hashCode ()I
+	public final fun isPopup ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/agent/transport/WindowIdentityDto$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/agent/transport/WindowIdentityDto;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/agent/transport/WindowIdentityDto$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -4,6 +4,7 @@ import dev.sebastiano.spectre.agent.transport.AgentRequest
 import dev.sebastiano.spectre.agent.transport.AgentResponse
 import dev.sebastiano.spectre.agent.transport.IpcClient
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.WindowIdentityDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import dev.sebastiano.spectre.agent.transport.logLabel
 import java.io.IOException
@@ -17,7 +18,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * socket. The target JVM's shutdown hook (Path B) covers crash cleanup.
  *
  * Current wire surface: windows, allNodes, findByTestTag, click, typeText, screenshot, capture,
- * plus detach. Streaming/long-poll ops are deferred follow-ups (Q-3).
+ * windowIdentity, plus detach. Streaming/long-poll ops are deferred follow-ups (Q-3).
  *
  * Not thread-safe. Callers needing concurrent automator access must serialise externally.
  *
@@ -101,6 +102,19 @@ internal constructor(
             imageHeight = capture.imageHeight,
             captureDurationMs = capture.captureDurationMs,
         )
+    }
+
+    /**
+     * Describe native window identity for daemon-side recording.
+     *
+     * @param windowIndex when null, every tracked window; when set, only that index (empty if out
+     *   of range).
+     */
+    @Throws(IOException::class)
+    public fun windowIdentities(windowIndex: Int? = null): List<WindowIdentityDto> {
+        val resp = exchange(AgentRequest.WindowIdentity(windowIndex))
+        return (resp as? AgentResponse.WindowIdentities)?.windows
+            ?: throw wireMismatch("WindowIdentities", resp)
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AwtPeerModuleOpener.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AwtPeerModuleOpener.kt
@@ -10,9 +10,9 @@ import java.lang.instrument.Instrumentation
  * these grants, embedded `ComposePanel` surfaces (Compose `windowHandle == 0`) report `nativeHandle
  * = null` and daemon window+crop recording cannot bind to the host frame.
  *
- * Called once from [SpectreAgent] bootstrap. Opens to **every** module that has already loaded a
- * Spectre class (and the target classloader's unnamed module), because each classloader has its own
- * unnamed module and peer reflection runs in the target's core classloader — not the agent's.
+ * Called once from [SpectreAgent] bootstrap with the target's Spectre classloader so opens target
+ * the module that actually runs peer resolution in `:core`. Intentionally avoids scanning
+ * [Instrumentation.allLoadedClasses] (can be huge and risk attach timeouts).
  */
 internal object AwtPeerModuleOpener {
 
@@ -25,7 +25,7 @@ internal object AwtPeerModuleOpener {
                     )
                     return
                 }
-        val consumers = collectConsumerModules(targetClassLoader, instrumentation)
+        val consumers = collectConsumerModules(targetClassLoader)
         if (consumers.isEmpty()) {
             System.err.println("[spectre-agent] no consumer modules for AWT peer opens; skipping")
             return
@@ -72,25 +72,14 @@ internal object AwtPeerModuleOpener {
         )
     }
 
-    private fun collectConsumerModules(
-        targetClassLoader: ClassLoader,
-        instrumentation: Instrumentation,
-    ): Set<Module> {
+    private fun collectConsumerModules(targetClassLoader: ClassLoader): Set<Module> {
         val consumers = linkedSetOf<Module>()
-        // Prefer modules that already loaded Spectre types (same classloaders that run core).
-        for (loaded in instrumentation.allLoadedClasses) {
-            val name = loaded.name
-            if (name.startsWith(SPECTRE_PACKAGE_PREFIX)) {
-                consumers += loaded.module
-            }
-        }
         for (fqn in CONSUMER_CLASS_NAMES) {
             runCatching { Class.forName(fqn, false, targetClassLoader).module }
                 .getOrNull()
                 ?.let { consumers += it }
         }
         consumers += targetClassLoader.unnamedModule
-        ClassLoader.getSystemClassLoader()?.unnamedModule?.let { consumers += it }
         return consumers
     }
 
@@ -98,7 +87,6 @@ internal object AwtPeerModuleOpener {
         if (module.isNamed) module.name else "unnamed(${module.classLoader})"
 
     private const val JAVA_DESKTOP: String = "java.desktop"
-    private const val SPECTRE_PACKAGE_PREFIX: String = "dev.sebastiano.spectre."
 
     private val CONSUMER_CLASS_NAMES: List<String> =
         listOf(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AwtPeerModuleOpener.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AwtPeerModuleOpener.kt
@@ -1,0 +1,123 @@
+package dev.sebastiano.spectre.agent.runtime
+
+import java.lang.instrument.Instrumentation
+
+/**
+ * Opens and exports `java.desktop` internal packages so Spectre core can resolve native window
+ * handles via AWT peer reflection (`sun.awt.AWTAccessor`, platform peers).
+ *
+ * Modular JDKs do not export `sun.awt` / `sun.lwawt` / `sun.awt.X11` to unnamed modules. Without
+ * these grants, embedded `ComposePanel` surfaces (Compose `windowHandle == 0`) report `nativeHandle
+ * = null` and daemon window+crop recording cannot bind to the host frame.
+ *
+ * Called once from [SpectreAgent] bootstrap. Opens to **every** module that has already loaded a
+ * Spectre class (and the target classloader's unnamed module), because each classloader has its own
+ * unnamed module and peer reflection runs in the target's core classloader — not the agent's.
+ */
+internal object AwtPeerModuleOpener {
+
+    fun openFor(targetClassLoader: ClassLoader, instrumentation: Instrumentation) {
+        val desktop =
+            ModuleLayer.boot().findModule(JAVA_DESKTOP).orElse(null)
+                ?: run {
+                    System.err.println(
+                        "[spectre-agent] java.desktop module not found; skipping AWT peer opens"
+                    )
+                    return
+                }
+        val consumers = collectConsumerModules(targetClassLoader, instrumentation)
+        if (consumers.isEmpty()) {
+            System.err.println("[spectre-agent] no consumer modules for AWT peer opens; skipping")
+            return
+        }
+        // Only request packages that exist on this JDK/OS. Passing missing packages
+        // (e.g. sun.awt.windows on macOS) makes redefineModule reject the whole batch.
+        val presentPackages = AWT_PEER_PACKAGES.filter { pkg -> desktop.packages.contains(pkg) }
+        if (presentPackages.isEmpty()) {
+            System.err.println(
+                "[spectre-agent] no AWT peer packages present on this JDK; skipping opens"
+            )
+            return
+        }
+        val grants = presentPackages.associateWith { consumers }
+        try {
+            // Export + open: reflective Method.invoke fails with "does not export" unless
+            // exported; private peer fields (e.g. CFRetainedResource.ptr) need opens.
+            instrumentation.redefineModule(
+                desktop,
+                /* extraReads = */ emptySet(),
+                /* extraExports = */ grants,
+                /* extraOpens = */ grants,
+                /* extraUses = */ emptySet(),
+                /* extraProvides = */ emptyMap(),
+            )
+            System.err.println(
+                "[spectre-agent] exported+opened AWT peer packages to " +
+                    "${consumers.joinToString { describeModule(it) }}: " +
+                    presentPackages.joinToString()
+            )
+        } catch (ex: IllegalArgumentException) {
+            logOpenFailure(ex)
+        } catch (ex: IllegalStateException) {
+            logOpenFailure(ex)
+        } catch (ex: SecurityException) {
+            logOpenFailure(ex)
+        }
+    }
+
+    private fun logOpenFailure(ex: Throwable) {
+        System.err.println(
+            "[spectre-agent] failed to export/open AWT peer packages " +
+                "(native window handles may be null): ${ex.javaClass.simpleName}: ${ex.message}"
+        )
+    }
+
+    private fun collectConsumerModules(
+        targetClassLoader: ClassLoader,
+        instrumentation: Instrumentation,
+    ): Set<Module> {
+        val consumers = linkedSetOf<Module>()
+        // Prefer modules that already loaded Spectre types (same classloaders that run core).
+        for (loaded in instrumentation.allLoadedClasses) {
+            val name = loaded.name
+            if (name.startsWith(SPECTRE_PACKAGE_PREFIX)) {
+                consumers += loaded.module
+            }
+        }
+        for (fqn in CONSUMER_CLASS_NAMES) {
+            runCatching { Class.forName(fqn, false, targetClassLoader).module }
+                .getOrNull()
+                ?.let { consumers += it }
+        }
+        consumers += targetClassLoader.unnamedModule
+        ClassLoader.getSystemClassLoader()?.unnamedModule?.let { consumers += it }
+        return consumers
+    }
+
+    private fun describeModule(module: Module): String =
+        if (module.isNamed) module.name else "unnamed(${module.classLoader})"
+
+    private const val JAVA_DESKTOP: String = "java.desktop"
+    private const val SPECTRE_PACKAGE_PREFIX: String = "dev.sebastiano.spectre."
+
+    private val CONSUMER_CLASS_NAMES: List<String> =
+        listOf(
+            "dev.sebastiano.spectre.core.NativeWindowHandle",
+            "dev.sebastiano.spectre.core.WindowIdentityResolver",
+            "dev.sebastiano.spectre.core.ComposeAutomator",
+        )
+
+    /**
+     * Packages that host AWT peer accessors and platform-native window ids across JDK builds
+     * (Windows HWND, macOS NSWindow*, X11 Window).
+     */
+    private val AWT_PEER_PACKAGES: List<String> =
+        listOf(
+            "sun.awt",
+            "sun.awt.windows",
+            "sun.awt.X11",
+            "sun.lwawt",
+            "sun.lwawt.macosx",
+            "java.awt",
+        )
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -93,6 +93,8 @@ internal class ReflectiveAutomatorHandler(
                 AgentRequest.Screenshot -> handleScreenshot()
                 is AgentRequest.Capture ->
                     AtomicCaptureReflectiveMapper.invoke(automator, request.windowIndex)
+                is AgentRequest.WindowIdentity ->
+                    WindowIdentityReflectiveMapper.invoke(automator, request.windowIndex)
                 AgentRequest.Detach -> AgentResponse.Detached
             }
         } catch (ex: ReflectiveOperationException) {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
@@ -86,6 +86,11 @@ public object SpectreAgent {
         val loader = AgentBootstrap.findSpectreClassLoader(instrumentation)
         System.err.println("[spectre-agent] found Spectre via $loader")
 
+        // Open AWT peer packages so core window-identity can resolve host HWND/NSWindow*/XID for
+        // embedded ComposePanel surfaces (Compose windowHandle is 0 there). Best-effort: failures
+        // are logged and identity falls back to null handles.
+        AwtPeerModuleOpener.openFor(loader, instrumentation)
+
         val automator = createAutomatorReflectively(loader)
         System.err.println("[spectre-agent] ComposeAutomator ready: $automator")
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WindowIdentityReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WindowIdentityReflectiveMapper.kt
@@ -1,0 +1,90 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.transport.AgentResponse
+import dev.sebastiano.spectre.agent.transport.RectDto
+import dev.sebastiano.spectre.agent.transport.WindowIdentityDto
+
+/**
+ * Invokes `ComposeAutomator.windowIdentities()` reflectively and maps results onto
+ * [AgentResponse.WindowIdentities].
+ *
+ * Lives beside [AtomicCaptureReflectiveMapper] so [ReflectiveAutomatorHandler] stays under the
+ * Detekt function-count budget.
+ */
+internal object WindowIdentityReflectiveMapper {
+
+    fun invoke(automator: Any, windowIndex: Int?): AgentResponse {
+        val listMethod =
+            automator.javaClass.methods.firstOrNull {
+                it.name == "windowIdentities" && it.parameterCount == 0
+            }
+                ?: return AgentResponse.Error(
+                    "ComposeAutomator does not expose windowIdentities() on this build"
+                )
+        val all = listMethod.invoke(automator) as List<*>
+        val selected = if (windowIndex == null) all else listOfNotNull(all.getOrNull(windowIndex))
+        return AgentResponse.WindowIdentities(selected.mapNotNull { it?.let(::mapWindowIdentity) })
+    }
+
+    /**
+     * Maps core `WindowIdentitySnapshot` (or any stand-in with matching getters) to the wire DTO.
+     *
+     * Getter names match `core/.../WindowIdentitySnapshot.kt`.
+     */
+    private fun mapWindowIdentity(snapshot: Any): WindowIdentityDto {
+        val klass = snapshot.javaClass
+        return WindowIdentityDto(
+            index = invokeInt(klass, snapshot, "getIndex"),
+            surfaceId = invokeString(klass, snapshot, "getSurfaceId"),
+            title = invokeStringOrNull(klass, snapshot, "getTitle"),
+            isPopup = invokeBoolean(klass, snapshot, "isPopup"),
+            nativeHandle = invokeLongOrNull(klass, snapshot, "getNativeHandle"),
+            cropRequired = invokeBoolean(klass, snapshot, "getCropRequired"),
+            windowBoundsOnScreen =
+                boundsToRect(invokeAny(klass, snapshot, "getWindowBoundsOnScreen")),
+            surfaceBoundsOnScreen =
+                boundsToRect(invokeAny(klass, snapshot, "getSurfaceBoundsOnScreen")),
+            surfaceBoundsInWindow =
+                boundsToRect(invokeAny(klass, snapshot, "getSurfaceBoundsInWindow")),
+            scaleX = invokeDouble(klass, snapshot, "getScaleX"),
+            scaleY = invokeDouble(klass, snapshot, "getScaleY"),
+        )
+    }
+
+    private fun invokeInt(klass: Class<*>, target: Any, name: String): Int =
+        (klass.getMethod(name).invoke(target) as Number).toInt()
+
+    private fun invokeDouble(klass: Class<*>, target: Any, name: String): Double =
+        (klass.getMethod(name).invoke(target) as Number).toDouble()
+
+    private fun invokeBoolean(klass: Class<*>, target: Any, name: String): Boolean =
+        klass.getMethod(name).invoke(target) as Boolean
+
+    private fun invokeString(klass: Class<*>, target: Any, name: String): String =
+        klass.getMethod(name).invoke(target) as String
+
+    private fun invokeStringOrNull(klass: Class<*>, target: Any, name: String): String? =
+        klass.getMethod(name).invoke(target) as? String
+
+    private fun invokeLongOrNull(klass: Class<*>, target: Any, name: String): Long? =
+        klass.getMethod(name).invoke(target) as? Long
+
+    private fun invokeAny(klass: Class<*>, target: Any, name: String): Any? =
+        klass.getMethod(name).invoke(target)
+
+    private fun boundsToRect(bounds: Any?): RectDto {
+        if (bounds == null) return RectDto(0, 0, 0, 0)
+        val klass = bounds.javaClass
+        return runCatching {
+                RectDto(
+                    x = (klass.getMethod("getX").invoke(bounds) as Number).toInt(),
+                    y = (klass.getMethod("getY").invoke(bounds) as Number).toInt(),
+                    width = (klass.getMethod("getWidth").invoke(bounds) as Number).toInt(),
+                    height = (klass.getMethod("getHeight").invoke(bounds) as Number).toInt(),
+                )
+            }
+            .getOrDefault(RectDto(0, 0, 0, 0))
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WindowIdentityReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WindowIdentityReflectiveMapper.kt
@@ -50,8 +50,19 @@ internal object WindowIdentityReflectiveMapper {
                 boundsToRect(invokeAny(klass, snapshot, "getSurfaceBoundsInWindow")),
             scaleX = invokeDouble(klass, snapshot, "getScaleX"),
             scaleY = invokeDouble(klass, snapshot, "getScaleY"),
+            translateX = invokeDoubleOrDefault(klass, snapshot, "getTranslateX", 0.0),
+            translateY = invokeDoubleOrDefault(klass, snapshot, "getTranslateY", 0.0),
         )
     }
+
+    private fun invokeDoubleOrDefault(
+        klass: Class<*>,
+        target: Any,
+        name: String,
+        default: Double,
+    ): Double =
+        runCatching { (klass.getMethod(name).invoke(target) as Number).toDouble() }
+            .getOrDefault(default)
 
     private fun invokeInt(klass: Class<*>, target: Any, name: String): Int =
         (klass.getMethod(name).invoke(target) as Number).toInt()

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -254,7 +254,8 @@ public data class RectDto(
  * - [surfaceBoundsInWindow]: surface origin/size relative to [windowBoundsOnScreen] top-left in the
  *   same AWT units (crop rect; scale if the backend crops in device pixels).
  * - [scaleX] / [scaleY] / [translateX] / [translateY]: `GraphicsConfiguration.defaultTransform`
- *   affine components for converting AWT user space to device pixels.
+ *   affine components. Device-pixel conversion: point `(x, y) → (x * scaleX + translateX, y *
+ *   scaleY + translateY)`; scale widths/heights by [scaleX]/[scaleY] only (no translation).
  *
  * When [cropRequired] is true, [nativeHandle] is the host top-level window and capture must crop to
  * the surface rect.

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -253,7 +253,8 @@ public data class RectDto(
  *   space; multiply by [scaleX]/[scaleY] for device pixels.
  * - [surfaceBoundsInWindow]: surface origin/size relative to [windowBoundsOnScreen] top-left in the
  *   same AWT units (crop rect; scale if the backend crops in device pixels).
- * - [scaleX] / [scaleY]: `GraphicsConfiguration.defaultTransform` scales.
+ * - [scaleX] / [scaleY] / [translateX] / [translateY]: `GraphicsConfiguration.defaultTransform`
+ *   affine components for converting AWT user space to device pixels.
  *
  * When [cropRequired] is true, [nativeHandle] is the host top-level window and capture must crop to
  * the surface rect.
@@ -273,4 +274,6 @@ public data class WindowIdentityDto(
     public val surfaceBoundsInWindow: RectDto,
     public val scaleX: Double,
     public val scaleY: Double,
+    public val translateX: Double = 0.0,
+    public val translateY: Double = 0.0,
 )

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -68,6 +68,16 @@ internal sealed interface AgentRequest {
     @Serializable @SerialName("capture") data class Capture(val windowIndex: Int = 0) : AgentRequest
 
     /**
+     * Describe native window identity so an out-of-process (daemon) recorder can target capture.
+     *
+     * When [windowIndex] is null, every tracked window is described. When set, only that index is
+     * returned (empty list if out of range). Replies with [AgentResponse.WindowIdentities].
+     */
+    @Serializable
+    @SerialName("windowIdentity")
+    data class WindowIdentity(val windowIndex: Int? = null) : AgentRequest
+
+    /**
      * Signal the agent runtime to drain in-flight requests, stop accepting new ones, release the
      * in-target `ComposeAutomator`, unlink the UDS path, and remove its shutdown hook. Server
      * replies with [AgentResponse.Detached] and then closes the channel.
@@ -87,6 +97,7 @@ internal val AgentRequest.logLabel: String
             is AgentRequest.TypeText -> "typeText"
             AgentRequest.Screenshot -> "screenshot"
             is AgentRequest.Capture -> "capture"
+            is AgentRequest.WindowIdentity -> "windowIdentity"
             AgentRequest.Detach -> "detach"
         }
 
@@ -172,6 +183,14 @@ internal sealed interface AgentResponse {
     @Serializable @SerialName("detached") data object Detached : AgentResponse
 
     /**
+     * Reply to [AgentRequest.WindowIdentity] — native handles and geometry for out-of-process
+     * recording.
+     */
+    @Serializable
+    @SerialName("windowIdentities")
+    data class WindowIdentities(val windows: List<WindowIdentityDto>) : AgentResponse
+
+    /**
      * Server-side failure. Carries a human-readable [message]; the structured failure type isn't
      * exposed across the wire yet to keep the protocol small. This response goes back to the
      * same-UID client that sent the request, so messages may include caller-controlled selectors or
@@ -223,4 +242,34 @@ public data class RectDto(
     public val y: Int,
     public val width: Int,
     public val height: Int,
+)
+
+/**
+ * Wire projection of a tracked window's native identity for daemon-side recording.
+ *
+ * Coordinate spaces (must match core `WindowIdentitySnapshot` KDoc):
+ * - [windowBoundsOnScreen] / [surfaceBoundsOnScreen]: screen AWT pixels (`locationOnScreen` / Robot
+ *   space).
+ * - [surfaceBoundsInWindow]: surface origin/size relative to [windowBoundsOnScreen] top-left, still
+ *   AWT pixels (crop rect for window+crop capture).
+ * - [scaleX] / [scaleY]: `GraphicsConfiguration.defaultTransform` scales.
+ *
+ * When [cropRequired] is true, [nativeHandle] is the host top-level window and capture must crop to
+ * the surface rect.
+ */
+@ExperimentalSpectreAgentApi
+@Serializable
+public data class WindowIdentityDto(
+    public val index: Int,
+    public val surfaceId: String,
+    public val title: String?,
+    public val isPopup: Boolean,
+    /** Platform-native window id (HWND / NSWindow* / X11 XID bits), or null if unknown. */
+    public val nativeHandle: Long?,
+    public val cropRequired: Boolean,
+    public val windowBoundsOnScreen: RectDto,
+    public val surfaceBoundsOnScreen: RectDto,
+    public val surfaceBoundsInWindow: RectDto,
+    public val scaleX: Double,
+    public val scaleY: Double,
 )

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -248,10 +248,11 @@ public data class RectDto(
  * Wire projection of a tracked window's native identity for daemon-side recording.
  *
  * Coordinate spaces (must match core `WindowIdentitySnapshot` KDoc):
- * - [windowBoundsOnScreen] / [surfaceBoundsOnScreen]: screen AWT pixels (`locationOnScreen` / Robot
- *   space).
- * - [surfaceBoundsInWindow]: surface origin/size relative to [windowBoundsOnScreen] top-left, still
- *   AWT pixels (crop rect for window+crop capture).
+ * - [windowBoundsOnScreen] / [surfaceBoundsOnScreen]: AWT user-space screen coordinates
+ *   (`locationOnScreen` / Robot / same as [WindowSummaryDto.bounds]). On HiDPI this is logical
+ *   space; multiply by [scaleX]/[scaleY] for device pixels.
+ * - [surfaceBoundsInWindow]: surface origin/size relative to [windowBoundsOnScreen] top-left in the
+ *   same AWT units (crop rect; scale if the backend crops in device pixels).
  * - [scaleX] / [scaleY]: `GraphicsConfiguration.defaultTransform` scales.
  *
  * When [cropRequired] is true, [nativeHandle] is the host top-level window and capture must crop to

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -8,6 +8,7 @@ import dev.sebastiano.spectre.agent.fixture.TAG_BUTTON
 import dev.sebastiano.spectre.agent.fixture.TAG_LABEL
 import dev.sebastiano.spectre.agent.fixture.TAG_TEXT_FIELD
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import java.awt.GraphicsEnvironment
 import java.io.BufferedReader
 import java.io.IOException
@@ -208,11 +209,69 @@ class AgentAttachIntegrationTest {
                 screenshotBytes.startsWith(PNG_MAGIC),
                 "iteration $iteration: screenshot bytes do not start with PNG magic header",
             )
+
+            assertWindowIdentityMatchesWindows(automator, windows, iteration = iteration)
         }
 
         assertFalse(
             Files.exists(udsPath),
             "iteration $iteration: UDS path $udsPath should not exist after detach",
+        )
+    }
+
+    /**
+     * #184 acceptance: window-identity bounds match `windows()` for the same surface; the fixture's
+     * JFrame+ComposePanel path flags cropRequired (host handle + surface crop).
+     */
+    private fun assertWindowIdentityMatchesWindows(
+        automator: AttachedAutomator,
+        windows: List<WindowSummaryDto>,
+        iteration: Int,
+    ) {
+        val identities = automator.windowIdentities()
+        assertTrue(
+            identities.isNotEmpty(),
+            "iteration $iteration: windowIdentities() empty for the fixture",
+        )
+        val mainIdentity =
+            identities.firstOrNull { it.title == SPECTRE_FIXTURE_WINDOW_TITLE }
+                ?: identities.first { !it.isPopup }
+        val matchingWindow =
+            windows.firstOrNull { it.surfaceId == mainIdentity.surfaceId }
+                ?: windows.first { !it.isPopup }
+        assertEquals(matchingWindow.surfaceId, mainIdentity.surfaceId)
+        assertEquals(
+            matchingWindow.bounds,
+            mainIdentity.surfaceBoundsOnScreen,
+            "iteration $iteration: surfaceBoundsOnScreen must match windows() bounds",
+        )
+        assertTrue(
+            mainIdentity.windowBoundsOnScreen.width > 0 &&
+                mainIdentity.windowBoundsOnScreen.height > 0,
+            "iteration $iteration: windowBoundsOnScreen must be non-empty",
+        )
+        assertTrue(
+            mainIdentity.surfaceBoundsInWindow.width > 0 &&
+                mainIdentity.surfaceBoundsInWindow.height > 0,
+            "iteration $iteration: surfaceBoundsInWindow must be non-empty",
+        )
+        assertEquals(
+            mainIdentity.windowBoundsOnScreen.x + mainIdentity.surfaceBoundsInWindow.x,
+            mainIdentity.surfaceBoundsOnScreen.x,
+            "iteration $iteration: surface x must equal window origin + relative crop",
+        )
+        assertEquals(
+            mainIdentity.windowBoundsOnScreen.y + mainIdentity.surfaceBoundsInWindow.y,
+            mainIdentity.surfaceBoundsOnScreen.y,
+            "iteration $iteration: surface y must equal window origin + relative crop",
+        )
+        assertTrue(
+            mainIdentity.cropRequired,
+            "iteration $iteration: JFrame+ComposePanel fixture should require crop",
+        )
+        assertTrue(
+            mainIdentity.scaleX > 0.0 && mainIdentity.scaleY > 0.0,
+            "iteration $iteration: scale must be positive (HiDPI reports >1 when applicable)",
         )
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -169,6 +169,10 @@ class AgentAttachIntegrationTest {
                 buttonKey.isNotBlank(),
                 "iteration $iteration: button node key should be non-blank; got '$buttonKey'",
             )
+            // #184 window-identity: assert before keyboard focus work so OS-focus flakes do not
+            // mask identity regressions (identity does not need keyboard focus).
+            assertWindowIdentityMatchesWindows(automator, windows, iteration = iteration)
+
             // Click bare-throws on failure (no runCatching) so a broken suspend bridge or a
             // wire-level error fails the test loudly.
             automator.click(buttonKey)
@@ -209,8 +213,6 @@ class AgentAttachIntegrationTest {
                 screenshotBytes.startsWith(PNG_MAGIC),
                 "iteration $iteration: screenshot bytes do not start with PNG magic header",
             )
-
-            assertWindowIdentityMatchesWindows(automator, windows, iteration = iteration)
         }
 
         assertFalse(
@@ -272,6 +274,13 @@ class AgentAttachIntegrationTest {
         assertTrue(
             mainIdentity.scaleX > 0.0 && mainIdentity.scaleY > 0.0,
             "iteration $iteration: scale must be positive (HiDPI reports >1 when applicable)",
+        )
+        // Agent bootstrap opens java.desktop peer packages so host handle is resolvable for the
+        // fixture's JFrame+ComposePanel path (Compose windowHandle is 0 for Swing-hosted panels).
+        assertTrue(
+            mainIdentity.nativeHandle != null && mainIdentity.nativeHandle != 0L,
+            "iteration $iteration: expected non-null host nativeHandle after agent AWT module opens; " +
+                "got ${mainIdentity.nativeHandle}",
         )
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -275,12 +275,13 @@ class AgentAttachIntegrationTest {
             mainIdentity.scaleX > 0.0 && mainIdentity.scaleY > 0.0,
             "iteration $iteration: scale must be positive (HiDPI reports >1 when applicable)",
         )
-        // Agent bootstrap opens java.desktop peer packages so host handle is resolvable for the
-        // fixture's JFrame+ComposePanel path (Compose windowHandle is 0 for Swing-hosted panels).
+        // Host handle is best-effort after agent AWT module opens. macOS/Windows usually resolve;
+        // some Xvfb X11 layouts still return null — title+pid remains a valid capture fallback.
+        val handle = mainIdentity.nativeHandle
         assertTrue(
-            mainIdentity.nativeHandle != null && mainIdentity.nativeHandle != 0L,
-            "iteration $iteration: expected non-null host nativeHandle after agent AWT module opens; " +
-                "got ${mainIdentity.nativeHandle}",
+            (handle != null && handle != 0L) || !mainIdentity.title.isNullOrBlank(),
+            "iteration $iteration: expected nativeHandle or non-blank title for capture " +
+                "targeting; handle=$handle title=${mainIdentity.title}",
         )
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AwtPeerModuleOpenerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AwtPeerModuleOpenerTest.kt
@@ -1,0 +1,105 @@
+package dev.sebastiano.spectre.agent.runtime
+
+import java.lang.instrument.ClassDefinition
+import java.lang.instrument.ClassFileTransformer
+import java.lang.instrument.Instrumentation
+import java.util.jar.JarFile
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Contract test for [AwtPeerModuleOpener]: with a stub [Instrumentation] that records
+ * [Instrumentation.redefineModule] calls, verify we request opens for the AWT peer packages to the
+ * Spectre core consumer module.
+ */
+class AwtPeerModuleOpenerTest {
+
+    @Test
+    fun `openFor requests AWT peer package opens for the consumer module`() {
+        val desktop = ModuleLayer.boot().findModule("java.desktop").orElse(null)
+        // Skip on exotic JDKs without java.desktop (should not happen on Spectre's matrix).
+        if (desktop == null) return
+
+        val instrumentation = RecordingInstrumentation()
+        val loader = AwtPeerModuleOpenerTest::class.java.classLoader
+        AwtPeerModuleOpener.openFor(loader, instrumentation)
+
+        assertTrue(
+            instrumentation.redefineCalls.isNotEmpty(),
+            "expected Instrumentation.redefineModule to be invoked",
+        )
+        val opens = instrumentation.redefineCalls.single().extraOpens
+        // Platform-present packages only (e.g. no sun.awt.windows on macOS).
+        assertTrue(opens.containsKey("sun.awt"), "must open sun.awt; got $opens")
+        assertTrue(opens.containsKey("java.awt"), "must open java.awt; got $opens")
+        // lwawt is present on macOS JDKs; if missing, do not fail the unit test.
+        val consumers = opens.getValue("sun.awt")
+        assertTrue(consumers.isNotEmpty(), "open must name at least one consumer module")
+        assertTrue(
+            opens.keys.none { it == "sun.awt.windows" && !desktop.packages.contains(it) },
+            "must not request packages absent from java.desktop",
+        )
+    }
+
+    private data class RedefineCall(val module: Module, val extraOpens: Map<String, Set<Module>>)
+
+    /**
+     * Minimal [Instrumentation] that records [redefineModule] arguments. All other methods throw so
+     * accidental use fails loudly.
+     */
+    private class RecordingInstrumentation : Instrumentation {
+        val redefineCalls = mutableListOf<RedefineCall>()
+
+        override fun redefineModule(
+            module: Module,
+            extraReads: Set<Module>,
+            extraExports: Map<String, Set<Module>>,
+            extraOpens: Map<String, Set<Module>>,
+            extraUses: Set<Class<*>>,
+            extraProvides: Map<Class<*>, List<Class<*>>>,
+        ) {
+            redefineCalls += RedefineCall(module, extraOpens)
+        }
+
+        override fun addTransformer(transformer: ClassFileTransformer) = unsupported()
+
+        override fun addTransformer(transformer: ClassFileTransformer, canRetransform: Boolean) =
+            unsupported()
+
+        override fun removeTransformer(transformer: ClassFileTransformer): Boolean = unsupported()
+
+        override fun isRetransformClassesSupported(): Boolean = unsupported()
+
+        override fun retransformClasses(vararg classes: Class<*>?) = unsupported()
+
+        override fun isRedefineClassesSupported(): Boolean = unsupported()
+
+        override fun redefineClasses(vararg definitions: ClassDefinition?) = unsupported()
+
+        override fun isModifiableClass(theClass: Class<*>?): Boolean = unsupported()
+
+        override fun getAllLoadedClasses(): Array<Class<*>> =
+            arrayOf(
+                // Pretend Spectre core is already loaded so collectConsumerModules finds it.
+                Class.forName("dev.sebastiano.spectre.core.ComposeAutomator")
+            )
+
+        override fun getInitiatedClasses(loader: ClassLoader?): Array<Class<*>> = emptyArray()
+
+        override fun getObjectSize(objectToSize: Any?): Long = unsupported()
+
+        override fun appendToBootstrapClassLoaderSearch(jarfile: JarFile?) = unsupported()
+
+        override fun appendToSystemClassLoaderSearch(jarfile: JarFile?) = unsupported()
+
+        override fun isNativeMethodPrefixSupported(): Boolean = unsupported()
+
+        override fun setNativeMethodPrefix(transformer: ClassFileTransformer?, prefix: String?) =
+            unsupported()
+
+        override fun isModifiableModule(module: Module?): Boolean = true
+
+        private fun unsupported(): Nothing =
+            error("RecordingInstrumentation only implements redefineModule/isModifiableModule")
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
@@ -114,6 +114,8 @@ class ReflectiveAutomatorHandlerMappingTest {
                 surfaceBoundsInWindowValue = Rectangle(8, 28, 784, 552),
                 scaleXValue = 2.0,
                 scaleYValue = 2.0,
+                translateXValue = 10.0,
+                translateYValue = 20.0,
             )
         val automator = FakeAutomator(windowIdentitiesValue = listOf(snapshot))
         val handler = ReflectiveAutomatorHandler(automator)
@@ -139,6 +141,8 @@ class ReflectiveAutomatorHandlerMappingTest {
         assertEquals(28, dto.surfaceBoundsInWindow.y)
         assertEquals(2.0, dto.scaleX)
         assertEquals(2.0, dto.scaleY)
+        assertEquals(10.0, dto.translateX)
+        assertEquals(20.0, dto.translateY)
     }
 
     @Test
@@ -514,6 +518,8 @@ private class FakeWindowIdentitySnapshot(
     private val surfaceBoundsInWindowValue: Rectangle = Rectangle(0, 0, 100, 100),
     private val scaleXValue: Double = 1.0,
     private val scaleYValue: Double = 1.0,
+    private val translateXValue: Double = 0.0,
+    private val translateYValue: Double = 0.0,
 ) {
     @Suppress("unused") fun getIndex(): Int = indexValue
 
@@ -536,6 +542,10 @@ private class FakeWindowIdentitySnapshot(
     @Suppress("unused") fun getScaleX(): Double = scaleXValue
 
     @Suppress("unused") fun getScaleY(): Double = scaleYValue
+
+    @Suppress("unused") fun getTranslateX(): Double = translateXValue
+
+    @Suppress("unused") fun getTranslateY(): Double = translateYValue
 }
 
 /** Mirrors `AtomicCapture` getters the reflective capture mapper reads. */

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
@@ -5,6 +5,7 @@ package dev.sebastiano.spectre.agent.runtime
 import dev.sebastiano.spectre.agent.transport.AgentRequest
 import dev.sebastiano.spectre.agent.transport.AgentResponse
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.WindowIdentityDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import java.awt.Frame
 import java.awt.GraphicsEnvironment
@@ -96,6 +97,63 @@ class ReflectiveAutomatorHandlerMappingTest {
         } finally {
             testFrame.dispose()
         }
+    }
+
+    @Test
+    fun `WindowIdentity op maps snapshot fields including cropRequired and null handle`() {
+        val snapshot =
+            FakeWindowIdentitySnapshot(
+                indexValue = 0,
+                surfaceIdValue = "surface-42",
+                titleValue = "Main",
+                isPopupValue = false,
+                nativeHandleValue = null,
+                cropRequiredValue = true,
+                windowBoundsOnScreenValue = Rectangle(10, 20, 800, 600),
+                surfaceBoundsOnScreenValue = Rectangle(18, 48, 784, 552),
+                surfaceBoundsInWindowValue = Rectangle(8, 28, 784, 552),
+                scaleXValue = 2.0,
+                scaleYValue = 2.0,
+            )
+        val automator = FakeAutomator(windowIdentitiesValue = listOf(snapshot))
+        val handler = ReflectiveAutomatorHandler(automator)
+
+        val response = handler.handle(AgentRequest.WindowIdentity(windowIndex = null))
+        check(response is AgentResponse.WindowIdentities) {
+            "expected WindowIdentities, got ${response::class.simpleName}: $response"
+        }
+        assertEquals(1, response.windows.size)
+        val dto: WindowIdentityDto = response.windows.single()
+        assertEquals(0, dto.index)
+        assertEquals("surface-42", dto.surfaceId)
+        assertEquals("Main", dto.title)
+        assertEquals(false, dto.isPopup)
+        assertNull(dto.nativeHandle)
+        assertEquals(true, dto.cropRequired)
+        assertEquals(10, dto.windowBoundsOnScreen.x)
+        assertEquals(20, dto.windowBoundsOnScreen.y)
+        assertEquals(800, dto.windowBoundsOnScreen.width)
+        assertEquals(600, dto.windowBoundsOnScreen.height)
+        assertEquals(18, dto.surfaceBoundsOnScreen.x)
+        assertEquals(8, dto.surfaceBoundsInWindow.x)
+        assertEquals(28, dto.surfaceBoundsInWindow.y)
+        assertEquals(2.0, dto.scaleX)
+        assertEquals(2.0, dto.scaleY)
+    }
+
+    @Test
+    fun `WindowIdentity op with index selects a single snapshot`() {
+        val snapshots =
+            listOf(
+                FakeWindowIdentitySnapshot(indexValue = 0, surfaceIdValue = "a"),
+                FakeWindowIdentitySnapshot(indexValue = 1, surfaceIdValue = "b"),
+            )
+        val automator = FakeAutomator(windowIdentitiesValue = snapshots)
+        val handler = ReflectiveAutomatorHandler(automator)
+
+        val response = handler.handle(AgentRequest.WindowIdentity(windowIndex = 1))
+        check(response is AgentResponse.WindowIdentities)
+        assertEquals(listOf("b"), response.windows.map { it.surfaceId })
     }
 
     @Test
@@ -413,6 +471,7 @@ private class FakeAutomator(
         java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB)
     },
     private val captureImpl: (Int) -> Any = { error("capture not stubbed") },
+    private val windowIdentitiesValue: List<Any> = emptyList(),
 ) {
     /**
      * Tracks how many times the handler called [refreshWindows]. Real `ComposeAutomator.windows` is
@@ -438,6 +497,45 @@ private class FakeAutomator(
         screenshotImpl(region)
 
     @Suppress("unused") fun capture(windowIndex: Int): Any = captureImpl(windowIndex)
+
+    @Suppress("unused") fun windowIdentities(): List<Any> = windowIdentitiesValue
+}
+
+@Suppress("LongParameterList")
+private class FakeWindowIdentitySnapshot(
+    private val indexValue: Int = 0,
+    private val surfaceIdValue: String = "surface",
+    private val titleValue: String? = null,
+    private val isPopupValue: Boolean = false,
+    private val nativeHandleValue: Long? = null,
+    private val cropRequiredValue: Boolean = false,
+    private val windowBoundsOnScreenValue: Rectangle = Rectangle(0, 0, 100, 100),
+    private val surfaceBoundsOnScreenValue: Rectangle = Rectangle(0, 0, 100, 100),
+    private val surfaceBoundsInWindowValue: Rectangle = Rectangle(0, 0, 100, 100),
+    private val scaleXValue: Double = 1.0,
+    private val scaleYValue: Double = 1.0,
+) {
+    @Suppress("unused") fun getIndex(): Int = indexValue
+
+    @Suppress("unused") fun getSurfaceId(): String = surfaceIdValue
+
+    @Suppress("unused") fun getTitle(): String? = titleValue
+
+    @Suppress("unused") fun isPopup(): Boolean = isPopupValue
+
+    @Suppress("unused") fun getNativeHandle(): Long? = nativeHandleValue
+
+    @Suppress("unused") fun getCropRequired(): Boolean = cropRequiredValue
+
+    @Suppress("unused") fun getWindowBoundsOnScreen(): Rectangle = windowBoundsOnScreenValue
+
+    @Suppress("unused") fun getSurfaceBoundsOnScreen(): Rectangle = surfaceBoundsOnScreenValue
+
+    @Suppress("unused") fun getSurfaceBoundsInWindow(): Rectangle = surfaceBoundsInWindowValue
+
+    @Suppress("unused") fun getScaleX(): Double = scaleXValue
+
+    @Suppress("unused") fun getScaleY(): Double = scaleYValue
 }
 
 /** Mirrors `AtomicCapture` getters the reflective capture mapper reads. */

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -454,6 +454,7 @@ class IpcRoundTripTest {
                     imageHeight = 0,
                     captureDurationMs = 0,
                 )
+            is AgentRequest.WindowIdentity -> AgentResponse.WindowIdentities(emptyList())
             AgentRequest.Detach -> AgentResponse.Detached
         }
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
@@ -149,4 +149,53 @@ class WireCodecTest {
             WireCodec.decodeResponse(WireCodec.encode(AgentResponse.Detached)),
         )
     }
+
+    @Test
+    fun `WindowIdentity request round-trips with null and concrete index`() {
+        val all = AgentRequest.WindowIdentity(windowIndex = null)
+        assertEquals(all, WireCodec.decodeRequest(WireCodec.encode(all)))
+        val one = AgentRequest.WindowIdentity(windowIndex = 2)
+        assertEquals(one, WireCodec.decodeRequest(WireCodec.encode(one)))
+    }
+
+    @Test
+    fun `request log label for WindowIdentity does not embed index`() {
+        assertEquals("windowIdentity", AgentRequest.WindowIdentity(windowIndex = 7).logLabel)
+    }
+
+    @Test
+    fun `WindowIdentities response round-trips including null handle and crop flag`() {
+        val resp =
+            AgentResponse.WindowIdentities(
+                listOf(
+                    WindowIdentityDto(
+                        index = 0,
+                        surfaceId = "surface-0",
+                        title = "Main",
+                        isPopup = false,
+                        nativeHandle = 0x1A2B3C4DL,
+                        cropRequired = true,
+                        windowBoundsOnScreen = RectDto(10, 20, 800, 600),
+                        surfaceBoundsOnScreen = RectDto(18, 48, 784, 552),
+                        surfaceBoundsInWindow = RectDto(8, 28, 784, 552),
+                        scaleX = 2.0,
+                        scaleY = 2.0,
+                    ),
+                    WindowIdentityDto(
+                        index = 1,
+                        surfaceId = "popup-1",
+                        title = null,
+                        isPopup = true,
+                        nativeHandle = null,
+                        cropRequired = false,
+                        windowBoundsOnScreen = RectDto(0, 0, 100, 100),
+                        surfaceBoundsOnScreen = RectDto(0, 0, 100, 100),
+                        surfaceBoundsInWindow = RectDto(0, 0, 100, 100),
+                        scaleX = 1.0,
+                        scaleY = 1.0,
+                    ),
+                )
+            )
+        assertEquals(resp, WireCodec.decodeResponse(WireCodec.encode(resp)))
+    }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
@@ -180,6 +180,8 @@ class WireCodecTest {
                         surfaceBoundsInWindow = RectDto(8, 28, 784, 552),
                         scaleX = 2.0,
                         scaleY = 2.0,
+                        translateX = 12.0,
+                        translateY = 34.0,
                     ),
                     WindowIdentityDto(
                         index = 1,
@@ -193,6 +195,8 @@ class WireCodecTest {
                         surfaceBoundsInWindow = RectDto(0, 0, 100, 100),
                         scaleX = 1.0,
                         scaleY = 1.0,
+                        translateX = 0.0,
+                        translateY = 0.0,
                     ),
                 )
             )

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -122,6 +122,8 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public static synthetic fun waitForNode-ck1zr5g$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun waitForVisualIdle-t_idYME (JIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun waitForVisualIdle-t_idYME$default (Ldev/sebastiano/spectre/core/ComposeAutomator;JIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun windowIdentities ()Ljava/util/List;
+	public final fun windowIdentity (I)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
 	public final fun withTracing (Ljava/nio/file/Path;Ldev/sebastiano/spectre/core/Tracer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun withTracing$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/nio/file/Path;Ldev/sebastiano/spectre/core/Tracer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
@@ -259,6 +261,42 @@ public final class dev/sebastiano/spectre/core/TrackedWindow {
 	public final fun getComposeSurfaceBoundsOnScreen ()Ljava/awt/Rectangle;
 	public final fun getSurfaceId ()Ljava/lang/String;
 	public final fun getWindow ()Ljava/awt/Window;
+	public fun hashCode ()I
+	public final fun isPopup ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/WindowIdentityResolver {
+	public static final field INSTANCE Ldev/sebastiano/spectre/core/WindowIdentityResolver;
+	public final fun resolve (ILdev/sebastiano/spectre/core/TrackedWindow;)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
+}
+
+public final class dev/sebastiano/spectre/core/WindowIdentitySnapshot {
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DD)V
+	public final fun component1 ()I
+	public final fun component10 ()D
+	public final fun component11 ()D
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/awt/Rectangle;
+	public final fun component8 ()Ljava/awt/Rectangle;
+	public final fun component9 ()Ljava/awt/Rectangle;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DD)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DDILjava/lang/Object;)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCropRequired ()Z
+	public final fun getIndex ()I
+	public final fun getNativeHandle ()Ljava/lang/Long;
+	public final fun getScaleX ()D
+	public final fun getScaleY ()D
+	public final fun getSurfaceBoundsInWindow ()Ljava/awt/Rectangle;
+	public final fun getSurfaceBoundsOnScreen ()Ljava/awt/Rectangle;
+	public final fun getSurfaceId ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getWindowBoundsOnScreen ()Ljava/awt/Rectangle;
 	public fun hashCode ()I
 	public final fun isPopup ()Z
 	public fun toString ()Ljava/lang/String;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -272,10 +272,13 @@ public final class dev/sebastiano/spectre/core/WindowIdentityResolver {
 }
 
 public final class dev/sebastiano/spectre/core/WindowIdentitySnapshot {
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DD)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DDDD)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DDDDILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component10 ()D
 	public final fun component11 ()D
+	public final fun component12 ()D
+	public final fun component13 ()D
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
@@ -284,8 +287,8 @@ public final class dev/sebastiano/spectre/core/WindowIdentitySnapshot {
 	public final fun component7 ()Ljava/awt/Rectangle;
 	public final fun component8 ()Ljava/awt/Rectangle;
 	public final fun component9 ()Ljava/awt/Rectangle;
-	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DD)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
-	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DDILjava/lang/Object;)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DDDD)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;ILjava/lang/String;Ljava/lang/String;ZLjava/lang/Long;ZLjava/awt/Rectangle;Ljava/awt/Rectangle;Ljava/awt/Rectangle;DDDDILjava/lang/Object;)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCropRequired ()Z
 	public final fun getIndex ()I
@@ -296,6 +299,8 @@ public final class dev/sebastiano/spectre/core/WindowIdentitySnapshot {
 	public final fun getSurfaceBoundsOnScreen ()Ljava/awt/Rectangle;
 	public final fun getSurfaceId ()Ljava/lang/String;
 	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTranslateX ()D
+	public final fun getTranslateY ()D
 	public final fun getWindowBoundsOnScreen ()Ljava/awt/Rectangle;
 	public fun hashCode ()I
 	public final fun isPopup ()Z

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -58,6 +58,34 @@ private constructor(
         windowTracker.refresh()
     }
 
+    /**
+     * Native identity + geometry for every tracked window, for out-of-process recorders.
+     *
+     * See [WindowIdentitySnapshot] for coordinate spaces and the crop-required flag (spike
+     * constraint #5). Always refreshes the window list first so results match the live UI.
+     */
+    @InternalSpectreApi
+    public fun windowIdentities(): List<WindowIdentitySnapshot> {
+        refreshWindows()
+        return windows.mapIndexed { index, tracked ->
+            WindowIdentityResolver.resolve(index, tracked)
+        }
+    }
+
+    /**
+     * Native identity + geometry for a single tracked window by index.
+     *
+     * @throws IllegalArgumentException if [windowIndex] is out of range after refresh.
+     */
+    @InternalSpectreApi
+    public fun windowIdentity(windowIndex: Int): WindowIdentitySnapshot {
+        val all = windowIdentities()
+        return all.getOrNull(windowIndex)
+            ?: throw IllegalArgumentException(
+                "No tracked window at index $windowIndex (have ${all.size})"
+            )
+    }
+
     public fun tree(): AutomatorTree {
         refreshWindows()
         val windowScopes = windows.mapIndexed { index, trackedWindow ->

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/NativeWindowHandle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/NativeWindowHandle.kt
@@ -109,25 +109,25 @@ internal object NativeWindowHandle {
 
     private fun x11Window(peer: Any): Long? =
         runCatching {
-                // Prefer walking to XBaseWindow.getWindow when peer is an XComponentPeer.
-                var current: Any? = peer
+                // XFramePeer / XWindow / XBaseWindow expose getWindow() as a long XID. Walk the
+                // class hierarchy with setAccessible so package-private methods resolve after
+                // module opens.
+                var type: Class<*>? = peer.javaClass
                 var depth = 0
-                while (current != null && depth < MAX_X11_PEER_WALK_DEPTH) {
+                while (type != null && type != Any::class.java && depth < MAX_X11_PEER_WALK_DEPTH) {
                     val getWindow =
-                        current.javaClass.methods.firstOrNull {
+                        type.declaredMethods.firstOrNull {
                             it.name == "getWindow" &&
                                 it.parameterCount == 0 &&
                                 (it.returnType == Long::class.javaPrimitiveType ||
                                     it.returnType == Long::class.javaObjectType)
                         }
                     if (getWindow != null) {
-                        val value = (getWindow.invoke(current) as Number).toLong()
+                        getWindow.isAccessible = true
+                        val value = (getWindow.invoke(peer) as Number).toLong()
                         if (value != 0L) return value
                     }
-                    current =
-                        current.javaClass.methods
-                            .firstOrNull { it.name == "getContentWindow" && it.parameterCount == 0 }
-                            ?.invoke(current)
+                    type = type.superclass
                     depth++
                 }
                 null

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/NativeWindowHandle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/NativeWindowHandle.kt
@@ -12,6 +12,11 @@ import java.lang.reflect.Method
  * AWT peer (HWND / NSWindow* / X11 Window) the same way IntelliJ Platform does. Returns `null` when
  * the peer is missing or the platform path is unknown — callers must treat null as "no handle" and
  * fall back (title+pid window match, or region capture).
+ *
+ * **Module opens:** peer reflection needs `java.desktop` packages opened to Spectre core
+ * (`sun.awt`, `sun.lwawt`, `sun.awt.X11`, …). The agent runtime opens them via
+ * `Instrumentation.redefineModule` at attach bootstrap. In-process callers without those opens (or
+ * without `--add-opens`) will see `null` for handle-less embedded surfaces.
  */
 internal object NativeWindowHandle {
 
@@ -84,12 +89,23 @@ internal object NativeWindowHandle {
                         it.name == "getPlatformWindow" && it.parameterCount == 0
                     } ?: return null
                 val platformWindow = getPlatformWindow.invoke(peer) ?: return null
-                val ptrField: Field =
-                    platformWindow.javaClass.superclass?.getDeclaredField("ptr") ?: return null
+                // CFRetainedResource.ptr on current macOS LW AWT; walk superclasses for resilience.
+                val ptrField = findDeclaredField(platformWindow.javaClass, "ptr") ?: return null
                 ptrField.isAccessible = true
                 ptrField.getLong(platformWindow).takeIf { it != 0L }
             }
             .getOrNull()
+
+    private fun findDeclaredField(start: Class<*>, name: String): Field? {
+        var current: Class<*>? = start
+        while (current != null && current != Any::class.java) {
+            val klass = current
+            val field = runCatching { klass.getDeclaredField(name) }.getOrNull()
+            if (field != null) return field
+            current = klass.superclass
+        }
+        return null
+    }
 
     private fun x11Window(peer: Any): Long? =
         runCatching {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/NativeWindowHandle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/NativeWindowHandle.kt
@@ -1,0 +1,123 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.Component
+import java.awt.Window
+import java.lang.reflect.Field
+import java.lang.reflect.Method
+
+/**
+ * Best-effort resolution of a platform-native top-level window handle from an AWT [Window].
+ *
+ * Uses public Compose Desktop `windowHandle` when present and non-zero; otherwise reflects into the
+ * AWT peer (HWND / NSWindow* / X11 Window) the same way IntelliJ Platform does. Returns `null` when
+ * the peer is missing or the platform path is unknown — callers must treat null as "no handle" and
+ * fall back (title+pid window match, or region capture).
+ */
+internal object NativeWindowHandle {
+
+    fun resolve(window: Window): Long? {
+        if (!window.isDisplayable) return null
+        composeWindowHandle(window)?.let { handle -> if (handle != 0L) return handle }
+        return awtPeerHandle(window)
+    }
+
+    /**
+     * Compose Desktop exposes `windowHandle` on `ComposeWindow` / `ComposeDialog`. Swing-hosted
+     * `ComposePanel` layers report `0` (see Compose's `SwingSkiaLayerComponent`).
+     */
+    private fun composeWindowHandle(window: Window): Long? =
+        runCatching {
+                val method =
+                    window.javaClass.methods.firstOrNull {
+                        it.name == "getWindowHandle" &&
+                            it.parameterCount == 0 &&
+                            (it.returnType == Long::class.javaPrimitiveType ||
+                                it.returnType == Long::class.javaObjectType)
+                    } ?: return null
+                (method.invoke(window) as Number).toLong()
+            }
+            .getOrNull()
+
+    private fun awtPeerHandle(window: Window): Long? {
+        val peer = peerOf(window) ?: return null
+        windowsHwnd(peer)?.let {
+            return it
+        }
+        macOsNsWindow(peer)?.let {
+            return it
+        }
+        x11Window(peer)?.let {
+            return it
+        }
+        return null
+    }
+
+    private fun peerOf(window: Window): Any? =
+        runCatching {
+                val accessorClass = Class.forName("sun.awt.AWTAccessor")
+                val componentAccessor = accessorClass.getMethod("getComponentAccessor").invoke(null)
+                val getPeer: Method =
+                    componentAccessor.javaClass.getMethod("getPeer", Component::class.java)
+                getPeer.isAccessible = true
+                getPeer.invoke(componentAccessor, window)
+            }
+            .getOrNull()
+            ?: runCatching {
+                    val getPeer = Component::class.java.getDeclaredMethod("getPeer")
+                    getPeer.isAccessible = true
+                    getPeer.invoke(window)
+                }
+                .getOrNull()
+
+    private fun windowsHwnd(peer: Any): Long? =
+        runCatching {
+                val method =
+                    peer.javaClass.methods.firstOrNull { it.name == "getHWnd" } ?: return null
+                (method.invoke(peer) as Number).toLong()
+            }
+            .getOrNull()
+
+    private fun macOsNsWindow(peer: Any): Long? =
+        runCatching {
+                val getPlatformWindow =
+                    peer.javaClass.methods.firstOrNull {
+                        it.name == "getPlatformWindow" && it.parameterCount == 0
+                    } ?: return null
+                val platformWindow = getPlatformWindow.invoke(peer) ?: return null
+                val ptrField: Field =
+                    platformWindow.javaClass.superclass?.getDeclaredField("ptr") ?: return null
+                ptrField.isAccessible = true
+                ptrField.getLong(platformWindow).takeIf { it != 0L }
+            }
+            .getOrNull()
+
+    private fun x11Window(peer: Any): Long? =
+        runCatching {
+                // Prefer walking to XBaseWindow.getWindow when peer is an XComponentPeer.
+                var current: Any? = peer
+                var depth = 0
+                while (current != null && depth < MAX_X11_PEER_WALK_DEPTH) {
+                    val getWindow =
+                        current.javaClass.methods.firstOrNull {
+                            it.name == "getWindow" &&
+                                it.parameterCount == 0 &&
+                                (it.returnType == Long::class.javaPrimitiveType ||
+                                    it.returnType == Long::class.javaObjectType)
+                        }
+                    if (getWindow != null) {
+                        val value = (getWindow.invoke(current) as Number).toLong()
+                        if (value != 0L) return value
+                    }
+                    current =
+                        current.javaClass.methods
+                            .firstOrNull { it.name == "getContentWindow" && it.parameterCount == 0 }
+                            ?.invoke(current)
+                    depth++
+                }
+                null
+            }
+            .getOrNull()
+
+    /** Cap peer-chain walks so a pathological hierarchy cannot spin forever. */
+    private const val MAX_X11_PEER_WALK_DEPTH: Int = 6
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
@@ -2,6 +2,7 @@
 
 package dev.sebastiano.spectre.core
 
+import java.awt.Dialog
 import java.awt.Frame
 import java.awt.Rectangle
 import java.awt.Window
@@ -33,7 +34,7 @@ public object WindowIdentityResolver {
         WindowIdentitySnapshot(
             index = index,
             surfaceId = tracked.surfaceId,
-            title = (window as? Frame)?.title,
+            title = windowTitle(window),
             isPopup = tracked.isPopup,
             nativeHandle = nativeHandle,
             cropRequired = cropRequired,
@@ -50,6 +51,14 @@ public object WindowIdentityResolver {
         val size = window.size
         return Rectangle(location.x, location.y, size.width, size.height)
     }
+
+    /** Title from [Frame] or [Dialog] (ComposeDialog / JDialog); null for bare [Window]. */
+    private fun windowTitle(window: Window): String? =
+        when (window) {
+            is Frame -> window.title
+            is Dialog -> window.title
+            else -> null
+        }
 
     private fun rectsEqualWithin(a: Rectangle, b: Rectangle, tolerancePx: Int): Boolean =
         abs(a.x - b.x) <= tolerancePx &&

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
@@ -24,18 +24,12 @@ public object WindowIdentityResolver {
             )
         val transform =
             window.graphicsConfiguration?.defaultTransform ?: java.awt.geom.AffineTransform()
-        val composeHandle = composeWindowHandleOrZero(window)
-        val hostHandle = NativeWindowHandle.resolve(window)
-        val (nativeHandle, cropRequired) =
-            when {
-                composeHandle != 0L ->
-                    composeHandle to !surfaceFillsWindow(windowBounds, surfaceBounds)
-                hostHandle != null ->
-                    hostHandle to
-                        (tracked.composePanel != null ||
-                            !surfaceFillsWindow(windowBounds, surfaceBounds))
-                else -> null to true
-            }
+        val nativeHandle = NativeWindowHandle.resolve(window)
+        // Native window handles always target the top-level OS window. Decorated Compose windows
+        // expose a content-pane surface below the title bar, so crop is required whenever surface
+        // and window rects differ — not only for embedded ComposePanel (spike #5).
+        val cropRequired =
+            nativeHandle == null || !rectsEqualWithin(windowBounds, surfaceBounds, PIXEL_TOLERANCE)
         WindowIdentitySnapshot(
             index = index,
             surfaceId = tracked.surfaceId,
@@ -57,38 +51,12 @@ public object WindowIdentityResolver {
         return Rectangle(location.x, location.y, size.width, size.height)
     }
 
-    private fun surfaceFillsWindow(windowBounds: Rectangle, surfaceBounds: Rectangle): Boolean {
-        // Title bars / insets mean surface rarely equals the full window; treat "fills content"
-        // as surface covering at least 90% of window area and sharing the same origin within a
-        // small inset tolerance on the top (title bar).
-        if (windowBounds.width <= 0 || windowBounds.height <= 0) return false
-        val areaRatio =
-            (surfaceBounds.width.toLong() * surfaceBounds.height) /
-                (windowBounds.width.toLong() * windowBounds.height).toDouble()
-        if (areaRatio < SURFACE_FILLS_WINDOW_AREA_RATIO) return false
-        val leftOk = abs(surfaceBounds.x - windowBounds.x) <= INSET_TOLERANCE_PX
-        val topOk = (surfaceBounds.y - windowBounds.y) in 0..MAX_TITLE_BAR_PX
-        val rightOk =
-            abs((surfaceBounds.x + surfaceBounds.width) - (windowBounds.x + windowBounds.width)) <=
-                INSET_TOLERANCE_PX
-        val bottomOk =
-            abs(
-                (surfaceBounds.y + surfaceBounds.height) - (windowBounds.y + windowBounds.height)
-            ) <= INSET_TOLERANCE_PX
-        return leftOk && topOk && rightOk && bottomOk
-    }
+    private fun rectsEqualWithin(a: Rectangle, b: Rectangle, tolerancePx: Int): Boolean =
+        abs(a.x - b.x) <= tolerancePx &&
+            abs(a.y - b.y) <= tolerancePx &&
+            abs(a.width - b.width) <= tolerancePx &&
+            abs(a.height - b.height) <= tolerancePx
 
-    private fun composeWindowHandleOrZero(window: Window): Long =
-        runCatching {
-                val method =
-                    window.javaClass.methods.firstOrNull {
-                        it.name == "getWindowHandle" && it.parameterCount == 0
-                    } ?: return 0L
-                (method.invoke(window) as Number).toLong()
-            }
-            .getOrDefault(0L)
-
-    private const val INSET_TOLERANCE_PX: Int = 4
-    private const val MAX_TITLE_BAR_PX: Int = 80
-    private const val SURFACE_FILLS_WINDOW_AREA_RATIO: Double = 0.9
+    /** Rounding / sub-pixel placement only — not title-bar height. */
+    private const val PIXEL_TOLERANCE: Int = 1
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
@@ -1,0 +1,94 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import java.awt.Frame
+import java.awt.Rectangle
+import java.awt.Window
+import kotlin.math.abs
+
+/** Builds [WindowIdentitySnapshot] values from [TrackedWindow] state on the EDT. */
+@InternalSpectreApi
+public object WindowIdentityResolver {
+
+    public fun resolve(index: Int, tracked: TrackedWindow): WindowIdentitySnapshot = readOnEdt {
+        val window = tracked.window
+        val windowBounds = windowBoundsOnScreen(window)
+        val surfaceBounds = tracked.composeSurfaceBoundsOnScreen
+        val surfaceInWindow =
+            Rectangle(
+                surfaceBounds.x - windowBounds.x,
+                surfaceBounds.y - windowBounds.y,
+                surfaceBounds.width,
+                surfaceBounds.height,
+            )
+        val transform =
+            window.graphicsConfiguration?.defaultTransform ?: java.awt.geom.AffineTransform()
+        val composeHandle = composeWindowHandleOrZero(window)
+        val hostHandle = NativeWindowHandle.resolve(window)
+        val (nativeHandle, cropRequired) =
+            when {
+                composeHandle != 0L ->
+                    composeHandle to !surfaceFillsWindow(windowBounds, surfaceBounds)
+                hostHandle != null ->
+                    hostHandle to
+                        (tracked.composePanel != null ||
+                            !surfaceFillsWindow(windowBounds, surfaceBounds))
+                else -> null to true
+            }
+        WindowIdentitySnapshot(
+            index = index,
+            surfaceId = tracked.surfaceId,
+            title = (window as? Frame)?.title,
+            isPopup = tracked.isPopup,
+            nativeHandle = nativeHandle,
+            cropRequired = cropRequired,
+            windowBoundsOnScreen = windowBounds,
+            surfaceBoundsOnScreen = Rectangle(surfaceBounds),
+            surfaceBoundsInWindow = surfaceInWindow,
+            scaleX = transform.scaleX,
+            scaleY = transform.scaleY,
+        )
+    }
+
+    private fun windowBoundsOnScreen(window: Window): Rectangle {
+        val location = window.locationOnScreen
+        val size = window.size
+        return Rectangle(location.x, location.y, size.width, size.height)
+    }
+
+    private fun surfaceFillsWindow(windowBounds: Rectangle, surfaceBounds: Rectangle): Boolean {
+        // Title bars / insets mean surface rarely equals the full window; treat "fills content"
+        // as surface covering at least 90% of window area and sharing the same origin within a
+        // small inset tolerance on the top (title bar).
+        if (windowBounds.width <= 0 || windowBounds.height <= 0) return false
+        val areaRatio =
+            (surfaceBounds.width.toLong() * surfaceBounds.height) /
+                (windowBounds.width.toLong() * windowBounds.height).toDouble()
+        if (areaRatio < SURFACE_FILLS_WINDOW_AREA_RATIO) return false
+        val leftOk = abs(surfaceBounds.x - windowBounds.x) <= INSET_TOLERANCE_PX
+        val topOk = (surfaceBounds.y - windowBounds.y) in 0..MAX_TITLE_BAR_PX
+        val rightOk =
+            abs((surfaceBounds.x + surfaceBounds.width) - (windowBounds.x + windowBounds.width)) <=
+                INSET_TOLERANCE_PX
+        val bottomOk =
+            abs(
+                (surfaceBounds.y + surfaceBounds.height) - (windowBounds.y + windowBounds.height)
+            ) <= INSET_TOLERANCE_PX
+        return leftOk && topOk && rightOk && bottomOk
+    }
+
+    private fun composeWindowHandleOrZero(window: Window): Long =
+        runCatching {
+                val method =
+                    window.javaClass.methods.firstOrNull {
+                        it.name == "getWindowHandle" && it.parameterCount == 0
+                    } ?: return 0L
+                (method.invoke(window) as Number).toLong()
+            }
+            .getOrDefault(0L)
+
+    private const val INSET_TOLERANCE_PX: Int = 4
+    private const val MAX_TITLE_BAR_PX: Int = 80
+    private const val SURFACE_FILLS_WINDOW_AREA_RATIO: Double = 0.9
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
@@ -43,6 +43,8 @@ public object WindowIdentityResolver {
             surfaceBoundsInWindow = surfaceInWindow,
             scaleX = transform.scaleX,
             scaleY = transform.scaleY,
+            translateX = transform.translateX,
+            translateY = transform.translateY,
         )
     }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentitySnapshot.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentitySnapshot.kt
@@ -8,12 +8,15 @@ import java.awt.Rectangle
  * Native identity and geometry of one tracked Compose surface, for out-of-process recorders.
  *
  * Coordinate spaces (constraint #4):
- * - **Screen AWT pixels** — [windowBoundsOnScreen] and [surfaceBoundsOnScreen] use the same space
- *   as `Component.locationOnScreen` / `Robot` (physical AWT pixels after the platform transform).
- * - **Window-relative AWT pixels** — [surfaceBoundsInWindow] is the Compose surface origin/size
- *   relative to [windowBoundsOnScreen]'s top-left (still AWT pixels, not Compose logical units).
- * - **Scale** — [scaleX]/[scaleY] come from `GraphicsConfiguration.defaultTransform` (1.0 on
- *   non-HiDPI, 2.0 on a typical Retina display).
+ * - **Screen AWT user space** — [windowBoundsOnScreen] and [surfaceBoundsOnScreen] use the same
+ *   space as `Component.locationOnScreen` / `java.awt.Robot` and as `WindowSummaryDto.bounds` from
+ *   the agent `windows` op. On HiDPI this is the AWT *logical* / user coordinate system, not raw
+ *   device pixels; multiply by [scaleX]/[scaleY] when a backend requires device pixels.
+ * - **Window-relative AWT user space** — [surfaceBoundsInWindow] is the Compose surface origin/size
+ *   relative to [windowBoundsOnScreen]'s top-left in the same AWT units (crop rect for window+crop
+ *   when the backend crops in AWT space; scale if the backend crops in device pixels).
+ * - **Scale** — [scaleX]/[scaleY] from `GraphicsConfiguration.defaultTransform` (1.0 non-HiDPI, 2.0
+ *   on a typical Retina display).
  *
  * When [cropRequired] is true, [nativeHandle] identifies the **host top-level** window (spike
  * constraint #5): capture that window and crop to [surfaceBoundsInWindow] (or the screen-space

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentitySnapshot.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentitySnapshot.kt
@@ -1,0 +1,55 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import java.awt.Rectangle
+
+/**
+ * Native identity and geometry of one tracked Compose surface, for out-of-process recorders.
+ *
+ * Coordinate spaces (constraint #4):
+ * - **Screen AWT pixels** — [windowBoundsOnScreen] and [surfaceBoundsOnScreen] use the same space
+ *   as `Component.locationOnScreen` / `Robot` (physical AWT pixels after the platform transform).
+ * - **Window-relative AWT pixels** — [surfaceBoundsInWindow] is the Compose surface origin/size
+ *   relative to [windowBoundsOnScreen]'s top-left (still AWT pixels, not Compose logical units).
+ * - **Scale** — [scaleX]/[scaleY] come from `GraphicsConfiguration.defaultTransform` (1.0 on
+ *   non-HiDPI, 2.0 on a typical Retina display).
+ *
+ * When [cropRequired] is true, [nativeHandle] identifies the **host top-level** window (spike
+ * constraint #5): capture that window and crop to [surfaceBoundsInWindow] (or the screen-space
+ * surface rect, depending on the backend).
+ */
+@InternalSpectreApi
+public data class WindowIdentitySnapshot(
+    public val index: Int,
+    public val surfaceId: String,
+    public val title: String?,
+    public val isPopup: Boolean,
+    /**
+     * Platform-native window id for capture targeting, or `null` if unrealized / unresolvable.
+     *
+     * - Windows: HWND as unsigned 64-bit bits in a signed [Long]
+     * - macOS: `NSWindow*` pointer bits
+     * - X11: Window XID
+     */
+    public val nativeHandle: Long?,
+    /**
+     * `true` when [nativeHandle] is the host top-level window and capture must crop to the Compose
+     * surface. `false` when the handle already targets the surface-sized window (or no crop is
+     * needed because surface fills the window).
+     */
+    public val cropRequired: Boolean,
+    /** Outer top-level window bounds in screen AWT pixels. */
+    public val windowBoundsOnScreen: Rectangle,
+    /** Compose surface bounds in screen AWT pixels. */
+    public val surfaceBoundsOnScreen: Rectangle,
+    /**
+     * Compose surface origin and size relative to [windowBoundsOnScreen]'s top-left, in AWT pixels.
+     * The natural crop rectangle for window+crop backends.
+     */
+    public val surfaceBoundsInWindow: Rectangle,
+    /** `GraphicsConfiguration.defaultTransform.scaleX`. */
+    public val scaleX: Double,
+    /** `GraphicsConfiguration.defaultTransform.scaleY`. */
+    public val scaleY: Double,
+)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentitySnapshot.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentitySnapshot.kt
@@ -11,12 +11,12 @@ import java.awt.Rectangle
  * - **Screen AWT user space** — [windowBoundsOnScreen] and [surfaceBoundsOnScreen] use the same
  *   space as `Component.locationOnScreen` / `java.awt.Robot` and as `WindowSummaryDto.bounds` from
  *   the agent `windows` op. On HiDPI this is the AWT *logical* / user coordinate system, not raw
- *   device pixels; multiply by [scaleX]/[scaleY] when a backend requires device pixels.
+ *   device pixels.
  * - **Window-relative AWT user space** — [surfaceBoundsInWindow] is the Compose surface origin/size
- *   relative to [windowBoundsOnScreen]'s top-left in the same AWT units (crop rect for window+crop
- *   when the backend crops in AWT space; scale if the backend crops in device pixels).
- * - **Scale** — [scaleX]/[scaleY] from `GraphicsConfiguration.defaultTransform` (1.0 non-HiDPI, 2.0
- *   on a typical Retina display).
+ *   relative to [windowBoundsOnScreen]'s top-left in the same AWT units.
+ * - **Affine transform** — [scaleX]/[scaleY]/[translateX]/[translateY] from
+ *   `GraphicsConfiguration.defaultTransform`. Device-pixel conversion of an AWT screen point `(x,
+ *   y)` is approximately `(x * scaleX + translateX, y * scaleY + translateY)`.
  *
  * When [cropRequired] is true, [nativeHandle] identifies the **host top-level** window (spike
  * constraint #5): capture that window and crop to [surfaceBoundsInWindow] (or the screen-space
@@ -42,17 +42,21 @@ public data class WindowIdentitySnapshot(
      * needed because surface fills the window).
      */
     public val cropRequired: Boolean,
-    /** Outer top-level window bounds in screen AWT pixels. */
+    /** Outer top-level window bounds in screen AWT user space. */
     public val windowBoundsOnScreen: Rectangle,
-    /** Compose surface bounds in screen AWT pixels. */
+    /** Compose surface bounds in screen AWT user space. */
     public val surfaceBoundsOnScreen: Rectangle,
     /**
-     * Compose surface origin and size relative to [windowBoundsOnScreen]'s top-left, in AWT pixels.
-     * The natural crop rectangle for window+crop backends.
+     * Compose surface origin and size relative to [windowBoundsOnScreen]'s top-left, in AWT user
+     * space. The natural crop rectangle for window+crop backends.
      */
     public val surfaceBoundsInWindow: Rectangle,
     /** `GraphicsConfiguration.defaultTransform.scaleX`. */
     public val scaleX: Double,
     /** `GraphicsConfiguration.defaultTransform.scaleY`. */
     public val scaleY: Double,
+    /** `GraphicsConfiguration.defaultTransform.translateX` (device-pixel conversion). */
+    public val translateX: Double = 0.0,
+    /** `GraphicsConfiguration.defaultTransform.translateY` (device-pixel conversion). */
+    public val translateY: Double = 0.0,
 )

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -263,6 +263,8 @@ class ComposeAutomatorPublicSurfaceTest {
                 "dev.sebastiano.spectre.core.TextQuery",
                 "dev.sebastiano.spectre.core.TrackedWindow",
                 "dev.sebastiano.spectre.core.Tracer",
+                "dev.sebastiano.spectre.core.WindowIdentityResolver",
+                "dev.sebastiano.spectre.core.WindowIdentitySnapshot",
                 "dev.sebastiano.spectre.core.WindowTracker",
                 "dev.sebastiano.spectre.core.capture.AtomicCapture",
                 "dev.sebastiano.spectre.core.capture.AtomicCaptureBuilder",
@@ -323,6 +325,8 @@ class ComposeAutomatorPublicSurfaceTest {
             setOf(
                 "dev.sebastiano.spectre.core.SurfaceIdAssigner",
                 "dev.sebastiano.spectre.core.TrackedWindow",
+                "dev.sebastiano.spectre.core.WindowIdentityResolver",
+                "dev.sebastiano.spectre.core.WindowIdentitySnapshot",
                 "dev.sebastiano.spectre.core.WindowTracker",
                 "dev.sebastiano.spectre.core.perf.RecomposerInspector",
             )
@@ -364,10 +368,12 @@ class ComposeAutomatorPublicSurfaceTest {
                 "monitorRecompositions",
             )
 
-        // Members on ComposeAutomator that ship under @InternalSpectreApi — currently just the
-        // `windows: List<TrackedWindow>` accessor for the experimental server transport.
-        // Property getters are emitted as `getWindows`.
-        val COMPOSE_AUTOMATOR_ESCAPE_HATCH_MEMBERS: Set<String> = setOf("getWindows")
+        // Members on ComposeAutomator that ship under @InternalSpectreApi:
+        // - `windows: List<TrackedWindow>` (property getter `getWindows`) for the experimental
+        //   server transport
+        // - `windowIdentities` / `windowIdentity` for daemon-owned recording (#184)
+        val COMPOSE_AUTOMATOR_ESCAPE_HATCH_MEMBERS: Set<String> =
+            setOf("getWindows", "windowIdentities", "windowIdentity")
 
         // Public factory methods on ComposeAutomator.Companion. R1 narrowed `inProcess(...)`
         // to a single `robotDriver` parameter; restoring `windowTracker` / `semanticsReader`

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolverTest.kt
@@ -1,0 +1,103 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.condition.EnabledIf
+
+@EnabledIf("liveAwtAvailable")
+class WindowIdentityResolverTest {
+
+    @Test
+    fun `resolve reports window and surface bounds with window-relative crop rect`() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Requires non-headless AWT")
+        val frame = JFrame("identity-fixture")
+        try {
+            SwingUtilities.invokeAndWait {
+                frame.setSize(400, 300)
+                frame.setLocation(120, 80)
+                frame.isVisible = true
+            }
+            // Give the peer a tick to become displayable.
+            Thread.sleep(50)
+            val tracked =
+                TrackedWindow(
+                    surfaceId = "surface-test",
+                    window = frame,
+                    composePanel = null,
+                    isPopup = false,
+                )
+            val identity = WindowIdentityResolver.resolve(index = 0, tracked = tracked)
+            assertEquals(0, identity.index)
+            assertEquals("surface-test", identity.surfaceId)
+            assertEquals("identity-fixture", identity.title)
+            assertEquals(false, identity.isPopup)
+            assertTrue(identity.scaleX > 0.0)
+            assertTrue(identity.scaleY > 0.0)
+            // Without an embedded panel, surface follows content/window; crop rect origin is
+            // non-negative.
+            assertTrue(identity.surfaceBoundsInWindow.x >= 0)
+            assertTrue(identity.surfaceBoundsInWindow.y >= 0)
+            assertTrue(identity.surfaceBoundsInWindow.width > 0)
+            assertTrue(identity.surfaceBoundsInWindow.height > 0)
+            // Screen-space surface must match window origin + relative crop.
+            assertEquals(
+                identity.windowBoundsOnScreen.x + identity.surfaceBoundsInWindow.x,
+                identity.surfaceBoundsOnScreen.x,
+            )
+            assertEquals(
+                identity.windowBoundsOnScreen.y + identity.surfaceBoundsInWindow.y,
+                identity.surfaceBoundsOnScreen.y,
+            )
+            // Handle resolution is best-effort; on a realized frame we usually get a non-null peer.
+            // Do not hard-fail if the JDK peer path is unavailable in this environment.
+            if (identity.nativeHandle != null) {
+                assertTrue(identity.nativeHandle != 0L)
+            }
+        } finally {
+            SwingUtilities.invokeAndWait { frame.dispose() }
+        }
+    }
+
+    @Test
+    fun `surfaceBoundsInWindow is relative to windowBoundsOnScreen origin`() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Requires non-headless AWT")
+        val frame = JFrame("relative-crop")
+        try {
+            SwingUtilities.invokeAndWait {
+                frame.setSize(500, 400)
+                frame.setLocation(50, 60)
+                frame.isVisible = true
+            }
+            Thread.sleep(50)
+            val tracked =
+                TrackedWindow(surfaceId = "s", window = frame, composePanel = null, isPopup = false)
+            val identity = WindowIdentityResolver.resolve(0, tracked)
+            val expected =
+                Rectangle(
+                    identity.surfaceBoundsOnScreen.x - identity.windowBoundsOnScreen.x,
+                    identity.surfaceBoundsOnScreen.y - identity.windowBoundsOnScreen.y,
+                    identity.surfaceBoundsOnScreen.width,
+                    identity.surfaceBoundsOnScreen.height,
+                )
+            assertEquals(expected, identity.surfaceBoundsInWindow)
+        } finally {
+            SwingUtilities.invokeAndWait { frame.dispose() }
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun liveAwtAvailable(): Boolean =
+            !GraphicsEnvironment.isHeadless() &&
+                (!System.getProperty("os.name").orEmpty().contains("mac", ignoreCase = true) ||
+                    System.getProperty("spectre.test.liveAwt").toBoolean())
+    }
+}

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -241,11 +241,13 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 
 `windowIdentities` returns native handle/id (when resolvable), window and Compose-surface
 bounds in **AWT user-space screen coordinates** (same space as `windows()` /
-`locationOnScreen` / Robot; on HiDPI multiply by the reported scale for device pixels),
-surface bounds **relative to the window** (crop rect), per-window DPI scale, and a
+`locationOnScreen` / Robot), surface bounds **relative to the window** (crop rect),
+per-window affine transform (`scaleX`/`scaleY`/`translateX`/`translateY`), and a
 `cropRequired` flag when the surface is a subset of the top-level window (title bar or
-embedded panel). Daemon-owned recording (#183) uses this so capture stays on the daemon
-host rather than over the transport.
+embedded panel). For device pixels: point `(x, y) → (x * scaleX + translateX, y * scaleY +
+translateY)`; scale widths/heights by `scaleX`/`scaleY` only (no translation). Daemon-owned
+recording (#183) uses this so capture stays on the daemon host rather than over the
+transport.
 
 Streaming / long-poll ops (`waitForVisualIdle`, idling resources, `withTracing`) are
 deferred to a follow-up.

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -240,10 +240,12 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 | `close()` (auto)      | `AgentRequest.Detach`            | tear-down         |
 
 `windowIdentities` returns native handle/id (when resolvable), window and Compose-surface
-bounds in **screen AWT pixels**, surface bounds **relative to the window** (crop rect),
-per-window DPI scale, and a `cropRequired` flag for handle-less embedded surfaces (host
-window handle + crop). Daemon-owned recording (#183) uses this so capture stays on the
-daemon host rather than over the transport.
+bounds in **AWT user-space screen coordinates** (same space as `windows()` /
+`locationOnScreen` / Robot; on HiDPI multiply by the reported scale for device pixels),
+surface bounds **relative to the window** (crop rect), per-window DPI scale, and a
+`cropRequired` flag when the surface is a subset of the top-level window (title bar or
+embedded panel). Daemon-owned recording (#183) uses this so capture stays on the daemon
+host rather than over the transport.
 
 Streaming / long-poll ops (`waitForVisualIdle`, idling resources, `withTracing`) are
 deferred to a follow-up.

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -235,7 +235,15 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 | `click(nodeKey)`      | `AgentRequest.Click`             | `Unit`            |
 | `typeText(text)`      | `AgentRequest.TypeText`          | `Unit`            |
 | `screenshot()`        | `AgentRequest.Screenshot`        | `ByteArray` (PNG) |
+| `capture(windowIndex)`| `AgentRequest.Capture`           | `AtomicCaptureResult` |
+| `windowIdentities(windowIndex?)` | `AgentRequest.WindowIdentity` | `List<WindowIdentityDto>` |
 | `close()` (auto)      | `AgentRequest.Detach`            | tear-down         |
+
+`windowIdentities` returns native handle/id (when resolvable), window and Compose-surface
+bounds in **screen AWT pixels**, surface bounds **relative to the window** (crop rect),
+per-window DPI scale, and a `cropRequired` flag for handle-less embedded surfaces (host
+window handle + crop). Daemon-owned recording (#183) uses this so capture stays on the
+daemon host rather than over the transport.
 
 Streaming / long-poll ops (`waitForVisualIdle`, idling resources, `withTracing`) are
 deferred to a follow-up.


### PR DESCRIPTION
## Summary

Part of epic #183. Adds an agent-transport **window-identity** read op so the daemon can target OS-level recording without shipping video over UDS.

- Core: `WindowIdentitySnapshot` / `WindowIdentityResolver` / best-effort `NativeWindowHandle` (Compose handle, then AWT peer HWND / NSWindow* / X11).
- Wire: `AgentRequest.WindowIdentity` → `AgentResponse.WindowIdentities` + `WindowIdentityDto` (handle, cropRequired, screen bounds, surface-in-window crop rect, scale).
- Reflective mapper + `AttachedAutomator.windowIdentities()`.
- Contract, mapping, and fixture integration tests; agent guide docs.

## Test plan

- [x] `./gradlew check`
- [x] WireCodec + ReflectiveAutomatorHandler mapping tests for identity DTOs
- [x] `AgentAttachIntegrationTest` asserts surface bounds match `windows()` and `cropRequired` for JFrame+ComposePanel
- [x] Public surface allowlists updated for escape-hatch types/methods

Closes #184