### PR TITLE
Add fixture-level waitForNode cancel against live Compose attach

### DIFF
--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
@@ -3,6 +3,7 @@
 package dev.sebastiano.spectre.agent
 
 import dev.sebastiano.spectre.agent.fixture.READY_SENTINEL
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
 import dev.sebastiano.spectre.testing.contract.AutomatorContractCorpus
 import dev.sebastiano.spectre.testing.contract.AutomatorContractDriver
 import dev.sebastiano.spectre.testing.contract.AutomatorTransport
@@ -18,8 +19,12 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.AfterTest
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeFalse
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
@@ -67,6 +72,77 @@ class AgentContractCorpusTest {
                 val capture = automator.capture(windowIndex = 0)
                 check(capture.pngBytes.isNotEmpty()) { "capture png empty" }
                 check(capture.captureJson.isNotBlank()) { "capture json blank" }
+            }
+        }
+    }
+
+    /**
+     * #201 fixture cancel: interrupt a live [AttachedAutomator.waitForNode] against the Compose
+     * fixture. Client interrupt cancels the remote op; taxonomy must be `cancelled` (not hang /
+     * timeout / connection error). Complements infrastructure cancel tests that use a reflective
+     * fake automator without a real Compose tree.
+     */
+    @Test
+    fun `waitForNode on live fixture is cancelled when the client thread is interrupted`() {
+        assumeFalse(
+            GraphicsEnvironment.isHeadless(),
+            "Requires non-headless JVM for Compose Desktop + java.awt.Robot",
+        )
+        val agentJar = locateAgentJarOrSkip()
+
+        spawnComposeFixture().use { fixture ->
+            val udsPath = AttachOptions.defaultUdsPath(fixture.pid)
+            orphanUdsFiles.add(udsPath)
+            val options =
+                AttachOptions(
+                    agentJarPath = agentJar,
+                    udsPath = udsPath,
+                    attachTimeoutMs = ATTACH_TIMEOUT_MS,
+                )
+            AgentAttach.attach(fixture.pid, options).use { automator ->
+                // Prove the fixture is live before starting a long wait.
+                assertTrue(automator.windows().isNotEmpty(), "fixture should expose a window")
+
+                val error = AtomicReference<Throwable?>(null)
+                val started = CountDownLatch(1)
+                val waiter =
+                    Thread({
+                            try {
+                                started.countDown()
+                                automator.waitForNode(
+                                    tag = "agent-fixture-never-appears-cancel",
+                                    timeoutMs = 25_000,
+                                )
+                                error.set(
+                                    AssertionError("waitForNode was expected to be cancelled")
+                                )
+                            } catch (ex: Throwable) {
+                                error.set(ex)
+                            }
+                        })
+                        .apply {
+                            isDaemon = true
+                            name = "fixture-wait-cancel"
+                            start()
+                        }
+
+                assertTrue(started.await(3, TimeUnit.SECONDS), "wait thread never started")
+                // Let the WaitForNode op leave the client and enter the agent worker.
+                Thread.sleep(200)
+                waiter.interrupt()
+                waiter.join(10_000)
+                assertTrue(!waiter.isAlive, "wait thread still running after interrupt")
+
+                val thrown = error.get()
+                val agentEx =
+                    assertIs<SpectreAgentException>(
+                        thrown,
+                        "expected SpectreAgentException, got $thrown",
+                    )
+                assertEquals(AgentErrorCategory.Cancelled, agentEx.category)
+
+                // Session remains usable after cancel.
+                assertTrue(automator.windows().isNotEmpty(), "windows() after cancel")
             }
         }
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
@@ -104,14 +104,16 @@ class AgentContractCorpusTest {
                 assertTrue(automator.windows().isNotEmpty(), "fixture should expose a window")
 
                 val error = AtomicReference<Throwable?>(null)
-                val started = CountDownLatch(1)
+                val enteredWaitCall = CountDownLatch(1)
                 val waiter =
                     Thread({
                             try {
-                                started.countDown()
+                                enteredWaitCall.countDown()
                                 automator.waitForNode(
                                     tag = "agent-fixture-never-appears-cancel",
+                                    // Short poll so the agent enters the wait loop quickly.
                                     timeoutMs = 25_000,
+                                    pollIntervalMs = 50,
                                 )
                                 error.set(
                                     AssertionError("waitForNode was expected to be cancelled")
@@ -126,9 +128,42 @@ class AgentContractCorpusTest {
                             start()
                         }
 
-                assertTrue(started.await(3, TimeUnit.SECONDS), "wait thread never started")
-                // Let the WaitForNode op leave the client and enter the agent worker.
-                Thread.sleep(200)
+                assertTrue(
+                    enteredWaitCall.await(3, TimeUnit.SECONDS),
+                    "wait thread never entered waitForNode",
+                )
+                // WaitForNode is multiplexed: a concurrent snapshot must complete while the long
+                // wait is in flight. Stronger than a fixed sleep — WaitForNode must have been
+                // accepted and be holding a worker for the wait to still be running when
+                // windows() returns on another client thread.
+                val inFlight = CountDownLatch(1)
+                val probe =
+                    Thread({
+                            val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+                            while (System.nanoTime() < deadline && waiter.isAlive) {
+                                try {
+                                    if (automator.windows().isNotEmpty()) {
+                                        inFlight.countDown()
+                                        return@Thread
+                                    }
+                                } catch (_: Exception) {
+                                    // Brief write contention while the wait frame is in flight.
+                                }
+                                Thread.sleep(20)
+                            }
+                        })
+                        .apply {
+                            isDaemon = true
+                            name = "fixture-wait-inflight-probe"
+                            start()
+                        }
+                assertTrue(
+                    inFlight.await(5, TimeUnit.SECONDS),
+                    "concurrent windows() never succeeded while waitForNode was running — " +
+                        "wait may not have been in flight on the agent",
+                )
+                probe.join(1_000)
+
                 waiter.interrupt()
                 waiter.join(10_000)
                 assertTrue(!waiter.isAlive, "wait thread still running after interrupt")


### PR DESCRIPTION
## Summary

Closes the remaining skeptic gap for epic #197 / #201: wait **cancel** must run on a live fixture path, not only IPC stubs or a reflective fake.

- New `AgentContractCorpusTest` case attaches to `:agent-test-fixture`, starts `waitForNode` for a never-present tag, interrupts the client thread, and asserts `SpectreAgentException` with category `cancelled`.
- Session stays usable after cancel (`windows()` still works).

## Test plan

- [x] `./gradlew :agent:test --tests '*AgentContractCorpusTest*'` (2 tests, both green, non-headless macOS)
- [ ] CI Linux Xvfb agent corpus job