### PR TITLE
Add waitForNode and waitForVisualIdle over agent IPC (#201)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -94,6 +94,10 @@ public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/Au
 	public final fun screenshot (Ljava/lang/Integer;Ljava/lang/String;Z)[B
 	public static synthetic fun screenshot$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/Integer;Ljava/lang/String;ZILjava/lang/Object;)[B
 	public final fun typeText (Ljava/lang/String;)V
+	public final fun waitForNode (Ljava/lang/String;Ljava/lang/String;JJ)Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;
+	public static synthetic fun waitForNode$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/String;Ljava/lang/String;JJILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;
+	public final fun waitForVisualIdle (JIJ)V
+	public static synthetic fun waitForVisualIdle$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;JIJILjava/lang/Object;)V
 	public final fun windowIdentities (Ljava/lang/Integer;)Ljava/util/List;
 	public static synthetic fun windowIdentities$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/Integer;ILjava/lang/Object;)Ljava/util/List;
 	public final fun windows ()Ljava/util/List;

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -136,6 +136,59 @@ internal constructor(
     }
 
     /**
+     * Wait until a semantics node matches [tag] and/or [text] (AND when both are set), same as
+     * in-process `ComposeAutomator.waitForNode` (#201).
+     *
+     * Propagates [timeoutMs] as an absolute deadline on the wire so the agent and client share one
+     * budget. Throws [SpectreAgentException] with category `timeout` when the wait expires.
+     */
+    @Throws(IOException::class)
+    public fun waitForNode(
+        tag: String? = null,
+        text: String? = null,
+        timeoutMs: Long = 5_000,
+        pollIntervalMs: Long = 100,
+    ): NodeSnapshotDto {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        val resp =
+            exchange(
+                AgentRequest.WaitForNode(
+                    tag = tag,
+                    text = text,
+                    timeoutMs = timeoutMs,
+                    pollIntervalMs = pollIntervalMs,
+                ),
+                deadlineEpochMs = deadline,
+            )
+        val nodes = (resp as? AgentResponse.Nodes)?.nodes ?: throw wireMismatch("Nodes", resp)
+        return nodes.singleOrNull()
+            ?: throw IOException("waitForNode expected a single node, got ${nodes.size}")
+    }
+
+    /**
+     * Wait until consecutive visual frames are stable (#201). Same semantics as in-process
+     * `ComposeAutomator.waitForVisualIdle`.
+     */
+    @Throws(IOException::class)
+    public fun waitForVisualIdle(
+        timeoutMs: Long = 5_000,
+        stableFrames: Int = 3,
+        pollIntervalMs: Long = 16,
+    ) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        val resp =
+            exchange(
+                AgentRequest.WaitForVisualIdle(
+                    timeoutMs = timeoutMs,
+                    stableFrames = stableFrames,
+                    pollIntervalMs = pollIntervalMs,
+                ),
+                deadlineEpochMs = deadline,
+            )
+        if (resp !is AgentResponse.Ok) throw wireMismatch("Ok", resp)
+    }
+
+    /**
      * Send [AgentRequest.Detach], wait for [AgentResponse.Detached], close the underlying client.
      * Idempotent — calling twice is a no-op.
      */
@@ -159,9 +212,9 @@ internal constructor(
         }
     }
 
