### PR TITLE
Add Compose Hot Reload detection and waitForReloadSettled (#211)

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -136,6 +136,10 @@ tasks.shadowJar {
                 "-dontwarn ch.qos.logback.classic.**",
                 "-keepattributes SourceFile,LineNumberTable",
                 "-keep class dev.sebastiano.spectre.cli.** { *; }",
+                // Compose Hot Reload orchestration uses reflection + service loaders for message
+                // encoders; keep the public client surface used by waitForReloadSettled (#211).
+                "-keep class org.jetbrains.compose.reload.** { *; }",
+                "-dontwarn org.jetbrains.compose.reload.**",
             )
         }
     }
@@ -349,11 +353,19 @@ dependencies {
     implementation(libs.kotlinx.serialization.cbor)
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.mcp.kotlin.sdk.server)
+    // Compose Hot Reload orchestration client (#211). Daemon/CLI/MCP only — never a dependency
+    // of :core / :agent / :testing. Pin stays aligned with HotReloadVersions.PINNED.
+    // `hot-reload-core` is required on the compile classpath for Task/Try/Either types exposed by
+    // the orchestration public API (Kotlin does not re-export transitive compile deps).
+    implementation(libs.compose.hotReload.orchestration)
+    implementation(libs.compose.hotReload.core)
+    implementation(libs.kotlinx.coroutines.core)
 
     detektPlugins(libs.compose.rules.detekt)
 
     testImplementation(libs.kotlin.testJunit5)
     testImplementation(libs.mcp.kotlin.sdk.client)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(projects.agentTestFixture)
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -138,6 +138,7 @@ private class RootCommand(
             FindByTextCommand(request, output),
             WaitForNodeCommand(request, output),
             WaitForVisualIdleCommand(request, output),
+            WaitCommand(request, output),
             ClickCommand(request, output),
             DoubleClickCommand(request, output),
             LongClickCommand(request, output),
@@ -716,6 +717,54 @@ private class WaitForVisualIdleCommand(
     }
 }
 
