### PR TITLE
macOS TCC preflight: fail fast, never prompt implicitly (#187)

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/PermissionsCommand.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/PermissionsCommand.kt
@@ -1,0 +1,99 @@
+package dev.sebastiano.spectre.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import dev.sebastiano.spectre.recording.screencapturekit.MacOsScreenCaptureAccess
+import dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureAccessResult
+import java.io.IOException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Human-facing TCC helpers (#187). Check never prompts; request may trigger the system flow and
+ * must only be run with a human present. Does not go through the daemon.
+ */
+internal class PermissionsCommand(output: Appendable) : CliktCommand(name = "permissions") {
+    init {
+        subcommands(PermissionsCheckCommand(output), PermissionsRequestCommand(output))
+    }
+
+    override fun run(): Unit = Unit
+}
+
+private class PermissionsCheckCommand(private val output: Appendable) :
+    CliktCommand(name = "check") {
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val result =
+            try {
+                MacOsScreenCaptureAccess.preflight()
+            } catch (exception: IOException) {
+                throw CliOutputException(
+                    IOException(exception.message ?: "permissions check failed", exception)
+                )
+            } catch (exception: IllegalStateException) {
+                throw CliOutputException(
+                    IOException(exception.message ?: "permissions check failed", exception)
+                )
+            }
+        printPermissions(result, json, output)
+        if (!result.granted) throw ProgramResult(1)
+    }
+}
+
+private class PermissionsRequestCommand(private val output: Appendable) :
+    CliktCommand(name = "request") {
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val result =
+            try {
+                MacOsScreenCaptureAccess.request()
+            } catch (exception: IOException) {
+                throw CliOutputException(
+                    IOException(exception.message ?: "permissions request failed", exception)
+                )
+            } catch (exception: IllegalStateException) {
+                throw CliOutputException(
+                    IOException(exception.message ?: "permissions request failed", exception)
+                )
+            }
+        printPermissions(result, json, output)
+        if (!result.granted) throw ProgramResult(1)
+    }
+}
+
+private fun printPermissions(result: ScreenCaptureAccessResult, json: Boolean, output: Appendable) {
+    if (json) {
+        output.append(
+            PERMISSIONS_JSON.encodeToString(
+                PermissionsJson(
+                    granted = result.granted,
+                    binary = result.binaryPath,
+                    settingsPath = result.settingsPath,
+                    deepLink = result.deepLink,
+                    guidance = result.guidance,
+                )
+            )
+        )
+    } else {
+        output.append(result.relayMessage())
+    }
+    output.appendLine()
+}
+
+@Serializable
+private data class PermissionsJson(
+    val granted: Boolean,
+    val binary: String,
+    val settingsPath: String,
+    val deepLink: String,
+    val guidance: String,
+)
+
+private val PERMISSIONS_JSON = Json { encodeDefaults = true }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.parse
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
@@ -59,6 +60,10 @@ public class SpectreCli(
         return try {
             command.parse(arguments)
             EXIT_SUCCESS
+        } catch (exception: ProgramResult) {
+            // Intentional early exit with a custom status (e.g. permissions denied → 1). Do not
+            // treat as a usage error or print Clikt help — the command already wrote its output.
+            exception.statusCode
         } catch (exception: CliktError) {
             val destination = if (exception.statusCode == EXIT_SUCCESS) output else errorOutput
             destination.append(command.getFormattedHelp(exception))

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -136,6 +136,7 @@ private class RootCommand(
             CaptureCommand(request, output),
             CapturesCommand(request, output),
             RecordCommand(request, output),
+            PermissionsCommand(output),
             PsCommand(request, output),
             DaemonCommand(request, shutdownRequest, output),
             McpCommand(request),
@@ -817,7 +818,7 @@ private const val EXIT_DAEMON_FAILURE: Int = 5
 private const val JSON_VERSION: Int = 1
 private val CLI_JSON: Json = Json { encodeDefaults = true }
 
-private class CliOutputException(cause: IOException) : IOException(cause.message, cause)
+internal class CliOutputException(cause: IOException) : IOException(cause.message, cause)
 
 private class DaemonCommandException(response: DaemonResponse.Error) :
     IOException(response.message) {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
@@ -7,6 +7,8 @@ import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import dev.sebastiano.spectre.recording.AutoRecorder
 import dev.sebastiano.spectre.recording.RecordingHandle
+import dev.sebastiano.spectre.recording.screencapturekit.MacOsScreenCaptureAccess
+import dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureAccessDeniedException
 import java.awt.Rectangle
 import java.io.IOException
 import java.nio.file.Path
@@ -55,6 +57,12 @@ internal class AttachedDaemonSession(private val delegate: AttachedAutomator) :
     override fun startRecording(outputPath: String): String {
         if (recording != null)
             throw IOException("a recording is already in progress for this session")
+        // Fail fast on macOS before any capture path that could pop a TCC prompt (#187).
+        try {
+            MacOsScreenCaptureAccess.requireGranted()
+        } catch (exception: ScreenCaptureAccessDeniedException) {
+            throw IOException(exception.message ?: "Screen Recording not granted", exception)
+        }
         val window =
             windows().firstOrNull { !it.isPopup }
                 ?: throw IOException("the target has no non-popup window to record")
@@ -72,6 +80,8 @@ internal class AttachedDaemonSession(private val delegate: AttachedAutomator) :
                         destination,
                     )
             outputPath
+        } catch (exception: ScreenCaptureAccessDeniedException) {
+            throw IOException(exception.message ?: "Screen Recording not granted", exception)
         } catch (exception: IllegalStateException) {
             throw IOException(exception.message ?: "failed to start recording", exception)
         } catch (exception: IllegalArgumentException) {

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/PermissionsCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/PermissionsCliTest.kt
@@ -51,4 +51,36 @@ class PermissionsCliTest {
         assertEquals(0, code)
         assertTrue(out.toString().contains("deepLink") || out.toString().contains("\"granted\""))
     }
+
+    @Test
+    fun `permissions check never remaps a clean run to usage failure exit 2`() {
+        // Regression: SpectreCli used to map ProgramResult(1) (denied) → EXIT_USAGE_FAILURE(2).
+        // A clean permissions check must exit 0 (granted/n/a) or 1 (denied), never 2.
+        val out = StringBuilder()
+        val err = StringBuilder()
+        val code =
+            SpectreCli(request = { error("no daemon") }, output = out, errorOutput = err)
+                .run(listOf("permissions", "check"))
+        assertTrue(
+            code == 0 || code == 1,
+            "permissions check exit must be 0 or 1, got $code out=$out err=$err",
+        )
+        assertTrue(
+            !err.toString().contains("Usage:"),
+            "ProgramResult/denied path must not print Clikt help; err=$err",
+        )
+    }
+
+    @Test
+    fun `usage errors still exit with usage failure code 2`() {
+        val err = StringBuilder()
+        val code =
+            SpectreCli(
+                    request = { error("no daemon") },
+                    output = StringBuilder(),
+                    errorOutput = err,
+                )
+                .run(listOf("permissions", "not-a-subcommand"))
+        assertEquals(2, code, "err=$err")
+    }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/PermissionsCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/PermissionsCliTest.kt
@@ -1,0 +1,54 @@
+package dev.sebastiano.spectre.cli
+
+import dev.sebastiano.spectre.cli.daemon.DaemonRequest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * CLI `permissions` is local (no daemon). On non-macOS CI/Linux runners, preflight returns
+ * not-applicable granted=true without invoking the helper.
+ */
+class PermissionsCliTest {
+
+    @Test
+    fun `permissions check succeeds on non-macOS without daemon`() {
+        val out = StringBuilder()
+        val err = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { error("daemon must not be called for permissions: $it") },
+                output = out,
+                errorOutput = err,
+            )
+        val code = cli.run(listOf("permissions", "check"))
+        // Non-macOS: granted / not applicable → 0. macOS: depends on local TCC.
+        val os = System.getProperty("os.name").orEmpty().lowercase()
+        if (!os.contains("mac")) {
+            assertEquals(0, code, "err=$err out=$out")
+            assertTrue(
+                out.toString().contains("not applicable") || out.toString().contains("granted")
+            )
+        } else {
+            // On macOS the helper must run; exit 0 or 1 depending on grant.
+            assertTrue(code == 0 || code == 1, "unexpected exit $code out=$out err=$err")
+            assertTrue(out.isNotEmpty() || err.isNotEmpty())
+        }
+    }
+
+    @Test
+    fun `permissions check --json includes deep_link field name on non-macOS`() {
+        val out = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { _: DaemonRequest -> error("no daemon") },
+                output = out,
+                errorOutput = StringBuilder(),
+            )
+        val os = System.getProperty("os.name").orEmpty().lowercase()
+        if (os.contains("mac")) return
+        val code = cli.run(listOf("permissions", "check", "--json"))
+        assertEquals(0, code)
+        assertTrue(out.toString().contains("deepLink") || out.toString().contains("\"granted\""))
+    }
+}

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -38,6 +38,14 @@ routers that pick the right one per call.
     actionable error. `ffmpeg` on `PATH` is only relevant if you instantiate the explicit
     legacy ffmpeg backends.
 
+!!! note "macOS TCC preflight (v1)"
+    Capture and recording **never** pop the Screen Recording TCC prompt implicitly.
+    The helper preflights with `CGPreflightScreenCaptureAccess` and fails fast with a
+    structured error (Settings path + deep link) when access is missing. Agents cannot
+    click TCC prompts. With a human present, run `spectre permissions check` or
+    `spectre permissions request` (the only path that may call
+    `CGRequestScreenCaptureAccess`).
+
 ## Still Window Screenshots
 
 `ComposeAutomator.screenshot(...)` lives in `spectre-core` and captures a rectangle

--- a/recording/api/recording.api
+++ b/recording/api/recording.api
@@ -68,6 +68,7 @@ public final class dev/sebastiano/spectre/recording/LinuxX11Recorder : dev/sebas
 public final class dev/sebastiano/spectre/recording/MacOsRecordingPermissions {
 	public static final field INSTANCE Ldev/sebastiano/spectre/recording/MacOsRecordingPermissions;
 	public final fun diagnose ()Ldev/sebastiano/spectre/recording/PermissionDiagnostic;
+	public final fun preflightScreenRecording ()Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;
 }
 
 public final class dev/sebastiano/spectre/recording/PermissionDiagnostic {
@@ -175,6 +176,61 @@ public final class dev/sebastiano/spectre/recording/portal/WaylandWindowSourceRe
 }
 
 public final class dev/sebastiano/spectre/recording/screencapturekit/HelperNotBundledException : java/lang/IllegalStateException {
+}
+
+public final class dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess {
+	public static final field DEEP_LINK Ljava/lang/String;
+	public static final field HELPER_EXIT_NOT_GRANTED I
+	public static final field INSTANCE Ldev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess;
+	public static final field SETTINGS_PATH Ljava/lang/String;
+	public final fun preflight ()Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;
+	public final fun request ()Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;
+	public final fun requireGranted ()V
+}
+
+public final class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessDeniedException : java/lang/IllegalStateException {
+	public fun <init> (Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;)V
+	public final fun getResult ()Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;
+}
+
+public final class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult {
+	public static final field Companion Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult$Companion;
+	public fun <init> (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApi ()Ljava/lang/String;
+	public final fun getBinaryPath ()Ljava/lang/String;
+	public final fun getDeepLink ()Ljava/lang/String;
+	public final fun getGranted ()Z
+	public final fun getGuidance ()Ljava/lang/String;
+	public final fun getSettingsPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun relayMessage ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult$Companion {
+	public final fun notApplicable ()Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureAccessResult;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder : dev/sebastiano/spectre/recording/Recorder, dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder {

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
@@ -11,8 +11,11 @@ import UniformTypeIdentifiers
 // MARK: - CLI contract
 //
 // spectre-screencapture
-//   --mode <recording|screenshot>  Optional. Default recording.
-//   --source <window|region>   Optional. Default window.
+//   --mode <recording|screenshot|preflight|request>
+//                              Optional. Default recording.
+//                              preflight: CGPreflightScreenCaptureAccess only (never prompts).
+//                              request:   CGRequestScreenCaptureAccess (human-invoked only).
+//   --source <window|region>   Optional. Default window. Ignored for preflight/request.
 //   --pid <jvm pid>            Required for window source. Filters CGWindowList by owner PID so we never
 //                              capture another process's window matching the discriminator.
 //   --title-contains <suffix>  Required for window source. Substring match on the target window's kCGWindowName.
@@ -21,13 +24,13 @@ import UniformTypeIdentifiers
 //   --region <x,y,w,h>         Required for region source. Coordinates use the selected
 //                              display's top-left ScreenCaptureKit sourceRect space.
 //   --display-index <int>      Optional for region source. Default 0; primary display first.
-//   --output <path>            Required. Destination .mov/.mp4 file. Overwritten if it exists.
+//   --output <path>            Required for recording/screenshot. Destination .mov/.mp4/.png.
 //   --fps <int>                Optional. Default 30.
 //   --cursor <true|false>      Optional. Default true.
 //   --file-type <mov|mp4>      Optional. AVAssetWriter container type. Defaults from output path.
 //   --discovery-timeout-ms <int>  Optional. Default 2000.
 //
-// Lifecycle:
+// Lifecycle (recording/screenshot):
 //   - On start, scans CGWindowListCopyWindowInfo until a window matching (pid, title-contains)
 //     appears or the discovery timeout elapses.
 //   - Streams frames via SCStream into AVAssetWriter (H.264) until either:
@@ -36,20 +39,36 @@ import UniformTypeIdentifiers
 //       * SIGTERM
 //   - Always finalises the writer before exit so the requested movie file is playable.
 //
+// Preflight / request:
+//   - Emit one JSON object on stdout (see ScreenCaptureAccessResult).
+//   - Never start ScreenCaptureKit capture.
+//
 // Exit codes:
-//   0  clean shutdown, file finalised
+//   0  clean shutdown / access granted (preflight/request)
 //   2  bad arguments
 //   3  window not found within the discovery timeout
-//   4  permission denied (Screen Recording TCC)
+//   4  permission denied mid-capture (Screen Recording TCC during SCStream)
 //   5  capture pipeline error after start
+//   6  preflight/request: Screen Recording not granted (structured JSON on stdout)
 
 public enum SpectreScreenCaptureCommand {
     public static func main(_ argv: [String] = CommandLine.arguments) async -> Never {
         do {
             let args = try Arguments.parse(argv)
-            let recorder = Recorder(arguments: args)
-            try await recorder.run()
-            exit(0)
+            switch args.mode {
+            case .preflight:
+                let result = ScreenCaptureAccess.preflight(binaryPath: argv.first ?? "spectre-screencapture")
+                FileHandle.standardOutput.write(Data(result.jsonLine.utf8))
+                exit(result.granted ? 0 : 6)
+            case .request:
+                let result = ScreenCaptureAccess.request(binaryPath: argv.first ?? "spectre-screencapture")
+                FileHandle.standardOutput.write(Data(result.jsonLine.utf8))
+                exit(result.granted ? 0 : 6)
+            case .recording, .screenshot:
+                let recorder = Recorder(arguments: args)
+                try await recorder.run()
+                exit(0)
+            }
         } catch let error as CLIError {
             FileHandle.standardError.write(Data("spectre-screencapture: \(error.message)\n".utf8))
             exit(error.code)
@@ -58,6 +77,77 @@ public enum SpectreScreenCaptureCommand {
                 Data("spectre-screencapture: unexpected error: \(error)\n".utf8))
             exit(5)
         }
+    }
+}
+
+/// Structured TCC preflight / request result. One JSON object per line on stdout.
+struct ScreenCaptureAccessResult {
+    let granted: Bool
+    let binaryPath: String
+    let settingsPath: String
+    let deepLink: String
+    let guidance: String
+
+    var jsonLine: String {
+        // Manual JSON — keep the helper free of extra dependencies.
+        let esc: (String) -> String = { raw in
+            raw
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+                .replacingOccurrences(of: "\n", with: "\\n")
+        }
+        return
+            "{"
+            + "\"granted\":\(granted ? "true" : "false"),"
+            + "\"api\":\"CGPreflightScreenCaptureAccess\","
+            + "\"binary\":\"\(esc(binaryPath))\","
+            + "\"settings_path\":\"\(esc(settingsPath))\","
+            + "\"deep_link\":\"\(esc(deepLink))\","
+            + "\"guidance\":\"\(esc(guidance))\""
+            + "}\n"
+    }
+}
+
+enum ScreenCaptureAccess {
+    static let settingsPath =
+        "System Settings → Privacy & Security → Screen & System Audio Recording"
+    static let deepLink =
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+
+    /// Never prompts. Uses CGPreflightScreenCaptureAccess only.
+    static func preflight(binaryPath: String) -> ScreenCaptureAccessResult {
+        let granted = CGPreflightScreenCaptureAccess()
+        return result(granted: granted, binaryPath: binaryPath)
+    }
+
+    /// May prompt / create a System Settings row. Human-invoked only.
+    static func request(binaryPath: String) -> ScreenCaptureAccessResult {
+        _ = CGRequestScreenCaptureAccess()
+        // Re-check; the user may still deny.
+        let granted = CGPreflightScreenCaptureAccess()
+        return result(granted: granted, binaryPath: binaryPath)
+    }
+
+    private static func result(granted: Bool, binaryPath: String) -> ScreenCaptureAccessResult {
+        let guidance: String
+        if granted {
+            guidance =
+                "Screen Recording is granted for \(binaryPath). Capture may proceed."
+        } else {
+            guidance =
+                "Screen Recording is NOT granted for \(binaryPath). "
+                + "An agent cannot click the TCC prompt (SecurityAgent is not automatable). "
+                + "A human must open \(settingsPath) (deep link: \(deepLink)), enable "
+                + "\(binaryPath) (or the host JVM that launches it), then restart that process. "
+                + "Run `spectre permissions request` only when a human is present to approve."
+        }
+        return ScreenCaptureAccessResult(
+            granted: granted,
+            binaryPath: binaryPath,
+            settingsPath: settingsPath,
+            deepLink: deepLink,
+            guidance: guidance
+        )
     }
 }
 
@@ -95,6 +185,17 @@ struct Arguments {
         var i = 1
         while i < argv.count {
             let key = argv[i]
+            // Boolean flag form for preflight (issue #187): --preflight with no value.
+            if key == "--preflight" {
+                mode = .preflight
+                i += 1
+                continue
+            }
+            if key == "--request-access" {
+                mode = .request
+                i += 1
+                continue
+            }
             guard i + 1 < argv.count else {
                 throw CLIError(code: 2, message: "missing value for \(key)")
             }
@@ -102,7 +203,9 @@ struct Arguments {
             switch key {
             case "--mode":
                 guard let parsed = CaptureMode(rawValue: value) else {
-                    throw CLIError(code: 2, message: "--mode must be recording or screenshot")
+                    throw CLIError(
+                        code: 2,
+                        message: "--mode must be recording, screenshot, preflight, or request")
                 }
                 mode = parsed
             case "--source":
@@ -152,6 +255,24 @@ struct Arguments {
             i += 2
         }
 
+        if mode == .preflight || mode == .request {
+            // Dummy output — preflight/request never open the file.
+            let dummy = URL(fileURLWithPath: "/dev/null")
+            return Arguments(
+                mode: mode,
+                source: source,
+                pid: pid,
+                titleContains: titleContains,
+                region: region,
+                displayIndex: displayIndex,
+                output: dummy,
+                fps: fps,
+                captureCursor: cursor,
+                fileType: fileType ?? .mp4,
+                discoveryTimeoutMs: discoveryTimeoutMs
+            )
+        }
+
         switch source {
         case .window:
             guard pid != nil else { throw CLIError(code: 2, message: "--pid is required") }
@@ -188,6 +309,8 @@ struct Arguments {
 enum CaptureMode: String {
     case recording
     case screenshot
+    case preflight
+    case request
 }
 
 enum CaptureSource: String {

--- a/recording/native/macos/Tests/SpectreScreenCaptureCoreTests/ArgumentsTests.swift
+++ b/recording/native/macos/Tests/SpectreScreenCaptureCoreTests/ArgumentsTests.swift
@@ -47,4 +47,30 @@ final class ArgumentsTests: XCTestCase {
             ])
         )
     }
+
+    func testArgumentsAcceptPreflightModeWithoutOutput() throws {
+        let args = try Arguments.parse([
+            "spectre-screencapture",
+            "--mode",
+            "preflight",
+        ])
+        XCTAssertEqual(args.mode, .preflight)
+    }
+
+    func testArgumentsAcceptPreflightFlag() throws {
+        let args = try Arguments.parse([
+            "spectre-screencapture",
+            "--preflight",
+        ])
+        XCTAssertEqual(args.mode, .preflight)
+    }
+
+    func testArgumentsAcceptRequestMode() throws {
+        let args = try Arguments.parse([
+            "spectre-screencapture",
+            "--mode",
+            "request",
+        ])
+        XCTAssertEqual(args.mode, .request)
+    }
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/MacOsRecordingPermissions.kt
@@ -1,33 +1,22 @@
 package dev.sebastiano.spectre.recording
 
+import dev.sebastiano.spectre.recording.screencapturekit.MacOsScreenCaptureAccess
+import dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureAccessResult
 import java.util.concurrent.TimeUnit
 
 /**
- * Best-effort startup diagnostics for the macOS permissions Spectre needs.
+ * Startup diagnostics for the macOS permissions Spectre needs.
  *
- * The Spectre automator interacts with the OS in two ways that gated by macOS TCC permissions:
- * - **Screen Recording** — required for [FfmpegRecorder]'s avfoundation device and for AWT
- *   `Robot.createScreenCapture` (which is what the core RobotDriver's screenshot path uses on
- *   macOS).
- * - **Accessibility (input control)** — required for AWT `Robot` to actually move the mouse and
- *   synthesize key events. Without it, mouse/key calls silently no-op.
- *
- * Detecting these without JNI is awkward — the canonical native APIs
- * (`CGPreflightScreenCaptureAccess`, `AXIsProcessTrusted`) live in CoreGraphics /
- * ApplicationServices and aren't reachable from pure JVM. Spectre currently ships the diagnostic
- * surface as documentation plus a probe-style heuristic via the `tccutil` / `osascript` CLIs where
- * available. Full native detection (calling into CoreGraphics / ApplicationServices via JNI or
- * Panama) is a future improvement; in the meantime callers see the actual permission outcome at
- * recording start because
- * [ScreenCaptureKitRecorder][dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureKitRecorder]
- * detects TCC denial via the helper's exit code.
+ * - **Screen Recording** — [MacOsScreenCaptureAccess.preflight] via the ScreenCaptureKit helper
+ *   (`CGPreflightScreenCaptureAccess`). Never prompts.
+ * - **Accessibility** — best-effort probe via `osascript` / System Events (Automation is a separate
+ *   TCC entry and may leave Accessibility unknown).
  */
 public object MacOsRecordingPermissions {
 
     /**
      * Returns a human-readable diagnostic that downstream tooling can dump at startup. On non-macOS
-     * platforms returns [PermissionStatus.NotApplicable]. On macOS, runs a best-effort probe via
-     * `osascript` if available, otherwise returns [PermissionStatus.Unknown] with guidance text.
+     * platforms returns [PermissionStatus.NotApplicable].
      */
     public fun diagnose(): PermissionDiagnostic {
         if (!isMacOs()) return PermissionDiagnostic(NOT_MAC_MESSAGE, PermissionStatus.NotApplicable)
@@ -46,22 +35,23 @@ public object MacOsRecordingPermissions {
         )
     }
 
+    /**
+     * Screen Recording only — structured result for agents/CLI. Never prompts. Prefer this over
+     * [diagnose] when only capture access matters.
+     */
+    public fun preflightScreenRecording(): ScreenCaptureAccessResult =
+        MacOsScreenCaptureAccess.preflight()
+
     private fun probeScreenRecordingPermission(): PermissionStatus {
-        // CGPreflightScreenCaptureAccess lives in CoreGraphics and isn't reachable from pure
-        // JVM. There's no AppleScript proxy for the Screen Recording TCC entry either, so we
-        // honestly report Unknown rather than pretending we know — callers see the actual
-        // outcome at recording start when the SCK helper exits with a TCC-denied code.
-        return PermissionStatus.Unknown
+        return try {
+            val result = MacOsScreenCaptureAccess.preflight()
+            if (result.granted) PermissionStatus.Granted else PermissionStatus.Denied
+        } catch (_: Exception) {
+            PermissionStatus.Unknown
+        }
     }
 
     private fun probeAccessibilityPermission(): PermissionStatus {
-        // The probe asks System Events for a process name. Three outcomes:
-        //   - exit 0 with non-blank output: Accessibility is granted.
-        //   - exit non-zero with the explicit Accessibility denial string: Denied.
-        //   - exit non-zero with anything else (including the AppleEvents/Automation
-        //     authorisation error -1743 / "Not authorized to send Apple events to System
-        //     Events"): Unknown — Automation and Accessibility are separate macOS TCC
-        //     entries, so an Automation refusal does NOT prove Accessibility is denied.
         val result =
             runOsascript("tell application \"System Events\" to return name of first process")
         return when {
@@ -78,7 +68,6 @@ public object MacOsRecordingPermissions {
         }
     }
 
-    /** Combine multiple statuses into a single rollup using the worst-known value. */
     private fun combine(vararg statuses: PermissionStatus): PermissionStatus =
         when {
             statuses.any { it == PermissionStatus.Denied } -> PermissionStatus.Denied
@@ -106,8 +95,6 @@ public object MacOsRecordingPermissions {
                 )
             }
         } catch (_: InterruptedException) {
-            // Cancellation is meaningful upstream — surface the interrupt so callers'
-            // timeout/cancellation logic can react instead of silently swallowing it.
             process.destroyForcibly()
             Thread.currentThread().interrupt()
             null
@@ -127,11 +114,11 @@ public object MacOsRecordingPermissions {
         "Spectre macOS permission diagnostics: not applicable on this platform."
 
     private const val GUIDANCE: String =
-        "If a status is Denied or Unknown, grant the JVM (your IDE / your test runner / java)\n" +
-            "the relevant permission under System Settings → Privacy & Security:\n" +
-            "  - Screen Recording: required for ffmpeg avfoundation capture and for Robot screenshots.\n" +
-            "  - Accessibility:    required for Robot mouse/keyboard control.\n" +
-            "Restart the JVM after granting; macOS does not refresh TCC entitlements live."
+        "If Screen Recording is Denied, run `spectre permissions request` with a human present,\n" +
+            "or open ${MacOsScreenCaptureAccess.SETTINGS_PATH}\n" +
+            "(${MacOsScreenCaptureAccess.DEEP_LINK}) and enable the spectre-screencapture helper\n" +
+            "and/or the host JVM. Restart the process after granting.\n" +
+            "Accessibility is required for Robot mouse/keyboard control."
 }
 
 /** Coarse permission status we can detect without JNI. */

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
@@ -1,0 +1,195 @@
+package dev.sebastiano.spectre.recording.screencapturekit
+
+import java.io.IOException
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+
+/**
+ * macOS Screen Recording TCC preflight / request via the `spectre-screencapture` helper.
+ *
+ * Agents cannot click TCC prompts (SecurityAgent is not automatable). Capture paths must call
+ * [preflight] and fail fast when access is missing. Only [request] may call
+ * `CGRequestScreenCaptureAccess` — and only behind an explicit human-invoked CLI/MCP command.
+ *
+ * On non-macOS hosts, [preflight] returns [ScreenCaptureAccessResult.notApplicable].
+ */
+public object MacOsScreenCaptureAccess {
+
+    public const val SETTINGS_PATH: String =
+        "System Settings → Privacy & Security → Screen & System Audio Recording"
+    public const val DEEP_LINK: String =
+        "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+    public const val HELPER_EXIT_NOT_GRANTED: Int = 6
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    /** Check Screen Recording without prompting. */
+    public fun preflight(): ScreenCaptureAccessResult =
+        preflight(HelperBinaryExtractor(), DefaultProcessFactory)
+
+    /**
+     * Trigger the system permission flow (may prompt). **Human-invoked only** — never call from
+     * automated capture/recording paths.
+     */
+    public fun request(): ScreenCaptureAccessResult =
+        request(HelperBinaryExtractor(), DefaultProcessFactory)
+
+    /**
+     * Fail fast when Screen Recording is missing. No-op on non-macOS. Throws
+     * [ScreenCaptureAccessDeniedException] with a structured, agent-relayable message.
+     */
+    public fun requireGranted() {
+        if (!isMacOs()) return
+        val result = preflight()
+        if (!result.granted) throw ScreenCaptureAccessDeniedException(result)
+    }
+
+    /** Test-visible overload that injects helper extraction and process spawning. */
+    internal fun preflight(
+        helperExtractor: HelperBinaryExtractor,
+        processFactory: ProcessFactory,
+    ): ScreenCaptureAccessResult {
+        if (!isMacOs()) return ScreenCaptureAccessResult.notApplicable()
+        return runHelper(
+            mode = "preflight",
+            helperPath = helperExtractor.extract(),
+            processFactory = processFactory,
+        )
+    }
+
+    internal fun request(
+        helperExtractor: HelperBinaryExtractor,
+        processFactory: ProcessFactory,
+    ): ScreenCaptureAccessResult {
+        if (!isMacOs()) return ScreenCaptureAccessResult.notApplicable()
+        return runHelper(
+            mode = "request",
+            helperPath = helperExtractor.extract(),
+            processFactory = processFactory,
+        )
+    }
+
+    internal fun requireGranted(
+        helperExtractor: HelperBinaryExtractor,
+        processFactory: ProcessFactory = DefaultProcessFactory,
+    ) {
+        if (!isMacOs()) return
+        val result = preflight(helperExtractor, processFactory)
+        if (!result.granted) throw ScreenCaptureAccessDeniedException(result)
+    }
+
+    private fun runHelper(
+        mode: String,
+        helperPath: Path,
+        processFactory: ProcessFactory,
+    ): ScreenCaptureAccessResult {
+        val argv = listOf(helperPath.toString(), "--mode", mode)
+        val process =
+            try {
+                processFactory.start(argv)
+            } catch (ex: IOException) {
+                throw IllegalStateException(
+                    "failed to start spectre-screencapture for TCC $mode: ${ex.message}",
+                    ex,
+                )
+            }
+        val (stdout, exitCode) = awaitHelper(process, mode)
+        val line =
+            stdout.lineSequence().firstOrNull { it.isNotBlank() }
+                ?: error("spectre-screencapture $mode produced no JSON (exit=$exitCode)")
+        val parsed = parseResultJson(line, mode)
+        // Exit 0 = granted, 6 = not granted; other codes are hard failures.
+        check(exitCode == 0 || exitCode == HELPER_EXIT_NOT_GRANTED) {
+            "spectre-screencapture $mode failed with exit=$exitCode: ${parsed.guidance}"
+        }
+        return if (parsed.binaryPath.isBlank()) {
+            parsed.copy(binaryPath = helperPath.toString())
+        } else {
+            parsed
+        }
+    }
+
+    private fun awaitHelper(process: Process, mode: String): Pair<String, Int> {
+        try {
+            if (!process.waitFor(HELPER_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                process.destroyForcibly()
+                error("spectre-screencapture $mode timed out after ${HELPER_TIMEOUT_SECONDS}s")
+            }
+            val stdout = process.inputStream.bufferedReader().use { it.readText() }
+            return stdout to process.exitValue()
+        } catch (ex: InterruptedException) {
+            process.destroyForcibly()
+            Thread.currentThread().interrupt()
+            throw IllegalStateException("interrupted while waiting for TCC $mode", ex)
+        }
+    }
+
+    private fun parseResultJson(line: String, mode: String): ScreenCaptureAccessResult =
+        try {
+            json.decodeFromString(ScreenCaptureAccessResult.serializer(), line)
+        } catch (ex: kotlinx.serialization.SerializationException) {
+            throw IllegalStateException(
+                "spectre-screencapture $mode returned unparseable JSON: $line",
+                ex,
+            )
+        } catch (ex: IllegalArgumentException) {
+            throw IllegalStateException(
+                "spectre-screencapture $mode returned unparseable JSON: $line",
+                ex,
+            )
+        }
+
+    private fun isMacOs(): Boolean =
+        System.getProperty("os.name").orEmpty().lowercase().contains("mac")
+
+    internal fun interface ProcessFactory {
+        fun start(argv: List<String>): Process
+    }
+
+    private object DefaultProcessFactory : ProcessFactory {
+        override fun start(argv: List<String>): Process =
+            ProcessBuilder(argv).redirectErrorStream(true).start()
+    }
+
+    private const val HELPER_TIMEOUT_SECONDS: Long = 15
+}
+
+/** Result of a Screen Recording TCC preflight or request. */
+@Serializable
+public data class ScreenCaptureAccessResult(
+    public val granted: Boolean,
+    @SerialName("binary") public val binaryPath: String = "",
+    @SerialName("settings_path")
+    public val settingsPath: String = MacOsScreenCaptureAccess.SETTINGS_PATH,
+    @SerialName("deep_link") public val deepLink: String = MacOsScreenCaptureAccess.DEEP_LINK,
+    public val guidance: String = "",
+    public val api: String = "CGPreflightScreenCaptureAccess",
+) {
+    public companion object {
+        public fun notApplicable(): ScreenCaptureAccessResult =
+            ScreenCaptureAccessResult(
+                granted = true,
+                binaryPath = "",
+                guidance = "Screen Recording preflight is not applicable on this platform.",
+                api = "n/a",
+            )
+    }
+
+    /** Multi-line text suitable for CLI/MCP relay to a human. */
+    public fun relayMessage(): String =
+        buildString {
+                appendLine(if (granted) "Screen Recording: granted" else "Screen Recording: DENIED")
+                if (binaryPath.isNotBlank()) appendLine("Binary needing grant: $binaryPath")
+                appendLine("Settings: $settingsPath")
+                appendLine("Deep link: $deepLink")
+                if (guidance.isNotBlank()) appendLine(guidance)
+            }
+            .trimEnd()
+}
+
+/** Thrown when capture is refused because Screen Recording TCC is missing. */
+public class ScreenCaptureAccessDeniedException(public val result: ScreenCaptureAccessResult) :
+    IllegalStateException(result.relayMessage())

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
@@ -47,37 +47,46 @@ public object MacOsScreenCaptureAccess {
         if (!result.granted) throw ScreenCaptureAccessDeniedException(result)
     }
 
-    /** Test-visible overload that injects helper extraction and process spawning. */
+    /**
+     * Test-visible overload that injects helper extraction, process spawning, and the OS gate. Pass
+     * [isMacOs] = `{ true }` so fake-helper tests exercise the process path on Linux CI.
+     */
     internal fun preflight(
         helperExtractor: HelperBinaryExtractor,
         processFactory: ProcessFactory,
+        isMacOs: () -> Boolean = ::isMacOs,
     ): ScreenCaptureAccessResult {
         if (!isMacOs()) return ScreenCaptureAccessResult.notApplicable()
         return runHelper(
             mode = "preflight",
             helperPath = helperExtractor.extract(),
             processFactory = processFactory,
+            timeoutSeconds = PREFLIGHT_TIMEOUT_SECONDS,
         )
     }
 
     internal fun request(
         helperExtractor: HelperBinaryExtractor,
         processFactory: ProcessFactory,
+        isMacOs: () -> Boolean = ::isMacOs,
     ): ScreenCaptureAccessResult {
         if (!isMacOs()) return ScreenCaptureAccessResult.notApplicable()
         return runHelper(
             mode = "request",
             helperPath = helperExtractor.extract(),
             processFactory = processFactory,
+            // CGRequestScreenCaptureAccess blocks on the system dialog until a human responds.
+            timeoutSeconds = REQUEST_TIMEOUT_SECONDS,
         )
     }
 
     internal fun requireGranted(
         helperExtractor: HelperBinaryExtractor,
         processFactory: ProcessFactory = DefaultProcessFactory,
+        isMacOs: () -> Boolean = ::isMacOs,
     ) {
         if (!isMacOs()) return
-        val result = preflight(helperExtractor, processFactory)
+        val result = preflight(helperExtractor, processFactory, isMacOs)
         if (!result.granted) throw ScreenCaptureAccessDeniedException(result)
     }
 
@@ -85,6 +94,7 @@ public object MacOsScreenCaptureAccess {
         mode: String,
         helperPath: Path,
         processFactory: ProcessFactory,
+        timeoutSeconds: Long,
     ): ScreenCaptureAccessResult {
         val argv = listOf(helperPath.toString(), "--mode", mode)
         val process =
@@ -96,7 +106,7 @@ public object MacOsScreenCaptureAccess {
                     ex,
                 )
             }
-        val (stdout, exitCode) = awaitHelper(process, mode)
+        val (stdout, exitCode) = awaitHelper(process, mode, timeoutSeconds)
         val line =
             stdout.lineSequence().firstOrNull { it.isNotBlank() }
                 ?: error("spectre-screencapture $mode produced no JSON (exit=$exitCode)")
@@ -112,11 +122,15 @@ public object MacOsScreenCaptureAccess {
         }
     }
 
-    private fun awaitHelper(process: Process, mode: String): Pair<String, Int> {
+    private fun awaitHelper(
+        process: Process,
+        mode: String,
+        timeoutSeconds: Long,
+    ): Pair<String, Int> {
         try {
-            if (!process.waitFor(HELPER_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            if (!process.waitFor(timeoutSeconds, TimeUnit.SECONDS)) {
                 process.destroyForcibly()
-                error("spectre-screencapture $mode timed out after ${HELPER_TIMEOUT_SECONDS}s")
+                error("spectre-screencapture $mode timed out after ${timeoutSeconds}s")
             }
             val stdout = process.inputStream.bufferedReader().use { it.readText() }
             return stdout to process.exitValue()
@@ -154,7 +168,14 @@ public object MacOsScreenCaptureAccess {
             ProcessBuilder(argv).redirectErrorStream(true).start()
     }
 
-    private const val HELPER_TIMEOUT_SECONDS: Long = 15
+    /** Non-interactive preflight must stay snappy. */
+    private const val PREFLIGHT_TIMEOUT_SECONDS: Long = 15
+
+    /**
+     * Request may block on the TCC system dialog until a human responds. Five minutes is long
+     * enough for a deliberate grant without hanging CI forever if a fake process never exits.
+     */
+    private const val REQUEST_TIMEOUT_SECONDS: Long = 300
 }
 
 /** Result of a Screen Recording TCC preflight or request. */

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -38,6 +38,9 @@ public class ScreenCaptureKitRecorder
 internal constructor(
     private val helperExtractor: HelperBinaryExtractor,
     private val processFactory: ProcessFactory,
+    private val requireScreenCaptureAccess: () -> Unit = {
+        MacOsScreenCaptureAccess.requireGranted()
+    },
 ) : WindowRecorder, Recorder {
 
     public constructor() : this(HelperBinaryExtractor(), SystemProcessFactory)
@@ -123,6 +126,8 @@ internal constructor(
         argv: List<String>,
         cleanup: () -> Unit,
     ): RecordingHandle {
+        // Fail fast before any SCStream work that could pop a TCC prompt mid-run (#187).
+        requireScreenCaptureAccess()
         val process = processFactory.start(argv)
 
         // Wait for the helper to either:

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitScreenshotter.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitScreenshotter.kt
@@ -11,12 +11,17 @@ public class ScreenCaptureKitScreenshotter
 internal constructor(
     private val helperExtractor: HelperBinaryExtractor,
     private val processFactory: ScreenCaptureKitRecorder.ProcessFactory,
+    private val requireScreenCaptureAccess: () -> Unit = {
+        MacOsScreenCaptureAccess.requireGranted(helperExtractor)
+    },
 ) : WindowScreenshotter {
 
     public constructor() :
         this(HelperBinaryExtractor(), ScreenCaptureKitRecorder.SystemProcessFactory)
 
     override fun captureWindow(window: TitledWindow, windowOwnerPid: Long): BufferedImage {
+        // Fail fast before SCStream so agents never hang on an implicit TCC prompt (#187).
+        requireScreenCaptureAccess()
         val helperPath = helperExtractor.extract()
         val output = Files.createTempFile("spectre-sck-window-screenshot-", ".png")
         val discriminator = TitleDiscriminator(window)

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccessTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccessTest.kt
@@ -1,0 +1,108 @@
+package dev.sebastiano.spectre.recording.screencapturekit
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class MacOsScreenCaptureAccessTest {
+
+    @Test
+    fun `preflight parses granted JSON from helper`() {
+        val json =
+            """{"granted":true,"api":"CGPreflightScreenCaptureAccess","binary":"/tmp/h","settings_path":"Settings","deep_link":"x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture","guidance":"ok"}"""
+        val factory = MacOsScreenCaptureAccess.ProcessFactory {
+            FakeProcess(stdout = json + "\n", exitCode = 0)
+        }
+        val extractor = stubExtractor()
+        val result =
+            MacOsScreenCaptureAccess.preflight(
+                helperExtractor = extractor,
+                processFactory = factory,
+            )
+        assertTrue(result.granted)
+        assertEquals("/tmp/h", result.binaryPath)
+        assertTrue(result.relayMessage().contains("granted", ignoreCase = true))
+    }
+
+    @Test
+    fun `preflight denied throws structured exception via requireGranted`() {
+        val json =
+            """{"granted":false,"api":"CGPreflightScreenCaptureAccess","binary":"/tmp/spectre-screencapture","settings_path":"System Settings → Privacy & Security → Screen & System Audio Recording","deep_link":"x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture","guidance":"denied for agents"}"""
+        val factory = MacOsScreenCaptureAccess.ProcessFactory {
+            FakeProcess(stdout = json + "\n", exitCode = 6)
+        }
+        val extractor = stubExtractor()
+        val denied =
+            assertFailsWith<ScreenCaptureAccessDeniedException> {
+                MacOsScreenCaptureAccess.requireGranted(
+                    helperExtractor = extractor,
+                    processFactory = factory,
+                )
+            }
+        assertFalse(denied.result.granted)
+        assertTrue(denied.message!!.contains("Deep link"))
+        assertTrue(denied.message!!.contains("Privacy_ScreenCapture"))
+        assertTrue(denied.message!!.contains("/tmp/spectre-screencapture"))
+    }
+
+    @Test
+    fun `request mode invokes helper with --mode request`() {
+        var argv: List<String> = emptyList()
+        val json =
+            """{"granted":true,"api":"CGPreflightScreenCaptureAccess","binary":"/h","settings_path":"s","deep_link":"d","guidance":"g"}"""
+        val factory = MacOsScreenCaptureAccess.ProcessFactory { args ->
+            argv = args
+            FakeProcess(stdout = json + "\n", exitCode = 0)
+        }
+        MacOsScreenCaptureAccess.request(
+            helperExtractor = stubExtractor(),
+            processFactory = factory,
+        )
+        assertEquals("request", argv[argv.indexOf("--mode") + 1])
+    }
+
+    private fun stubExtractor(): HelperBinaryExtractor {
+        val dir = Files.createTempDirectory("spectre-preflight-test")
+        val helper = dir.resolve("spectre-screencapture")
+        Files.writeString(helper, "#!/bin/sh\n")
+        helper.toFile().setExecutable(true)
+        return HelperBinaryExtractor(
+            envLookup = { key ->
+                if (key == "SPECTRE_SCREENCAPTURE_HELPER") helper.toString() else null
+            },
+            sysPropLookup = { null },
+            resourceLocator = { null },
+            targetDirProvider = { dir },
+        )
+    }
+
+    private class FakeProcess(stdout: String, private val exitCode: Int) : Process() {
+        private val input = ByteArrayInputStream(stdout.toByteArray())
+        private val error = ByteArrayInputStream(ByteArray(0))
+        private val output = ByteArrayOutputStream()
+
+        override fun getOutputStream(): OutputStream = output
+
+        override fun getInputStream(): InputStream = input
+
+        override fun getErrorStream(): InputStream = error
+
+        override fun waitFor(): Int = exitCode
+
+        override fun waitFor(timeout: Long, unit: TimeUnit): Boolean = true
+
+        override fun exitValue(): Int = exitCode
+
+        override fun destroy() = Unit
+
+        override fun destroyForcibly(): Process = this
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccessTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccessTest.kt
@@ -26,6 +26,7 @@ class MacOsScreenCaptureAccessTest {
             MacOsScreenCaptureAccess.preflight(
                 helperExtractor = extractor,
                 processFactory = factory,
+                isMacOs = { true },
             )
         assertTrue(result.granted)
         assertEquals("/tmp/h", result.binaryPath)
@@ -45,6 +46,7 @@ class MacOsScreenCaptureAccessTest {
                 MacOsScreenCaptureAccess.requireGranted(
                     helperExtractor = extractor,
                     processFactory = factory,
+                    isMacOs = { true },
                 )
             }
         assertFalse(denied.result.granted)
@@ -65,8 +67,24 @@ class MacOsScreenCaptureAccessTest {
         MacOsScreenCaptureAccess.request(
             helperExtractor = stubExtractor(),
             processFactory = factory,
+            isMacOs = { true },
         )
         assertEquals("request", argv[argv.indexOf("--mode") + 1])
+    }
+
+    @Test
+    fun `preflight returns notApplicable when not macOS`() {
+        val factory = MacOsScreenCaptureAccess.ProcessFactory {
+            error("helper must not start off macOS")
+        }
+        val result =
+            MacOsScreenCaptureAccess.preflight(
+                helperExtractor = stubExtractor(),
+                processFactory = factory,
+                isMacOs = { false },
+            )
+        assertTrue(result.granted)
+        assertEquals("n/a", result.api)
     }
 
     private fun stubExtractor(): HelperBinaryExtractor {

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorderTest.kt
@@ -31,8 +31,11 @@ class ScreenCaptureKitRecorderTest {
                 resourceLocator = { ByteArrayInputStream(byteArrayOf(0x01)) },
                 targetDirProvider = { helperPath.parent ?: Path.of("/tmp") },
             )
-        return ScreenCaptureKitRecorder(helperExtractor = extractor, processFactory = factory) to
-            factory
+        return ScreenCaptureKitRecorder(
+            helperExtractor = extractor,
+            processFactory = factory,
+            requireScreenCaptureAccess = {},
+        ) to factory
     }
 
     @Test

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitScreenshotterTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitScreenshotterTest.kt
@@ -26,7 +26,11 @@ class ScreenCaptureKitScreenshotterTest {
                 targetDirProvider = { Path.of("/tmp") },
             )
         val screenshotter =
-            ScreenCaptureKitScreenshotter(helperExtractor = extractor, processFactory = factory)
+            ScreenCaptureKitScreenshotter(
+                helperExtractor = extractor,
+                processFactory = factory,
+                requireScreenCaptureAccess = {},
+            )
         val window = ScreenshotFakeTitledWindow(initialTitle = "MyApp")
 
         val image = screenshotter.captureWindow(window = window, windowOwnerPid = 4242L)
@@ -55,7 +59,11 @@ class ScreenCaptureKitScreenshotterTest {
                 targetDirProvider = { Path.of("/tmp") },
             )
         val screenshotter =
-            ScreenCaptureKitScreenshotter(helperExtractor = extractor, processFactory = factory)
+            ScreenCaptureKitScreenshotter(
+                helperExtractor = extractor,
+                processFactory = factory,
+                requireScreenCaptureAccess = {},
+            )
         val window = ScreenshotFakeTitledWindow(initialTitle = "MyApp")
 
         try {


### PR DESCRIPTION
## Summary

Part of epic #183 / issue #187.

- Swift helper: `--mode preflight` (never prompts) and `--mode request` (human-only), JSON stdout, exit 6 when denied
- `MacOsScreenCaptureAccess` JVM API + `ScreenCaptureAccessDeniedException` with Settings path + deep link
- SCK recorder/screenshotter fail-fast preflight before SCStream
- Daemon `startRecording` preflights on macOS
- CLI: `spectre permissions check|request`

## Test plan

- [x] `./gradlew check`
- [x] Unit tests for JSON parse / denied exception structure
- [x] Real helper `--mode preflight` emits granted JSON (local TCC)
- [x] CLI permissions check on non-macOS returns not-applicable

Closes #187