### PR TITLE
Daemon-owned window recording sessions with capture dirs (#185)

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -266,7 +266,11 @@ private class CaptureCommand(
 private class RecordCommand(request: (DaemonRequest) -> DaemonResponse, output: Appendable) :
     CliktCommand(name = "record") {
     init {
-        subcommands(RecordStartCommand(request, output), RecordStopCommand(request, output))
+        subcommands(
+            RecordStartCommand(request, output),
+            RecordStopCommand(request, output),
+            RecordStatusCommand(request, output),
+        )
     }
 
     override fun run(): Unit = Unit
@@ -278,23 +282,27 @@ private class RecordStartCommand(
 ) : CliktCommand(name = "start") {
     private val sessionId: String by argument()
     private val outputPath: Path? by option("--output").path()
+    private val windowIndex: Int by option("--window-index").int().default(0)
     private val json: Boolean by option("--json").flag(default = false)
 
     override fun run() {
+        // Null --output: daemon allocates under the capture root (ledger + live prune).
         val destination =
             try {
-                (outputPath
-                        ?: Files.createTempFile("spectre-recording-", ".mp4")
-                            .also(Files::deleteIfExists))
-                    .toAbsolutePath()
-                    .normalize()
+                outputPath?.toAbsolutePath()?.normalize()?.toString()
             } catch (exception: IOException) {
                 throw CliOutputException(exception)
             }
         val recording =
             when (
                 val response =
-                    request(DaemonRequest.StartRecording(sessionId, destination.toString()))
+                    request(
+                        DaemonRequest.StartRecording(
+                            sessionId = sessionId,
+                            outputPath = destination,
+                            windowIndex = windowIndex,
+                        )
+                    )
             ) {
                 is DaemonResponse.RecordingStarted -> response
                 is DaemonResponse.Error -> throw DaemonCommandException(response)
@@ -327,6 +335,53 @@ private class RecordStopCommand(
         )
     }
 }
+
+private class RecordStatusCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "status") {
+    private val sessionId: String by argument()
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val status =
+            when (val response = request(DaemonRequest.RecordingStatus(sessionId))) {
+                is DaemonResponse.RecordingStatus -> response
+                is DaemonResponse.Error -> throw DaemonCommandException(response)
+                else -> error("Daemon returned an unexpected response to record status")
+            }
+        if (json) {
+            output.append(
+                CLI_JSON.encodeToString(
+                    RecordingStatusJson(
+                        sessionId = status.sessionId,
+                        active = status.active,
+                        path = status.outputPath,
+                        captureDirectory = status.captureDirectory,
+                    )
+                )
+            )
+            output.appendLine()
+            return
+        }
+        if (!status.active) {
+            output.append("No active recording for session ${status.sessionId}")
+            output.appendLine()
+            return
+        }
+        output.append("Recording active: ${status.outputPath}")
+        status.captureDirectory?.let { output.append(" (capture dir $it)") }
+        output.appendLine()
+    }
+}
+
+@Serializable
+private data class RecordingStatusJson(
+    val sessionId: String,
+    val active: Boolean,
+    val path: String? = null,
+    val captureDirectory: String? = null,
+)
 
 @OptIn(ExperimentalSpectreAgentApi::class)
 private class ClickCommand(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -43,7 +43,8 @@ public object DaemonProtocol {
             is DaemonRequest.Screenshot -> versionFor(SESSION_COMMANDS_INTRODUCED_MINOR)
             is DaemonRequest.ListJvmProcesses -> versionFor(LIST_JVM_PROCESSES_INTRODUCED_MINOR)
             is DaemonRequest.StartRecording,
-            is DaemonRequest.StopRecording -> versionFor(RECORDING_INTRODUCED_MINOR)
+            is DaemonRequest.StopRecording,
+            is DaemonRequest.RecordingStatus -> versionFor(RECORDING_INTRODUCED_MINOR)
             is DaemonRequest.Capture -> versionFor(CAPTURE_INTRODUCED_MINOR)
         }
 
@@ -123,12 +124,20 @@ public sealed interface DaemonRequest {
 
     @Serializable
     @SerialName("startRecording")
-    public data class StartRecording(public val sessionId: String, public val outputPath: String) :
-        DaemonRequest
+    public data class StartRecording(
+        public val sessionId: String,
+        /** Absolute path to the .mp4, or null to allocate under the capture root. */
+        public val outputPath: String? = null,
+        public val windowIndex: Int = 0,
+    ) : DaemonRequest
 
     @Serializable
     @SerialName("stopRecording")
     public data class StopRecording(public val sessionId: String) : DaemonRequest
+
+    @Serializable
+    @SerialName("recordingStatus")
+    public data class RecordingStatus(public val sessionId: String) : DaemonRequest
 
     @Serializable @SerialName("shutdown") public data object Shutdown : DaemonRequest
 }
@@ -228,6 +237,15 @@ public sealed interface DaemonResponse {
     public data class RecordingStopped(
         public val sessionId: String,
         public val outputPath: String,
+    ) : DaemonResponse
+
+    @Serializable
+    @SerialName("recordingStatus")
+    public data class RecordingStatus(
+        public val sessionId: String,
+        public val active: Boolean,
+        public val outputPath: String? = null,
+        public val captureDirectory: String? = null,
     ) : DaemonResponse
 
     @Serializable @SerialName("shuttingDown") public data object ShuttingDown : DaemonResponse

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.cbor.Cbor
 /** Shared client/daemon wire protocol metadata for Spectre's agent-facing entrypoints. */
 @OptIn(ExperimentalSerializationApi::class)
 public object DaemonProtocol {
-    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 5)
+    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 6)
 
     public val cbor: Cbor = Cbor {
         ignoreUnknownKeys = true
@@ -44,7 +44,7 @@ public object DaemonProtocol {
             is DaemonRequest.ListJvmProcesses -> versionFor(LIST_JVM_PROCESSES_INTRODUCED_MINOR)
             is DaemonRequest.StartRecording,
             is DaemonRequest.StopRecording,
-            is DaemonRequest.RecordingStatus -> versionFor(RECORDING_INTRODUCED_MINOR)
+            is DaemonRequest.RecordingStatus -> versionFor(RECORDING_SESSION_INTRODUCED_MINOR)
             is DaemonRequest.Capture -> versionFor(CAPTURE_INTRODUCED_MINOR)
         }
 
@@ -55,8 +55,9 @@ public object DaemonProtocol {
     private const val SESSION_LIFECYCLE_INTRODUCED_MINOR: Int = 1
     private const val SESSION_COMMANDS_INTRODUCED_MINOR: Int = 2
     private const val LIST_JVM_PROCESSES_INTRODUCED_MINOR: Int = 3
-    private const val RECORDING_INTRODUCED_MINOR: Int = 4
     private const val CAPTURE_INTRODUCED_MINOR: Int = 5
+    /** Optional outputPath, windowIndex, and recordingStatus (#185). */
+    private const val RECORDING_SESSION_INTRODUCED_MINOR: Int = 6
 }
 
 @Serializable public data class DaemonProtocolVersion(public val major: Int, public val minor: Int)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
@@ -34,7 +34,7 @@ internal interface DaemonSessionAutomator : AutoCloseable {
     @Throws(IOException::class)
     fun startRecording(outputPath: String?, windowIndex: Int = 0): String
 
-    @Throws(IOException::class) fun stopRecording(): String
+    @Throws(IOException::class) fun stopRecording(liveSessionIds: Set<String>): String
 
     /** Active recording path, or null when idle. */
     fun recordingStatus(): RecordingStatus
@@ -46,7 +46,6 @@ internal class AttachedDaemonSession(
     sessionId: String,
     clock: Clock = Clock.systemUTC(),
     ledger: CaptureLedger = CaptureLifecycle.ledger(),
-    liveSessionIds: () -> Set<String> = { setOf(sessionId) },
 ) : DaemonSessionAutomator {
     private val recording =
         DaemonSessionRecording(
@@ -54,7 +53,6 @@ internal class AttachedDaemonSession(
             sessionId = sessionId,
             clock = clock,
             ledger = ledger,
-            liveSessionIds = liveSessionIds,
         )
 
     override fun windows(): List<WindowSummaryDto> = delegate.windows()
@@ -74,14 +72,15 @@ internal class AttachedDaemonSession(
     override fun startRecording(outputPath: String?, windowIndex: Int): String =
         recording.start(outputPath, windowIndex)
 
-    override fun stopRecording(): String = recording.stop()
+    override fun stopRecording(liveSessionIds: Set<String>): String = recording.stop(liveSessionIds)
 
     override fun recordingStatus(): RecordingStatus = recording.status()
 
     override fun close() {
         try {
             // Finalize recording on detach even if the target JVM is already dead (#185).
-            recording.finalizeIfActive()
+            // liveSessionIds is empty here because this session is leaving the table.
+            recording.finalizeIfActive(liveSessionIds = emptySet())
         } finally {
             delegate.close()
         }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
@@ -5,13 +5,8 @@ import dev.sebastiano.spectre.agent.AttachedAutomator
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
-import dev.sebastiano.spectre.recording.AutoRecorder
-import dev.sebastiano.spectre.recording.RecordingHandle
-import dev.sebastiano.spectre.recording.screencapturekit.MacOsScreenCaptureAccess
-import dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureAccessDeniedException
-import java.awt.Rectangle
 import java.io.IOException
-import java.nio.file.Path
+import java.time.Clock
 
 /** Operation surface retained by one daemon session. */
 @OptIn(ExperimentalSpectreAgentApi::class)
@@ -30,15 +25,37 @@ internal interface DaemonSessionAutomator : AutoCloseable {
 
     @Throws(IOException::class) fun capture(windowIndex: Int = 0): AtomicCaptureResult
 
-    @Throws(IOException::class) fun startRecording(outputPath: String): String
+    /**
+     * Start daemon-owned window recording for this attach session.
+     *
+     * @param outputPath absolute path to the .mp4, or null to allocate under the capture root
+     *   (`NNNN-timestamp/recording.mp4`) and ledger the directory (#181 / #185).
+     */
+    @Throws(IOException::class)
+    fun startRecording(outputPath: String?, windowIndex: Int = 0): String
 
     @Throws(IOException::class) fun stopRecording(): String
+
+    /** Active recording path, or null when idle. */
+    fun recordingStatus(): RecordingStatus
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)
-internal class AttachedDaemonSession(private val delegate: AttachedAutomator) :
-    DaemonSessionAutomator {
-    private var recording: RecordingHandle? = null
+internal class AttachedDaemonSession(
+    private val delegate: AttachedAutomator,
+    sessionId: String,
+    clock: Clock = Clock.systemUTC(),
+    ledger: CaptureLedger = CaptureLifecycle.ledger(),
+    liveSessionIds: () -> Set<String> = { setOf(sessionId) },
+) : DaemonSessionAutomator {
+    private val recording =
+        DaemonSessionRecording(
+            delegate = delegate,
+            sessionId = sessionId,
+            clock = clock,
+            ledger = ledger,
+            liveSessionIds = liveSessionIds,
+        )
 
     override fun windows(): List<WindowSummaryDto> = delegate.windows()
 
@@ -54,58 +71,18 @@ internal class AttachedDaemonSession(private val delegate: AttachedAutomator) :
 
     override fun capture(windowIndex: Int): AtomicCaptureResult = delegate.capture(windowIndex)
 
-    override fun startRecording(outputPath: String): String {
-        if (recording != null)
-            throw IOException("a recording is already in progress for this session")
-        // Fail fast on macOS before any capture path that could pop a TCC prompt (#187).
-        try {
-            MacOsScreenCaptureAccess.requireGranted()
-        } catch (exception: ScreenCaptureAccessDeniedException) {
-            throw IOException(exception.message ?: "Screen Recording not granted", exception)
-        }
-        val window =
-            windows().firstOrNull { !it.isPopup }
-                ?: throw IOException("the target has no non-popup window to record")
-        val destination = Path.of(outputPath)
-        return try {
-            recording =
-                AutoRecorder()
-                    .startRegion(
-                        Rectangle(
-                            window.bounds.x,
-                            window.bounds.y,
-                            window.bounds.width,
-                            window.bounds.height,
-                        ),
-                        destination,
-                    )
-            outputPath
-        } catch (exception: ScreenCaptureAccessDeniedException) {
-            throw IOException(exception.message ?: "Screen Recording not granted", exception)
-        } catch (exception: IllegalStateException) {
-            throw IOException(exception.message ?: "failed to start recording", exception)
-        } catch (exception: IllegalArgumentException) {
-            throw IOException(exception.message ?: "failed to start recording", exception)
-        }
-    }
+    override fun startRecording(outputPath: String?, windowIndex: Int): String =
+        recording.start(outputPath, windowIndex)
 
-    override fun stopRecording(): String {
-        val active = recording ?: throw IOException("no recording is in progress for this session")
-        return try {
-            active.stop()
-            active.output.toString()
-        } catch (exception: IllegalStateException) {
-            throw IOException(exception.message ?: "failed to stop recording", exception)
-        } finally {
-            recording = null
-        }
-    }
+    override fun stopRecording(): String = recording.stop()
+
+    override fun recordingStatus(): RecordingStatus = recording.status()
 
     override fun close() {
         try {
-            runCatching { recording?.stop() }
+            // Finalize recording on detach even if the target JVM is already dead (#185).
+            recording.finalizeIfActive()
         } finally {
-            recording = null
             delegate.close()
         }
     }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
@@ -38,6 +38,12 @@ internal interface DaemonSessionAutomator : AutoCloseable {
 
     /** Active recording path, or null when idle. */
     fun recordingStatus(): RecordingStatus
+
+    /**
+     * Finalize any active recording before the session is dropped. [remainingLiveSessionIds] must
+     * be every other still-attached session so retention does not delete their capture dirs.
+     */
+    fun finalizeRecording(remainingLiveSessionIds: Set<String>)
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)
@@ -76,10 +82,14 @@ internal class AttachedDaemonSession(
 
     override fun recordingStatus(): RecordingStatus = recording.status()
 
+    override fun finalizeRecording(remainingLiveSessionIds: Set<String>) {
+        recording.finalizeIfActive(remainingLiveSessionIds)
+    }
+
     override fun close() {
         try {
-            // Finalize recording on detach even if the target JVM is already dead (#185).
-            // liveSessionIds is empty here because this session is leaving the table.
+            // Prefer finalizeRecording from the registry with remaining live IDs. Fallback if
+            // close is called without that (e.g. daemon shutdown of last session).
             recording.finalizeIfActive(liveSessionIds = emptySet())
         } finally {
             delegate.close()

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
@@ -42,6 +42,7 @@ internal class DaemonSessionRecording(
         requireScreenCaptureAccess()
         val identity = requireRecordableIdentity(windowIndex)
         val title = requireNonBlankTitle(identity)
+        requireUniqueTitle(title, identity.index)
         val (destination, directory, explicit) = resolveOutput(outputPath)
         destination.parent?.let { Files.createDirectories(it) }
         return try {
@@ -50,7 +51,7 @@ internal class DaemonSessionRecording(
             recordingOutput = destination
             captureDirectory = directory
             ledgerExplicitOutDir = explicit
-            appendLedger(directory, sizeBytes = 0L, explicit = explicit)
+            // Ledger only after stop with final size — avoids double-counting (#185 review).
             destination.toString()
         } catch (exception: ScreenCaptureAccessDeniedException) {
             throw IOException(exception.message ?: "Screen Recording not granted", exception)
@@ -134,6 +135,29 @@ internal class DaemonSessionRecording(
                 "window ${identity.index} has a blank title; cannot target for window " +
                     "capture. Set a unique window title or pass region mode later."
             )
+
+    private fun requireUniqueTitle(title: String, selectedIndex: Int) {
+        val all =
+            try {
+                delegate.windowIdentities(null)
+            } catch (exception: IOException) {
+                throw IOException(
+                    "failed to enumerate windows for title uniqueness: ${exception.message}",
+                    exception,
+                )
+            }
+        val collisions = all.filter { identity ->
+            !identity.isPopup && identity.title.orEmpty().contains(title)
+        }
+        if (collisions.size > 1) {
+            val indexes = collisions.map { it.index }.joinToString(", ")
+            throw IOException(
+                "window title \"$title\" is ambiguous among non-popup windows " +
+                    "[$indexes] (selected index $selectedIndex). Use a unique title so " +
+                    "remote capture can match the intended window."
+            )
+        }
+    }
 
     private fun startWindowRecorder(
         identity: WindowIdentityDto,

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
@@ -54,13 +54,26 @@ internal class DaemonSessionRecording(
             // Ledger only after stop with final size — avoids double-counting (#185 review).
             destination.toString()
         } catch (exception: ScreenCaptureAccessDeniedException) {
+            discardAllocatedDirectory(directory, explicit)
             throw IOException(exception.message ?: "Screen Recording not granted", exception)
         } catch (exception: IllegalStateException) {
+            discardAllocatedDirectory(directory, explicit)
             throw IOException(exception.message ?: "failed to start recording", exception)
         } catch (exception: IllegalArgumentException) {
+            discardAllocatedDirectory(directory, explicit)
             throw IOException(exception.message ?: "failed to start recording", exception)
         } catch (exception: UnsupportedOperationException) {
+            discardAllocatedDirectory(directory, explicit)
             throw IOException(exception.message ?: "failed to start recording", exception)
+        } catch (exception: IOException) {
+            discardAllocatedDirectory(directory, explicit)
+            throw exception
+        }
+    }
+
+    private fun discardAllocatedDirectory(directory: Path, explicit: Boolean) {
+        if (!explicit) {
+            runCatching { directory.toFile().deleteRecursively() }
         }
     }
 
@@ -146,15 +159,14 @@ internal class DaemonSessionRecording(
                     exception,
                 )
             }
-        val collisions = all.filter { identity ->
-            !identity.isPopup && identity.title.orEmpty().contains(title)
-        }
+        // Include popups: helpers match by title among all same-PID windows (#185 review).
+        val collisions = all.filter { identity -> identity.title.orEmpty().contains(title) }
         if (collisions.size > 1) {
             val indexes = collisions.map { it.index }.joinToString(", ")
             throw IOException(
-                "window title \"$title\" is ambiguous among non-popup windows " +
-                    "[$indexes] (selected index $selectedIndex). Use a unique title so " +
-                    "remote capture can match the intended window."
+                "window title \"$title\" is ambiguous among windows " +
+                    "[$indexes] (selected index $selectedIndex; includes popups). " +
+                    "Use a unique title so remote capture can match the intended window."
             )
         }
     }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
@@ -29,7 +29,6 @@ internal class DaemonSessionRecording(
     private val sessionId: String,
     private val clock: Clock = Clock.systemUTC(),
     private val ledger: CaptureLedger = CaptureLifecycle.ledger(),
-    private val liveSessionIds: () -> Set<String> = { setOf(sessionId) },
 ) {
     private var recording: RecordingHandle? = null
     private var recordingOutput: Path? = null
@@ -64,7 +63,7 @@ internal class DaemonSessionRecording(
         }
     }
 
-    fun stop(): String {
+    fun stop(liveSessionIds: Set<String>): String {
         val active = recording ?: throw IOException("no recording is in progress for this session")
         val directory = captureDirectory
         return try {
@@ -80,7 +79,8 @@ internal class DaemonSessionRecording(
                     CaptureRetention.enforce(
                         defaultRoot = CaptureLifecycle.defaultCapturesRoot(),
                         ledger = ledger,
-                        liveSessionIds = liveSessionIds(),
+                        // Protect every still-attached session's capture dirs (#185 review).
+                        liveSessionIds = liveSessionIds + sessionId,
                     )
                 }
             }
@@ -102,8 +102,8 @@ internal class DaemonSessionRecording(
     }
 
     /** Finalize any active recording (detach / close). Safe if idle. */
-    fun finalizeIfActive() {
-        if (recording != null) runCatching { stop() }
+    fun finalizeIfActive(liveSessionIds: Set<String>) {
+        if (recording != null) runCatching { stop(liveSessionIds) }
         clear()
     }
 
@@ -175,27 +175,28 @@ internal class DaemonSessionRecording(
     }
 
     private fun selectIdentity(windowIndex: Int): WindowIdentityDto? {
-        val byIndex =
+        val identities =
             try {
-                if (windowIndex >= 0) {
-                    delegate.windowIdentities(windowIndex).firstOrNull()
-                } else {
-                    null
-                }
-            } catch (_: IOException) {
-                null
-            }
-        if (byIndex != null && !byIndex.isPopup) return byIndex
-        val all =
-            try {
-                delegate.windowIdentities(null)
+                delegate.windowIdentities(windowIndex)
             } catch (exception: IOException) {
                 throw IOException(
                     "failed to read window identity for recording: ${exception.message}",
                     exception,
                 )
             }
-        return all.firstOrNull { !it.isPopup }
+        val match = identities.firstOrNull()
+        if (match == null) {
+            throw IOException(
+                "no window identity at windowIndex=$windowIndex " +
+                    "(out of range or no tracked windows)"
+            )
+        }
+        if (match.isPopup) {
+            throw IOException(
+                "windowIndex=$windowIndex is a popup; pass a non-popup window index for recording"
+            )
+        }
+        return match
     }
 
     private data class ResolvedOutput(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
@@ -70,20 +70,20 @@ internal class DaemonSessionRecording(
         return try {
             active.stop()
             val path = active.output.toString()
-            if (directory != null) {
+            // Only ledger Spectre-allocated capture directories. Never ledger a user --output
+            // parent (e.g. /tmp) — prune would recursively delete unrelated files (#185 review).
+            if (directory != null && !ledgerExplicitOutDir) {
                 appendLedger(
                     directory,
                     sizeBytes = CaptureLifecycle.directorySizeBytes(directory),
-                    explicit = ledgerExplicitOutDir,
+                    explicit = false,
                 )
-                if (!ledgerExplicitOutDir) {
-                    CaptureRetention.enforce(
-                        defaultRoot = CaptureLifecycle.defaultCapturesRoot(),
-                        ledger = ledger,
-                        // Protect every still-attached session's capture dirs (#185 review).
-                        liveSessionIds = liveSessionIds + sessionId,
-                    )
-                }
+                CaptureRetention.enforce(
+                    defaultRoot = CaptureLifecycle.defaultCapturesRoot(),
+                    ledger = ledger,
+                    // Protect every still-attached session's capture dirs.
+                    liveSessionIds = liveSessionIds + sessionId,
+                )
             }
             path
         } catch (exception: IllegalStateException) {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
@@ -82,33 +82,37 @@ internal class DaemonSessionRecording(
         val directory = captureDirectory
         val explicit = ledgerExplicitOutDir
         val knownOutput = recordingOutput?.toString()
-        var result: String? = null
-        var error: IOException? = null
-        try {
-            active.stop()
-            result = active.output.toString()
-        } catch (exception: IllegalStateException) {
-            error = IOException(exception.message ?: "failed to stop recording", exception)
-        }
-        // Always ledger Spectre-allocated dirs (including partial files after a failed stop)
-        // so prune/retention can clean them up. Never ledger user --output parents.
-        if (directory != null && !explicit) {
-            appendLedger(
-                directory,
-                sizeBytes = CaptureLifecycle.directorySizeBytes(directory),
-                explicit = false,
-            )
-            runCatching {
-                CaptureRetention.enforce(
-                    defaultRoot = CaptureLifecycle.defaultCapturesRoot(),
-                    ledger = ledger,
-                    liveSessionIds = liveSessionIds + sessionId,
-                )
+        return try {
+            var result: String? = null
+            var error: IOException? = null
+            try {
+                active.stop()
+                result = active.output.toString()
+            } catch (exception: IllegalStateException) {
+                error = IOException(exception.message ?: "failed to stop recording", exception)
             }
+            // Always ledger Spectre-allocated dirs (including partial files after a failed stop)
+            // so prune/retention can clean them up. Never ledger user --output parents.
+            if (directory != null && !explicit) {
+                runCatching {
+                    appendLedger(
+                        directory,
+                        sizeBytes = CaptureLifecycle.directorySizeBytes(directory),
+                        explicit = false,
+                    )
+                    CaptureRetention.enforce(
+                        defaultRoot = CaptureLifecycle.defaultCapturesRoot(),
+                        ledger = ledger,
+                        liveSessionIds = liveSessionIds + sessionId,
+                    )
+                }
+            }
+            if (error != null) throw error
+            result ?: knownOutput ?: error("recording stopped without an output path")
+        } finally {
+            // Always clear in-memory state so a failed stop cannot leave start() blocked.
+            clear()
         }
-        clear()
-        if (error != null) throw error
-        return result ?: knownOutput ?: error("recording stopped without an output path")
     }
 
     fun status(): RecordingStatus {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
@@ -1,0 +1,220 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.AttachedAutomator
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.WindowIdentityDto
+import dev.sebastiano.spectre.recording.AutoRecorder
+import dev.sebastiano.spectre.recording.RecordingHandle
+import dev.sebastiano.spectre.recording.screencapturekit.MacOsScreenCaptureAccess
+import dev.sebastiano.spectre.recording.screencapturekit.ScreenCaptureAccessDeniedException
+import java.awt.Rectangle
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Clock
+
+internal data class RecordingStatus(
+    val active: Boolean,
+    val outputPath: String? = null,
+    val captureDirectory: String? = null,
+)
+
+/**
+ * Daemon-owned window recording for one attach session (#185): window identity → AutoRecorder
+ * window(+crop), capture-dir allocation, ledger, and finalize-on-close.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal class DaemonSessionRecording(
+    private val delegate: AttachedAutomator,
+    private val sessionId: String,
+    private val clock: Clock = Clock.systemUTC(),
+    private val ledger: CaptureLedger = CaptureLifecycle.ledger(),
+    private val liveSessionIds: () -> Set<String> = { setOf(sessionId) },
+) {
+    private var recording: RecordingHandle? = null
+    private var recordingOutput: Path? = null
+    private var captureDirectory: Path? = null
+    private var ledgerExplicitOutDir: Boolean = false
+
+    fun start(outputPath: String?, windowIndex: Int): String {
+        if (recording != null) {
+            throw IOException("a recording is already in progress for this session")
+        }
+        requireScreenCaptureAccess()
+        val identity = requireRecordableIdentity(windowIndex)
+        val title = requireNonBlankTitle(identity)
+        val (destination, directory, explicit) = resolveOutput(outputPath)
+        destination.parent?.let { Files.createDirectories(it) }
+        return try {
+            val handle = startWindowRecorder(identity, title, destination)
+            recording = handle
+            recordingOutput = destination
+            captureDirectory = directory
+            ledgerExplicitOutDir = explicit
+            appendLedger(directory, sizeBytes = 0L, explicit = explicit)
+            destination.toString()
+        } catch (exception: ScreenCaptureAccessDeniedException) {
+            throw IOException(exception.message ?: "Screen Recording not granted", exception)
+        } catch (exception: IllegalStateException) {
+            throw IOException(exception.message ?: "failed to start recording", exception)
+        } catch (exception: IllegalArgumentException) {
+            throw IOException(exception.message ?: "failed to start recording", exception)
+        } catch (exception: UnsupportedOperationException) {
+            throw IOException(exception.message ?: "failed to start recording", exception)
+        }
+    }
+
+    fun stop(): String {
+        val active = recording ?: throw IOException("no recording is in progress for this session")
+        val directory = captureDirectory
+        return try {
+            active.stop()
+            val path = active.output.toString()
+            if (directory != null) {
+                appendLedger(
+                    directory,
+                    sizeBytes = CaptureLifecycle.directorySizeBytes(directory),
+                    explicit = ledgerExplicitOutDir,
+                )
+                if (!ledgerExplicitOutDir) {
+                    CaptureRetention.enforce(
+                        defaultRoot = CaptureLifecycle.defaultCapturesRoot(),
+                        ledger = ledger,
+                        liveSessionIds = liveSessionIds(),
+                    )
+                }
+            }
+            path
+        } catch (exception: IllegalStateException) {
+            throw IOException(exception.message ?: "failed to stop recording", exception)
+        } finally {
+            clear()
+        }
+    }
+
+    fun status(): RecordingStatus {
+        val output = recordingOutput
+        return RecordingStatus(
+            active = recording != null,
+            outputPath = output?.toString(),
+            captureDirectory = captureDirectory?.toString(),
+        )
+    }
+
+    /** Finalize any active recording (detach / close). Safe if idle. */
+    fun finalizeIfActive() {
+        if (recording != null) runCatching { stop() }
+        clear()
+    }
+
+    private fun clear() {
+        recording = null
+        recordingOutput = null
+        captureDirectory = null
+    }
+
+    private fun requireScreenCaptureAccess() {
+        try {
+            MacOsScreenCaptureAccess.requireGranted()
+        } catch (exception: ScreenCaptureAccessDeniedException) {
+            throw IOException(exception.message ?: "Screen Recording not granted", exception)
+        }
+    }
+
+    private fun requireRecordableIdentity(windowIndex: Int): WindowIdentityDto =
+        selectIdentity(windowIndex)
+            ?: throw IOException(
+                "the target has no non-popup window identity to record " +
+                    "(windowIndex=$windowIndex)"
+            )
+
+    private fun requireNonBlankTitle(identity: WindowIdentityDto): String =
+        identity.title?.takeIf { it.isNotBlank() }
+            ?: throw IOException(
+                "window ${identity.index} has a blank title; cannot target for window " +
+                    "capture. Set a unique window title or pass region mode later."
+            )
+
+    private fun startWindowRecorder(
+        identity: WindowIdentityDto,
+        title: String,
+        destination: Path,
+    ): RecordingHandle {
+        val crop =
+            if (identity.cropRequired) {
+                Rectangle(
+                    identity.surfaceBoundsInWindow.x,
+                    identity.surfaceBoundsInWindow.y,
+                    identity.surfaceBoundsInWindow.width,
+                    identity.surfaceBoundsInWindow.height,
+                )
+            } else {
+                null
+            }
+        return AutoRecorder()
+            .startWindowByTitle(
+                title = title,
+                windowOwnerPid = delegate.pid,
+                output = destination,
+                cropInWindow = crop,
+                scaleX = identity.scaleX,
+                scaleY = identity.scaleY,
+            )
+    }
+
+    private fun appendLedger(directory: Path, sizeBytes: Long, explicit: Boolean) {
+        ledger.append(
+            CaptureLedgerEntry(
+                sessionId = sessionId,
+                path = directory.toAbsolutePath().normalize().toString(),
+                createdAtEpochMs = clock.millis(),
+                sizeBytes = sizeBytes,
+                explicitOutDir = explicit,
+            )
+        )
+    }
+
+    private fun selectIdentity(windowIndex: Int): WindowIdentityDto? {
+        val byIndex =
+            try {
+                if (windowIndex >= 0) {
+                    delegate.windowIdentities(windowIndex).firstOrNull()
+                } else {
+                    null
+                }
+            } catch (_: IOException) {
+                null
+            }
+        if (byIndex != null && !byIndex.isPopup) return byIndex
+        val all =
+            try {
+                delegate.windowIdentities(null)
+            } catch (exception: IOException) {
+                throw IOException(
+                    "failed to read window identity for recording: ${exception.message}",
+                    exception,
+                )
+            }
+        return all.firstOrNull { !it.isPopup }
+    }
+
+    private data class ResolvedOutput(
+        val file: Path,
+        val directory: Path,
+        val explicitOutDir: Boolean,
+    )
+
+    private fun resolveOutput(outputPath: String?): ResolvedOutput {
+        if (outputPath.isNullOrBlank()) {
+            val directory = CaptureLifecycle.allocateDirectory(outDir = null, clock = clock)
+            return ResolvedOutput(
+                file = directory.resolve("recording.mp4"),
+                directory = directory,
+                explicitOutDir = false,
+            )
+        }
+        val file = Path.of(outputPath).toAbsolutePath().normalize()
+        val directory = file.parent ?: Path.of(".")
+        return ResolvedOutput(file = file, directory = directory, explicitOutDir = true)
+    }
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
@@ -80,30 +80,35 @@ internal class DaemonSessionRecording(
     fun stop(liveSessionIds: Set<String>): String {
         val active = recording ?: throw IOException("no recording is in progress for this session")
         val directory = captureDirectory
-        return try {
+        val explicit = ledgerExplicitOutDir
+        val knownOutput = recordingOutput?.toString()
+        var result: String? = null
+        var error: IOException? = null
+        try {
             active.stop()
-            val path = active.output.toString()
-            // Only ledger Spectre-allocated capture directories. Never ledger a user --output
-            // parent (e.g. /tmp) — prune would recursively delete unrelated files (#185 review).
-            if (directory != null && !ledgerExplicitOutDir) {
-                appendLedger(
-                    directory,
-                    sizeBytes = CaptureLifecycle.directorySizeBytes(directory),
-                    explicit = false,
-                )
+            result = active.output.toString()
+        } catch (exception: IllegalStateException) {
+            error = IOException(exception.message ?: "failed to stop recording", exception)
+        }
+        // Always ledger Spectre-allocated dirs (including partial files after a failed stop)
+        // so prune/retention can clean them up. Never ledger user --output parents.
+        if (directory != null && !explicit) {
+            appendLedger(
+                directory,
+                sizeBytes = CaptureLifecycle.directorySizeBytes(directory),
+                explicit = false,
+            )
+            runCatching {
                 CaptureRetention.enforce(
                     defaultRoot = CaptureLifecycle.defaultCapturesRoot(),
                     ledger = ledger,
-                    // Protect every still-attached session's capture dirs.
                     liveSessionIds = liveSessionIds + sessionId,
                 )
             }
-            path
-        } catch (exception: IllegalStateException) {
-            throw IOException(exception.message ?: "failed to stop recording", exception)
-        } finally {
-            clear()
         }
+        clear()
+        if (error != null) throw error
+        return result ?: knownOutput ?: error("recording stopped without an output path")
     }
 
     fun status(): RecordingStatus {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -96,7 +96,10 @@ internal constructor(
                 }
             is DaemonRequest.StopRecording ->
                 invoke(request.sessionId) { automator ->
-                    DaemonResponse.RecordingStopped(request.sessionId, automator.stopRecording())
+                    DaemonResponse.RecordingStopped(
+                        request.sessionId,
+                        automator.stopRecording(liveSessionIds()),
+                    )
                 }
             is DaemonRequest.RecordingStatus ->
                 invoke(request.sessionId) { automator ->

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -13,7 +13,8 @@ internal constructor(
     private val jvmProcessDiscovery: DaemonJvmProcessDiscovery = DaemonJvmProcessDiscovery(),
     private val attachAutomator: (Long) -> DaemonSessionAutomator = { targetPid ->
         installEmbeddedAgentRuntimeIfNeeded()
-        AttachedDaemonSession(AgentAttach.attach(targetPid))
+        val automator = AgentAttach.attach(targetPid)
+        AttachedDaemonSession(delegate = automator, sessionId = "pid-$targetPid")
     },
 ) : AutoCloseable {
     private val sessionsByPid: MutableMap<Long, DaemonSession> = linkedMapOf()
@@ -44,7 +45,8 @@ internal constructor(
             is DaemonRequest.Screenshot,
             is DaemonRequest.Capture,
             is DaemonRequest.StartRecording,
-            is DaemonRequest.StopRecording -> handleSessionCommand(request)
+            is DaemonRequest.StopRecording,
+            is DaemonRequest.RecordingStatus -> handleSessionCommand(request)
             DaemonRequest.Shutdown -> shutdown()
         }
 
@@ -89,12 +91,22 @@ internal constructor(
                 invoke(request.sessionId) { automator ->
                     DaemonResponse.RecordingStarted(
                         request.sessionId,
-                        automator.startRecording(request.outputPath),
+                        automator.startRecording(request.outputPath, request.windowIndex),
                     )
                 }
             is DaemonRequest.StopRecording ->
                 invoke(request.sessionId) { automator ->
                     DaemonResponse.RecordingStopped(request.sessionId, automator.stopRecording())
+                }
+            is DaemonRequest.RecordingStatus ->
+                invoke(request.sessionId) { automator ->
+                    val status = automator.recordingStatus()
+                    DaemonResponse.RecordingStatus(
+                        sessionId = request.sessionId,
+                        active = status.active,
+                        outputPath = status.outputPath,
+                        captureDirectory = status.captureDirectory,
+                    )
                 }
             else ->
                 error(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -162,7 +162,11 @@ internal constructor(
                     code = DaemonErrorCode.SessionNotFound,
                     message = "session not found: $sessionId",
                 )
-        sessionsByPid.remove(removed.key)?.automator?.close()
+        val remainingLive = liveSessionIds() - sessionId
+        val automator = sessionsByPid.remove(removed.key)?.automator
+        // Finalize recording while other sessions are still known live (#185 review).
+        automator?.finalizeRecording(remainingLive)
+        automator?.close()
         return CaptureSessionReport.forDetach(sessionId)
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -251,13 +251,45 @@ public object SpectreMcpServer {
         server.addTool(
             name = "record_start",
             description =
-                "Start recording an attached session to the supplied absolute output path.",
-            inputSchema = schema("session_id" to "string", "output_path" to "string"),
+                "Start daemon-owned window recording for an attached session. " +
+                    "output_path is optional — omit to allocate under the Spectre capture root. " +
+                    "Returns the output path only (no video bytes).",
+            inputSchema =
+                ToolSchema(
+                    properties =
+                        buildJsonObject {
+                            put("session_id", buildJsonObject { put("type", "string") })
+                            put("output_path", buildJsonObject { put("type", "string") })
+                            put("window_index", buildJsonObject { put("type", "integer") })
+                        },
+                    required = listOf("session_id"),
+                ),
         ) { call ->
+            val outputRaw =
+                call.arguments?.get("output_path")?.jsonPrimitive?.content?.takeIf {
+                    it.isNotBlank()
+                }
+            val windowIndexArg = call.arguments?.get("window_index")?.jsonPrimitive?.content
+            val windowIndex =
+                if (windowIndexArg == null) {
+                    0
+                } else {
+                    windowIndexArg.toIntOrNull()
+                        ?: return@addTool CallToolResult(
+                            listOf(
+                                TextContent(
+                                    "MCP tool argument 'window_index' must be an integer, " +
+                                        "got '$windowIndexArg'."
+                                )
+                            ),
+                            isError = true,
+                        )
+                }
             request(
                     DaemonRequest.StartRecording(
-                        call.requiredString("session_id"),
-                        normalizeRecordingOutputPath(call.requiredString("output_path")),
+                        sessionId = call.requiredString("session_id"),
+                        outputPath = outputRaw?.let(::normalizeRecordingOutputPath),
+                        windowIndex = windowIndex,
                     )
                 )
                 .asResult { it is DaemonResponse.RecordingStarted }
@@ -269,6 +301,15 @@ public object SpectreMcpServer {
         ) { call ->
             request(DaemonRequest.StopRecording(call.requiredString("session_id"))).asResult {
                 it is DaemonResponse.RecordingStopped
+            }
+        }
+        server.addTool(
+            name = "record_status",
+            description = "Report whether a session has an active recording and its output path.",
+            inputSchema = sessionSchema(),
+        ) { call ->
+            request(DaemonRequest.RecordingStatus(call.requiredString("session_id"))).asResult {
+                it is DaemonResponse.RecordingStatus
             }
         }
     }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -117,7 +117,11 @@ class SpectreCliTest {
             SpectreCli(
                 request = { request ->
                     assertEquals(
-                        DaemonRequest.StartRecording("pid-42", recordingPath.toString()),
+                        DaemonRequest.StartRecording(
+                            sessionId = "pid-42",
+                            outputPath = recordingPath.toString(),
+                            windowIndex = 0,
+                        ),
                         request,
                     )
                     DaemonResponse.RecordingStarted("pid-42", recordingPath.toString())
@@ -163,7 +167,14 @@ class SpectreCliTest {
         val cli =
             SpectreCli(
                 request = { request ->
-                    assertEquals(DaemonRequest.StartRecording("pid-42", expectedPath), request)
+                    assertEquals(
+                        DaemonRequest.StartRecording(
+                            sessionId = "pid-42",
+                            outputPath = expectedPath,
+                            windowIndex = 0,
+                        ),
+                        request,
+                    )
                     DaemonResponse.RecordingStarted("pid-42", expectedPath)
                 },
                 output = output,
@@ -171,6 +182,46 @@ class SpectreCliTest {
 
         assertEquals(0, cli.run(listOf("record", "start", "pid-42", "--output", "capture.mp4")))
         assertEquals("Recording to $expectedPath.\n", output.toString())
+    }
+
+    @Test
+    fun `record start without output sends null path for daemon allocation`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(
+                        DaemonRequest.StartRecording(
+                            sessionId = "pid-42",
+                            outputPath = null,
+                            windowIndex = 0,
+                        ),
+                        request,
+                    )
+                    DaemonResponse.RecordingStarted(
+                        "pid-42",
+                        "/tmp/spectre/captures/0001/recording.mp4",
+                    )
+                },
+                output = output,
+            )
+        assertEquals(0, cli.run(listOf("record", "start", "pid-42")))
+        assertTrue(output.toString().contains("Recording to"))
+    }
+
+    @Test
+    fun `record status prints idle when not recording`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(DaemonRequest.RecordingStatus("pid-42"), request)
+                    DaemonResponse.RecordingStatus("pid-42", active = false)
+                },
+                output = output,
+            )
+        assertEquals(0, cli.run(listOf("record", "status", "pid-42")))
+        assertTrue(output.toString().contains("No active recording"))
     }
 
     @Test

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
@@ -34,6 +34,7 @@ class DaemonEndpointTest {
     fun `discovers prior minor-version sockets during the stable endpoint migration`() {
         assertEquals(
             listOf(
+                Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-5.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-4.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-3.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-2.sock"),

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
@@ -20,7 +20,7 @@ class DaemonHandshakeTest {
 
         val hello = assertIs<DaemonRequest.Hello>(decoded)
         assertEquals(1, hello.clientVersion.major)
-        assertEquals(5, hello.clientVersion.minor)
+        assertEquals(6, hello.clientVersion.minor)
     }
 
     @Test
@@ -63,10 +63,14 @@ class DaemonHandshakeTest {
             DaemonProtocol.minimumDaemonVersion(DaemonRequest.ListJvmProcesses(requesterPid = 1234)),
         )
         assertEquals(
-            DaemonProtocolVersion(major = 1, minor = 4),
+            DaemonProtocolVersion(major = 1, minor = 6),
             DaemonProtocol.minimumDaemonVersion(
                 DaemonRequest.StartRecording("session-1234", "/tmp/capture.mp4")
             ),
+        )
+        assertEquals(
+            DaemonProtocolVersion(major = 1, minor = 6),
+            DaemonProtocol.minimumDaemonVersion(DaemonRequest.RecordingStatus("session-1234")),
         )
         assertEquals(
             DaemonProtocolVersion(major = 1, minor = 5),

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
@@ -196,13 +196,18 @@ class DaemonSessionRegistryTest {
     fun `starts and stops a recording through the attached session`() {
         val outputPath = "/tmp/spectre-recording.mp4"
         var startedAt: String? = null
+        var startedWindowIndex: Int? = null
         val registry = DaemonSessionRegistry {
             TestDaemonSessionAutomator(
-                startRecordingAction = { path ->
+                startRecordingAction = { path, windowIndex ->
                     startedAt = path
-                    path
+                    startedWindowIndex = windowIndex
+                    path ?: outputPath
                 },
                 stopRecordingResult = { outputPath },
+                recordingStatusResult = {
+                    RecordingStatus(active = startedAt != null, outputPath = startedAt)
+                },
             )
         }
         val sessionId =
@@ -210,9 +215,14 @@ class DaemonSessionRegistryTest {
 
         assertEquals(
             DaemonResponse.RecordingStarted(sessionId, outputPath),
-            registry.handle(DaemonRequest.StartRecording(sessionId, outputPath)),
+            registry.handle(DaemonRequest.StartRecording(sessionId, outputPath, windowIndex = 0)),
         )
         assertEquals(outputPath, startedAt)
+        assertEquals(0, startedWindowIndex)
+        assertEquals(
+            DaemonResponse.RecordingStatus(sessionId, active = true, outputPath = outputPath),
+            registry.handle(DaemonRequest.RecordingStatus(sessionId)),
+        )
         assertEquals(
             DaemonResponse.RecordingStopped(sessionId, outputPath),
             registry.handle(DaemonRequest.StopRecording(sessionId)),
@@ -223,7 +233,7 @@ class DaemonSessionRegistryTest {
     fun `maps recording lifecycle failures to operation errors`() {
         val registry = DaemonSessionRegistry {
             TestDaemonSessionAutomator(
-                startRecordingAction = { throw IOException("recording already started") }
+                startRecordingAction = { _, _ -> throw IOException("recording already started") }
             )
         }
         val sessionId =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
@@ -27,8 +27,11 @@ internal class TestDaemonSessionAutomator(
             captureDurationMs = 0,
         )
     },
-    private val startRecordingAction: (String) -> String = { it },
+    private val startRecordingAction: (String?, Int) -> String = { path, _ ->
+        path ?: "/tmp/spectre-recording.mp4"
+    },
     private val stopRecordingResult: () -> String = { error("no recording is in progress") },
+    private val recordingStatusResult: () -> RecordingStatus = { RecordingStatus(active = false) },
     private val closeAction: () -> Unit = {},
 ) : DaemonSessionAutomator {
     override fun windows(): List<WindowSummaryDto> = windowsResult()
@@ -45,9 +48,12 @@ internal class TestDaemonSessionAutomator(
 
     override fun capture(windowIndex: Int): AtomicCaptureResult = captureResult(windowIndex)
 
-    override fun startRecording(outputPath: String): String = startRecordingAction(outputPath)
+    override fun startRecording(outputPath: String?, windowIndex: Int): String =
+        startRecordingAction(outputPath, windowIndex)
 
     override fun stopRecording(): String = stopRecordingResult()
+
+    override fun recordingStatus(): RecordingStatus = recordingStatusResult()
 
     override fun close(): Unit = closeAction()
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
@@ -58,5 +58,7 @@ internal class TestDaemonSessionAutomator(
 
     override fun recordingStatus(): RecordingStatus = recordingStatusResult()
 
+    override fun finalizeRecording(remainingLiveSessionIds: Set<String>): Unit = Unit
+
     override fun close(): Unit = closeAction()
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
@@ -30,7 +30,9 @@ internal class TestDaemonSessionAutomator(
     private val startRecordingAction: (String?, Int) -> String = { path, _ ->
         path ?: "/tmp/spectre-recording.mp4"
     },
-    private val stopRecordingResult: () -> String = { error("no recording is in progress") },
+    private val stopRecordingResult: (Set<String>) -> String = {
+        error("no recording is in progress")
+    },
     private val recordingStatusResult: () -> RecordingStatus = { RecordingStatus(active = false) },
     private val closeAction: () -> Unit = {},
 ) : DaemonSessionAutomator {
@@ -51,7 +53,8 @@ internal class TestDaemonSessionAutomator(
     override fun startRecording(outputPath: String?, windowIndex: Int): String =
         startRecordingAction(outputPath, windowIndex)
 
-    override fun stopRecording(): String = stopRecordingResult()
+    override fun stopRecording(liveSessionIds: Set<String>): String =
+        stopRecordingResult(liveSessionIds)
 
     override fun recordingStatus(): RecordingStatus = recordingStatusResult()
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
@@ -38,6 +38,7 @@ class SpectreMcpServerTest {
                 "capture",
                 "record_start",
                 "record_stop",
+                "record_status",
             ),
             server.tools.keys,
         )

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -50,6 +50,7 @@ class SpectreMcpStdioIntegrationTest {
                         "list_processes",
                         "record_start",
                         "record_stop",
+                        "record_status",
                         "screenshot",
                         "tree",
                         "type_text",

--- a/recording/api/recording.api
+++ b/recording/api/recording.api
@@ -13,6 +13,8 @@ public final class dev/sebastiano/spectre/recording/AutoRecorder {
 	public final fun startWindow (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;JLjava/awt/Rectangle;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public static synthetic fun startWindow$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;JILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public static synthetic fun startWindow$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;JLjava/awt/Rectangle;DDILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public final fun startWindowByTitle (Ljava/lang/String;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;Ljava/awt/Rectangle;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun startWindowByTitle$default (Ldev/sebastiano/spectre/recording/AutoRecorder;Ljava/lang/String;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;Ljava/awt/Rectangle;DDILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public final class dev/sebastiano/spectre/recording/AutoScreenshotter {
@@ -242,6 +244,8 @@ public final class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptu
 	public fun start (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public fun start (Ljava/awt/Rectangle;Ljava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 	public fun startCropped (Ldev/sebastiano/spectre/recording/screencapturekit/TitledWindow;Ljava/awt/Rectangle;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;DD)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public final fun startMatchingTitle (Ljava/lang/String;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;Ljava/awt/Rectangle;)Ldev/sebastiano/spectre/recording/RecordingHandle;
+	public static synthetic fun startMatchingTitle$default (Ldev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder;Ljava/lang/String;JLjava/nio/file/Path;Ldev/sebastiano/spectre/recording/RecordingOptions;Ljava/awt/Rectangle;ILjava/lang/Object;)Ldev/sebastiano/spectre/recording/RecordingHandle;
 }
 
 public abstract interface class dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder$ProcessFactory {

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -228,20 +228,13 @@ internal constructor(
             }
         }
         if (isLinux() || isWayland()) {
-            // Linux window match still needs a titled window for ximagesrc/portal; crop
-            // unsupported.
-            if (cropInWindow != null) {
-                error(
-                    "Window capture + crop is not available on this Linux session. " +
-                        "Use startRegion(...) only as an explicit last resort."
-                )
-            }
-            val remoteWindow =
-                object : TitledWindow {
-                    override var title: String? = title
-                    override val bounds: Rectangle = Rectangle(0, 0, 1, 1)
-                }
-            return startWindow(remoteWindow, output, options, windowOwnerPid)
+            // Remote attach path cannot invent portal/X11 crop geometry. Use startWindow with a
+            // real local TitledWindow, or startRegion with real screen bounds.
+            error(
+                "startWindowByTitle is not supported on Linux/Wayland for out-of-process " +
+                    "targets (no remote window bounds/handle path). Use startRegion with " +
+                    "explicit screen bounds, or run recording in-process with startWindow."
+            )
         }
         throw unsupportedWindowCapture()
     }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/AutoRecorder.kt
@@ -166,6 +166,86 @@ internal constructor(
         throw unsupportedWindowCapture()
     }
 
+    /**
+     * Window-targeted capture for an out-of-process window identified by title + owner pid (daemon
+     * attach / #185). Does not stamp a local AWT title discriminator — the [title] must already
+     * uniquely identify the target among windows of [windowOwnerPid].
+     *
+     * When [cropInWindow] is set, applies window+crop (#186). Prefer this over [startRegion] for
+     * attached targets.
+     */
+    public fun startWindowByTitle(
+        title: String,
+        windowOwnerPid: Long,
+        output: Path,
+        options: RecordingOptions = RecordingOptions(),
+        cropInWindow: Rectangle? = null,
+        scaleX: Double = 1.0,
+        scaleY: Double = 1.0,
+    ): RecordingHandle {
+        require(title.isNotBlank()) { "startWindowByTitle requires a non-blank title" }
+        if (isMacOs()) {
+            val sck =
+                sckRecorder as? ScreenCaptureKitRecorder
+                    ?: throw unavailable(
+                        "macOS remote window capture",
+                        IllegalStateException(
+                            "SCK recorder is not ScreenCaptureKitRecorder; cannot match by title alone"
+                        ),
+                    )
+            return try {
+                sck.startMatchingTitle(
+                    titleContains = title,
+                    windowOwnerPid = windowOwnerPid,
+                    output = output,
+                    options = options,
+                    crop = cropInWindow,
+                )
+            } catch (e: HelperNotBundledException) {
+                throw unavailable("macOS remote window capture", e)
+            }
+        }
+        if (isWindows()) {
+            val recorder =
+                windowsWindowRecorder ?: throw unavailable("Windows remote window capture", null)
+            val remoteWindow =
+                object : TitledWindow {
+                    override var title: String? = title
+                    override val bounds: Rectangle = cropInWindow ?: Rectangle(0, 0, 1, 1)
+                }
+            return if (cropInWindow != null) {
+                recorder.startCropped(
+                    window = remoteWindow,
+                    cropInWindow = cropInWindow,
+                    windowOwnerPid = windowOwnerPid,
+                    output = output,
+                    options = options,
+                    scaleX = scaleX,
+                    scaleY = scaleY,
+                )
+            } else {
+                recorder.start(remoteWindow, windowOwnerPid, output, options)
+            }
+        }
+        if (isLinux() || isWayland()) {
+            // Linux window match still needs a titled window for ximagesrc/portal; crop
+            // unsupported.
+            if (cropInWindow != null) {
+                error(
+                    "Window capture + crop is not available on this Linux session. " +
+                        "Use startRegion(...) only as an explicit last resort."
+                )
+            }
+            val remoteWindow =
+                object : TitledWindow {
+                    override var title: String? = title
+                    override val bounds: Rectangle = Rectangle(0, 0, 1, 1)
+                }
+            return startWindow(remoteWindow, output, options, windowOwnerPid)
+        }
+        throw unsupportedWindowCapture()
+    }
+
     private fun startWindowCropped(
         window: TitledWindow,
         cropInWindow: Rectangle,

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -70,6 +70,46 @@ internal constructor(
         return startWindow(window, windowOwnerPid, output, options, crop = cropInWindow)
     }
 
+    /**
+     * Window-targeted capture by existing title substring + owner pid, without stamping a
+     * [TitleDiscriminator] on a local AWT window. For daemon/attach scenarios where the target
+     * window lives in another JVM (#185).
+     */
+    public fun startMatchingTitle(
+        titleContains: String,
+        windowOwnerPid: Long,
+        output: Path,
+        options: RecordingOptions = RecordingOptions(),
+        crop: Rectangle? = null,
+    ): RecordingHandle {
+        require(titleContains.isNotBlank()) {
+            "titleContains must be non-blank for remote window matching"
+        }
+        validateOptions(options)
+        val helperPath = helperExtractor.extract()
+        output.toAbsolutePath().parent?.let(Files::createDirectories)
+        if (crop != null) {
+            System.err.println(
+                "spectre: window+crop is fixed at start " +
+                    "(${crop.x},${crop.y} ${crop.width}x${crop.height}); " +
+                    "surface move/resize mid-recording is not followed in v1."
+            )
+        }
+        val argv =
+            HelperArguments(
+                    source = HelperSource.Window,
+                    pid = windowOwnerPid,
+                    titleContains = titleContains,
+                    crop = crop,
+                    output = output,
+                    fps = options.frameRate,
+                    captureCursor = options.captureCursor,
+                    discoveryTimeoutMs = DEFAULT_DISCOVERY_TIMEOUT_MS,
+                )
+                .toArgv(helperPath)
+        return startHelper(output, argv) {}
+    }
+
     private fun startWindow(
         window: TitledWindow,
         windowOwnerPid: Long,


### PR DESCRIPTION
## Summary

Part of epic #183 / closes #185.

Daemon owns window-targeted recording for attach/agent sessions:

- Reads window identity and starts AutoRecorder.startWindowByTitle with optional crop when cropRequired
- Default output: capture-root NNNN-timestamp/recording.mp4 with ledger and live prune protection
- Explicit --output still supported
- spectre record start|stop|status; MCP record_start|stop|status path only
- Finalize on detach even if the target is dead

## Validation

CI=true ./gradlew check green locally.

## Follow-ups

- Full e2e attach-record-kill-target acceptance under CI
- Linux window+crop still unavailable from #186 evaluation