### PR TITLE
Add IPC long-op multiplexing, cancel, and deadlines (#200)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -168,6 +168,7 @@ public final class dev/sebastiano/spectre/agent/runtime/SpectreAgent {
 }
 
 public final class dev/sebastiano/spectre/agent/transport/AgentErrorCategory : java/lang/Enum {
+	public static final field Cancelled Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
 	public static final field Companion Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory$Companion;
 	public static final field InputRejected Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
 	public static final field InternalError Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -104,6 +104,7 @@ internal class ReflectiveAutomatorHandler(
                         protocolVersion =
                             dev.sebastiano.spectre.agent.transport.ProtocolVersion.CURRENT
                     )
+                is AgentRequest.Cancel -> AgentResponse.Ok
             }
         } catch (ex: ReflectiveOperationException) {
             val message = "Reflective call failed: ${ex.targetMessage()}"

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/AgentErrorCategory.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/AgentErrorCategory.kt
@@ -29,6 +29,9 @@ public enum class AgentErrorCategory {
     /** Operation exceeded its deadline. */
     @SerialName("timeout") Timeout,
 
+    /** Explicit cancel of an in-flight op (#200). */
+    @SerialName("cancelled") Cancelled,
+
     /** Input was refused (focus, permissions, Robot backend rejection). */
     @SerialName("inputRejected") InputRejected,
 
@@ -44,6 +47,7 @@ public enum class AgentErrorCategory {
                 InvalidSelector -> "invalidSelector"
                 NodeNotFound -> "nodeNotFound"
                 Timeout -> "timeout"
+                Cancelled -> "cancelled"
                 InputRejected -> "inputRejected"
                 InternalError -> "internalError"
             }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -113,10 +113,13 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
         try {
             val frame = OpRequest(opId = opId, deadlineEpochMs = deadlineEpochMs, body = request)
             synchronized(writeLock) { Framing.writeFrame(output, WireCodec.encode(frame)) }
-            // Already-elapsed deadlines still need time for the server to return taxonomy
-            // `timeout` (Codex P2 / Windows flake: 1ms wait raced the UDS round-trip).
-            val waitMs = clientWaitMs(deadlineEpochMs)
-            return future.get(waitMs, TimeUnit.MILLISECONDS)
+            // No client-side deadline: wait indefinitely for the server (matches pre-#200
+            // blocking read). With a deadline: pad so server taxonomy timeout can still arrive.
+            return if (deadlineEpochMs == null) {
+                future.get()
+            } else {
+                future.get(clientWaitMs(deadlineEpochMs), TimeUnit.MILLISECONDS)
+            }
         } catch (ex: java.util.concurrent.TimeoutException) {
             pending.remove(opId)
             runCatching { cancel(opId) }
@@ -235,15 +238,13 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
         failAllPending(EOFException("IpcClient closed"))
     }
 
-    private fun clientWaitMs(deadlineEpochMs: Long?): Long {
-        if (deadlineEpochMs == null) return DEFAULT_WAIT_MS
+    private fun clientWaitMs(deadlineEpochMs: Long): Long {
         val remaining = deadlineEpochMs - System.currentTimeMillis()
         // Always pad so a server-side timeout response can still arrive after the deadline.
         return remaining.coerceAtLeast(0L) + ELAPSED_DEADLINE_GRACE_MS
     }
 
     private companion object {
-        const val DEFAULT_WAIT_MS: Long = 120_000
         /** Floor so a server-side timeout/cancel response can arrive over UDS. */
         const val ELAPSED_DEADLINE_GRACE_MS: Long = 5_000
         const val CANCEL_ACK_WAIT_MS: Long = 5_000

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -113,9 +113,9 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
         try {
             val frame = OpRequest(opId = opId, deadlineEpochMs = deadlineEpochMs, body = request)
             synchronized(writeLock) { Framing.writeFrame(output, WireCodec.encode(frame)) }
-            val waitMs =
-                deadlineEpochMs?.let { (it - System.currentTimeMillis()).coerceAtLeast(1L) }
-                    ?: DEFAULT_WAIT_MS
+            // Already-elapsed deadlines still need time for the server to return taxonomy
+            // `timeout` (Codex P2 / Windows flake: 1ms wait raced the UDS round-trip).
+            val waitMs = clientWaitMs(deadlineEpochMs)
             return future.get(waitMs, TimeUnit.MILLISECONDS)
         } catch (ex: java.util.concurrent.TimeoutException) {
             pending.remove(opId)
@@ -224,8 +224,17 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
         failAllPending(EOFException("IpcClient closed"))
     }
 
+    private fun clientWaitMs(deadlineEpochMs: Long?): Long {
+        if (deadlineEpochMs == null) return DEFAULT_WAIT_MS
+        val remaining = deadlineEpochMs - System.currentTimeMillis()
+        // Always pad so a server-side timeout response can still arrive after the deadline.
+        return remaining.coerceAtLeast(0L) + ELAPSED_DEADLINE_GRACE_MS
+    }
+
     private companion object {
         const val DEFAULT_WAIT_MS: Long = 120_000
+        /** Floor so a server-side timeout/cancel response can arrive over UDS. */
+        const val ELAPSED_DEADLINE_GRACE_MS: Long = 5_000
         const val CANCEL_ACK_WAIT_MS: Long = 5_000
         const val READER_JOIN_MS: Long = 1_000
     }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -10,30 +10,28 @@ import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
 import java.nio.channels.SocketChannel
 import java.nio.file.Path
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 
 /**
- * Client-side IPC endpoint: opens a connection to the agent's Unix Domain Socket at [udsPath] and
- * synchronously sends [AgentRequest]s with [send].
+ * Client-side IPC endpoint (#200 multiplexed ops).
  *
- * Single-shot send/receive: each [send] writes one framed CBOR request and reads the next framed
- * response. The current wire protocol is strictly request/response (no streaming), so this is safe
- * to use without explicit pipelining.
+ * After Hello handshake, every request is an [OpRequest] with a unique [opId]. A background reader
+ * thread demultiplexes [OpResponse] frames so a cancel (or a second quick op) can share the
+ * connection with a long-running wait without blocking the accept path on the server.
  *
- * Not thread-safe — callers that need concurrent automator access should synchronise externally.
- * The `AttachedAutomator` wrapper exposes only serial operations.
+ * Public [send] remains synchronous for [AttachedAutomator]; [cancel] aborts an in-flight op by id.
+ *
+ * [close] only drops the socket — it does **not** send [AgentRequest.Detach]. Detach is an
+ * intentional agent teardown (see [dev.sebastiano.spectre.agent.AttachedAutomator.close]); a plain
+ * client close must leave the server free to accept another connection (e.g. reconnect / tests).
  */
 internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) : AutoCloseable {
     private val channel: SocketChannel =
         SocketChannel.open(StandardProtocolFamily.UNIX).also { channel ->
-            // Outer `success` sentinel + `finally` so the channel is unconditionally closed
-            // if `connect()` throws (e.g. agent hasn't bound yet, connection refused, path
-            // doesn't exist). Without this, the opened `SocketChannel` would only get
-            // reclaimed on the next GC cycle via `sun.nio.ch.SocketChannelImpl`'s registered
-            // `Cleaner` — relying on GC for resource lifecycle is anti-pattern. Same fix
-            // shape as `IpcServer`'s constructor (Bugbot LOW on b98e93c) applied to the
-            // symmetric client side. Bugbot caught this side too (LOW). No unit-level
-            // regression test — the GC-reclaim path makes an FD-count assertion flaky
-            // (see the explanatory NOTE in `IpcRoundTripTest`).
             var success = false
             try {
                 channel.connect(UnixDomainSocketAddress.of(udsPath))
@@ -44,14 +42,17 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
         }
     private val input: InputStream = Channels.newInputStream(channel)
     private val output: OutputStream = Channels.newOutputStream(channel)
+    private val writeLock = Any()
+    private val nextOpId = AtomicLong(1)
+    private val pending = ConcurrentHashMap<Long, CompletableFuture<AgentResponse>>()
+    private val closed = AtomicBoolean(false)
+    private val readerThread: Thread
 
     init {
-        // #199: exact-match protocol handshake is the first exchange after connect.
-        // Always close the channel if handshake does not complete cleanly (no FD leak).
         var handshakeOk = false
         try {
             val hello = AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT)
-            val ack = sendWithoutHandshake(hello)
+            val ack = exchangeBare(hello)
             when (ack) {
                 is AgentResponse.HelloAck -> {
                     if (ack.protocolVersion != ProtocolVersion.CURRENT) {
@@ -66,16 +67,12 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
                     handshakeOk = true
                 }
                 is AgentResponse.Error -> {
-                    // Pre-#199 runtimes return message-only Error (defaults to internalError)
-                    // when they cannot decode Hello — treat as protocol mismatch, not internal.
                     val category =
                         when (val decoded = AgentErrorCategory.fromWire(ack.category)) {
                             AgentErrorCategory.InternalError -> AgentErrorCategory.ProtocolMismatch
                             else -> decoded
                         }
-                    // Best-effort Detach so a legacy runtime that only clears agentState on
-                    // Detach can be re-attached with a matching JAR after this failure.
-                    runCatching { sendWithoutHandshake(AgentRequest.Detach) }
+                    runCatching { exchangeBare(AgentRequest.Detach) }
                     throw SpectreAgentException(
                         category = category,
                         message =
@@ -95,17 +92,121 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
         } finally {
             if (!handshakeOk) runCatching { channel.close() }
         }
+
+        readerThread =
+            Thread(::readerLoop, "spectre-ipc-client-reader").apply {
+                isDaemon = true
+                start()
+            }
     }
 
     /**
-     * Sends [request], blocks until the matching response arrives, returns it. Throws [IOException]
-     * if the channel closes mid-exchange or the wire protocol is violated.
+     * Sends [request] and blocks until the correlated response arrives. [deadlineEpochMs] is an
+     * absolute epoch-millis deadline propagated to the runtime (#200).
      */
     @Throws(IOException::class)
-    fun send(request: AgentRequest): AgentResponse = sendWithoutHandshake(request)
+    fun send(request: AgentRequest, deadlineEpochMs: Long? = null): AgentResponse {
+        check(!closed.get()) { "IpcClient is closed" }
+        val opId = nextOpId.getAndIncrement()
+        val future = CompletableFuture<AgentResponse>()
+        pending[opId] = future
+        try {
+            val frame = OpRequest(opId = opId, deadlineEpochMs = deadlineEpochMs, body = request)
+            synchronized(writeLock) { Framing.writeFrame(output, WireCodec.encode(frame)) }
+            val waitMs =
+                deadlineEpochMs?.let { (it - System.currentTimeMillis()).coerceAtLeast(1L) }
+                    ?: DEFAULT_WAIT_MS
+            return future.get(waitMs, TimeUnit.MILLISECONDS)
+        } catch (ex: java.util.concurrent.TimeoutException) {
+            pending.remove(opId)
+            runCatching { cancel(opId) }
+            throw SpectreAgentException(
+                category = AgentErrorCategory.Timeout,
+                message = "Timed out waiting for response to ${request.logLabel} (opId=$opId)",
+                cause = ex,
+            )
+        } catch (ex: java.util.concurrent.ExecutionException) {
+            pending.remove(opId)
+            throw unwrapExecutionFailure(opId, ex)
+        } finally {
+            pending.remove(opId)
+        }
+    }
 
+    /** Explicit cancel for [opId] (#200). Best-effort; safe if the op already completed. */
     @Throws(IOException::class)
-    private fun sendWithoutHandshake(request: AgentRequest): AgentResponse {
+    fun cancel(opId: Long) {
+        check(!closed.get()) { "IpcClient is closed" }
+        val cancelId = nextOpId.getAndIncrement()
+        val future = CompletableFuture<AgentResponse>()
+        pending[cancelId] = future
+        try {
+            val frame = OpRequest(opId = cancelId, body = AgentRequest.Cancel(opId = opId))
+            synchronized(writeLock) { Framing.writeFrame(output, WireCodec.encode(frame)) }
+            future.get(CANCEL_ACK_WAIT_MS, TimeUnit.MILLISECONDS)
+        } catch (_: java.util.concurrent.TimeoutException) {
+            // Best-effort: cancel ack lag is non-fatal.
+        } catch (_: java.util.concurrent.ExecutionException) {
+            // Best-effort: transport error while waiting for cancel ack.
+        } catch (_: java.util.concurrent.CancellationException) {
+            // Best-effort: local future cancelled during client close.
+        } catch (_: IOException) {
+            // Best-effort: write failed (peer already gone).
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        } finally {
+            pending.remove(cancelId)
+        }
+    }
+
+    private fun unwrapExecutionFailure(
+        opId: Long,
+        ex: java.util.concurrent.ExecutionException,
+    ): IOException {
+        val cause = ex.cause
+        return when (cause) {
+            is IOException -> cause
+            null -> IOException("Op $opId failed: ${ex.message}", ex)
+            else -> IOException("Op $opId failed: ${cause.message}", cause)
+        }
+    }
+
+    /** Last assigned op id (for tests). */
+    internal fun lastOpId(): Long = nextOpId.get() - 1
+
+    private fun readerLoop() {
+        try {
+            while (!closed.get()) {
+                val bytes = Framing.readFrame(input) ?: break
+                dispatchOpResponse(bytes)
+            }
+        } catch (_: Exception) {
+            // Channel closed or transport error — complete outstanding futures below.
+        } finally {
+            failAllPending(EOFException("Agent closed the connection while waiting for a response"))
+        }
+    }
+
+    private fun dispatchOpResponse(bytes: ByteArray) {
+        val opResponse =
+            try {
+                WireCodec.decodeOpResponse(bytes)
+            } catch (_: Exception) {
+                // Legacy bare response should not appear after handshake; treat as disconnect.
+                failAllPending(EOFException("Unexpected non-envelope response after handshake"))
+                return
+            }
+        pending.remove(opResponse.opId)?.complete(opResponse.body)
+    }
+
+    private fun failAllPending(err: Exception) {
+        pending.forEach { (_, future) -> future.completeExceptionally(err) }
+        pending.clear()
+    }
+
+    /** Bare (pre-envelope) exchange used only for Hello / best-effort Detach on failed Hello. */
+    @Throws(IOException::class)
+    private fun exchangeBare(request: AgentRequest): AgentResponse {
         Framing.writeFrame(output, WireCodec.encode(request))
         val responseBytes =
             Framing.readFrame(input)
@@ -116,6 +217,16 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
     }
 
     override fun close() {
-        channel.close()
+        if (!closed.compareAndSet(false, true)) return
+        // Drop the socket only — Detach is explicit agent teardown, not implied by close.
+        runCatching { channel.close() }
+        runCatching { readerThread.join(READER_JOIN_MS) }
+        failAllPending(EOFException("IpcClient closed"))
+    }
+
+    private companion object {
+        const val DEFAULT_WAIT_MS: Long = 120_000
+        const val CANCEL_ACK_WAIT_MS: Long = 5_000
+        const val READER_JOIN_MS: Long = 1_000
     }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -125,6 +125,17 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
                 message = "Timed out waiting for response to ${request.logLabel} (opId=$opId)",
                 cause = ex,
             )
+        } catch (ex: InterruptedException) {
+            // Caller thread interrupted while waiting — cancel the remote op so UI work stops
+            // (Codex P2).
+            pending.remove(opId)
+            runCatching { cancel(opId) }
+            Thread.currentThread().interrupt()
+            throw SpectreAgentException(
+                category = AgentErrorCategory.Cancelled,
+                message = "Interrupted while waiting for ${request.logLabel} (opId=$opId)",
+                cause = ex,
+            )
         } catch (ex: java.util.concurrent.ExecutionException) {
             pending.remove(opId)
             throw unwrapExecutionFailure(opId, ex)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -11,11 +11,6 @@ import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
-import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import java.util.concurrent.Future
-import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -143,7 +138,7 @@ constructor(
             // Phase 1: bare Hello (#199).
             if (!performHandshake(input, output)) return
             // Phase 2: multiplexed OpRequest frames on a worker pool (#200).
-            runMultiplexedSession(input, output)
+            MultiplexedIpcSession(handler, running, onDetach).run(input, output)
         }
     }
 
@@ -178,211 +173,6 @@ constructor(
             }
         }
         return handshakeComplete
-    }
-
-    /**
-     * Multiplexed session: accept thread only reads/dispatches; work runs on [workers] so long ops
-     * do not block cancel/detach (#200).
-     *
-     * Client EOF (socket close without Detach) ends the session only — [running] stays true so
-     * another client can connect. Explicit Detach tears the agent down via [onDetach].
-     */
-    private fun runMultiplexedSession(input: InputStream, output: OutputStream) {
-        val workers: ExecutorService = Executors.newCachedThreadPool { r ->
-            Thread(r, "spectre-agent-op-worker").apply { isDaemon = true }
-        }
-        val inFlight = ConcurrentHashMap<Long, Future<*>>()
-        val writeLock = Any()
-        try {
-            serveOps(input, output, workers, inFlight, writeLock)
-        } finally {
-            inFlight.values.forEach { it.cancel(true) }
-            workers.shutdownNow()
-            runCatching { workers.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
-        }
-    }
-
-    private fun serveOps(
-        input: InputStream,
-        output: OutputStream,
-        workers: ExecutorService,
-        inFlight: ConcurrentHashMap<Long, Future<*>>,
-        writeLock: Any,
-    ) {
-        while (running.get()) {
-            val requestBytes = Framing.readFrame(input) ?: return
-            val op = decodeOpOrReport(requestBytes, output, writeLock) ?: continue
-            when (val body = op.body) {
-                is AgentRequest.Cancel -> handleCancel(body, op.opId, output, writeLock, inFlight)
-                AgentRequest.Detach -> {
-                    handleDetach(op.opId, output, writeLock, inFlight)
-                    return
-                }
-                else -> dispatchOp(op, body, workers, inFlight, output, writeLock)
-            }
-        }
-    }
-
-    private fun decodeOpOrReport(
-        requestBytes: ByteArray,
-        output: OutputStream,
-        writeLock: Any,
-    ): OpRequest? =
-        try {
-            WireCodec.decodeOpRequest(requestBytes)
-        } catch (ex: kotlinx.serialization.SerializationException) {
-            // Unknown/malformed envelope — report and continue serving.
-            writeOpResponse(
-                output,
-                writeLock,
-                opId = -1L,
-                AgentResponse.Error(
-                    message = "Malformed or unsupported op frame: ${ex.message}",
-                    category = AgentErrorCategory.UnsupportedOperation.wireName,
-                ),
-            )
-            null
-        }
-
-    private fun handleCancel(
-        cancel: AgentRequest.Cancel,
-        cancelFrameOpId: Long,
-        output: OutputStream,
-        writeLock: Any,
-        inFlight: ConcurrentHashMap<Long, Future<*>>,
-    ) {
-        val cancelled = inFlight.remove(cancel.opId)
-        cancelled?.cancel(/* mayInterruptIfRunning= */ true)
-        // Reply on the cancelled op's channel so the waiting client unblocks,
-        // then ack the cancel frame itself.
-        if (cancelled != null) {
-            writeOpResponse(
-                output,
-                writeLock,
-                cancel.opId,
-                AgentResponse.Error(
-                    message = "Operation cancelled",
-                    category = AgentErrorCategory.Cancelled.wireName,
-                ),
-            )
-        }
-        writeOpResponse(output, writeLock, cancelFrameOpId, AgentResponse.Ok)
-    }
-
-    private fun handleDetach(
-        opId: Long,
-        output: OutputStream,
-        writeLock: Any,
-        inFlight: ConcurrentHashMap<Long, Future<*>>,
-    ) {
-        inFlight.values.forEach { it.cancel(true) }
-        try {
-            writeOpResponse(output, writeLock, opId, AgentResponse.Detached)
-        } finally {
-            running.set(false)
-            onDetach()
-        }
-    }
-
-    private fun dispatchOp(
-        op: OpRequest,
-        body: AgentRequest,
-        workers: ExecutorService,
-        inFlight: ConcurrentHashMap<Long, Future<*>>,
-        output: OutputStream,
-        writeLock: Any,
-    ) {
-        // Register a placeholder before submit so cancel cannot race past an empty map.
-        val placeholder = CompletableFuturePlaceholder()
-        inFlight[op.opId] = placeholder
-        val future = workers.submit {
-            try {
-                if (Thread.currentThread().isInterrupted) return@submit
-                val response = executeOp(body, op.deadlineEpochMs)
-                // Cancel path may already have written cancelled for this opId.
-                if (!Thread.currentThread().isInterrupted) {
-                    writeOpResponse(output, writeLock, op.opId, response)
-                }
-            } finally {
-                inFlight.remove(op.opId)
-            }
-        }
-        // Replace placeholder with the real Future so cancel interrupts the worker.
-        if (!inFlight.replace(op.opId, placeholder, future)) {
-            // Cancel already removed the placeholder — interrupt the just-started work.
-            future.cancel(true)
-        }
-    }
-
-    /**
-     * Stand-in [Future] registered before [ExecutorService.submit] so a concurrent cancel always
-     * finds the op id. [cancel] is a no-op until the real future replaces this entry.
-     */
-    private class CompletableFuturePlaceholder : Future<Unit> {
-        private val cancelled = AtomicBoolean(false)
-
-        override fun cancel(mayInterruptIfRunning: Boolean): Boolean =
-            cancelled.compareAndSet(false, true)
-
-        override fun isCancelled(): Boolean = cancelled.get()
-
-        override fun isDone(): Boolean = cancelled.get()
-
-        override fun get(): Unit = Unit
-
-        override fun get(timeout: Long, unit: TimeUnit): Unit = Unit
-    }
-
-    @Suppress("TooGenericExceptionCaught")
-    private fun executeOp(request: AgentRequest, deadlineEpochMs: Long?): AgentResponse {
-        if (deadlineEpochMs != null && System.currentTimeMillis() > deadlineEpochMs) {
-            return AgentResponse.Error(
-                message = "Deadline already elapsed before op started",
-                category = AgentErrorCategory.Timeout.wireName,
-            )
-        }
-        return try {
-            // Cooperative deadline: if the op is slow, BlockingSuspendInvoker still has its own
-            // timeout; we also re-check deadline after the call.
-            val response = handler.handle(request)
-            if (deadlineEpochMs != null && System.currentTimeMillis() > deadlineEpochMs) {
-                AgentResponse.Error(
-                    message = "Deadline elapsed during op",
-                    category = AgentErrorCategory.Timeout.wireName,
-                )
-            } else {
-                response
-            }
-        } catch (ex: InterruptedException) {
-            Thread.currentThread().interrupt()
-            AgentResponse.Error(
-                message = "Operation cancelled",
-                category = AgentErrorCategory.Cancelled.wireName,
-            )
-        } catch (ex: Exception) {
-            val category =
-                when (ex) {
-                    is java.util.concurrent.TimeoutException -> AgentErrorCategory.Timeout
-                    is IllegalArgumentException -> AgentErrorCategory.InvalidSelector
-                    is NoSuchElementException -> AgentErrorCategory.NodeNotFound
-                    else -> AgentErrorCategory.InternalError
-                }
-            AgentResponse.Error(
-                message = "${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}",
-                category = category.wireName,
-            )
-        }
-    }
-
-    private fun writeOpResponse(
-        output: OutputStream,
-        writeLock: Any,
-        opId: Long,
-        body: AgentResponse,
-    ) {
-        synchronized(writeLock) {
-            Framing.writeFrame(output, WireCodec.encode(OpResponse(opId = opId, body = body)))
-        }
     }
 
     /** Decode failure response; pre-handshake failures tear down agent state (#199). */
@@ -508,10 +298,6 @@ constructor(
             // Best-effort — if the parent is gone or non-empty, leaving it is safer.
         }
         acceptThread.interrupt()
-    }
-
-    private companion object {
-        const val WORKER_SHUTDOWN_SEC: Long = 2
     }
 }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -1,6 +1,8 @@
 package dev.sebastiano.spectre.agent.transport
 
 import java.io.IOException
+import java.io.InputStream
+import java.io.OutputStream
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
@@ -9,6 +11,11 @@ import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -21,8 +28,9 @@ import java.util.concurrent.atomic.AtomicBoolean
  * layering client multiplexing on top would just paint over reality. Multi-client support, if it
  * ever lands, is a follow-up.
  *
- * The accept loop runs on a single daemon thread; per-request work happens inline on that thread.
- * [close] interrupts the loop, closes the server channel, and unlinks the UDS path.
+ * The accept loop runs on a single daemon thread. After Hello, request bodies run on a worker pool
+ * (#200) so long ops do not block cancel/detach dispatch. [close] interrupts the loop, closes the
+ * server channel, and unlinks the UDS path.
  *
  * Created and managed by [dev.sebastiano.spectre.agent.runtime.SpectreAgent] inside the target JVM
  * after the classloader bootstrap succeeds.
@@ -132,110 +140,254 @@ constructor(
         client.use { socket ->
             val input = Channels.newInputStream(socket)
             val output = Channels.newOutputStream(socket)
-            var keepReading = true
-            // #199: each connection must complete Hello/HelloAck before any other op.
-            var handshakeComplete = false
-            while (running.get() && keepReading) {
-                keepReading =
-                    handleOneRequest(input, output, handshakeComplete) { handshakeComplete = it }
+            // Phase 1: bare Hello (#199).
+            if (!performHandshake(input, output)) return
+            // Phase 2: multiplexed OpRequest frames on a worker pool (#200).
+            runMultiplexedSession(input, output)
+        }
+    }
+
+    /** Bare Hello handshake. Returns false if the connection should end. */
+    private fun performHandshake(input: InputStream, output: OutputStream): Boolean {
+        var handshakeComplete = false
+        while (running.get() && !handshakeComplete) {
+            val requestBytes =
+                try {
+                    Framing.readFrame(input) ?: return false
+                } catch (ex: IllegalStateException) {
+                    running.set(false)
+                    onDetach()
+                    throw ex
+                }
+            val request =
+                try {
+                    WireCodec.decodeRequest(requestBytes)
+                } catch (ex: kotlinx.serialization.SerializationException) {
+                    respondDecodeFailure(output, ex, handshakeComplete = false)
+                    return false
+                }
+            when (request) {
+                is AgentRequest.Hello -> {
+                    val ok = respondHello(output, request) { handshakeComplete = it }
+                    if (!ok) return false
+                }
+                else -> {
+                    rejectPreHandshake(output, request)
+                    return false
+                }
             }
+        }
+        return handshakeComplete
+    }
+
+    /**
+     * Multiplexed session: accept thread only reads/dispatches; work runs on [workers] so long ops
+     * do not block cancel/detach (#200).
+     *
+     * Client EOF (socket close without Detach) ends the session only — [running] stays true so
+     * another client can connect. Explicit Detach tears the agent down via [onDetach].
+     */
+    private fun runMultiplexedSession(input: InputStream, output: OutputStream) {
+        val workers: ExecutorService = Executors.newCachedThreadPool { r ->
+            Thread(r, "spectre-agent-op-worker").apply { isDaemon = true }
+        }
+        val inFlight = ConcurrentHashMap<Long, Future<*>>()
+        val writeLock = Any()
+        try {
+            serveOps(input, output, workers, inFlight, writeLock)
+        } finally {
+            inFlight.values.forEach { it.cancel(true) }
+            workers.shutdownNow()
+            runCatching { workers.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
+        }
+    }
+
+    private fun serveOps(
+        input: InputStream,
+        output: OutputStream,
+        workers: ExecutorService,
+        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        writeLock: Any,
+    ) {
+        while (running.get()) {
+            val requestBytes = Framing.readFrame(input) ?: return
+            val op = decodeOpOrReport(requestBytes, output, writeLock) ?: continue
+            when (val body = op.body) {
+                is AgentRequest.Cancel -> handleCancel(body, op.opId, output, writeLock, inFlight)
+                AgentRequest.Detach -> {
+                    handleDetach(op.opId, output, writeLock, inFlight)
+                    return
+                }
+                else -> dispatchOp(op, body, workers, inFlight, output, writeLock)
+            }
+        }
+    }
+
+    private fun decodeOpOrReport(
+        requestBytes: ByteArray,
+        output: OutputStream,
+        writeLock: Any,
+    ): OpRequest? =
+        try {
+            WireCodec.decodeOpRequest(requestBytes)
+        } catch (ex: kotlinx.serialization.SerializationException) {
+            // Unknown/malformed envelope — report and continue serving.
+            writeOpResponse(
+                output,
+                writeLock,
+                opId = -1L,
+                AgentResponse.Error(
+                    message = "Malformed or unsupported op frame: ${ex.message}",
+                    category = AgentErrorCategory.UnsupportedOperation.wireName,
+                ),
+            )
+            null
+        }
+
+    private fun handleCancel(
+        cancel: AgentRequest.Cancel,
+        cancelFrameOpId: Long,
+        output: OutputStream,
+        writeLock: Any,
+        inFlight: ConcurrentHashMap<Long, Future<*>>,
+    ) {
+        val cancelled = inFlight.remove(cancel.opId)
+        cancelled?.cancel(/* mayInterruptIfRunning= */ true)
+        // Reply on the cancelled op's channel so the waiting client unblocks,
+        // then ack the cancel frame itself.
+        if (cancelled != null) {
+            writeOpResponse(
+                output,
+                writeLock,
+                cancel.opId,
+                AgentResponse.Error(
+                    message = "Operation cancelled",
+                    category = AgentErrorCategory.Cancelled.wireName,
+                ),
+            )
+        }
+        writeOpResponse(output, writeLock, cancelFrameOpId, AgentResponse.Ok)
+    }
+
+    private fun handleDetach(
+        opId: Long,
+        output: OutputStream,
+        writeLock: Any,
+        inFlight: ConcurrentHashMap<Long, Future<*>>,
+    ) {
+        inFlight.values.forEach { it.cancel(true) }
+        try {
+            writeOpResponse(output, writeLock, opId, AgentResponse.Detached)
+        } finally {
+            running.set(false)
+            onDetach()
+        }
+    }
+
+    private fun dispatchOp(
+        op: OpRequest,
+        body: AgentRequest,
+        workers: ExecutorService,
+        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        output: OutputStream,
+        writeLock: Any,
+    ) {
+        // Register a placeholder before submit so cancel cannot race past an empty map.
+        val placeholder = CompletableFuturePlaceholder()
+        inFlight[op.opId] = placeholder
+        val future = workers.submit {
+            try {
+                if (Thread.currentThread().isInterrupted) return@submit
+                val response = executeOp(body, op.deadlineEpochMs)
+                // Cancel path may already have written cancelled for this opId.
+                if (!Thread.currentThread().isInterrupted) {
+                    writeOpResponse(output, writeLock, op.opId, response)
+                }
+            } finally {
+                inFlight.remove(op.opId)
+            }
+        }
+        // Replace placeholder with the real Future so cancel interrupts the worker.
+        if (!inFlight.replace(op.opId, placeholder, future)) {
+            // Cancel already removed the placeholder — interrupt the just-started work.
+            future.cancel(true)
         }
     }
 
     /**
-     * Reads one request frame, dispatches it to the handler, writes the response. Returns `false`
-     * on clean EOF or after processing an [AgentRequest.Detach] — the caller uses the return value
-     * as the single loop-exit signal.
-     *
-     * [handshakeComplete] tracks whether this connection has accepted [AgentRequest.Hello]; non-
-     * Hello ops before that get [AgentErrorCategory.ProtocolMismatch].
+     * Stand-in [Future] registered before [ExecutorService.submit] so a concurrent cancel always
+     * finds the op id. [cancel] is a no-op until the real future replaces this entry.
      */
+    private class CompletableFuturePlaceholder : Future<Unit> {
+        private val cancelled = AtomicBoolean(false)
+
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean =
+            cancelled.compareAndSet(false, true)
+
+        override fun isCancelled(): Boolean = cancelled.get()
+
+        override fun isDone(): Boolean = cancelled.get()
+
+        override fun get(): Unit = Unit
+
+        override fun get(timeout: Long, unit: TimeUnit): Unit = Unit
+    }
+
     @Suppress("TooGenericExceptionCaught")
-    private fun handleOneRequest(
-        input: java.io.InputStream,
-        output: java.io.OutputStream,
-        handshakeComplete: Boolean,
-        setHandshakeComplete: (Boolean) -> Unit,
-    ): Boolean {
-        val requestBytes =
-            try {
-                Framing.readFrame(input) ?: return false
-            } catch (ex: IllegalStateException) {
-                // Oversized/negative length prefix before handshake — tear down so re-attach works.
-                if (!handshakeComplete) {
-                    running.set(false)
-                    onDetach()
-                }
-                throw ex
-            }
-        val request =
-            try {
-                WireCodec.decodeRequest(requestBytes)
-            } catch (ex: kotlinx.serialization.SerializationException) {
-                return respondDecodeFailure(output, ex, handshakeComplete)
-            }
-
-        // Hello is handled here (not in ReflectiveAutomatorHandler) so the handshake does not
-        // require a live ComposeAutomator (#199).
-        if (request is AgentRequest.Hello) {
-            return respondHello(output, request, setHandshakeComplete)
+    private fun executeOp(request: AgentRequest, deadlineEpochMs: Long?): AgentResponse {
+        if (deadlineEpochMs != null && System.currentTimeMillis() > deadlineEpochMs) {
+            return AgentResponse.Error(
+                message = "Deadline already elapsed before op started",
+                category = AgentErrorCategory.Timeout.wireName,
+            )
         }
-
-        if (!handshakeComplete) {
-            return rejectPreHandshake(output, request)
-        }
-
-        // Generic Exception catch: an automator handler may throw NPE / CCE / ISE (unchecked)
-        // when the target's `ComposeAutomator` is in an unexpected state, OR a checked
-        // exception such as `java.util.concurrent.TimeoutException` from
-        // [dev.sebastiano.spectre.agent.runtime.BlockingSuspendInvoker] when a suspend op
-        // (click/typeText) hangs. Both must surface to the client as `AgentResponse.Error`
-        // rather than kill the accept thread and orphan the connection (a `TimeoutException`
-        // is `Exception`, NOT `RuntimeException`, so a narrower catch would let it escape
-        // through `handleConnection` → `acceptLoop` and permanently crash the IPC server
-        // after one slow UI op). Errors (OOM, StackOverflow) are intentionally NOT caught.
-        // Detekt's TooGenericExceptionCaught is suppressed here with rationale.
-        val response: AgentResponse =
-            try {
-                handler.handle(request)
-            } catch (ex: Exception) {
-                val category =
-                    when (ex) {
-                        is java.util.concurrent.TimeoutException -> AgentErrorCategory.Timeout
-                        is IllegalArgumentException -> AgentErrorCategory.InvalidSelector
-                        is NoSuchElementException -> AgentErrorCategory.NodeNotFound
-                        else -> AgentErrorCategory.InternalError
-                    }
+        return try {
+            // Cooperative deadline: if the op is slow, BlockingSuspendInvoker still has its own
+            // timeout; we also re-check deadline after the call.
+            val response = handler.handle(request)
+            if (deadlineEpochMs != null && System.currentTimeMillis() > deadlineEpochMs) {
                 AgentResponse.Error(
-                    message = "${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}",
-                    category = category.wireName,
+                    message = "Deadline elapsed during op",
+                    category = AgentErrorCategory.Timeout.wireName,
                 )
+            } else {
+                response
             }
-        // Detach side-effects (`running.set(false)` + `onDetach()`) MUST run even if writing
-        // the response fails — e.g. the attaching client closed mid-Detach. Without the
-        // `finally`, an `IOException` from `writeFrame` would propagate out, the per-
-        // connection catch in `acceptLoop` would absorb it, and the server would stay
-        // alive — but `SpectreAgent.agentState` would remain non-null, so the next
-        // re-attach attempt hits the idempotency guard, skips creating a new IPC server
-        // for the new UDS path, and the caller's `waitForUdsPath` polls until
-        // `AgentBootstrapTimeoutException`. The target JVM would become permanently
-        // un-attachable until restart. Bugbot caught this (MEDIUM); the regression test
-        // "Detach cleanup fires even when the response write fails" pins the contract.
-        val isDetach = request is AgentRequest.Detach
-        try {
-            Framing.writeFrame(output, WireCodec.encode(response))
-        } finally {
-            if (isDetach) {
-                running.set(false)
-                onDetach()
-            }
+        } catch (ex: InterruptedException) {
+            Thread.currentThread().interrupt()
+            AgentResponse.Error(
+                message = "Operation cancelled",
+                category = AgentErrorCategory.Cancelled.wireName,
+            )
+        } catch (ex: Exception) {
+            val category =
+                when (ex) {
+                    is java.util.concurrent.TimeoutException -> AgentErrorCategory.Timeout
+                    is IllegalArgumentException -> AgentErrorCategory.InvalidSelector
+                    is NoSuchElementException -> AgentErrorCategory.NodeNotFound
+                    else -> AgentErrorCategory.InternalError
+                }
+            AgentResponse.Error(
+                message = "${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}",
+                category = category.wireName,
+            )
         }
-        return !isDetach
+    }
+
+    private fun writeOpResponse(
+        output: OutputStream,
+        writeLock: Any,
+        opId: Long,
+        body: AgentResponse,
+    ) {
+        synchronized(writeLock) {
+            Framing.writeFrame(output, WireCodec.encode(OpResponse(opId = opId, body = body)))
+        }
     }
 
     /** Decode failure response; pre-handshake failures tear down agent state (#199). */
     private fun respondDecodeFailure(
-        output: java.io.OutputStream,
+        output: OutputStream,
         ex: kotlinx.serialization.SerializationException,
         handshakeComplete: Boolean,
     ): Boolean {
@@ -267,7 +419,7 @@ constructor(
 
     /** Hello handshake; mismatch tears down agent state so re-attach can re-bootstrap (#199). */
     private fun respondHello(
-        output: java.io.OutputStream,
+        output: OutputStream,
         request: AgentRequest.Hello,
         setHandshakeComplete: (Boolean) -> Unit,
     ): Boolean {
@@ -301,7 +453,7 @@ constructor(
     }
 
     /** Non-Hello first frame (pre-#199 attacher); tear down and close the connection (#199). */
-    private fun rejectPreHandshake(output: java.io.OutputStream, request: AgentRequest): Boolean {
+    private fun rejectPreHandshake(output: OutputStream, request: AgentRequest): Boolean {
         try {
             Framing.writeFrame(
                 output,
@@ -356,6 +508,10 @@ constructor(
             // Best-effort — if the parent is gone or non-empty, leaving it is safer.
         }
         acceptThread.interrupt()
+    }
+
+    private companion object {
+        const val WORKER_SHUTDOWN_SEC: Long = 2
     }
 }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -7,6 +7,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -109,6 +110,7 @@ internal class MultiplexedIpcSession(
     ) {
         val slot = inFlight.remove(cancel.opId)
         if (slot != null) {
+            slot.cancelDeadlineTask()
             slot.abortRunningWork()
             if (slot.tryClaimResponse()) {
                 writeOpResponse(
@@ -159,6 +161,7 @@ internal class MultiplexedIpcSession(
             }
             val response = executeOp(body, op.deadlineEpochMs)
             // Only the winner of tryClaimResponse may write (cancel/deadline may have won).
+            slot.cancelDeadlineTask()
             if (slot.tryClaimResponse()) {
                 inFlight.remove(op.opId, slot)
                 writeOpResponse(output, writeLock, op.opId, response)
@@ -173,12 +176,15 @@ internal class MultiplexedIpcSession(
             inFlight.remove(op.opId, slot)
             return
         }
-        scheduleDeadline(op, slot, deadlineScheduler, inFlight, output, writeLock)
+        slot.attachDeadlineTask(
+            scheduleDeadline(op, slot, deadlineScheduler, inFlight, output, writeLock)
+        )
     }
 
     /**
      * When [OpRequest.deadlineEpochMs] is in the future, interrupt the worker at the deadline and
-     * claim the response as taxonomy `timeout`.
+     * claim the response as taxonomy `timeout`. Returns the scheduled task so the slot can cancel
+     * it when the op completes early.
      */
     private fun scheduleDeadline(
         op: OpRequest,
@@ -187,10 +193,10 @@ internal class MultiplexedIpcSession(
         inFlight: ConcurrentHashMap<Long, OpSlot>,
         output: OutputStream,
         writeLock: Any,
-    ) {
-        val deadline = op.deadlineEpochMs ?: return
+    ): ScheduledFuture<*>? {
+        val deadline = op.deadlineEpochMs ?: return null
         val delayMs = deadline - System.currentTimeMillis()
-        val fireTimeout = {
+        val fireTimeout = Runnable {
             if (inFlight.remove(op.opId, slot)) {
                 slot.abortRunningWork()
                 if (slot.tryClaimResponse()) {
@@ -207,10 +213,10 @@ internal class MultiplexedIpcSession(
             }
         }
         if (delayMs <= 0L) {
-            fireTimeout()
-            return
+            fireTimeout.run()
+            return null
         }
-        deadlineScheduler.schedule(fireTimeout, delayMs, TimeUnit.MILLISECONDS)
+        return deadlineScheduler.schedule(fireTimeout, delayMs, TimeUnit.MILLISECONDS)
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -271,6 +277,7 @@ internal class MultiplexedIpcSession(
         private val aborted = AtomicBoolean(false)
         private val responseClaimed = AtomicBoolean(false)
         private val future = AtomicReference<Future<*>?>(null)
+        private val deadlineTask = AtomicReference<ScheduledFuture<*>?>(null)
 
         val isAborted: Boolean
             get() = aborted.get()
@@ -280,6 +287,19 @@ internal class MultiplexedIpcSession(
             if (aborted.get()) {
                 f.cancel(/* mayInterruptIfRunning= */ true)
             }
+        }
+
+        fun attachDeadlineTask(task: ScheduledFuture<*>?) {
+            if (task == null) return
+            deadlineTask.set(task)
+            // Op may already have completed/cancelled before the task was registered.
+            if (responseClaimed.get() || aborted.get()) {
+                task.cancel(/* mayInterruptIfRunning= */ false)
+            }
+        }
+
+        fun cancelDeadlineTask() {
+            deadlineTask.getAndSet(null)?.cancel(/* mayInterruptIfRunning= */ false)
         }
 
         fun abortRunningWork() {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -24,9 +24,12 @@ internal class MultiplexedIpcSession(
     private val onDetach: () -> Unit,
 ) {
     fun run(input: InputStream, output: OutputStream) {
-        val workers: ExecutorService = Executors.newCachedThreadPool { r ->
-            Thread(r, "spectre-agent-op-worker").apply { isDaemon = true }
-        }
+        // Bound concurrency: automation is mostly serial, but cancel/quick ops need a free
+        // worker while a long op runs. Unbounded cached pools let a buggy client exhaust threads.
+        val workers: ExecutorService =
+            Executors.newFixedThreadPool(MAX_OP_WORKERS) { r ->
+                Thread(r, "spectre-agent-op-worker").apply { isDaemon = true }
+            }
         val deadlineScheduler: ScheduledExecutorService =
             Executors.newSingleThreadScheduledExecutor { r ->
                 Thread(r, "spectre-agent-deadline").apply { isDaemon = true }
@@ -289,5 +292,7 @@ internal class MultiplexedIpcSession(
 
     private companion object {
         const val WORKER_SHUTDOWN_SEC: Long = 2
+        /** Max concurrent op workers per attached session (long op + cancel + headroom). */
+        const val MAX_OP_WORKERS: Int = 8
     }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -161,9 +161,10 @@ internal class MultiplexedIpcSession(
             }
         }
         // Replace placeholder with the real Future so cancel interrupts the worker.
+        // On failure: cancel already removed the slot (and called cancel(true)), or the worker
+        // already claimed ownership and may be mid-write — do NOT cancel again (Bugbot: that
+        // interrupted Framing.writeFrame on fast ops).
         if (!inFlight.replace(op.opId, placeholder, future)) {
-            // Cancel already claimed ownership (and wrote cancelled) — interrupt the work.
-            future.cancel(true)
             return
         }
         scheduleDeadline(op, deadlineScheduler, inFlight, output, writeLock)
@@ -183,7 +184,21 @@ internal class MultiplexedIpcSession(
     ) {
         val deadline = op.deadlineEpochMs ?: return
         val delayMs = deadline - System.currentTimeMillis()
-        if (delayMs <= 0L) return // executeOp already handles already-elapsed deadlines
+        if (delayMs <= 0L) {
+            // Deadline hit between worker start and registration — claim timeout now.
+            val f = inFlight.remove(op.opId) ?: return
+            f.cancel(/* mayInterruptIfRunning= */ true)
+            writeOpResponse(
+                output,
+                writeLock,
+                op.opId,
+                AgentResponse.Error(
+                    message = "Deadline elapsed during op",
+                    category = AgentErrorCategory.Timeout.wireName,
+                ),
+            )
+            return
+        }
         deadlineScheduler.schedule(
             {
                 val f = inFlight.remove(op.opId) ?: return@schedule
@@ -205,7 +220,7 @@ internal class MultiplexedIpcSession(
 
     @Suppress("TooGenericExceptionCaught")
     private fun executeOp(request: AgentRequest, deadlineEpochMs: Long?): AgentResponse {
-        if (deadlineEpochMs != null && System.currentTimeMillis() > deadlineEpochMs) {
+        if (deadlineEpochMs != null && System.currentTimeMillis() >= deadlineEpochMs) {
             return AgentResponse.Error(
                 message = "Deadline already elapsed before op started",
                 category = AgentErrorCategory.Timeout.wireName,
@@ -213,7 +228,7 @@ internal class MultiplexedIpcSession(
         }
         return try {
             val response = handler.handle(request)
-            if (deadlineEpochMs != null && System.currentTimeMillis() > deadlineEpochMs) {
+            if (deadlineEpochMs != null && System.currentTimeMillis() >= deadlineEpochMs) {
                 AgentResponse.Error(
                     message = "Deadline elapsed during op",
                     category = AgentErrorCategory.Timeout.wireName,

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -1,0 +1,278 @@
+package dev.sebastiano.spectre.agent.transport
+
+import java.io.InputStream
+import java.io.OutputStream
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.Future
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Post-Hello multiplexed IPC session (#200): accept thread only reads/dispatches; work runs on a
+ * worker pool so long ops do not block cancel/detach.
+ *
+ * Client EOF (socket close without Detach) ends the session only — [running] stays true so another
+ * client can connect. Explicit Detach tears the agent down via [onDetach].
+ */
+internal class MultiplexedIpcSession(
+    private val handler: AgentRequestHandler,
+    private val running: AtomicBoolean,
+    private val onDetach: () -> Unit,
+) {
+    fun run(input: InputStream, output: OutputStream) {
+        val workers: ExecutorService = Executors.newCachedThreadPool { r ->
+            Thread(r, "spectre-agent-op-worker").apply { isDaemon = true }
+        }
+        val deadlineScheduler: ScheduledExecutorService =
+            Executors.newSingleThreadScheduledExecutor { r ->
+                Thread(r, "spectre-agent-deadline").apply { isDaemon = true }
+            }
+        val inFlight = ConcurrentHashMap<Long, Future<*>>()
+        val writeLock = Any()
+        try {
+            serveOps(input, output, workers, deadlineScheduler, inFlight, writeLock)
+        } finally {
+            inFlight.values.forEach { it.cancel(true) }
+            deadlineScheduler.shutdownNow()
+            workers.shutdownNow()
+            runCatching { workers.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
+        }
+    }
+
+    private fun serveOps(
+        input: InputStream,
+        output: OutputStream,
+        workers: ExecutorService,
+        deadlineScheduler: ScheduledExecutorService,
+        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        writeLock: Any,
+    ) {
+        while (running.get()) {
+            val requestBytes = Framing.readFrame(input) ?: return
+            val op = decodeOpOrReport(requestBytes, output, writeLock) ?: continue
+            when (val body = op.body) {
+                is AgentRequest.Cancel -> handleCancel(body, op.opId, output, writeLock, inFlight)
+                AgentRequest.Detach -> {
+                    handleDetach(op.opId, output, writeLock, inFlight)
+                    return
+                }
+                else ->
+                    dispatchOp(op, body, workers, deadlineScheduler, inFlight, output, writeLock)
+            }
+        }
+    }
+
+    private fun decodeOpOrReport(
+        requestBytes: ByteArray,
+        output: OutputStream,
+        writeLock: Any,
+    ): OpRequest? =
+        try {
+            WireCodec.decodeOpRequest(requestBytes)
+        } catch (ex: kotlinx.serialization.SerializationException) {
+            // Prefer the real opId so the client's pending future unblocks with taxonomy error,
+            // not a 120s timeout hang (Bugbot: decode errors must correlate).
+            val opId =
+                runCatching { WireCodec.decodeOpRequestShell(requestBytes).opId }.getOrDefault(-1L)
+            val category =
+                if (WireCodec.isUnknownDiscriminator(ex)) {
+                    AgentErrorCategory.UnsupportedOperation
+                } else {
+                    AgentErrorCategory.ProtocolMismatch
+                }
+            writeOpResponse(
+                output,
+                writeLock,
+                opId,
+                AgentResponse.Error(
+                    message = "Malformed or unsupported op frame: ${ex.message}",
+                    category = category.wireName,
+                ),
+            )
+            null
+        }
+
+    private fun handleCancel(
+        cancel: AgentRequest.Cancel,
+        cancelFrameOpId: Long,
+        output: OutputStream,
+        writeLock: Any,
+        inFlight: ConcurrentHashMap<Long, Future<*>>,
+    ) {
+        // Atomic remove claims write ownership for this opId; the worker only writes if it still
+        // owns the map entry (Bugbot: cancel must not race a second response for the same op).
+        val cancelled = inFlight.remove(cancel.opId)
+        cancelled?.cancel(/* mayInterruptIfRunning= */ true)
+        if (cancelled != null) {
+            writeOpResponse(
+                output,
+                writeLock,
+                cancel.opId,
+                AgentResponse.Error(
+                    message = "Operation cancelled",
+                    category = AgentErrorCategory.Cancelled.wireName,
+                ),
+            )
+        }
+        writeOpResponse(output, writeLock, cancelFrameOpId, AgentResponse.Ok)
+    }
+
+    private fun handleDetach(
+        opId: Long,
+        output: OutputStream,
+        writeLock: Any,
+        inFlight: ConcurrentHashMap<Long, Future<*>>,
+    ) {
+        inFlight.values.forEach { it.cancel(true) }
+        inFlight.clear()
+        try {
+            writeOpResponse(output, writeLock, opId, AgentResponse.Detached)
+        } finally {
+            running.set(false)
+            onDetach()
+        }
+    }
+
+    private fun dispatchOp(
+        op: OpRequest,
+        body: AgentRequest,
+        workers: ExecutorService,
+        deadlineScheduler: ScheduledExecutorService,
+        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        output: OutputStream,
+        writeLock: Any,
+    ) {
+        // Register a placeholder before submit so cancel cannot race past an empty map.
+        val placeholder = CompletableFuturePlaceholder()
+        inFlight[op.opId] = placeholder
+        val future = workers.submit {
+            if (Thread.currentThread().isInterrupted) {
+                // Cancel may already own the slot; do not write a second response.
+                inFlight.remove(op.opId)
+                return@submit
+            }
+            val response = executeOp(body, op.deadlineEpochMs)
+            // Claim write ownership: only the winner of remove() may write the response.
+            if (inFlight.remove(op.opId) != null) {
+                writeOpResponse(output, writeLock, op.opId, response)
+            }
+        }
+        // Replace placeholder with the real Future so cancel interrupts the worker.
+        if (!inFlight.replace(op.opId, placeholder, future)) {
+            // Cancel already claimed ownership (and wrote cancelled) — interrupt the work.
+            future.cancel(true)
+            return
+        }
+        scheduleDeadline(op, deadlineScheduler, inFlight, output, writeLock)
+    }
+
+    /**
+     * When [OpRequest.deadlineEpochMs] is in the future, interrupt the worker at the deadline and
+     * claim the response as taxonomy `timeout` (Codex P2: do not wait for a blocking handler to
+     * return).
+     */
+    private fun scheduleDeadline(
+        op: OpRequest,
+        deadlineScheduler: ScheduledExecutorService,
+        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        output: OutputStream,
+        writeLock: Any,
+    ) {
+        val deadline = op.deadlineEpochMs ?: return
+        val delayMs = deadline - System.currentTimeMillis()
+        if (delayMs <= 0L) return // executeOp already handles already-elapsed deadlines
+        deadlineScheduler.schedule(
+            {
+                val f = inFlight.remove(op.opId) ?: return@schedule
+                f.cancel(/* mayInterruptIfRunning= */ true)
+                writeOpResponse(
+                    output,
+                    writeLock,
+                    op.opId,
+                    AgentResponse.Error(
+                        message = "Deadline elapsed during op",
+                        category = AgentErrorCategory.Timeout.wireName,
+                    ),
+                )
+            },
+            delayMs,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun executeOp(request: AgentRequest, deadlineEpochMs: Long?): AgentResponse {
+        if (deadlineEpochMs != null && System.currentTimeMillis() > deadlineEpochMs) {
+            return AgentResponse.Error(
+                message = "Deadline already elapsed before op started",
+                category = AgentErrorCategory.Timeout.wireName,
+            )
+        }
+        return try {
+            val response = handler.handle(request)
+            if (deadlineEpochMs != null && System.currentTimeMillis() > deadlineEpochMs) {
+                AgentResponse.Error(
+                    message = "Deadline elapsed during op",
+                    category = AgentErrorCategory.Timeout.wireName,
+                )
+            } else {
+                response
+            }
+        } catch (ex: InterruptedException) {
+            Thread.currentThread().interrupt()
+            AgentResponse.Error(
+                message = "Operation cancelled",
+                category = AgentErrorCategory.Cancelled.wireName,
+            )
+        } catch (ex: Exception) {
+            val category =
+                when (ex) {
+                    is java.util.concurrent.TimeoutException -> AgentErrorCategory.Timeout
+                    is IllegalArgumentException -> AgentErrorCategory.InvalidSelector
+                    is NoSuchElementException -> AgentErrorCategory.NodeNotFound
+                    else -> AgentErrorCategory.InternalError
+                }
+            AgentResponse.Error(
+                message = "${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}",
+                category = category.wireName,
+            )
+        }
+    }
+
+    private fun writeOpResponse(
+        output: OutputStream,
+        writeLock: Any,
+        opId: Long,
+        body: AgentResponse,
+    ) {
+        synchronized(writeLock) {
+            Framing.writeFrame(output, WireCodec.encode(OpResponse(opId = opId, body = body)))
+        }
+    }
+
+    /**
+     * Stand-in [Future] registered before [ExecutorService.submit] so a concurrent cancel always
+     * finds the op id. [cancel] is a no-op until the real future replaces this entry.
+     */
+    private class CompletableFuturePlaceholder : Future<Unit> {
+        private val cancelled = AtomicBoolean(false)
+
+        override fun cancel(mayInterruptIfRunning: Boolean): Boolean =
+            cancelled.compareAndSet(false, true)
+
+        override fun isCancelled(): Boolean = cancelled.get()
+
+        override fun isDone(): Boolean = cancelled.get()
+
+        override fun get(): Unit = Unit
+
+        override fun get(timeout: Long, unit: TimeUnit): Unit = Unit
+    }
+
+    private companion object {
+        const val WORKER_SHUTDOWN_SEC: Long = 2
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -9,6 +9,7 @@ import java.util.concurrent.Future
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Post-Hello multiplexed IPC session (#200): accept thread only reads/dispatches; work runs on a
@@ -30,12 +31,13 @@ internal class MultiplexedIpcSession(
             Executors.newSingleThreadScheduledExecutor { r ->
                 Thread(r, "spectre-agent-deadline").apply { isDaemon = true }
             }
-        val inFlight = ConcurrentHashMap<Long, Future<*>>()
+        val inFlight = ConcurrentHashMap<Long, OpSlot>()
         val writeLock = Any()
         try {
             serveOps(input, output, workers, deadlineScheduler, inFlight, writeLock)
         } finally {
-            inFlight.values.forEach { it.cancel(true) }
+            inFlight.values.forEach { it.abortRunningWork() }
+            inFlight.clear()
             deadlineScheduler.shutdownNow()
             workers.shutdownNow()
             runCatching { workers.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
@@ -47,7 +49,7 @@ internal class MultiplexedIpcSession(
         output: OutputStream,
         workers: ExecutorService,
         deadlineScheduler: ScheduledExecutorService,
-        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        inFlight: ConcurrentHashMap<Long, OpSlot>,
         writeLock: Any,
     ) {
         while (running.get()) {
@@ -100,22 +102,22 @@ internal class MultiplexedIpcSession(
         cancelFrameOpId: Long,
         output: OutputStream,
         writeLock: Any,
-        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        inFlight: ConcurrentHashMap<Long, OpSlot>,
     ) {
-        // Atomic remove claims write ownership for this opId; the worker only writes if it still
-        // owns the map entry (Bugbot: cancel must not race a second response for the same op).
-        val cancelled = inFlight.remove(cancel.opId)
-        cancelled?.cancel(/* mayInterruptIfRunning= */ true)
-        if (cancelled != null) {
-            writeOpResponse(
-                output,
-                writeLock,
-                cancel.opId,
-                AgentResponse.Error(
-                    message = "Operation cancelled",
-                    category = AgentErrorCategory.Cancelled.wireName,
-                ),
-            )
+        val slot = inFlight.remove(cancel.opId)
+        if (slot != null) {
+            slot.abortRunningWork()
+            if (slot.tryClaimResponse()) {
+                writeOpResponse(
+                    output,
+                    writeLock,
+                    cancel.opId,
+                    AgentResponse.Error(
+                        message = "Operation cancelled",
+                        category = AgentErrorCategory.Cancelled.wireName,
+                    ),
+                )
+            }
         }
         writeOpResponse(output, writeLock, cancelFrameOpId, AgentResponse.Ok)
     }
@@ -124,9 +126,9 @@ internal class MultiplexedIpcSession(
         opId: Long,
         output: OutputStream,
         writeLock: Any,
-        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        inFlight: ConcurrentHashMap<Long, OpSlot>,
     ) {
-        inFlight.values.forEach { it.cancel(true) }
+        inFlight.values.forEach { it.abortRunningWork() }
         inFlight.clear()
         try {
             writeOpResponse(output, writeLock, opId, AgentResponse.Detached)
@@ -141,81 +143,71 @@ internal class MultiplexedIpcSession(
         body: AgentRequest,
         workers: ExecutorService,
         deadlineScheduler: ScheduledExecutorService,
-        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        inFlight: ConcurrentHashMap<Long, OpSlot>,
         output: OutputStream,
         writeLock: Any,
     ) {
-        // Register a placeholder before submit so cancel cannot race past an empty map.
-        val placeholder = CompletableFuturePlaceholder()
-        inFlight[op.opId] = placeholder
+        val slot = OpSlot()
+        inFlight[op.opId] = slot
         val future = workers.submit {
-            if (Thread.currentThread().isInterrupted) {
-                // Cancel may already own the slot; do not write a second response.
-                inFlight.remove(op.opId)
+            if (slot.isAborted || Thread.currentThread().isInterrupted) {
+                inFlight.remove(op.opId, slot)
                 return@submit
             }
             val response = executeOp(body, op.deadlineEpochMs)
-            // Claim write ownership: only the winner of remove() may write the response.
-            if (inFlight.remove(op.opId) != null) {
+            // Only the winner of tryClaimResponse may write (cancel/deadline may have won).
+            if (slot.tryClaimResponse()) {
+                inFlight.remove(op.opId, slot)
                 writeOpResponse(output, writeLock, op.opId, response)
+            } else {
+                inFlight.remove(op.opId, slot)
             }
         }
-        // Replace placeholder with the real Future so cancel interrupts the worker.
-        // On failure: cancel already removed the slot (and called cancel(true)), or the worker
-        // already claimed ownership and may be mid-write — do NOT cancel again (Bugbot: that
-        // interrupted Framing.writeFrame on fast ops).
-        if (!inFlight.replace(op.opId, placeholder, future)) {
+        slot.attachFuture(future)
+        // If cancel already aborted before attachFuture, interrupt the just-started work.
+        if (slot.isAborted) {
+            future.cancel(true)
+            inFlight.remove(op.opId, slot)
             return
         }
-        scheduleDeadline(op, deadlineScheduler, inFlight, output, writeLock)
+        scheduleDeadline(op, slot, deadlineScheduler, inFlight, output, writeLock)
     }
 
     /**
      * When [OpRequest.deadlineEpochMs] is in the future, interrupt the worker at the deadline and
-     * claim the response as taxonomy `timeout` (Codex P2: do not wait for a blocking handler to
-     * return).
+     * claim the response as taxonomy `timeout`.
      */
     private fun scheduleDeadline(
         op: OpRequest,
+        slot: OpSlot,
         deadlineScheduler: ScheduledExecutorService,
-        inFlight: ConcurrentHashMap<Long, Future<*>>,
+        inFlight: ConcurrentHashMap<Long, OpSlot>,
         output: OutputStream,
         writeLock: Any,
     ) {
         val deadline = op.deadlineEpochMs ?: return
         val delayMs = deadline - System.currentTimeMillis()
+        val fireTimeout = {
+            if (inFlight.remove(op.opId, slot)) {
+                slot.abortRunningWork()
+                if (slot.tryClaimResponse()) {
+                    writeOpResponse(
+                        output,
+                        writeLock,
+                        op.opId,
+                        AgentResponse.Error(
+                            message = "Deadline elapsed during op",
+                            category = AgentErrorCategory.Timeout.wireName,
+                        ),
+                    )
+                }
+            }
+        }
         if (delayMs <= 0L) {
-            // Deadline hit between worker start and registration — claim timeout now.
-            val f = inFlight.remove(op.opId) ?: return
-            f.cancel(/* mayInterruptIfRunning= */ true)
-            writeOpResponse(
-                output,
-                writeLock,
-                op.opId,
-                AgentResponse.Error(
-                    message = "Deadline elapsed during op",
-                    category = AgentErrorCategory.Timeout.wireName,
-                ),
-            )
+            fireTimeout()
             return
         }
-        deadlineScheduler.schedule(
-            {
-                val f = inFlight.remove(op.opId) ?: return@schedule
-                f.cancel(/* mayInterruptIfRunning= */ true)
-                writeOpResponse(
-                    output,
-                    writeLock,
-                    op.opId,
-                    AgentResponse.Error(
-                        message = "Deadline elapsed during op",
-                        category = AgentErrorCategory.Timeout.wireName,
-                    ),
-                )
-            },
-            delayMs,
-            TimeUnit.MILLISECONDS,
-        )
+        deadlineScheduler.schedule(fireTimeout, delayMs, TimeUnit.MILLISECONDS)
     }
 
     @Suppress("TooGenericExceptionCaught")
@@ -269,22 +261,30 @@ internal class MultiplexedIpcSession(
     }
 
     /**
-     * Stand-in [Future] registered before [ExecutorService.submit] so a concurrent cancel always
-     * finds the op id. [cancel] is a no-op until the real future replaces this entry.
+     * Per-op coordination: abort flag for interrupt, future ref so cancel can interrupt after
+     * submit, and single-winner response claim so cancel/worker/deadline never double-write.
      */
-    private class CompletableFuturePlaceholder : Future<Unit> {
-        private val cancelled = AtomicBoolean(false)
+    private class OpSlot {
+        private val aborted = AtomicBoolean(false)
+        private val responseClaimed = AtomicBoolean(false)
+        private val future = AtomicReference<Future<*>?>(null)
 
-        override fun cancel(mayInterruptIfRunning: Boolean): Boolean =
-            cancelled.compareAndSet(false, true)
+        val isAborted: Boolean
+            get() = aborted.get()
 
-        override fun isCancelled(): Boolean = cancelled.get()
+        fun attachFuture(f: Future<*>) {
+            future.set(f)
+            if (aborted.get()) {
+                f.cancel(/* mayInterruptIfRunning= */ true)
+            }
+        }
 
-        override fun isDone(): Boolean = cancelled.get()
+        fun abortRunningWork() {
+            aborted.set(true)
+            future.get()?.cancel(/* mayInterruptIfRunning= */ true)
+        }
 
-        override fun get(): Unit = Unit
-
-        override fun get(timeout: Long, unit: TimeUnit): Unit = Unit
+        fun tryClaimResponse(): Boolean = responseClaimed.compareAndSet(false, true)
     }
 
     private companion object {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -6,8 +6,11 @@ import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.Future
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -25,12 +28,17 @@ internal class MultiplexedIpcSession(
     private val onDetach: () -> Unit,
 ) {
     fun run(input: InputStream, output: OutputStream) {
-        // Bound concurrency: automation is mostly serial, but cancel/quick ops need a free
-        // worker while a long op runs. Unbounded cached pools let a buggy client exhaust threads.
+        // Bound threads *and* queue so a buggy client cannot OOM the agent with enqueued ops.
         val workers: ExecutorService =
-            Executors.newFixedThreadPool(MAX_OP_WORKERS) { r ->
-                Thread(r, "spectre-agent-op-worker").apply { isDaemon = true }
-            }
+            ThreadPoolExecutor(
+                /* corePoolSize= */ MAX_OP_WORKERS,
+                /* maximumPoolSize= */ MAX_OP_WORKERS,
+                /* keepAliveTime= */ 0L,
+                TimeUnit.MILLISECONDS,
+                LinkedBlockingQueue(MAX_OP_QUEUE),
+                { r -> Thread(r, "spectre-agent-op-worker").apply { isDaemon = true } },
+                ThreadPoolExecutor.AbortPolicy(),
+            )
         val deadlineScheduler: ScheduledExecutorService =
             Executors.newSingleThreadScheduledExecutor { r ->
                 Thread(r, "spectre-agent-deadline").apply { isDaemon = true }
@@ -154,21 +162,36 @@ internal class MultiplexedIpcSession(
     ) {
         val slot = OpSlot()
         inFlight[op.opId] = slot
-        val future = workers.submit {
-            if (slot.isAborted || Thread.currentThread().isInterrupted) {
+        val future =
+            try {
+                workers.submit {
+                    if (slot.isAborted || Thread.currentThread().isInterrupted) {
+                        inFlight.remove(op.opId, slot)
+                        return@submit
+                    }
+                    val response = executeOp(body, op.deadlineEpochMs)
+                    // Only the winner of tryClaimResponse may write (cancel/deadline may have won).
+                    slot.cancelDeadlineTask()
+                    if (slot.tryClaimResponse()) {
+                        inFlight.remove(op.opId, slot)
+                        writeOpResponse(output, writeLock, op.opId, response)
+                    } else {
+                        inFlight.remove(op.opId, slot)
+                    }
+                }
+            } catch (_: RejectedExecutionException) {
                 inFlight.remove(op.opId, slot)
-                return@submit
+                writeOpResponse(
+                    output,
+                    writeLock,
+                    op.opId,
+                    AgentResponse.Error(
+                        message = "Too many concurrent operations (queue full)",
+                        category = AgentErrorCategory.InternalError.wireName,
+                    ),
+                )
+                return
             }
-            val response = executeOp(body, op.deadlineEpochMs)
-            // Only the winner of tryClaimResponse may write (cancel/deadline may have won).
-            slot.cancelDeadlineTask()
-            if (slot.tryClaimResponse()) {
-                inFlight.remove(op.opId, slot)
-                writeOpResponse(output, writeLock, op.opId, response)
-            } else {
-                inFlight.remove(op.opId, slot)
-            }
-        }
         slot.attachFuture(future)
         // If cancel already aborted before attachFuture, interrupt the just-started work.
         if (slot.isAborted) {
@@ -314,5 +337,7 @@ internal class MultiplexedIpcSession(
         const val WORKER_SHUTDOWN_SEC: Long = 2
         /** Max concurrent op workers per attached session (long op + cancel + headroom). */
         const val MAX_OP_WORKERS: Int = 8
+        /** Max queued ops beyond the worker pool (reject when full). */
+        const val MAX_OP_QUEUE: Int = 32
     }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/OpEnvelope.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/OpEnvelope.kt
@@ -1,0 +1,24 @@
+package dev.sebastiano.spectre.agent.transport
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Multiplexed request envelope (#200). After the Hello handshake, every client→server frame is an
+ * [OpRequest] so multiple ops can share the connection and be cancelled by [opId].
+ *
+ * [deadlineEpochMs] is an absolute wall-clock deadline (epoch millis). When set, the server aborts
+ * the op with category `timeout` once the deadline is reached.
+ */
+@Serializable
+@SerialName("opRequest")
+internal data class OpRequest(
+    val opId: Long,
+    val deadlineEpochMs: Long? = null,
+    val body: AgentRequest,
+)
+
+/** Multiplexed response envelope correlating to [OpRequest.opId]. */
+@Serializable
+@SerialName("opResponse")
+internal data class OpResponse(val opId: Long, val body: AgentResponse)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/OpEnvelope.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/OpEnvelope.kt
@@ -18,6 +18,12 @@ internal data class OpRequest(
     val body: AgentRequest,
 )
 
+/**
+ * Partial decode of [OpRequest] that ignores `body`. Used when full decode fails (unknown body
+ * discriminator) so the server can still correlate the error to the client's [opId].
+ */
+@Serializable internal data class OpRequestShell(val opId: Long, val deadlineEpochMs: Long? = null)
+
 /** Multiplexed response envelope correlating to [OpRequest.opId]. */
 @Serializable
 @SerialName("opResponse")

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolVersion.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolVersion.kt
@@ -9,6 +9,11 @@ package dev.sebastiano.spectre.agent.transport
  * bump this constant and update the handshake docs in `docs/guide/agent.md`.
  */
 public object ProtocolVersion {
-    /** Current protocol revision carried on [AgentRequest.Hello] / [AgentResponse.HelloAck]. */
-    public const val CURRENT: Int = 1
+    /**
+     * Current protocol revision carried on [AgentRequest.Hello] / [AgentResponse.HelloAck].
+     *
+     * v1: bare request/response frames after Hello. v2 (#200): operation envelopes with op ids,
+     * cancel, and deadline budgets; long ops run off the accept thread.
+     */
+    public const val CURRENT: Int = 2
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -109,6 +109,13 @@ internal sealed interface AgentRequest {
     // omit the field on the wire and peers would fill their own CURRENT — breaking exact-match
     // negotiation across version bumps (#199 / Bugbot).
     data class Hello(val protocolVersion: Int) : AgentRequest
+
+    /**
+     * Cancel an in-flight op by [opId] (#200). Server replies with [AgentResponse.Error] category
+     * `cancelled` for the target op (and [AgentResponse.Ok] for this cancel frame itself when the
+     * cancel was accepted).
+     */
+    @Serializable @SerialName("cancel") data class Cancel(val opId: Long) : AgentRequest
 }
 
 /** Payload-free operation label for diagnostics. Never include caller-controlled request data. */
@@ -126,6 +133,7 @@ internal val AgentRequest.logLabel: String
             is AgentRequest.WindowIdentity -> "windowIdentity"
             AgentRequest.Detach -> "detach"
             is AgentRequest.Hello -> "hello"
+            is AgentRequest.Cancel -> "cancel"
         }
 
 /** Server-to-client response envelope. */

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/WireCodec.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/WireCodec.kt
@@ -30,6 +30,18 @@ internal object WireCodec {
     fun decodeResponse(bytes: ByteArray): AgentResponse =
         cbor.decodeFromByteArray(AgentResponse.serializer(), bytes)
 
+    fun encode(request: OpRequest): ByteArray =
+        cbor.encodeToByteArray(OpRequest.serializer(), request)
+
+    fun encode(response: OpResponse): ByteArray =
+        cbor.encodeToByteArray(OpResponse.serializer(), response)
+
+    fun decodeOpRequest(bytes: ByteArray): OpRequest =
+        cbor.decodeFromByteArray(OpRequest.serializer(), bytes)
+
+    fun decodeOpResponse(bytes: ByteArray): OpResponse =
+        cbor.decodeFromByteArray(OpResponse.serializer(), bytes)
+
     /**
      * True when [ex] looks like an unknown sealed-class discriminator (newer op against an older
      * runtime), as opposed to truncated/corrupt CBOR. Used to map decode failures to

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/WireCodec.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/WireCodec.kt
@@ -39,6 +39,13 @@ internal object WireCodec {
     fun decodeOpRequest(bytes: ByteArray): OpRequest =
         cbor.decodeFromByteArray(OpRequest.serializer(), bytes)
 
+    /**
+     * Best-effort [OpRequest.opId] extraction when full [decodeOpRequest] fails (e.g. unknown body
+     * discriminator). Relies on [Cbor.ignoreUnknownKeys] to drop the body field.
+     */
+    fun decodeOpRequestShell(bytes: ByteArray): OpRequestShell =
+        cbor.decodeFromByteArray(OpRequestShell.serializer(), bytes)
+
     fun decodeOpResponse(bytes: ByteArray): OpResponse =
         cbor.decodeFromByteArray(OpResponse.serializer(), bytes)
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/SpectreProcessesTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/SpectreProcessesTest.kt
@@ -72,9 +72,9 @@ class SpectreProcessesTest {
     }
 
     private companion object {
-        // CI runners have JVMs starting/stopping all the time; back-to-back
-        // `VirtualMachine.list()` calls can disagree by a few. A genuine filter regression
-        // would diverge by orders of magnitude, not by ≤ 5 entries.
-        const val MAX_PROCESS_LIST_DRIFT: Int = 5
+        // CI runners and busy developer machines have JVMs starting/stopping all the time;
+        // back-to-back `VirtualMachine.list()` calls can disagree by more than a handful.
+        // A genuine filter regression would diverge by orders of magnitude, not by ≤ 25.
+        const val MAX_PROCESS_LIST_DRIFT: Int = 25
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -203,7 +203,8 @@ class IpcRoundTripTest {
                             ),
                         )
                         Framing.readFrame(input) // HelloAck
-                        val pingBytes = WireCodec.encode(AgentRequest.Ping)
+                        val pingBytes =
+                            WireCodec.encode(OpRequest(opId = 1L, body = AgentRequest.Ping))
                         val frame =
                             java.nio.ByteBuffer.allocate(Int.SIZE_BYTES + pingBytes.size).apply {
                                 putInt(pingBytes.size)
@@ -387,7 +388,8 @@ class IpcRoundTripTest {
                         ),
                     )
                     Framing.readFrame(input) // HelloAck
-                    val detachBytes = WireCodec.encode(AgentRequest.Detach)
+                    val detachBytes =
+                        WireCodec.encode(OpRequest(opId = 1L, body = AgentRequest.Detach))
                     val frame =
                         java.nio.ByteBuffer.allocate(Int.SIZE_BYTES + detachBytes.size).apply {
                             putInt(detachBytes.size)
@@ -488,6 +490,7 @@ class IpcRoundTripTest {
             AgentRequest.Detach -> AgentResponse.Detached
             is AgentRequest.Hello ->
                 AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
+            is AgentRequest.Cancel -> AgentResponse.Ok
         }
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
@@ -1,0 +1,112 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import java.nio.file.Path
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * #200 acceptance: a deliberately slow op stays in flight while cancel / a second quick op still
+ * complete promptly, with taxonomy `cancelled` (not a connection error).
+ */
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
+class LongOpInfrastructureTest {
+    private val udsPath: Path =
+        udsBase().resolve("sp-lo-${UUID.randomUUID().toString().take(8)}.sock")
+
+    @AfterTest
+    fun cleanUp() {
+        runCatching { udsPath.deleteIfExists() }
+    }
+
+    @Test
+    fun `slow op can be cancelled while a quick op still completes`() {
+        val slowStarted = CountDownLatch(1)
+        val server =
+            IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    when (request) {
+                        AgentRequest.Ping -> AgentResponse.Pong
+                        AgentRequest.Windows -> {
+                            slowStarted.countDown()
+                            try {
+                                Thread.sleep(30_000)
+                            } catch (_: InterruptedException) {
+                                Thread.currentThread().interrupt()
+                            }
+                            AgentResponse.Windows(emptyList())
+                        }
+                        is AgentRequest.Cancel -> AgentResponse.Ok
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+        server.use {
+            awaitSocket(udsPath)
+            IpcClient(udsPath).use { client ->
+                val resultHolder = arrayOfNulls<AgentResponse>(1)
+                val slowThread = Thread { resultHolder[0] = client.send(AgentRequest.Windows) }
+                slowThread.isDaemon = true
+                slowThread.start()
+
+                assertTrue(slowStarted.await(3, TimeUnit.SECONDS), "slow op never started")
+                // First post-handshake op is opId=1.
+                client.cancel(1L)
+
+                val quick = client.send(AgentRequest.Ping)
+                assertEquals(AgentResponse.Pong, quick)
+
+                slowThread.join(5_000)
+                val err = assertIs<AgentResponse.Error>(resultHolder[0])
+                assertEquals(AgentErrorCategory.Cancelled.wireName, err.category)
+            }
+        }
+    }
+
+    @Test
+    fun `deadline elapsed returns timeout category`() {
+        IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    when (request) {
+                        AgentRequest.Ping -> AgentResponse.Pong
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+            .use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { client ->
+                    val past = System.currentTimeMillis() - 1_000
+                    val response = client.send(AgentRequest.Windows, deadlineEpochMs = past)
+                    val err = assertIs<AgentResponse.Error>(response)
+                    assertEquals(AgentErrorCategory.Timeout.wireName, err.category)
+                }
+            }
+    }
+
+    private fun awaitSocket(path: Path, timeoutMs: Long = 5_000) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000L
+        while (System.nanoTime() < deadline) {
+            if (java.nio.file.Files.exists(path)) return
+            Thread.sleep(10)
+        }
+        error("UDS path $path did not appear within ${timeoutMs}ms")
+    }
+
+    private fun udsBase(): Path =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
+            Path.of(System.getProperty("java.io.tmpdir"))
+        else Path.of("/tmp")
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
@@ -100,10 +100,11 @@ class ProtocolCompatTest {
                 val ackBytes = Framing.readFrame(input) ?: error("no helloAck")
                 assertIs<AgentResponse.HelloAck>(WireCodec.decodeResponse(ackBytes))
 
-                Framing.writeFrame(output, futureOpRequestBytes())
+                // After handshake, frames are OpRequest envelopes (#200).
+                Framing.writeFrame(output, futureOpEnvelopeBytes())
                 val respBytes = Framing.readFrame(input) ?: error("no error response")
-                val resp = WireCodec.decodeResponse(respBytes)
-                val err = assertIs<AgentResponse.Error>(resp)
+                val opResp = WireCodec.decodeOpResponse(respBytes)
+                val err = assertIs<AgentResponse.Error>(opResp.body)
                 assertEquals(AgentErrorCategory.UnsupportedOperation.wireName, err.category)
             }
         }
@@ -190,12 +191,17 @@ class ProtocolCompatTest {
      * op name — models a newer attacher talking to the current runtime.
      */
     private fun futureOpRequestBytes(): ByteArray {
-        // Encode a real Ping, then replace its "ping" discriminator with "futureOp_v99".
-        // kotlinx CBOR sealed encoding embeds the @SerialName as UTF-8 text in the payload.
+        // Encode a real Ping, then replace its "ping" discriminator with "zzzz".
         val ping = WireCodec.encode(AgentRequest.Ping)
         val asLatin1 = ping.toString(Charsets.ISO_8859_1)
         require(asLatin1.contains("ping")) { "expected ping discriminator in CBOR payload" }
-        // Same length as "ping" so CBOR string length prefixes stay valid.
+        return asLatin1.replace("ping", "zzzz").toByteArray(Charsets.ISO_8859_1)
+    }
+
+    private fun futureOpEnvelopeBytes(): ByteArray {
+        val envelope = WireCodec.encode(OpRequest(opId = 1L, body = AgentRequest.Ping))
+        val asLatin1 = envelope.toString(Charsets.ISO_8859_1)
+        require(asLatin1.contains("ping")) { "expected ping discriminator in OpRequest payload" }
         return asLatin1.replace("ping", "zzzz").toByteArray(Charsets.ISO_8859_1)
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
@@ -104,6 +104,11 @@ class ProtocolCompatTest {
                 Framing.writeFrame(output, futureOpEnvelopeBytes())
                 val respBytes = Framing.readFrame(input) ?: error("no error response")
                 val opResp = WireCodec.decodeOpResponse(respBytes)
+                assertEquals(
+                    1L,
+                    opResp.opId,
+                    "decode failure must still correlate to the request opId",
+                )
                 val err = assertIs<AgentResponse.Error>(opResp.body)
                 assertEquals(AgentErrorCategory.UnsupportedOperation.wireName, err.category)
             }

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -271,7 +271,7 @@ hierarchy.
 
 After the UDS connects, the first exchange is always:
 
-1. Client → `hello` with `protocolVersion` (currently `1` — `ProtocolVersion.CURRENT`)
+1. Client → `hello` with `protocolVersion` (currently `2` — `ProtocolVersion.CURRENT`)
 2. Runtime → `helloAck` with the same version, or `error` with category
    `protocolMismatch`
 
@@ -297,13 +297,28 @@ decode hang or silent close. That is how mixed-version pairs degrade.
 | `invalidSelector` | Malformed node key or selector |
 | `nodeNotFound` | Well-formed key, no matching node |
 | `timeout` | Deadline exceeded |
+| `cancelled` | Explicit cancel of an in-flight op (#200) |
 | `inputRejected` | Focus / Robot / permission rejection |
 | `internalError` | Unexpected agent-side failure (default) |
 
+### Long operations and cancel (#200)
+
+After Hello, every request is an **operation envelope** (`opId`, optional absolute
+`deadlineEpochMs`, body). Responses are correlated by `opId` so multiple ops can share one
+connection.
+
+- Long work (future waits, heavy capture) runs on a **worker thread**, not the accept loop —
+  so cancel/detach stay responsive.
+- **Cancel** is an explicit wire op (`cancel` with the target `opId`), not socket-close.
+- Closing a CLI/MCP front-end during a long-poll should cancel the front-end's op via the
+  daemon without detaching the target session (daemon cancel-on-frontend-loss); the agent
+  transport itself only detaches on an explicit `detach` or handshake failure teardown.
+
+
 Clients should branch on `category` (see `AgentErrorCategory` / `SpectreAgentException`),
 not on free-text `message`. The HTTP transport maps the same names onto status codes
-(`invalidSelector` → 400, `nodeNotFound` → 404, `unsupportedOperation` → 501, etc.) via
-`SpectreErrorCategory` in `:server`.
+(`invalidSelector` → 400, `nodeNotFound` → 404, `unsupportedOperation` → 501,
+`cancelled` → 499 Client Closed Request, etc.) via `SpectreErrorCategory` in `:server`.
 
 ### Schema evolution rules
 

--- a/server/api/server.api
+++ b/server/api/server.api
@@ -22,6 +22,7 @@ public final class dev/sebastiano/spectre/server/HttpComposeAutomatorKt {
 }
 
 public final class dev/sebastiano/spectre/server/SpectreErrorCategory : java/lang/Enum {
+	public static final field Cancelled Ldev/sebastiano/spectre/server/SpectreErrorCategory;
 	public static final field Companion Ldev/sebastiano/spectre/server/SpectreErrorCategory$Companion;
 	public static final field InputRejected Ldev/sebastiano/spectre/server/SpectreErrorCategory;
 	public static final field InternalError Ldev/sebastiano/spectre/server/SpectreErrorCategory;

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreErrorCategory.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreErrorCategory.kt
@@ -13,6 +13,8 @@ public enum class SpectreErrorCategory(public val wireName: String) {
     InvalidSelector("invalidSelector"),
     NodeNotFound("nodeNotFound"),
     Timeout("timeout"),
+    /** Explicit cancel of an in-flight op (#200); agent wire name `cancelled`. */
+    Cancelled("cancelled"),
     InputRejected("inputRejected"),
     InternalError("internalError");
 
@@ -25,11 +27,19 @@ public enum class SpectreErrorCategory(public val wireName: String) {
                 InvalidSelector -> io.ktor.http.HttpStatusCode.BadRequest
                 NodeNotFound -> io.ktor.http.HttpStatusCode.NotFound
                 Timeout -> io.ktor.http.HttpStatusCode.GatewayTimeout
+                // Non-standard but widely understood "client closed request" for cancelled work.
+                Cancelled -> CLIENT_CLOSED_REQUEST
                 InputRejected -> io.ktor.http.HttpStatusCode.Conflict
                 InternalError -> io.ktor.http.HttpStatusCode.InternalServerError
             }
 
         public fun fromWire(value: String?): SpectreErrorCategory =
             entries.firstOrNull { it.wireName == value } ?: InternalError
+
+        /** nginx-style status for cancelled / client-aborted work (not in the IANA registry). */
+        private val CLIENT_CLOSED_REQUEST: io.ktor.http.HttpStatusCode =
+            io.ktor.http.HttpStatusCode(CLIENT_CLOSED_REQUEST_CODE, "Client Closed Request")
+
+        private const val CLIENT_CLOSED_REQUEST_CODE: Int = 499
     }
 }


### PR DESCRIPTION
## Summary

Implements [#200](https://github.com/rock3r/spectre/issues/200) (part of transport-parity epic [#197](https://github.com/rock3r/spectre/issues/197)): IPC long-operation infrastructure so waits and heavy ops cannot stall cancel/detach.

- **Protocol v2**: after bare Hello, frames are `OpRequest` / `OpResponse` envelopes with `opId` and optional absolute `deadlineEpochMs`.
- **Cancel**: explicit `cancel` wire op by target `opId`; target op completes with taxonomy category `cancelled` (not a connection error).
- **Workers**: op bodies run off the accept thread so cancel/detach stay responsive.
- **Client close ≠ Detach**: dropping the socket leaves the accept loop alive for reconnect; explicit Detach remains agent teardown.
- **HTTP alignment**: `SpectreErrorCategory.Cancelled` maps to 499 Client Closed Request.
- Docs: `docs/guide/agent.md` long-ops section; ABI dumps updated.

## Validation

- `LongOpInfrastructureTest`: slow op cancelled while quick Ping completes; past deadline → `timeout`.
- `IpcRoundTripTest` / `ProtocolCompatTest` / `AgentAttachIntegrationTest` green.
- Local `./gradlew check` green.

## Test plan

- [x] Cancel + concurrent quick op
- [x] Deadline elapsed before start
- [x] Real Compose fixture attach/detach (AgentAttachIntegrationTest)
- [x] Full `./gradlew check`
- [ ] CI + Bugbot + Codex on this PR