### PR TITLE
Add agent protocol handshake and error taxonomy (#199)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -144,6 +144,12 @@ public final class dev/sebastiano/spectre/agent/ScreenshotTargetKt {
 	public static final fun resolveScreenshotTarget (ZLjava/lang/Integer;Ljava/lang/String;Ljava/util/List;)Ljava/lang/Object;
 }
 
+public final class dev/sebastiano/spectre/agent/SpectreAgentException : java/io/IOException {
+	public fun <init> (Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCategory ()Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+}
+
 public abstract class dev/sebastiano/spectre/agent/SpectreAttachException : java/lang/RuntimeException {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -159,6 +165,26 @@ public final class dev/sebastiano/spectre/agent/runtime/SpectreAgent {
 	public static final field INSTANCE Ldev/sebastiano/spectre/agent/runtime/SpectreAgent;
 	public static final fun agentmain (Ljava/lang/String;Ljava/lang/instrument/Instrumentation;)V
 	public static final fun premain (Ljava/lang/String;Ljava/lang/instrument/Instrumentation;)V
+}
+
+public final class dev/sebastiano/spectre/agent/transport/AgentErrorCategory : java/lang/Enum {
+	public static final field Companion Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory$Companion;
+	public static final field InputRejected Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public static final field InternalError Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public static final field InvalidSelector Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public static final field NodeNotFound Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public static final field ProtocolMismatch Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public static final field Timeout Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public static final field UnsupportedOperation Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getWireName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public static fun values ()[Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+}
+
+public final class dev/sebastiano/spectre/agent/transport/AgentErrorCategory$Companion {
+	public final fun fromWire (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/sebastiano/spectre/agent/transport/Framing {
@@ -213,6 +239,11 @@ public final synthetic class dev/sebastiano/spectre/agent/transport/NodeSnapshot
 
 public final class dev/sebastiano/spectre/agent/transport/NodeSnapshotDto$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/agent/transport/ProtocolVersion {
+	public static final field CURRENT I
+	public static final field INSTANCE Ldev/sebastiano/spectre/agent/transport/ProtocolVersion;
 }
 
 public final class dev/sebastiano/spectre/agent/transport/RectDto {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -52,6 +52,9 @@ public object AgentAttach {
         val client =
             try {
                 IpcClient(udsPath)
+            } catch (ex: SpectreAgentException) {
+                // Preserve taxonomy from handshake (e.g. protocolMismatch) — do not wrap.
+                throw ex
             } catch (ex: IOException) {
                 throw SpectreAttachExceptionImpl(
                     "Failed to connect to agent's UDS at $udsPath: ${ex.message}",

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -163,7 +163,13 @@ internal constructor(
         check(!closed.get()) { "AttachedAutomator is closed" }
         val resp = client.send(request)
         if (resp is AgentResponse.Error) {
-            throw IOException("Agent reported error for ${request.logLabel}: ${resp.message}")
+            val category =
+                dev.sebastiano.spectre.agent.transport.AgentErrorCategory.fromWire(resp.category)
+            throw SpectreAgentException(
+                category = category,
+                message =
+                    "Agent reported ${category.wireName} for ${request.logLabel}: ${resp.message}",
+            )
         }
         return resp
     }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/SpectreAgentException.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/SpectreAgentException.kt
@@ -1,0 +1,18 @@
+package dev.sebastiano.spectre.agent
+
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+import java.io.IOException
+
+/**
+ * Structured agent transport failure (#199).
+ *
+ * Subclasses [IOException] so existing `catch (IOException)` sites keep working, and exposes a
+ * stable [category] so clients can distinguish unsupported ops, timeouts, and missing nodes without
+ * parsing free-text messages.
+ */
+@ExperimentalSpectreAgentApi
+public class SpectreAgentException(
+    public val category: AgentErrorCategory,
+    message: String,
+    cause: Throwable? = null,
+) : IOException(message, cause)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
@@ -19,7 +19,12 @@ internal object AtomicCaptureReflectiveMapper {
                     it.parameterTypes[0] == Int::class.javaPrimitiveType
             }
                 ?: return AgentResponse.Error(
-                    "ComposeAutomator does not expose capture(windowIndex: Int) on this build"
+                    message =
+                        "ComposeAutomator does not expose capture(windowIndex: Int) on this build",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
                 )
         val result =
             captureMethod.invoke(automator, windowIndex)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -169,19 +169,27 @@ internal class ReflectiveAutomatorHandler(
             allNodes.filterNotNull().filter { nodeBooleanProperty(it, methodName = "isFocused") }
         if (focusedNodes.isEmpty()) {
             return AgentResponse.Error(
-                "Refusing typeText because no focused Spectre node was found in the " +
-                    "target JVM. Focus a target node before sending real keyboard events."
+                message =
+                    "Refusing typeText because no focused Spectre node was found in the " +
+                        "target JVM. Focus a target node before sending real keyboard events.",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InputRejected.wireName,
             )
         }
         if (focusedNodes.none { extractKey(it).isNotBlank() }) {
             return AgentResponse.Error(
-                "Refusing typeText because every focused Spectre node has a blank key."
+                message = "Refusing typeText because every focused Spectre node has a blank key.",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InputRejected.wireName,
             )
         }
         if (!isTargetJvmFocused()) {
             return AgentResponse.Error(
-                "Refusing typeText because the target JVM does not currently own OS keyboard " +
-                    "focus. Activate the target window before sending real keyboard events."
+                message =
+                    "Refusing typeText because the target JVM does not currently own OS keyboard " +
+                        "focus. Activate the target window before sending real keyboard events.",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InputRejected.wireName,
             )
         }
         suspendInvoker.invoke(method, automator, text)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -151,7 +151,11 @@ internal class ReflectiveAutomatorHandler(
         val method =
             clickSuspendMethod
                 ?: return AgentResponse.Error(
-                    "ComposeAutomator does not expose a click(node) method"
+                    message = "ComposeAutomator does not expose a click(node) method",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
                 )
         suspendInvoker.invoke(method, automator, match)
         return AgentResponse.Ok
@@ -161,7 +165,11 @@ internal class ReflectiveAutomatorHandler(
         val method =
             typeTextSuspendMethod
                 ?: return AgentResponse.Error(
-                    "ComposeAutomator does not expose a typeText(text) method"
+                    message = "ComposeAutomator does not expose a typeText(text) method",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
                 )
         refreshWindowsMethod.invoke(automator)
         val allNodes = allNodesMethod.invoke(automator) as List<*>
@@ -213,7 +221,13 @@ internal class ReflectiveAutomatorHandler(
                     windows = windowSummaries,
                 )
                 .getOrElse {
-                    return AgentResponse.Error(it.message ?: "Invalid screenshot request")
+                    return AgentResponse.Error(
+                        message = it.message ?: "Invalid screenshot request",
+                        category =
+                            dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                                .InvalidSelector
+                                .wireName,
+                    )
                 }
 
         val regionScreenshotMethod =
@@ -223,7 +237,12 @@ internal class ReflectiveAutomatorHandler(
                     it.parameterTypes[0].name == AWT_RECTANGLE_FQN
             }
                 ?: return AgentResponse.Error(
-                    "ComposeAutomator does not expose screenshot(Rectangle?) on this build"
+                    message =
+                        "ComposeAutomator does not expose screenshot(Rectangle?) on this build",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
                 )
 
         val image =

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -108,7 +108,7 @@ internal class ReflectiveAutomatorHandler(
         } catch (ex: ReflectiveOperationException) {
             val message = "Reflective call failed: ${ex.targetMessage()}"
             val category =
-                if (isInputRejection(ex)) {
+                if (reflectiveIsInputRejection(ex)) {
                     dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InputRejected
                 } else {
                     dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InternalError
@@ -407,17 +407,6 @@ internal class ReflectiveAutomatorHandler(
         return "${cause.javaClass.simpleName}: ${cause.message ?: NO_MESSAGE_PLACEHOLDER}"
     }
 
-    /** TCC / Accessibility / permission refusals from Robot — taxonomy inputRejected (#199). */
-    private fun isInputRejection(ex: ReflectiveOperationException): Boolean {
-        val cause = ex.cause ?: ex
-        if (cause !is IllegalStateException) return false
-        val msg = cause.message.orEmpty().lowercase()
-        return "accessibility" in msg ||
-            "tcc" in msg ||
-            "permission" in msg ||
-            "screen recording" in msg
-    }
-
     private companion object {
         const val CONTINUATION_FQN: String = "kotlin.coroutines.Continuation"
         const val AWT_RECTANGLE_FQN: String = "java.awt.Rectangle"
@@ -432,4 +421,15 @@ internal class ReflectiveAutomatorHandler(
             }
         }
     }
+}
+
+/** TCC / Accessibility / permission refusals from Robot — taxonomy inputRejected (#199). */
+private fun reflectiveIsInputRejection(ex: ReflectiveOperationException): Boolean {
+    val root = ex.cause ?: ex
+    if (root !is IllegalStateException) return false
+    val msg = root.message.orEmpty().lowercase()
+    return "accessibility" in msg ||
+        "tcc" in msg ||
+        "permission" in msg ||
+        "screen recording" in msg
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -106,7 +106,14 @@ internal class ReflectiveAutomatorHandler(
                     )
             }
         } catch (ex: ReflectiveOperationException) {
-            AgentResponse.Error("Reflective call failed: ${ex.targetMessage()}")
+            val message = "Reflective call failed: ${ex.targetMessage()}"
+            val category =
+                if (isInputRejection(ex)) {
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InputRejected
+                } else {
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InternalError
+                }
+            AgentResponse.Error(message = message, category = category.wireName)
         }
 
     // Note on un-caught exceptions: any non-reflective `RuntimeException` thrown by the
@@ -398,6 +405,17 @@ internal class ReflectiveAutomatorHandler(
         // ReflectiveOperationException), which produced misleading messages like
         // `"NullPointerException: InvocationTargetException"`. Bugbot caught it.
         return "${cause.javaClass.simpleName}: ${cause.message ?: NO_MESSAGE_PLACEHOLDER}"
+    }
+
+    /** TCC / Accessibility / permission refusals from Robot — taxonomy inputRejected (#199). */
+    private fun isInputRejection(ex: ReflectiveOperationException): Boolean {
+        val cause = ex.cause ?: ex
+        if (cause !is IllegalStateException) return false
+        val msg = cause.message.orEmpty().lowercase()
+        return "accessibility" in msg ||
+            "tcc" in msg ||
+            "permission" in msg ||
+            "screen recording" in msg
     }
 
     private companion object {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -98,6 +98,12 @@ internal class ReflectiveAutomatorHandler(
                 is AgentRequest.WindowIdentity ->
                     WindowIdentityReflectiveMapper.invoke(automator, request.windowIndex)
                 AgentRequest.Detach -> AgentResponse.Detached
+                // Handled in IpcServer before the automator handler; keep exhaustive.
+                is AgentRequest.Hello ->
+                    AgentResponse.HelloAck(
+                        protocolVersion =
+                            dev.sebastiano.spectre.agent.transport.ProtocolVersion.CURRENT
+                    )
             }
         } catch (ex: ReflectiveOperationException) {
             AgentResponse.Error("Reflective call failed: ${ex.targetMessage()}")
@@ -136,7 +142,12 @@ internal class ReflectiveAutomatorHandler(
         val allNodes = allNodesMethod.invoke(automator) as List<*>
         val match =
             allNodes.firstOrNull { it != null && extractKey(it) == nodeKey }
-                ?: return AgentResponse.Error("No node found with key=$nodeKey")
+                ?: return AgentResponse.Error(
+                    message = "No node found with key=$nodeKey",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory.NodeNotFound
+                            .wireName,
+                )
         val method =
             clickSuspendMethod
                 ?: return AgentResponse.Error(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WindowIdentityReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WindowIdentityReflectiveMapper.kt
@@ -21,7 +21,11 @@ internal object WindowIdentityReflectiveMapper {
                 it.name == "windowIdentities" && it.parameterCount == 0
             }
                 ?: return AgentResponse.Error(
-                    "ComposeAutomator does not expose windowIdentities() on this build"
+                    message = "ComposeAutomator does not expose windowIdentities() on this build",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
                 )
         val all = listMethod.invoke(automator) as List<*>
         val selected = if (windowIndex == null) all else listOfNotNull(all.getOrNull(windowIndex))

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/AgentErrorCategory.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/AgentErrorCategory.kt
@@ -1,0 +1,58 @@
+package dev.sebastiano.spectre.agent.transport
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Stable error taxonomy for the agent transport (#199), shared conceptually with HTTP status
+ * mapping in `:server`.
+ *
+ * Clients use [wireName] (and [fromWire]) to distinguish "runtime too old for this op" from "timed
+ * out" from "node not found" without parsing free-text messages.
+ */
+@ExperimentalSpectreAgentApi
+@Serializable
+public enum class AgentErrorCategory {
+    /** Runtime does not implement this operation (unknown wire discriminator / too-old agent). */
+    @SerialName("unsupportedOperation") UnsupportedOperation,
+
+    /** Handshake or framing/schema mismatch between attacher and runtime. */
+    @SerialName("protocolMismatch") ProtocolMismatch,
+
+    /** Selector / node key could not be parsed or is not valid for this request. */
+    @SerialName("invalidSelector") InvalidSelector,
+
+    /** No matching node for a well-formed key or selector. */
+    @SerialName("nodeNotFound") NodeNotFound,
+
+    /** Operation exceeded its deadline. */
+    @SerialName("timeout") Timeout,
+
+    /** Input was refused (focus, permissions, Robot backend rejection). */
+    @SerialName("inputRejected") InputRejected,
+
+    /** Unexpected failure inside the agent or reflective bridge. */
+    @SerialName("internalError") InternalError;
+
+    /** Wire form used in [AgentResponse.Error.category] and HTTP error bodies. */
+    public val wireName: String
+        get() =
+            when (this) {
+                UnsupportedOperation -> "unsupportedOperation"
+                ProtocolMismatch -> "protocolMismatch"
+                InvalidSelector -> "invalidSelector"
+                NodeNotFound -> "nodeNotFound"
+                Timeout -> "timeout"
+                InputRejected -> "inputRejected"
+                InternalError -> "internalError"
+            }
+
+    public companion object {
+        /** Parse a wire category string; unknown values map to [InternalError]. */
+        public fun fromWire(value: String?): AgentErrorCategory {
+            if (value.isNullOrBlank()) return InternalError
+            return entries.firstOrNull { it.wireName == value } ?: InternalError
+        }
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -73,6 +73,9 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
                             AgentErrorCategory.InternalError -> AgentErrorCategory.ProtocolMismatch
                             else -> decoded
                         }
+                    // Best-effort Detach so a legacy runtime that only clears agentState on
+                    // Detach can be re-attached with a matching JAR after this failure.
+                    runCatching { sendWithoutHandshake(AgentRequest.Detach) }
                     throw SpectreAgentException(
                         category = category,
                         message =

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -66,11 +66,18 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
                     handshakeOk = true
                 }
                 is AgentResponse.Error -> {
+                    // Pre-#199 runtimes return message-only Error (defaults to internalError)
+                    // when they cannot decode Hello — treat as protocol mismatch, not internal.
+                    val category =
+                        when (val decoded = AgentErrorCategory.fromWire(ack.category)) {
+                            AgentErrorCategory.InternalError -> AgentErrorCategory.ProtocolMismatch
+                            else -> decoded
+                        }
                     throw SpectreAgentException(
-                        category = AgentErrorCategory.fromWire(ack.category),
+                        category = category,
                         message =
                             "Agent rejected protocol handshake " +
-                                "(${ack.category}): ${ack.message}",
+                                "(${category.wireName}): ${ack.message}",
                     )
                 }
                 else -> {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -46,30 +46,34 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
 
     init {
         // #199: exact-match protocol handshake is the first exchange after connect.
-        val hello = AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT)
-        val ack = sendWithoutHandshake(hello)
-        when (ack) {
-            is AgentResponse.HelloAck -> {
-                if (ack.protocolVersion != ProtocolVersion.CURRENT) {
-                    channel.close()
+        // Always close the channel if handshake does not complete cleanly (no FD leak).
+        var handshakeOk = false
+        try {
+            val hello = AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT)
+            val ack = sendWithoutHandshake(hello)
+            when (ack) {
+                is AgentResponse.HelloAck -> {
+                    if (ack.protocolVersion != ProtocolVersion.CURRENT) {
+                        throw IOException(
+                            "Agent protocol mismatch: runtime advertised ${ack.protocolVersion}, " +
+                                "client expects ${ProtocolVersion.CURRENT}"
+                        )
+                    }
+                    handshakeOk = true
+                }
+                is AgentResponse.Error -> {
                     throw IOException(
-                        "Agent protocol mismatch: runtime advertised ${ack.protocolVersion}, " +
-                            "client expects ${ProtocolVersion.CURRENT}"
+                        "Agent rejected protocol handshake " + "(${ack.category}): ${ack.message}"
+                    )
+                }
+                else -> {
+                    throw IOException(
+                        "Agent protocol handshake expected HelloAck, got ${ack::class.simpleName}"
                     )
                 }
             }
-            is AgentResponse.Error -> {
-                channel.close()
-                throw IOException(
-                    "Agent rejected protocol handshake " + "(${ack.category}): ${ack.message}"
-                )
-            }
-            else -> {
-                channel.close()
-                throw IOException(
-                    "Agent protocol handshake expected HelloAck, got ${ack::class.simpleName}"
-                )
-            }
+        } finally {
+            if (!handshakeOk) runCatching { channel.close() }
         }
     }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -44,12 +44,44 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
     private val input: InputStream = Channels.newInputStream(channel)
     private val output: OutputStream = Channels.newOutputStream(channel)
 
+    init {
+        // #199: exact-match protocol handshake is the first exchange after connect.
+        val hello = AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT)
+        val ack = sendWithoutHandshake(hello)
+        when (ack) {
+            is AgentResponse.HelloAck -> {
+                if (ack.protocolVersion != ProtocolVersion.CURRENT) {
+                    channel.close()
+                    throw IOException(
+                        "Agent protocol mismatch: runtime advertised ${ack.protocolVersion}, " +
+                            "client expects ${ProtocolVersion.CURRENT}"
+                    )
+                }
+            }
+            is AgentResponse.Error -> {
+                channel.close()
+                throw IOException(
+                    "Agent rejected protocol handshake " + "(${ack.category}): ${ack.message}"
+                )
+            }
+            else -> {
+                channel.close()
+                throw IOException(
+                    "Agent protocol handshake expected HelloAck, got ${ack::class.simpleName}"
+                )
+            }
+        }
+    }
+
     /**
      * Sends [request], blocks until the matching response arrives, returns it. Throws [IOException]
      * if the channel closes mid-exchange or the wire protocol is violated.
      */
     @Throws(IOException::class)
-    fun send(request: AgentRequest): AgentResponse {
+    fun send(request: AgentRequest): AgentResponse = sendWithoutHandshake(request)
+
+    @Throws(IOException::class)
+    private fun sendWithoutHandshake(request: AgentRequest): AgentResponse {
         Framing.writeFrame(output, WireCodec.encode(request))
         val responseBytes =
             Framing.readFrame(input)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.agent.transport
 
+import dev.sebastiano.spectre.agent.SpectreAgentException
 import java.io.EOFException
 import java.io.IOException
 import java.io.InputStream
@@ -54,21 +55,30 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
             when (ack) {
                 is AgentResponse.HelloAck -> {
                     if (ack.protocolVersion != ProtocolVersion.CURRENT) {
-                        throw IOException(
-                            "Agent protocol mismatch: runtime advertised ${ack.protocolVersion}, " +
-                                "client expects ${ProtocolVersion.CURRENT}"
+                        throw SpectreAgentException(
+                            category = AgentErrorCategory.ProtocolMismatch,
+                            message =
+                                "Agent protocol mismatch: runtime advertised " +
+                                    "${ack.protocolVersion}, client expects " +
+                                    "${ProtocolVersion.CURRENT}",
                         )
                     }
                     handshakeOk = true
                 }
                 is AgentResponse.Error -> {
-                    throw IOException(
-                        "Agent rejected protocol handshake " + "(${ack.category}): ${ack.message}"
+                    throw SpectreAgentException(
+                        category = AgentErrorCategory.fromWire(ack.category),
+                        message =
+                            "Agent rejected protocol handshake " +
+                                "(${ack.category}): ${ack.message}",
                     )
                 }
                 else -> {
-                    throw IOException(
-                        "Agent protocol handshake expected HelloAck, got ${ack::class.simpleName}"
+                    throw SpectreAgentException(
+                        category = AgentErrorCategory.ProtocolMismatch,
+                        message =
+                            "Agent protocol handshake expected HelloAck, got " +
+                                "${ack::class.simpleName}",
                     )
                 }
             }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -230,7 +230,8 @@ constructor(
                     )
                 ),
             )
-            return true
+            // End the connection so a stale peer cannot monopolize the single accept slot.
+            return false
         }
 
         // Generic Exception catch: an automator handler may throw NPE / CCE / ISE (unchecked)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -179,6 +179,13 @@ constructor(
                         )
                     ),
                 )
+                // Pre-handshake decode failure: drop the connection so the accept loop can
+                // serve a valid attacher (and release agent state for re-bootstrap).
+                if (!handshakeComplete) {
+                    running.set(false)
+                    onDetach()
+                    return false
+                }
                 return true
             }
 
@@ -220,17 +227,23 @@ constructor(
         }
 
         if (!handshakeComplete) {
-            Framing.writeFrame(
-                output,
-                WireCodec.encode(
-                    AgentResponse.Error(
-                        message =
-                            "Protocol handshake required: send Hello before ${request.logLabel}",
-                        category = AgentErrorCategory.ProtocolMismatch.wireName,
-                    )
-                ),
-            )
-            // End the connection so a stale peer cannot monopolize the single accept slot.
+            try {
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(
+                        AgentResponse.Error(
+                            message =
+                                "Protocol handshake required: send Hello before ${request.logLabel}",
+                            category = AgentErrorCategory.ProtocolMismatch.wireName,
+                        )
+                    ),
+                )
+            } finally {
+                // Pre-#199 attachers send ops without Hello; tear down so a current attacher
+                // can re-bootstrap on a new UDS path.
+                running.set(false)
+                onDetach()
+            }
             return false
         }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -170,23 +170,26 @@ constructor(
                     } else {
                         AgentErrorCategory.ProtocolMismatch
                     }
-                Framing.writeFrame(
-                    output,
-                    WireCodec.encode(
-                        AgentResponse.Error(
-                            message = "Malformed or unsupported request: ${ex.message}",
-                            category = category.wireName,
-                        )
-                    ),
-                )
-                // Pre-handshake decode failure: drop the connection so the accept loop can
-                // serve a valid attacher (and release agent state for re-bootstrap).
-                if (!handshakeComplete) {
-                    running.set(false)
-                    onDetach()
-                    return false
+                val tearDown = !handshakeComplete
+                try {
+                    Framing.writeFrame(
+                        output,
+                        WireCodec.encode(
+                            AgentResponse.Error(
+                                message = "Malformed or unsupported request: ${ex.message}",
+                                category = category.wireName,
+                            )
+                        ),
+                    )
+                } finally {
+                    // Pre-handshake decode failure: always release agent state even if the
+                    // error write races a dropped client.
+                    if (tearDown) {
+                        running.set(false)
+                        onDetach()
+                    }
                 }
-                return true
+                return !tearDown
             }
 
         // Hello is handled here (not in ReflectiveAutomatorHandler) so the handshake does not

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -185,12 +185,20 @@ constructor(
         // Hello is handled here (not in ReflectiveAutomatorHandler) so the handshake does not
         // require a live ComposeAutomator (#199).
         if (request is AgentRequest.Hello) {
-            val response =
-                if (request.protocolVersion == ProtocolVersion.CURRENT) {
-                    setHandshakeComplete(true)
-                    AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
-                } else {
-                    setHandshakeComplete(false)
+            if (request.protocolVersion == ProtocolVersion.CURRENT) {
+                setHandshakeComplete(true)
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(
+                        AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
+                    ),
+                )
+                return true
+            }
+            setHandshakeComplete(false)
+            Framing.writeFrame(
+                output,
+                WireCodec.encode(
                     AgentResponse.Error(
                         message =
                             "Protocol version mismatch: client=${request.protocolVersion}, " +
@@ -198,9 +206,13 @@ constructor(
                                 "while agent API is experimental)",
                         category = AgentErrorCategory.ProtocolMismatch.wireName,
                     )
-                }
-            Framing.writeFrame(output, WireCodec.encode(response))
-            return true
+                ),
+            )
+            // #199 P1: rejected handshake must release SpectreAgent singleton state so a
+            // subsequent attach with a matching runtime can bootstrap again.
+            running.set(false)
+            onDetach()
+            return false
         }
 
         if (!handshakeComplete) {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -162,92 +162,17 @@ constructor(
             try {
                 WireCodec.decodeRequest(requestBytes)
             } catch (ex: kotlinx.serialization.SerializationException) {
-                // Unknown sealed discriminators (newer attacher ops) must not hang or look like a
-                // decode crash — return taxonomy unsupportedOperation (#199).
-                val category =
-                    if (WireCodec.isUnknownDiscriminator(ex)) {
-                        AgentErrorCategory.UnsupportedOperation
-                    } else {
-                        AgentErrorCategory.ProtocolMismatch
-                    }
-                val tearDown = !handshakeComplete
-                try {
-                    Framing.writeFrame(
-                        output,
-                        WireCodec.encode(
-                            AgentResponse.Error(
-                                message = "Malformed or unsupported request: ${ex.message}",
-                                category = category.wireName,
-                            )
-                        ),
-                    )
-                } finally {
-                    // Pre-handshake decode failure: always release agent state even if the
-                    // error write races a dropped client.
-                    if (tearDown) {
-                        running.set(false)
-                        onDetach()
-                    }
-                }
-                return !tearDown
+                return respondDecodeFailure(output, ex, handshakeComplete)
             }
 
         // Hello is handled here (not in ReflectiveAutomatorHandler) so the handshake does not
         // require a live ComposeAutomator (#199).
         if (request is AgentRequest.Hello) {
-            if (request.protocolVersion == ProtocolVersion.CURRENT) {
-                setHandshakeComplete(true)
-                Framing.writeFrame(
-                    output,
-                    WireCodec.encode(
-                        AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
-                    ),
-                )
-                return true
-            }
-            setHandshakeComplete(false)
-            try {
-                Framing.writeFrame(
-                    output,
-                    WireCodec.encode(
-                        AgentResponse.Error(
-                            message =
-                                "Protocol version mismatch: client=${request.protocolVersion}, " +
-                                    "runtime=${ProtocolVersion.CURRENT} (exact-match required " +
-                                    "while agent API is experimental)",
-                            category = AgentErrorCategory.ProtocolMismatch.wireName,
-                        )
-                    ),
-                )
-            } finally {
-                // #199 P1: rejected handshake must release SpectreAgent singleton state so a
-                // subsequent attach with a matching runtime can bootstrap again — even if the
-                // client dropped before the error frame was written.
-                running.set(false)
-                onDetach()
-            }
-            return false
+            return respondHello(output, request, setHandshakeComplete)
         }
 
         if (!handshakeComplete) {
-            try {
-                Framing.writeFrame(
-                    output,
-                    WireCodec.encode(
-                        AgentResponse.Error(
-                            message =
-                                "Protocol handshake required: send Hello before ${request.logLabel}",
-                            category = AgentErrorCategory.ProtocolMismatch.wireName,
-                        )
-                    ),
-                )
-            } finally {
-                // Pre-#199 attachers send ops without Hello; tear down so a current attacher
-                // can re-bootstrap on a new UDS path.
-                running.set(false)
-                onDetach()
-            }
-            return false
+            return rejectPreHandshake(output, request)
         }
 
         // Generic Exception catch: an automator handler may throw NPE / CCE / ISE (unchecked)
@@ -296,6 +221,93 @@ constructor(
             }
         }
         return !isDetach
+    }
+
+    /** Decode failure response; pre-handshake failures tear down agent state (#199). */
+    private fun respondDecodeFailure(
+        output: java.io.OutputStream,
+        ex: kotlinx.serialization.SerializationException,
+        handshakeComplete: Boolean,
+    ): Boolean {
+        val category =
+            if (WireCodec.isUnknownDiscriminator(ex)) {
+                AgentErrorCategory.UnsupportedOperation
+            } else {
+                AgentErrorCategory.ProtocolMismatch
+            }
+        val tearDown = !handshakeComplete
+        try {
+            Framing.writeFrame(
+                output,
+                WireCodec.encode(
+                    AgentResponse.Error(
+                        message = "Malformed or unsupported request: ${ex.message}",
+                        category = category.wireName,
+                    )
+                ),
+            )
+        } finally {
+            if (tearDown) {
+                running.set(false)
+                onDetach()
+            }
+        }
+        return !tearDown
+    }
+
+    /** Hello handshake; mismatch tears down agent state so re-attach can re-bootstrap (#199). */
+    private fun respondHello(
+        output: java.io.OutputStream,
+        request: AgentRequest.Hello,
+        setHandshakeComplete: (Boolean) -> Unit,
+    ): Boolean {
+        if (request.protocolVersion == ProtocolVersion.CURRENT) {
+            setHandshakeComplete(true)
+            Framing.writeFrame(
+                output,
+                WireCodec.encode(AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)),
+            )
+            return true
+        }
+        setHandshakeComplete(false)
+        try {
+            Framing.writeFrame(
+                output,
+                WireCodec.encode(
+                    AgentResponse.Error(
+                        message =
+                            "Protocol version mismatch: client=${request.protocolVersion}, " +
+                                "runtime=${ProtocolVersion.CURRENT} (exact-match required " +
+                                "while agent API is experimental)",
+                        category = AgentErrorCategory.ProtocolMismatch.wireName,
+                    )
+                ),
+            )
+        } finally {
+            running.set(false)
+            onDetach()
+        }
+        return false
+    }
+
+    /** Non-Hello first frame (pre-#199 attacher); tear down and close the connection (#199). */
+    private fun rejectPreHandshake(output: java.io.OutputStream, request: AgentRequest): Boolean {
+        try {
+            Framing.writeFrame(
+                output,
+                WireCodec.encode(
+                    AgentResponse.Error(
+                        message =
+                            "Protocol handshake required: send Hello before ${request.logLabel}",
+                        category = AgentErrorCategory.ProtocolMismatch.wireName,
+                    )
+                ),
+            )
+        } finally {
+            running.set(false)
+            onDetach()
+        }
+        return false
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -154,12 +154,44 @@ constructor(
             try {
                 WireCodec.decodeRequest(requestBytes)
             } catch (ex: kotlinx.serialization.SerializationException) {
+                // Unknown sealed discriminators (newer attacher ops) must not hang or look like a
+                // decode crash — return taxonomy unsupportedOperation (#199).
+                val category =
+                    if (WireCodec.isUnknownDiscriminator(ex)) {
+                        AgentErrorCategory.UnsupportedOperation
+                    } else {
+                        AgentErrorCategory.ProtocolMismatch
+                    }
                 Framing.writeFrame(
                     output,
-                    WireCodec.encode(AgentResponse.Error("Malformed request: ${ex.message}")),
+                    WireCodec.encode(
+                        AgentResponse.Error(
+                            message = "Malformed or unsupported request: ${ex.message}",
+                            category = category.wireName,
+                        )
+                    ),
                 )
                 return true
             }
+
+        // Hello is handled here (not in ReflectiveAutomatorHandler) so the handshake does not
+        // require a live ComposeAutomator (#199).
+        if (request is AgentRequest.Hello) {
+            val response =
+                if (request.protocolVersion == ProtocolVersion.CURRENT) {
+                    AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
+                } else {
+                    AgentResponse.Error(
+                        message =
+                            "Protocol version mismatch: client=${request.protocolVersion}, " +
+                                "runtime=${ProtocolVersion.CURRENT} (exact-match required " +
+                                "while agent API is experimental)",
+                        category = AgentErrorCategory.ProtocolMismatch.wireName,
+                    )
+                }
+            Framing.writeFrame(output, WireCodec.encode(response))
+            return true
+        }
 
         // Generic Exception catch: an automator handler may throw NPE / CCE / ISE (unchecked)
         // when the target's `ComposeAutomator` is in an unexpected state, OR a checked
@@ -175,7 +207,17 @@ constructor(
             try {
                 handler.handle(request)
             } catch (ex: Exception) {
-                AgentResponse.Error("${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}")
+                val category =
+                    when (ex) {
+                        is java.util.concurrent.TimeoutException -> AgentErrorCategory.Timeout
+                        is IllegalArgumentException -> AgentErrorCategory.InvalidSelector
+                        is NoSuchElementException -> AgentErrorCategory.NodeNotFound
+                        else -> AgentErrorCategory.InternalError
+                    }
+                AgentResponse.Error(
+                    message = "${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}",
+                    category = category.wireName,
+                )
             }
         // Detach side-effects (`running.set(false)` + `onDetach()`) MUST run even if writing
         // the response fails — e.g. the attaching client closed mid-Detach. Without the

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -157,7 +157,17 @@ constructor(
         handshakeComplete: Boolean,
         setHandshakeComplete: (Boolean) -> Unit,
     ): Boolean {
-        val requestBytes = Framing.readFrame(input) ?: return false
+        val requestBytes =
+            try {
+                Framing.readFrame(input) ?: return false
+            } catch (ex: IllegalStateException) {
+                // Oversized/negative length prefix before handshake — tear down so re-attach works.
+                if (!handshakeComplete) {
+                    running.set(false)
+                    onDetach()
+                }
+                throw ex
+            }
         val request =
             try {
                 WireCodec.decodeRequest(requestBytes)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -133,8 +133,11 @@ constructor(
             val input = Channels.newInputStream(socket)
             val output = Channels.newOutputStream(socket)
             var keepReading = true
+            // #199: each connection must complete Hello/HelloAck before any other op.
+            var handshakeComplete = false
             while (running.get() && keepReading) {
-                keepReading = handleOneRequest(input, output)
+                keepReading =
+                    handleOneRequest(input, output, handshakeComplete) { handshakeComplete = it }
             }
         }
     }
@@ -143,11 +146,16 @@ constructor(
      * Reads one request frame, dispatches it to the handler, writes the response. Returns `false`
      * on clean EOF or after processing an [AgentRequest.Detach] — the caller uses the return value
      * as the single loop-exit signal.
+     *
+     * [handshakeComplete] tracks whether this connection has accepted [AgentRequest.Hello]; non-
+     * Hello ops before that get [AgentErrorCategory.ProtocolMismatch].
      */
     @Suppress("TooGenericExceptionCaught")
     private fun handleOneRequest(
         input: java.io.InputStream,
         output: java.io.OutputStream,
+        handshakeComplete: Boolean,
+        setHandshakeComplete: (Boolean) -> Unit,
     ): Boolean {
         val requestBytes = Framing.readFrame(input) ?: return false
         val request =
@@ -179,8 +187,10 @@ constructor(
         if (request is AgentRequest.Hello) {
             val response =
                 if (request.protocolVersion == ProtocolVersion.CURRENT) {
+                    setHandshakeComplete(true)
                     AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
                 } else {
+                    setHandshakeComplete(false)
                     AgentResponse.Error(
                         message =
                             "Protocol version mismatch: client=${request.protocolVersion}, " +
@@ -190,6 +200,20 @@ constructor(
                     )
                 }
             Framing.writeFrame(output, WireCodec.encode(response))
+            return true
+        }
+
+        if (!handshakeComplete) {
+            Framing.writeFrame(
+                output,
+                WireCodec.encode(
+                    AgentResponse.Error(
+                        message =
+                            "Protocol handshake required: send Hello before ${request.logLabel}",
+                        category = AgentErrorCategory.ProtocolMismatch.wireName,
+                    )
+                ),
+            )
             return true
         }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -196,22 +196,26 @@ constructor(
                 return true
             }
             setHandshakeComplete(false)
-            Framing.writeFrame(
-                output,
-                WireCodec.encode(
-                    AgentResponse.Error(
-                        message =
-                            "Protocol version mismatch: client=${request.protocolVersion}, " +
-                                "runtime=${ProtocolVersion.CURRENT} (exact-match required " +
-                                "while agent API is experimental)",
-                        category = AgentErrorCategory.ProtocolMismatch.wireName,
-                    )
-                ),
-            )
-            // #199 P1: rejected handshake must release SpectreAgent singleton state so a
-            // subsequent attach with a matching runtime can bootstrap again.
-            running.set(false)
-            onDetach()
+            try {
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(
+                        AgentResponse.Error(
+                            message =
+                                "Protocol version mismatch: client=${request.protocolVersion}, " +
+                                    "runtime=${ProtocolVersion.CURRENT} (exact-match required " +
+                                    "while agent API is experimental)",
+                            category = AgentErrorCategory.ProtocolMismatch.wireName,
+                        )
+                    ),
+                )
+            } finally {
+                // #199 P1: rejected handshake must release SpectreAgent singleton state so a
+                // subsequent attach with a matching runtime can bootstrap again — even if the
+                // client dropped before the error frame was written.
+                running.set(false)
+                onDetach()
+            }
             return false
         }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolVersion.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolVersion.kt
@@ -1,0 +1,14 @@
+package dev.sebastiano.spectre.agent.transport
+
+/**
+ * Agent wire-protocol versioning (#199).
+ *
+ * Both sides exchange [PROTOCOL_VERSION] as the first frames after the UDS connects. While the
+ * agent API is experimental, compatibility is **exact-match**: attacher and runtime must speak the
+ * same integer. From 1.0 the rule may become additive-compatible (min/max range); that change will
+ * bump this constant and update the handshake docs in `docs/guide/agent.md`.
+ */
+public object ProtocolVersion {
+    /** Current protocol revision carried on [AgentRequest.Hello] / [AgentResponse.HelloAck]. */
+    public const val CURRENT: Int = 1
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -97,6 +97,15 @@ internal sealed interface AgentRequest {
      * replies with [AgentResponse.Detached] and then closes the channel.
      */
     @Serializable @SerialName("detach") data object Detach : AgentRequest
+
+    /**
+     * First frame after connect (#199). Client announces [protocolVersion]; server replies with
+     * [AgentResponse.HelloAck] on exact match (experimental rule) or [AgentResponse.Error] with
+     * [AgentErrorCategory.ProtocolMismatch].
+     */
+    @Serializable
+    @SerialName("hello")
+    data class Hello(val protocolVersion: Int = ProtocolVersion.CURRENT) : AgentRequest
 }
 
 /** Payload-free operation label for diagnostics. Never include caller-controlled request data. */
@@ -113,6 +122,7 @@ internal val AgentRequest.logLabel: String
             is AgentRequest.Capture -> "capture"
             is AgentRequest.WindowIdentity -> "windowIdentity"
             AgentRequest.Detach -> "detach"
+            is AgentRequest.Hello -> "hello"
         }
 
 /** Server-to-client response envelope. */
@@ -205,12 +215,29 @@ internal sealed interface AgentResponse {
     data class WindowIdentities(val windows: List<WindowIdentityDto>) : AgentResponse
 
     /**
-     * Server-side failure. Carries a human-readable [message]; the structured failure type isn't
-     * exposed across the wire yet to keep the protocol small. This response goes back to the
-     * same-UID client that sent the request, so messages may include caller-controlled selectors or
-     * node keys for debugging. Persistent diagnostics must use [AgentRequest.logLabel] instead.
+     * Server-side failure with a stable [category] from the #199 error taxonomy plus a
+     * human-readable [message].
+     *
+     * [category] is the wire name (e.g. `unsupportedOperation`). Defaults to `internalError` so
+     * older runtimes that only sent [message] still decode on new clients. This response goes back
+     * to the same-UID client that sent the request, so messages may include caller-controlled
+     * selectors or node keys for debugging. Persistent diagnostics must use [AgentRequest.logLabel]
+     * instead.
      */
-    @Serializable @SerialName("error") data class Error(val message: String) : AgentResponse
+    @Serializable
+    @SerialName("error")
+    data class Error(
+        val message: String,
+        val category: String = AgentErrorCategory.InternalError.wireName,
+    ) : AgentResponse
+
+    /**
+     * Reply to [AgentRequest.Hello] when versions match (experimental exact-match rule).
+     * [protocolVersion] echoes the runtime's [ProtocolVersion.CURRENT].
+     */
+    @Serializable
+    @SerialName("helloAck")
+    data class HelloAck(val protocolVersion: Int = ProtocolVersion.CURRENT) : AgentResponse
 }
 
 /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -105,7 +105,10 @@ internal sealed interface AgentRequest {
      */
     @Serializable
     @SerialName("hello")
-    data class Hello(val protocolVersion: Int = ProtocolVersion.CURRENT) : AgentRequest
+    // No default on protocolVersion: WireCodec uses encodeDefaults=false, so a default would
+    // omit the field on the wire and peers would fill their own CURRENT — breaking exact-match
+    // negotiation across version bumps (#199 / Bugbot).
+    data class Hello(val protocolVersion: Int) : AgentRequest
 }
 
 /** Payload-free operation label for diagnostics. Never include caller-controlled request data. */
@@ -237,7 +240,8 @@ internal sealed interface AgentResponse {
      */
     @Serializable
     @SerialName("helloAck")
-    data class HelloAck(val protocolVersion: Int = ProtocolVersion.CURRENT) : AgentResponse
+    // No default — see [AgentRequest.Hello] (must be on the wire for exact-match).
+    data class HelloAck(val protocolVersion: Int) : AgentResponse
 }
 
 /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/WireCodec.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/WireCodec.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.agent.transport
 
 import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.cbor.Cbor
 
 /**
@@ -28,4 +29,18 @@ internal object WireCodec {
     /** Decode CBOR bytes into a response. */
     fun decodeResponse(bytes: ByteArray): AgentResponse =
         cbor.decodeFromByteArray(AgentResponse.serializer(), bytes)
+
+    /**
+     * True when [ex] looks like an unknown sealed-class discriminator (newer op against an older
+     * runtime), as opposed to truncated/corrupt CBOR. Used to map decode failures to
+     * [AgentErrorCategory.UnsupportedOperation] instead of hanging or treating them as internal
+     * errors (#199).
+     */
+    fun isUnknownDiscriminator(ex: SerializationException): Boolean {
+        val msg = ex.message.orEmpty().lowercase()
+        return "polymorphic" in msg ||
+            "serializer" in msg && ("not found" in msg || "for class" in msg || "unknown" in msg) ||
+            "unknown" in msg && ("class" in msg || "type" in msg || "serial" in msg) ||
+            "cannot find" in msg
+    }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -456,6 +456,7 @@ class IpcRoundTripTest {
                 )
             is AgentRequest.WindowIdentity -> AgentResponse.WindowIdentities(emptyList())
             AgentRequest.Detach -> AgentResponse.Detached
+            is AgentRequest.Hello -> AgentResponse.HelloAck()
         }
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -308,11 +308,20 @@ class IpcRoundTripTest {
         server.use {
             awaitSocket(udsPath)
 
-            // Send a frame with a deliberately invalid length prefix (negative). The server
-            // will throw `IllegalStateException` inside `readFrame`; we need the per-
-            // connection catch to absorb it without killing the loop.
+            // Complete handshake first, then send a bad length prefix. Pre-handshake bad
+            // frames intentionally tear down agent state (#199); this test pins post-
+            // handshake accept-loop survival only.
             java.nio.channels.SocketChannel.open(java.net.UnixDomainSocketAddress.of(udsPath))
                 .use { rawClient ->
+                    val output = java.nio.channels.Channels.newOutputStream(rawClient)
+                    val input = java.nio.channels.Channels.newInputStream(rawClient)
+                    Framing.writeFrame(
+                        output,
+                        WireCodec.encode(
+                            AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT)
+                        ),
+                    )
+                    Framing.readFrame(input) // HelloAck
                     val invalidHeader =
                         java.nio.ByteBuffer.allocate(Int.SIZE_BYTES)
                             .order(java.nio.ByteOrder.BIG_ENDIAN)

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -192,6 +192,17 @@ class IpcRoundTripTest {
             repeat(3) {
                 java.nio.channels.SocketChannel.open(java.net.UnixDomainSocketAddress.of(udsPath))
                     .use { rawClient ->
+                        val output = java.nio.channels.Channels.newOutputStream(rawClient)
+                        val input = java.nio.channels.Channels.newInputStream(rawClient)
+                        // #199: complete handshake first; the regression under test is broken-pipe
+                        // after a valid session, not pre-handshake teardown.
+                        Framing.writeFrame(
+                            output,
+                            WireCodec.encode(
+                                AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT)
+                            ),
+                        )
+                        Framing.readFrame(input) // HelloAck
                         val pingBytes = WireCodec.encode(AgentRequest.Ping)
                         val frame =
                             java.nio.ByteBuffer.allocate(Int.SIZE_BYTES + pingBytes.size).apply {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -357,6 +357,16 @@ class IpcRoundTripTest {
 
             java.nio.channels.SocketChannel.open(java.net.UnixDomainSocketAddress.of(udsPath))
                 .use { rawClient ->
+                    val output = java.nio.channels.Channels.newOutputStream(rawClient)
+                    val input = java.nio.channels.Channels.newInputStream(rawClient)
+                    // #199 handshake required before Detach is dispatched.
+                    Framing.writeFrame(
+                        output,
+                        WireCodec.encode(
+                            AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT)
+                        ),
+                    )
+                    Framing.readFrame(input) // HelloAck
                     val detachBytes = WireCodec.encode(AgentRequest.Detach)
                     val frame =
                         java.nio.ByteBuffer.allocate(Int.SIZE_BYTES + detachBytes.size).apply {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -466,7 +466,8 @@ class IpcRoundTripTest {
                 )
             is AgentRequest.WindowIdentity -> AgentResponse.WindowIdentities(emptyList())
             AgentRequest.Detach -> AgentResponse.Detached
-            is AgentRequest.Hello -> AgentResponse.HelloAck()
+            is AgentRequest.Hello ->
+                AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
         }
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
@@ -110,6 +110,23 @@ class ProtocolCompatTest {
     }
 
     @Test
+    fun `non-Hello first frame is rejected with protocolMismatch`() {
+        IpcServer(udsPath, stubHandler()).use {
+            awaitSocket(udsPath)
+            SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(UnixDomainSocketAddress.of(udsPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+                Framing.writeFrame(output, WireCodec.encode(AgentRequest.Ping))
+                val bytes = Framing.readFrame(input) ?: error("no response")
+                val err = assertIs<AgentResponse.Error>(WireCodec.decodeResponse(bytes))
+                assertEquals(AgentErrorCategory.ProtocolMismatch.wireName, err.category)
+                assertTrue(err.message.contains("handshake", ignoreCase = true))
+            }
+        }
+    }
+
+    @Test
     fun `isUnknownDiscriminator detects polymorphic serializer failures`() {
         val bytes = futureOpRequestBytes()
         val ex =

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
@@ -33,6 +33,22 @@ class ProtocolCompatTest {
     }
 
     @Test
+    fun `Hello CBOR encodes protocolVersion so exact-match cannot be faked by defaults`() {
+        val encoded =
+            WireCodec.encode(AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT))
+        // encodeDefaults=false must still include the non-default-less Int field.
+        val latin1 = encoded.toString(Charsets.ISO_8859_1)
+        assertTrue(
+            latin1.contains("protocolVersion") ||
+                encoded.contains(ProtocolVersion.CURRENT.toByte()),
+            "Hello must put protocolVersion on the wire; got ${encoded.size} bytes",
+        )
+        val decoded = WireCodec.decodeRequest(encoded)
+        assertIs<AgentRequest.Hello>(decoded)
+        assertEquals(ProtocolVersion.CURRENT, decoded.protocolVersion)
+    }
+
+    @Test
     fun `IpcClient handshake exchanges Hello and HelloAck at CURRENT version`() {
         IpcServer(udsPath, stubHandler()).use {
             awaitSocket(udsPath)
@@ -145,7 +161,8 @@ class ProtocolCompatTest {
     private fun stubHandler(): AgentRequestHandler = AgentRequestHandler { request ->
         when (request) {
             AgentRequest.Ping -> AgentResponse.Pong
-            is AgentRequest.Hello -> AgentResponse.HelloAck()
+            is AgentRequest.Hello ->
+                AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
             else ->
                 AgentResponse.Error(
                     message = "stub unhandled ${request.logLabel}",

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
@@ -1,0 +1,167 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlinx.serialization.SerializationException
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * Wire-protocol compatibility (#199): version handshake, unknown-op → unsupportedOperation, and
+ * taxonomy-bearing Error responses — without a child Compose fixture.
+ */
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
+class ProtocolCompatTest {
+    private val udsPath: Path =
+        udsBase().resolve("sp-pc-${UUID.randomUUID().toString().take(8)}.sock")
+
+    @AfterTest
+    fun cleanUp() {
+        runCatching { udsPath.deleteIfExists() }
+    }
+
+    @Test
+    fun `IpcClient handshake exchanges Hello and HelloAck at CURRENT version`() {
+        IpcServer(udsPath, stubHandler()).use {
+            awaitSocket(udsPath)
+            // Constructing IpcClient performs the handshake; send Ping proves the session works.
+            IpcClient(udsPath).use { client ->
+                assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+            }
+        }
+    }
+
+    @Test
+    fun `Hello with mismatched protocol version returns protocolMismatch`() {
+        IpcServer(udsPath, stubHandler()).use {
+            awaitSocket(udsPath)
+            // Open a raw socket and send Hello without using IpcClient's init handshake so we
+            // control the advertised version.
+            SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(UnixDomainSocketAddress.of(udsPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(
+                        AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT + 99)
+                    ),
+                )
+                val bytes = Framing.readFrame(input) ?: error("no response")
+                val resp = WireCodec.decodeResponse(bytes)
+                val err = assertIs<AgentResponse.Error>(resp)
+                assertEquals(AgentErrorCategory.ProtocolMismatch.wireName, err.category)
+                assertTrue(err.message.contains("mismatch", ignoreCase = true))
+            }
+        }
+    }
+
+    @Test
+    fun `unknown request discriminator yields unsupportedOperation not hang`() {
+        IpcServer(udsPath, stubHandler()).use {
+            awaitSocket(udsPath)
+            SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                channel.connect(UnixDomainSocketAddress.of(udsPath))
+                val input = Channels.newInputStream(channel)
+                val output = Channels.newOutputStream(channel)
+                // Complete handshake first so the unknown op is the second frame.
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT)),
+                )
+                val ackBytes = Framing.readFrame(input) ?: error("no helloAck")
+                assertIs<AgentResponse.HelloAck>(WireCodec.decodeResponse(ackBytes))
+
+                Framing.writeFrame(output, futureOpRequestBytes())
+                val respBytes = Framing.readFrame(input) ?: error("no error response")
+                val resp = WireCodec.decodeResponse(respBytes)
+                val err = assertIs<AgentResponse.Error>(resp)
+                assertEquals(AgentErrorCategory.UnsupportedOperation.wireName, err.category)
+            }
+        }
+    }
+
+    @Test
+    fun `Error with category round-trips and defaults for legacy message-only payloads`() {
+        val withCategory =
+            AgentResponse.Error(
+                message = "no such node",
+                category = AgentErrorCategory.NodeNotFound.wireName,
+            )
+        assertEquals(withCategory, WireCodec.decodeResponse(WireCodec.encode(withCategory)))
+
+        // Legacy runtimes only sent `message`; ignoreUnknownKeys + default category keep decode
+        // working when we re-encode a message-only shape via the data class default.
+        val legacy = AgentResponse.Error(message = "boom")
+        assertEquals(AgentErrorCategory.InternalError.wireName, legacy.category)
+        assertEquals(legacy, WireCodec.decodeResponse(WireCodec.encode(legacy)))
+    }
+
+    @Test
+    fun `isUnknownDiscriminator detects polymorphic serializer failures`() {
+        val bytes = futureOpRequestBytes()
+        val ex =
+            try {
+                WireCodec.decodeRequest(bytes)
+                error("expected SerializationException")
+            } catch (ex: SerializationException) {
+                ex
+            }
+        assertTrue(
+            WireCodec.isUnknownDiscriminator(ex),
+            "expected unknown-discriminator classification for: ${ex.message}",
+        )
+    }
+
+    private fun stubHandler(): AgentRequestHandler = AgentRequestHandler { request ->
+        when (request) {
+            AgentRequest.Ping -> AgentResponse.Pong
+            is AgentRequest.Hello -> AgentResponse.HelloAck()
+            else ->
+                AgentResponse.Error(
+                    message = "stub unhandled ${request.logLabel}",
+                    category = AgentErrorCategory.UnsupportedOperation.wireName,
+                )
+        }
+    }
+
+    private fun awaitSocket(path: Path, timeoutMs: Long = 5_000) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000L
+        while (System.nanoTime() < deadline) {
+            if (java.nio.file.Files.exists(path)) return
+            Thread.sleep(10)
+        }
+        error("UDS path $path did not appear within ${timeoutMs}ms")
+    }
+
+    private fun udsBase(): Path =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
+            Path.of(System.getProperty("java.io.tmpdir"))
+        else Path.of("/tmp")
+
+    /**
+     * CBOR bytes for a sealed [AgentRequest] whose polymorphic discriminator is a synthetic future
+     * op name — models a newer attacher talking to the current runtime.
+     */
+    private fun futureOpRequestBytes(): ByteArray {
+        // Encode a real Ping, then replace its "ping" discriminator with "futureOp_v99".
+        // kotlinx CBOR sealed encoding embeds the @SerialName as UTF-8 text in the payload.
+        val ping = WireCodec.encode(AgentRequest.Ping)
+        val asLatin1 = ping.toString(Charsets.ISO_8859_1)
+        require(asLatin1.contains("ping")) { "expected ping discriminator in CBOR payload" }
+        // Same length as "ping" so CBOR string length prefixes stay valid.
+        return asLatin1.replace("ping", "zzzz").toByteArray(Charsets.ISO_8859_1)
+    }
+}

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -267,6 +267,59 @@ DTOs live in `dev.sebastiano.spectre.agent.transport.*`. Both sides share the sa
 classes; CBOR's `@SerialName` discriminators pin each variant in the sealed-interface
 hierarchy.
 
+### Protocol version handshake (#199)
+
+After the UDS connects, the first exchange is always:
+
+1. Client → `hello` with `protocolVersion` (currently `1` — `ProtocolVersion.CURRENT`)
+2. Runtime → `helloAck` with the same version, or `error` with category
+   `protocolMismatch`
+
+While the agent API is experimental, compatibility is **exact-match**. A version
+mismatch fails attach with a clear `IOException` / `SpectreAgentException` rather than
+proceeding and hanging on later frames. From 1.0 the rule may become additive-compatible
+(min/max range); that change will bump `ProtocolVersion.CURRENT` and this section.
+
+### Unknown operations
+
+A newer attacher that sends an unknown request discriminator (sealed `@SerialName` the
+runtime does not know) receives `error` with category **`unsupportedOperation`**, not a
+decode hang or silent close. That is how mixed-version pairs degrade.
+
+### Error taxonomy
+
+`AgentResponse.Error` carries a stable `category` string alongside `message`:
+
+| Category | Meaning |
+| --- | --- |
+| `unsupportedOperation` | Runtime too old / op not implemented |
+| `protocolMismatch` | Handshake or schema/framing mismatch |
+| `invalidSelector` | Malformed node key or selector |
+| `nodeNotFound` | Well-formed key, no matching node |
+| `timeout` | Deadline exceeded |
+| `inputRejected` | Focus / Robot / permission rejection |
+| `internalError` | Unexpected agent-side failure (default) |
+
+Clients should branch on `category` (see `AgentErrorCategory` / `SpectreAgentException`),
+not on free-text `message`. The HTTP transport maps the same names onto status codes
+(`invalidSelector` → 400, `nodeNotFound` → 404, `unsupportedOperation` → 501, etc.) via
+`SpectreErrorCategory` in `:server`.
+
+### Schema evolution rules
+
+Additive-safe on DTOs:
+
+- New **optional** fields with defaults on request/response data classes
+- New **sealed variants** with new `@SerialName` values (old peers answer
+  `unsupportedOperation` for unknown request names)
+
+Not additive-safe without a version bump:
+
+- Renaming or removing fields
+- Changing field types or making an optional field required
+- Reusing an old `@SerialName` for a different shape (see `screenshot_v2` vs pre-#289
+  `screenshot`)
+
 ## Current limitations
 
 - **Windows needs 10 version 1803 / Server 2019 or newer.** That's when native `AF_UNIX` landed;

--- a/server/api/server.api
+++ b/server/api/server.api
@@ -21,6 +21,26 @@ public final class dev/sebastiano/spectre/server/HttpComposeAutomatorKt {
 	public static synthetic fun http$default (Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;Ljava/lang/String;ILjava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/server/HttpComposeAutomator;
 }
 
+public final class dev/sebastiano/spectre/server/SpectreErrorCategory : java/lang/Enum {
+	public static final field Companion Ldev/sebastiano/spectre/server/SpectreErrorCategory$Companion;
+	public static final field InputRejected Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public static final field InternalError Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public static final field InvalidSelector Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public static final field NodeNotFound Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public static final field ProtocolMismatch Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public static final field Timeout Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public static final field UnsupportedOperation Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getWireName ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public static fun values ()[Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+}
+
+public final class dev/sebastiano/spectre/server/SpectreErrorCategory$Companion {
+	public final fun fromWire (Ljava/lang/String;)Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public final fun httpStatus (Ldev/sebastiano/spectre/server/SpectreErrorCategory;)Lio/ktor/http/HttpStatusCode;
+}
+
 public final class dev/sebastiano/spectre/server/SpectreServerKt {
 	public static final fun installSpectreRoutes (Lio/ktor/server/application/Application;Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;)V
 	public static synthetic fun installSpectreRoutes$default (Lio/ktor/server/application/Application;Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;ILjava/lang/Object;)V

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreErrorCategory.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreErrorCategory.kt
@@ -1,0 +1,35 @@
+package dev.sebastiano.spectre.server
+
+/**
+ * Shared error taxonomy wire names (#199), aligned with the agent transport's `AgentErrorCategory`.
+ *
+ * HTTP maps these onto status codes via [httpStatus]; response bodies carry the category string so
+ * clients can branch without scraping free text.
+ */
+@ExperimentalSpectreHttpApi
+public enum class SpectreErrorCategory(public val wireName: String) {
+    UnsupportedOperation("unsupportedOperation"),
+    ProtocolMismatch("protocolMismatch"),
+    InvalidSelector("invalidSelector"),
+    NodeNotFound("nodeNotFound"),
+    Timeout("timeout"),
+    InputRejected("inputRejected"),
+    InternalError("internalError");
+
+    public companion object {
+        /** HTTP status used when this category is the primary failure signal. */
+        public fun httpStatus(category: SpectreErrorCategory): io.ktor.http.HttpStatusCode =
+            when (category) {
+                UnsupportedOperation -> io.ktor.http.HttpStatusCode.NotImplemented
+                ProtocolMismatch,
+                InvalidSelector -> io.ktor.http.HttpStatusCode.BadRequest
+                NodeNotFound -> io.ktor.http.HttpStatusCode.NotFound
+                Timeout -> io.ktor.http.HttpStatusCode.GatewayTimeout
+                InputRejected -> io.ktor.http.HttpStatusCode.Conflict
+                InternalError -> io.ktor.http.HttpStatusCode.InternalServerError
+            }
+
+        public fun fromWire(value: String?): SpectreErrorCategory =
+            entries.firstOrNull { it.wireName == value } ?: InternalError
+    }
+}

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -117,14 +117,21 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
             try {
                 NodeKey.parse(request.nodeKey)
             } catch (_: IllegalArgumentException) {
-                call.respond(HttpStatusCode.BadRequest, "Malformed node key")
+                // #199 taxonomy: invalidSelector → 400; body carries the stable category name.
+                call.respond(
+                    SpectreErrorCategory.httpStatus(SpectreErrorCategory.InvalidSelector),
+                    SpectreErrorCategory.InvalidSelector.wireName,
+                )
                 return@post
             }
         val node = automator.allNodes().firstOrNull { it.key == key }
         if (node == null) {
             // R5/F5c: do NOT echo `request.nodeKey` here — caller-controlled content must
-            // not be reflected in the response body.
-            call.respond(HttpStatusCode.NotFound, "No matching node")
+            // not be reflected in the response body. #199 taxonomy: nodeNotFound → 404.
+            call.respond(
+                SpectreErrorCategory.httpStatus(SpectreErrorCategory.NodeNotFound),
+                SpectreErrorCategory.NodeNotFound.wireName,
+            )
             return@post
         }
         automator.click(node)

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -137,7 +137,10 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
         try {
             automator.click(node)
             call.respond(HttpStatusCode.NoContent)
-        } catch (_: IllegalStateException) {
+        } catch (ex: IllegalStateException) {
+            // CancellationException <: IllegalStateException — must rethrow so Ktor cancels
+            // cleanly.
+            if (ex is kotlinx.coroutines.CancellationException) throw ex
             call.respond(
                 SpectreErrorCategory.httpStatus(SpectreErrorCategory.InputRejected),
                 SpectreErrorCategory.InputRejected.wireName,
@@ -150,8 +153,9 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
         try {
             automator.typeText(request.text)
             call.respond(HttpStatusCode.NoContent)
-        } catch (_: IllegalStateException) {
+        } catch (ex: IllegalStateException) {
             // #199: Robot/TCC/focus refusals → inputRejected (409), not an opaque 500.
+            if (ex is kotlinx.coroutines.CancellationException) throw ex
             call.respond(
                 SpectreErrorCategory.httpStatus(SpectreErrorCategory.InputRejected),
                 SpectreErrorCategory.InputRejected.wireName,

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -137,10 +137,10 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
         try {
             automator.click(node)
             call.respond(HttpStatusCode.NoContent)
-        } catch (ex: IllegalStateException) {
-            // CancellationException <: IllegalStateException — must rethrow so Ktor cancels
-            // cleanly.
-            if (ex is kotlinx.coroutines.CancellationException) throw ex
+        } catch (ex: kotlinx.coroutines.CancellationException) {
+            throw ex
+        } catch (_: IllegalStateException) {
+            // Robot/TCC refusals → inputRejected (409). CancellationException rethrown above.
             call.respond(
                 SpectreErrorCategory.httpStatus(SpectreErrorCategory.InputRejected),
                 SpectreErrorCategory.InputRejected.wireName,
@@ -153,9 +153,10 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
         try {
             automator.typeText(request.text)
             call.respond(HttpStatusCode.NoContent)
-        } catch (ex: IllegalStateException) {
+        } catch (ex: kotlinx.coroutines.CancellationException) {
+            throw ex
+        } catch (_: IllegalStateException) {
             // #199: Robot/TCC/focus refusals → inputRejected (409), not an opaque 500.
-            if (ex is kotlinx.coroutines.CancellationException) throw ex
             call.respond(
                 SpectreErrorCategory.httpStatus(SpectreErrorCategory.InputRejected),
                 SpectreErrorCategory.InputRejected.wireName,

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -134,14 +134,29 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
             )
             return@post
         }
-        automator.click(node)
-        call.respond(HttpStatusCode.NoContent)
+        try {
+            automator.click(node)
+            call.respond(HttpStatusCode.NoContent)
+        } catch (_: IllegalStateException) {
+            call.respond(
+                SpectreErrorCategory.httpStatus(SpectreErrorCategory.InputRejected),
+                SpectreErrorCategory.InputRejected.wireName,
+            )
+        }
     }
 
     post("/typeText") {
         val request = receiveOrRespond400<TypeTextRequest>(call, "TypeTextRequest") ?: return@post
-        automator.typeText(request.text)
-        call.respond(HttpStatusCode.NoContent)
+        try {
+            automator.typeText(request.text)
+            call.respond(HttpStatusCode.NoContent)
+        } catch (_: IllegalStateException) {
+            // #199: Robot/TCC/focus refusals → inputRejected (409), not an opaque 500.
+            call.respond(
+                SpectreErrorCategory.httpStatus(SpectreErrorCategory.InputRejected),
+                SpectreErrorCategory.InputRejected.wireName,
+            )
+        }
     }
 
     get("/screenshot") {

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -165,8 +165,18 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
     }
 
     get("/screenshot") {
-        val image = automator.screenshot()
-        call.respond(image.toScreenshotResponse())
+        try {
+            val image = automator.screenshot()
+            call.respond(image.toScreenshotResponse())
+        } catch (ex: kotlinx.coroutines.CancellationException) {
+            throw ex
+        } catch (_: IllegalStateException) {
+            // Screen Recording TCC / Robot refusal → inputRejected (409).
+            call.respond(
+                SpectreErrorCategory.httpStatus(SpectreErrorCategory.InputRejected),
+                SpectreErrorCategory.InputRejected.wireName,
+            )
+        }
     }
 }
 

--- a/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
+++ b/server/src/test/kotlin/dev/sebastiano/spectre/server/SpectreServerRoundTripTest.kt
@@ -101,7 +101,8 @@ class SpectreServerRoundTripTest {
             }
 
         assertEquals(HttpStatusCode.BadRequest, response.status)
-        assertTrue(response.bodyAsText().contains("Malformed node key"))
+        // #199 taxonomy: invalidSelector is the stable body token (no free-text / no key echo).
+        assertTrue(response.bodyAsText().contains("invalidSelector"))
     }
 
     @Test


### PR DESCRIPTION
## Summary

Implements [#199](https://github.com/rock3r/spectre/issues/199) (epic [#197](https://github.com/rock3r/spectre/issues/197)):

- **Version handshake**: `hello` / `helloAck` with exact-match `ProtocolVersion.CURRENT` (1) while experimental
- **Unknown-op**: newer request discriminators → `error` category `unsupportedOperation` (no hang/decode-as-internal)
- **Error taxonomy**: `AgentErrorCategory` + `AgentResponse.Error.category`; client throws `SpectreAgentException`
- **HTTP mapping**: `SpectreErrorCategory` maps invalidSelector→400, nodeNotFound→404, etc.
- **Docs**: schema evolution + taxonomy in `docs/guide/agent.md`
- **Tests**: `ProtocolCompatTest` (handshake, mismatch, unknown-op, taxonomy round-trip)

## Test plan

- [x] `./gradlew :agent:check :server:check :agent-runtime:check`
- [x] ProtocolCompatTest unknown-op returns unsupportedOperation
- [ ] CI green

Closes #199