### PR TITLE
Gate Homebrew formula install contracts on check

### DIFF
--- a/.github/scripts/test-generate-cli-package-manifests.sh
+++ b/.github/scripts/test-generate-cli-package-manifests.sh
@@ -1,32 +1,92 @@
 #!/usr/bin/env bash
+# Contract + behavioral tests for Homebrew/Scoop package manifest generation.
+# Wired into ./gradlew check (verifyCliPackageManifests) and CI.
 set -euo pipefail
 
 root="$(cd "$(dirname "$0")/../.." && pwd)"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
+
 printf arm > "$tmp/spectre-macosArm64.zip"
 printf intel > "$tmp/spectre-macosX64.zip"
 printf windows > "$tmp/spectre-windowsX64.zip"
+
 python3 "$root/.github/scripts/generate-cli-package-manifests.py" \
   --version 1.2.3 \
   --macos-arm64 "$tmp/spectre-macosArm64.zip" \
   --macos-x64 "$tmp/spectre-macosX64.zip" \
   --windows-x64 "$tmp/spectre-windowsX64.zip" \
   --output-dir "$tmp/out"
-ruby -c "$tmp/out/Formula/spectre.rb"
+
+generated_formula="$tmp/out/Formula/spectre.rb"
+committed_formula="$root/Formula/spectre.rb"
+
+ruby -c "$generated_formula"
 python3 -m json.tool "$tmp/out/bucket/spectre.json" >/dev/null
-grep -q 'version "1.2.3"' "$tmp/out/Formula/spectre.rb"
-grep -q 'sha256 "ddf7ff5ebd9d66ce161466c1c0262430fa04de32b0e420ee3f489e2e2112e386"' "$tmp/out/Formula/spectre.rb"
-grep -q 'shell_output("#{bin}/spectre --help")' "$tmp/out/Formula/spectre.rb"
+
+grep -q 'version "1.2.3"' "$generated_formula"
+grep -q 'sha256 "ddf7ff5ebd9d66ce161466c1c0262430fa04de32b0e420ee3f489e2e2112e386"' "$generated_formula"
+grep -q 'shell_output("#{bin}/spectre --help")' "$generated_formula"
+grep -q '"bin": "spectre-cli-1.2.3/spectre.exe"' "$tmp/out/bucket/spectre.json"
+
 # Dual-layout app discovery: Homebrew may leave spectre-cli-*/ or strip it to top-level Spectre.app
-grep -q 'Dir\["spectre-cli-\*/Spectre.app"\]\.first || Dir\["Spectre.app"\]\.first' "$tmp/out/Formula/spectre.rb"
-# Wrapper entry point: do not expose a raw symlink of the Roast binary as the only bin entry
-# (symlink argv[0] breaks Roast config lookup under bin/). Prefer a shell wrapper that execs the real path.
-if grep -q 'bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"' "$tmp/out/Formula/spectre.rb"; then
-  echo "formula must not use raw bin.install_symlink of the Roast binary as the CLI entry point" >&2
+grep -q 'Dir\["spectre-cli-\*/Spectre.app"\]\.first || Dir\["Spectre.app"\]\.first' "$generated_formula"
+
+# Wrapper entry point: raw Roast symlink breaks argv[0] config lookup under Homebrew bin/
+if grep -q 'bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"' "$generated_formula"; then
+  echo "generated formula must not use raw bin.install_symlink of the Roast binary as the CLI entry point" >&2
   exit 1
 fi
