### PR TITLE
Harden daemon kill-target recording and restore_token unit coverage

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
@@ -26,13 +26,55 @@ internal data class RecordingStatus(
  */
 @OptIn(ExperimentalSpectreAgentApi::class)
 internal class DaemonSessionRecording(
-    private val delegate: AttachedAutomator,
     private val sessionId: String,
+    private val targetPid: Long,
+    private val windowIdentities: (windowIndex: Int?) -> List<WindowIdentityDto>,
     private val clock: Clock = Clock.systemUTC(),
     private val ledger: CaptureLedger = CaptureLifecycle.ledger(),
     private val fullscreenRegionBounds: () -> Rectangle = ::requireFullscreenRegionBounds,
     private val autoRecorderFactory: () -> AutoRecorder = { AutoRecorder() },
+    /**
+     * Out-of-process window recording seam (default: [AutoRecorder.startWindowByTitle]). Tests
+     * inject a fake starter so kill-target / finalize behaviour is CI-safe without SCK/WGC/portal.
+     */
+    private val startWindowByTitle:
+        (
+            title: String,
+            windowOwnerPid: Long,
+            output: Path,
+            cropInWindow: Rectangle?,
+            scaleX: Double,
+            scaleY: Double,
+        ) -> RecordingHandle =
+        { title, windowOwnerPid, output, cropInWindow, scaleX, scaleY ->
+            autoRecorderFactory()
+                .startWindowByTitle(
+                    title = title,
+                    windowOwnerPid = windowOwnerPid,
+                    output = output,
+                    cropInWindow = cropInWindow,
+                    scaleX = scaleX,
+                    scaleY = scaleY,
+                )
+        },
 ) {
+    constructor(
+        delegate: AttachedAutomator,
+        sessionId: String,
+        clock: Clock = Clock.systemUTC(),
+        ledger: CaptureLedger = CaptureLifecycle.ledger(),
+        fullscreenRegionBounds: () -> Rectangle = ::requireFullscreenRegionBounds,
+        autoRecorderFactory: () -> AutoRecorder = { AutoRecorder() },
+    ) : this(
+        sessionId = sessionId,
+        targetPid = delegate.pid,
+        windowIdentities = { index -> delegate.windowIdentities(index) },
+        clock = clock,
+        ledger = ledger,
+        fullscreenRegionBounds = fullscreenRegionBounds,
+        autoRecorderFactory = autoRecorderFactory,
+    )
+
     private var recording: RecordingHandle? = null
     private var recordingOutput: Path? = null
     private var captureDirectory: Path? = null
@@ -182,7 +224,7 @@ internal class DaemonSessionRecording(
     private fun requireUniqueTitle(title: String, selectedIndex: Int) {
         val all =
             try {
-                delegate.windowIdentities(null)
+                windowIdentities(null)
             } catch (exception: IOException) {
                 throw IOException(
                     "failed to enumerate windows for title uniqueness: ${exception.message}",
@@ -217,15 +259,14 @@ internal class DaemonSessionRecording(
             } else {
                 null
             }
-        return autoRecorderFactory()
-            .startWindowByTitle(
-                title = title,
-                windowOwnerPid = delegate.pid,
-                output = destination,
-                cropInWindow = crop,
-                scaleX = identity.scaleX,
-                scaleY = identity.scaleY,
-            )
+        return startWindowByTitle(
+            title,
+            targetPid,
+            destination,
+            crop,
+            identity.scaleX,
+            identity.scaleY,
+        )
     }
 
     private fun appendLedger(directory: Path, sizeBytes: Long, explicit: Boolean) {
@@ -243,7 +284,7 @@ internal class DaemonSessionRecording(
     private fun selectIdentity(windowIndex: Int): WindowIdentityDto? {
         val identities =
             try {
-                delegate.windowIdentities(windowIndex)
+                windowIdentities(windowIndex)
             } catch (exception: IOException) {
                 throw IOException(
                     "failed to read window identity for recording: ${exception.message}",

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecording.kt
@@ -34,6 +34,11 @@ internal class DaemonSessionRecording(
     private val fullscreenRegionBounds: () -> Rectangle = ::requireFullscreenRegionBounds,
     private val autoRecorderFactory: () -> AutoRecorder = { AutoRecorder() },
     /**
+     * Screen Recording TCC preflight (macOS). Tests inject a no-op so kill-target coverage does not
+     * require real TCC on hermetic CI runners.
+     */
+    private val requireScreenCaptureAccess: () -> Unit = ::defaultRequireScreenCaptureAccess,
+    /**
      * Out-of-process window recording seam (default: [AutoRecorder.startWindowByTitle]). Tests
      * inject a fake starter so kill-target / finalize behaviour is CI-safe without SCK/WGC/portal.
      */
@@ -199,14 +204,6 @@ internal class DaemonSessionRecording(
         captureDirectory = null
     }
 
-    private fun requireScreenCaptureAccess() {
-        try {
-            MacOsScreenCaptureAccess.requireGranted()
-        } catch (exception: ScreenCaptureAccessDeniedException) {
-            throw IOException(exception.message ?: "Screen Recording not granted", exception)
-        }
-    }
-
     private fun requireRecordableIdentity(windowIndex: Int): WindowIdentityDto =
         selectIdentity(windowIndex)
             ?: throw IOException(
@@ -324,6 +321,14 @@ internal class DaemonSessionRecording(
         val file = Path.of(outputPath).toAbsolutePath().normalize()
         val directory = file.parent ?: Path.of(".")
         return ResolvedOutput(file = file, directory = directory, explicitOutDir = true)
+    }
+}
+
+private fun defaultRequireScreenCaptureAccess() {
+    try {
+        MacOsScreenCaptureAccess.requireGranted()
+    } catch (exception: ScreenCaptureAccessDeniedException) {
+        throw IOException(exception.message ?: "Screen Recording not granted", exception)
     }
 }
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -35,6 +35,7 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 
@@ -228,6 +229,72 @@ class DaemonFixtureIntegrationTest {
             deleteTemporaryDaemonFixtureSocketPath(socketPath)
         }
     }
+
+    /**
+     * #185 kill-target acceptance (real attach): daemon-owned record start → kill fixture mid-
+     * record → stop still finalises a non-empty MP4. Skips on headless CI and when Screen Recording
+     * is not granted (macOS TCC).
+     */
+    @Test
+    @EnabledOnOs(OS.MAC)
+    fun `CLI record stop finalizes after killing the attached target process`() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
+        assumeTrue(
+            runCatching {
+                    dev.sebastiano.spectre.recording.screencapturekit.MacOsScreenCaptureAccess
+                        .preflight()
+                        .granted
+                }
+                .getOrDefault(false),
+            "Screen Recording TCC not granted for this runner",
+        )
+        val daemonUser = "spectre-record-kill-e2e-${UUID.randomUUID()}"
+        val output = Files.createTempFile("spectre-record-kill-", ".mp4")
+        Files.deleteIfExists(output)
+
+        try {
+            spawnComposeFixture().use { fixture ->
+                val attached = runCliBinary(daemonUser, "attach", fixture.pid.toString(), "--json")
+                assertEquals(0, attached.exitCode, attached.output + attached.errorOutput)
+                val sessionId =
+                    Json.parseToJsonElement(attached.output)
+                        .jsonObject
+                        .getValue("id")
+                        .jsonPrimitive
+                        .content
+
+                val start =
+                    runCliBinary(
+                        daemonUser,
+                        "record",
+                        "start",
+                        sessionId,
+                        "--output",
+                        output.toString(),
+                        "--json",
+                    )
+                assertEquals(0, start.exitCode, start.output + start.errorOutput)
+                assertTrue(Files.exists(output) || start.output.contains("mp4"), start.output)
+
+                // Kill the target mid-record; daemon + SCK helper must keep running.
+                fixture.close()
+                Thread.sleep(RECORD_AFTER_KILL_SETTLE_MILLIS)
+
+                val stop = runCliBinary(daemonUser, "record", "stop", sessionId, "--json")
+                // Stop may report helper exit 5 if the window vanished; the file must still exist.
+                assertTrue(
+                    Files.isRegularFile(output) && Files.size(output) > 0,
+                    "expected finalized MP4 after kill+stop; stop.exit=${stop.exitCode} " +
+                        "out=${stop.output} err=${stop.errorOutput} size=" +
+                        runCatching { Files.size(output) }.getOrDefault(-1),
+                )
+            }
+        } finally {
+            runCatching { runCliBinary(daemonUser, "daemon", "kill") }
+            Files.deleteIfExists(output)
+            deleteDaemonSocketAndParent(DaemonEndpoint.defaultSocketPath(userName = daemonUser))
+        }
+    }
 }
 
 private fun temporaryDaemonFixtureSocketPath(): Path =
@@ -418,6 +485,7 @@ private const val FIXTURE_STOP_TIMEOUT_SECONDS: Long = 2
 private const val DRAINER_JOIN_TIMEOUT_MILLIS: Long = 500
 private const val CLI_PROCESS_TIMEOUT_SECONDS: Long = 30
 private const val MCP_CONNECTION_TIMEOUT_MILLIS: Long = 10_000
+private const val RECORD_AFTER_KILL_SETTLE_MILLIS: Long = 1_500
 private const val MIN_PNG_BYTES: Int = 100
 private val PNG_MAGIC: ByteArray =
     byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecordingKillTargetTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecordingKillTargetTest.kt
@@ -42,6 +42,7 @@ class DaemonSessionRecordingKillTargetTest {
                     }
                     if (index == null) list else list.filter { it.index == index }
                 },
+                requireScreenCaptureAccess = {},
                 startWindowByTitle = { _, _, _, _, _, _ -> handle },
             )
 
@@ -71,6 +72,7 @@ class DaemonSessionRecordingKillTargetTest {
                 sessionId = "session-finalize",
                 targetPid = 99L,
                 windowIdentities = { listOf(identity) },
+                requireScreenCaptureAccess = {},
                 startWindowByTitle = { _, _, _, _, _, _ -> handle },
             )
         recording.start(outputPath = output.toString(), windowIndex = 0)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecordingKillTargetTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRecordingKillTargetTest.kt
@@ -1,0 +1,114 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.RectDto
+import dev.sebastiano.spectre.agent.transport.WindowIdentityDto
+import dev.sebastiano.spectre.recording.RecordingHandle
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * #185 kill-target acceptance without real OS capture: the daemon owns [RecordingHandle]; stop must
+ * still finalise after the attach target is gone (identity reads may fail; the handle must not).
+ */
+class DaemonSessionRecordingKillTargetTest {
+
+    @Test
+    fun `stop finalizes a daemon-owned recording after the target can no longer answer identity`() {
+        val output = Files.createTempFile("spectre-kill-target-", ".mp4")
+        val stopCount = AtomicInteger(0)
+        val handle = fakeHandle(output, stopCount)
+        val identity = uniqueIdentity(title = "Kill Target Fixture")
+        val identities = AtomicReference<List<WindowIdentityDto>>(listOf(identity))
+
+        val recording =
+            DaemonSessionRecording(
+                sessionId = "session-kill-target",
+                targetPid = 42_424L,
+                windowIdentities = { index ->
+                    val list = identities.get()
+                    if (list.isEmpty()) {
+                        throw IOException("target process is gone")
+                    }
+                    if (index == null) list else list.filter { it.index == index }
+                },
+                startWindowByTitle = { _, _, _, _, _, _ -> handle },
+            )
+
+        val started = recording.start(outputPath = output.toString(), windowIndex = 0)
+        assertEquals(output.toAbsolutePath().normalize().toString(), started)
+        assertTrue(recording.status().active)
+
+        // Simulate target death: identity reads now fail, but the daemon still holds the handle.
+        identities.set(emptyList())
+
+        val stoppedPath = recording.stop(liveSessionIds = emptySet())
+        assertEquals(output.toAbsolutePath().normalize().toString(), stoppedPath)
+        assertEquals(1, stopCount.get(), "stop must invoke the daemon-owned handle once")
+        assertTrue(Files.size(output) > 0, "finalized output must be non-empty")
+        assertFalse(recording.status().active)
+        Files.deleteIfExists(output)
+    }
+
+    @Test
+    fun `finalizeIfActive stops an in-flight recording when the attach session closes`() {
+        val output = Files.createTempFile("spectre-finalize-", ".mp4")
+        val stopCount = AtomicInteger(0)
+        val handle = fakeHandle(output, stopCount)
+        val identity = uniqueIdentity(title = "Finalize Fixture")
+        val recording =
+            DaemonSessionRecording(
+                sessionId = "session-finalize",
+                targetPid = 99L,
+                windowIdentities = { listOf(identity) },
+                startWindowByTitle = { _, _, _, _, _, _ -> handle },
+            )
+        recording.start(outputPath = output.toString(), windowIndex = 0)
+        recording.finalizeIfActive(liveSessionIds = emptySet())
+        assertEquals(1, stopCount.get())
+        assertFalse(recording.status().active)
+        Files.deleteIfExists(output)
+    }
+
+    private fun fakeHandle(output: Path, stopCount: AtomicInteger): RecordingHandle =
+        object : RecordingHandle {
+            private val stopped = AtomicBoolean(false)
+            override val output: Path = output
+            override val isStopped: Boolean
+                get() = stopped.get()
+
+            override fun stop() {
+                if (stopped.compareAndSet(false, true)) {
+                    stopCount.incrementAndGet()
+                    Files.write(output, ByteArray(64) { 0x00 })
+                }
+            }
+        }
+
+    private fun uniqueIdentity(title: String): WindowIdentityDto {
+        val bounds = RectDto(0, 0, 320, 200)
+        return WindowIdentityDto(
+            index = 0,
+            surfaceId = "embedded:0",
+            title = title,
+            isPopup = false,
+            nativeHandle = 1L,
+            cropRequired = false,
+            windowBoundsOnScreen = bounds,
+            surfaceBoundsOnScreen = bounds,
+            surfaceBoundsInWindow = bounds,
+            scaleX = 1.0,
+            scaleY = 1.0,
+        )
+    }
+}

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -50,8 +50,11 @@ failure modes, and the section below
 
 CI and hermetic tests can redirect token storage with:
 
-- `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` — directory for per-source token files (mode `0700`)
-- `SPECTRE_WAYLAND_RESTORE_TOKEN_PATH` — single-file override (mode `0600`)
+- `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` — directory for per-source token files (mode `0700`).
+  Files are named `wayland-screencast-restore-token-{key}` (e.g. `…-monitor-embedded`).
+- `SPECTRE_WAYLAND_RESTORE_TOKEN_PATH` — **base path** (not a single flat file). Spectre
+  writes `{basename}-{key}` next to that path (mode `0600`), so keys stay separate.
+  Prefer `DIR` when you only need to relocate the directory.
 
 Headless runners without a seated GNOME session will not expose
 `org.freedesktop.portal.ScreenCast`; unit tests cover persist/reuse/clear without a
@@ -60,7 +63,7 @@ live portal. Interactive first-consent still requires a real compositor seat.
 On Linux Wayland, the ScreenCast portal consent dialog is the analogue of macOS TCC:
 interactive and not automatable. Spectre's `spectre-wayland-helper` uses portal
 `persist_mode=persistent` and stores a `restore_token` under
-`$XDG_STATE_HOME/spectre/wayland-screencast-restore-token` (mode `0600`, directory
+`$XDG_STATE_HOME/spectre/wayland-screencast-restore-token-{key}` (mode `0600`, directory
 `0700`; override with `SPECTRE_WAYLAND_RESTORE_TOKEN_PATH` or
 `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR`).
 

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -48,6 +48,15 @@ failure modes, and the section below
 
 ## Wayland restore_token (agent non-interactive runs)
 
+CI and hermetic tests can redirect token storage with:
+
+- `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` — directory for per-source token files (mode `0700`)
+- `SPECTRE_WAYLAND_RESTORE_TOKEN_PATH` — single-file override (mode `0600`)
+
+Headless runners without a seated GNOME session will not expose
+`org.freedesktop.portal.ScreenCast`; unit tests cover persist/reuse/clear without a
+live portal. Interactive first-consent still requires a real compositor seat.
+
 On Linux Wayland, the ScreenCast portal consent dialog is the analogue of macOS TCC:
 interactive and not automatable. Spectre's `spectre-wayland-helper` uses portal
 `persist_mode=persistent` and stores a `restore_token` under

--- a/recording/native/linux/src/portal.rs
+++ b/recording/native/linux/src/portal.rs
@@ -849,15 +849,14 @@ mod restore_token_tests {
             load_restore_token("monitor-embedded").unwrap().as_deref(),
             Some("second-overwrite")
         );
-        // No leftover *.tmp from the atomic rename path.
+        // write_private_file temps are named ".{name}.tmp.{pid}" (extension is the pid, not "tmp").
         let leftovers: Vec<_> = fs::read_dir(&dir)
             .unwrap()
             .filter_map(|e| e.ok())
             .filter(|e| {
-                e.path()
-                    .extension()
-                    .and_then(|x| x.to_str())
-                    .is_some_and(|x| x == "tmp")
+                e.file_name()
+                    .to_str()
+                    .is_some_and(|name| name.starts_with('.') && name.contains(".tmp."))
             })
             .collect();
         assert!(leftovers.is_empty(), "tmp leftovers: {leftovers:?}");

--- a/recording/native/linux/src/portal.rs
+++ b/recording/native/linux/src/portal.rs
@@ -797,4 +797,72 @@ mod restore_token_tests {
         clear_restore_token("monitor-embedded").unwrap();
         std::env::remove_var("SPECTRE_WAYLAND_RESTORE_TOKEN_PATH");
     }
+
+    #[test]
+    fn restore_token_key_is_stable_per_source_and_cursor() {
+        let monitor_embedded =
+            restore_token_key(&[SourceType::Monitor], CursorMode::Embedded);
+        let monitor_hidden = restore_token_key(&[SourceType::Monitor], CursorMode::Hidden);
+        let window_embedded = restore_token_key(&[SourceType::Window], CursorMode::Embedded);
+        assert_eq!(monitor_embedded, "monitor-embedded");
+        assert_eq!(monitor_hidden, "monitor-hidden");
+        assert_eq!(window_embedded, "window-embedded");
+        assert_ne!(monitor_embedded, monitor_hidden);
+        assert_ne!(monitor_embedded, window_embedded);
+    }
+
+    #[test]
+    fn is_restore_token_rejection_only_matches_select_or_start_token_failures() {
+        assert!(is_restore_token_rejection(&anyhow::anyhow!(
+            "SelectSources rejected (response code 2): stored restore_token"
+        )));
+        assert!(is_restore_token_rejection(&anyhow::anyhow!(
+            "Start rejected: restore_token no longer valid"
+        )));
+        // Timeouts and CreateSession failures must NOT clear a still-valid grant.
+        assert!(!is_restore_token_rejection(&anyhow::anyhow!(
+            "Timed out after 60s waiting for Response signal"
+        )));
+        assert!(!is_restore_token_rejection(&anyhow::anyhow!(
+            "CreateSession rejected (response code 2)"
+        )));
+        assert!(!is_restore_token_rejection(&anyhow::anyhow!(
+            "OpenPipeWireRemote failed"
+        )));
+    }
+
+    #[test]
+    fn save_restore_token_is_atomic_and_does_not_leave_partial_files() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!(
+            "spectre-restore-atomic-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&dir);
+        fs::create_dir_all(&dir).unwrap();
+        std::env::set_var("SPECTRE_WAYLAND_RESTORE_TOKEN_DIR", &dir);
+        std::env::remove_var("SPECTRE_WAYLAND_RESTORE_TOKEN_PATH");
+
+        save_restore_token("monitor-embedded", "first").unwrap();
+        save_restore_token("monitor-embedded", "second-overwrite").unwrap();
+        assert_eq!(
+            load_restore_token("monitor-embedded").unwrap().as_deref(),
+            Some("second-overwrite")
+        );
+        // No leftover *.tmp from the atomic rename path.
+        let leftovers: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.path()
+                    .extension()
+                    .and_then(|x| x.to_str())
+                    .is_some_and(|x| x == "tmp")
+            })
+            .collect();
+        assert!(leftovers.is_empty(), "tmp leftovers: {leftovers:?}");
+
+        std::env::remove_var("SPECTRE_WAYLAND_RESTORE_TOKEN_DIR");
+        let _ = fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION
## Summary

Post-epic #183 follow-ups (excluding #189):

- **Kill-target / finalize CI seam**: `DaemonSessionRecording` takes injectible `targetPid`, `windowIdentities`, and `startWindowByTitle` so tests can prove stop/finalize still finalises a daemon-owned handle after the attach target is gone, without SCK/WGC/portal.
- **macOS e2e**: attach → `record start` → kill fixture mid-record → `record stop` still leaves a non-empty MP4 (gated on display + Screen Recording TCC).
- **Wayland restore_token unit hardening**: key stability, rejection-string matching (only SelectSources/Start token failures clear), atomic overwrite without leftover `.tmp` files.
- **Docs**: `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` / `PATH` for hermetic/CI token storage; headless portal still needs a real seat for first consent.

## Test plan

- [x] `./gradlew check` (local)
- [x] `:cli` KillTarget + SessionRecording + Fixture tests
- [x] Docker/guest cargo: restore_token unit tests (5)
- [ ] CI green on this PR
- [ ] macOS runner with TCC: kill-target e2e (assumes when TCC missing)

## Out of scope

- Epic #189 (separate)