-    private fun exchange(request: AgentRequest): AgentResponse {
+    private fun exchange(request: AgentRequest, deadlineEpochMs: Long? = null): AgentResponse {
         check(!closed.get()) { "AttachedAutomator is closed" }
-        val resp = client.send(request)
+        val resp = client.send(request, deadlineEpochMs = deadlineEpochMs)
         if (resp is AgentResponse.Error) {
             val category =
                 dev.sebastiano.spectre.agent.transport.AgentErrorCategory.fromWire(resp.category)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
@@ -35,6 +35,10 @@ internal class BlockingSuspendInvoker(private val timeoutMs: Long = DEFAULT_TIME
      * Invokes [method] on [target] with [args] plus an appended [LatchingContinuation]. Returns the
      * suspend function's eventual result, or throws the exception that resumed the continuation
      * with failure.
+     *
+     * @param timeoutMsOverride when set, overrides the constructor default (used for long waits
+     *   such as `waitForNode` / `waitForVisualIdle` so the suspend bridge outlives the wait budget
+     *   slightly and the automator's own timeout wins).
      */
     // Both spreads below (`*args` into `arrayOf`, `*argsWithCont` into the Java reflection
     // call) are unavoidable: we need to append `cont` to the caller-supplied vararg array,
@@ -42,11 +46,17 @@ internal class BlockingSuspendInvoker(private val timeoutMs: Long = DEFAULT_TIME
     // Kotlin doesn't pass the array as a single argument. The array is small (caller-supplied
     // suspend-function args + 1 continuation), so the per-call copy is not material.
     @Suppress("SpreadOperator")
-    fun invoke(method: Method, target: Any, vararg args: Any?): Any? {
+    fun invoke(
+        method: Method,
+        target: Any,
+        vararg args: Any?,
+        timeoutMsOverride: Long? = null,
+    ): Any? {
         val cont = LatchingContinuation()
         val argsWithCont: Array<Any?> = arrayOf(*args, cont)
         val raw = method.invoke(target, *argsWithCont)
-        return if (raw === COROUTINE_SUSPENDED) cont.await(timeoutMs) else raw
+        val waitMs = timeoutMsOverride ?: timeoutMs
+        return if (raw === COROUTINE_SUSPENDED) cont.await(waitMs) else raw
     }
 
     private class LatchingContinuation : Continuation<Any?> {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -36,6 +36,9 @@ import javax.imageio.ImageIO
  * developers expect them; we deliberately don't ship them across the wire because that would mean
  * smuggling `Throwable` types we can't safely reconstruct on the client side.
  */
+// Snapshot/input/wait ops each live in helpers where possible; remaining private methods stay
+// under detekt's function-count budget.
+@Suppress("TooManyFunctions")
 internal class ReflectiveAutomatorHandler(
     private val automator: Any,
     private val isTargetJvmFocused: () -> Boolean = ::targetJvmHasKeyboardFocus,
@@ -82,30 +85,11 @@ internal class ReflectiveAutomatorHandler(
         }
 
     private val suspendInvoker = BlockingSuspendInvoker()
+    private val waitOps = WaitOpsReflectiveMapper(automator, suspendInvoker, ::mapAutomatorNode)
 
     override fun handle(request: AgentRequest): AgentResponse =
         try {
-            when (request) {
-                AgentRequest.Ping -> AgentResponse.Pong
-                AgentRequest.Windows -> handleWindows()
-                AgentRequest.AllNodes -> handleAllNodes()
-                is AgentRequest.FindByTestTag -> handleFindByTestTag(request.tag)
-                is AgentRequest.Click -> handleClick(request.nodeKey)
-                is AgentRequest.TypeText -> handleTypeText(request.text)
-                is AgentRequest.Screenshot -> handleScreenshot(request)
-                is AgentRequest.Capture ->
-                    AtomicCaptureReflectiveMapper.invoke(automator, request.windowIndex)
-                is AgentRequest.WindowIdentity ->
-                    WindowIdentityReflectiveMapper.invoke(automator, request.windowIndex)
-                AgentRequest.Detach -> AgentResponse.Detached
-                // Handled in IpcServer before the automator handler; keep exhaustive.
-                is AgentRequest.Hello ->
-                    AgentResponse.HelloAck(
-                        protocolVersion =
-                            dev.sebastiano.spectre.agent.transport.ProtocolVersion.CURRENT
-                    )
-                is AgentRequest.Cancel -> AgentResponse.Ok
-            }
+            dispatch(request)
         } catch (ex: ReflectiveOperationException) {
             val message = "Reflective call failed: ${ex.targetMessage()}"
             val category =
@@ -115,6 +99,36 @@ internal class ReflectiveAutomatorHandler(
                     dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InternalError
                 }
             AgentResponse.Error(message = message, category = category.wireName)
+        } catch (ex: java.util.concurrent.TimeoutException) {
+            AgentResponse.Error(
+                message = "${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.Timeout.wireName,
+            )
+        }
+
+    private fun dispatch(request: AgentRequest): AgentResponse =
+        when (request) {
+            AgentRequest.Ping -> AgentResponse.Pong
+            AgentRequest.Windows -> handleWindows()
+            AgentRequest.AllNodes -> handleAllNodes()
+            is AgentRequest.FindByTestTag -> handleFindByTestTag(request.tag)
+            is AgentRequest.Click -> handleClick(request.nodeKey)
+            is AgentRequest.TypeText -> handleTypeText(request.text)
+            is AgentRequest.Screenshot -> handleScreenshot(request)
+            is AgentRequest.Capture ->
+                AtomicCaptureReflectiveMapper.invoke(automator, request.windowIndex)
+            is AgentRequest.WindowIdentity ->
+                WindowIdentityReflectiveMapper.invoke(automator, request.windowIndex)
+            AgentRequest.Detach -> AgentResponse.Detached
+            // Handled in IpcServer before the automator handler; keep exhaustive.
+            is AgentRequest.Hello ->
+                AgentResponse.HelloAck(
+                    protocolVersion = dev.sebastiano.spectre.agent.transport.ProtocolVersion.CURRENT
+                )
+            is AgentRequest.Cancel -> AgentResponse.Ok
+            is AgentRequest.WaitForNode -> waitOps.handleWaitForNode(request)
+            is AgentRequest.WaitForVisualIdle -> waitOps.handleWaitForVisualIdle(request)
         }
 
     // Note on un-caught exceptions: any non-reflective `RuntimeException` thrown by the

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
@@ -1,0 +1,136 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+import dev.sebastiano.spectre.agent.transport.AgentRequest
+import dev.sebastiano.spectre.agent.transport.AgentResponse
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import java.lang.reflect.Method
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * Reflective bridge for [AgentRequest.WaitForNode] / [AgentRequest.WaitForVisualIdle] (#201). Lives
+ * outside [ReflectiveAutomatorHandler] to keep that class under detekt complexity limits.
+ */
+internal class WaitOpsReflectiveMapper(
+    private val automator: Any,
+    private val suspendInvoker: BlockingSuspendInvoker,
+    private val mapNode: (Any) -> NodeSnapshotDto,
+) {
+    private val automatorClass: Class<*> = automator.javaClass
+
+    private val waitForNodeSuspendMethod: Method? =
+        automatorClass.methods.firstOrNull {
+            it.name == "waitForNode" &&
+                it.parameterTypes.size == 5 &&
+                it.parameterTypes[4].name == CONTINUATION_FQN
+        }
+
+    private val waitForVisualIdleSuspendMethod: Method? =
+        automatorClass.methods.firstOrNull {
+            it.name == "waitForVisualIdle" &&
+                it.parameterTypes.size == 4 &&
+                it.parameterTypes[3].name == CONTINUATION_FQN
+        }
+
+    fun handleWaitForNode(request: AgentRequest.WaitForNode): AgentResponse {
+        if (request.tag == null && request.text == null) {
+            return AgentResponse.Error(
+                message = "Either tag or text must be specified",
+                category = AgentErrorCategory.InvalidSelector.wireName,
+            )
+        }
+        val method =
+            waitForNodeSuspendMethod
+                ?: return AgentResponse.Error(
+                    message = "ComposeAutomator does not expose waitForNode",
+                    category = AgentErrorCategory.UnsupportedOperation.wireName,
+                )
+        val timeoutMs = request.timeoutMs ?: DEFAULT_WAIT_TIMEOUT_MS
+        val pollMs = request.pollIntervalMs ?: DEFAULT_WAIT_POLL_MS
+        return runWait {
+            val node =
+                suspendInvoker.invoke(
+                    method,
+                    automator,
+                    request.tag,
+                    request.text,
+                    timeoutMs.milliseconds,
+                    pollMs.milliseconds,
+                    timeoutMsOverride = timeoutMs + SUSPEND_BRIDGE_SLACK_MS,
+                )
+            if (node == null) {
+                AgentResponse.Error(
+                    message = "waitForNode returned null",
+                    category = AgentErrorCategory.InternalError.wireName,
+                )
+            } else {
+                AgentResponse.Nodes(listOf(mapNode(node)))
+            }
+        }
+    }
+
+    fun handleWaitForVisualIdle(request: AgentRequest.WaitForVisualIdle): AgentResponse {
+        val method =
+            waitForVisualIdleSuspendMethod
+                ?: return AgentResponse.Error(
+                    message = "ComposeAutomator does not expose waitForVisualIdle",
+                    category = AgentErrorCategory.UnsupportedOperation.wireName,
+                )
+        val timeoutMs = request.timeoutMs ?: DEFAULT_WAIT_TIMEOUT_MS
+        val pollMs = request.pollIntervalMs ?: DEFAULT_VISUAL_POLL_MS
+        val stableFrames = request.stableFrames ?: DEFAULT_STABLE_FRAMES
+        return runWait {
+            suspendInvoker.invoke(
+                method,
+                automator,
+                timeoutMs.milliseconds,
+                stableFrames,
+                pollMs.milliseconds,
+                timeoutMsOverride = timeoutMs + SUSPEND_BRIDGE_SLACK_MS,
+            )
+            AgentResponse.Ok
+        }
+    }
+
+    /**
+     * Maps wait-loop timeouts (stdlib [TimeoutException], IdleTimeoutException,
+     * TimeoutCancellationException) to taxonomy `timeout`; rethrows everything else.
+     */
+    @Suppress("TooGenericExceptionCaught") // IdleTimeoutException and TimeoutCancellationException.
+    private fun runWait(block: () -> AgentResponse): AgentResponse =
+        try {
+            block()
+        } catch (ex: Exception) {
+            if (ex is java.util.concurrent.TimeoutException || isWaitTimeout(ex)) {
+                timeoutError(ex)
+            } else {
+                throw ex
+            }
+        }
+
+    private fun timeoutError(ex: Exception): AgentResponse.Error =
+        AgentResponse.Error(
+            message = "${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}",
+            category = AgentErrorCategory.Timeout.wireName,
+        )
+
+    private companion object {
+        const val CONTINUATION_FQN: String = "kotlin.coroutines.Continuation"
+        const val DEFAULT_WAIT_TIMEOUT_MS: Long = 5_000
+        const val DEFAULT_WAIT_POLL_MS: Long = 100
+        const val DEFAULT_VISUAL_POLL_MS: Long = 16
+        const val DEFAULT_STABLE_FRAMES: Int = 3
+        const val SUSPEND_BRIDGE_SLACK_MS: Long = 2_000
+
+        fun isWaitTimeout(ex: Exception): Boolean {
+            val name = ex.javaClass.name
+            val msg = ex.message.orEmpty().lowercase()
+            return name.endsWith("IdleTimeoutException") ||
+                name.endsWith("TimeoutCancellationException") ||
+                "timed out" in msg ||
+                "timeout" in name.lowercase()
+        }
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
@@ -12,6 +12,9 @@ import kotlin.time.Duration.Companion.milliseconds
 /**
  * Reflective bridge for [AgentRequest.WaitForNode] / [AgentRequest.WaitForVisualIdle] (#201). Lives
  * outside [ReflectiveAutomatorHandler] to keep that class under detekt complexity limits.
+ *
+ * Kotlin mangles `Duration` parameters into primitive `long` (nanoseconds) and renames methods
+ * (e.g. `waitForNode-ck1zr5g`). Lookups use parameter types, not the unmangled source name.
  */
 internal class WaitOpsReflectiveMapper(
     private val automator: Any,
@@ -19,18 +22,27 @@ internal class WaitOpsReflectiveMapper(
     private val mapNode: (Any) -> NodeSnapshotDto,
 ) {
     private val automatorClass: Class<*> = automator.javaClass
+    private val longPrimitive: Class<*> = Long::class.javaPrimitiveType!!
+    private val intPrimitive: Class<*> = Int::class.javaPrimitiveType!!
 
     private val waitForNodeSuspendMethod: Method? =
         automatorClass.methods.firstOrNull {
-            it.name == "waitForNode" &&
+            it.name.startsWith("waitForNode") &&
                 it.parameterTypes.size == 5 &&
+                it.parameterTypes[0] == String::class.java &&
+                it.parameterTypes[1] == String::class.java &&
+                it.parameterTypes[2] == longPrimitive &&
+                it.parameterTypes[3] == longPrimitive &&
                 it.parameterTypes[4].name == CONTINUATION_FQN
         }
 
     private val waitForVisualIdleSuspendMethod: Method? =
         automatorClass.methods.firstOrNull {
-            it.name == "waitForVisualIdle" &&
+            it.name.startsWith("waitForVisualIdle") &&
                 it.parameterTypes.size == 4 &&
+                it.parameterTypes[0] == longPrimitive &&
+                it.parameterTypes[1] == intPrimitive &&
+                it.parameterTypes[2] == longPrimitive &&
                 it.parameterTypes[3].name == CONTINUATION_FQN
         }
 
@@ -56,8 +68,9 @@ internal class WaitOpsReflectiveMapper(
                     automator,
                     request.tag,
                     request.text,
-                    timeoutMs.milliseconds,
-                    pollMs.milliseconds,
+                    // Duration is a value class: JVM surface is primitive long nanoseconds.
+                    timeoutMs.milliseconds.inWholeNanoseconds,
+                    pollMs.milliseconds.inWholeNanoseconds,
                     timeoutMsOverride = timeoutMs + SUSPEND_BRIDGE_SLACK_MS,
                 )
             if (node == null) {
@@ -85,9 +98,9 @@ internal class WaitOpsReflectiveMapper(
             suspendInvoker.invoke(
                 method,
                 automator,
-                timeoutMs.milliseconds,
+                timeoutMs.milliseconds.inWholeNanoseconds,
                 stableFrames,
-                pollMs.milliseconds,
+                pollMs.milliseconds.inWholeNanoseconds,
                 timeoutMsOverride = timeoutMs + SUSPEND_BRIDGE_SLACK_MS,
             )
             AgentResponse.Ok

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
@@ -22,8 +22,10 @@ internal class WaitOpsReflectiveMapper(
     private val mapNode: (Any) -> NodeSnapshotDto,
 ) {
     private val automatorClass: Class<*> = automator.javaClass
-    private val longPrimitive: Class<*> = Long::class.javaPrimitiveType!!
-    private val intPrimitive: Class<*> = Int::class.javaPrimitiveType!!
+    private val longPrimitive: Class<*> =
+        Long::class.javaPrimitiveType ?: error("Long primitive type missing")
+    private val intPrimitive: Class<*> =
+        Int::class.javaPrimitiveType ?: error("Int primitive type missing")
 
     private val waitForNodeSuspendMethod: Method? =
         automatorClass.methods.firstOrNull {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
@@ -98,11 +98,13 @@ internal class WaitOpsReflectiveMapper(
      * Maps wait-loop timeouts (stdlib [TimeoutException], IdleTimeoutException,
      * TimeoutCancellationException) to taxonomy `timeout`; rethrows everything else.
      */
-    @Suppress("TooGenericExceptionCaught") // IdleTimeoutException and TimeoutCancellationException.
+    @Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException")
     private fun runWait(block: () -> AgentResponse): AgentResponse =
         try {
             block()
         } catch (ex: Exception) {
+            // IdleTimeoutException / TimeoutCancellationException are not on the classpath of
+            // :agent; match by type name so wait timeouts become taxonomy `timeout`.
             if (ex is java.util.concurrent.TimeoutException || isWaitTimeout(ex)) {
                 timeoutError(ex)
             } else {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -116,6 +116,36 @@ internal sealed interface AgentRequest {
      * cancel was accepted).
      */
     @Serializable @SerialName("cancel") data class Cancel(val opId: Long) : AgentRequest
+
+    /**
+     * Wait until a semantics node matches [tag] and/or [text] (AND when both set), same semantics
+     * as in-process `ComposeAutomator.waitForNode` (#201).
+     *
+     * Timeouts are milliseconds; null uses the automator defaults (5s timeout, 100ms poll). Replies
+     * with [AgentResponse.Nodes] (single match) or [AgentResponse.Error] (`timeout` /
+     * `invalidSelector`).
+     */
+    @Serializable
+    @SerialName("waitForNode")
+    data class WaitForNode(
+        val tag: String? = null,
+        val text: String? = null,
+        val timeoutMs: Long? = null,
+        val pollIntervalMs: Long? = null,
+    ) : AgentRequest
+
+    /**
+     * Wait until consecutive visual frames are stable (#201). Same semantics as in-process
+     * `ComposeAutomator.waitForVisualIdle`. Null durations use automator defaults. Replies with
+     * [AgentResponse.Ok] or [AgentResponse.Error] category `timeout`.
+     */
+    @Serializable
+    @SerialName("waitForVisualIdle")
+    data class WaitForVisualIdle(
+        val timeoutMs: Long? = null,
+        val stableFrames: Int? = null,
+        val pollIntervalMs: Long? = null,
+    ) : AgentRequest
 }
 
 /** Payload-free operation label for diagnostics. Never include caller-controlled request data. */
@@ -134,6 +164,8 @@ internal val AgentRequest.logLabel: String
             AgentRequest.Detach -> "detach"
             is AgentRequest.Hello -> "hello"
             is AgentRequest.Cancel -> "cancel"
+            is AgentRequest.WaitForNode -> "waitForNode"
+            is AgentRequest.WaitForVisualIdle -> "waitForVisualIdle"
         }
 
 /** Server-to-client response envelope. */

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -491,6 +491,8 @@ class IpcRoundTripTest {
             is AgentRequest.Hello ->
                 AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
             is AgentRequest.Cancel -> AgentResponse.Ok
+            is AgentRequest.WaitForNode -> AgentResponse.Nodes(emptyList())
+            is AgentRequest.WaitForVisualIdle -> AgentResponse.Ok
         }
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WaitOpsInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WaitOpsInfrastructureTest.kt
@@ -1,0 +1,157 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import java.nio.file.Path
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/** #201: wait ops over multiplexed IPC — success path, timeout taxonomy, cancel while waiting. */
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
+class WaitOpsInfrastructureTest {
+    private val udsPath: Path =
+        udsBase().resolve("sp-w-${UUID.randomUUID().toString().take(8)}.sock")
+
+    @AfterTest
+    fun cleanUp() {
+        runCatching { udsPath.deleteIfExists() }
+    }
+
+    @Test
+    fun `waitForNode returns matching node`() {
+        val node =
+            NodeSnapshotDto(
+                key = "s:0:1",
+                testTag = "Counter",
+                texts = listOf("0"),
+                role = null,
+                contentDescription = null,
+                isVisible = true,
+                bounds = RectDto(0, 0, 10, 10),
+            )
+        IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    when (request) {
+                        is AgentRequest.WaitForNode -> {
+                            assertEquals("Counter", request.tag)
+                            AgentResponse.Nodes(listOf(node))
+                        }
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+            .use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { client ->
+                    val resp =
+                        client.send(AgentRequest.WaitForNode(tag = "Counter", timeoutMs = 1_000))
+                    val nodes = assertIs<AgentResponse.Nodes>(resp)
+                    assertEquals(listOf(node), nodes.nodes)
+                }
+            }
+    }
+
+    @Test
+    fun `waitForVisualIdle Ok and timeout taxonomy`() {
+        val calls = AtomicInteger(0)
+        IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    when (request) {
+                        is AgentRequest.WaitForVisualIdle -> {
+                            if (calls.getAndIncrement() == 0) {
+                                AgentResponse.Ok
+                            } else {
+                                AgentResponse.Error(
+                                    message = "waitForVisualIdle timed out",
+                                    category = AgentErrorCategory.Timeout.wireName,
+                                )
+                            }
+                        }
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+            .use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { client ->
+                    assertEquals(
+                        AgentResponse.Ok,
+                        client.send(AgentRequest.WaitForVisualIdle(timeoutMs = 500)),
+                    )
+                    val err =
+                        assertIs<AgentResponse.Error>(
+                            client.send(AgentRequest.WaitForVisualIdle(timeoutMs = 100))
+                        )
+                    assertEquals(AgentErrorCategory.Timeout.wireName, err.category)
+                }
+            }
+    }
+
+    @Test
+    fun `slow waitForNode can be cancelled`() {
+        val started = CountDownLatch(1)
+        IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    when (request) {
+                        is AgentRequest.WaitForNode -> {
+                            started.countDown()
+                            try {
+                                Thread.sleep(30_000)
+                            } catch (_: InterruptedException) {
+                                Thread.currentThread().interrupt()
+                            }
+                            AgentResponse.Nodes(emptyList())
+                        }
+                        is AgentRequest.Cancel -> AgentResponse.Ok
+                        AgentRequest.Ping -> AgentResponse.Pong
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+            .use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { client ->
+                    val holder = arrayOfNulls<AgentResponse>(1)
+                    val t = Thread {
+                        holder[0] =
+                            client.send(AgentRequest.WaitForNode(tag = "x", timeoutMs = 25_000))
+                    }
+                    t.isDaemon = true
+                    t.start()
+                    assertTrue(started.await(3, TimeUnit.SECONDS))
+                    client.cancel(1L)
+                    assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+                    t.join(5_000)
+                    val err = assertIs<AgentResponse.Error>(holder[0])
+                    assertEquals(AgentErrorCategory.Cancelled.wireName, err.category)
+                }
+            }
+    }
+
+    private fun awaitSocket(path: Path, timeoutMs: Long = 5_000) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000L
+        while (System.nanoTime() < deadline) {
+            if (java.nio.file.Files.exists(path)) return
+            Thread.sleep(10)
+        }
+        error("UDS path $path did not appear within ${timeoutMs}ms")
+    }
+
+    private fun udsBase(): Path =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
+            Path.of(System.getProperty("java.io.tmpdir"))
+        else Path.of("/tmp")
+}

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -252,7 +252,8 @@ translateY)`; scale widths/heights by `scaleX`/`scaleY` only (no translation). D
 recording (#183) uses this so capture stays on the daemon host rather than over the
 transport.
 
-Streaming / long-poll ops (`waitForVisualIdle`, idling resources, `withTracing`) are
+`waitForNode` and `waitForVisualIdle` are available over the agent transport (#201).
+Streaming / long-poll idling resources and `withTracing` remain
 deferred to a follow-up.
 
 ## Wire format
@@ -357,7 +358,8 @@ Not additive-safe without a version bump:
 
 - **Windows needs 10 version 1803 / Server 2019 or newer.** That's when native `AF_UNIX` landed;
   older Windows fails the attach preflight with `AttachPlatformUnsupportedException`.
-- **No streaming ops.** `waitForVisualIdle` and friends are HTTP-only or in-process only for now.
+- **Wait ops.** `waitForNode` / `waitForVisualIdle` are supported over agent IPC (#201) with
+  shared deadline budgets and cancel. Idling-resource `waitForIdle` stays in-process only.
 - **IntelliJ-hosted Compose**: the classloader-disambiguation rule (D-14 in the plan) was
   designed to handle `PluginClassLoader` chains but isn't automatically tested yet. If
   you hit issues attaching to an IntelliJ-hosted target, file a Spectre issue with the

--- a/docs/guide/capability-matrix.md
+++ b/docs/guide/capability-matrix.md
@@ -69,7 +69,7 @@ boundary without a different design:
 | `withTracing` | Live tracer hooks |
 | `waitForIdle` (idling-resource variant) | Same as idling resources |
 
-Remote **waits** (`waitForNode`, `waitForVisualIdle`), richer **selectors**, and **input verbs**
+Remote **waits** (`waitForNode`, `waitForVisualIdle` over agent — #201), richer **selectors**, and **input verbs**
 (drag / scroll / chords) are tracked as **Not yet CI-executed** on HTTP/agent until epic
 #197 sub-issues #201–#203 land. Do not document them as supported on remote transports until
 the matrix says so.


### PR DESCRIPTION
## Summary

Implements the **agent-transport** half of [#201](https://github.com/rock3r/spectre/issues/201) (epic [#197](https://github.com/rock3r/spectre/issues/197)).

- Wire: `waitForNode` / `waitForVisualIdle` request variants
- Reflective target: maps to `ComposeAutomator` suspend waits with timeout taxonomy
- `AttachedAutomator.waitForNode` / `waitForVisualIdle` with shared absolute deadlines (#200)
- Cancel while waiting covered by multiplex tests
- Docs + capability-matrix note

**Out of this PR (explicit):** `spectre wait` CLI and MCP tools — can follow once daemon routing is wired; agent attach API is the contract prerequisite.

## Validation

- `WaitOpsInfrastructureTest`
- `./gradlew :agent:check`