### PR TITLE
Homebrew formula: find Spectre.app after archive strip

### DIFF
--- a/.github/scripts/generate-cli-package-manifests.py
+++ b/.github/scripts/generate-cli-package-manifests.py
@@ -56,7 +56,9 @@ def main() -> None:
   end
 
   def install
-    app = Dir["spectre-cli-*/Spectre.app"].first
+    # Homebrew strips a single top-level directory when staging, so accept both
+    # nested (archive as shipped) and top-level (post-strip) layouts.
+    app = Dir["spectre-cli-*/Spectre.app"].first || Dir["Spectre.app"].first
     odie "missing Spectre.app in release archive" if app.nil?
     libexec.install app
     bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"

--- a/.github/scripts/test-generate-cli-package-manifests.sh
+++ b/.github/scripts/test-generate-cli-package-manifests.sh
@@ -18,4 +18,6 @@ python3 -m json.tool "$tmp/out/bucket/spectre.json" >/dev/null
 grep -q 'version "1.2.3"' "$tmp/out/Formula/spectre.rb"
 grep -q 'sha256 "ddf7ff5ebd9d66ce161466c1c0262430fa04de32b0e420ee3f489e2e2112e386"' "$tmp/out/Formula/spectre.rb"
 grep -q 'shell_output("#{bin}/spectre --help")' "$tmp/out/Formula/spectre.rb"
+# Dual-layout app discovery: Homebrew may leave spectre-cli-*/ or strip it to top-level Spectre.app
+grep -q 'Dir\["spectre-cli-\*/Spectre.app"\]\.first || Dir\["Spectre.app"\]\.first' "$tmp/out/Formula/spectre.rb"
 grep -q '"bin": "spectre-cli-1.2.3/spectre.exe"' "$tmp/out/bucket/spectre.json"

--- a/Formula/spectre.rb
+++ b/Formula/spectre.rb
@@ -14,7 +14,9 @@ class Spectre < Formula
   end
 
   def install
-    app = Dir["spectre-cli-*/Spectre.app"].first
+    # Homebrew strips a single top-level directory when staging, so accept both
+    # nested (archive as shipped) and top-level (post-strip) layouts.
+    app = Dir["spectre-cli-*/Spectre.app"].first || Dir["Spectre.app"].first
     odie "missing Spectre.app in release archive" if app.nil?
     libexec.install app
     bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"


### PR DESCRIPTION
## Summary
- Accept both `spectre-cli-*/Spectre.app` and top-level `Spectre.app` in the Homebrew formula install step.
- Homebrew strips a single top-level directory when staging, so the nested-only glob fails with `missing Spectre.app in release archive`.
- Generator template and committed formula stay in sync; generator test asserts the dual-layout expression so regenerator cannot drop it.

Closes #283

## Test plan
- [x] `bash .github/scripts/test-generate-cli-package-manifests.sh` (dual-layout grep)
- [x] Ruby layout simulation: nested, flat (strip), empty → odie
- [x] `./gradlew check`
- [ ] CI green