### PR TITLE
Homebrew formula: wrapper CLI entry instead of Roast symlink

### DIFF
--- a/.github/scripts/generate-cli-package-manifests.py
+++ b/.github/scripts/generate-cli-package-manifests.py
@@ -61,7 +61,13 @@ def main() -> None:
     app = Dir["spectre-cli-*/Spectre.app"].first || Dir["Spectre.app"].first
     odie "missing Spectre.app in release archive" if app.nil?
     libexec.install app
-    bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"
+    # Roast derives config paths from argv[0]; a bin symlink makes those paths
+    # nonsense. Install a wrapper that execs the real bundle binary instead.
+    (bin/"spectre").write <<~SH
+      #!/bin/sh
+      exec "#{{libexec}}/Spectre.app/Contents/MacOS/spectre" "$@"
+    SH
+    (bin/"spectre").chmod 0755
   end
 
   test do

--- a/.github/scripts/test-generate-cli-package-manifests.sh
+++ b/.github/scripts/test-generate-cli-package-manifests.sh
@@ -20,4 +20,13 @@ grep -q 'sha256 "ddf7ff5ebd9d66ce161466c1c0262430fa04de32b0e420ee3f489e2e2112e38
 grep -q 'shell_output("#{bin}/spectre --help")' "$tmp/out/Formula/spectre.rb"
 # Dual-layout app discovery: Homebrew may leave spectre-cli-*/ or strip it to top-level Spectre.app
 grep -q 'Dir\["spectre-cli-\*/Spectre.app"\]\.first || Dir\["Spectre.app"\]\.first' "$tmp/out/Formula/spectre.rb"
+# Wrapper entry point: do not expose a raw symlink of the Roast binary as the only bin entry
+# (symlink argv[0] breaks Roast config lookup under bin/). Prefer a shell wrapper that execs the real path.
+if grep -q 'bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"' "$tmp/out/Formula/spectre.rb"; then
+  echo "formula must not use raw bin.install_symlink of the Roast binary as the CLI entry point" >&2
+  exit 1
+fi
+grep -q '(bin/"spectre").write' "$tmp/out/Formula/spectre.rb"
+grep -q 'exec "#{libexec}/Spectre.app/Contents/MacOS/spectre" "$@"' "$tmp/out/Formula/spectre.rb"
+grep -q '(bin/"spectre").chmod 0755' "$tmp/out/Formula/spectre.rb"
 grep -q '"bin": "spectre-cli-1.2.3/spectre.exe"' "$tmp/out/bucket/spectre.json"

--- a/Formula/spectre.rb
+++ b/Formula/spectre.rb
@@ -19,7 +19,13 @@ class Spectre < Formula
     app = Dir["spectre-cli-*/Spectre.app"].first || Dir["Spectre.app"].first
     odie "missing Spectre.app in release archive" if app.nil?
     libexec.install app
-    bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"
+    # Roast derives config paths from argv[0]; a bin symlink makes those paths
+    # nonsense. Install a wrapper that execs the real bundle binary instead.
+    (bin/"spectre").write <<~SH
+      #!/bin/sh
+      exec "#{libexec}/Spectre.app/Contents/MacOS/spectre" "$@"
+    SH
+    (bin/"spectre").chmod 0755
   end
 
   test do


### PR DESCRIPTION
## Summary
- Replace `bin.install_symlink` of the Roast MacOS binary with a `bin/spectre` shell wrapper that `exec`s the real bundle path.
- Roast derives config from `argv[0]`; through a symlink under Homebrew `bin` it panics looking for config under `bin/app/…`.
- Generator template and committed formula stay in sync; generator test forbids the raw symlink entry point and requires the wrapper.
- Dual-layout `Spectre.app` discovery from #283 is preserved.

Closes #284

## Test plan
- [x] `bash .github/scripts/test-generate-cli-package-manifests.sh`
- [x] Staged install simulation: wrapper execs real path
- [x] Real v0.3.0 `spectre-macosArm64.zip`: symlink panics; wrapper `--help` twice exits 0 with `Usage:`
- [x] `./gradlew check`
- [ ] CI green