### PR TITLE
Add selector parity and node DTO convergence (#202)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -89,7 +89,11 @@ public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/Au
 	public static synthetic fun capture$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;IILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AtomicCaptureResult;
 	public final fun click (Ljava/lang/String;)V
 	public fun close ()V
+	public final fun findByContentDescription (Ljava/lang/String;)Ljava/util/List;
+	public final fun findByRole (Ljava/lang/String;)Ljava/util/List;
 	public final fun findByTestTag (Ljava/lang/String;)Ljava/util/List;
+	public final fun findByText (Ljava/lang/String;Z)Ljava/util/List;
+	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
 	public final fun getPid ()J
 	public final fun screenshot (Ljava/lang/Integer;Ljava/lang/String;Z)[B
 	public static synthetic fun screenshot$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/Integer;Ljava/lang/String;ZILjava/lang/Object;)[B
@@ -205,29 +209,35 @@ public final class dev/sebastiano/spectre/agent/transport/FramingKt {
 
 public final class dev/sebastiano/spectre/agent/transport/NodeSnapshotDto {
 	public static final field Companion Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLdev/sebastiano/spectre/agent/transport/RectDto;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLdev/sebastiano/spectre/agent/transport/RectDto;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZZZLdev/sebastiano/spectre/agent/transport/RectDto;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZZZLdev/sebastiano/spectre/agent/transport/RectDto;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component12 ()Ldev/sebastiano/spectre/agent/transport/RectDto;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Z
+	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Z
-	public final fun component9 ()Ldev/sebastiano/spectre/agent/transport/RectDto;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLdev/sebastiano/spectre/agent/transport/RectDto;)Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;
-	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZZLdev/sebastiano/spectre/agent/transport/RectDto;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZZZLdev/sebastiano/spectre/agent/transport/RectDto;)Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ZZZZLdev/sebastiano/spectre/agent/transport/RectDto;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBounds ()Ldev/sebastiano/spectre/agent/transport/RectDto;
 	public final fun getContentDescription ()Ljava/lang/String;
+	public final fun getContentDescriptions ()Ljava/util/List;
 	public final fun getEditableText ()Ljava/lang/String;
 	public final fun getKey ()Ljava/lang/String;
 	public final fun getRole ()Ljava/lang/String;
 	public final fun getTestTag ()Ljava/lang/String;
 	public final fun getTexts ()Ljava/util/List;
 	public fun hashCode ()I
+	public final fun isDisabled ()Z
 	public final fun isFocused ()Z
+	public final fun isSelected ()Z
 	public final fun isVisible ()Z
 	public fun toString ()Ljava/lang/String;
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -25,6 +25,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * @property pid the target JVM's process id; informational, set by [AgentAttach.attach].
  */
 @ExperimentalSpectreAgentApi
+@Suppress("TooManyFunctions") // Public wire surface mirrors ComposeAutomator selectors + waits.
 public class AttachedAutomator
 internal constructor(
     public val pid: Long,
@@ -52,6 +53,30 @@ internal constructor(
     @Throws(IOException::class)
     public fun findByTestTag(tag: String): List<NodeSnapshotDto> {
         val resp = exchange(AgentRequest.FindByTestTag(tag))
+        return (resp as? AgentResponse.Nodes)?.nodes ?: throw wireMismatch("Nodes", resp)
+    }
+
+    /** Find nodes by text (#202). See in-process `findByText`. */
+    @Throws(IOException::class)
+    public fun findByText(text: String, exact: Boolean = true): List<NodeSnapshotDto> {
+        val resp = exchange(AgentRequest.FindByText(text = text, exact = exact))
+        return (resp as? AgentResponse.Nodes)?.nodes ?: throw wireMismatch("Nodes", resp)
+    }
+
+    /** Find nodes by content description (#202). */
+    @Throws(IOException::class)
+    public fun findByContentDescription(description: String): List<NodeSnapshotDto> {
+        val resp = exchange(AgentRequest.FindByContentDescription(description))
+        return (resp as? AgentResponse.Nodes)?.nodes ?: throw wireMismatch("Nodes", resp)
+    }
+
+    /**
+     * Find nodes by Compose [role] name (e.g. `"Button"`) (#202). Unknown names throw
+     * [SpectreAgentException] with category `invalidSelector`.
+     */
+    @Throws(IOException::class)
+    public fun findByRole(role: String): List<NodeSnapshotDto> {
+        val resp = exchange(AgentRequest.FindByRole(role))
         return (resp as? AgentResponse.Nodes)?.nodes ?: throw wireMismatch("Nodes", resp)
     }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -48,6 +48,19 @@ internal class ReflectiveAutomatorHandler(
     private val getWindowsMethod = automatorClass.getMethod("getWindows")
     private val allNodesMethod = automatorClass.getMethod("allNodes")
     private val findByTestTagMethod = automatorClass.getMethod("findByTestTag", String::class.java)
+    private val findByTextMethod =
+        automatorClass.methods.firstOrNull {
+            it.name == "findByText" &&
+                it.parameterTypes.size == 2 &&
+                it.parameterTypes[0] == String::class.java &&
+                it.parameterTypes[1] == Boolean::class.javaPrimitiveType
+        }
+    private val findByContentDescriptionMethod =
+        automatorClass.methods.firstOrNull {
+            it.name == "findByContentDescription" &&
+                it.parameterTypes.size == 1 &&
+                it.parameterTypes[0] == String::class.java
+        }
     private val nodeBooleanMethods = ConcurrentHashMap<Pair<Class<*>, String>, Method>()
     private val nodeEditableTextMethods = ConcurrentHashMap<Class<*>, Method>()
 
@@ -107,12 +120,17 @@ internal class ReflectiveAutomatorHandler(
             )
         }
 
+    @Suppress("CyclomaticComplexMethod") // Exhaustive wire dispatch table.
     private fun dispatch(request: AgentRequest): AgentResponse =
         when (request) {
             AgentRequest.Ping -> AgentResponse.Pong
             AgentRequest.Windows -> handleWindows()
             AgentRequest.AllNodes -> handleAllNodes()
             is AgentRequest.FindByTestTag -> handleFindByTestTag(request.tag)
+            is AgentRequest.FindByText -> handleFindByText(request)
+            is AgentRequest.FindByContentDescription ->
+                handleFindByContentDescription(request.description)
+            is AgentRequest.FindByRole -> handleFindByRole(request.role)
             is AgentRequest.Click -> handleClick(request.nodeKey)
             is AgentRequest.TypeText -> handleTypeText(request.text)
             is AgentRequest.Screenshot -> handleScreenshot(request)
@@ -153,6 +171,70 @@ internal class ReflectiveAutomatorHandler(
         refreshWindowsMethod.invoke(automator)
         val nodes = findByTestTagMethod.invoke(automator, tag) as List<*>
         return AgentResponse.Nodes(nodes.mapNotNull { it?.let(::mapAutomatorNode) })
+    }
+
+    private fun handleFindByText(request: AgentRequest.FindByText): AgentResponse {
+        val method =
+            findByTextMethod
+                ?: return AgentResponse.Error(
+                    message = "ComposeAutomator does not expose findByText(text, exact)",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
+                )
+        if (request.text.isBlank()) {
+            return AgentResponse.Error(
+                message = "text must be non-blank",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InvalidSelector
+                        .wireName,
+            )
+        }
+        refreshWindowsMethod.invoke(automator)
+        val nodes = method.invoke(automator, request.text, request.exact) as List<*>
+        return AgentResponse.Nodes(nodes.mapNotNull { it?.let(::mapAutomatorNode) })
+    }
+
+    private fun handleFindByContentDescription(description: String): AgentResponse {
+        if (description.isBlank()) {
+            return AgentResponse.Error(
+                message = "description must be non-blank",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InvalidSelector
+                        .wireName,
+            )
+        }
+        val method =
+            findByContentDescriptionMethod
+                ?: return AgentResponse.Error(
+                    message = "ComposeAutomator does not expose findByContentDescription",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
+                )
+        refreshWindowsMethod.invoke(automator)
+        val nodes = method.invoke(automator, description) as List<*>
+        return AgentResponse.Nodes(nodes.mapNotNull { it?.let(::mapAutomatorNode) })
+    }
+
+    private fun handleFindByRole(roleName: String): AgentResponse {
+        if (roleName.isBlank()) {
+            return AgentResponse.Error(
+                message = "role must be non-blank",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InvalidSelector
+                        .wireName,
+            )
+        }
+        // Role is a Compose value class; match by role.toString() on the snapshot to avoid
+        // packing Role constants reflectively.
+        refreshWindowsMethod.invoke(automator)
+        val nodes = allNodesMethod.invoke(automator) as List<*>
+        val matches =
+            nodes.mapNotNull { it?.let(::mapAutomatorNode) }.filter { it.role == roleName }
+        return AgentResponse.Nodes(matches)
     }
 
     private fun handleClick(nodeKey: String): AgentResponse {
@@ -328,6 +410,17 @@ internal class ReflectiveAutomatorHandler(
 
     private fun mapAutomatorNode(node: Any): NodeSnapshotDto {
         val klass = node.javaClass
+        val descriptions =
+            (klass.methods
+                    .firstOrNull { it.name == "getContentDescriptions" && it.parameterCount == 0 }
+                    ?.invoke(node) as? List<*>)
+                ?.filterIsInstance<String>()
+                .orEmpty()
+        val singularDescription =
+            descriptions.firstOrNull()
+                ?: klass.methods
+                    .firstOrNull { it.name == "getContentDescription" && it.parameterCount == 0 }
+                    ?.invoke(node) as? String
         return NodeSnapshotDto(
             key = extractKey(node),
             testTag =
@@ -346,17 +439,15 @@ internal class ReflectiveAutomatorHandler(
                     .firstOrNull { it.name == "getRole" && it.parameterCount == 0 }
                     ?.invoke(node)
                     ?.toString(),
-            contentDescription =
-                klass.methods
-                    .firstOrNull { it.name == "getContentDescription" && it.parameterCount == 0 }
-                    ?.invoke(node) as? String,
-            isFocused = nodeBooleanProperty(node, methodName = "isFocused"),
-            isVisible = nodeBooleanProperty(node, methodName = "isVisible"),
+            contentDescription = singularDescription,
+            contentDescriptions = descriptions.ifEmpty { listOfNotNull(singularDescription) },
+            isFocused = nodeBooleanProperty(node, methodName = "isFocused", default = false),
+            isDisabled = nodeBooleanProperty(node, methodName = "isDisabled", default = false),
+            isSelected = nodeBooleanProperty(node, methodName = "isSelected", default = false),
+            isVisible = nodeBooleanProperty(node, methodName = "isVisible", default = true),
             bounds =
                 boundsToRect(
-                    // `AutomatorNode.boundsOnScreen: Rectangle` → getBoundsOnScreen(). The
-                    // earlier draft used `getBoundsInScreen` which doesn't exist and silently
-                    // produced RectDto(0,0,0,0).
+                    // `AutomatorNode.boundsOnScreen: Rectangle` → getBoundsOnScreen().
                     klass.methods
                         .firstOrNull { it.name == "getBoundsOnScreen" && it.parameterCount == 0 }
                         ?.invoke(node)
@@ -370,13 +461,19 @@ internal class ReflectiveAutomatorHandler(
             ?.invoke(node)
             ?.toString() ?: node.toString()
 
-    private fun nodeBooleanProperty(node: Any, methodName: String): Boolean =
-        nodeBooleanMethods
-            .computeIfAbsent(node.javaClass to methodName) { (klass, name) ->
+    private fun nodeBooleanProperty(
+        node: Any,
+        methodName: String,
+        default: Boolean = false,
+    ): Boolean {
+        val method =
+            nodeBooleanMethods.computeIfAbsent(node.javaClass to methodName) { (klass, name) ->
                 klass.methods.firstOrNull { it.name == name && it.parameterCount == 0 }
-                    ?: error("AutomatorNode API mismatch: ${klass.name} does not expose $name()")
+                    ?: MISSING_BOOLEAN_METHOD
             }
-            .invoke(node) as Boolean
+        if (method === MISSING_BOOLEAN_METHOD) return default
+        return method.invoke(node) as Boolean
+    }
 
     private fun nodeEditableText(node: Any): String? =
         nodeEditableTextMethods
@@ -426,6 +523,8 @@ internal class ReflectiveAutomatorHandler(
         const val CONTINUATION_FQN: String = "kotlin.coroutines.Continuation"
         const val AWT_RECTANGLE_FQN: String = "java.awt.Rectangle"
         const val NO_MESSAGE_PLACEHOLDER: String = "<no message>"
+        /** Sentinel when a fake/partial AutomatorNode lacks an optional boolean getter. */
+        val MISSING_BOOLEAN_METHOD: Method = Object::class.java.getMethod("hashCode")
 
         fun targetJvmHasKeyboardFocus(): Boolean {
             val focusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager()

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -183,9 +183,11 @@ internal class ReflectiveAutomatorHandler(
                             .UnsupportedOperation
                             .wireName,
                 )
-        if (request.text.isBlank()) {
+        // Empty text is valid in-process (exact match on empty EditableText). Whitespace-only is
+        // almost never intentional and diverges from useful substring semantics — reject it.
+        if (request.text.isNotEmpty() && request.text.isBlank()) {
             return AgentResponse.Error(
-                message = "text must be non-blank",
+                message = "text must not be whitespace-only",
                 category =
                     dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InvalidSelector
                         .wireName,
@@ -220,16 +222,19 @@ internal class ReflectiveAutomatorHandler(
     }
 
     private fun handleFindByRole(roleName: String): AgentResponse {
-        if (roleName.isBlank()) {
+        if (roleName.isBlank() || roleName !in KNOWN_ROLE_WIRE_NAMES) {
             return AgentResponse.Error(
-                message = "role must be non-blank",
+                message =
+                    if (roleName.isBlank()) "role must be non-blank"
+                    else "unknown role name: $roleName",
                 category =
                     dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InvalidSelector
                         .wireName,
             )
         }
         // Role is a Compose value class; match by role.toString() on the snapshot to avoid
-        // packing Role constants reflectively.
+        // packing Role constants reflectively. Names match Role.toString() (ValuePicker →
+        // "Picker").
         refreshWindowsMethod.invoke(automator)
         val nodes = allNodesMethod.invoke(automator) as List<*>
         val matches =
@@ -444,7 +449,9 @@ internal class ReflectiveAutomatorHandler(
             isFocused = nodeBooleanProperty(node, methodName = "isFocused", default = false),
             isDisabled = nodeBooleanProperty(node, methodName = "isDisabled", default = false),
             isSelected = nodeBooleanProperty(node, methodName = "isSelected", default = false),
-            isVisible = nodeBooleanProperty(node, methodName = "isVisible", default = true),
+            // isVisible is part of the long-standing AutomatorNode contract — fail loudly if
+            // absent.
+            isVisible = requireNodeBoolean(node, methodName = "isVisible"),
             bounds =
                 boundsToRect(
                     // `AutomatorNode.boundsOnScreen: Rectangle` → getBoundsOnScreen().
@@ -461,19 +468,37 @@ internal class ReflectiveAutomatorHandler(
             ?.invoke(node)
             ?.toString() ?: node.toString()
 
+    /**
+     * Soft boolean lookup: missing accessors return [default]. Used for optional snapshot fields
+     * (`isDisabled` / `isSelected` / `isFocused`) so older fakes and partial test doubles still map
+     * cleanly.
+     */
     private fun nodeBooleanProperty(
         node: Any,
         methodName: String,
         default: Boolean = false,
     ): Boolean {
-        val method =
-            nodeBooleanMethods.computeIfAbsent(node.javaClass to methodName) { (klass, name) ->
-                klass.methods.firstOrNull { it.name == name && it.parameterCount == 0 }
-                    ?: MISSING_BOOLEAN_METHOD
-            }
+        val method = resolveBooleanMethod(node, methodName)
         if (method === MISSING_BOOLEAN_METHOD) return default
         return method.invoke(node) as Boolean
     }
+
+    /** Hard boolean lookup: missing accessor is an AutomatorNode API mismatch. */
+    private fun requireNodeBoolean(node: Any, methodName: String): Boolean {
+        val method = resolveBooleanMethod(node, methodName)
+        if (method === MISSING_BOOLEAN_METHOD) {
+            error(
+                "AutomatorNode API mismatch: ${node.javaClass.name} does not expose $methodName()"
+            )
+        }
+        return method.invoke(node) as Boolean
+    }
+
+    private fun resolveBooleanMethod(node: Any, methodName: String): Method =
+        nodeBooleanMethods.computeIfAbsent(node.javaClass to methodName) { (klass, name) ->
+            klass.methods.firstOrNull { it.name == name && it.parameterCount == 0 }
+                ?: MISSING_BOOLEAN_METHOD
+        }
 
     private fun nodeEditableText(node: Any): String? =
         nodeEditableTextMethods
@@ -525,6 +550,24 @@ internal class ReflectiveAutomatorHandler(
         const val NO_MESSAGE_PLACEHOLDER: String = "<no message>"
         /** Sentinel when a fake/partial AutomatorNode lacks an optional boolean getter. */
         val MISSING_BOOLEAN_METHOD: Method = Object::class.java.getMethod("hashCode")
+
+        /**
+         * Compose [androidx.compose.ui.semantics.Role] wire names — the strings [Role.toString]
+         * returns. Agent has no compile-time Compose dependency, so the set is duplicated here.
+         * Note [Role.ValuePicker] stringifies as `"Picker"`, not `"ValuePicker"`.
+         */
+        val KNOWN_ROLE_WIRE_NAMES: Set<String> =
+            setOf(
+                "Button",
+                "Checkbox",
+                "Switch",
+                "RadioButton",
+                "Tab",
+                "Image",
+                "DropdownList",
+                "Picker",
+                "Carousel",
+            )
 
         fun targetJvmHasKeyboardFocus(): Boolean {
             val focusManager = KeyboardFocusManager.getCurrentKeyboardFocusManager()

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -344,7 +344,9 @@ public data class NodeSnapshotDto(
     public val isFocused: Boolean = false,
     public val isDisabled: Boolean = false,
     public val isSelected: Boolean = false,
-    public val isVisible: Boolean = true,
+    // Required (no default): encodeDefaults=false would omit a defaulted true and break older
+    // v2 clients whose NodeSnapshotDto decoder still requires this field on the wire.
+    public val isVisible: Boolean,
     public val bounds: RectDto,
 )
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -339,7 +339,9 @@ public data class NodeSnapshotDto(
     public val texts: List<String>,
     public val editableText: String? = null,
     public val role: String?,
-    public val contentDescription: String? = null,
+    // Required nullable (no default): encodeDefaults=false would omit a defaulted null and break
+    // older v2 clients whose decoder still requires contentDescription on every node snapshot.
+    public val contentDescription: String?,
     public val contentDescriptions: List<String> = emptyList(),
     public val isFocused: Boolean = false,
     public val isDisabled: Boolean = false,

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -42,6 +42,25 @@ internal sealed interface AgentRequest {
     data class FindByTestTag(val tag: String) : AgentRequest
 
     /**
+     * Find nodes by text (#202). [exact] true = case-sensitive equality; false = substring,
+     * case-insensitive (matches in-process `findByText`).
+     */
+    @Serializable
+    @SerialName("findByText")
+    data class FindByText(val text: String, val exact: Boolean = true) : AgentRequest
+
+    /** Find nodes by content description (#202). */
+    @Serializable
+    @SerialName("findByContentDescription")
+    data class FindByContentDescription(val description: String) : AgentRequest
+
+    /**
+     * Find nodes by role name (#202). [role] is the `Role` enum name as string (e.g. `Button`).
+     * Unknown role names yield [AgentErrorCategory.InvalidSelector].
+     */
+    @Serializable @SerialName("findByRole") data class FindByRole(val role: String) : AgentRequest
+
+    /**
      * Synthesize a click on the node identified by [nodeKey] (the canonical
      * `surfaceId:ownerIndex:nodeId` string). Server replies with [AgentResponse.Ok] on success or
      * [AgentResponse.Error] otherwise.
@@ -156,6 +175,9 @@ internal val AgentRequest.logLabel: String
             AgentRequest.Windows -> "windows"
             AgentRequest.AllNodes -> "allNodes"
             is AgentRequest.FindByTestTag -> "findByTestTag"
+            is AgentRequest.FindByText -> "findByText"
+            is AgentRequest.FindByContentDescription -> "findByContentDescription"
+            is AgentRequest.FindByRole -> "findByRole"
             is AgentRequest.Click -> "click"
             is AgentRequest.TypeText -> "typeText"
             is AgentRequest.Screenshot -> "screenshot"
@@ -302,8 +324,12 @@ public data class WindowSummaryDto(
 )
 
 /**
- * Read-only projection of an `AutomatorNode`. The [key] follows the canonical
- * `surfaceId:ownerIndex:nodeId` form used by Spectre's selector contract.
+ * Read-only projection of an `AutomatorNode` (#202 DTO convergence). The [key] is
+ * `surfaceId:ownerIndex:nodeId`.
+ *
+ * Field set aligns with HTTP `NodeSnapshotDto` where practical: [contentDescriptions], state flags.
+ * [contentDescription] is the first description (legacy singular). [bounds] is on-screen integer
+ * AWT coords (agent/Robot); HTTP keeps window+screen double rects — intentional divergence.
  */
 @ExperimentalSpectreAgentApi
 @Serializable
@@ -313,9 +339,12 @@ public data class NodeSnapshotDto(
     public val texts: List<String>,
     public val editableText: String? = null,
     public val role: String?,
-    public val contentDescription: String?,
+    public val contentDescription: String? = null,
+    public val contentDescriptions: List<String> = emptyList(),
     public val isFocused: Boolean = false,
-    public val isVisible: Boolean,
+    public val isDisabled: Boolean = false,
+    public val isSelected: Boolean = false,
+    public val isVisible: Boolean = true,
     public val bounds: RectDto,
 )
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
@@ -233,6 +233,59 @@ class ReflectiveAutomatorHandlerMappingTest {
     }
 
     @Test
+    fun `FindByText empty exact is forwarded for empty editableText parity`() {
+        val emptyField =
+            FakeAutomatorNode(
+                keyValue = "empty-field",
+                editableTextValue = "",
+                textsValue = emptyList(),
+            )
+        var received: Pair<String, Boolean>? = null
+        val automator =
+            FakeAutomator(
+                allNodesValue = listOf(emptyField),
+                findByTextImpl = { text, exact ->
+                    received = text to exact
+                    if (text.isEmpty() && exact) listOf(emptyField) else emptyList()
+                },
+            )
+        val handler = ReflectiveAutomatorHandler(automator)
+
+        val response = handler.handle(AgentRequest.FindByText(text = "", exact = true))
+        assertEquals("" to true, received)
+        check(response is AgentResponse.Nodes)
+        assertEquals(listOf("empty-field"), response.nodes.map { it.key })
+    }
+
+    @Test
+    fun `FindByRole unknown name is invalidSelector`() {
+        val automator =
+            FakeAutomator(
+                allNodesValue = listOf(FakeAutomatorNode(keyValue = "k", roleValue = "Button"))
+            )
+        val handler = ReflectiveAutomatorHandler(automator)
+
+        val response = handler.handle(AgentRequest.FindByRole("not-a-role"))
+        check(response is AgentResponse.Error)
+        assertEquals(
+            dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InvalidSelector.wireName,
+            response.category,
+        )
+    }
+
+    @Test
+    fun `FindByRole Button returns nodes whose mapped role matches`() {
+        val button = FakeAutomatorNode(keyValue = "btn", roleValue = "Button")
+        val other = FakeAutomatorNode(keyValue = "img", roleValue = "Image")
+        val automator = FakeAutomator(allNodesValue = listOf(button, other))
+        val handler = ReflectiveAutomatorHandler(automator)
+
+        val response = handler.handle(AgentRequest.FindByRole("Button"))
+        check(response is AgentResponse.Nodes)
+        assertEquals(listOf("btn"), response.nodes.map { it.key })
+    }
+
+    @Test
     fun `Screenshot op defaults to window surface bounds not full desktop`() {
         var receivedRegion: Any? = "<not invoked>"
         val image = java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_INT_ARGB)
@@ -596,6 +649,8 @@ private class FakeAutomator(
     private val allNodesValue: List<Any> = emptyList(),
     private val allNodesImpl: (() -> List<Any>)? = null,
     private val findByTestTagImpl: (String) -> List<Any> = { allNodesValue },
+    private val findByTextImpl: (String, Boolean) -> List<Any> = { _, _ -> emptyList() },
+    private val findByContentDescriptionImpl: (String) -> List<Any> = { emptyList() },
     private val screenshotImpl: (java.awt.Rectangle?) -> java.awt.image.BufferedImage = { _ ->
         java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB)
     },
@@ -623,6 +678,13 @@ private class FakeAutomator(
     @Suppress("unused") fun allNodes(): List<Any> = allNodesImpl?.invoke() ?: allNodesValue
 
     @Suppress("unused") fun findByTestTag(tag: String): List<Any> = findByTestTagImpl(tag)
+
+    @Suppress("unused")
+    fun findByText(text: String, exact: Boolean): List<Any> = findByTextImpl(text, exact)
+
+    @Suppress("unused")
+    fun findByContentDescription(description: String): List<Any> =
+        findByContentDescriptionImpl(description)
 
     @Suppress("unused")
     fun screenshot(region: java.awt.Rectangle?): java.awt.image.BufferedImage =

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -468,13 +468,16 @@ class IpcRoundTripTest {
         when (request) {
             AgentRequest.Ping -> AgentResponse.Pong
             AgentRequest.Windows -> AgentResponse.Windows(emptyList())
-            AgentRequest.AllNodes -> AgentResponse.Nodes(emptyList())
-            is AgentRequest.FindByTestTag -> AgentResponse.Nodes(emptyList())
-            is AgentRequest.FindByText -> AgentResponse.Nodes(emptyList())
-            is AgentRequest.FindByContentDescription -> AgentResponse.Nodes(emptyList())
-            is AgentRequest.FindByRole -> AgentResponse.Nodes(emptyList())
-            is AgentRequest.Click -> AgentResponse.Ok
-            is AgentRequest.TypeText -> AgentResponse.Ok
+            AgentRequest.AllNodes,
+            is AgentRequest.FindByTestTag,
+            is AgentRequest.FindByText,
+            is AgentRequest.FindByContentDescription,
+            is AgentRequest.FindByRole,
+            is AgentRequest.WaitForNode -> AgentResponse.Nodes(emptyList())
+            is AgentRequest.Click,
+            is AgentRequest.TypeText,
+            is AgentRequest.Cancel,
+            is AgentRequest.WaitForVisualIdle -> AgentResponse.Ok
             is AgentRequest.Screenshot -> AgentResponse.Screenshot(ByteArray(0))
             is AgentRequest.Capture ->
                 AgentResponse.Capture(
@@ -493,9 +496,6 @@ class IpcRoundTripTest {
             AgentRequest.Detach -> AgentResponse.Detached
             is AgentRequest.Hello ->
                 AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
-            is AgentRequest.Cancel -> AgentResponse.Ok
-            is AgentRequest.WaitForNode -> AgentResponse.Nodes(emptyList())
-            is AgentRequest.WaitForVisualIdle -> AgentResponse.Ok
         }
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -470,6 +470,9 @@ class IpcRoundTripTest {
             AgentRequest.Windows -> AgentResponse.Windows(emptyList())
             AgentRequest.AllNodes -> AgentResponse.Nodes(emptyList())
             is AgentRequest.FindByTestTag -> AgentResponse.Nodes(emptyList())
+            is AgentRequest.FindByText -> AgentResponse.Nodes(emptyList())
+            is AgentRequest.FindByContentDescription -> AgentResponse.Nodes(emptyList())
+            is AgentRequest.FindByRole -> AgentResponse.Nodes(emptyList())
             is AgentRequest.Click -> AgentResponse.Ok
             is AgentRequest.TypeText -> AgentResponse.Ok
             is AgentRequest.Screenshot -> AgentResponse.Screenshot(ByteArray(0))

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/SelectorParityTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/SelectorParityTest.kt
@@ -1,0 +1,103 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/** #202: findByText / contentDescription / role over agent IPC. */
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
+class SelectorParityTest {
+    private val udsPath: Path =
+        udsBase().resolve("sp-sel-${UUID.randomUUID().toString().take(8)}.sock")
+
+    private val sample =
+        NodeSnapshotDto(
+            key = "s:0:1",
+            testTag = "Submit",
+            texts = listOf("OK"),
+            role = "Button",
+            contentDescription = "Confirm",
+            contentDescriptions = listOf("Confirm"),
+            isVisible = true,
+            bounds = RectDto(0, 0, 20, 10),
+        )
+
+    @AfterTest
+    fun cleanUp() {
+        runCatching { udsPath.deleteIfExists() }
+    }
+
+    @Test
+    fun `findByText exact returns nodes`() {
+        IpcServer(
+                udsPath,
+                AgentRequestHandler { req ->
+                    when (req) {
+                        is AgentRequest.FindByText -> {
+                            assertEquals("OK", req.text)
+                            assertEquals(true, req.exact)
+                            AgentResponse.Nodes(listOf(sample))
+                        }
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+            .use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { client ->
+                    val nodes =
+                        assertIs<AgentResponse.Nodes>(
+                            client.send(AgentRequest.FindByText(text = "OK", exact = true))
+                        )
+                    assertEquals(1, nodes.nodes.size)
+                    assertEquals("Button", nodes.nodes.single().role)
+                }
+            }
+    }
+
+    @Test
+    fun `findByRole and contentDescription round-trip`() {
+        IpcServer(
+                udsPath,
+                AgentRequestHandler { req ->
+                    when (req) {
+                        is AgentRequest.FindByRole -> AgentResponse.Nodes(listOf(sample))
+                        is AgentRequest.FindByContentDescription ->
+                            AgentResponse.Nodes(listOf(sample))
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+            .use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { client ->
+                    assertIs<AgentResponse.Nodes>(client.send(AgentRequest.FindByRole("Button")))
+                    assertIs<AgentResponse.Nodes>(
+                        client.send(AgentRequest.FindByContentDescription("Confirm"))
+                    )
+                }
+            }
+    }
+
+    private fun awaitSocket(path: Path, timeoutMs: Long = 5_000) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000L
+        while (System.nanoTime() < deadline) {
+            if (java.nio.file.Files.exists(path)) return
+            Thread.sleep(10)
+        }
+        error("UDS path $path did not appear")
+    }
+
+    private fun udsBase(): Path =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
+            Path.of(System.getProperty("java.io.tmpdir"))
+        else Path.of("/tmp")
+}

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -303,6 +303,20 @@ decode hang or silent close. That is how mixed-version pairs degrade.
 | `inputRejected` | Focus / Robot / permission rejection |
 | `internalError` | Unexpected agent-side failure (default) |
 
+### Selectors (#202)
+
+Beyond `findByTestTag`, the agent transport supports:
+
+| Wire op | Notes |
+| --- | --- |
+| `findByText` | `text`, `exact` (default true) |
+| `findByContentDescription` | `description` |
+| `findByRole` | `role` string (e.g. `Button`); matches `role.toString()` |
+
+`NodeSnapshotDto` includes `contentDescriptions`, `isDisabled`, `isSelected` (HTTP field-set
+parity). On-screen `bounds` stay integer AWT units on the agent; HTTP keeps double
+window+screen rects.
+
 ### Payload limits (#204)
 
 Each IPC frame is length-prefixed and hard-capped at **16 MiB** (`MAX_FRAME_BYTES`). This is a

--- a/docs/guide/capability-matrix.md
+++ b/docs/guide/capability-matrix.md
@@ -69,7 +69,8 @@ boundary without a different design:
 | `withTracing` | Live tracer hooks |
 | `waitForIdle` (idling-resource variant) | Same as idling resources |
 
-Remote **waits** (`waitForNode`, `waitForVisualIdle` over agent — #201), richer **selectors**, and **input verbs**
+Remote **waits** (`waitForNode`, `waitForVisualIdle` over agent — #201), richer **selectors**
+(`findByText` / content-description / role — #202), and **input verbs**
 (drag / scroll / chords) are tracked as **Not yet CI-executed** on HTTP/agent until epic
 #197 sub-issues #201–#203 land. Do not document them as supported on remote transports until
 the matrix says so.

--- a/server/api/server.api
+++ b/server/api/server.api
@@ -7,7 +7,11 @@ public final class dev/sebastiano/spectre/server/HttpComposeAutomator : java/lan
 	public final fun allNodes (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun click (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun close ()V
+	public final fun findByContentDescription (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun findByRole (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun findByTestTag (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun findByText (Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/server/HttpComposeAutomator;Ljava/lang/String;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun screenshot (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun typeText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun windows (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/HttpComposeAutomator.kt
@@ -56,6 +56,24 @@ public class HttpComposeAutomator internal constructor(private val baseUrl: Stri
         client.get("$baseUrl/nodes").body<NodesResponse>().nodes
 
     /** Fetches semantics nodes carrying the given `testTag` from the remote automator. */
+    public suspend fun findByText(text: String, exact: Boolean = true): List<NodeSnapshotDto> =
+        client
+            .get("$baseUrl/nodes") {
+                parameter("text", text)
+                parameter("exact", exact.toString())
+            }
+            .body<NodesResponse>()
+            .nodes
+
+    public suspend fun findByContentDescription(description: String): List<NodeSnapshotDto> =
+        client
+            .get("$baseUrl/nodes") { parameter("contentDescription", description) }
+            .body<NodesResponse>()
+            .nodes
+
+    public suspend fun findByRole(role: String): List<NodeSnapshotDto> =
+        client.get("$baseUrl/nodes") { parameter("role", role) }.body<NodesResponse>().nodes
+
     public suspend fun findByTestTag(tag: String): List<NodeSnapshotDto> =
         client.get("$baseUrl/nodes") { parameter("testTag", tag) }.body<NodesResponse>().nodes
 

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -96,12 +96,38 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
         // Query handlers always refresh first: in-process callers control when to refresh, but
         // remote callers expect a request to reflect current state without an explicit prelude.
         automator.refreshWindows()
-        val testTag = call.request.queryParameters["testTag"]
+        val params = call.request.queryParameters
+        val testTag = params["testTag"]
+        val text = params["text"]
+        val contentDescription = params["contentDescription"]
+        val role = params["role"]
+        val selectorCount = listOfNotNull(testTag, text, contentDescription, role).size
+        if (selectorCount > 1) {
+            call.respond(
+                SpectreErrorCategory.httpStatus(SpectreErrorCategory.InvalidSelector),
+                SpectreErrorCategory.InvalidSelector.wireName,
+            )
+            return@get
+        }
         val nodes =
-            if (testTag != null) {
-                automator.findByTestTag(testTag)
-            } else {
-                automator.allNodes()
+            when {
+                testTag != null -> automator.findByTestTag(testTag)
+                text != null -> {
+                    val exact = params["exact"]?.toBooleanStrictOrNull() ?: true
+                    automator.findByText(text, exact = exact)
+                }
+                contentDescription != null -> automator.findByContentDescription(contentDescription)
+                role != null -> {
+                    // Role is a Compose value class (int-backed); match by toString() name
+                    // so HTTP callers pass "Button" etc. without packing Role constants.
+                    val matches = automator.allNodes().filter { it.role?.toString() == role }
+                    if (matches.isEmpty() && automator.allNodes().none { it.role != null }) {
+                        // No roles in tree is fine (empty list). Unknown names with other
+                        // roles present still return empty — same as in-process findByRole.
+                    }
+                    matches
+                }
+                else -> automator.allNodes()
             }
         call.respond(NodesResponse(nodes = nodes.map { it.toDto() }))
     }

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -214,7 +214,15 @@ private fun selectNodes(
         text != null -> {
             // Whitespace-only (but not empty) is almost never intentional.
             if (text.isNotEmpty() && text.isBlank()) return null
-            val exact = params["exact"]?.toBooleanStrictOrNull() ?: true
+            // Absent `exact` defaults to true; present-but-non-boolean is invalidSelector
+            // (do not silently coerce `FALSE` / `yes` into the default).
+            val exactParam = params["exact"]
+            val exact =
+                if (exactParam == null) {
+                    true
+                } else {
+                    exactParam.toBooleanStrictOrNull() ?: return null
+                }
             automator.findByText(text, exact = exact)
         }
         contentDescription != null -> {

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -193,8 +193,12 @@ internal fun BufferedImage.toScreenshotResponse(): ScreenshotResponse {
 }
 
 /**
- * Resolves `/nodes` selectors (#202). Returns null when more than one selector query param is set
- * (invalidSelector).
+ * Resolves `/nodes` selectors (#202). Returns null for invalidSelector cases: more than one
+ * selector query param, whitespace-only text, blank contentDescription/role, or an unknown role
+ * name.
+ *
+ * Empty text (`text=`) is allowed so exact match can target empty [editableText] fields, matching
+ * in-process `findByText("")`.
  */
 private fun selectNodes(
     automator: ComposeAutomator,
@@ -208,15 +212,41 @@ private fun selectNodes(
     return when {
         testTag != null -> automator.findByTestTag(testTag)
         text != null -> {
+            // Whitespace-only (but not empty) is almost never intentional.
+            if (text.isNotEmpty() && text.isBlank()) return null
             val exact = params["exact"]?.toBooleanStrictOrNull() ?: true
             automator.findByText(text, exact = exact)
         }
-        contentDescription != null -> automator.findByContentDescription(contentDescription)
+        contentDescription != null -> {
+            if (contentDescription.isBlank()) return null
+            automator.findByContentDescription(contentDescription)
+        }
         // Role is a Compose value class; match by toString() name ("Button", …).
-        role != null -> automator.allNodes().filter { it.role?.toString() == role }
+        role != null -> {
+            if (role.isBlank() || role !in KNOWN_ROLE_WIRE_NAMES) return null
+            automator.allNodes().filter { it.role?.toString() == role }
+        }
         else -> automator.allNodes()
     }
 }
+
+/**
+ * Compose [androidx.compose.ui.semantics.Role.toString] names. Kept local to the server module so
+ * HTTP and agent agree without a shared compile-time Role dependency in agent. [Role.ValuePicker]
+ * stringifies as `"Picker"`.
+ */
+private val KNOWN_ROLE_WIRE_NAMES: Set<String> =
+    setOf(
+        "Button",
+        "Checkbox",
+        "Switch",
+        "RadioButton",
+        "Tab",
+        "Image",
+        "DropdownList",
+        "Picker",
+        "Carousel",
+    )
 
 /**
  * Narrow decode-error mapping for `call.receive<T>()` (R4): Ktor's default response when

--- a/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
+++ b/server/src/main/kotlin/dev/sebastiano/spectre/server/SpectreServer.kt
@@ -93,42 +93,15 @@ private fun Route.spectreRoutes(automator: ComposeAutomator) {
     }
 
     get("/nodes") {
-        // Query handlers always refresh first: in-process callers control when to refresh, but
-        // remote callers expect a request to reflect current state without an explicit prelude.
         automator.refreshWindows()
-        val params = call.request.queryParameters
-        val testTag = params["testTag"]
-        val text = params["text"]
-        val contentDescription = params["contentDescription"]
-        val role = params["role"]
-        val selectorCount = listOfNotNull(testTag, text, contentDescription, role).size
-        if (selectorCount > 1) {
+        val nodes = selectNodes(automator, call.request.queryParameters)
+        if (nodes == null) {
             call.respond(
                 SpectreErrorCategory.httpStatus(SpectreErrorCategory.InvalidSelector),
                 SpectreErrorCategory.InvalidSelector.wireName,
             )
             return@get
         }
-        val nodes =
-            when {
-                testTag != null -> automator.findByTestTag(testTag)
-                text != null -> {
-                    val exact = params["exact"]?.toBooleanStrictOrNull() ?: true
-                    automator.findByText(text, exact = exact)
-                }
-                contentDescription != null -> automator.findByContentDescription(contentDescription)
-                role != null -> {
-                    // Role is a Compose value class (int-backed); match by toString() name
-                    // so HTTP callers pass "Button" etc. without packing Role constants.
-                    val matches = automator.allNodes().filter { it.role?.toString() == role }
-                    if (matches.isEmpty() && automator.allNodes().none { it.role != null }) {
-                        // No roles in tree is fine (empty list). Unknown names with other
-                        // roles present still return empty — same as in-process findByRole.
-                    }
-                    matches
-                }
-                else -> automator.allNodes()
-            }
         call.respond(NodesResponse(nodes = nodes.map { it.toDto() }))
     }
 
@@ -217,6 +190,32 @@ internal fun BufferedImage.toScreenshotResponse(): ScreenshotResponse {
         width = width,
         height = height,
     )
+}
+
+/**
+ * Resolves `/nodes` selectors (#202). Returns null when more than one selector query param is set
+ * (invalidSelector).
+ */
+private fun selectNodes(
+    automator: ComposeAutomator,
+    params: io.ktor.http.Parameters,
+): List<dev.sebastiano.spectre.core.AutomatorNode>? {
+    val testTag = params["testTag"]
+    val text = params["text"]
+    val contentDescription = params["contentDescription"]
+    val role = params["role"]
+    if (listOfNotNull(testTag, text, contentDescription, role).size > 1) return null
+    return when {
+        testTag != null -> automator.findByTestTag(testTag)
+        text != null -> {
+            val exact = params["exact"]?.toBooleanStrictOrNull() ?: true
+            automator.findByText(text, exact = exact)
+        }
+        contentDescription != null -> automator.findByContentDescription(contentDescription)
+        // Role is a Compose value class; match by toString() name ("Button", …).
+        role != null -> automator.allNodes().filter { it.role?.toString() == role }
+        else -> automator.allNodes()
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

[#202](https://github.com/rock3r/spectre/issues/202) / epic [#197](https://github.com/rock3r/spectre/issues/197).

- Agent + HTTP: `findByText`, `findByContentDescription`, `findByRole`
- Agent `NodeSnapshotDto`: `contentDescriptions`, `isDisabled`, `isSelected` (+ legacy singular description)
- Documented bounds divergence (agent int on-screen vs HTTP double window+screen)
- `invalidSelector` when multiple HTTP selector query params are combined

## Validation

- `SelectorParityTest`, mapping tests
- `./gradlew :agent:check :server:check`