### PR TITLE
Window capture + crop for embedded Compose surfaces (#186)

### DIFF
--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -152,21 +152,23 @@ failure modes, and the section below
 
 ## Region capture
 
-- **Region capture, not window capture**. Region capture records a fixed `Rectangle` of
-  the virtual desktop — whatever pixels the screen happens to be showing inside that
-  region land in the file. The region is bound at `Recorder.start(...)` time and does
-  not follow a window. Use `ScreenCaptureKitRecorder` (macOS) or
-  `WindowsGraphicsCaptureRecorder` (Windows) when you have a top-level window to target — the next section covers what
-  the window-targeted backends do differently.
-- **Embedded `ComposePanel` surfaces without an adaptable top-level `Frame` need explicit
-  region capture.**
-  `AutoRecorder.startWindow(...)` uses window-targeted capture only and fails loudly when
-  no true window target is available. The `Frame.asTitledWindow()` adapter exposes the
-  title and bounds for any top-level `Frame`, including `ComposeWindow` and `JFrame`
-  hosts. A panel embedded inside an IntelliJ tool window or a `SwingPanel` host inside
-  Compose has no separate titled `Frame` to adapt — callers use
-  `AutoRecorder.startRegion(...)`. Practical
-  consequences:
+- **Region capture is the last resort, not the default for embedded surfaces.** Region capture
+  records a fixed `Rectangle` of the virtual desktop — whatever pixels the screen happens to
+  be showing inside that region land in the file. The region is bound at `Recorder.start(...)`
+  time and does not follow a window. Prefer window-targeted capture
+  (`ScreenCaptureKitRecorder` / `WindowsGraphicsCaptureRecorder`) when you have a top-level
+  window, and window+crop when only an embedded surface lacks its own native handle.
+- **Embedded `ComposePanel` surfaces: prefer host window + crop over region capture.**
+  When the panel lives inside a top-level host `Frame`/`JFrame` (IntelliJ tool window, Swing
+  host, etc.), use `AutoRecorder.startWindow(window, output, cropInWindow = surfaceBoundsInWindow,
+  scaleX = …, scaleY = …)`. That captures the host window's pixels and crops to the panel
+  (macOS `sourceRect`, Windows pre-encode crop). Benefits: occlusion-immune (overlapping
+  apps are not recorded) and the host window still moves with the OS compositor.
+  **v1 crop is fixed at start** — if the panel is moved/resized mid-recording, frames may
+  misalign until you stop and restart. A stderr warning is printed when crop is used.
+  Linux X11/Wayland do not implement window+crop yet (evaluated for parity; not wired).
+  `startRegion(...)` remains the **explicit last resort** when no host window handle exists.
+  Practical consequences of region fallback:
   - Anything that visually overlaps the panel — other windows, the menu bar, OS notifications, a
     floating popup that escapes the panel's bounds — appears in the recording.
   - The captured region is the panel's screen-space bounds at start. If the host window moves or

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -71,8 +71,10 @@ ImageIO.write(image, "png", File("build/reports/window.png"))
 | Linux Xorg/Xvfb | Linux helper + GStreamer `ximagesrc` | Captures visible screen pixels | The target window must be visible/frontmost, same limitation as `ComposeAutomator.screenshot(...)`; window mode needs a non-blank exact title |
 | Linux Wayland | Linux helper + portal/PipeWire one-frame capture | Portal-scoped; region mode captures the selected monitor stream, window mode captures the selected window stream | Requires the compositor portal dialog to be accepted. Window mode needs `xprop` and `_GTK_FRAME_EXTENTS`, same as `WaylandPortalWindowRecorder` |
 
-Embedded `ComposePanel` surfaces without a top-level OS window still need region
-screenshots, because native window APIs need a real top-level window to bind to.
+Embedded `ComposePanel` surfaces without their own top-level OS window still need the
+**host** top-level window for still screenshots and video. Prefer capturing that host
+window (optionally cropped to the panel) over framebuffer region shots when the host
+exposes a titled `Frame`.
 
 ### Still Screenshot Smoke Tests
 
@@ -150,9 +152,9 @@ view for when you want to know what each backend can and cannot do.
 | Recorder | Capture shape | Follows window resize? | Captures occluding windows / popups? | Prerequisites | Platforms |
 | --- | --- | --- | --- | --- | --- |
 | `FfmpegRecorder` (deprecated) | Screen region (fixed `Rectangle`) | No — region fixed at `start()` | Yes — anything visible inside the region lands in the frame, including occluding apps and overlapping Compose `OnWindow` popups | `ffmpeg` on `PATH`; macOS Screen Recording TCC for the launching app | macOS · Windows legacy/explicit · Linux X11 legacy/explicit |
-| `WindowsGraphicsCaptureRecorder` | Named window (exact title + owner pid) or screen region | Window mode follows the target window across moves; region mode is fixed at `start()` | Window mode captures only the target window's pixels, so occluders are excluded and separate `OnWindow` popups are not captured. Region/fullscreen mode captures the visible monitor pixels inside the requested rectangle, including overlapping windows and popups | `spectre-recording-windows` runtime helper (`spectre-window-capture.exe`); Windows 10 version 1903 or newer; .NET 8 Desktop Runtime; Windows App Runtime 1.8 | Windows |
+| `WindowsGraphicsCaptureRecorder` | Named window (exact title + owner pid), optional pre-encode crop, or screen region | Window mode follows the target window across moves; optional crop is **fixed at start** (v1). Region mode is fixed at `start()` | Window mode (with or without crop) captures only the target window's pixels — occluders excluded. Region/fullscreen mode captures visible monitor pixels including overlapping windows and popups | `spectre-recording-windows` runtime helper (`spectre-window-capture.exe`); Windows 10 version 1903 or newer; .NET 8 Desktop Runtime; Windows App Runtime 1.8 | Windows |
 | `FfmpegWindowRecorder` (deprecated) | Legacy named window (`gdigrab title=`) | Yes — `gdigrab` retracks the window across moves and resizes | No — only the window's pixels are captured. Compose `OnWindow` popups land in a separate OS window with a different title, so they are **not** captured. `OnSameCanvas` / `OnComponent` popups are part of the window surface and are captured | `ffmpeg` on `PATH`; visible window with a non-blank exact title | Windows |
-| `ScreenCaptureKitRecorder` | Named window (pid + title substring) or screen region | Window mode reads the window backing store directly and follows moves/resizes; region mode is fixed at `start()` | Window mode has the same window-source semantics as WGC: occluders and `OnWindow` popups are not captured. Region mode captures visible display pixels in the requested rectangle, including overlapping windows and popups | `spectre-recording-macos` runtime helper (`spectre-screencapture`); macOS Screen Recording TCC for the launching app | macOS |
+| `ScreenCaptureKitRecorder` | Named window (pid + title substring), optional window-relative crop, or screen region | Window mode follows moves/resizes of the host window; optional `sourceRect` crop is **fixed at start** (v1). Region mode is fixed at `start()` | Window mode (with or without crop) captures only the window's pixels — occluders excluded. Region mode captures visible display pixels including overlapping apps | `spectre-recording-macos` runtime helper (`spectre-screencapture`); macOS Screen Recording TCC for the launching app | macOS |
 | `LinuxX11Recorder` | Screen region or named X11 window (`ximagesrc`) | Region mode is fixed at `start()`; window mode uses GStreamer's `xname` source selection | Captures visible X server pixels for the selected source; occluding apps can appear in region capture | `spectre-recording-linux` runtime helper; `gst-launch-1.0` with `ximagesrc`, `videorate`, `x264enc`, and `mp4mux`; `DISPLAY` | Linux Xorg/Xvfb; named XWayland windows only when the process is deliberately forced onto the X11 backend |
 | `WaylandPortalRecorder` | Monitor region (portal `SourceType.MONITOR`, cropped) | No — monitor-level source | Depends on the compositor. Validated on GNOME/Mutter to include the user's overlays but exclude apps occluding the recorded region | `spectre-recording-linux` runtime helper (`spectre-wayland-helper`); `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`. First call pops the compositor's "share screen" dialog | Linux Wayland |
 | `WaylandPortalWindowRecorder` | Named window (portal `SourceType.WINDOW` + fixed crop) | **No.** The crop is computed once from `_GTK_FRAME_EXTENTS` at `start()` and stays at those pixel coordinates for the rest of the recording. If the user moves or resizes the window during the recording, the crop no longer aligns with the window's pixels (typically the recording shows blank / black for the unrendered area of the original rectangle) — see `WaylandPortalWindowRecorder`'s KDoc for the detailed rationale | No — only the picked window's pixels are in the stream. `OnWindow` popups not captured | `spectre-recording-linux` runtime helper; `xdg-desktop-portal` + PipeWire; `gst-launch-1.0` on `PATH`; `xprop` on `PATH`; compositor must publish `_GTK_FRAME_EXTENTS` (GNOME/Mutter verified; older Mutter / KDE / sway may not — the recorder throws rather than producing misaligned video) | Linux Wayland |
@@ -162,15 +164,16 @@ what makes window-targeted Wayland capture different from ffmpeg-on-X11 region c
 crop is fixed at `start()`, so the recording is robust against occluders but not against the
 user moving or resizing the window mid-recording.
 
-Embedded-host implications: `ComposePanel`s without a top-level OS window — including
-Jewel-hosted Compose inside an IntelliJ plugin tool window — have no exact window title for
-the native Windows helper to bind to and no top-level window for the SCK helper to discover.
-`AutoRecorder` falls through to region capture (`ScreenCaptureKitRecorder` on macOS,
-`WindowsGraphicsCaptureRecorder` on Windows, `LinuxX11Recorder` on Linux Xorg/Xvfb,
-and `WaylandPortalRecorder` on Linux Wayland)
-for those surfaces. Linux support is
-best-effort: portal capture is exercised against GNOME/Mutter on Ubuntu 22.04 and 24.04;
-KDE / sway / wlroots may behave differently and are not validated.
+Embedded-host implications: a `ComposePanel` inside a host top-level window (including
+Jewel-hosted Compose in an IntelliJ tool window) should use **window capture + crop**, not
+region capture. Pass the host window as a `TitledWindow` and the panel's bounds relative to
+that window (AWT user space — same as window-identity `surfaceBoundsInWindow`) via
+`AutoRecorder.startWindow(..., cropInWindow = ..., scaleX = ..., scaleY = ...)`. macOS uses
+`SCStreamConfiguration.sourceRect`; Windows crops pre-encode in the WGC helper. The crop is
+**fixed at start** in v1 — surface move/resize mid-recording is not followed (a stderr
+warning is emitted). Linux X11/Wayland window+crop is not implemented yet; those platforms
+fail loudly rather than silently falling back. Use `startRegion(...)` only as an
+**explicit last resort** (occlusion-sensitive, fixed screen rectangle).
 
 ## `AutoRecorder` — pick a backend per call
 
@@ -185,6 +188,7 @@ import java.awt.Rectangle
 import java.nio.file.Path
 
 val recorder = AutoRecorder()
+// Full window (occlusion-immune):
 val handle = recorder.startWindow(
     window = composeWindow.asTitledWindow(), // any java.awt.Frame works
     output = Path.of("build/recordings/my-test.mp4"),

--- a/recording/api/recording.api
+++ b/recording/api/recording.api
@@ -10,7 +10,9 @@ public final class dev/sebastiano/spectre/recording/AutoRecorder {
 	public final fun startRegion (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public static synthetic fun startRegion$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public final fun startWindow (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;J)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public final fun startWindow (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;JLjava/awt/Rectangle;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public static synthetic fun startWindow$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;JILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun startWindow$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;JLjava/awt/Rectangle;DDILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public final class dev/sebastiano/spectre/recording/AutoScreenshotter {
@@ -45,6 +47,7 @@ public final class dev/sebastiano/spectre/recording/FfmpegWindowRecorder : dev/s
 	public fun <init> (Ljava/nio/file/Path;)V
 	public synthetic fun <init> (Ljava/nio/file/Path;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public fun startCropped (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public final class dev/sebastiano/spectre/recording/FfmpegWindowScreenshotter : dev/sebastiano/spectre/recording/WindowScreenshotter {
@@ -63,6 +66,7 @@ public final class dev/sebastiano/spectre/recording/LinuxX11Recorder : dev/sebas
 	public fun <init> ()V
 	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public fun start (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public fun startCropped (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public final class dev/sebastiano/spectre/recording/MacOsRecordingPermissions {
@@ -237,6 +241,7 @@ public final class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptu
 	public fun <init> ()V
 	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public fun start (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public fun startCropped (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public abstract interface class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder$ProcessFactory {
@@ -261,16 +266,21 @@ public final class dev/sebastiano/spectre/recording/screencapturekit/TitledWindo
 public abstract interface class dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder {
 	public abstract fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public fun startCropped (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun startCropped$default (Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;DDILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public final class dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder$DefaultImpls {
 	public static synthetic fun start$default (Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static fun startCropped (Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun startCropped$default (Ldev/sebastiano/spectre/recording/screencapturekit/WindowRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;DDILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public final class dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureRecorder : dev/sebastiano/spectre/recording/Recorder, dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder {
 	public fun <init> ()V
 	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public fun start (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public fun startCropped (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public final class dev/sebastiano/spectre/recording/windows/WindowsWindowScreenshotter : dev/sebastiano/spectre/recording/WindowScreenshotter {

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
@@ -23,6 +23,9 @@ import UniformTypeIdentifiers
 //                              title for the recording's lifetime so this is unique.
 //   --region <x,y,w,h>         Required for region source. Coordinates use the selected
 //                              display's top-left ScreenCaptureKit sourceRect space.
+//   --crop <x,y,w,h>           Optional for window source. Crop rect relative to the window's
+//                              top-left in the same point space as SCWindow.frame / AWT user
+//                              space. Fixed for the recording lifetime (issue #186).
 //   --display-index <int>      Optional for region source. Default 0; primary display first.
 //   --output <path>            Required for recording/screenshot. Destination .mov/.mp4/.png.
 //   --fps <int>                Optional. Default 30.
@@ -162,6 +165,8 @@ struct Arguments {
     let pid: pid_t?
     let titleContains: String?
     let region: CaptureRegion?
+    /// Optional window-relative crop (points). Only valid for window source.
+    let crop: CaptureRegion?
     let displayIndex: Int
     let output: URL
     let fps: Int
@@ -175,6 +180,7 @@ struct Arguments {
         var pid: pid_t?
         var titleContains: String?
         var region: CaptureRegion?
+        var crop: CaptureRegion?
         var displayIndex = 0
         var output: String?
         var fps = 30
@@ -221,7 +227,9 @@ struct Arguments {
             case "--title-contains":
                 titleContains = value
             case "--region":
-                region = try CaptureRegion.parse(value)
+                region = try CaptureRegion.parse(value, flag: "--region")
+            case "--crop":
+                crop = try CaptureRegion.parse(value, flag: "--crop")
             case "--display-index":
                 guard let parsed = Int(value), parsed >= 0 else {
                     throw CLIError(code: 2, message: "--display-index must be >= 0")
@@ -264,6 +272,7 @@ struct Arguments {
                 pid: pid,
                 titleContains: titleContains,
                 region: region,
+                crop: crop,
                 displayIndex: displayIndex,
                 output: dummy,
                 fps: fps,
@@ -284,6 +293,11 @@ struct Arguments {
             guard mode == .recording else {
                 throw CLIError(code: 2, message: "region source only supports --mode recording")
             }
+            if crop != nil {
+                throw CLIError(
+                    code: 2,
+                    message: "--crop is only valid with --source window (region uses --region)")
+            }
         }
         guard let output, !output.isEmpty else {
             throw CLIError(code: 2, message: "--output is required")
@@ -296,6 +310,7 @@ struct Arguments {
             pid: pid,
             titleContains: titleContains,
             region: region,
+            crop: crop,
             displayIndex: displayIndex,
             output: outputUrl,
             fps: fps,
@@ -345,18 +360,18 @@ struct CaptureRegion {
     let width: Int
     let height: Int
 
-    static func parse(_ value: String) throws -> CaptureRegion {
+    static func parse(_ value: String, flag: String = "--region") throws -> CaptureRegion {
         let parts = value.split(separator: ",", omittingEmptySubsequences: false)
         guard parts.count == 4, let x = Int(parts[0]), let y = Int(parts[1]),
             let width = Int(parts[2]), let height = Int(parts[3])
         else {
-            throw CLIError(code: 2, message: "--region must be x,y,width,height")
+            throw CLIError(code: 2, message: "\(flag) must be x,y,width,height")
         }
         guard x >= 0, y >= 0, width > 0, height > 0 else {
             throw CLIError(
                 code: 2,
                 message:
-                    "--region x/y must be non-negative and width/height must be positive")
+                    "\(flag) x/y must be non-negative and width/height must be positive")
         }
         return CaptureRegion(x: x, y: y, width: width, height: height)
     }
@@ -601,21 +616,22 @@ final class Recorder {
             // off the main screen. Falls back to NSScreen.main and finally a hardcoded 2.0 if
             // neither lookup succeeds — neither degrades worse than the previous behaviour.
             let scale = backingScaleFactor(for: targetWindow.frame)
-            width = max(2, Int((targetWindow.frame.width * scale).rounded()))
-            height = max(2, Int((targetWindow.frame.height * scale).rounded()))
 
-            // Window-attached filter — output is exactly the target window's pixels, sized to
-            // `config.width` × `config.height`, with no display-coordinate masking. Display-mode
-            // filters (`SCContentFilter(display:including:)`) deliver frames just as well but
-            // place the window inside the display's coordinate space, leaving large black areas
-            // outside the window in the output buffer.
-            //
-            // Earlier diagnostic runs suggested this filter dropped frames; that was actually the
-            // FrameOutput being released right after `startCapture` returned (we hadn't retained
-            // it as a member). With the strong reference in place SCStream delivers frames at the
-            // configured rate even for window-attached filters.
+            // Window-attached filter — output is the target window's pixels (optionally cropped
+            // via sourceRect for embedded Compose surfaces / handle-less panels, issue #186).
+            // Display-mode filters leave large black areas outside the window in the buffer.
             filter = SCContentFilter(desktopIndependentWindow: targetWindow)
-            sourceRect = nil
+            if let crop = args.crop {
+                // Crop is window-relative points (same space as SCWindow.frame / AWT user space).
+                // Fixed at start for v1 — mid-recording resize/move of the surface is not followed.
+                sourceRect = crop.sourceRect()
+                width = max(2, Int((CGFloat(crop.width) * scale).rounded()))
+                height = max(2, Int((CGFloat(crop.height) * scale).rounded()))
+            } else {
+                sourceRect = nil
+                width = max(2, Int((targetWindow.frame.width * scale).rounded()))
+                height = max(2, Int((targetWindow.frame.height * scale).rounded()))
+            }
         case .region(let display, let region):
             width = max(2, region.width)
             height = max(2, region.height)

--- a/recording/native/macos/Tests/SpectreScreenCaptureCoreTests/ArgumentsTests.swift
+++ b/recording/native/macos/Tests/SpectreScreenCaptureCoreTests/ArgumentsTests.swift
@@ -73,4 +73,38 @@ final class ArgumentsTests: XCTestCase {
         ])
         XCTAssertEqual(args.mode, .request)
     }
+
+    func testArgumentsAcceptWindowCrop() throws {
+        let args = try Arguments.parse([
+            "spectre-screencapture",
+            "--pid",
+            "123",
+            "--title-contains",
+            "Spectre/crop",
+            "--crop",
+            "10,20,300,200",
+            "--output",
+            "/tmp/spectre-crop.mp4",
+        ])
+        XCTAssertEqual(args.crop?.x, 10)
+        XCTAssertEqual(args.crop?.y, 20)
+        XCTAssertEqual(args.crop?.width, 300)
+        XCTAssertEqual(args.crop?.height, 200)
+    }
+
+    func testArgumentsRejectCropOnRegionSource() {
+        XCTAssertThrowsError(
+            try Arguments.parse([
+                "spectre-screencapture",
+                "--source",
+                "region",
+                "--region",
+                "0,0,100,100",
+                "--crop",
+                "0,0,50,50",
+                "--output",
+                "/tmp/out.mp4",
+            ])
+        )
+    }
 }

--- a/recording/native/windows/Options.cs
+++ b/recording/native/windows/Options.cs
@@ -23,6 +23,9 @@ internal sealed record Options(
     string? Title,
     long? OwnerPid,
     CaptureRect? Region,
+    // Optional crop relative to the captured window top-left, in device pixels (WGC item space).
+    // Only valid for window source. Fixed for the recording lifetime (issue #186).
+    CaptureRect? Crop,
     int Fps,
     bool CaptureCursor,
     string Output)
@@ -37,6 +40,10 @@ internal sealed record Options(
         int? y = null;
         int? width = null;
         int? height = null;
+        int? cropX = null;
+        int? cropY = null;
+        int? cropWidth = null;
+        int? cropHeight = null;
         int? fps = null;
         bool? captureCursor = null;
         string? output = null;
@@ -68,6 +75,18 @@ internal sealed record Options(
                 case "--height":
                     height = ParsePositiveInt(ReadValue(args, ref i, "--height"), "--height");
                     break;
+                case "--crop-x":
+                    cropX = ParseNonNegativeInt(ReadValue(args, ref i, "--crop-x"), "--crop-x");
+                    break;
+                case "--crop-y":
+                    cropY = ParseNonNegativeInt(ReadValue(args, ref i, "--crop-y"), "--crop-y");
+                    break;
+                case "--crop-width":
+                    cropWidth = ParsePositiveInt(ReadValue(args, ref i, "--crop-width"), "--crop-width");
+                    break;
+                case "--crop-height":
+                    cropHeight = ParsePositiveInt(ReadValue(args, ref i, "--crop-height"), "--crop-height");
+                    break;
                 case "--fps":
                     fps = ParsePositiveInt(ReadValue(args, ref i, "--fps"), "--fps");
                     break;
@@ -89,6 +108,9 @@ internal sealed record Options(
 
         var parsedSource = source ?? throw new ArgumentException("--source is required.");
         CaptureRect? region = null;
+        CaptureRect? crop = null;
+        var cropPartsProvided =
+            cropX is not null || cropY is not null || cropWidth is not null || cropHeight is not null;
         switch (parsedSource)
         {
             case CaptureSource.Window:
@@ -100,8 +122,20 @@ internal sealed record Options(
                 {
                     throw new ArgumentException("--owner-pid is required.");
                 }
+                if (cropPartsProvided)
+                {
+                    crop = new CaptureRect(
+                        cropX ?? throw new ArgumentException("--crop-x is required when any --crop-* flag is set."),
+                        cropY ?? throw new ArgumentException("--crop-y is required when any --crop-* flag is set."),
+                        cropWidth ?? throw new ArgumentException("--crop-width is required when any --crop-* flag is set."),
+                        cropHeight ?? throw new ArgumentException("--crop-height is required when any --crop-* flag is set."));
+                }
                 break;
             case CaptureSource.Region:
+                if (cropPartsProvided)
+                {
+                    throw new ArgumentException("--crop-* flags are only valid with --source window.");
+                }
                 region = new CaptureRect(
                     x ?? throw new ArgumentException("--x is required."),
                     y ?? throw new ArgumentException("--y is required."),
@@ -116,6 +150,7 @@ internal sealed record Options(
             title,
             ownerPid,
             region,
+            crop,
             fps ?? 30,
             captureCursor ?? true,
             output);
@@ -162,6 +197,17 @@ internal sealed record Options(
         if (parsed <= 0)
         {
             throw new ArgumentException($"{name} must be a positive integer.");
+        }
+
+        return parsed;
+    }
+
+    private static int ParseNonNegativeInt(string value, string name)
+    {
+        var parsed = ParseInt(value, name);
+        if (parsed < 0)
+        {
+            throw new ArgumentException($"{name} must be a non-negative integer.");
         }
 
         return parsed;

--- a/recording/native/windows/Program.cs
+++ b/recording/native/windows/Program.cs
@@ -90,8 +90,9 @@ internal static class Program
         bool captureCursor,
         CaptureRect? crop)
     {
-        // Reuse the recording frame path so --crop-* applies identically (issue #186).
-        using var frameSource = WgcFrameSource.StartWindow(hwnd, captureCursor, crop);
+        // Same crop clamp as recording, but padToEven:false so PNGs keep true pixel size
+        // (H.264 even-padding is recording-only).
+        using var frameSource = WgcFrameSource.StartWindow(hwnd, captureCursor, crop, padToEven: false);
         if (frameSource.Width <= 0 || frameSource.Height <= 0)
         {
             throw new InvalidOperationException(
@@ -429,13 +430,21 @@ internal static class Program
 
         public int Height { get; }
 
-        public static WgcFrameSource StartWindow(IntPtr hwnd, bool captureCursor, CaptureRect? cropInWindow = null)
+        public static WgcFrameSource StartWindow(
+            IntPtr hwnd,
+            bool captureCursor,
+            CaptureRect? cropInWindow = null,
+            bool padToEven = true)
         {
             var canvasDevice = new CanvasDevice();
             var item = GraphicsCaptureItemInterop.CreateForWindow(hwnd);
             var full = new CaptureRect(0, 0, item.Size.Width, item.Size.Height);
             var crop = cropInWindow is null ? full : ClampCropToItem(cropInWindow, full);
-            var outputSize = (Even(crop.Width), Even(crop.Height));
+            // Recording needs even dimensions for H.264; screenshots keep exact crop size.
+            var outputSize =
+                padToEven
+                    ? (Even(crop.Width), Even(crop.Height))
+                    : (crop.Width, crop.Height);
             return Start(canvasDevice, item, captureCursor, crop, outputSize);
         }
 

--- a/recording/native/windows/Program.cs
+++ b/recording/native/windows/Program.cs
@@ -167,7 +167,7 @@ internal static class Program
 
     private static async Task<int> RecordWindowAsync(Options options, IntPtr hwnd)
     {
-        using var frameSource = WgcFrameSource.StartWindow(hwnd, options.CaptureCursor);
+        using var frameSource = WgcFrameSource.StartWindow(hwnd, options.CaptureCursor, options.Crop);
         if (frameSource.Width <= 0 || frameSource.Height <= 0)
         {
             throw new InvalidOperationException(
@@ -477,13 +477,40 @@ internal static class Program
 
         public int Height { get; }
 
-        public static WgcFrameSource StartWindow(IntPtr hwnd, bool captureCursor)
+        public static WgcFrameSource StartWindow(IntPtr hwnd, bool captureCursor, CaptureRect? cropInWindow = null)
         {
             var canvasDevice = new CanvasDevice();
             var item = GraphicsCaptureItemInterop.CreateForWindow(hwnd);
-            var crop = new CaptureRect(0, 0, item.Size.Width, item.Size.Height);
-            var outputSize = (Even(item.Size.Width), Even(item.Size.Height));
+            var full = new CaptureRect(0, 0, item.Size.Width, item.Size.Height);
+            var crop = cropInWindow is null ? full : ClampCropToItem(cropInWindow, full);
+            var outputSize = (Even(crop.Width), Even(crop.Height));
             return Start(canvasDevice, item, captureCursor, crop, outputSize);
+        }
+
+        private static CaptureRect ClampCropToItem(CaptureRect crop, CaptureRect itemBounds)
+        {
+            if (crop.X < 0 || crop.Y < 0 || crop.Width <= 0 || crop.Height <= 0)
+            {
+                throw new ArgumentException(
+                    $"Window crop must be non-negative with positive size; got {crop.X},{crop.Y} {crop.Width}x{crop.Height}.");
+            }
+
+            if (crop.Right > itemBounds.Width || crop.Bottom > itemBounds.Height)
+            {
+                // Soft clamp rather than fail hard: HiDPI rounding can overshoot by a pixel.
+                var width = Math.Min(crop.Width, itemBounds.Width - crop.X);
+                var height = Math.Min(crop.Height, itemBounds.Height - crop.Y);
+                if (width <= 0 || height <= 0)
+                {
+                    throw new ArgumentException(
+                        $"Window crop {crop.X},{crop.Y} {crop.Width}x{crop.Height} is outside the capture item " +
+                        $"{itemBounds.Width}x{itemBounds.Height}.");
+                }
+
+                return new CaptureRect(crop.X, crop.Y, width, height);
+            }
+
+            return crop;
         }
 
         public static WgcFrameSource StartRegion(CaptureRect region, bool captureCursor)

--- a/recording/native/windows/Program.cs
+++ b/recording/native/windows/Program.cs
@@ -66,7 +66,8 @@ internal static class Program
 
         return options.Mode switch
         {
-            CaptureMode.Screenshot => await CaptureScreenshotAsync(hwnd, options.Output, options.CaptureCursor),
+            CaptureMode.Screenshot =>
+                await CaptureScreenshotAsync(hwnd, options.Output, options.CaptureCursor, options.Crop),
             CaptureMode.Recording => await RecordWindowAsync(options, hwnd),
             _ => ExitArgumentsRejected,
         };
@@ -83,85 +84,36 @@ internal static class Program
         return 0;
     }
 
-    private static async Task<int> CaptureScreenshotAsync(IntPtr hwnd, string output, bool captureCursor)
+    private static async Task<int> CaptureScreenshotAsync(
+        IntPtr hwnd,
+        string output,
+        bool captureCursor,
+        CaptureRect? crop)
     {
-        var item = GraphicsCaptureItemInterop.CreateForWindow(hwnd);
-        if (item.Size.Width <= 0 || item.Size.Height <= 0)
+        // Reuse the recording frame path so --crop-* applies identically (issue #186).
+        using var frameSource = WgcFrameSource.StartWindow(hwnd, captureCursor, crop);
+        if (frameSource.Width <= 0 || frameSource.Height <= 0)
         {
             throw new InvalidOperationException(
-                $"Window has invalid dimensions: {item.Size.Width}x{item.Size.Height}.");
+                $"Window has invalid dimensions: {frameSource.Width}x{frameSource.Height}.");
+        }
+
+        using var stop = new CancellationTokenSource(FrameTimeout);
+        var bytes = frameSource.WaitForFrameBytes(stop.Token);
+        if (bytes is null)
+        {
+            throw new TimeoutException("Timed out waiting for a Windows Graphics Capture frame.");
         }
 
         using var canvasDevice = new CanvasDevice();
-        using var framePool =
-            Direct3D11CaptureFramePool.CreateFreeThreaded(
+        using var bitmap =
+            CanvasBitmap.CreateFromBytes(
                 canvasDevice,
-                DirectXPixelFormat.B8G8R8A8UIntNormalized,
-                numberOfBuffers: 1,
-                item.Size);
-        using var session = framePool.CreateCaptureSession(item);
-        session.IsCursorCaptureEnabled = captureCursor;
-        WgcFrameSource.TryDisableCaptureBorder(session);
-        using var frameReady = new ManualResetEventSlim();
-        Direct3D11CaptureFrame? capturedFrame = null;
-        var frameLock = new object();
-
-        void OnFrameArrived(Direct3D11CaptureFramePool sender, object args)
-        {
-            lock (frameLock)
-            {
-                if (capturedFrame is not null)
-                {
-                    return;
-                }
-
-                var frame = sender.TryGetNextFrame();
-                if (frame is null)
-                {
-                    return;
-                }
-
-                capturedFrame = frame;
-                sender.FrameArrived -= OnFrameArrived;
-                frameReady.Set();
-            }
-        }
-
-        framePool.FrameArrived += OnFrameArrived;
-        try
-        {
-            session.StartCapture();
-            if (!frameReady.Wait(FrameTimeout))
-            {
-                throw new TimeoutException("Timed out waiting for a Windows Graphics Capture frame.");
-            }
-
-            Direct3D11CaptureFrame? frameToSave;
-            lock (frameLock)
-            {
-                frameToSave = capturedFrame;
-                capturedFrame = null;
-            }
-
-            using (frameToSave)
-            {
-                if (frameToSave is null)
-                {
-                    throw new InvalidOperationException(
-                        "Windows Graphics Capture did not return a frame.");
-                }
-
-                using var bitmap =
-                    CanvasBitmap.CreateFromDirect3D11Surface(canvasDevice, frameToSave.Surface);
-                await bitmap.SaveAsync(Path.GetFullPath(output), CanvasBitmapFileFormat.Png);
-            }
-        }
-        finally
-        {
-            framePool.FrameArrived -= OnFrameArrived;
-            capturedFrame?.Dispose();
-        }
-
+                bytes,
+                frameSource.Width,
+                frameSource.Height,
+                DirectXPixelFormat.B8G8R8A8UIntNormalized);
+        await bitmap.SaveAsync(Path.GetFullPath(output), CanvasBitmapFileFormat.Png);
         return 0;
     }
 

--- a/recording/native/windows/SpectreWindowCapture.Tests/OptionsParsingTests.cs
+++ b/recording/native/windows/SpectreWindowCapture.Tests/OptionsParsingTests.cs
@@ -61,6 +61,60 @@ public sealed class OptionsParsingTests
         Assert.True(options.CaptureCursor);
     }
 
+    [Fact]
+    public void ParseAcceptsWindowCropFlags()
+    {
+        var options =
+            Options.Parse([
+                "--mode",
+                "recording",
+                "--source",
+                "window",
+                "--title",
+                "Spectre",
+                "--owner-pid",
+                "99",
+                "--crop-x",
+                "8",
+                "--crop-y",
+                "40",
+                "--crop-width",
+                "640",
+                "--crop-height",
+                "480",
+                "--output",
+                "out.mp4",
+            ]);
+
+        Assert.Equal(new CaptureRect(8, 40, 640, 480), options.Crop);
+        Assert.Null(options.Region);
+    }
+
+    [Fact]
+    public void ParseRejectsCropOnRegionSource()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            Options.Parse([
+                "--mode",
+                "recording",
+                "--source",
+                "region",
+                "--x",
+                "0",
+                "--y",
+                "0",
+                "--width",
+                "100",
+                "--height",
+                "100",
+                "--crop-x",
+                "0",
+                "--output",
+                "out.mp4",
+            ]));
+        Assert.Contains("--crop-", ex.Message);
+    }
+
     public static IEnumerable<object[]> InvalidArgumentCases()
     {
         yield return new object[] { "--output is required", Array.Empty<string>() };

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -77,7 +77,53 @@ internal constructor(
         output: Path,
         options: RecordingOptions = RecordingOptions(),
         windowOwnerPid: Long = ProcessHandle.current().pid(),
+    ): RecordingHandle =
+        startWindow(
+            window = window,
+            output = output,
+            options = options,
+            windowOwnerPid = windowOwnerPid,
+            cropInWindow = null,
+            scaleX = 1.0,
+            scaleY = 1.0,
+        )
+
+    /**
+     * Window-targeted capture, optionally cropped to an embedded surface.
+     *
+     * When [cropInWindow] is non-null, captures the host top-level [window] and crops to that
+     * rectangle (AWT user space relative to the window top-left — same as window-identity
+     * `surfaceBoundsInWindow`). This is the preferred path for handle-less Compose surfaces (spike
+     * constraint #5 / #186). Prefer this over [startRegion], which is occlusion-sensitive and does
+     * not follow the window.
+     *
+     * [scaleX]/[scaleY] come from `GraphicsConfiguration.defaultTransform` (window-identity
+     * snapshot). They convert AWT user-space crop to device pixels on Windows; macOS uses points
+     * and applies the window's backing scale inside the helper.
+     *
+     * **v1:** crop is fixed at start. Linux Wayland/X11 do not yet implement window+crop; callers
+     * get an actionable error rather than a silent region fallback.
+     */
+    public fun startWindow(
+        window: TitledWindow,
+        output: Path,
+        options: RecordingOptions = RecordingOptions(),
+        windowOwnerPid: Long = ProcessHandle.current().pid(),
+        cropInWindow: Rectangle?,
+        scaleX: Double = 1.0,
+        scaleY: Double = 1.0,
     ): RecordingHandle {
+        if (cropInWindow != null) {
+            return startWindowCropped(
+                window,
+                cropInWindow,
+                output,
+                options,
+                windowOwnerPid,
+                scaleX,
+                scaleY,
+            )
+        }
         if (isWayland()) {
             val recorder =
                 waylandPortalWindowRecorder
@@ -118,6 +164,65 @@ internal constructor(
                 ?: throw unavailable("Linux X11 window capture", null)
         }
         throw unsupportedWindowCapture()
+    }
+
+    private fun startWindowCropped(
+        window: TitledWindow,
+        cropInWindow: Rectangle,
+        output: Path,
+        options: RecordingOptions,
+        windowOwnerPid: Long,
+        scaleX: Double,
+        scaleY: Double,
+    ): RecordingHandle {
+        require(cropInWindow.width > 0 && cropInWindow.height > 0) {
+            "cropInWindow must be non-empty; got $cropInWindow"
+        }
+        require(cropInWindow.x >= 0 && cropInWindow.y >= 0) {
+            "cropInWindow origin must be non-negative; got $cropInWindow"
+        }
+        if (isMacOs()) {
+            return try {
+                sckRecorder.startCropped(
+                    window = window,
+                    cropInWindow = cropInWindow,
+                    windowOwnerPid = windowOwnerPid,
+                    output = output,
+                    options = options,
+                    scaleX = scaleX,
+                    scaleY = scaleY,
+                )
+            } catch (e: HelperNotBundledException) {
+                throw unavailable("macOS window+crop capture", e)
+            }
+        }
+        if (isWindows()) {
+            val title = window.title
+            require(!title.isNullOrBlank()) {
+                "AutoRecorder.startWindow (cropped) requires a non-blank window title on Windows."
+            }
+            val recorder =
+                windowsWindowRecorder ?: throw unavailable("Windows window+crop capture", null)
+            return recorder.startCropped(
+                window = window,
+                cropInWindow = cropInWindow,
+                windowOwnerPid = windowOwnerPid,
+                output = output,
+                options = options,
+                scaleX = scaleX,
+                scaleY = scaleY,
+            )
+        }
+        // Linux parity evaluation (#186): X11 ximagesrc can grab a named window but has no
+        // capture-side surface crop that keeps occlusion immunity; Wayland portal window streams
+        // could videocrop stream-relative rects but that path is not wired yet. Fail loud rather
+        // than silently degrading to region capture (region is the explicit last resort).
+        error(
+            "Window capture + crop is not available on this Linux session. " +
+                "macOS (ScreenCaptureKit sourceRect) and Windows (WGC pre-encode crop) support " +
+                "it; Linux X11/Wayland parity is not implemented in v1. Use startRegion(...) " +
+                "only as an explicit last resort (occlusion-sensitive, fixed screen rect)."
+        )
     }
 
     public fun startRegion(

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperArguments.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperArguments.kt
@@ -7,10 +7,10 @@ import java.nio.file.Path
  * Strongly-typed inputs to the `spectre-screencapture` Swift helper.
  *
  * The helper's CLI contract lives at the top of
- * `recording/native/macos/Sources/SpectreScreenCapture/main.swift`. This data class is the single
- * place that translates JVM-side recording intent into the exact argv shape the helper accepts.
- * Keep it in lockstep with the Swift `Arguments.parse` body — adding a flag here without updating
- * the helper (or vice versa) will surface as `exit=2` on first use.
+ * `recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift`. This data
+ * class is the single place that translates JVM-side recording intent into the exact argv shape the
+ * helper accepts. Keep it in lockstep with the Swift `Arguments.parse` body — adding a flag here
+ * without updating the helper (or vice versa) will surface as `exit=2` on first use.
  *
  * Construction-time preconditions mirror the helper's own validation so callers see typed Kotlin
  * failures instead of opaque `exit=2` from the subprocess.
@@ -21,6 +21,11 @@ internal data class HelperArguments(
     val pid: Long? = null,
     val titleContains: String? = null,
     val region: Rectangle? = null,
+    /**
+     * Optional window-relative crop in AWT / SCK point space (top-left origin). Only valid for
+     * [HelperSource.Window]. Fixed for the recording lifetime (#186).
+     */
+    val crop: Rectangle? = null,
     val displayIndex: Int = 0,
     val output: Path,
     val fps: Int,
@@ -40,6 +45,7 @@ internal data class HelperArguments(
                 require(discriminator.isNotBlank()) {
                     "titleContains must be a non-blank substring; the helper rejects empty discriminators"
                 }
+                crop?.let { validateCrop(it) }
             }
             HelperSource.Region -> {
                 val captureRegion =
@@ -52,6 +58,9 @@ internal data class HelperArguments(
                 }
                 require(displayIndex >= 0) {
                     "displayIndex must be non-negative (got $displayIndex)"
+                }
+                require(crop == null) {
+                    "crop is only valid for window source; region uses --region"
                 }
             }
         }
@@ -78,6 +87,10 @@ internal data class HelperArguments(
                 add(pid.toString())
                 add("--title-contains")
                 add(titleContains.orEmpty())
+                crop?.let { c ->
+                    add("--crop")
+                    add(listOf(c.x, c.y, c.width, c.height).joinToString(","))
+                }
             }
             HelperSource.Region -> {
                 val captureRegion = requireNotNull(region)
@@ -123,6 +136,13 @@ internal data class HelperArguments(
                 "mp4" -> RecordingFileType.Mp4
                 else -> RecordingFileType.Mov
             }
+
+        fun validateCrop(crop: Rectangle) {
+            require(crop.x >= 0 && crop.y >= 0) { "crop origin must be non-negative; got $crop" }
+            require(crop.width > 0 && crop.height > 0) {
+                "crop dimensions must be positive; got $crop"
+            }
+        }
     }
 }
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -50,6 +50,32 @@ internal constructor(
         windowOwnerPid: Long,
         output: Path,
         options: RecordingOptions,
+    ): RecordingHandle = startWindow(window, windowOwnerPid, output, options, crop = null)
+
+    override fun startCropped(
+        window: TitledWindow,
+        cropInWindow: Rectangle,
+        windowOwnerPid: Long,
+        output: Path,
+        options: RecordingOptions,
+        scaleX: Double,
+        scaleY: Double,
+    ): RecordingHandle {
+        // SCK window sourceRect uses the same point space as SCWindow.frame / AWT user space.
+        // scaleX/scaleY are accepted for API parity with Windows but not applied on macOS —
+        // the helper multiplies crop size by the window's backing scale for pixel output.
+        require(scaleX > 0.0 && scaleY > 0.0) {
+            "scaleX/scaleY must be positive; got scaleX=$scaleX scaleY=$scaleY"
+        }
+        return startWindow(window, windowOwnerPid, output, options, crop = cropInWindow)
+    }
+
+    private fun startWindow(
+        window: TitledWindow,
+        windowOwnerPid: Long,
+        output: Path,
+        options: RecordingOptions,
+        crop: Rectangle?,
     ): RecordingHandle {
         validateOptions(options)
         // Resolve everything that can fail without touching window state first. Anything we do
@@ -58,6 +84,14 @@ internal constructor(
         // discriminator and would otherwise stay dirty across a failed start).
         val helperPath = helperExtractor.extract()
         output.toAbsolutePath().parent?.let(Files::createDirectories)
+
+        if (crop != null) {
+            System.err.println(
+                "spectre: window+crop is fixed at start " +
+                    "(${crop.x},${crop.y} ${crop.width}x${crop.height}); " +
+                    "surface move/resize mid-recording is not followed in v1."
+            )
+        }
 
         val discriminator = TitleDiscriminator(window)
         discriminator.apply()
@@ -71,6 +105,7 @@ internal constructor(
                         source = HelperSource.Window,
                         pid = windowOwnerPid,
                         titleContains = discriminator.value,
+                        crop = crop,
                         output = output,
                         fps = options.frameRate,
                         captureCursor = options.captureCursor,

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/WindowRecorder.kt
@@ -2,18 +2,21 @@ package dev.sebastiano.spectre.recording.screencapturekit
 
 import dev.sebastiano.spectre.recording.RecordingHandle
 import dev.sebastiano.spectre.recording.RecordingOptions
+import java.awt.Rectangle
 import java.lang.ProcessHandle
 import java.nio.file.Path
 
 /**
  * Window-targeted recorder surface — captures the pixels of a single window identified by
  * [TitledWindow] regardless of where on screen it sits or what's overlapping it. Implemented by
- * [ScreenCaptureKitRecorder] on macOS; future Windows / Linux backends would implement the same
- * interface.
+ * [ScreenCaptureKitRecorder] on macOS and [WindowsGraphicsCaptureRecorder] on Windows.
  *
  * Distinct from `Recorder` (which is region-based) because window-targeted capture has
  * fundamentally different ergonomics — coordinates aren't necessary, occlusion isn't a concern,
  * window movement is automatically followed.
+ *
+ * For handle-less embedded surfaces (ComposePanel inside a host top-level window), use
+ * [startCropped] so the host window is captured and cropped to the surface bounds (#186).
  *
  * The high-level [dev.sebastiano.spectre.recording.AutoRecorder] router takes both a
  * [WindowRecorder] and a [dev.sebastiano.spectre.recording.Recorder] and picks the right one per
@@ -26,4 +29,34 @@ public interface WindowRecorder {
         output: Path,
         options: RecordingOptions = RecordingOptions(),
     ): RecordingHandle
+
+    /**
+     * Capture [window] and crop output to [cropInWindow].
+     *
+     * [cropInWindow] is relative to the window's top-left in **AWT user space** (same units as
+     * `Component.bounds` / window-identity `surfaceBoundsInWindow`). Backends convert to the units
+     * their native helpers expect (SCK points on macOS; device pixels on Windows when
+     * [scaleX]/[scaleY] are supplied).
+     *
+     * **v1 semantics:** the crop rectangle is fixed at [startCropped] and is **not** updated if the
+     * surface is moved or resized mid-recording. Callers that can detect a bounds change should
+     * stop and restart, or accept misaligned frames.
+     *
+     * Default implementation throws; platforms that support window+crop override it.
+     */
+    public fun startCropped(
+        window: TitledWindow,
+        cropInWindow: Rectangle,
+        windowOwnerPid: Long = ProcessHandle.current().pid(),
+        output: Path,
+        options: RecordingOptions = RecordingOptions(),
+        scaleX: Double = 1.0,
+        scaleY: Double = 1.0,
+    ): RecordingHandle {
+        throw UnsupportedOperationException(
+            "${this::class.simpleName} does not support window capture + crop. " +
+                "Use startRegion(...) only as an explicit last resort, or a platform backend " +
+                "that implements startCropped (macOS ScreenCaptureKit / Windows Graphics Capture)."
+        )
+    }
 }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureArguments.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureArguments.kt
@@ -19,6 +19,11 @@ internal data class WindowsGraphicsCaptureArguments(
     val title: String? = null,
     val ownerPid: Long? = null,
     val region: Rectangle? = null,
+    /**
+     * Optional window-relative crop in **device pixels** (WGC capture-item space). Only valid for
+     * [WindowsGraphicsCaptureSource.Window]. Fixed for the recording lifetime (#186).
+     */
+    val crop: Rectangle? = null,
     val output: Path,
     val fps: Int,
     val captureCursor: Boolean,
@@ -31,12 +36,19 @@ internal data class WindowsGraphicsCaptureArguments(
                 require(ownerPid != null && ownerPid > 0) {
                     "ownerPid must be positive, was $ownerPid"
                 }
+                crop?.let { c ->
+                    require(c.x >= 0 && c.y >= 0) { "crop origin must be non-negative; got $c" }
+                    require(c.width > 0 && c.height > 0) {
+                        "crop dimensions must be positive; got $c"
+                    }
+                }
             }
             WindowsGraphicsCaptureSource.Region -> {
                 requireNotNull(region) { "region is required for region capture" }
                 require(region.width > 0 && region.height > 0) {
                     "region dimensions must be positive, was ${region.width}x${region.height}"
                 }
+                require(crop == null) { "crop is only valid for window source" }
             }
         }
         require(fps > 0) { "fps must be positive, was $fps" }
@@ -54,6 +66,16 @@ internal data class WindowsGraphicsCaptureArguments(
                 add(requireNotNull(title))
                 add("--owner-pid")
                 add(requireNotNull(ownerPid).toString())
+                crop?.let { c ->
+                    add("--crop-x")
+                    add(c.x.toString())
+                    add("--crop-y")
+                    add(c.y.toString())
+                    add("--crop-width")
+                    add(c.width.toString())
+                    add("--crop-height")
+                    add(c.height.toString())
+                }
             }
             WindowsGraphicsCaptureSource.Region -> {
                 val requiredRegion = requireNotNull(region)

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureRecorder.kt
@@ -13,6 +13,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
 
 /** Windows MP4 recorder backed by Windows Graphics Capture. */
 public class WindowsGraphicsCaptureRecorder
@@ -44,13 +45,14 @@ internal constructor(
         require(scaleX > 0.0 && scaleY > 0.0) {
             "scaleX/scaleY must be positive; got scaleX=$scaleX scaleY=$scaleY"
         }
-        // WGC capture-item space is device pixels; convert from AWT user space.
+        // WGC capture-item space is device pixels; convert from AWT user space with rounding
+        // (matches macOS .rounded() for HiDPI 125%/150% scales).
         val cropDevice =
             Rectangle(
-                (cropInWindow.x * scaleX).toInt(),
-                (cropInWindow.y * scaleY).toInt(),
-                (cropInWindow.width * scaleX).toInt().coerceAtLeast(1),
-                (cropInWindow.height * scaleY).toInt().coerceAtLeast(1),
+                (cropInWindow.x * scaleX).roundToInt().coerceAtLeast(0),
+                (cropInWindow.y * scaleY).roundToInt().coerceAtLeast(0),
+                (cropInWindow.width * scaleX).roundToInt().coerceAtLeast(1),
+                (cropInWindow.height * scaleY).roundToInt().coerceAtLeast(1),
             )
         return startWindow(window, windowOwnerPid, output, options, cropDevicePixels = cropDevice)
     }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureRecorder.kt
@@ -29,6 +29,38 @@ internal constructor(
         windowOwnerPid: Long,
         output: Path,
         options: RecordingOptions,
+    ): RecordingHandle =
+        startWindow(window, windowOwnerPid, output, options, cropDevicePixels = null)
+
+    override fun startCropped(
+        window: TitledWindow,
+        cropInWindow: Rectangle,
+        windowOwnerPid: Long,
+        output: Path,
+        options: RecordingOptions,
+        scaleX: Double,
+        scaleY: Double,
+    ): RecordingHandle {
+        require(scaleX > 0.0 && scaleY > 0.0) {
+            "scaleX/scaleY must be positive; got scaleX=$scaleX scaleY=$scaleY"
+        }
+        // WGC capture-item space is device pixels; convert from AWT user space.
+        val cropDevice =
+            Rectangle(
+                (cropInWindow.x * scaleX).toInt(),
+                (cropInWindow.y * scaleY).toInt(),
+                (cropInWindow.width * scaleX).toInt().coerceAtLeast(1),
+                (cropInWindow.height * scaleY).toInt().coerceAtLeast(1),
+            )
+        return startWindow(window, windowOwnerPid, output, options, cropDevicePixels = cropDevice)
+    }
+
+    private fun startWindow(
+        window: TitledWindow,
+        windowOwnerPid: Long,
+        output: Path,
+        options: RecordingOptions,
+        cropDevicePixels: Rectangle?,
     ): RecordingHandle {
         val title = window.title
         require(!title.isNullOrBlank()) {
@@ -36,6 +68,14 @@ internal constructor(
         }
         validateOptions(options)
         output.toAbsolutePath().parent?.let(Files::createDirectories)
+        if (cropDevicePixels != null) {
+            System.err.println(
+                "spectre: window+crop is fixed at start " +
+                    "(${cropDevicePixels.x},${cropDevicePixels.y} " +
+                    "${cropDevicePixels.width}x${cropDevicePixels.height} device px); " +
+                    "surface move/resize mid-recording is not followed in v1."
+            )
+        }
         val helperPath = helperExtractor.extract()
         val argv =
             WindowsGraphicsCaptureArguments(
@@ -43,6 +83,7 @@ internal constructor(
                     source = WindowsGraphicsCaptureSource.Window,
                     title = title,
                     ownerPid = windowOwnerPid,
+                    crop = cropDevicePixels,
                     output = output,
                     fps = options.frameRate,
                     captureCursor = options.captureCursor,

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/AutoRecorderTest.kt
@@ -252,6 +252,91 @@ class AutoRecorderTest {
     }
 
     @Test
+    fun `startWindow with crop routes to startCropped on macOS and not region`() {
+        val sck = StubWindowRecorder(name = "sck")
+        val ffmpeg = StubRegionRecorder()
+        val recorder = autoRecorder(sckRecorder = sck, isMacOs = { true })
+        val output = tempMov()
+        val crop = Rectangle(10, 40, 200, 150)
+        try {
+            recorder.startWindow(
+                window = StubTitledWindow(title = "Host"),
+                output = output,
+                cropInWindow = crop,
+                scaleX = 2.0,
+                scaleY = 2.0,
+            )
+            assertEquals(0, sck.startCallCount)
+            assertEquals(1, sck.startCroppedCallCount)
+            assertEquals(crop, sck.lastCrop)
+            assertEquals(2.0, sck.lastScaleX)
+            assertEquals(2.0, sck.lastScaleY)
+            assertFalse(ffmpeg.startCalled, "window+crop must not degrade to region")
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startWindow with crop routes to startCropped on Windows`() {
+        val windowRecorder = StubWindowRecorder(name = "wgc")
+        val ffmpeg = StubRegionRecorder()
+        val recorder =
+            autoRecorder(
+                windowsWindowRecorder = windowRecorder,
+                isMacOs = { false },
+                isWindows = { true },
+            )
+        val output = tempMov()
+        val crop = Rectangle(8, 32, 640, 480)
+        try {
+            recorder.startWindow(
+                window = StubTitledWindow(title = "Host"),
+                output = output,
+                cropInWindow = crop,
+                scaleX = 1.25,
+                scaleY = 1.25,
+            )
+            assertEquals(1, windowRecorder.startCroppedCallCount)
+            assertEquals(crop, windowRecorder.lastCrop)
+            assertFalse(ffmpeg.startCalled)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `startWindow with crop fails loudly on Linux instead of region fallback`() {
+        val ffmpeg = StubRegionRecorder()
+        val linuxWindow = StubWindowRecorder(name = "linux")
+        val recorder =
+            autoRecorder(
+                linuxWindowRecorder = linuxWindow,
+                isMacOs = { false },
+                isWindows = { false },
+                isLinux = { true },
+                isWayland = { false },
+            )
+        val output = tempMov()
+        try {
+            val error =
+                assertFailsWith<IllegalStateException> {
+                    recorder.startWindow(
+                        window = StubTitledWindow(title = "Host"),
+                        output = output,
+                        cropInWindow = Rectangle(0, 0, 100, 100),
+                    )
+                }
+            assertTrue(error.message.orEmpty().contains("not available on this Linux"))
+            assertEquals(0, linuxWindow.startCallCount)
+            assertEquals(0, linuxWindow.startCroppedCallCount)
+            assertFalse(ffmpeg.startCalled)
+        } finally {
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
     fun `startWindow propagates missing SCK helper as loud window-capture failure`() {
         val sck = StubWindowRecorder(name = "sck", behavior = StubBehavior.HelperNotBundled)
         val ffmpeg = StubRegionRecorder()
@@ -474,6 +559,18 @@ private class StubWindowRecorder(
     var startCallCount: Int = 0
         private set
 
+    var startCroppedCallCount: Int = 0
+        private set
+
+    var lastCrop: Rectangle? = null
+        private set
+
+    var lastScaleX: Double? = null
+        private set
+
+    var lastScaleY: Double? = null
+        private set
+
     override fun start(
         window: TitledWindow,
         windowOwnerPid: Long,
@@ -488,6 +585,29 @@ private class StubWindowRecorder(
             StubBehavior.RuntimeFailure -> error("test [$name]: runtime failure")
             StubBehavior.ShouldNeverBeCalled ->
                 error("StubWindowRecorder[$name] was not supposed to be invoked in this test")
+        }
+    }
+
+    override fun startCropped(
+        window: TitledWindow,
+        cropInWindow: Rectangle,
+        windowOwnerPid: Long,
+        output: Path,
+        options: RecordingOptions,
+        scaleX: Double,
+        scaleY: Double,
+    ): RecordingHandle {
+        startCroppedCallCount += 1
+        lastCrop = Rectangle(cropInWindow)
+        lastScaleX = scaleX
+        lastScaleY = scaleY
+        return when (behavior) {
+            StubBehavior.Succeeds -> NoopHandle(output)
+            StubBehavior.HelperNotBundled ->
+                throw HelperNotBundledException("test [$name]: helper not bundled")
+            StubBehavior.RuntimeFailure -> error("test [$name]: runtime failure")
+            StubBehavior.ShouldNeverBeCalled ->
+                error("StubWindowRecorder[$name] startCropped was not supposed to be invoked")
         }
     }
 }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperArgumentsTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperArgumentsTest.kt
@@ -87,6 +87,56 @@ class HelperArgumentsTest {
     }
 
     @Test
+    fun `toArgv emits optional window crop flag`() {
+        val helper = Path.of("/tmp/spectre-screencapture")
+        val args =
+            HelperArguments(
+                source = HelperSource.Window,
+                pid = 9,
+                titleContains = "Spectre/crop",
+                crop = Rectangle(12, 34, 200, 100),
+                output = Path.of("/tmp/out.mp4"),
+                fps = 30,
+                captureCursor = false,
+                discoveryTimeoutMs = 1000,
+            )
+        val argv = args.toArgv(helper)
+        assertEquals("12,34,200,100", argv[argv.indexOf("--crop") + 1])
+        assertTrue("--crop" in argv)
+    }
+
+    @Test
+    fun `window crop rejects non-positive dimensions`() {
+        assertFailsWith<IllegalArgumentException> {
+            HelperArguments(
+                source = HelperSource.Window,
+                pid = 1,
+                titleContains = "x",
+                crop = Rectangle(0, 0, 0, 10),
+                output = Path.of("/tmp/o.mp4"),
+                fps = 30,
+                captureCursor = true,
+                discoveryTimeoutMs = 0,
+            )
+        }
+    }
+
+    @Test
+    fun `region source rejects crop`() {
+        assertFailsWith<IllegalArgumentException> {
+            HelperArguments(
+                source = HelperSource.Region,
+                region = Rectangle(0, 0, 10, 10),
+                crop = Rectangle(0, 0, 5, 5),
+                output = Path.of("/tmp/o.mp4"),
+                fps = 30,
+                captureCursor = true,
+                discoveryTimeoutMs = 0,
+            )
+        }
+    }
+
+    @Test
     fun `toArgv encodes captureCursor as the literal true or false expected by the helper`() {
         val helper = Path.of("/tmp/spectre-screencapture")
         val baseline =

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureArgumentsTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/windows/WindowsGraphicsCaptureArgumentsTest.kt
@@ -107,6 +107,28 @@ class WindowsGraphicsCaptureArgumentsTest {
     }
 
     @Test
+    fun `window argv includes crop flags when crop is set`() {
+        val helper = Path.of("helper.exe")
+        val output = Path.of("out.mp4")
+        val argv =
+            WindowsGraphicsCaptureArguments(
+                    mode = WindowsGraphicsCaptureMode.Recording,
+                    source = WindowsGraphicsCaptureSource.Window,
+                    title = "Spectre",
+                    ownerPid = 9,
+                    crop = Rectangle(8, 40, 640, 480),
+                    output = output,
+                    fps = 30,
+                    captureCursor = true,
+                )
+                .toArgv(helper)
+        assertEquals("8", argv[argv.indexOf("--crop-x") + 1])
+        assertEquals("40", argv[argv.indexOf("--crop-y") + 1])
+        assertEquals("640", argv[argv.indexOf("--crop-width") + 1])
+        assertEquals("480", argv[argv.indexOf("--crop-height") + 1])
+    }
+
+    @Test
     fun `arguments reject invalid values`() {
         assertFailsWith<IllegalArgumentException> {
             WindowsGraphicsCaptureArguments(


### PR DESCRIPTION
## Summary

Part of epic #183 / closes #186.

Implements **window capture + crop** so embedded Compose surfaces without their own native handle can be recorded via the host top-level window (occlusion-immune) rather than screen region capture.

### API
- `AutoRecorder.startWindow(..., cropInWindow, scaleX, scaleY)` — preferred path when `cropRequired` / panel bounds are known
- `WindowRecorder.startCropped(...)` — default throws; SCK + WGC implement
- Crop is **AWT user space** relative to window top-left (same as window-identity `surfaceBoundsInWindow`)

### Backends
| Platform | Mechanism |
|---|---|
| macOS | `--crop x,y,w,h` → `SCStreamConfiguration.sourceRect` on window filter; output size = crop × backing scale |
| Windows | `--crop-x/y/width/height` in device pixels (JVM converts via scale); WGC pre-encode crop |
| Linux | Loud error (parity evaluated, not wired in v1) |

### v1 semantics
- Crop fixed at start; surface move/resize mid-recording not followed
- stderr warning when crop is used
- Region capture demoted to **explicit last resort** in docs

### Tests
- Helper argv / Windows argv / AutoRecorder routing (macOS, Windows, Linux fail-loud)
- Swift `ArgumentsTests` + C# `OptionsParsingTests` for crop flags

## Validation
- `CI=true ./gradlew check` green locally

## Not in this PR
- Daemon wiring of identity → crop (#185)
- Linux videocrop parity
- Mid-recording crop-update protocol