### PR TITLE
Add payloadTooLarge taxonomy for oversize agent frames (#204)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -174,6 +174,7 @@ public final class dev/sebastiano/spectre/agent/transport/AgentErrorCategory : j
 	public static final field InternalError Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
 	public static final field InvalidSelector Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
 	public static final field NodeNotFound Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
+	public static final field PayloadTooLarge Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
 	public static final field ProtocolMismatch Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
 	public static final field Timeout Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;
 	public static final field UnsupportedOperation Ldev/sebastiano/spectre/agent/transport/AgentErrorCategory;

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/AgentErrorCategory.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/AgentErrorCategory.kt
@@ -32,6 +32,12 @@ public enum class AgentErrorCategory {
     /** Explicit cancel of an in-flight op (#200). */
     @SerialName("cancelled") Cancelled,
 
+    /**
+     * Response (or request) payload exceeds the framing hard limit ([MAX_FRAME_BYTES]) (#204).
+     * Deterministic fail-closed behaviour — never truncate or hang.
+     */
+    @SerialName("payloadTooLarge") PayloadTooLarge,
+
     /** Input was refused (focus, permissions, Robot backend rejection). */
     @SerialName("inputRejected") InputRejected,
 
@@ -48,6 +54,7 @@ public enum class AgentErrorCategory {
                 NodeNotFound -> "nodeNotFound"
                 Timeout -> "timeout"
                 Cancelled -> "cancelled"
+                PayloadTooLarge -> "payloadTooLarge"
                 InputRejected -> "inputRejected"
                 InternalError -> "internalError"
             }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -287,9 +287,26 @@ internal class MultiplexedIpcSession(
         opId: Long,
         body: AgentResponse,
     ) {
-        synchronized(writeLock) {
-            Framing.writeFrame(output, WireCodec.encode(OpResponse(opId = opId, body = body)))
-        }
+        val payload = WireCodec.encode(OpResponse(opId = opId, body = body))
+        val toWrite =
+            if (payload.size <= MAX_FRAME_BYTES) {
+                payload
+            } else {
+                // Fail closed with a small taxonomy error instead of throwing mid-write (#204).
+                WireCodec.encode(
+                    OpResponse(
+                        opId = opId,
+                        body =
+                            AgentResponse.Error(
+                                message =
+                                    "Response payload size ${payload.size} exceeds " +
+                                        "MAX_FRAME_BYTES=$MAX_FRAME_BYTES",
+                                category = AgentErrorCategory.PayloadTooLarge.wireName,
+                            ),
+                    )
+                )
+            }
+        synchronized(writeLock) { Framing.writeFrame(output, toWrite) }
     }
 
     /**

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/PayloadLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/PayloadLimitsTest.kt
@@ -1,0 +1,96 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * #204: oversized responses fail closed with taxonomy `payloadTooLarge`, never hang or truncate.
+ */
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
+class PayloadLimitsTest {
+    private val udsPath: Path =
+        udsBase().resolve("sp-pl-${UUID.randomUUID().toString().take(8)}.sock")
+
+    @AfterTest
+    fun cleanUp() {
+        runCatching { udsPath.deleteIfExists() }
+    }
+
+    @Test
+    fun `oversized screenshot response returns payloadTooLarge`() {
+        // A PNG larger than the frame budget once wrapped in OpResponse CBOR.
+        val hugePng = ByteArray(MAX_FRAME_BYTES) { 0xAB.toByte() }
+        IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    when (request) {
+                        is AgentRequest.Screenshot -> AgentResponse.Screenshot(pngBytes = hugePng)
+                        AgentRequest.Ping -> AgentResponse.Pong
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+            .use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { client ->
+                    val response =
+                        client.send(
+                            AgentRequest.Screenshot(
+                                windowIndex = 0,
+                                surfaceId = null,
+                                fullscreen = false,
+                            )
+                        )
+                    val err = assertIs<AgentResponse.Error>(response)
+                    assertEquals(AgentErrorCategory.PayloadTooLarge.wireName, err.category)
+                    assertTrue(
+                        err.message.contains("MAX_FRAME_BYTES") ||
+                            err.message.contains("payload", ignoreCase = true),
+                        "expected size-limit message; got: ${err.message}",
+                    )
+                    // Connection stays usable after a payloadTooLarge error.
+                    assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+                }
+            }
+    }
+
+    @Test
+    fun `encoded OpResponse Error for payloadTooLarge fits under frame cap`() {
+        val err =
+            AgentResponse.Error(
+                message =
+                    "Response payload size ${MAX_FRAME_BYTES + 1} exceeds " +
+                        "MAX_FRAME_BYTES=$MAX_FRAME_BYTES",
+                category = AgentErrorCategory.PayloadTooLarge.wireName,
+            )
+        val bytes = WireCodec.encode(OpResponse(opId = 1L, body = err))
+        assertTrue(
+            bytes.size < MAX_FRAME_BYTES,
+            "taxonomy error itself must always fit under the frame cap (${bytes.size})",
+        )
+    }
+
+    private fun awaitSocket(path: Path, timeoutMs: Long = 5_000) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000L
+        while (System.nanoTime() < deadline) {
+            if (java.nio.file.Files.exists(path)) return
+            Thread.sleep(10)
+        }
+        error("UDS path $path did not appear within ${timeoutMs}ms")
+    }
+
+    private fun udsBase(): Path =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
+            Path.of(System.getProperty("java.io.tmpdir"))
+        else Path.of("/tmp")
+}

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -298,8 +298,25 @@ decode hang or silent close. That is how mixed-version pairs degrade.
 | `nodeNotFound` | Well-formed key, no matching node |
 | `timeout` | Deadline exceeded |
 | `cancelled` | Explicit cancel of an in-flight op (#200) |
+| `payloadTooLarge` | Response/request exceeds the frame hard limit (#204) |
 | `inputRejected` | Focus / Robot / permission rejection |
 | `internalError` | Unexpected agent-side failure (default) |
+
+### Payload limits (#204)
+
+Each IPC frame is length-prefixed and hard-capped at **16 MiB** (`MAX_FRAME_BYTES`). This is a
+**fail-closed** policy:
+
+- Responses that encode larger than the cap (e.g. a huge screenshot) are **not** truncated or
+  spilled to disk by the agent transport. The runtime replies with `error` category
+  **`payloadTooLarge`** and a message that includes the sizes.
+- The connection stays open; subsequent ops on the same session continue normally.
+- Parity CI can rely on deterministic taxonomy behaviour instead of size-threshold flakes.
+
+Spill-to-file for large captures remains a higher-level concern (capture directories / daemon
+shared FS from #181); the wire layer does not invent a second path for oversized frames.
+
+HTTP maps `payloadTooLarge` → **413 Payload Too Large**.
 
 ### Long operations and cancel (#200)
 
@@ -318,7 +335,8 @@ connection.
 Clients should branch on `category` (see `AgentErrorCategory` / `SpectreAgentException`),
 not on free-text `message`. The HTTP transport maps the same names onto status codes
 (`invalidSelector` → 400, `nodeNotFound` → 404, `unsupportedOperation` → 501,
-`cancelled` → 499 Client Closed Request, etc.) via `SpectreErrorCategory` in `:server`.
+`cancelled` → 499 Client Closed Request, `payloadTooLarge` → 413, etc.) via
+`SpectreErrorCategory` in `:server`.
 
 ### Schema evolution rules
 

--- a/server/api/server.api
+++ b/server/api/server.api
@@ -28,6 +28,7 @@ public final class dev/sebastiano/spectre/server/SpectreErrorCategory : java/lan
 	public static final field InternalError Ldev/sebastiano/spectre/server/SpectreErrorCategory;
 	public static final field InvalidSelector Ldev/sebastiano/spectre/server/SpectreErrorCategory;
 	public static final field NodeNotFound Ldev/sebastiano/spectre/server/SpectreErrorCategory;
+	public static final field PayloadTooLarge Ldev/sebastiano/spectre/server/SpectreErrorCategory;
 	public static final field ProtocolMismatch Ldev/sebastiano/spectre/server/SpectreErrorCategory;
 	public static final field Timeout Ldev/sebastiano/spectre/server/SpectreErrorCategory;
 	public static final field UnsupportedOperation Ldev/sebastiano/spectre/server/SpectreErrorCategory;

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreErrorCategory.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreErrorCategory.kt
@@ -15,6 +15,8 @@ public enum class SpectreErrorCategory(public val wireName: String) {
     Timeout("timeout"),
     /** Explicit cancel of an in-flight op (#200); agent wire name `cancelled`. */
     Cancelled("cancelled"),
+    /** Payload exceeds the transport hard limit (#204). */
+    PayloadTooLarge("payloadTooLarge"),
     InputRejected("inputRejected"),
     InternalError("internalError");
 
@@ -29,6 +31,7 @@ public enum class SpectreErrorCategory(public val wireName: String) {
                 Timeout -> io.ktor.http.HttpStatusCode.GatewayTimeout
                 // Non-standard but widely understood "client closed request" for cancelled work.
                 Cancelled -> CLIENT_CLOSED_REQUEST
+                PayloadTooLarge -> io.ktor.http.HttpStatusCode.PayloadTooLarge
                 InputRejected -> io.ktor.http.HttpStatusCode.Conflict
                 InternalError -> io.ktor.http.HttpStatusCode.InternalServerError
             }


### PR DESCRIPTION
## Summary

Implements [#204](https://github.com/rock3r/spectre/issues/204) (part of [#197](https://github.com/rock3r/spectre/issues/197)).

- Hard frame cap remains **16 MiB** (`MAX_FRAME_BYTES`).
- Oversized **responses** are replaced with `AgentResponse.Error` category **`payloadTooLarge`** (fail-closed; no truncate/spill on the wire).
- Connection stays usable after the error.
- Docs: wire-format / taxonomy section in `docs/guide/agent.md`.
- HTTP: `SpectreErrorCategory.PayloadTooLarge` → 413.

## Validation

- `PayloadLimitsTest` (oversized screenshot → taxonomy + follow-up Ping)
- `./gradlew :agent:check :server:check`

## Test plan

- [x] Local payload-limit tests
- [x] agent + server check
- [ ] CI