-grep -q '(bin/"spectre").write' "$tmp/out/Formula/spectre.rb"
-grep -q 'exec "#{libexec}/Spectre.app/Contents/MacOS/spectre" "$@"' "$tmp/out/Formula/spectre.rb"
-grep -q '(bin/"spectre").chmod 0755' "$tmp/out/Formula/spectre.rb"
-grep -q '"bin": "spectre-cli-1.2.3/spectre.exe"' "$tmp/out/bucket/spectre.json"
+grep -q '(bin/"spectre").write' "$generated_formula"
+grep -q 'exec "#{libexec}/Spectre.app/Contents/MacOS/spectre" "$@"' "$generated_formula"
+grep -q '(bin/"spectre").chmod 0755' "$generated_formula"
+
+# Committed formula must carry the same install/entry contracts (release automation only rewrites
+# version/url/sha256; a hand-edit or stale commit must not reintroduce the #283/#284 bugs).
+if [[ ! -f "$committed_formula" ]]; then
+  echo "missing committed formula: $committed_formula" >&2
+  exit 1
+fi
+grep -q 'Dir\["spectre-cli-\*/Spectre.app"\]\.first || Dir\["Spectre.app"\]\.first' "$committed_formula"
+if grep -q 'bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"' "$committed_formula"; then
+  echo "committed Formula/spectre.rb must not use raw bin.install_symlink of the Roast binary" >&2
+  exit 1
+fi
+grep -q '(bin/"spectre").write' "$committed_formula"
+grep -q 'exec "#{libexec}/Spectre.app/Contents/MacOS/spectre" "$@"' "$committed_formula"
+grep -q '(bin/"spectre").chmod 0755' "$committed_formula"
+
+# Install-method bodies (excluding version/url/sha) must stay aligned between generator output
+# and the committed formula so regenerating manifests cannot silently diverge from main.
+extract_install_body() {
+  # From "def install" through the matching "end" of that method (indent-aware enough for this formula).
+  ruby -e '
+    text = File.read(ARGV[0])
+    start = text.index(/^  def install\n/)
+    abort "no def install in #{ARGV[0]}" unless start
+    rest = text[start..]
+    # Method ends at the first line that is exactly "  end" after the def (formula style).
+    body = rest[/\A  def install\n.*?\n  end\n/m]
+    abort "could not extract install method from #{ARGV[0]}" unless body
+    # Drop comment lines so comment-only drift does not fail the gate.
+    puts body.lines.reject { |l| l.match?(/^\s*#/) }.join
+  ' "$1"
+}
+
+generated_install="$(extract_install_body "$generated_formula")"
+committed_install="$(extract_install_body "$committed_formula")"
+if [[ "$generated_install" != "$committed_install" ]]; then
+  echo "install method body differs between generated and committed Formula/spectre.rb" >&2
+  echo "----- generated -----" >&2
+  echo "$generated_install" >&2
+  echo "----- committed -----" >&2
+  echo "$committed_install" >&2
+  exit 1
+fi
+
+# Behavioral semantics (layouts + wrapper vs symlink) against both formula texts.
+ruby "$root/.github/scripts/test-homebrew-formula-install-semantics.rb" \
+  "$generated_formula" \
+  "$committed_formula"
+
+echo "test-generate-cli-package-manifests: OK"

--- a/.github/scripts/test-generate-cli-package-manifests.sh
+++ b/.github/scripts/test-generate-cli-package-manifests.sh
@@ -68,8 +68,9 @@ extract_install_body() {
     # Method ends at the first line that is exactly "  end" after the def (formula style).
     body = rest[/\A  def install\n.*?\n  end\n/m]
     abort "could not extract install method from #{ARGV[0]}" unless body
-    # Drop comment lines so comment-only drift does not fail the gate.
-    puts body.lines.reject { |l| l.match?(/^\s*#/) }.join
+    # Drop Ruby comment lines (indent + "#" + space/end) so comment-only drift
+    # does not fail the gate. Keep shebangs inside the wrapper heredoc (#!/bin/sh).
+    puts body.lines.reject { |l| l.match?(/^\s+#(\s|$)/) }.join
   ' "$1"
 }
 

--- a/.github/scripts/test-homebrew-formula-install-semantics.rb
+++ b/.github/scripts/test-homebrew-formula-install-semantics.rb
@@ -1,0 +1,285 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Behavioral contract tests for the Homebrew formula install path.
+#
+# These would have failed before:
+#   - #283 (only nested spectre-cli-*/Spectre.app; Homebrew strip leaves top-level Spectre.app)
+#   - #284 (bin.install_symlink of the Roast binary; argv[0]-relative config lookup panics)
+#
+# App discovery is evaluated from the formula source (not a reimplemented ideal), so a
+# nested-only glob regresses the stripped-layout case.
+#
+# Run via test-generate-cli-package-manifests.sh or directly:
+#   ruby .github/scripts/test-homebrew-formula-install-semantics.rb [formula.rb ...]
+
+require "fileutils"
+require "tmpdir"
+require "pathname"
+
+module SpectreHomebrewInstallSemantics
+  module_function
+
+  FORBIDDEN_SYMLINK = 'bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"'
+
+  REQUIRED_SNIPPETS = [
+    '(bin/"spectre").write',
+    'exec "#{libexec}/Spectre.app/Contents/MacOS/spectre" "$@"',
+    '(bin/"spectre").chmod 0755',
+    'assert_match "Usage:", shell_output("#{bin}/spectre --help")',
+  ].freeze
+
+  # Extract `app = ...` RHS from the formula install method and evaluate it in the
+  # current directory (Dir[] is relative to cwd). Only allows Dir[...].first chains.
+  def find_app_expression(formula_text)
+    match = formula_text.match(/^\s*app = (.+)$/)
+    raise "formula install method has no `app = ...` assignment" unless match
+
+    expr = match[1].strip
+    unless expr.match?(/\ADir\["[^"]+"\]\.first(?:\s*\|\|\s*Dir\["[^"]+"\]\.first)*\z/)
+      raise "refusing to evaluate unexpected app expression: #{expr.inspect}"
+    end
+
+    expr
+  end
+
+  def find_app(formula_text)
+    # rubocop:disable Security/Eval -- expression is allowlisted above to Dir[].first chains only
+    eval(find_app_expression(formula_text))
+    # rubocop:enable Security/Eval
+  end
+
+  def uses_raw_roast_symlink?(formula_text)
+    formula_text.include?(FORBIDDEN_SYMLINK)
+  end
+
+  def write_wrapper(bin_path, real_binary)
+    File.write(
+      bin_path,
+      <<~SH
+        #!/bin/sh
+        exec "#{real_binary}" "$@"
+      SH
+    )
+    FileUtils.chmod(0o755, bin_path)
+  end
+
+  # Roast-like stub: succeeds only when argv[0] is the real MacOS binary path.
+  def write_argv0_sensitive_binary(path)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(
+      path,
+      <<~SH
+        #!/bin/sh
+        case "$0" in
+          */Contents/MacOS/spectre)
+            echo "Usage: spectre [<options>] <command>"
+            exit 0
+            ;;
+          *)
+            echo "Unable to read config file $(dirname "$0")/app/$0.json" >&2
+            exit 101
+            ;;
+        esac
+      SH
+    )
+    FileUtils.chmod(0o755, path)
+  end
+
+  def stage_app_tree(root, nested:)
+    base =
+      if nested
+        File.join(root, "spectre-cli-0.3.0", "Spectre.app")
+      else
+        File.join(root, "Spectre.app")
+      end
+    mac_bin = File.join(base, "Contents", "MacOS", "spectre")
+    write_argv0_sensitive_binary(mac_bin)
+    base
+  end
+
+  def simulate_wrapper_install(stage_dir, cellar_prefix, formula_text)
+    app = nil
+    Dir.chdir(stage_dir) { app = find_app(formula_text) }
+    raise "missing Spectre.app in release archive" if app.nil?
+
+    libexec = File.join(cellar_prefix, "libexec")
+    bin = File.join(cellar_prefix, "bin")
+    FileUtils.mkdir_p(libexec)
+    FileUtils.mkdir_p(bin)
+    FileUtils.cp_r(File.join(stage_dir, app), libexec)
+    real = File.join(libexec, "Spectre.app", "Contents", "MacOS", "spectre")
+    wrapper = File.join(bin, "spectre")
+    write_wrapper(wrapper, real)
+    { libexec: libexec, bin: bin, wrapper: wrapper, real: real, app: app }
+  end
+end
+
+def assert!(condition, message)
+  raise message unless condition
+end
+
+def run_cmd(cmd)
+  output = `#{cmd} 2>&1`
+  [output, $?.exitstatus]
+end
+
+failures = []
+
+def record_failure(failures, name)
+  yield
+rescue StandardError => e
+  failures << "#{name}: #{e.message}"
+  warn "FAIL #{name}: #{e.message}"
+else
+  puts "ok #{name}"
+end
+
+formula_paths = ARGV.dup
+if formula_paths.empty?
+  root = File.expand_path("../..", __dir__)
+  formula_paths = [File.join(root, "Formula", "spectre.rb")]
+end
+
+formula_paths.each do |path|
+  assert!(File.file?(path), "missing formula file #{path}")
+  formula_text = File.read(path)
+  label = File.basename(path) == "spectre.rb" ? path : path
+
+  record_failure(failures, "formula text contract (#{label})") do
+    SpectreHomebrewInstallSemantics::REQUIRED_SNIPPETS.each do |snippet|
+      assert!(formula_text.include?(snippet), "#{path} missing required snippet:\n  #{snippet}")
+    end
+    assert!(
+      !SpectreHomebrewInstallSemantics.uses_raw_roast_symlink?(formula_text),
+      "#{path} must not use raw bin.install_symlink of the Roast binary"
+    )
+    expr = SpectreHomebrewInstallSemantics.find_app_expression(formula_text)
+    assert!(
+      expr.include?('Dir["Spectre.app"].first'),
+      "#{path} app discovery must accept top-level Spectre.app (Homebrew strip); got #{expr}"
+    )
+    assert!(
+      expr.include?('Dir["spectre-cli-*/Spectre.app"].first'),
+      "#{path} app discovery must accept nested spectre-cli-*/Spectre.app; got #{expr}"
+    )
+  end
+
+  record_failure(failures, "find_app nested layout (#{label})") do
+    Dir.mktmpdir do |tmp|
+      SpectreHomebrewInstallSemantics.stage_app_tree(tmp, nested: true)
+      Dir.chdir(tmp) do
+        app = SpectreHomebrewInstallSemantics.find_app(formula_text)
+        assert!(!app.nil?, "expected nested Spectre.app, got nil")
+        assert!(
+          app == "spectre-cli-0.3.0/Spectre.app",
+          "expected spectre-cli-0.3.0/Spectre.app, got #{app.inspect}"
+        )
+      end
+    end
+  end
+
+  record_failure(failures, "find_app stripped Homebrew layout (#{label})") do
+    Dir.mktmpdir do |tmp|
+      SpectreHomebrewInstallSemantics.stage_app_tree(tmp, nested: false)
+      Dir.chdir(tmp) do
+        app = SpectreHomebrewInstallSemantics.find_app(formula_text)
+        assert!(
+          !app.nil?,
+          "expected top-level Spectre.app after Homebrew strip (this is #283); got nil " \
+            "from expression #{SpectreHomebrewInstallSemantics.find_app_expression(formula_text)}"
+        )
+        assert!(app == "Spectre.app", "expected Spectre.app, got #{app.inspect}")
+      end
+    end
+  end
+
+  record_failure(failures, "find_app missing is nil (#{label})") do
+    Dir.mktmpdir do |tmp|
+      Dir.chdir(tmp) do
+        app = SpectreHomebrewInstallSemantics.find_app(formula_text)
+        assert!(app.nil?, "expected nil when Spectre.app is absent")
+      end
+    end
+  end
+
+  record_failure(failures, "install stripped layout + wrapper --help (#{label})") do
+    Dir.mktmpdir do |tmp|
+      stage = File.join(tmp, "stage")
+      cellar = File.join(tmp, "cellar")
+      FileUtils.mkdir_p(stage)
+      SpectreHomebrewInstallSemantics.stage_app_tree(stage, nested: false)
+      result =
+        SpectreHomebrewInstallSemantics.simulate_wrapper_install(stage, cellar, formula_text)
+
+      assert!(
+        File.directory?(File.join(result[:libexec], "Spectre.app")),
+        "libexec must contain Spectre.app (empty cellar was a real #283 symptom)"
+      )
+      assert!(File.executable?(result[:real]), "real MacOS binary must be executable")
+      assert!(
+        !File.symlink?(result[:wrapper]),
+        "bin/spectre must not be a symlink of the Roast binary"
+      )
+      wrapper_body = File.read(result[:wrapper])
+      assert!(wrapper_body.include?("#!/bin/sh"), "wrapper must be a shell script")
+      assert!(
+        wrapper_body.include?(%(exec "#{result[:real]}")),
+        "wrapper must exec the real bundle binary path"
+      )
+
+      out1, status1 = run_cmd(result[:wrapper].inspect)
+      out2, status2 = run_cmd(result[:wrapper].inspect)
+      assert!(status1.zero?, "wrapper --help run1 exit #{status1}: #{out1}")
+      assert!(status2.zero?, "wrapper --help run2 exit #{status2}: #{out2}")
+      assert!(out1.include?("Usage:"), "run1 stdout must match formula test: #{out1.inspect}")
+      assert!(out2.include?("Usage:"), "run2 stdout must match formula test: #{out2.inspect}")
+    end
+  end
+
+  record_failure(failures, "install nested layout + wrapper --help (#{label})") do
+    Dir.mktmpdir do |tmp|
+      stage = File.join(tmp, "stage")
+      cellar = File.join(tmp, "cellar")
+      FileUtils.mkdir_p(stage)
+      SpectreHomebrewInstallSemantics.stage_app_tree(stage, nested: true)
+      result =
+        SpectreHomebrewInstallSemantics.simulate_wrapper_install(stage, cellar, formula_text)
+      assert!(result[:app] == "spectre-cli-0.3.0/Spectre.app", "unexpected app path #{result[:app]}")
+      out, status = run_cmd(result[:wrapper].inspect)
+      assert!(status.zero? && out.include?("Usage:"), "nested install wrapper failed: #{out}")
+    end
+  end
+end
+
+# Symlink entry point breaks argv[0]-sensitive launcher (documents #284 invariant).
+record_failure(failures, "raw bin symlink fails argv0-sensitive binary") do
+  Dir.mktmpdir do |tmp|
+    stage = File.join(tmp, "stage")
+    FileUtils.mkdir_p(stage)
+    SpectreHomebrewInstallSemantics.stage_app_tree(stage, nested: false)
+    libexec = File.join(tmp, "libexec")
+    bin = File.join(tmp, "bin")
+    FileUtils.mkdir_p(libexec)
+    FileUtils.mkdir_p(bin)
+    FileUtils.cp_r(File.join(stage, "Spectre.app"), libexec)
+    real = File.join(libexec, "Spectre.app", "Contents", "MacOS", "spectre")
+    link = File.join(bin, "spectre")
+    FileUtils.ln_s(real, link)
+    out, status = run_cmd(link.inspect)
+    assert!(!status.zero?, "symlink entry must fail for argv0-sensitive binary, got 0: #{out}")
+    assert!(
+      out.include?("Unable to read config file") || status == 101,
+      "expected Roast-style config panic via symlink, got: #{out.inspect}"
+    )
+  end
+end
+
+if failures.empty?
+  puts "All Homebrew formula install semantics tests passed."
+  exit 0
+end
+
+warn "\n#{failures.size} failure(s):"
+failures.each { |f| warn "  - #{f}" }
+exit 1

--- a/.github/scripts/test-homebrew-formula-install-semantics.rb
+++ b/.github/scripts/test-homebrew-formula-install-semantics.rb
@@ -24,6 +24,7 @@ module SpectreHomebrewInstallSemantics
 
   REQUIRED_SNIPPETS = [
     '(bin/"spectre").write',
+    "#!/bin/sh",
     'exec "#{libexec}/Spectre.app/Contents/MacOS/spectre" "$@"',
     '(bin/"spectre").chmod 0755',
     'assert_match "Usage:", shell_output("#{bin}/spectre --help")',
@@ -65,6 +66,7 @@ module SpectreHomebrewInstallSemantics
   end
 
   # Roast-like stub: succeeds only when argv[0] is the real MacOS binary path.
+  # Echoes args so tests can prove the wrapper forwards "$@" (formula test uses --help).
   def write_argv0_sensitive_binary(path)
     FileUtils.mkdir_p(File.dirname(path))
     File.write(
@@ -74,6 +76,7 @@ module SpectreHomebrewInstallSemantics
         case "$0" in
           */Contents/MacOS/spectre)
             echo "Usage: spectre [<options>] <command>"
+            echo "args:$*"
             exit 0
             ;;
           *)
@@ -228,12 +231,14 @@ formula_paths.each do |path|
         "wrapper must exec the real bundle binary path"
       )
 
-      out1, status1 = run_cmd(result[:wrapper].inspect)
-      out2, status2 = run_cmd(result[:wrapper].inspect)
+      # Match formula test do: shell_output("#{bin}/spectre --help") — twice.
+      out1, status1 = run_cmd("#{result[:wrapper].inspect} --help")
+      out2, status2 = run_cmd("#{result[:wrapper].inspect} --help")
       assert!(status1.zero?, "wrapper --help run1 exit #{status1}: #{out1}")
       assert!(status2.zero?, "wrapper --help run2 exit #{status2}: #{out2}")
       assert!(out1.include?("Usage:"), "run1 stdout must match formula test: #{out1.inspect}")
       assert!(out2.include?("Usage:"), "run2 stdout must match formula test: #{out2.inspect}")
+      assert!(out1.include?("args:--help"), "wrapper must forward --help via \"$@\": #{out1.inspect}")
     end
   end
 
@@ -246,8 +251,9 @@ formula_paths.each do |path|
       result =
         SpectreHomebrewInstallSemantics.simulate_wrapper_install(stage, cellar, formula_text)
       assert!(result[:app] == "spectre-cli-0.3.0/Spectre.app", "unexpected app path #{result[:app]}")
-      out, status = run_cmd(result[:wrapper].inspect)
+      out, status = run_cmd("#{result[:wrapper].inspect} --help")
       assert!(status.zero? && out.include?("Usage:"), "nested install wrapper failed: #{out}")
+      assert!(out.include?("args:--help"), "wrapper must forward --help: #{out.inspect}")
     end
   end
 end

--- a/.github/workflows/package-channels.yml
+++ b/.github/workflows/package-channels.yml
@@ -38,9 +38,14 @@ jobs:
             --macos-x64 "$RUNNER_TEMP/cli-bundles/spectre-macosX64.zip" \
             --windows-x64 "$RUNNER_TEMP/cli-bundles/spectre-windowsX64.zip" \
             --output-dir "$output"
+          # Generator + install-body contracts (fixture archives). Fails the job if main's
+          # formula install method has drifted from the generator template.
+          bash .github/scripts/test-generate-cli-package-manifests.sh
           git fetch origin main
           git rebase origin/main
           cp -R "$output/Formula" "$output/bucket" .
+          # Behavioral gate on the exact formula about to be committed (real version/sha).
+          ruby .github/scripts/test-homebrew-formula-install-semantics.rb Formula/spectre.rb
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add Formula/spectre.rb bucket/spectre.json

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ import dev.detekt.gradle.extensions.DetektExtension
 import java.util.jar.JarFile
 import java.util.zip.ZipFile
 import javax.xml.parsers.DocumentBuilderFactory
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SourceTask
 import org.w3c.dom.Element
 
@@ -44,7 +45,47 @@ configure<DetektExtension> {
     basePath.set(rootProject.layout.projectDirectory)
 }
 
-tasks.named("check") { dependsOn("detekt", "ktfmtCheck") }
+// Homebrew/Scoop package-manifest contracts + install semantics (#283/#284).
+// Cheap (python + ruby), no JDK; keep on the default check graph so formula
+// regressions fail PRs the same way as unit tests.
+val verifyCliPackageManifests by
+    tasks.registering(Exec::class) {
+        description =
+            "Generates CLI package manifests and asserts Homebrew install contracts " +
+                "(dual-layout Spectre.app discovery, wrapper bin entry, install-body sync)."
+        group = "verification"
+        workingDir = rootProject.layout.projectDirectory.asFile
+        commandLine("bash", ".github/scripts/test-generate-cli-package-manifests.sh")
+        inputs
+            .files(
+                ".github/scripts/generate-cli-package-manifests.py",
+                ".github/scripts/test-generate-cli-package-manifests.sh",
+                ".github/scripts/test-homebrew-formula-install-semantics.rb",
+                "Formula/spectre.rb",
+            )
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+        // Always re-run: generator is pure but failures are cheap to catch on every check.
+        outputs.upToDateWhen { false }
+    }
+
+val verifyReleaseVersionScript by
+    tasks.registering(Exec::class) {
+        description = "Runs contract tests for .github/scripts/derive-release-version.sh."
+        group = "verification"
+        workingDir = rootProject.layout.projectDirectory.asFile
+        commandLine("bash", ".github/scripts/test-derive-release-version.sh")
+        inputs
+            .files(
+                ".github/scripts/derive-release-version.sh",
+                ".github/scripts/test-derive-release-version.sh",
+            )
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+        outputs.upToDateWhen { false }
+    }
+
+tasks.named("check") {
+    dependsOn("detekt", "ktfmtCheck", verifyCliPackageManifests, verifyReleaseVersionScript)
+}
 
 tasks.withType<Detekt>().configureEach {
     jvmTarget = "21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,8 +46,11 @@ configure<DetektExtension> {
 }
 
 // Homebrew/Scoop package-manifest contracts + install semantics (#283/#284).
-// Cheap (python + ruby), no JDK; keep on the default check graph so formula
-// regressions fail PRs the same way as unit tests.
+// Cheap (python + ruby + bash). Wired into check on Unix only: Windows CI has no
+// bash/WSL, and Homebrew install semantics are not a Windows concern (Linux CI
+// already runs ./gradlew check with bash).
+val hostIsWindows = System.getProperty("os.name").orEmpty().startsWith("Windows")
+
 val verifyCliPackageManifests by
     tasks.registering(Exec::class) {
         description =
@@ -56,6 +59,7 @@ val verifyCliPackageManifests by
         group = "verification"
         workingDir = rootProject.layout.projectDirectory.asFile
         commandLine("bash", ".github/scripts/test-generate-cli-package-manifests.sh")
+        onlyIf { !hostIsWindows }
         inputs
             .files(
                 ".github/scripts/generate-cli-package-manifests.py",
@@ -74,6 +78,7 @@ val verifyReleaseVersionScript by
         group = "verification"
         workingDir = rootProject.layout.projectDirectory.asFile
         commandLine("bash", ".github/scripts/test-derive-release-version.sh")
+        onlyIf { !hostIsWindows }
         inputs
             .files(
                 ".github/scripts/derive-release-version.sh",

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,8 +49,7 @@ configure<DetektExtension> {
 // Cheap (python + ruby + bash). Wired into check on Unix only: Windows CI has no
 // bash/WSL, and Homebrew install semantics are not a Windows concern (Linux CI
 // already runs ./gradlew check with bash).
-val hostIsWindows = System.getProperty("os.name").orEmpty().startsWith("Windows")
-
+// onlyIf lambdas must not close over the Gradle script object (configuration cache).
 val verifyCliPackageManifests by
     tasks.registering(Exec::class) {
         description =
@@ -59,7 +58,9 @@ val verifyCliPackageManifests by
         group = "verification"
         workingDir = rootProject.layout.projectDirectory.asFile
         commandLine("bash", ".github/scripts/test-generate-cli-package-manifests.sh")
-        onlyIf { !hostIsWindows }
+        onlyIf("Unix host with bash") {
+            !System.getProperty("os.name").orEmpty().startsWith("Windows")
+        }
         inputs
             .files(
                 ".github/scripts/generate-cli-package-manifests.py",
@@ -78,7 +79,9 @@ val verifyReleaseVersionScript by
         group = "verification"
         workingDir = rootProject.layout.projectDirectory.asFile
         commandLine("bash", ".github/scripts/test-derive-release-version.sh")
-        onlyIf { !hostIsWindows }
+        onlyIf("Unix host with bash") {
+            !System.getProperty("os.name").orEmpty().startsWith("Windows")
+        }
         inputs
             .files(
                 ".github/scripts/derive-release-version.sh",

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -62,6 +62,12 @@ tap formula and `bucket/spectre.json` is the Scoop bucket manifest. Publishing t
 release regenerates both from its public CLI archives and their SHA-256 values, then commits them
 to `main`.
 
+Package-manifest generation and Homebrew install contracts are gated by
+`./gradlew verifyCliPackageManifests` (part of `./gradlew check`): the generator is exercised with
+fixture archives, the committed formula's `install` body must stay aligned with the generator, and
+behavioral tests cover dual-layout `Spectre.app` discovery (Homebrew strip) plus the wrapper bin
+entry (Roast is argv[0]-sensitive and cannot be exposed via `bin.install_symlink`).
+
 On macOS, use the repository as an explicit tap because its name is `spectre`, not Homebrew's
 `homebrew-*` shorthand:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -34,6 +34,18 @@ Before marking testing work complete:
 - confirm each one has a corresponding test or a deliberate manual-validation note
 - fill the gaps before moving on
 
+## Package-channel (Homebrew / Scoop) contracts
+
+CLI package manifests are not optional docs — they are install paths. Keep them on the
+`./gradlew check` graph via `verifyCliPackageManifests`:
+
+- generator smoke: `.github/scripts/test-generate-cli-package-manifests.sh`
+- install semantics: `.github/scripts/test-homebrew-formula-install-semantics.rb`
+
+Those tests evaluate the formula's real `app = Dir[...]` expression against nested and
+Homebrew-stripped layouts, require a wrapper (not a Roast `bin.install_symlink`), and
+assert the committed `Formula/spectre.rb` `install` body stays aligned with the generator.
+
 ## Cross-Boundary Contract Tests
 
 When a feature spans a boundary, add at least one test that exercises the real boundary shape.


### PR DESCRIPTION
## Summary

The greps added for #283/#284 only inspected generator output and were never invoked by CI or `./gradlew check`, so the original bugs would still have shipped.

This PR makes those contracts real automated gates:

- `verifyCliPackageManifests` (and `verifyReleaseVersionScript`) on the root `check` graph
- Behavioral Ruby tests that eval the formula real `app = Dir[...]` expression against nested and Homebrew-stripped layouts
- Full install simulation: libexec gets Spectre.app, wrapper execs the real MacOS binary, double --help with an argv0-sensitive stub
- Proves a raw bin.install_symlink entry fails that stub (the #284 failure mode)
- Install-method body must stay aligned between generator output and committed Formula/spectre.rb
- package-channels re-runs the gates before committing release manifests

## Would have failed before the fixes

- Nested-only glob → stripped layout returns nil (missing Spectre.app)
- bin.install_symlink of Roast binary → text contract fails; symlink path panics on argv0-sensitive binary

## Test plan

- [x] bash .github/scripts/test-generate-cli-package-manifests.sh
- [x] Broken nested-only formula fails stripped-layout behavioral tests
- [x] Broken symlink formula fails wrapper contract
- [x] ./gradlew verifyCliPackageManifests verifyReleaseVersionScript
- [x] ./gradlew ktfmtCheck (scripts)
- [ ] CI green
