### PR TITLE
Close epic #197 skeptic acceptance gaps on corpus and waits

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/InputOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/InputOpsReflectiveMapper.kt
@@ -268,9 +268,16 @@ internal class InputOpsReflectiveMapper(
          */
         fun durationStorageFromMs(ms: Long): Long {
             require(ms >= 0L) { "duration ms must be non-negative" }
-            val nanos = ms * 1_000_000L
-            // Matches Duration's "fits in nanos" threshold (Long.MAX_VALUE / 2).
-            return if (nanos <= Long.MAX_VALUE / 2) nanos shl 1 else (ms shl 1) + 1
+            // Compare against the nanos-storage threshold in ms-space first so
+            // `ms * NANOS_PER_MS` cannot overflow Long before the millis-unit branch.
+            val maxMsStoredAsNanos = (Long.MAX_VALUE / 2) / NANOS_PER_MS
+            return if (ms <= maxMsStoredAsNanos) {
+                (ms * NANOS_PER_MS) shl 1
+            } else {
+                (ms shl 1) + 1
+            }
         }
+
+        private const val NANOS_PER_MS: Long = 1_000_000L
     }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
@@ -7,14 +7,15 @@ import dev.sebastiano.spectre.agent.transport.AgentRequest
 import dev.sebastiano.spectre.agent.transport.AgentResponse
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import java.lang.reflect.Method
-import kotlin.time.Duration.Companion.milliseconds
 
 /**
  * Reflective bridge for [AgentRequest.WaitForNode] / [AgentRequest.WaitForVisualIdle] (#201). Lives
  * outside [ReflectiveAutomatorHandler] to keep that class under detekt complexity limits.
  *
- * Kotlin mangles `Duration` parameters into primitive `long` (nanoseconds) and renames methods
- * (e.g. `waitForNode-ck1zr5g`). Lookups use parameter types, not the unmangled source name.
+ * Kotlin mangles `Duration` parameters into primitive `long` carrying [kotlin.time.Duration]'s
+ * packed `rawValue` (not plain nanoseconds) and renames methods (e.g. `waitForNode-ck1zr5g`).
+ * Lookups use parameter types, not the unmangled source name; invocations use
+ * [durationStorageFromMs].
  */
 internal class WaitOpsReflectiveMapper(
     private val automator: Any,
@@ -70,9 +71,9 @@ internal class WaitOpsReflectiveMapper(
                     automator,
                     request.tag,
                     request.text,
-                    // Duration is a value class: JVM surface is primitive long nanoseconds.
-                    timeoutMs.milliseconds.inWholeNanoseconds,
-                    pollMs.milliseconds.inWholeNanoseconds,
+                    // Duration is a value class: JVM surface is packed rawValue, not plain nanos.
+                    durationStorageFromMs(timeoutMs),
+                    durationStorageFromMs(pollMs),
                     timeoutMsOverride = timeoutMs + SUSPEND_BRIDGE_SLACK_MS,
                 )
             if (node == null) {
@@ -100,9 +101,9 @@ internal class WaitOpsReflectiveMapper(
             suspendInvoker.invoke(
                 method,
                 automator,
-                timeoutMs.milliseconds.inWholeNanoseconds,
+                durationStorageFromMs(timeoutMs),
                 stableFrames,
-                pollMs.milliseconds.inWholeNanoseconds,
+                durationStorageFromMs(pollMs),
                 timeoutMsOverride = timeoutMs + SUSPEND_BRIDGE_SLACK_MS,
             )
             AgentResponse.Ok
@@ -112,22 +113,27 @@ internal class WaitOpsReflectiveMapper(
     /**
      * Maps wait-loop timeouts (stdlib [TimeoutException], IdleTimeoutException,
      * TimeoutCancellationException) to taxonomy `timeout`; rethrows everything else.
+     *
+     * Reflective [java.lang.reflect.Method.invoke] wraps checked/runtime failures in
+     * [java.lang.reflect.InvocationTargetException]; unwrap so taxonomy matching sees the
+     * automator's real exception type/message.
      */
     @Suppress("TooGenericExceptionCaught", "InstanceOfCheckForException")
     private fun runWait(block: () -> AgentResponse): AgentResponse =
         try {
             block()
         } catch (ex: Exception) {
+            val root = unwrapReflective(ex)
             // IdleTimeoutException / TimeoutCancellationException are not on the classpath of
             // :agent; match by type name so wait timeouts become taxonomy `timeout`.
-            if (ex is java.util.concurrent.TimeoutException || isWaitTimeout(ex)) {
-                timeoutError(ex)
+            if (root is java.util.concurrent.TimeoutException || isWaitTimeout(root)) {
+                timeoutError(root)
             } else {
                 throw ex
             }
         }
 
-    private fun timeoutError(ex: Exception): AgentResponse.Error =
+    private fun timeoutError(ex: Throwable): AgentResponse.Error =
         AgentResponse.Error(
             message = "${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}",
             category = AgentErrorCategory.Timeout.wireName,
@@ -141,13 +147,35 @@ internal class WaitOpsReflectiveMapper(
         const val DEFAULT_STABLE_FRAMES: Int = 3
         const val SUSPEND_BRIDGE_SLACK_MS: Long = 2_000
 
-        fun isWaitTimeout(ex: Exception): Boolean {
+        fun unwrapReflective(ex: Exception): Throwable {
+            var current: Throwable = ex
+            while (current is java.lang.reflect.InvocationTargetException) {
+                current = current.cause ?: return current
+            }
+            return current
+        }
+
+        fun isWaitTimeout(ex: Throwable): Boolean {
             val name = ex.javaClass.name
             val msg = ex.message.orEmpty().lowercase()
             return name.endsWith("IdleTimeoutException") ||
                 name.endsWith("TimeoutCancellationException") ||
                 "timed out" in msg ||
                 "timeout" in name.lowercase()
+        }
+
+        /**
+         * Packs milliseconds into the `long` storage used by Kotlin [kotlin.time.Duration] on the
+         * JVM (nanos << 1 for small values; millis << 1 | 1 when nanos would overflow).
+         *
+         * Must match [InputOpsReflectiveMapper]'s packing — plain
+         * [kotlin.time.Duration.inWholeNanoseconds] is half the intended length once Duration
+         * reinterprets the low unit bit.
+         */
+        fun durationStorageFromMs(ms: Long): Long {
+            require(ms >= 0L) { "duration ms must be non-negative" }
+            val nanos = ms * 1_000_000L
+            return if (nanos <= Long.MAX_VALUE / 2) nanos shl 1 else (ms shl 1) + 1
         }
     }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
@@ -174,8 +174,16 @@ internal class WaitOpsReflectiveMapper(
          */
         fun durationStorageFromMs(ms: Long): Long {
             require(ms >= 0L) { "duration ms must be non-negative" }
-            val nanos = ms * 1_000_000L
-            return if (nanos <= Long.MAX_VALUE / 2) nanos shl 1 else (ms shl 1) + 1
+            // Compare against the nanos-storage threshold in ms-space first so
+            // `ms * NANOS_PER_MS` cannot overflow Long before the millis-unit branch.
+            val maxMsStoredAsNanos = (Long.MAX_VALUE / 2) / NANOS_PER_MS
+            return if (ms <= maxMsStoredAsNanos) {
+                (ms * NANOS_PER_MS) shl 1
+            } else {
+                (ms shl 1) + 1
+            }
         }
+
+        private const val NANOS_PER_MS: Long = 1_000_000L
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
@@ -186,8 +186,23 @@ class AgentContractCorpusTest {
                 )
             }
 
+        override val supportsWaitTaxonomy: Boolean = true
+
         override fun waitForNode(tag: String?, text: String?, timeoutMs: Long): String =
             automator.waitForNode(tag = tag, text = text, timeoutMs = timeoutMs).key
+
+        override fun waitForNodeFailureCategory(
+            tag: String?,
+            text: String?,
+            timeoutMs: Long,
+        ): String {
+            try {
+                automator.waitForNode(tag = tag, text = text, timeoutMs = timeoutMs)
+                error("waitForNode was expected to time out")
+            } catch (ex: SpectreAgentException) {
+                return ex.category.wireName
+            }
+        }
 
         override fun click(nodeKey: String) {
             automator.click(nodeKey)

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveHandlerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveHandlerTest.kt
@@ -1,0 +1,150 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+import dev.sebastiano.spectre.agent.transport.AgentRequest
+import dev.sebastiano.spectre.agent.transport.AgentResponse
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * #201 wait ops through the real [ReflectiveAutomatorHandler] reflective bridge: success path,
+ * Duration packing (packed rawValue, not plain nanoseconds), timeout taxonomy, and invalid-selector
+ * rejection. Cancel-while-waiting is covered in [WaitOpsInfrastructureTest] over multiplexed IPC.
+ */
+class WaitOpsReflectiveHandlerTest {
+
+    @Test
+    fun `WaitForNode success returns the matched node`() {
+        val node = WaitFakeNode(keyValue = "btn", testTagValue = "Counter")
+        val fake = WaitFakeAutomator(allNodesValue = listOf(node))
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response = handler.handle(AgentRequest.WaitForNode(tag = "Counter", timeoutMs = 1_000))
+        check(response is AgentResponse.Nodes) { "expected Nodes, got $response" }
+        assertEquals(1, response.nodes.size)
+        assertEquals("btn", response.nodes.single().key)
+        assertEquals(listOf<String?>("Counter"), fake.waitForNodeTags.toList())
+        // Packed Duration rawValue for 1000ms: nanos << 1 = 1_000_000_000 << 1.
+        val expectedTimeoutRaw = 1_000L * 1_000_000L shl 1
+        assertEquals(listOf(expectedTimeoutRaw), fake.waitForNodeTimeoutRaw.toList())
+    }
+
+    @Test
+    fun `WaitForNode timeout maps to taxonomy timeout`() {
+        val fake =
+            WaitFakeAutomator(
+                waitForNodeImpl = { _: String?, _: String?, _: Long, _: Long ->
+                    throw FakeIdleTimeoutException("waitForNode timed out after 400 ms")
+                }
+            )
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response =
+            handler.handle(
+                AgentRequest.WaitForNode(
+                    tag = "never-appears",
+                    timeoutMs = 400,
+                    pollIntervalMs = 50,
+                )
+            )
+        check(response is AgentResponse.Error) { "expected Error, got $response" }
+        assertEquals(AgentErrorCategory.Timeout.wireName, response.category)
+        // 400ms → nanos << 1 packing (not plain inWholeNanoseconds).
+        val expectedTimeoutRaw = 400L * 1_000_000L shl 1
+        assertEquals(listOf(expectedTimeoutRaw), fake.waitForNodeTimeoutRaw.toList())
+    }
+
+    @Test
+    fun `WaitForNode refuses when neither tag nor text is set`() {
+        val handler = ReflectiveAutomatorHandler(WaitFakeAutomator())
+        val response = handler.handle(AgentRequest.WaitForNode(tag = null, text = null))
+        check(response is AgentResponse.Error)
+        assertEquals(AgentErrorCategory.InvalidSelector.wireName, response.category)
+    }
+}
+
+/** Name-shape matches core IdleTimeoutException for WaitOps taxonomy matching. */
+private class FakeIdleTimeoutException(message: String) : RuntimeException(message)
+
+/**
+ * JVM-public stand-in for ComposeAutomator wait surface. Must not be package-private:
+ * [BlockingSuspendInvoker] is in this package but Method.invoke still requires a public class.
+ */
+internal class WaitFakeAutomator(
+    private val allNodesValue: List<Any> = emptyList(),
+    private val waitForNodeImpl: ((String?, String?, Long, Long) -> Any?)? = null,
+) {
+    val waitForNodeTags = mutableListOf<String?>()
+    val waitForNodeTimeoutRaw = mutableListOf<Long>()
+
+    @Suppress("unused") fun refreshWindows() = Unit
+
+    @Suppress("unused") fun getWindows(): List<Any> = emptyList()
+
+    @Suppress("unused") fun allNodes(): List<Any> = allNodesValue
+
+    @Suppress("unused") fun findByTestTag(tag: String): List<Any> = emptyList()
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun waitForNode(
+        tag: String?,
+        text: String?,
+        timeoutRaw: Long,
+        pollRaw: Long,
+        continuation: kotlin.coroutines.Continuation<Any?>,
+    ): Any? {
+        waitForNodeTags += tag
+        waitForNodeTimeoutRaw += timeoutRaw
+        waitForNodeImpl?.let {
+            return it(tag, text, timeoutRaw, pollRaw)
+        }
+        return allNodesValue.firstOrNull { node ->
+            val nodeTag =
+                node.javaClass.methods
+                    .firstOrNull { it.name == "getTestTag" && it.parameterCount == 0 }
+                    ?.invoke(node) as? String
+            tag != null && nodeTag == tag
+        }
+    }
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun waitForVisualIdle(
+        timeoutRaw: Long,
+        stableFrames: Int,
+        pollRaw: Long,
+        continuation: kotlin.coroutines.Continuation<Any?>,
+    ): Any? = Unit
+}
+
+internal class WaitFakeNode(
+    private val keyValue: String,
+    private val testTagValue: String? = null,
+    private val textsValue: List<String> = emptyList(),
+    private val editableTextValue: String? = null,
+    private val roleValue: String? = null,
+    private val contentDescriptionValue: String? = null,
+    private val isFocusedValue: Boolean = false,
+    private val isVisibleValue: Boolean = true,
+    private val boundsOnScreenValue: Rectangle = Rectangle(0, 0, 0, 0),
+) {
+    @Suppress("unused") fun getKey(): String = keyValue
+
+    @Suppress("unused") fun getTestTag(): String? = testTagValue
+
+    @Suppress("unused") fun getTexts(): List<String> = textsValue
+
+    @Suppress("unused") fun getEditableText(): String? = editableTextValue
+
+    @Suppress("unused") fun getRole(): String? = roleValue
+
+    @Suppress("unused") fun getContentDescription(): String? = contentDescriptionValue
+
+    @Suppress("unused") fun isFocused(): Boolean = isFocusedValue
+
+    @Suppress("unused") fun isVisible(): Boolean = isVisibleValue
+
+    @Suppress("unused") fun getBoundsOnScreen(): Rectangle = boundsOnScreenValue
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WaitOpsInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WaitOpsInfrastructureTest.kt
@@ -2,6 +2,7 @@
 
 package dev.sebastiano.spectre.agent.transport
 
+import dev.sebastiano.spectre.agent.runtime.ReflectiveAutomatorHandler
 import java.nio.file.Path
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
@@ -141,6 +142,40 @@ class WaitOpsInfrastructureTest {
             }
     }
 
+    /**
+     * Same cancel taxonomy, but the server dispatches through the real [ReflectiveAutomatorHandler]
+     * + wait reflective bridge (not a canned WaitForNode stub). Proves cancel wins while the
+     *   suspend bridge is blocked inside a long waitForNode.
+     */
+    @Test
+    fun `slow waitForNode through ReflectiveAutomatorHandler can be cancelled`() {
+        val started = CountDownLatch(1)
+        val automator = SlowWaitFakeAutomator(onWaitStarted = { started.countDown() })
+        val handler = ReflectiveAutomatorHandler(automator)
+        IpcServer(udsPath, handler).use {
+            awaitSocket(udsPath)
+            IpcClient(udsPath).use { client ->
+                val holder = arrayOfNulls<AgentResponse>(1)
+                val t = Thread {
+                    holder[0] =
+                        client.send(AgentRequest.WaitForNode(tag = "never", timeoutMs = 25_000))
+                }
+                t.isDaemon = true
+                t.start()
+                assertTrue(
+                    started.await(5, TimeUnit.SECONDS),
+                    "IPC path never entered ReflectiveAutomatorHandler.waitForNode; " +
+                        "holder=${holder[0]}",
+                )
+                client.cancel(1L)
+                assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+                t.join(5_000)
+                val err = assertIs<AgentResponse.Error>(holder[0])
+                assertEquals(AgentErrorCategory.Cancelled.wireName, err.category)
+            }
+        }
+    }
+
     private fun awaitSocket(path: Path, timeoutMs: Long = 5_000) {
         val deadline = System.nanoTime() + timeoutMs * 1_000_000L
         while (System.nanoTime() < deadline) {
@@ -154,4 +189,62 @@ class WaitOpsInfrastructureTest {
         if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
             Path.of(System.getProperty("java.io.tmpdir"))
         else Path.of("/tmp")
+}
+
+/**
+ * Minimal stand-in whose JVM shape matches ComposeAutomator enough for [ReflectiveAutomatorHandler]
+ * construction + waitForNode dispatch. Sleeps inside waitForNode so cancel can interrupt the worker
+ * mid-op.
+ *
+ * Must be [internal] (JVM-public), not private: [BlockingSuspendInvoker] lives in another package
+ * and reflective Method.invoke cannot call members of a package-private class from outside.
+ */
+internal class SlowWaitFakeAutomator(private val onWaitStarted: () -> Unit) {
+    @Suppress("unused") fun refreshWindows() = Unit
+
+    @Suppress("unused") fun getWindows(): List<Any> = emptyList()
+
+    @Suppress("unused") fun allNodes(): List<Any> = emptyList()
+
+    @Suppress("unused") fun findByTestTag(tag: String): List<Any> = emptyList()
+
+    @Suppress("unused") fun findByText(text: String, exact: Boolean): List<Any> = emptyList()
+
+    @Suppress("unused") fun findByContentDescription(description: String): List<Any> = emptyList()
+
+    @Suppress("unused")
+    fun screenshot(region: java.awt.Rectangle?): java.awt.image.BufferedImage =
+        java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+
+    @Suppress("unused")
+    fun screenshot(windowIndex: Int): java.awt.image.BufferedImage =
+        java.awt.image.BufferedImage(1, 1, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+
+    @Suppress("unused") fun windowIdentities(): List<Any> = emptyList()
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun waitForNode(
+        tag: String?,
+        text: String?,
+        timeoutRaw: Long,
+        pollRaw: Long,
+        continuation: kotlin.coroutines.Continuation<Any?>,
+    ): Any? {
+        onWaitStarted()
+        try {
+            Thread.sleep(30_000)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw InterruptedException("waitForNode interrupted")
+        }
+        return null
+    }
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun waitForVisualIdle(
+        timeoutRaw: Long,
+        stableFrames: Int,
+        pollRaw: Long,
+        continuation: kotlin.coroutines.Continuation<Any?>,
+    ): Any? = Unit
 }

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -65,7 +65,8 @@ public abstract interface class dev/sebastiano/spectre/testing/contract/Automato
 	public fun findByText (Ljava/lang/String;Z)Ljava/util/List;
 	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
 	public fun getExpectsFixtureSemantics ()Z
-	public fun getSupportsExtendedParity ()Z
+	public fun getSupportsFixtureParity ()Z
+	public fun getSupportsWaitTaxonomy ()Z
 	public abstract fun getTransport ()Ldev/sebastiano/spectre/testing/contract/AutomatorTransport;
 	public fun pressKey (II)V
 	public static synthetic fun pressKey$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;IIILjava/lang/Object;)V
@@ -74,6 +75,7 @@ public abstract interface class dev/sebastiano/spectre/testing/contract/Automato
 	public fun swipe (Ljava/lang/String;Ljava/lang/String;)V
 	public abstract fun typeText (Ljava/lang/String;)V
 	public fun waitForNode (Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/String;
+	public fun waitForNodeFailureCategory (Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/String;
 	public abstract fun windows ()Ljava/util/List;
 }
 
@@ -85,13 +87,15 @@ public final class dev/sebastiano/spectre/testing/contract/AutomatorContractDriv
 	public static fun findByText (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Z)Ljava/util/List;
 	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
 	public static fun getExpectsFixtureSemantics (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
-	public static fun getSupportsExtendedParity (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
+	public static fun getSupportsFixtureParity (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
+	public static fun getSupportsWaitTaxonomy (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
 	public static fun pressKey (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;II)V
 	public static synthetic fun pressKey$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;IIILjava/lang/Object;)V
 	public static fun screenshotProbe (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Ldev/sebastiano/spectre/testing/contract/ScreenshotProbe;
 	public static fun scrollWheel (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;I)V
 	public static fun swipe (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Ljava/lang/String;)V
 	public static fun waitForNode (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/String;
+	public static fun waitForNodeFailureCategory (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/String;
 }
 
 public final class dev/sebastiano/spectre/testing/contract/AutomatorOperation : java/lang/Enum {

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -65,6 +65,7 @@ public abstract interface class dev/sebastiano/spectre/testing/contract/Automato
 	public fun findByText (Ljava/lang/String;Z)Ljava/util/List;
 	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
 	public fun getExpectsFixtureSemantics ()Z
+	public fun getSupportsExtendedParity ()Z
 	public fun getSupportsFixtureParity ()Z
 	public fun getSupportsWaitTaxonomy ()Z
 	public abstract fun getTransport ()Ldev/sebastiano/spectre/testing/contract/AutomatorTransport;
@@ -87,6 +88,7 @@ public final class dev/sebastiano/spectre/testing/contract/AutomatorContractDriv
 	public static fun findByText (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Z)Ljava/util/List;
 	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
 	public static fun getExpectsFixtureSemantics (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
+	public static fun getSupportsExtendedParity (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
 	public static fun getSupportsFixtureParity (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
 	public static fun getSupportsWaitTaxonomy (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
 	public static fun pressKey (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;II)V

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
@@ -25,7 +25,12 @@ public data class ContractNode(
  *
  * Methods must hit the **real** client entry point for that transport (no mocks of the unit under
  * test). Empty results are allowed when the matrix cell does not require a live fixture.
+ *
+ * Function count is intentionally above the default detekt budget: the corpus needs one method per
+ * tracked public entry (selectors, input verbs, waits + timeout taxonomy) so Supported matrix cells
+ * cannot soft-skip.
  */
+@Suppress("TooManyFunctions")
 public interface AutomatorContractDriver : AutoCloseable {
     public val transport: AutomatorTransport
 
@@ -76,11 +81,18 @@ public interface AutomatorContractDriver : AutoCloseable {
     }
 
     /**
-     * Optional wait (#201). [waitForNodeTimeoutMs] is the budget. Should throw on timeout when
-     * waiting for a never-present selector. Returns the matched node key on success.
+     * Optional wait (#201). Should throw on timeout when waiting for a never-present selector.
+     * Returns the matched node key on success.
      */
     public fun waitForNode(tag: String?, text: String?, timeoutMs: Long): String =
         error("waitForNode not implemented for $transport")
+
+    /**
+     * Stable error taxonomy name for a failed [waitForNode] (e.g. `"timeout"`). Implementations
+     * that cannot surface a category should throw rather than invent one.
+     */
+    public fun waitForNodeFailureCategory(tag: String?, text: String?, timeoutMs: Long): String =
+        error("waitForNodeFailureCategory not implemented for $transport")
 
     /**
      * Optional screenshot probe. Return `null` if the transport/driver does not exercise screenshot
@@ -88,9 +100,19 @@ public interface AutomatorContractDriver : AutoCloseable {
      */
     public fun screenshotProbe(): ScreenshotProbe? = null
 
-    /** When true, corpus runs #201–#203 extended scenarios (selectors/waits/input). */
-    public val supportsExtendedParity: Boolean
+    /**
+     * When true, corpus runs fixture-backed match/input scenarios that need a live Compose UI
+     * (agent Xvfb/macOS). Selector entry-point scenarios always run on all transports.
+     */
+    public val supportsFixtureParity: Boolean
         get() = expectsFixtureSemantics
+
+    /**
+     * When true, [waitForNodeFailureCategory] is implemented (agent + in-process). HTTP has no wait
+     * routes (#201 is agent-scoped).
+     */
+    public val supportsWaitTaxonomy: Boolean
+        get() = false
 
     override fun close() {}
 }
@@ -211,8 +233,8 @@ public object AutomatorContractCorpus {
                     check(probe.byteCount > 0) { "screenshot empty" }
                     "bytes=${probe.byteCount} format=${probe.formatHint}"
                 }
-            if (driver.supportsExtendedParity) {
-                results += extendedParityScenarios(driver)
+            if (driver.supportsFixtureParity) {
+                results += fixtureParityScenarios(driver)
             }
         } else {
             results +=
@@ -247,13 +269,63 @@ public object AutomatorContractCorpus {
                 )
         }
 
+        // Selector entry points + wait timeout taxonomy run on every transport (including
+        // headless).
+        results += crossTransportParityScenarios(driver)
+
         return RunResult(transport = driver.transport, results = results)
     }
 
-    /** #201–#203 scenarios against a live fixture-backed driver (agent Xvfb/macOS). */
-    private fun extendedParityScenarios(driver: AutomatorContractDriver): List<ScenarioResult> {
+    /**
+     * #201–#202 scenarios that run on **all three** transports. Headless trees may be empty; the
+     * contract is that entry points do not hang and wait timeout surfaces taxonomy `timeout`.
+     */
+    private fun crossTransportParityScenarios(
+        driver: AutomatorContractDriver
+    ): List<ScenarioResult> {
         val out = mutableListOf<ScenarioResult>()
-        // #202 selectors
+        out +=
+            scenario("find-by-text-entry", driver.transport) {
+                val nodes = driver.findByText("no-such-label-xyz", exact = true)
+                "matched=${nodes.size}"
+            }
+        out +=
+            scenario("find-by-role-entry", driver.transport) {
+                // Unknown role must fail closed as invalidSelector on agent/HTTP; in-process may
+                // return empty for a non-matching role name when filtering by string.
+                val result = runCatching { driver.findByRole("not-a-compose-role") }
+                when {
+                    result.isFailure -> "failed-as-expected"
+                    result.getOrNull().orEmpty().isEmpty() -> "empty-as-expected"
+                    else -> error("unknown role must not match nodes")
+                }
+            }
+        out +=
+            scenario("find-by-content-description-entry", driver.transport) {
+                val nodes = driver.findByContentDescription("no-such-description-xyz")
+                "matched=${nodes.size}"
+            }
+        if (driver.supportsWaitTaxonomy) {
+            out +=
+                scenario("wait-for-node-timeout-taxonomy", driver.transport) {
+                    val category =
+                        driver.waitForNodeFailureCategory(
+                            tag = "agent-fixture-never-appears",
+                            text = null,
+                            timeoutMs = 400,
+                        )
+                    check(category == "timeout") {
+                        "expected timeout taxonomy, got category=$category"
+                    }
+                    "category=$category"
+                }
+        }
+        return out
+    }
+
+    /** Fixture-backed match + input scenarios (agent Xvfb/macOS). */
+    private fun fixtureParityScenarios(driver: AutomatorContractDriver): List<ScenarioResult> {
+        val out = mutableListOf<ScenarioResult>()
         out +=
             scenario("find-by-text-fixture-label", driver.transport) {
                 val nodes = driver.findByText("Spectre agent fixture", exact = true)
@@ -278,7 +350,6 @@ public object AutomatorContractCorpus {
                 check(nodes.isNotEmpty()) { "findByContentDescription empty" }
                 "matched=${nodes.size}"
             }
-        // #201 waits
         out +=
             scenario("wait-for-node-present-tag", driver.transport) {
                 val key =
@@ -290,21 +361,7 @@ public object AutomatorContractCorpus {
                 check(key.isNotBlank()) { "waitForNode returned blank key" }
                 "key=$key"
             }
-        out +=
-            scenario("wait-for-node-timeout", driver.transport) {
-                val failed =
-                    runCatching {
-                            driver.waitForNode(
-                                tag = "agent-fixture-never-appears",
-                                text = null,
-                                timeoutMs = 400,
-                            )
-                        }
-                        .isFailure
-                check(failed) { "waitForNode for missing tag must fail/timeout" }
-                "timed-out-as-expected"
-            }
-        // #203 input verbs (real Robot on fixture)
+        // #203 input verbs (real Robot on fixture) — no soft-skip: failures fail the scenario.
         out +=
             scenario("double-click-fixture-button", driver.transport) {
                 val button =
@@ -333,16 +390,14 @@ public object AutomatorContractCorpus {
                 "scrolled=${label.key}"
             }
         out +=
-            scenario("press-key-tab", driver.transport) {
-                // VK_TAB = 9. Agent may refuse when the target lacks OS keyboard focus (CI).
-                val result = runCatching { driver.pressKey(keyCode = 9, modifiers = 0) }
-                val msg = result.exceptionOrNull()?.message.orEmpty()
-                if (result.isFailure && "keyboard focus" in msg) {
-                    "skipped:os-focus"
-                } else {
-                    result.getOrThrow()
-                    "pressKey=VK_TAB"
-                }
+            scenario("press-key-tab-after-focus", driver.transport) {
+                // Focus the text field first so OS keyboard focus is on the target JVM.
+                val field =
+                    driver.findByTestTag(ContractFixtureTags.TEXT_FIELD).firstOrNull()
+                        ?: error("fixture text field missing")
+                driver.click(field.key)
+                driver.pressKey(keyCode = 9, modifiers = 0) // VK_TAB
+                "pressKey=VK_TAB"
             }
         return out
     }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
@@ -108,6 +108,17 @@ public interface AutomatorContractDriver : AutoCloseable {
         get() = expectsFixtureSemantics
 
     /**
+     * Binary-compatible alias for [supportsFixtureParity]. Prefer [supportsFixtureParity]; this
+     * name remains so drivers compiled against older `testing` artifacts keep linking.
+     */
+    @Deprecated(
+        message = "Renamed to supportsFixtureParity",
+        replaceWith = ReplaceWith("supportsFixtureParity"),
+    )
+    public val supportsExtendedParity: Boolean
+        get() = supportsFixtureParity
+
+    /**
      * When true, [waitForNodeFailureCategory] is implemented (agent + in-process). HTTP has no wait
      * routes (#201 is agent-scoped).
      */

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/InProcessContractCorpusTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/InProcessContractCorpusTest.kt
@@ -105,11 +105,33 @@ private class InProcessContractDriver(private val automator: ComposeAutomator) :
         runBlocking { automator.pressKey(keyCode, modifiers) }
     }
 
+    override val supportsWaitTaxonomy: Boolean = true
+
     override fun waitForNode(tag: String?, text: String?, timeoutMs: Long): String = runBlocking {
         automator
             .waitForNode(tag = tag, text = text, timeout = timeoutMs.milliseconds)
             .key
             .toString()
+    }
+
+    override fun waitForNodeFailureCategory(tag: String?, text: String?, timeoutMs: Long): String {
+        try {
+            runBlocking {
+                automator.waitForNode(tag = tag, text = text, timeout = timeoutMs.milliseconds)
+            }
+            error("waitForNode was expected to time out")
+        } catch (ex: Exception) {
+            val name = ex.javaClass.name
+            val msg = ex.message.orEmpty().lowercase()
+            if (
+                name.endsWith("IdleTimeoutException") ||
+                    "timed out" in msg ||
+                    name.endsWith("TimeoutException")
+            ) {
+                return "timeout"
+            }
+            throw ex
+        }
     }
 
     override fun screenshotProbe(): ScreenshotProbe? {


### PR DESCRIPTION
## Summary

Follow-up after PR #300 / epic #197: skeptic review found corpus over-claims and wait taxonomy gaps.

- **Cross-transport corpus**: selector entry points (`findByText` / `findByRole` / `findByContentDescription`) always run on in-process, HTTP, and agent; fixture-backed match/input scenarios stay under `supportsFixtureParity`.
- **Wait timeout taxonomy**: `waitForNodeFailureCategory` + `wait-for-node-timeout-taxonomy` assert category `timeout` (agent + in-process); not mere `isFailure`.
- **PressKey / input**: fixture input scenarios (including `pressKey`) fail closed — no soft-skip recorded as pass on Supported cells.
- **Duration packing**: `WaitOpsReflectiveMapper` uses packed Duration `rawValue` (same as input ops), not plain `inWholeNanoseconds`.
- **Cancel e2e**: `WaitOpsInfrastructureTest` cancels a slow `waitForNode` through real `ReflectiveAutomatorHandler` + IPC; unit coverage in `WaitOpsReflectiveHandlerTest` for success, timeout taxonomy, and packing.

Closes the remaining skeptic gates for epic #197 acceptance.

## Test plan

- [x] `./gradlew :agent:check :testing:check :server:check`
- [x] `WaitOpsReflectiveHandlerTest` (timeout taxonomy + Duration packing)
- [x] `WaitOpsInfrastructureTest` (stub + ReflectiveAutomatorHandler cancel)
- [x] `InProcessContractCorpusTest` / `HttpContractCorpusTest` / agent corpus driver methods
- [ ] CI Linux Xvfb agent corpus + matrix evidence