+/**
+ * `spectre wait --reload-settled <session>` — await Compose Hot Reload settle (#211).
+ *
+ * Only meaningful on reload-aware sessions; non-HR targets fail closed immediately with
+ * `hotReloadUnavailable`.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+private class WaitCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "wait") {
+    private val sessionId: String by argument(help = "Attached session id")
+    private val reloadSettled: Boolean by
+        option(
+                "--reload-settled",
+                help =
+                    "Wait until a Compose Hot Reload completes (request → result → UIRendered → Ping/Ack).",
+            )
+            .flag(default = false)
+    private val timeoutMs: Long by option("--timeout-ms").long().default(60_000)
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        if (!reloadSettled) {
+            throw CliktError(
+                "Specify --reload-settled (the only wait mode supported by this command)."
+            )
+        }
+        val completedSessionId =
+            when (
+                val response =
+                    request(
+                        DaemonRequest.WaitForReloadSettled(
+                            sessionId = sessionId,
+                            timeoutMs = timeoutMs,
+                        )
+                    )
+            ) {
+                is DaemonResponse.Completed -> response.sessionId
+                is DaemonResponse.Error -> throw DaemonCommandException(response)
+                else -> error("Daemon returned an unexpected response to wait --reload-settled")
+            }
+        if (json) output.append(CLI_JSON.encodeToString(CompletionJson(id = completedSessionId)))
+        else output.append("Reload settled for session $completedSessionId.")
+        output.appendLine()
+    }
+}
+
 @OptIn(ExperimentalSpectreAgentApi::class)
 private class TreeCommand(
     private val request: (DaemonRequest) -> DaemonResponse,
@@ -1179,5 +1228,8 @@ private fun exitCodeFor(code: DaemonErrorCode): Int =
         DaemonErrorCode.SessionNotFound -> EXIT_TARGET_NOT_FOUND
         DaemonErrorCode.ProtocolError,
         DaemonErrorCode.ShutdownInProgress,
-        DaemonErrorCode.OperationFailed -> EXIT_DAEMON_FAILURE
+        DaemonErrorCode.OperationFailed,
+        DaemonErrorCode.HotReloadUnavailable,
+        DaemonErrorCode.ReloadFailed,
+        DaemonErrorCode.Timeout -> EXIT_DAEMON_FAILURE
     }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.cbor.Cbor
 /** Shared client/daemon wire protocol metadata for Spectre's agent-facing entrypoints. */
 @OptIn(ExperimentalSerializationApi::class)
 public object DaemonProtocol {
-    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 10)
+    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 11)
 
     public val cbor: Cbor = Cbor {
         ignoreUnknownKeys = true
@@ -47,6 +47,7 @@ public object DaemonProtocol {
             is DaemonRequest.PressKey -> versionFor(INPUT_VERBS_INTRODUCED_MINOR)
             is DaemonRequest.WaitForNode,
             is DaemonRequest.WaitForVisualIdle -> versionFor(WAIT_OPS_INTRODUCED_MINOR)
+            is DaemonRequest.WaitForReloadSettled -> versionFor(RELOAD_SETTLE_INTRODUCED_MINOR)
             is DaemonRequest.FindByText,
             is DaemonRequest.FindByContentDescription,
             is DaemonRequest.FindByRole -> versionFor(SELECTOR_PARITY_INTRODUCED_MINOR)
@@ -82,6 +83,8 @@ public object DaemonProtocol {
     /** waitForNode / waitForVisualIdle and selector finders over daemon (#201/#202). */
     private const val WAIT_OPS_INTRODUCED_MINOR: Int = 10
     private const val SELECTOR_PARITY_INTRODUCED_MINOR: Int = 10
+    /** waitForReloadSettled for Compose Hot Reload awareness (#211). */
+    private const val RELOAD_SETTLE_INTRODUCED_MINOR: Int = 11
 }
 
 @Serializable public data class DaemonProtocolVersion(public val major: Int, public val minor: Int)
@@ -215,6 +218,20 @@ public sealed interface DaemonRequest {
         public val timeoutMs: Long = 5_000,
         public val stableFrames: Int = 3,
         public val pollIntervalMs: Long = 16,
+    ) : DaemonRequest
+
+    /**
+     * Wait until a Compose Hot Reload settle chain completes (#211).
+     *
+     * Available only when the attach session is reload-aware. Failures carry
+     * a #199-style [DaemonResponse.Error.category] (`hotReloadUnavailable` / `reloadFailed` /
+     * `timeout` / `cancelled`).
+     */
+    @Serializable
+    @SerialName("waitForReloadSettled")
+    public data class WaitForReloadSettled(
+        public val sessionId: String,
+        public val timeoutMs: Long = 60_000,
     ) : DaemonRequest
 
     @Serializable
@@ -371,8 +388,15 @@ public sealed interface DaemonResponse {
 
     @Serializable
     @SerialName("error")
-    public data class Error(public val code: DaemonErrorCode, public val message: String) :
-        DaemonResponse
+    public data class Error(
+        public val code: DaemonErrorCode,
+        public val message: String,
+        /**
+         * Optional #199 taxonomy wire name (e.g. `timeout`, `hotReloadUnavailable`). Null for
+         * pre-taxonomy daemon failures.
+         */
+        public val category: String? = null,
+    ) : DaemonResponse
 }
 
 @Serializable
@@ -388,4 +412,10 @@ public enum class DaemonErrorCode {
     ProtocolError,
     ShutdownInProgress,
     OperationFailed,
+    /** Target is not running under Compose Hot Reload (#211). */
+    HotReloadUnavailable,
+    /** HR reported a failed class reload (#211). */
+    ReloadFailed,
+    /** Wait exceeded its deadline (#199 / #211). */
+    Timeout,
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -442,7 +442,12 @@ internal constructor(
     }
 
     private companion object {
-        const val WAIT_DRAIN_TIMEOUT_MS: Long = 30_000
+        /**
+         * Must cover long outside-lock waits such as [DaemonRequest.WaitForReloadSettled] (default
+         * 60s) so detach/close does not tear down mid-wait. Kept above
+         * [dev.sebastiano.spectre.cli.hotreload.HotReloadSession.DEFAULT_SETTLE_TIMEOUT_MS].
+         */
+        const val WAIT_DRAIN_TIMEOUT_MS: Long = 90_000
         const val WAIT_DRAIN_POLL_MS: Long = 10
         const val NANOS_PER_MS: Long = 1_000_000
     }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -151,6 +151,7 @@ internal constructor(
                 DaemonResponse.Completed(request.sessionId)
             }
             is DaemonRequest.WaitForReloadSettled -> runReloadSettleWait(session, request)
+            else -> error("not a wait request: ${request::class.simpleName}")
         }
 
     private fun runReloadSettleWait(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -3,6 +3,11 @@ package dev.sebastiano.spectre.cli.daemon
 import dev.sebastiano.spectre.agent.AgentAttach
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.SpectreAttachException
+import dev.sebastiano.spectre.cli.hotreload.HotReloadCapability
+import dev.sebastiano.spectre.cli.hotreload.HotReloadPortDiscovery
+import dev.sebastiano.spectre.cli.hotreload.HotReloadSession
+import dev.sebastiano.spectre.cli.hotreload.ReloadSettleErrorCategory
+import dev.sebastiano.spectre.cli.hotreload.mapReloadSettleOutcome
 import dev.sebastiano.spectre.cli.jdkPreflightError
 import java.io.IOException
 
@@ -11,6 +16,16 @@ import java.io.IOException
 public class DaemonSessionRegistry
 internal constructor(
     private val jvmProcessDiscovery: DaemonJvmProcessDiscovery = DaemonJvmProcessDiscovery(),
+    private val hotReloadSessionFactory: (Long) -> HotReloadCapability? = { targetPid ->
+        // Only become reload-aware when HR is detectable at attach time. Absent → no behavior
+        // change for the session (#211 layering rule).
+        if (HotReloadPortDiscovery.discover(targetPid) == null) {
+            null
+        } else {
+            HotReloadSession.forTargetPid(targetPid)
+        }
+    },
+    // Last so trailing-lambda call sites keep meaning attachAutomator.
     private val attachAutomator: (Long) -> DaemonSessionAutomator = { targetPid ->
         installEmbeddedAgentRuntimeIfNeeded()
         val automator = AgentAttach.attach(targetPid)
@@ -34,7 +49,8 @@ internal constructor(
     public fun handle(request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.WaitForNode,
-            is DaemonRequest.WaitForVisualIdle -> handleWaitOutsideLock(request)
+            is DaemonRequest.WaitForVisualIdle,
+            is DaemonRequest.WaitForReloadSettled -> handleWaitOutsideLock(request)
             else -> handleSynchronized(request)
         }
 
@@ -68,7 +84,9 @@ internal constructor(
             is DaemonRequest.RecordingStatus -> handleSessionCommand(request)
             // Wait ops are dispatched by [handle] outside the monitor.
             is DaemonRequest.WaitForNode,
-            is DaemonRequest.WaitForVisualIdle -> error("wait ops must use handleWaitOutsideLock")
+            is DaemonRequest.WaitForVisualIdle,
+            is DaemonRequest.WaitForReloadSettled ->
+                error("wait ops must use handleWaitOutsideLock")
             DaemonRequest.Shutdown -> shutdown()
         }
 
@@ -77,6 +95,7 @@ internal constructor(
             when (request) {
                 is DaemonRequest.WaitForNode -> request.sessionId
                 is DaemonRequest.WaitForVisualIdle -> request.sessionId
+                is DaemonRequest.WaitForReloadSettled -> request.sessionId
                 else -> error("not a wait request")
             }
         // Pin the session and bump activeWaits under the monitor so detach/close will wait
@@ -117,7 +136,22 @@ internal constructor(
                     )
                     DaemonResponse.Completed(request.sessionId)
                 }
-                else -> error("not a wait request")
+                is DaemonRequest.WaitForReloadSettled -> {
+                    val hotReload = session.hotReloadSession
+                    if (hotReload == null) {
+                        DaemonResponse.Error(
+                            code = DaemonErrorCode.HotReloadUnavailable,
+                            message = "hot reload is not available for this session",
+                            category = ReloadSettleErrorCategory.HOT_RELOAD_UNAVAILABLE,
+                        )
+                    } else {
+                        mapReloadSettleOutcome(
+                            hotReload.waitForReloadSettled(request.timeoutMs),
+                            request.sessionId,
+                            request.timeoutMs,
+                        )
+                    }
+                }
             }
         } catch (exception: IOException) {
             DaemonResponse.Error(
@@ -234,7 +268,18 @@ internal constructor(
                     message = exception.message ?: "Failed to prepare the agent runtime",
                 )
             }
-        val session = DaemonSession(summary = targetPid.toSessionSummary(), automator = attached)
+        val hotReload =
+            try {
+                hotReloadSessionFactory(targetPid)
+            } catch (_: Exception) {
+                null
+            }
+        val session =
+            DaemonSession(
+                summary = sessionSummaryFor(targetPid),
+                automator = attached,
+                hotReloadSession = hotReload,
+            )
         sessionsByPid[targetPid] = session
         return DaemonResponse.Attached(
             sessionId = session.summary.sessionId,
@@ -249,12 +294,13 @@ internal constructor(
                     code = DaemonErrorCode.SessionNotFound,
                     message = "session not found: $sessionId",
                 )
-        val remainingLive = liveSessionIds() - sessionId
+        val remainingLive = sessionsByPid.values.map { it.sessionId }.toSet() - sessionId
         val session = sessionsByPid.remove(removed.key)
         // Let in-flight waits finish before tearing down the automator (see handleWaitOutsideLock).
         session?.awaitIdleWaits()
         // Finalize recording while other sessions are still known live (#185 review).
         session?.automator?.finalizeRecording(remainingLive)
+        session?.hotReloadSession?.close()
         session?.automator?.close()
         return CaptureSessionReport.forDetach(sessionId)
     }
@@ -359,12 +405,6 @@ internal constructor(
         }
     }
 
-    private fun sessionNotFound(sessionId: String): DaemonResponse.Error =
-        DaemonResponse.Error(
-            code = DaemonErrorCode.SessionNotFound,
-            message = "session not found: $sessionId",
-        )
-
     private fun shutdown(): DaemonResponse {
         close()
         return DaemonResponse.ShuttingDown
@@ -378,16 +418,15 @@ internal constructor(
         // Outside the monitor after clear so wait finally-blocks can finish.
         snapshot.forEach { session ->
             session.awaitIdleWaits()
+            session.hotReloadSession?.close()
             session.automator.close()
         }
     }
 
-    private fun Long.toSessionSummary(): DaemonSessionSummary =
-        DaemonSessionSummary(sessionId = "pid-$this", targetPid = this)
-
     private data class DaemonSession(
         val summary: DaemonSessionSummary,
         val automator: DaemonSessionAutomator,
+        val hotReloadSession: HotReloadCapability? = null,
         val activeWaits: java.util.concurrent.atomic.AtomicInteger =
             java.util.concurrent.atomic.AtomicInteger(0),
     ) {
@@ -427,3 +466,12 @@ private fun attachPreflightFailure(): DaemonResponse.Error? =
     jdkPreflightError()?.let { message ->
         DaemonResponse.Error(code = DaemonErrorCode.AttachFailed, message = message)
     }
+
+private fun sessionNotFound(sessionId: String): DaemonResponse.Error =
+    DaemonResponse.Error(
+        code = DaemonErrorCode.SessionNotFound,
+        message = "session not found: $sessionId",
+    )
+
+private fun sessionSummaryFor(targetPid: Long): DaemonSessionSummary =
+    DaemonSessionSummary(sessionId = "pid-$targetPid", targetPid = targetPid)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -17,13 +17,7 @@ public class DaemonSessionRegistry
 internal constructor(
     private val jvmProcessDiscovery: DaemonJvmProcessDiscovery = DaemonJvmProcessDiscovery(),
     private val hotReloadSessionFactory: (Long) -> HotReloadCapability? = { targetPid ->
-        // Only become reload-aware when HR is detectable at attach time. Absent → no behavior
-        // change for the session (#211 layering rule).
-        if (HotReloadPortDiscovery.discover(targetPid) == null) {
-            null
-        } else {
-            HotReloadSession.forTargetPid(targetPid)
-        }
+        defaultHotReloadCapability(targetPid)
     },
     // Last so trailing-lambda call sites keep meaning attachAutomator.
     private val attachAutomator: (Long) -> DaemonSessionAutomator = { targetPid ->
@@ -98,6 +92,13 @@ internal constructor(
                 is DaemonRequest.WaitForReloadSettled -> request.sessionId
                 else -> error("not a wait request")
             }
+        val waitTimeoutMs =
+            when (request) {
+                is DaemonRequest.WaitForNode -> request.timeoutMs
+                is DaemonRequest.WaitForVisualIdle -> request.timeoutMs
+                is DaemonRequest.WaitForReloadSettled -> request.timeoutMs
+                else -> error("not a wait request")
+            }
         // Pin the session and bump activeWaits under the monitor so detach/close will wait
         // for in-flight waits before closing the automator.
         val session =
@@ -111,48 +112,12 @@ internal constructor(
                 val found =
                     sessionsByPid.values.firstOrNull { it.sessionId == sessionId }
                         ?: return sessionNotFound(sessionId)
+                found.noteWaitStarted(waitTimeoutMs)
                 found.activeWaits.incrementAndGet()
                 found
             }
         return try {
-            when (request) {
-                is DaemonRequest.WaitForNode ->
-                    DaemonResponse.Nodes(
-                        request.sessionId,
-                        listOf(
-                            session.automator.waitForNode(
-                                tag = request.tag,
-                                text = request.text,
-                                timeoutMs = request.timeoutMs,
-                                pollIntervalMs = request.pollIntervalMs,
-                            )
-                        ),
-                    )
-                is DaemonRequest.WaitForVisualIdle -> {
-                    session.automator.waitForVisualIdle(
-                        timeoutMs = request.timeoutMs,
-                        stableFrames = request.stableFrames,
-                        pollIntervalMs = request.pollIntervalMs,
-                    )
-                    DaemonResponse.Completed(request.sessionId)
-                }
-                is DaemonRequest.WaitForReloadSettled -> {
-                    val hotReload = session.hotReloadSession
-                    if (hotReload == null) {
-                        DaemonResponse.Error(
-                            code = DaemonErrorCode.HotReloadUnavailable,
-                            message = "hot reload is not available for this session",
-                            category = ReloadSettleErrorCategory.HOT_RELOAD_UNAVAILABLE,
-                        )
-                    } else {
-                        mapReloadSettleOutcome(
-                            hotReload.waitForReloadSettled(request.timeoutMs),
-                            request.sessionId,
-                            request.timeoutMs,
-                        )
-                    }
-                }
-            }
+            runWaitRequest(session, request)
         } catch (exception: IOException) {
             DaemonResponse.Error(
                 code = DaemonErrorCode.OperationFailed,
@@ -161,6 +126,50 @@ internal constructor(
         } finally {
             session.activeWaits.decrementAndGet()
         }
+    }
+
+    private fun runWaitRequest(session: DaemonSession, request: DaemonRequest): DaemonResponse =
+        when (request) {
+            is DaemonRequest.WaitForNode ->
+                DaemonResponse.Nodes(
+                    request.sessionId,
+                    listOf(
+                        session.automator.waitForNode(
+                            tag = request.tag,
+                            text = request.text,
+                            timeoutMs = request.timeoutMs,
+                            pollIntervalMs = request.pollIntervalMs,
+                        )
+                    ),
+                )
+            is DaemonRequest.WaitForVisualIdle -> {
+                session.automator.waitForVisualIdle(
+                    timeoutMs = request.timeoutMs,
+                    stableFrames = request.stableFrames,
+                    pollIntervalMs = request.pollIntervalMs,
+                )
+                DaemonResponse.Completed(request.sessionId)
+            }
+            is DaemonRequest.WaitForReloadSettled -> runReloadSettleWait(session, request)
+        }
+
+    private fun runReloadSettleWait(
+        session: DaemonSession,
+        request: DaemonRequest.WaitForReloadSettled,
+    ): DaemonResponse {
+        val hotReload = session.hotReloadSession
+        if (hotReload == null) {
+            return DaemonResponse.Error(
+                code = DaemonErrorCode.HotReloadUnavailable,
+                message = "hot reload is not available for this session",
+                category = ReloadSettleErrorCategory.HOT_RELOAD_UNAVAILABLE,
+            )
+        }
+        return mapReloadSettleOutcome(
+            hotReload.waitForReloadSettled(request.timeoutMs),
+            request.sessionId,
+            request.timeoutMs,
+        )
     }
 
     private fun handleSessionCommand(request: DaemonRequest): DaemonResponse =
@@ -429,12 +438,23 @@ internal constructor(
         val hotReloadSession: HotReloadCapability? = null,
         val activeWaits: java.util.concurrent.atomic.AtomicInteger =
             java.util.concurrent.atomic.AtomicInteger(0),
+        /** Absolute nanoTime deadline for the longest currently tracked outside-lock wait. */
+        val waitDeadlineNs: java.util.concurrent.atomic.AtomicLong =
+            java.util.concurrent.atomic.AtomicLong(0),
     ) {
         val sessionId: String
             get() = summary.sessionId
 
+        fun noteWaitStarted(timeoutMs: Long) {
+            val candidate = System.nanoTime() + timeoutMs.coerceAtLeast(0) * NANOS_PER_MS
+            waitDeadlineNs.updateAndGet { current -> maxOf(current, candidate) }
+        }
+
         fun awaitIdleWaits(timeoutMs: Long = WAIT_DRAIN_TIMEOUT_MS) {
-            val deadline = System.nanoTime() + timeoutMs * NANOS_PER_MS
+            val trackedRemainingMs =
+                ((waitDeadlineNs.get() - System.nanoTime()) / NANOS_PER_MS).coerceAtLeast(0)
+            val budgetMs = maxOf(timeoutMs, trackedRemainingMs + WAIT_DRAIN_MARGIN_MS)
+            val deadline = System.nanoTime() + budgetMs * NANOS_PER_MS
             while (activeWaits.get() > 0 && System.nanoTime() < deadline) {
                 Thread.sleep(WAIT_DRAIN_POLL_MS)
             }
@@ -443,11 +463,11 @@ internal constructor(
 
     private companion object {
         /**
-         * Must cover long outside-lock waits such as [DaemonRequest.WaitForReloadSettled] (default
-         * 60s) so detach/close does not tear down mid-wait. Kept above
-         * [dev.sebastiano.spectre.cli.hotreload.HotReloadSession.DEFAULT_SETTLE_TIMEOUT_MS].
+         * Floor for drain-before-close. Active waits may extend this via
+         * [DaemonSession.noteWaitStarted] so caller-chosen settle timeouts are honored.
          */
         const val WAIT_DRAIN_TIMEOUT_MS: Long = 90_000
+        const val WAIT_DRAIN_MARGIN_MS: Long = 5_000
         const val WAIT_DRAIN_POLL_MS: Long = 10
         const val NANOS_PER_MS: Long = 1_000_000
     }
@@ -460,6 +480,31 @@ private fun installEmbeddedAgentRuntimeIfNeeded() {
     EmbeddedAgentRuntime.install()?.let { runtime ->
         System.setProperty(AGENT_RUNTIME_JAR_PROPERTY, runtime.toString())
     }
+}
+
+/**
+ * Creates an HR capability when the target already exposes a port, or when it only advertises a
+ * pid-file path (port may appear shortly after attach while HR finishes writing the file).
+ */
+private fun defaultHotReloadCapability(targetPid: Long): HotReloadCapability? {
+    if (HotReloadPortDiscovery.discover(targetPid) != null) {
+        return HotReloadSession.forTargetPid(targetPid)
+    }
+    // Port not readable yet, but a pid-file property means HR is (or will be) present.
+    val args =
+        try {
+            ProcessHandle.of(targetPid)
+                .orElse(null)
+                ?.info()
+                ?.arguments()
+                ?.orElse(null)
+                ?.toList()
+                .orEmpty()
+        } catch (_: Exception) {
+            emptyList()
+        }
+    val pidFile = HotReloadPortDiscovery.parsePidFilePathFromJvmArgs(args) ?: return null
+    return HotReloadSession.forTargetPid(targetPid, explicitPidFile = pidFile)
 }
 
 private fun listJvmProcesses(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscovery.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscovery.kt
@@ -53,7 +53,8 @@ public object HotReloadPortDiscovery {
     public fun parsePortFromPidFileProperties(content: String): Int? {
         val properties = Properties()
         properties.load(StringReader(content))
-        return properties.getProperty(HotReloadVersions.PID_FILE_PORT_KEY)?.toIntOrNull()
+        val port = properties.getProperty(HotReloadVersions.PID_FILE_PORT_KEY)?.toIntOrNull()
+        return port?.takeIf { it in 1..MAX_TCP_PORT }
     }
 
     /** Reads [path] if it is a regular file and returns the orchestration port, if present. */

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscovery.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscovery.kt
@@ -30,7 +30,7 @@ public object HotReloadPortDiscovery {
         explicitPidFile: Path? = null,
     ): HotReloadPort? {
         explicitPidFile?.let { path ->
-            readPortFromPidFile(path)?.let { port ->
+            readPortFromPidFile(path, expectedPid = targetPid)?.let { port ->
                 return HotReloadPort(port = port, source = HotReloadPortSource.PidFile(path))
             }
         }
@@ -41,7 +41,7 @@ public object HotReloadPortDiscovery {
         }
 
         parsePidFilePathFromJvmArgs(args)?.let { path ->
-            readPortFromPidFile(path)?.let { port ->
+            readPortFromPidFile(path, expectedPid = targetPid)?.let { port ->
                 return HotReloadPort(port = port, source = HotReloadPortSource.PidFile(path))
             }
         }
@@ -49,18 +49,31 @@ public object HotReloadPortDiscovery {
         return null
     }
 
-    /** Parses a pid-file body (Java Properties format) for `orchestration.port`. */
-    public fun parsePortFromPidFileProperties(content: String): Int? {
+    /**
+     * Parses a pid-file body (Java Properties format) for `orchestration.port`.
+     *
+     * When [expectedPid] is non-null and the file carries a `pid` field, that field must match or
+     * the port is rejected (avoids treating another HR JVM's stale pid file as this target's).
+     */
+    public fun parsePortFromPidFileProperties(content: String, expectedPid: Long? = null): Int? {
         val properties = Properties()
         properties.load(StringReader(content))
+        val filePid = properties.getProperty(HotReloadVersions.PID_FILE_PID_KEY)?.toLongOrNull()
+        if (expectedPid != null && filePid != null && filePid != expectedPid) return null
         val port = properties.getProperty(HotReloadVersions.PID_FILE_PORT_KEY)?.toIntOrNull()
         return port?.takeIf { it in 1..MAX_TCP_PORT }
     }
 
-    /** Reads [path] if it is a regular file and returns the orchestration port, if present. */
-    public fun readPortFromPidFile(path: Path): Int? {
+    /**
+     * Reads [path] if it is a regular file and returns the orchestration port, if present and (when
+     * [expectedPid] is set) owned by that pid.
+     */
+    public fun readPortFromPidFile(path: Path, expectedPid: Long? = null): Int? {
         if (!path.isRegularFile()) return null
-        return runCatching { parsePortFromPidFileProperties(Files.readString(path)) }.getOrNull()
+        return runCatching {
+                parsePortFromPidFileProperties(Files.readString(path), expectedPid = expectedPid)
+            }
+            .getOrNull()
     }
 
     /**

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscovery.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscovery.kt
@@ -1,0 +1,123 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import java.io.StringReader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Optional
+import java.util.Properties
+import kotlin.io.path.isRegularFile
+
+/**
+ * Locates Compose Hot Reload's orchestration TCP port for a target JVM without assuming HR is
+ * present (#211).
+ *
+ * Discovery order:
+ * 1. `-Dcompose.reload.orchestration.port=` (or bare `compose.reload.orchestration.port=`) in the
+ *    process argument list
+ * 2. `-Dcompose.reload.pidFile=` → read `orchestration.port` from that file (PidFileInfo semantics)
+ * 3. Caller-supplied pid-file path override (tests / explicit attach options)
+ *
+ * Absent → session is simply not reload-aware.
+ */
+public object HotReloadPortDiscovery {
+    /**
+     * Discovers the orchestration port for [targetPid], using [processArguments] when provided
+     * (defaults to [ProcessHandle] lookup).
+     */
+    public fun discover(
+        targetPid: Long,
+        processArguments: List<String>? = null,
+        explicitPidFile: Path? = null,
+    ): HotReloadPort? {
+        explicitPidFile?.let { path ->
+            readPortFromPidFile(path)?.let { port ->
+                return HotReloadPort(port = port, source = HotReloadPortSource.PidFile(path))
+            }
+        }
+
+        val args = processArguments ?: readProcessArguments(targetPid).orEmpty()
+        parsePortFromJvmArgs(args)?.let {
+            return it
+        }
+
+        parsePidFilePathFromJvmArgs(args)?.let { path ->
+            readPortFromPidFile(path)?.let { port ->
+                return HotReloadPort(port = port, source = HotReloadPortSource.PidFile(path))
+            }
+        }
+
+        return null
+    }
+
+    /** Parses a pid-file body (Java Properties format) for `orchestration.port`. */
+    public fun parsePortFromPidFileProperties(content: String): Int? {
+        val properties = Properties()
+        properties.load(StringReader(content))
+        return properties.getProperty(HotReloadVersions.PID_FILE_PORT_KEY)?.toIntOrNull()
+    }
+
+    /** Reads [path] if it is a regular file and returns the orchestration port, if present. */
+    public fun readPortFromPidFile(path: Path): Int? {
+        if (!path.isRegularFile()) return null
+        return runCatching { parsePortFromPidFileProperties(Files.readString(path)) }.getOrNull()
+    }
+
+    /**
+     * Extracts orchestration port from JVM argument tokens. Recognizes both `-Dkey=value` and bare
+     * `key=value` forms used by some launchers.
+     */
+    public fun parsePortFromJvmArgs(args: List<String>): HotReloadPort? =
+        args.firstNotNullOfOrNull { arg ->
+            val value = propertyValue(arg, HotReloadVersions.ORCHESTRATION_PORT_PROPERTY)
+            val port = value?.toIntOrNull()
+            if (port != null && port in 1..MAX_TCP_PORT) {
+                HotReloadPort(port = port, source = HotReloadPortSource.SystemProperty)
+            } else {
+                null
+            }
+        }
+
+    /** Extracts the pid-file path from JVM argument tokens, if present. */
+    public fun parsePidFilePathFromJvmArgs(args: List<String>): Path? =
+        args.firstNotNullOfOrNull { arg ->
+            val value = propertyValue(arg, HotReloadVersions.PID_FILE_PROPERTY)
+            if (value.isNullOrBlank()) null else Path.of(value)
+        }
+
+    private fun propertyValue(arg: String, key: String): String? {
+        val dashD = "-D$key="
+        if (arg.startsWith(dashD)) return arg.removePrefix(dashD)
+        val bare = "$key="
+        if (arg.startsWith(bare)) return arg.removePrefix(bare)
+        return null
+    }
+
+    private fun readProcessArguments(targetPid: Long): List<String>? {
+        val handle =
+            try {
+                ProcessHandle.of(targetPid).orElse(null) ?: return null
+            } catch (_: UnsupportedOperationException) {
+                return null
+            } catch (_: SecurityException) {
+                return null
+            }
+        val info = handle.info()
+        val args: Optional<Array<String>> = info.arguments()
+        if (args.isEmpty) return null
+        return args.get().toList()
+    }
+
+    private const val MAX_TCP_PORT: Int = 65_535
+}
+
+/** A discovered orchestration port and how it was found. */
+public data class HotReloadPort(public val port: Int, public val source: HotReloadPortSource)
+
+/** Provenance for a [HotReloadPort] discovery result. */
+public sealed interface HotReloadPortSource {
+    /** From `-Dcompose.reload.orchestration.port` (or env-equivalent arg form). */
+    public data object SystemProperty : HotReloadPortSource
+
+    /** From HR's pid file `orchestration.port` field. */
+    public data class PidFile(public val path: Path) : HotReloadPortSource
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
@@ -1,0 +1,217 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeoutOrNull
+import org.jetbrains.compose.reload.core.getOrThrow
+import org.jetbrains.compose.reload.core.isFailure
+import org.jetbrains.compose.reload.orchestration.OrchestrationClientRole
+import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
+import org.jetbrains.compose.reload.orchestration.asChannel
+import org.jetbrains.compose.reload.orchestration.connectOrchestrationClient
+
+/**
+ * Daemon-facing Hot Reload capability for one attach session (#211).
+ *
+ * Production implementation is [HotReloadSession]; tests inject fakes via the registry factory.
+ */
+public interface HotReloadCapability : AutoCloseable {
+    /**
+     * Blocks until the full reload settle chain completes or [timeoutMs] elapses.
+     *
+     * When HR is not connected, returns [ReloadSettleOutcome.Unavailable] immediately.
+     */
+    public fun waitForReloadSettled(
+        timeoutMs: Long = HotReloadSession.DEFAULT_SETTLE_TIMEOUT_MS
+    ): ReloadSettleOutcome
+}
+
+/**
+ * Per-attach-session Hot Reload orchestration client (#211).
+ *
+ * Connects as [OrchestrationClientRole.Tooling], reconnects when the app restarts (same pattern as
+ * HR's own MCP), and exposes [waitForReloadSettled] for the full settle chain.
+ *
+ * Lifetime is owned by the daemon session: [close] on detach.
+ */
+public class HotReloadSession
+internal constructor(
+    private val portProvider: () -> Int?,
+    private val connect: suspend (port: Int) -> OrchestrationHandle? = ::defaultConnect,
+    private val reconnectDelayMs: Long = DEFAULT_RECONNECT_DELAY_MS,
+    // Injected so detekt InjectDispatcher accepts the default (see RobotDriver pattern).
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : HotReloadCapability {
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
+    private val handleRef = AtomicReference<OrchestrationHandle?>(null)
+    private val closed = AtomicBoolean(false)
+    private var reconnectJob: Job? = null
+
+    /** True when a live orchestration handle is connected. */
+    public val isConnected: Boolean
+        get() = handleRef.get() != null
+
+    /** Starts the reconnect loop. Safe to call once after construction. */
+    public fun start() {
+        if (closed.get()) return
+        reconnectJob = scope.launch { runReconnectLoop() }
+    }
+
+    private suspend fun runReconnectLoop() {
+        while (scope.isActive && !closed.get()) {
+            val handle = connectOnce()
+            if (handle == null) {
+                delay(reconnectDelayMs)
+            } else {
+                awaitConnectedHandle(handle)
+                if (!closed.get()) delay(reconnectDelayMs)
+            }
+        }
+    }
+
+    private suspend fun awaitConnectedHandle(handle: OrchestrationHandle) {
+        handleRef.set(handle)
+        try {
+            // Suspend until the handle finishes (app exit / disconnect).
+            handle.await()
+        } catch (_: Exception) {
+            // fall through to reconnect
+        } finally {
+            handleRef.compareAndSet(handle, null)
+            runCatching { handle.close() }
+        }
+    }
+
+    private suspend fun connectOnce(): OrchestrationHandle? {
+        val port = portProvider() ?: return null
+        return try {
+            connect(port)
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    override fun waitForReloadSettled(timeoutMs: Long): ReloadSettleOutcome {
+        if (closed.get()) return ReloadSettleOutcome.Cancelled
+        val handle = handleRef.get() ?: return ReloadSettleOutcome.Unavailable
+        return runBlocking { settleOn(handle, timeoutMs) }
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        reconnectJob?.cancel()
+        handleRef.getAndSet(null)?.let { runCatching { it.close() } }
+        scope.cancel()
+    }
+
+    private suspend fun settleOn(
+        handle: OrchestrationHandle,
+        timeoutMs: Long,
+    ): ReloadSettleOutcome {
+        val machine = ReloadSettleStateMachine()
+        val channel = handle.asChannel()
+        try {
+            val settled =
+                withTimeoutOrNull(timeoutMs) {
+                    while (true) {
+                        if (machine.needsPing()) {
+                            // Ping assigns its own messageId; match Ack against that id.
+                            val ping = OrchestrationMessage.Ping()
+                            handle.send(ping)
+                            machine.beginPingDrain(ping.messageId.toString())
+                        }
+                        val message =
+                            channel.receiveCatching().getOrNull()
+                                ?: return@withTimeoutOrNull ReloadSettleOutcome.Cancelled
+                        val event = message.toLifecycleEvent() ?: continue
+                        val outcome = machine.onEvent(event)
+                        if (outcome != null) return@withTimeoutOrNull outcome
+                    }
+                    @Suppress("UNREACHABLE_CODE") ReloadSettleOutcome.TimedOut
+                }
+            return settled ?: machine.onTimeout()
+        } finally {
+            channel.cancel()
+        }
+    }
+
+    public companion object {
+        public const val DEFAULT_SETTLE_TIMEOUT_MS: Long = 60_000
+        private const val DEFAULT_RECONNECT_DELAY_MS: Long = 2_000
+
+        /** Creates a session that discovers the port for [targetPid] on each reconnect attempt. */
+        public fun forTargetPid(
+            targetPid: Long,
+            explicitPidFile: java.nio.file.Path? = null,
+        ): HotReloadSession {
+            val session =
+                HotReloadSession(
+                    portProvider = {
+                        HotReloadPortDiscovery.discover(
+                                targetPid = targetPid,
+                                explicitPidFile = explicitPidFile,
+                            )
+                            ?.port
+                    }
+                )
+            session.start()
+            return session
+        }
+
+        /**
+         * Creates a session pinned to a fixed [port] (tests and explicit orchestration endpoints).
+         */
+        public fun forPort(port: Int): HotReloadSession {
+            val session = HotReloadSession(portProvider = { port })
+            session.start()
+            return session
+        }
+
+        /**
+         * Test seam: inject connect/port without starting automatic reconnect, for pure settle
+         * tests that own the handle.
+         */
+        internal fun forTesting(
+            portProvider: () -> Int?,
+            connect: suspend (Int) -> OrchestrationHandle?,
+            startReconnect: Boolean = true,
+        ): HotReloadSession {
+            val session = HotReloadSession(portProvider = portProvider, connect = connect)
+            if (startReconnect) session.start()
+            return session
+        }
+    }
+}
+
+private suspend fun defaultConnect(port: Int): OrchestrationHandle? {
+    val result = connectOrchestrationClient(OrchestrationClientRole.Tooling, port)
+    return if (result.isFailure()) null else result.getOrThrow()
+}
+
+internal fun OrchestrationMessage.toLifecycleEvent(): ReloadLifecycleEvent? =
+    when (this) {
+        is OrchestrationMessage.ReloadClassesRequest ->
+            ReloadLifecycleEvent.ReloadClassesRequest(messageId.toString())
+        is OrchestrationMessage.ReloadClassesResult ->
+            ReloadLifecycleEvent.ReloadClassesResult(
+                reloadRequestId = reloadRequestId.toString(),
+                isSuccess = isSuccess,
+                errorMessage = errorMessage,
+            )
+        is OrchestrationMessage.UIRendered ->
+            ReloadLifecycleEvent.UIRendered(reloadRequestId = reloadRequestId?.toString())
+        is OrchestrationMessage.Ack ->
+            ReloadLifecycleEvent.Ack(acknowledgedMessageId = acknowledgedMessageId.toString())
+        else -> null
+    }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
@@ -104,8 +104,41 @@ internal constructor(
 
     override fun waitForReloadSettled(timeoutMs: Long): ReloadSettleOutcome {
         if (closed.get()) return ReloadSettleOutcome.Cancelled
-        val handle = handleRef.get() ?: return ReloadSettleOutcome.Unavailable
-        return runBlocking { settleOn(handle, timeoutMs) }
+        // If reconnect was never started, fail closed immediately (tests / non-HR injection).
+        if (reconnectJob == null && handleRef.get() == null) {
+            return ReloadSettleOutcome.Unavailable
+        }
+        val startedNs = System.nanoTime()
+        val handle =
+            awaitConnection(timeoutMs)
+                ?: return if (closed.get()) {
+                    ReloadSettleOutcome.Cancelled
+                } else {
+                    ReloadSettleOutcome.Unavailable
+                }
+        val elapsedMs = (System.nanoTime() - startedNs) / NANOS_PER_MS
+        val remainingMs = (timeoutMs - elapsedMs).coerceAtLeast(0)
+        if (remainingMs == 0L) return ReloadSettleOutcome.TimedOut
+        return runBlocking { settleOn(handle, remainingMs) }
+    }
+
+    /**
+     * Waits up to [timeoutMs] for the Tooling client to finish its first (or next) connect. Avoids
+     * a race where attach creates a reload-aware session and an immediate wait reports
+     * `hotReloadUnavailable` before the reconnect loop connects.
+     */
+    private fun awaitConnection(timeoutMs: Long): OrchestrationHandle? {
+        handleRef.get()?.let {
+            return it
+        }
+        val deadlineMs = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadlineMs && !closed.get()) {
+            handleRef.get()?.let {
+                return it
+            }
+            Thread.sleep(CONNECT_POLL_MS)
+        }
+        return handleRef.get()
     }
 
     override fun close() {
@@ -149,6 +182,8 @@ internal constructor(
     public companion object {
         public const val DEFAULT_SETTLE_TIMEOUT_MS: Long = 60_000
         private const val DEFAULT_RECONNECT_DELAY_MS: Long = 2_000
+        private const val CONNECT_POLL_MS: Long = 50
+        private const val NANOS_PER_MS: Long = 1_000_000
 
         /** Creates a session that discovers the port for [targetPid] on each reconnect attempt. */
         public fun forTargetPid(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
@@ -111,10 +111,11 @@ internal constructor(
         val startedNs = System.nanoTime()
         val handle =
             awaitConnection(timeoutMs)
-                ?: return if (closed.get()) {
-                    ReloadSettleOutcome.Cancelled
-                } else {
-                    ReloadSettleOutcome.Unavailable
+                ?: return when {
+                    closed.get() -> ReloadSettleOutcome.Cancelled
+                    // Reconnect was running but never produced a handle within the budget →
+                    // settle-timeout, not "HR unavailable" (session is still reload-aware).
+                    else -> ReloadSettleOutcome.TimedOut
                 }
         val elapsedMs = (System.nanoTime() - startedNs) / NANOS_PER_MS
         val remainingMs = (timeoutMs - elapsedMs).coerceAtLeast(0)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadVersions.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadVersions.kt
@@ -1,0 +1,31 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+/**
+ * Tested Compose Hot Reload version range for Spectre's reload-awareness (#211).
+ *
+ * Protocol messages are version-gated by HR itself; older servers simply omit newer message types.
+ * Pin is documented for operators and release notes — keep in sync with the Gradle coordinate in
+ * `:cli`.
+ */
+public object HotReloadVersions {
+    /** Exact artifact version resolved by Spectre's CLI/daemon dependency. */
+    public const val PINNED: String = "1.2.0-rc01"
+
+    /** Inclusive lower bound of the supported 1.2 line (findings verified from alpha+211). */
+    public const val MIN_SUPPORTED: String = "1.2.0-alpha+211"
+
+    /** Inclusive upper bound of the currently tested range. */
+    public const val MAX_TESTED: String = "1.2.0-rc01"
+
+    /** System property / env key for the orchestration TCP port (HR's own key). */
+    public const val ORCHESTRATION_PORT_PROPERTY: String = "compose.reload.orchestration.port"
+
+    /** System property / env key for HR's pid file path. */
+    public const val PID_FILE_PROPERTY: String = "compose.reload.pidFile"
+
+    /** Property key inside the pid file for the orchestration port. */
+    public const val PID_FILE_PORT_KEY: String = "orchestration.port"
+
+    /** Property key inside the pid file for the application pid. */
+    public const val PID_FILE_PID_KEY: String = "pid"
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadSettleDaemonMapping.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadSettleDaemonMapping.kt
@@ -1,0 +1,38 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
+import dev.sebastiano.spectre.cli.daemon.DaemonResponse
+
+/** Maps a [ReloadSettleOutcome] onto the daemon wire response for `waitForReloadSettled` (#211). */
+internal fun mapReloadSettleOutcome(
+    outcome: ReloadSettleOutcome,
+    sessionId: String,
+    timeoutMs: Long,
+): DaemonResponse =
+    when (outcome) {
+        ReloadSettleOutcome.Settled -> DaemonResponse.Completed(sessionId)
+        ReloadSettleOutcome.Unavailable ->
+            DaemonResponse.Error(
+                code = DaemonErrorCode.HotReloadUnavailable,
+                message = "hot reload is not available for this session",
+                category = ReloadSettleErrorCategory.HOT_RELOAD_UNAVAILABLE,
+            )
+        is ReloadSettleOutcome.ReloadFailed ->
+            DaemonResponse.Error(
+                code = DaemonErrorCode.ReloadFailed,
+                message = "reload failed: ${outcome.errorMessage}",
+                category = ReloadSettleErrorCategory.RELOAD_FAILED,
+            )
+        ReloadSettleOutcome.TimedOut ->
+            DaemonResponse.Error(
+                code = DaemonErrorCode.Timeout,
+                message = "timed out waiting for reload to settle after ${timeoutMs}ms",
+                category = ReloadSettleErrorCategory.TIMEOUT,
+            )
+        ReloadSettleOutcome.Cancelled ->
+            DaemonResponse.Error(
+                code = DaemonErrorCode.OperationFailed,
+                message = "reload settle wait was cancelled",
+                category = ReloadSettleErrorCategory.CANCELLED,
+            )
+    }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadSettleStateMachine.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadSettleStateMachine.kt
@@ -1,0 +1,150 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+/**
+ * Pure state machine mirroring Compose Hot Reload's own settle chain (#211):
+ *
+ * `ReloadClassesRequest` → matching `ReloadClassesResult` → matching `UIRendered` → `Ping`/`Ack`
+ * drain.
+ *
+ * Decoupled from the orchestration TCP client so unit tests do not need a live HR process.
+ */
+public class ReloadSettleStateMachine {
+    private var phase: Phase = Phase.AwaitRequest
+    private var requestId: String? = null
+    private var pingId: String? = null
+
+    /** Current phase (for diagnostics / tests). */
+    public val currentPhase: String
+        get() = phase.name
+
+    /**
+     * Feeds one lifecycle [event]. Returns a terminal [ReloadSettleOutcome] when the chain
+     * completes or fails; `null` means keep waiting.
+     *
+     * When the machine enters [Phase.NeedsPing], the caller must send a Ping whose message id is
+     * supplied via [beginPingDrain] before further events are processed.
+     */
+    public fun onEvent(event: ReloadLifecycleEvent): ReloadSettleOutcome? =
+        when (phase) {
+            Phase.AwaitRequest -> onAwaitRequest(event)
+            Phase.AwaitResult -> onAwaitResult(event)
+            Phase.AwaitUiRendered -> onAwaitUiRendered(event)
+            Phase.NeedsPing -> null // beginPingDrain first
+            Phase.AwaitAck -> onAwaitAck(event)
+            Phase.Terminal -> null
+        }
+
+    private fun onAwaitRequest(event: ReloadLifecycleEvent): ReloadSettleOutcome? {
+        if (event is ReloadLifecycleEvent.ReloadClassesRequest) {
+            requestId = event.messageId
+            phase = Phase.AwaitResult
+        }
+        return null
+    }
+
+    private fun onAwaitResult(event: ReloadLifecycleEvent): ReloadSettleOutcome? {
+        if (event !is ReloadLifecycleEvent.ReloadClassesResult) return null
+        if (event.reloadRequestId != requestId) return null
+        if (!event.isSuccess) {
+            phase = Phase.Terminal
+            return ReloadSettleOutcome.ReloadFailed(event.errorMessage ?: "reload failed")
+        }
+        phase = Phase.AwaitUiRendered
+        return null
+    }
+
+    private fun onAwaitUiRendered(event: ReloadLifecycleEvent): ReloadSettleOutcome? {
+        if (event !is ReloadLifecycleEvent.UIRendered) return null
+        // Initial renderings carry a null reloadRequestId — skip them.
+        if (event.reloadRequestId == null || event.reloadRequestId != requestId) return null
+        phase = Phase.NeedsPing
+        return null
+    }
+
+    private fun onAwaitAck(event: ReloadLifecycleEvent): ReloadSettleOutcome? {
+        if (event !is ReloadLifecycleEvent.Ack) return null
+        if (event.acknowledgedMessageId != pingId) return null
+        phase = Phase.Terminal
+        return ReloadSettleOutcome.Settled
+    }
+
+    /**
+     * After [Phase.NeedsPing], the caller invents a Ping [messageId], sends it on the wire, then
+     * calls this to arm Ack matching.
+     */
+    public fun beginPingDrain(messageId: String) {
+        check(phase == Phase.NeedsPing) {
+            "beginPingDrain only valid in NeedsPing phase, was $phase"
+        }
+        pingId = messageId
+        phase = Phase.AwaitAck
+    }
+
+    /** Whether the caller should send a Ping and call [beginPingDrain]. */
+    public fun needsPing(): Boolean = phase == Phase.NeedsPing
+
+    /** Terminal timeout outcome (does not change phase if already terminal). */
+    public fun onTimeout(): ReloadSettleOutcome {
+        if (phase == Phase.Terminal) {
+            return ReloadSettleOutcome.Settled // already finished; timeout is a no-op
+        }
+        phase = Phase.Terminal
+        return ReloadSettleOutcome.TimedOut
+    }
+
+    private enum class Phase {
+        AwaitRequest,
+        AwaitResult,
+        AwaitUiRendered,
+        NeedsPing,
+        AwaitAck,
+        Terminal,
+    }
+}
+
+/** Wire-agnostic events observed on the orchestration bus during a settle wait. */
+public sealed interface ReloadLifecycleEvent {
+    public data class ReloadClassesRequest(public val messageId: String) : ReloadLifecycleEvent
+
+    public data class ReloadClassesResult(
+        public val reloadRequestId: String,
+        public val isSuccess: Boolean,
+        public val errorMessage: String? = null,
+    ) : ReloadLifecycleEvent
+
+    public data class UIRendered(public val reloadRequestId: String?) : ReloadLifecycleEvent
+
+    public data class Ack(public val acknowledgedMessageId: String) : ReloadLifecycleEvent
+}
+
+/** Terminal result of [ReloadSettleStateMachine] / [waitForReloadSettled]. */
+public sealed interface ReloadSettleOutcome {
+    public data object Settled : ReloadSettleOutcome
+
+    public data class ReloadFailed(public val errorMessage: String) : ReloadSettleOutcome
+
+    public data object TimedOut : ReloadSettleOutcome
+
+    public data object Unavailable : ReloadSettleOutcome
+
+    public data object Cancelled : ReloadSettleOutcome
+}
+
+/**
+ * Stable #199-style taxonomy wire names for reload settle failures, surfaced on the daemon wire.
+ */
+public object ReloadSettleErrorCategory {
+    public const val HOT_RELOAD_UNAVAILABLE: String = "hotReloadUnavailable"
+    public const val RELOAD_FAILED: String = "reloadFailed"
+    public const val TIMEOUT: String = "timeout"
+    public const val CANCELLED: String = "cancelled"
+
+    public fun forOutcome(outcome: ReloadSettleOutcome): String? =
+        when (outcome) {
+            is ReloadSettleOutcome.Settled -> null
+            is ReloadSettleOutcome.ReloadFailed -> RELOAD_FAILED
+            ReloadSettleOutcome.TimedOut -> TIMEOUT
+            ReloadSettleOutcome.Unavailable -> HOT_RELOAD_UNAVAILABLE
+            ReloadSettleOutcome.Cancelled -> CANCELLED
+        }
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -188,6 +188,28 @@ public object SpectreMcpServer {
                 .asResult { it is DaemonResponse.Completed }
         }
         server.addTool(
+            name = "wait_for_reload_settled",
+            description =
+                "Wait until a Compose Hot Reload settles for a reload-aware session (#211): " +
+                    "ReloadClassesRequest → matching ReloadClassesResult → matching UIRendered → " +
+                    "Ping/Ack drain. Fails immediately with hotReloadUnavailable when the target " +
+                    "is not running under HR. Distinguishes reloadFailed vs timeout.",
+            inputSchema =
+                schema(
+                    "session_id" to "string",
+                    "timeout_ms" to "integer",
+                    required = listOf("session_id"),
+                ),
+        ) { call ->
+            request(
+                    DaemonRequest.WaitForReloadSettled(
+                        sessionId = call.requiredString("session_id"),
+                        timeoutMs = call.optionalLong("timeout_ms") ?: 60_000L,
+                    )
+                )
+                .asResult { it is DaemonResponse.Completed }
+        }
+        server.addTool(
             name = "click",
             description =
                 "Click a visible semantics node by its node key. Refresh the tree after UI changes.",

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
@@ -34,6 +34,7 @@ class DaemonEndpointTest {
     fun `discovers prior minor-version sockets during the stable endpoint migration`() {
         assertEquals(
             listOf(
+                Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-10.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-9.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-8.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-7.sock"),

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
@@ -118,6 +118,12 @@ class DaemonHandshakeTest {
                 DaemonRequest.FindByText(sessionId = "session-1234", text = "hi")
             ),
         )
+        assertEquals(
+            DaemonProtocolVersion(major = 1, minor = 11),
+            DaemonProtocol.minimumDaemonVersion(
+                DaemonRequest.WaitForReloadSettled(sessionId = "session-1234")
+            ),
+        )
     }
 }
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadSettleTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadSettleTest.kt
@@ -1,0 +1,93 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
+import dev.sebastiano.spectre.cli.daemon.DaemonRequest
+import dev.sebastiano.spectre.cli.daemon.DaemonResponse
+import dev.sebastiano.spectre.cli.daemon.DaemonSessionRegistry
+import dev.sebastiano.spectre.cli.daemon.TestDaemonSessionAutomator
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+class DaemonReloadSettleTest {
+    @Test
+    fun `non-HR session fails closed immediately as hotReloadUnavailable`() {
+        val registry =
+            DaemonSessionRegistry(
+                attachAutomator = { TestDaemonSessionAutomator() },
+                hotReloadSessionFactory = { null },
+            )
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(4242))).sessionId
+
+        val started = System.nanoTime()
+        val response =
+            assertIs<DaemonResponse.Error>(
+                registry.handle(
+                    DaemonRequest.WaitForReloadSettled(sessionId = sessionId, timeoutMs = 30_000)
+                )
+            )
+        val elapsedMs = (System.nanoTime() - started) / 1_000_000
+
+        assertEquals(DaemonErrorCode.HotReloadUnavailable, response.code)
+        assertEquals(ReloadSettleErrorCategory.HOT_RELOAD_UNAVAILABLE, response.category)
+        assertTrue(
+            elapsedMs < 2_000,
+            "non-HR settle must fail closed immediately, took ${elapsedMs}ms",
+        )
+    }
+
+    @Test
+    fun `reload-aware session maps outcomes onto daemon error taxonomy`() {
+        val outcomes =
+            ConcurrentLinkedQueue(
+                listOf(
+                    ReloadSettleOutcome.ReloadFailed("boom"),
+                    ReloadSettleOutcome.TimedOut,
+                    ReloadSettleOutcome.Settled,
+                )
+            )
+        val controllable = ControllableHotReloadCapability(outcomes)
+        val registry =
+            DaemonSessionRegistry(
+                attachAutomator = { TestDaemonSessionAutomator() },
+                hotReloadSessionFactory = { controllable },
+            )
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(7))).sessionId
+
+        val failed =
+            assertIs<DaemonResponse.Error>(
+                registry.handle(DaemonRequest.WaitForReloadSettled(sessionId, timeoutMs = 5_000))
+            )
+        assertEquals(DaemonErrorCode.ReloadFailed, failed.code)
+        assertEquals(ReloadSettleErrorCategory.RELOAD_FAILED, failed.category)
+        assertTrue(failed.message.contains("boom"))
+
+        val timedOut =
+            assertIs<DaemonResponse.Error>(
+                registry.handle(DaemonRequest.WaitForReloadSettled(sessionId, timeoutMs = 5_000))
+            )
+        assertEquals(DaemonErrorCode.Timeout, timedOut.code)
+        assertEquals(ReloadSettleErrorCategory.TIMEOUT, timedOut.category)
+
+        val settled =
+            assertIs<DaemonResponse.Completed>(
+                registry.handle(DaemonRequest.WaitForReloadSettled(sessionId, timeoutMs = 5_000))
+            )
+        assertEquals(sessionId, settled.sessionId)
+    }
+}
+
+private class ControllableHotReloadCapability(
+    private val outcomes: java.util.Queue<ReloadSettleOutcome>
+) : HotReloadCapability {
+    override fun waitForReloadSettled(timeoutMs: Long): ReloadSettleOutcome =
+        outcomes.poll() ?: ReloadSettleOutcome.Unavailable
+
+    override fun close() = Unit
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscoveryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscoveryTest.kt
@@ -73,11 +73,12 @@ class HotReloadPortDiscoveryTest {
 
     @Test
     fun `pid file path is parsed from jvm args`() {
+        val expected = java.nio.file.Path.of("tmp", "app.pid")
         val path =
             HotReloadPortDiscovery.parsePidFilePathFromJvmArgs(
-                listOf("-Dcompose.reload.pidFile=/tmp/app.pid")
+                listOf("-Dcompose.reload.pidFile=${expected}")
             )
-        assertEquals("/tmp/app.pid", path?.toString())
+        assertEquals(expected, path)
     }
 
     @Test

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscoveryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscoveryTest.kt
@@ -34,6 +34,18 @@ class HotReloadPortDiscoveryTest {
     }
 
     @Test
+    fun `pid file port is rejected when pid does not match the target`() {
+        val content = "pid=111\norchestration.port=2222\n"
+        assertNull(
+            HotReloadPortDiscovery.parsePortFromPidFileProperties(content, expectedPid = 999L)
+        )
+        assertEquals(
+            2222,
+            HotReloadPortDiscovery.parsePortFromPidFileProperties(content, expectedPid = 111L),
+        )
+    }
+
+    @Test
     fun `jvm args dashD port property is discovered`() {
         val found =
             HotReloadPortDiscovery.parsePortFromJvmArgs(

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscoveryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscoveryTest.kt
@@ -26,6 +26,14 @@ class HotReloadPortDiscoveryTest {
     }
 
     @Test
+    fun `pid file rejects invalid orchestration ports`() {
+        assertNull(HotReloadPortDiscovery.parsePortFromPidFileProperties("orchestration.port=0\n"))
+        assertNull(
+            HotReloadPortDiscovery.parsePortFromPidFileProperties("orchestration.port=70000\n")
+        )
+    }
+
+    @Test
     fun `jvm args dashD port property is discovered`() {
         val found =
             HotReloadPortDiscovery.parsePortFromJvmArgs(

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscoveryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadPortDiscoveryTest.kt
@@ -1,0 +1,108 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class HotReloadPortDiscoveryTest {
+    @Test
+    fun `pid file properties yield orchestration port`() {
+        val content =
+            """
+            #pid file
+            pid=12345
+            orchestration.port=45678
+            """
+                .trimIndent()
+        assertEquals(45678, HotReloadPortDiscovery.parsePortFromPidFileProperties(content))
+    }
+
+    @Test
+    fun `pid file without port yields null`() {
+        assertNull(HotReloadPortDiscovery.parsePortFromPidFileProperties("pid=1\n"))
+    }
+
+    @Test
+    fun `jvm args dashD port property is discovered`() {
+        val found =
+            HotReloadPortDiscovery.parsePortFromJvmArgs(
+                listOf("-Xmx1g", "-Dcompose.reload.orchestration.port=19191", "Main")
+            )
+        assertEquals(19191, found?.port)
+        assertIs<HotReloadPortSource.SystemProperty>(found?.source)
+    }
+
+    @Test
+    fun `jvm args bare port property is discovered`() {
+        val found =
+            HotReloadPortDiscovery.parsePortFromJvmArgs(
+                listOf("compose.reload.orchestration.port=2222")
+            )
+        assertEquals(2222, found?.port)
+    }
+
+    @Test
+    fun `invalid port values are rejected`() {
+        assertNull(
+            HotReloadPortDiscovery.parsePortFromJvmArgs(
+                listOf("-Dcompose.reload.orchestration.port=0")
+            )
+        )
+        assertNull(
+            HotReloadPortDiscovery.parsePortFromJvmArgs(
+                listOf("-Dcompose.reload.orchestration.port=70000")
+            )
+        )
+        assertNull(
+            HotReloadPortDiscovery.parsePortFromJvmArgs(
+                listOf("-Dcompose.reload.orchestration.port=nope")
+            )
+        )
+    }
+
+    @Test
+    fun `pid file path is parsed from jvm args`() {
+        val path =
+            HotReloadPortDiscovery.parsePidFilePathFromJvmArgs(
+                listOf("-Dcompose.reload.pidFile=/tmp/app.pid")
+            )
+        assertEquals("/tmp/app.pid", path?.toString())
+    }
+
+    @Test
+    fun `discover reads explicit pid file`() {
+        val dir = Files.createTempDirectory("spectre-hr-pid")
+        val pidFile = dir.resolve("app.pid")
+        Files.writeString(pidFile, "pid=99\norchestration.port=33333\n")
+        val found =
+            HotReloadPortDiscovery.discover(
+                targetPid = 99L,
+                processArguments = emptyList(),
+                explicitPidFile = pidFile,
+            )
+        assertEquals(33333, found?.port)
+        val source = assertIs<HotReloadPortSource.PidFile>(found?.source)
+        assertTrue(source.path.endsWith("app.pid"))
+    }
+
+    @Test
+    fun `discover falls back from args port before pid file`() {
+        val found =
+            HotReloadPortDiscovery.discover(
+                targetPid = 1L,
+                processArguments = listOf("-Dcompose.reload.orchestration.port=4444"),
+            )
+        assertEquals(4444, found?.port)
+        assertIs<HotReloadPortSource.SystemProperty>(found?.source)
+    }
+
+    @Test
+    fun `discover returns null when nothing is present`() {
+        assertNull(
+            HotReloadPortDiscovery.discover(targetPid = 1L, processArguments = listOf("MainKt"))
+        )
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSessionIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSessionIntegrationTest.kt
@@ -1,0 +1,187 @@
+@file:OptIn(org.jetbrains.compose.reload.DelicateHotReloadApi::class)
+
+package dev.sebastiano.spectre.cli.hotreload
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.reload.core.getBlocking
+import org.jetbrains.compose.reload.core.getOrThrow
+import org.jetbrains.compose.reload.orchestration.OrchestrationClientRole
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
+import org.jetbrains.compose.reload.orchestration.asChannel
+import org.jetbrains.compose.reload.orchestration.connectOrchestrationClient
+import org.jetbrains.compose.reload.orchestration.sendBlocking
+import org.jetbrains.compose.reload.orchestration.startOrchestrationServer
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Exercises the real `hot-reload-orchestration` client against an in-process orchestration server
+ * (#211). This is the integration seam when a full `hotRun` fixture is unavailable (#208 still
+ * open): the settle chain uses the same HR APIs as production.
+ */
+class HotReloadSessionIntegrationTest {
+    @Test
+    @Timeout(30)
+    fun `waitForReloadSettled returns Settled only after full request result UIRendered Ping Ack chain`() {
+        val server = startOrchestrationServer()
+        val port = server.port.getBlocking(15.seconds).getOrThrow()
+        val appScope = applicationScope()
+        val appJob = startAckingApplicationClient(port, appScope)
+        val session = HotReloadSession.forPort(port)
+        try {
+            awaitConnected(session)
+
+            val outcomeRef = AtomicReference<ReloadSettleOutcome?>(null)
+            val done = CountDownLatch(1)
+            val waiter =
+                Thread(
+                    {
+                        outcomeRef.set(session.waitForReloadSettled(timeoutMs = 15_000))
+                        done.countDown()
+                    },
+                    "wait-for-reload-settled",
+                )
+            waiter.start()
+            // Give the waiter a moment to subscribe before broadcasting the chain.
+            Thread.sleep(200)
+
+            val request = OrchestrationMessage.ReloadClassesRequest()
+            server sendBlocking request
+            // Result alone must not complete the wait.
+            Thread.sleep(100)
+            assertTrue(
+                waiter.isAlive,
+                "settle must wait for UIRendered, not only ReloadClassesResult",
+            )
+
+            server sendBlocking
+                OrchestrationMessage.ReloadClassesResult(
+                    reloadRequestId = request.messageId,
+                    isSuccess = true,
+                )
+            Thread.sleep(100)
+            assertTrue(waiter.isAlive, "settle must wait for UIRendered after successful result")
+
+            server sendBlocking
+                OrchestrationMessage.UIRendered(
+                    windowId = null,
+                    reloadRequestId = request.messageId,
+                    iteration = 1,
+                )
+
+            assertTrue(done.await(10, TimeUnit.SECONDS), "settle did not complete in time")
+            assertEquals(ReloadSettleOutcome.Settled, outcomeRef.get())
+        } finally {
+            session.close()
+            appJob.cancel()
+            appScope.cancel()
+            server.close()
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    fun `waitForReloadSettled surfaces reload failure from ReloadClassesResult`() {
+        val server = startOrchestrationServer()
+        val port = server.port.getBlocking(15.seconds).getOrThrow()
+        val appScope = applicationScope()
+        val appJob = startAckingApplicationClient(port, appScope)
+        val session = HotReloadSession.forPort(port)
+        try {
+            awaitConnected(session)
+
+            val outcomeRef = AtomicReference<ReloadSettleOutcome?>(null)
+            val done = CountDownLatch(1)
+            Thread(
+                    {
+                        outcomeRef.set(session.waitForReloadSettled(timeoutMs = 15_000))
+                        done.countDown()
+                    },
+                    "wait-for-reload-failed",
+                )
+                .start()
+            Thread.sleep(200)
+
+            val request = OrchestrationMessage.ReloadClassesRequest()
+            server sendBlocking request
+            server sendBlocking
+                OrchestrationMessage.ReloadClassesResult(
+                    reloadRequestId = request.messageId,
+                    isSuccess = false,
+                    errorMessage = "synthetic redefine failure",
+                )
+
+            assertTrue(done.await(10, TimeUnit.SECONDS))
+            val failed = assertIs<ReloadSettleOutcome.ReloadFailed>(outcomeRef.get())
+            assertEquals("synthetic redefine failure", failed.errorMessage)
+        } finally {
+            session.close()
+            appJob.cancel()
+            appScope.cancel()
+            server.close()
+        }
+    }
+
+    @Test
+    fun `waitForReloadSettled is unavailable when no orchestration is connected`() {
+        val session =
+            HotReloadSession.forTesting(
+                portProvider = { null },
+                connect = { null },
+                startReconnect = false,
+            )
+        try {
+            assertEquals(
+                ReloadSettleOutcome.Unavailable,
+                session.waitForReloadSettled(timeoutMs = 100),
+            )
+        } finally {
+            session.close()
+        }
+    }
+
+    private fun applicationScope(
+        dispatcher: CoroutineDispatcher = Dispatchers.Default
+    ): CoroutineScope = CoroutineScope(dispatcher)
+
+    private fun awaitConnected(session: HotReloadSession, timeoutMs: Long = 10_000) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (!session.isConnected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50)
+        }
+        assertTrue(session.isConnected, "Tooling client did not connect to orchestration server")
+    }
+
+    /**
+     * Application-role client that replies to [OrchestrationMessage.Ping] with matching
+     * [OrchestrationMessage.Ack], mirroring what a real HR app does for the Ping/Ack drain.
+     */
+    private fun startAckingApplicationClient(port: Int, scope: CoroutineScope): Job = scope.launch {
+        val result = connectOrchestrationClient(OrchestrationClientRole.Application, port)
+        val client = result.getOrThrow()
+        val channel = client.asChannel()
+        try {
+            while (true) {
+                val message = channel.receiveCatching().getOrNull() ?: break
+                if (message is OrchestrationMessage.Ping) {
+                    client.send(OrchestrationMessage.Ack(message.messageId))
+                }
+            }
+        } finally {
+            channel.cancel()
+            client.close()
+        }
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadSettleStateMachineTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadSettleStateMachineTest.kt
@@ -1,0 +1,97 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ReloadSettleStateMachineTest {
+    @Test
+    fun `full chain settles only after matching UIRendered and Ack`() {
+        val machine = ReloadSettleStateMachine()
+        assertNull(machine.onEvent(ReloadLifecycleEvent.ReloadClassesRequest("req-1")))
+        assertNull(
+            machine.onEvent(
+                ReloadLifecycleEvent.ReloadClassesResult(
+                    reloadRequestId = "req-1",
+                    isSuccess = true,
+                )
+            )
+        )
+        // Initial render (null id) must not complete the chain.
+        assertNull(machine.onEvent(ReloadLifecycleEvent.UIRendered(reloadRequestId = null)))
+        // Wrong request id must not complete the chain.
+        assertNull(machine.onEvent(ReloadLifecycleEvent.UIRendered(reloadRequestId = "other")))
+        assertNull(machine.onEvent(ReloadLifecycleEvent.UIRendered(reloadRequestId = "req-1")))
+        assertTrue(machine.needsPing())
+        machine.beginPingDrain("ping-1")
+        // Unrelated ack ignored.
+        assertNull(machine.onEvent(ReloadLifecycleEvent.Ack("someone-else")))
+        val outcome = machine.onEvent(ReloadLifecycleEvent.Ack("ping-1"))
+        assertEquals(ReloadSettleOutcome.Settled, outcome)
+    }
+
+    @Test
+    fun `reload failure surfaces error message and does not wait for UIRendered`() {
+        val machine = ReloadSettleStateMachine()
+        machine.onEvent(ReloadLifecycleEvent.ReloadClassesRequest("req-2"))
+        val outcome =
+            machine.onEvent(
+                ReloadLifecycleEvent.ReloadClassesResult(
+                    reloadRequestId = "req-2",
+                    isSuccess = false,
+                    errorMessage = "class redefine exploded",
+                )
+            )
+        val failed = assertIs<ReloadSettleOutcome.ReloadFailed>(outcome)
+        assertEquals("class redefine exploded", failed.errorMessage)
+        // Further events are ignored once terminal.
+        assertNull(machine.onEvent(ReloadLifecycleEvent.UIRendered("req-2")))
+    }
+
+    @Test
+    fun `mismatched result id is ignored until matching result arrives`() {
+        val machine = ReloadSettleStateMachine()
+        machine.onEvent(ReloadLifecycleEvent.ReloadClassesRequest("want"))
+        assertNull(
+            machine.onEvent(
+                ReloadLifecycleEvent.ReloadClassesResult(
+                    reloadRequestId = "stale",
+                    isSuccess = true,
+                )
+            )
+        )
+        assertNull(
+            machine.onEvent(
+                ReloadLifecycleEvent.ReloadClassesResult(reloadRequestId = "want", isSuccess = true)
+            )
+        )
+        assertEquals("AwaitUiRendered", machine.currentPhase)
+    }
+
+    @Test
+    fun `timeout before settle yields TimedOut`() {
+        val machine = ReloadSettleStateMachine()
+        machine.onEvent(ReloadLifecycleEvent.ReloadClassesRequest("req"))
+        assertEquals(ReloadSettleOutcome.TimedOut, machine.onTimeout())
+    }
+
+    @Test
+    fun `taxonomy wire names match issue contract`() {
+        assertEquals(
+            "hotReloadUnavailable",
+            ReloadSettleErrorCategory.forOutcome(ReloadSettleOutcome.Unavailable),
+        )
+        assertEquals(
+            "reloadFailed",
+            ReloadSettleErrorCategory.forOutcome(ReloadSettleOutcome.ReloadFailed("x")),
+        )
+        assertEquals("timeout", ReloadSettleErrorCategory.forOutcome(ReloadSettleOutcome.TimedOut))
+        assertEquals(
+            "cancelled",
+            ReloadSettleErrorCategory.forOutcome(ReloadSettleOutcome.Cancelled),
+        )
+        assertNull(ReloadSettleErrorCategory.forOutcome(ReloadSettleOutcome.Settled))
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
@@ -35,6 +35,7 @@ class SpectreMcpServerTest {
                 "find_text",
                 "wait_for_node",
                 "wait_for_visual_idle",
+                "wait_for_reload_settled",
                 "click",
                 "double_click",
                 "long_click",

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -62,6 +62,7 @@ class SpectreMcpStdioIntegrationTest {
                         "type_text",
                         "wait_for_node",
                         "wait_for_visual_idle",
+                        "wait_for_reload_settled",
                         "windows",
                     ),
                     client.listTools().tools.map { it.name }.toSet(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,9 @@
 androidx-lifecycle = "2.10.0"
 androidx-tracing = "2.0.0-alpha06"
 composeMultiplatform = "1.10.3"
+# Compose Hot Reload orchestration client for daemon-side reload awareness (#211).
+# Keep aligned with cli HotReloadVersions.PINNED.
+composeHotReload = "1.2.0-rc01"
 clikt = "5.0.1"
 composeRules = "0.5.6"
 detekt = "2.0.0-alpha.3"
@@ -47,6 +50,8 @@ compose-material3 = { module = "org.jetbrains.compose.material3:material3", vers
 compose-rules-detekt = { module = "io.nlopez.compose.rules:detekt", version.ref = "composeRules" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "composeMultiplatform" }
 compose-components-resources = { module = "org.jetbrains.compose.components:components-resources", version.ref = "composeMultiplatform" }
+compose-hotReload-orchestration = { module = "org.jetbrains.compose.hot-reload:hot-reload-orchestration", version.ref = "composeHotReload" }
+compose-hotReload-core = { module = "org.jetbrains.compose.hot-reload:hot-reload-core", version.ref = "composeHotReload" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 compose-uiToolingPreview = { module = "org.jetbrains.compose.ui:ui-tooling-preview", version.ref = "composeMultiplatform" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }


### PR DESCRIPTION
## Summary
- Detect Compose Hot Reload per attached daemon session (pid-file `orchestration.port` / `compose.reload.orchestration.port`) without assuming HR is present.
- Connect as `OrchestrationClientRole.Tooling` via `hot-reload-orchestration` (pinned **1.2.0-rc01**), with reconnect-tolerant session lifetime on attach/detach.
- Add `waitForReloadSettled` settle chain: `ReloadClassesRequest` → matching `ReloadClassesResult` → matching `UIRendered` → Ping/Ack drain.
- Surfaces: `spectre wait --reload-settled` and MCP `wait_for_reload_settled` only — **not** on `:testing`. HR deps stay on `:cli`.
- Taxonomy: `hotReloadUnavailable` / `reloadFailed` / `timeout` / `cancelled` on daemon errors (protocol minor **11**).

Part of #210. Closes #211.

## Validation
- `./gradlew check` green
- Unit: port discovery + pure settle FSM
- Integration: real in-process orchestration server (full settle + reload failure)
- Daemon: non-HR session fails closed immediately as `hotReloadUnavailable`
- Layering scan: no HR surface on `:core` / `:agent` / `:testing`

## Notes
- Live `hotRun` fixture e2e is blocked on open #208; the orchestration-server integration drives the same HR client APIs production uses.
- #212 (cache invalidation + coexistence) and #213 (docs/skill) remain separate.

## Test plan
- [x] `./gradlew check`
- [x] CLI `spectre wait --help` shows `--reload-settled`
- [x] MCP tool list includes `wait_for_reload_settled`
- [ ] CI green