### PR TITLE
Invalidate pre-reload node keys after HR settle (#212)

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
@@ -23,6 +23,15 @@ internal fun rejectStaleNodeKey(
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)
-internal fun rememberNodeKeys(keyGuard: ReloadAwareKeyGuard?, nodes: List<NodeSnapshotDto>) {
-    keyGuard?.rememberIssuedKeys(nodes.map(NodeSnapshotDto::key))
+internal fun rememberNodeKeys(
+    keyGuard: ReloadAwareKeyGuard?,
+    generation: Long?,
+    nodes: List<NodeSnapshotDto>,
+) {
+    if (keyGuard == null) return
+    if (generation == null) {
+        keyGuard.rememberIssuedKeys(nodes.map(NodeSnapshotDto::key))
+    } else {
+        keyGuard.rememberIssuedKeysIfGeneration(generation, nodes.map(NodeSnapshotDto::key))
+    }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
@@ -4,43 +4,34 @@ import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.cli.hotreload.ReloadAwareKeyGuard
 
-/** Issue generation-stamped keys for a tree/find response (#212). */
+/** Query the automator and stamp keys, re-querying once if a reload settles mid-query (#212). */
 @OptIn(ExperimentalSpectreAgentApi::class)
-internal fun issueNodeKeys(
+internal fun issueNodesAcrossReload(
     keyGuard: ReloadAwareKeyGuard?,
-    nodes: List<NodeSnapshotDto>,
-): List<NodeSnapshotDto> = if (keyGuard == null) nodes else keyGuard.issueNodes(nodes)
-
-/** Issue a single stamped key (#212). */
-@OptIn(ExperimentalSpectreAgentApi::class)
-internal fun issueNodeKey(keyGuard: ReloadAwareKeyGuard?, node: NodeSnapshotDto): NodeSnapshotDto =
-    if (keyGuard == null) node else keyGuard.issueNode(node)
-
-/** Resolve a client key for agent dispatch. Returns an error when the key is stale after reload. */
-internal fun resolveNodeKeyForDispatch(
-    keyGuard: ReloadAwareKeyGuard?,
-    nodeKey: String?,
-): KeyResolution {
-    if (nodeKey == null) return KeyResolution.Missing
-    if (keyGuard == null) return KeyResolution.Raw(nodeKey)
-    val raw = keyGuard.resolveForDispatch(nodeKey)
-    return if (raw == null) {
-        KeyResolution.Stale(
-            DaemonResponse.Error(
-                code = DaemonErrorCode.OperationFailed,
-                message = "No node found with key=$nodeKey",
-                category = "nodeNotFound",
-            )
-        )
-    } else {
-        KeyResolution.Raw(raw)
+    query: () -> List<NodeSnapshotDto>,
+): List<NodeSnapshotDto> {
+    if (keyGuard == null) return query()
+    val gen1 = keyGuard.snapshotGeneration()
+    val nodes1 = query()
+    keyGuard.issueNodesIfGeneration(gen1, nodes1)?.let {
+        return it
     }
+    // Reload settled during the query — re-read under the new generation.
+    val gen2 = keyGuard.snapshotGeneration()
+    val nodes2 = query()
+    return keyGuard.issueNodesIfGeneration(gen2, nodes2)
+        ?: keyGuard.issueNodes(nodes2) // generation stable after re-query
 }
 
-internal sealed interface KeyResolution {
-    data object Missing : KeyResolution
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal fun issueNodeAcrossReload(
+    keyGuard: ReloadAwareKeyGuard?,
+    query: () -> NodeSnapshotDto,
+): NodeSnapshotDto = issueNodesAcrossReload(keyGuard) { listOf(query()) }.single()
 
-    data class Raw(val key: String) : KeyResolution
-
-    data class Stale(val error: DaemonResponse.Error) : KeyResolution
-}
+internal fun staleNodeKeyError(nodeKey: String): DaemonResponse.Error =
+    DaemonResponse.Error(
+        code = DaemonErrorCode.OperationFailed,
+        message = "No node found with key=$nodeKey",
+        category = "nodeNotFound",
+    )

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
@@ -4,34 +4,43 @@ import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.cli.hotreload.ReloadAwareKeyGuard
 
-/**
- * File-level helpers for reload-aware node-key invalidation (#212), kept out of
- * [DaemonSessionRegistry] to satisfy TooManyFunctions.
- */
+/** Issue generation-stamped keys for a tree/find response (#212). */
 @OptIn(ExperimentalSpectreAgentApi::class)
-internal fun rejectStaleNodeKey(
+internal fun issueNodeKeys(
+    keyGuard: ReloadAwareKeyGuard?,
+    nodes: List<NodeSnapshotDto>,
+): List<NodeSnapshotDto> = if (keyGuard == null) nodes else keyGuard.issueNodes(nodes)
+
+/** Issue a single stamped key (#212). */
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal fun issueNodeKey(keyGuard: ReloadAwareKeyGuard?, node: NodeSnapshotDto): NodeSnapshotDto =
+    if (keyGuard == null) node else keyGuard.issueNode(node)
+
+/** Resolve a client key for agent dispatch. Returns an error when the key is stale after reload. */
+internal fun resolveNodeKeyForDispatch(
     keyGuard: ReloadAwareKeyGuard?,
     nodeKey: String?,
-): DaemonResponse.Error? {
-    if (nodeKey == null || keyGuard == null) return null
-    if (keyGuard.accepts(nodeKey)) return null
-    return DaemonResponse.Error(
-        code = DaemonErrorCode.OperationFailed,
-        message = "No node found with key=$nodeKey",
-        category = "nodeNotFound",
-    )
+): KeyResolution {
+    if (nodeKey == null) return KeyResolution.Missing
+    if (keyGuard == null) return KeyResolution.Raw(nodeKey)
+    val raw = keyGuard.resolveForDispatch(nodeKey)
+    return if (raw == null) {
+        KeyResolution.Stale(
+            DaemonResponse.Error(
+                code = DaemonErrorCode.OperationFailed,
+                message = "No node found with key=$nodeKey",
+                category = "nodeNotFound",
+            )
+        )
+    } else {
+        KeyResolution.Raw(raw)
+    }
 }
 
-@OptIn(ExperimentalSpectreAgentApi::class)
-internal fun rememberNodeKeys(
-    keyGuard: ReloadAwareKeyGuard?,
-    generation: Long?,
-    nodes: List<NodeSnapshotDto>,
-) {
-    if (keyGuard == null) return
-    if (generation == null) {
-        keyGuard.rememberIssuedKeys(nodes.map(NodeSnapshotDto::key))
-    } else {
-        keyGuard.rememberIssuedKeysIfGeneration(generation, nodes.map(NodeSnapshotDto::key))
-    }
+internal sealed interface KeyResolution {
+    data object Missing : KeyResolution
+
+    data class Raw(val key: String) : KeyResolution
+
+    data class Stale(val error: DaemonResponse.Error) : KeyResolution
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
@@ -1,0 +1,28 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.cli.hotreload.ReloadAwareKeyGuard
+
+/**
+ * File-level helpers for reload-aware node-key invalidation (#212), kept out of
+ * [DaemonSessionRegistry] to satisfy TooManyFunctions.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal fun rejectStaleNodeKey(
+    keyGuard: ReloadAwareKeyGuard?,
+    nodeKey: String?,
+): DaemonResponse.Error? {
+    if (nodeKey == null || keyGuard == null) return null
+    if (keyGuard.accepts(nodeKey)) return null
+    return DaemonResponse.Error(
+        code = DaemonErrorCode.OperationFailed,
+        message = "No node found with key=$nodeKey",
+        category = "nodeNotFound",
+    )
+}
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal fun rememberNodeKeys(keyGuard: ReloadAwareKeyGuard?, nodes: List<NodeSnapshotDto>) {
+    keyGuard?.rememberIssuedKeys(nodes.map(NodeSnapshotDto::key))
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
@@ -9,13 +9,16 @@ import dev.sebastiano.spectre.cli.hotreload.ReloadAwareKeyGuard
  *
  * Never stamps a snapshot under a generation that advanced after the query — loops until the
  * generation is stable or the attempt budget is exhausted.
+ *
+ * @return stamped nodes, or `null` when the generation kept racing through [maxAttempts] (caller
+ *   must fail closed — do not report an empty tree as success).
  */
 @OptIn(ExperimentalSpectreAgentApi::class)
 internal fun issueNodesAcrossReload(
     keyGuard: ReloadAwareKeyGuard?,
     maxAttempts: Int = 4,
     query: () -> List<NodeSnapshotDto>,
-): List<NodeSnapshotDto> {
+): List<NodeSnapshotDto>? {
     if (keyGuard == null) return query()
     repeat(maxAttempts) {
         val gen = keyGuard.snapshotGeneration()
@@ -23,8 +26,8 @@ internal fun issueNodesAcrossReload(
         val stamped = keyGuard.issueNodesIfGeneration(gen, nodes)
         if (stamped != null) return stamped
     }
-    // Generation kept racing — return empty rather than stamping a stale snapshot.
-    return emptyList()
+    // Generation kept racing — fail closed rather than returning a false empty tree.
+    return null
 }
 
 /**
@@ -46,4 +49,12 @@ internal fun staleNodeKeyError(nodeKey: String): DaemonResponse.Error =
         code = DaemonErrorCode.OperationFailed,
         message = "No node found with key=$nodeKey",
         category = "nodeNotFound",
+    )
+
+/** Fail-closed error when [issueNodesAcrossReload] exhausts its generation-race budget. */
+internal fun reloadRaceExhaustedError(): DaemonResponse.Error =
+    DaemonResponse.Error(
+        code = DaemonErrorCode.OperationFailed,
+        message = "reload settled during tree query; re-query required",
+        category = "reloadRace",
     )

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonReloadKeyOps.kt
@@ -4,30 +4,42 @@ import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.cli.hotreload.ReloadAwareKeyGuard
 
-/** Query the automator and stamp keys, re-querying once if a reload settles mid-query (#212). */
+/**
+ * Query the automator and stamp keys, re-querying while a reload settles mid-query (#212).
+ *
+ * Never stamps a snapshot under a generation that advanced after the query — loops until the
+ * generation is stable or the attempt budget is exhausted.
+ */
 @OptIn(ExperimentalSpectreAgentApi::class)
 internal fun issueNodesAcrossReload(
     keyGuard: ReloadAwareKeyGuard?,
+    maxAttempts: Int = 4,
     query: () -> List<NodeSnapshotDto>,
 ): List<NodeSnapshotDto> {
     if (keyGuard == null) return query()
-    val gen1 = keyGuard.snapshotGeneration()
-    val nodes1 = query()
-    keyGuard.issueNodesIfGeneration(gen1, nodes1)?.let {
-        return it
+    repeat(maxAttempts) {
+        val gen = keyGuard.snapshotGeneration()
+        val nodes = query()
+        val stamped = keyGuard.issueNodesIfGeneration(gen, nodes)
+        if (stamped != null) return stamped
     }
-    // Reload settled during the query — re-read under the new generation.
-    val gen2 = keyGuard.snapshotGeneration()
-    val nodes2 = query()
-    return keyGuard.issueNodesIfGeneration(gen2, nodes2)
-        ?: keyGuard.issueNodes(nodes2) // generation stable after re-query
+    // Generation kept racing — return empty rather than stamping a stale snapshot.
+    return emptyList()
 }
 
+/**
+ * Stamp a single node that was already obtained (e.g. after waitForNode). Does **not** re-run the
+ * wait — if a reload raced the wait, returns null so the caller can fail closed.
+ */
 @OptIn(ExperimentalSpectreAgentApi::class)
-internal fun issueNodeAcrossReload(
+internal fun stampNodeIfCurrentGeneration(
     keyGuard: ReloadAwareKeyGuard?,
-    query: () -> NodeSnapshotDto,
-): NodeSnapshotDto = issueNodesAcrossReload(keyGuard) { listOf(query()) }.single()
+    expectedGeneration: Long,
+    node: NodeSnapshotDto,
+): NodeSnapshotDto? {
+    if (keyGuard == null) return node
+    return keyGuard.issueNodesIfGeneration(expectedGeneration, listOf(node))?.single()
+}
 
 internal fun staleNodeKeyError(nodeKey: String): DaemonResponse.Error =
     DaemonResponse.Error(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -188,7 +188,9 @@ internal constructor(
                 }
             is DaemonRequest.AllNodes ->
                 invokeWithSession(request.sessionId) { session, automator ->
-                    val nodes = issueNodesAcrossReload(session.keyGuard) { automator.allNodes() }
+                    val nodes =
+                        issueNodesAcrossReload(session.keyGuard) { automator.allNodes() }
+                            ?: return@invokeWithSession reloadRaceExhaustedError()
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByTestTag,
@@ -335,7 +337,7 @@ internal constructor(
                     val nodes =
                         issueNodesAcrossReload(session.keyGuard) {
                             automator.findByTestTag(request.tag)
-                        }
+                        } ?: return@invokeWithSession reloadRaceExhaustedError()
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByText ->
@@ -343,7 +345,7 @@ internal constructor(
                     val nodes =
                         issueNodesAcrossReload(session.keyGuard) {
                             automator.findByText(request.text, request.exact)
-                        }
+                        } ?: return@invokeWithSession reloadRaceExhaustedError()
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByContentDescription ->
@@ -351,7 +353,7 @@ internal constructor(
                     val nodes =
                         issueNodesAcrossReload(session.keyGuard) {
                             automator.findByContentDescription(request.description)
-                        }
+                        } ?: return@invokeWithSession reloadRaceExhaustedError()
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByRole ->
@@ -359,7 +361,7 @@ internal constructor(
                     val nodes =
                         issueNodesAcrossReload(session.keyGuard) {
                             automator.findByRole(request.role)
-                        }
+                        } ?: return@invokeWithSession reloadRaceExhaustedError()
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             else -> error("Not a query session command: ${request::class.simpleName}")
@@ -412,7 +414,7 @@ internal constructor(
                     durationMs = request.durationMs,
                 )
             } else {
-                val ok =
+                val staleKey =
                     guard.dispatchKeys(request.fromNodeKey, request.toNodeKey) { from, to ->
                         automator.swipe(
                             fromNodeKey = from,
@@ -425,9 +427,8 @@ internal constructor(
                             durationMs = request.durationMs,
                         )
                     }
-                if (!ok) {
-                    val bad = request.fromNodeKey ?: request.toNodeKey ?: "unknown"
-                    return@invokeWithSession staleNodeKeyError(bad)
+                if (staleKey != null) {
+                    return@invokeWithSession staleNodeKeyError(staleKey)
                 }
             }
             DaemonResponse.Completed(request.sessionId)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -6,6 +6,7 @@ import dev.sebastiano.spectre.agent.SpectreAttachException
 import dev.sebastiano.spectre.cli.hotreload.HotReloadCapability
 import dev.sebastiano.spectre.cli.hotreload.HotReloadPortDiscovery
 import dev.sebastiano.spectre.cli.hotreload.HotReloadSession
+import dev.sebastiano.spectre.cli.hotreload.ReloadAwareKeyGuard
 import dev.sebastiano.spectre.cli.hotreload.ReloadSettleErrorCategory
 import dev.sebastiano.spectre.cli.hotreload.mapReloadSettleOutcome
 import dev.sebastiano.spectre.cli.jdkPreflightError
@@ -130,18 +131,17 @@ internal constructor(
 
     private fun runWaitRequest(session: DaemonSession, request: DaemonRequest): DaemonResponse =
         when (request) {
-            is DaemonRequest.WaitForNode ->
-                DaemonResponse.Nodes(
-                    request.sessionId,
-                    listOf(
-                        session.automator.waitForNode(
-                            tag = request.tag,
-                            text = request.text,
-                            timeoutMs = request.timeoutMs,
-                            pollIntervalMs = request.pollIntervalMs,
-                        )
-                    ),
-                )
+            is DaemonRequest.WaitForNode -> {
+                val node =
+                    session.automator.waitForNode(
+                        tag = request.tag,
+                        text = request.text,
+                        timeoutMs = request.timeoutMs,
+                        pollIntervalMs = request.pollIntervalMs,
+                    )
+                rememberNodeKeys(session.keyGuard, listOf(node))
+                DaemonResponse.Nodes(request.sessionId, listOf(node))
+            }
             is DaemonRequest.WaitForVisualIdle -> {
                 session.automator.waitForVisualIdle(
                     timeoutMs = request.timeoutMs,
@@ -180,8 +180,10 @@ internal constructor(
                     DaemonResponse.Windows(request.sessionId, automator.windows())
                 }
             is DaemonRequest.AllNodes ->
-                invoke(request.sessionId) { automator ->
-                    DaemonResponse.Nodes(request.sessionId, automator.allNodes())
+                invokeWithSession(request.sessionId) { session, automator ->
+                    val nodes = automator.allNodes()
+                    rememberNodeKeys(session.keyGuard, nodes)
+                    DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByTestTag,
             is DaemonRequest.FindByText,
@@ -211,7 +213,7 @@ internal constructor(
                         sessionId = request.sessionId,
                         result = automator.capture(request.windowIndex),
                         outDir = request.outDir,
-                        liveSessionIds = liveSessionIds(),
+                        liveSessionIds = sessionsByPid.values.map { it.sessionId }.toSet(),
                     )
                 }
             is DaemonRequest.StartRecording ->
@@ -229,7 +231,7 @@ internal constructor(
                 invoke(request.sessionId) { automator ->
                     DaemonResponse.RecordingStopped(
                         request.sessionId,
-                        automator.stopRecording(liveSessionIds()),
+                        automator.stopRecording(sessionsByPid.values.map { it.sessionId }.toSet()),
                     )
                 }
             is DaemonRequest.RecordingStatus ->
@@ -284,11 +286,14 @@ internal constructor(
             } catch (_: Exception) {
                 null
             }
+        val keyGuard = if (hotReload != null) ReloadAwareKeyGuard() else null
+        hotReload?.setReloadSettledListener { keyGuard?.onReload() }
         val session =
             DaemonSession(
                 summary = sessionSummaryFor(targetPid),
                 automator = attached,
                 hotReloadSession = hotReload,
+                keyGuard = keyGuard,
             )
         sessionsByPid[targetPid] = session
         return DaemonResponse.Attached(
@@ -315,31 +320,31 @@ internal constructor(
         return CaptureSessionReport.forDetach(sessionId)
     }
 
-    private fun liveSessionIds(): Set<String> = sessionsByPid.values.map { it.sessionId }.toSet()
-
     private fun handleQuerySessionCommand(request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.FindByTestTag ->
-                invoke(request.sessionId) { automator ->
-                    DaemonResponse.Nodes(request.sessionId, automator.findByTestTag(request.tag))
+                invokeWithSession(request.sessionId) { session, automator ->
+                    val nodes = automator.findByTestTag(request.tag)
+                    rememberNodeKeys(session.keyGuard, nodes)
+                    DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByText ->
-                invoke(request.sessionId) { automator ->
-                    DaemonResponse.Nodes(
-                        request.sessionId,
-                        automator.findByText(request.text, request.exact),
-                    )
+                invokeWithSession(request.sessionId) { session, automator ->
+                    val nodes = automator.findByText(request.text, request.exact)
+                    rememberNodeKeys(session.keyGuard, nodes)
+                    DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByContentDescription ->
-                invoke(request.sessionId) { automator ->
-                    DaemonResponse.Nodes(
-                        request.sessionId,
-                        automator.findByContentDescription(request.description),
-                    )
+                invokeWithSession(request.sessionId) { session, automator ->
+                    val nodes = automator.findByContentDescription(request.description)
+                    rememberNodeKeys(session.keyGuard, nodes)
+                    DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByRole ->
-                invoke(request.sessionId) { automator ->
-                    DaemonResponse.Nodes(request.sessionId, automator.findByRole(request.role))
+                invokeWithSession(request.sessionId) { session, automator ->
+                    val nodes = automator.findByRole(request.role)
+                    rememberNodeKeys(session.keyGuard, nodes)
+                    DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             else -> error("Not a query session command: ${request::class.simpleName}")
         }
@@ -347,22 +352,37 @@ internal constructor(
     private fun handleInputSessionCommand(request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.Click ->
-                invoke(request.sessionId) { automator ->
+                invokeWithSession(request.sessionId) { session, automator ->
+                    rejectStaleNodeKey(session.keyGuard, request.nodeKey)?.let {
+                        return@invokeWithSession it
+                    }
                     automator.click(request.nodeKey)
                     DaemonResponse.Completed(request.sessionId)
                 }
             is DaemonRequest.DoubleClick ->
-                invoke(request.sessionId) { automator ->
+                invokeWithSession(request.sessionId) { session, automator ->
+                    rejectStaleNodeKey(session.keyGuard, request.nodeKey)?.let {
+                        return@invokeWithSession it
+                    }
                     automator.doubleClick(request.nodeKey)
                     DaemonResponse.Completed(request.sessionId)
                 }
             is DaemonRequest.LongClick ->
-                invoke(request.sessionId) { automator ->
+                invokeWithSession(request.sessionId) { session, automator ->
+                    rejectStaleNodeKey(session.keyGuard, request.nodeKey)?.let {
+                        return@invokeWithSession it
+                    }
                     automator.longClick(request.nodeKey, request.holdForMs)
                     DaemonResponse.Completed(request.sessionId)
                 }
             is DaemonRequest.Swipe ->
-                invoke(request.sessionId) { automator ->
+                invokeWithSession(request.sessionId) { session, automator ->
+                    rejectStaleNodeKey(session.keyGuard, request.fromNodeKey)?.let {
+                        return@invokeWithSession it
+                    }
+                    rejectStaleNodeKey(session.keyGuard, request.toNodeKey)?.let {
+                        return@invokeWithSession it
+                    }
                     automator.swipe(
                         fromNodeKey = request.fromNodeKey,
                         toNodeKey = request.toNodeKey,
@@ -376,7 +396,10 @@ internal constructor(
                     DaemonResponse.Completed(request.sessionId)
                 }
             is DaemonRequest.ScrollWheel ->
-                invoke(request.sessionId) { automator ->
+                invokeWithSession(request.sessionId) { session, automator ->
+                    rejectStaleNodeKey(session.keyGuard, request.nodeKey)?.let {
+                        return@invokeWithSession it
+                    }
                     automator.scrollWheel(request.nodeKey, request.wheelClicks)
                     DaemonResponse.Completed(request.sessionId)
                 }
@@ -401,12 +424,17 @@ internal constructor(
     private fun invoke(
         sessionId: String,
         operation: (DaemonSessionAutomator) -> DaemonResponse,
+    ): DaemonResponse = invokeWithSession(sessionId) { _, automator -> operation(automator) }
+
+    private fun invokeWithSession(
+        sessionId: String,
+        operation: (DaemonSession, DaemonSessionAutomator) -> DaemonResponse,
     ): DaemonResponse {
         val session =
             sessionsByPid.values.firstOrNull { it.sessionId == sessionId }
                 ?: return sessionNotFound(sessionId)
         return try {
-            operation(session.automator)
+            operation(session, session.automator)
         } catch (exception: IOException) {
             DaemonResponse.Error(
                 code = DaemonErrorCode.OperationFailed,
@@ -437,6 +465,7 @@ internal constructor(
         val summary: DaemonSessionSummary,
         val automator: DaemonSessionAutomator,
         val hotReloadSession: HotReloadCapability? = null,
+        val keyGuard: ReloadAwareKeyGuard? = null,
         val activeWaits: java.util.concurrent.atomic.AtomicInteger =
             java.util.concurrent.atomic.AtomicInteger(0),
         /** Absolute nanoTime deadline for the longest currently tracked outside-lock wait. */

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -132,6 +132,7 @@ internal constructor(
     private fun runWaitRequest(session: DaemonSession, request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.WaitForNode -> {
+                val gen = session.keyGuard?.snapshotGeneration()
                 val node =
                     session.automator.waitForNode(
                         tag = request.tag,
@@ -139,7 +140,7 @@ internal constructor(
                         timeoutMs = request.timeoutMs,
                         pollIntervalMs = request.pollIntervalMs,
                     )
-                rememberNodeKeys(session.keyGuard, listOf(node))
+                rememberNodeKeys(session.keyGuard, gen, listOf(node))
                 DaemonResponse.Nodes(request.sessionId, listOf(node))
             }
             is DaemonRequest.WaitForVisualIdle -> {
@@ -181,8 +182,9 @@ internal constructor(
                 }
             is DaemonRequest.AllNodes ->
                 invokeWithSession(request.sessionId) { session, automator ->
+                    val gen = session.keyGuard?.snapshotGeneration()
                     val nodes = automator.allNodes()
-                    rememberNodeKeys(session.keyGuard, nodes)
+                    rememberNodeKeys(session.keyGuard, gen, nodes)
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByTestTag,
@@ -326,26 +328,30 @@ internal constructor(
         when (request) {
             is DaemonRequest.FindByTestTag ->
                 invokeWithSession(request.sessionId) { session, automator ->
+                    val gen = session.keyGuard?.snapshotGeneration()
                     val nodes = automator.findByTestTag(request.tag)
-                    rememberNodeKeys(session.keyGuard, nodes)
+                    rememberNodeKeys(session.keyGuard, gen, nodes)
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByText ->
                 invokeWithSession(request.sessionId) { session, automator ->
+                    val gen = session.keyGuard?.snapshotGeneration()
                     val nodes = automator.findByText(request.text, request.exact)
-                    rememberNodeKeys(session.keyGuard, nodes)
+                    rememberNodeKeys(session.keyGuard, gen, nodes)
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByContentDescription ->
                 invokeWithSession(request.sessionId) { session, automator ->
+                    val gen = session.keyGuard?.snapshotGeneration()
                     val nodes = automator.findByContentDescription(request.description)
-                    rememberNodeKeys(session.keyGuard, nodes)
+                    rememberNodeKeys(session.keyGuard, gen, nodes)
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByRole ->
                 invokeWithSession(request.sessionId) { session, automator ->
+                    val gen = session.keyGuard?.snapshotGeneration()
                     val nodes = automator.findByRole(request.role)
-                    rememberNodeKeys(session.keyGuard, nodes)
+                    rememberNodeKeys(session.keyGuard, gen, nodes)
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             else -> error("Not a query session command: ${request::class.simpleName}")

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -56,7 +56,10 @@ internal constructor(
                 DaemonResponse.Hello(daemonVersion = DaemonProtocol.CurrentVersion)
             is DaemonRequest.Attach -> attach(request.targetPid)
             is DaemonRequest.Detach -> detach(request.sessionId)
-            DaemonRequest.ListSessions -> listSessions()
+            DaemonRequest.ListSessions ->
+                DaemonResponse.Sessions(
+                    sessions = sessionsByPid.values.map { it.summary }.sortedBy { it.targetPid }
+                )
             is DaemonRequest.ListJvmProcesses ->
                 listJvmProcesses(jvmProcessDiscovery, request.requesterPid)
             is DaemonRequest.Windows,
@@ -132,15 +135,16 @@ internal constructor(
     private fun runWaitRequest(session: DaemonSession, request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.WaitForNode -> {
-                val gen = session.keyGuard?.snapshotGeneration()
                 val node =
-                    session.automator.waitForNode(
-                        tag = request.tag,
-                        text = request.text,
-                        timeoutMs = request.timeoutMs,
-                        pollIntervalMs = request.pollIntervalMs,
+                    issueNodeKey(
+                        session.keyGuard,
+                        session.automator.waitForNode(
+                            tag = request.tag,
+                            text = request.text,
+                            timeoutMs = request.timeoutMs,
+                            pollIntervalMs = request.pollIntervalMs,
+                        ),
                     )
-                rememberNodeKeys(session.keyGuard, gen, listOf(node))
                 DaemonResponse.Nodes(request.sessionId, listOf(node))
             }
             is DaemonRequest.WaitForVisualIdle -> {
@@ -151,28 +155,24 @@ internal constructor(
                 )
                 DaemonResponse.Completed(request.sessionId)
             }
-            is DaemonRequest.WaitForReloadSettled -> runReloadSettleWait(session, request)
+            is DaemonRequest.WaitForReloadSettled -> {
+                val hotReload = session.hotReloadSession
+                if (hotReload == null) {
+                    DaemonResponse.Error(
+                        code = DaemonErrorCode.HotReloadUnavailable,
+                        message = "hot reload is not available for this session",
+                        category = ReloadSettleErrorCategory.HOT_RELOAD_UNAVAILABLE,
+                    )
+                } else {
+                    mapReloadSettleOutcome(
+                        hotReload.waitForReloadSettled(request.timeoutMs),
+                        request.sessionId,
+                        request.timeoutMs,
+                    )
+                }
+            }
             else -> error("not a wait request: ${request::class.simpleName}")
         }
-
-    private fun runReloadSettleWait(
-        session: DaemonSession,
-        request: DaemonRequest.WaitForReloadSettled,
-    ): DaemonResponse {
-        val hotReload = session.hotReloadSession
-        if (hotReload == null) {
-            return DaemonResponse.Error(
-                code = DaemonErrorCode.HotReloadUnavailable,
-                message = "hot reload is not available for this session",
-                category = ReloadSettleErrorCategory.HOT_RELOAD_UNAVAILABLE,
-            )
-        }
-        return mapReloadSettleOutcome(
-            hotReload.waitForReloadSettled(request.timeoutMs),
-            request.sessionId,
-            request.timeoutMs,
-        )
-    }
 
     private fun handleSessionCommand(request: DaemonRequest): DaemonResponse =
         when (request) {
@@ -182,9 +182,7 @@ internal constructor(
                 }
             is DaemonRequest.AllNodes ->
                 invokeWithSession(request.sessionId) { session, automator ->
-                    val gen = session.keyGuard?.snapshotGeneration()
-                    val nodes = automator.allNodes()
-                    rememberNodeKeys(session.keyGuard, gen, nodes)
+                    val nodes = issueNodeKeys(session.keyGuard, automator.allNodes())
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByTestTag,
@@ -328,30 +326,31 @@ internal constructor(
         when (request) {
             is DaemonRequest.FindByTestTag ->
                 invokeWithSession(request.sessionId) { session, automator ->
-                    val gen = session.keyGuard?.snapshotGeneration()
-                    val nodes = automator.findByTestTag(request.tag)
-                    rememberNodeKeys(session.keyGuard, gen, nodes)
+                    val nodes =
+                        issueNodeKeys(session.keyGuard, automator.findByTestTag(request.tag))
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByText ->
                 invokeWithSession(request.sessionId) { session, automator ->
-                    val gen = session.keyGuard?.snapshotGeneration()
-                    val nodes = automator.findByText(request.text, request.exact)
-                    rememberNodeKeys(session.keyGuard, gen, nodes)
+                    val nodes =
+                        issueNodeKeys(
+                            session.keyGuard,
+                            automator.findByText(request.text, request.exact),
+                        )
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByContentDescription ->
                 invokeWithSession(request.sessionId) { session, automator ->
-                    val gen = session.keyGuard?.snapshotGeneration()
-                    val nodes = automator.findByContentDescription(request.description)
-                    rememberNodeKeys(session.keyGuard, gen, nodes)
+                    val nodes =
+                        issueNodeKeys(
+                            session.keyGuard,
+                            automator.findByContentDescription(request.description),
+                        )
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByRole ->
                 invokeWithSession(request.sessionId) { session, automator ->
-                    val gen = session.keyGuard?.snapshotGeneration()
-                    val nodes = automator.findByRole(request.role)
-                    rememberNodeKeys(session.keyGuard, gen, nodes)
+                    val nodes = issueNodeKeys(session.keyGuard, automator.findByRole(request.role))
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             else -> error("Not a query session command: ${request::class.simpleName}")
@@ -360,57 +359,22 @@ internal constructor(
     private fun handleInputSessionCommand(request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.Click ->
-                invokeWithSession(request.sessionId) { session, automator ->
-                    rejectStaleNodeKey(session.keyGuard, request.nodeKey)?.let {
-                        return@invokeWithSession it
-                    }
-                    automator.click(request.nodeKey)
-                    DaemonResponse.Completed(request.sessionId)
+                invokeResolvedKey(request.sessionId, request.nodeKey) { auto, key ->
+                    auto.click(key)
                 }
             is DaemonRequest.DoubleClick ->
-                invokeWithSession(request.sessionId) { session, automator ->
-                    rejectStaleNodeKey(session.keyGuard, request.nodeKey)?.let {
-                        return@invokeWithSession it
-                    }
-                    automator.doubleClick(request.nodeKey)
-                    DaemonResponse.Completed(request.sessionId)
+                invokeResolvedKey(request.sessionId, request.nodeKey) { auto, key ->
+                    auto.doubleClick(key)
                 }
             is DaemonRequest.LongClick ->
-                invokeWithSession(request.sessionId) { session, automator ->
-                    rejectStaleNodeKey(session.keyGuard, request.nodeKey)?.let {
-                        return@invokeWithSession it
-                    }
-                    automator.longClick(request.nodeKey, request.holdForMs)
-                    DaemonResponse.Completed(request.sessionId)
-                }
-            is DaemonRequest.Swipe ->
-                invokeWithSession(request.sessionId) { session, automator ->
-                    rejectStaleNodeKey(session.keyGuard, request.fromNodeKey)?.let {
-                        return@invokeWithSession it
-                    }
-                    rejectStaleNodeKey(session.keyGuard, request.toNodeKey)?.let {
-                        return@invokeWithSession it
-                    }
-                    automator.swipe(
-                        fromNodeKey = request.fromNodeKey,
-                        toNodeKey = request.toNodeKey,
-                        startX = request.startX,
-                        startY = request.startY,
-                        endX = request.endX,
-                        endY = request.endY,
-                        steps = request.steps,
-                        durationMs = request.durationMs,
-                    )
-                    DaemonResponse.Completed(request.sessionId)
+                invokeResolvedKey(request.sessionId, request.nodeKey) { auto, key ->
+                    auto.longClick(key, request.holdForMs)
                 }
             is DaemonRequest.ScrollWheel ->
-                invokeWithSession(request.sessionId) { session, automator ->
-                    rejectStaleNodeKey(session.keyGuard, request.nodeKey)?.let {
-                        return@invokeWithSession it
-                    }
-                    automator.scrollWheel(request.nodeKey, request.wheelClicks)
-                    DaemonResponse.Completed(request.sessionId)
+                invokeResolvedKey(request.sessionId, request.nodeKey) { auto, key ->
+                    auto.scrollWheel(key, request.wheelClicks)
                 }
+            is DaemonRequest.Swipe -> handleSwipe(request)
             is DaemonRequest.PressKey ->
                 invoke(request.sessionId) { automator ->
                     automator.pressKey(request.keyCode, request.modifiers)
@@ -424,10 +388,46 @@ internal constructor(
             else -> error("Not an input session command: ${request::class.simpleName}")
         }
 
-    private fun listSessions(): DaemonResponse =
-        DaemonResponse.Sessions(
-            sessions = sessionsByPid.values.map { it.summary }.sortedBy { it.targetPid }
-        )
+    private fun handleSwipe(request: DaemonRequest.Swipe): DaemonResponse =
+        invokeWithSession(request.sessionId) { session, automator ->
+            val from =
+                when (val r = resolveNodeKeyForDispatch(session.keyGuard, request.fromNodeKey)) {
+                    is KeyResolution.Stale -> return@invokeWithSession r.error
+                    is KeyResolution.Raw -> r.key
+                    KeyResolution.Missing -> null
+                }
+            val to =
+                when (val r = resolveNodeKeyForDispatch(session.keyGuard, request.toNodeKey)) {
+                    is KeyResolution.Stale -> return@invokeWithSession r.error
+                    is KeyResolution.Raw -> r.key
+                    KeyResolution.Missing -> null
+                }
+            automator.swipe(
+                fromNodeKey = from,
+                toNodeKey = to,
+                startX = request.startX,
+                startY = request.startY,
+                endX = request.endX,
+                endY = request.endY,
+                steps = request.steps,
+                durationMs = request.durationMs,
+            )
+            DaemonResponse.Completed(request.sessionId)
+        }
+
+    private fun invokeResolvedKey(
+        sessionId: String,
+        nodeKey: String,
+        op: (DaemonSessionAutomator, String) -> Unit,
+    ): DaemonResponse =
+        invokeWithSession(sessionId) { session, automator ->
+            when (val resolved = resolveNodeKeyForDispatch(session.keyGuard, nodeKey)) {
+                is KeyResolution.Stale -> return@invokeWithSession resolved.error
+                is KeyResolution.Raw -> op(automator, resolved.key)
+                KeyResolution.Missing -> error("missing node key")
+            }
+            DaemonResponse.Completed(sessionId)
+        }
 
     private fun invoke(
         sessionId: String,
@@ -468,46 +468,40 @@ internal constructor(
             session.automator.close()
         }
     }
+}
 
-    private data class DaemonSession(
-        val summary: DaemonSessionSummary,
-        val automator: DaemonSessionAutomator,
-        val hotReloadSession: HotReloadCapability? = null,
-        val keyGuard: ReloadAwareKeyGuard? = null,
-        val activeWaits: java.util.concurrent.atomic.AtomicInteger =
-            java.util.concurrent.atomic.AtomicInteger(0),
-        /** Absolute nanoTime deadline for the longest currently tracked outside-lock wait. */
-        val waitDeadlineNs: java.util.concurrent.atomic.AtomicLong =
-            java.util.concurrent.atomic.AtomicLong(0),
-    ) {
-        val sessionId: String
-            get() = summary.sessionId
+private const val WAIT_DRAIN_TIMEOUT_MS: Long = 90_000
+private const val WAIT_DRAIN_MARGIN_MS: Long = 5_000
+private const val WAIT_DRAIN_POLL_MS: Long = 10
+private const val NANOS_PER_MS: Long = 1_000_000
 
-        fun noteWaitStarted(timeoutMs: Long) {
-            val candidate = System.nanoTime() + timeoutMs.coerceAtLeast(0) * NANOS_PER_MS
-            waitDeadlineNs.updateAndGet { current -> maxOf(current, candidate) }
-        }
+private data class DaemonSession(
+    val summary: DaemonSessionSummary,
+    val automator: DaemonSessionAutomator,
+    val hotReloadSession: HotReloadCapability? = null,
+    val keyGuard: ReloadAwareKeyGuard? = null,
+    val activeWaits: java.util.concurrent.atomic.AtomicInteger =
+        java.util.concurrent.atomic.AtomicInteger(0),
+    /** Absolute nanoTime deadline for the longest currently tracked outside-lock wait. */
+    val waitDeadlineNs: java.util.concurrent.atomic.AtomicLong =
+        java.util.concurrent.atomic.AtomicLong(0),
+) {
+    val sessionId: String
+        get() = summary.sessionId
 
-        fun awaitIdleWaits(timeoutMs: Long = WAIT_DRAIN_TIMEOUT_MS) {
-            val trackedRemainingMs =
-                ((waitDeadlineNs.get() - System.nanoTime()) / NANOS_PER_MS).coerceAtLeast(0)
-            val budgetMs = maxOf(timeoutMs, trackedRemainingMs + WAIT_DRAIN_MARGIN_MS)
-            val deadline = System.nanoTime() + budgetMs * NANOS_PER_MS
-            while (activeWaits.get() > 0 && System.nanoTime() < deadline) {
-                Thread.sleep(WAIT_DRAIN_POLL_MS)
-            }
-        }
+    fun noteWaitStarted(timeoutMs: Long) {
+        val candidate = System.nanoTime() + timeoutMs.coerceAtLeast(0) * NANOS_PER_MS
+        waitDeadlineNs.updateAndGet { current -> maxOf(current, candidate) }
     }
 
-    private companion object {
-        /**
-         * Floor for drain-before-close. Active waits may extend this via
-         * [DaemonSession.noteWaitStarted] so caller-chosen settle timeouts are honored.
-         */
-        const val WAIT_DRAIN_TIMEOUT_MS: Long = 90_000
-        const val WAIT_DRAIN_MARGIN_MS: Long = 5_000
-        const val WAIT_DRAIN_POLL_MS: Long = 10
-        const val NANOS_PER_MS: Long = 1_000_000
+    fun awaitIdleWaits(timeoutMs: Long = WAIT_DRAIN_TIMEOUT_MS) {
+        val trackedRemainingMs =
+            ((waitDeadlineNs.get() - System.nanoTime()) / NANOS_PER_MS).coerceAtLeast(0)
+        val budgetMs = maxOf(timeoutMs, trackedRemainingMs + WAIT_DRAIN_MARGIN_MS)
+        val deadline = System.nanoTime() + budgetMs * NANOS_PER_MS
+        while (activeWaits.get() > 0 && System.nanoTime() < deadline) {
+            Thread.sleep(WAIT_DRAIN_POLL_MS)
+        }
     }
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -135,16 +135,23 @@ internal constructor(
     private fun runWaitRequest(session: DaemonSession, request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.WaitForNode -> {
-                val node =
-                    issueNodeAcrossReload(session.keyGuard) {
-                        session.automator.waitForNode(
-                            tag = request.tag,
-                            text = request.text,
-                            timeoutMs = request.timeoutMs,
-                            pollIntervalMs = request.pollIntervalMs,
+                val gen = session.keyGuard?.snapshotGeneration() ?: 0L
+                val rawNode =
+                    session.automator.waitForNode(
+                        tag = request.tag,
+                        text = request.text,
+                        timeoutMs = request.timeoutMs,
+                        pollIntervalMs = request.pollIntervalMs,
+                    )
+                val stamped =
+                    stampNodeIfCurrentGeneration(session.keyGuard, gen, rawNode)
+                        ?: return DaemonResponse.Error(
+                            code = DaemonErrorCode.OperationFailed,
+                            message =
+                                "No node found with key=${rawNode.key} (reload settled during wait)",
+                            category = "nodeNotFound",
                         )
-                    }
-                DaemonResponse.Nodes(request.sessionId, listOf(node))
+                DaemonResponse.Nodes(request.sessionId, listOf(stamped))
             }
             is DaemonRequest.WaitForVisualIdle -> {
                 session.automator.waitForVisualIdle(
@@ -393,28 +400,36 @@ internal constructor(
     private fun handleSwipe(request: DaemonRequest.Swipe): DaemonResponse =
         invokeWithSession(request.sessionId) { session, automator ->
             val guard = session.keyGuard
-            var from: String? = request.fromNodeKey
-            var to: String? = request.toNodeKey
-            if (guard != null) {
-                if (request.fromNodeKey != null) {
-                    val ok = guard.dispatch(request.fromNodeKey) { raw -> from = raw }
-                    if (!ok) return@invokeWithSession staleNodeKeyError(request.fromNodeKey)
-                }
-                if (request.toNodeKey != null) {
-                    val ok = guard.dispatch(request.toNodeKey) { raw -> to = raw }
-                    if (!ok) return@invokeWithSession staleNodeKeyError(request.toNodeKey)
+            if (guard == null) {
+                automator.swipe(
+                    fromNodeKey = request.fromNodeKey,
+                    toNodeKey = request.toNodeKey,
+                    startX = request.startX,
+                    startY = request.startY,
+                    endX = request.endX,
+                    endY = request.endY,
+                    steps = request.steps,
+                    durationMs = request.durationMs,
+                )
+            } else {
+                val ok =
+                    guard.dispatchKeys(request.fromNodeKey, request.toNodeKey) { from, to ->
+                        automator.swipe(
+                            fromNodeKey = from,
+                            toNodeKey = to,
+                            startX = request.startX,
+                            startY = request.startY,
+                            endX = request.endX,
+                            endY = request.endY,
+                            steps = request.steps,
+                            durationMs = request.durationMs,
+                        )
+                    }
+                if (!ok) {
+                    val bad = request.fromNodeKey ?: request.toNodeKey ?: "unknown"
+                    return@invokeWithSession staleNodeKeyError(bad)
                 }
             }
-            automator.swipe(
-                fromNodeKey = from,
-                toNodeKey = to,
-                startX = request.startX,
-                startY = request.startY,
-                endX = request.endX,
-                endY = request.endY,
-                steps = request.steps,
-                durationMs = request.durationMs,
-            )
             DaemonResponse.Completed(request.sessionId)
         }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -136,15 +136,14 @@ internal constructor(
         when (request) {
             is DaemonRequest.WaitForNode -> {
                 val node =
-                    issueNodeKey(
-                        session.keyGuard,
+                    issueNodeAcrossReload(session.keyGuard) {
                         session.automator.waitForNode(
                             tag = request.tag,
                             text = request.text,
                             timeoutMs = request.timeoutMs,
                             pollIntervalMs = request.pollIntervalMs,
-                        ),
-                    )
+                        )
+                    }
                 DaemonResponse.Nodes(request.sessionId, listOf(node))
             }
             is DaemonRequest.WaitForVisualIdle -> {
@@ -182,7 +181,7 @@ internal constructor(
                 }
             is DaemonRequest.AllNodes ->
                 invokeWithSession(request.sessionId) { session, automator ->
-                    val nodes = issueNodeKeys(session.keyGuard, automator.allNodes())
+                    val nodes = issueNodesAcrossReload(session.keyGuard) { automator.allNodes() }
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByTestTag,
@@ -327,30 +326,33 @@ internal constructor(
             is DaemonRequest.FindByTestTag ->
                 invokeWithSession(request.sessionId) { session, automator ->
                     val nodes =
-                        issueNodeKeys(session.keyGuard, automator.findByTestTag(request.tag))
+                        issueNodesAcrossReload(session.keyGuard) {
+                            automator.findByTestTag(request.tag)
+                        }
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByText ->
                 invokeWithSession(request.sessionId) { session, automator ->
                     val nodes =
-                        issueNodeKeys(
-                            session.keyGuard,
-                            automator.findByText(request.text, request.exact),
-                        )
+                        issueNodesAcrossReload(session.keyGuard) {
+                            automator.findByText(request.text, request.exact)
+                        }
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByContentDescription ->
                 invokeWithSession(request.sessionId) { session, automator ->
                     val nodes =
-                        issueNodeKeys(
-                            session.keyGuard,
-                            automator.findByContentDescription(request.description),
-                        )
+                        issueNodesAcrossReload(session.keyGuard) {
+                            automator.findByContentDescription(request.description)
+                        }
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             is DaemonRequest.FindByRole ->
                 invokeWithSession(request.sessionId) { session, automator ->
-                    val nodes = issueNodeKeys(session.keyGuard, automator.findByRole(request.role))
+                    val nodes =
+                        issueNodesAcrossReload(session.keyGuard) {
+                            automator.findByRole(request.role)
+                        }
                     DaemonResponse.Nodes(request.sessionId, nodes)
                 }
             else -> error("Not a query session command: ${request::class.simpleName}")
@@ -390,18 +392,19 @@ internal constructor(
 
     private fun handleSwipe(request: DaemonRequest.Swipe): DaemonResponse =
         invokeWithSession(request.sessionId) { session, automator ->
-            val from =
-                when (val r = resolveNodeKeyForDispatch(session.keyGuard, request.fromNodeKey)) {
-                    is KeyResolution.Stale -> return@invokeWithSession r.error
-                    is KeyResolution.Raw -> r.key
-                    KeyResolution.Missing -> null
+            val guard = session.keyGuard
+            var from: String? = request.fromNodeKey
+            var to: String? = request.toNodeKey
+            if (guard != null) {
+                if (request.fromNodeKey != null) {
+                    val ok = guard.dispatch(request.fromNodeKey) { raw -> from = raw }
+                    if (!ok) return@invokeWithSession staleNodeKeyError(request.fromNodeKey)
                 }
-            val to =
-                when (val r = resolveNodeKeyForDispatch(session.keyGuard, request.toNodeKey)) {
-                    is KeyResolution.Stale -> return@invokeWithSession r.error
-                    is KeyResolution.Raw -> r.key
-                    KeyResolution.Missing -> null
+                if (request.toNodeKey != null) {
+                    val ok = guard.dispatch(request.toNodeKey) { raw -> to = raw }
+                    if (!ok) return@invokeWithSession staleNodeKeyError(request.toNodeKey)
                 }
+            }
             automator.swipe(
                 fromNodeKey = from,
                 toNodeKey = to,
@@ -421,10 +424,11 @@ internal constructor(
         op: (DaemonSessionAutomator, String) -> Unit,
     ): DaemonResponse =
         invokeWithSession(sessionId) { session, automator ->
-            when (val resolved = resolveNodeKeyForDispatch(session.keyGuard, nodeKey)) {
-                is KeyResolution.Stale -> return@invokeWithSession resolved.error
-                is KeyResolution.Raw -> op(automator, resolved.key)
-                KeyResolution.Missing -> error("missing node key")
+            val guard = session.keyGuard
+            if (guard == null) {
+                op(automator, nodeKey)
+            } else if (!guard.dispatch(nodeKey) { raw -> op(automator, raw) }) {
+                return@invokeWithSession staleNodeKeyError(nodeKey)
             }
             DaemonResponse.Completed(sessionId)
         }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -287,7 +287,9 @@ internal constructor(
                 null
             }
         val keyGuard = if (hotReload != null) ReloadAwareKeyGuard() else null
+        // Wire invalidation before the reconnect loop connects so the first settle is not missed.
         hotReload?.setReloadSettledListener { keyGuard?.onReload() }
+        (hotReload as? HotReloadSession)?.start()
         val session =
             DaemonSession(
                 summary = sessionSummaryFor(targetPid),
@@ -517,8 +519,9 @@ private fun installEmbeddedAgentRuntimeIfNeeded() {
  * pid-file path (port may appear shortly after attach while HR finishes writing the file).
  */
 private fun defaultHotReloadCapability(targetPid: Long): HotReloadCapability? {
+    // autoStart=false: attach wires the invalidation listener then calls start().
     if (HotReloadPortDiscovery.discover(targetPid) != null) {
-        return HotReloadSession.forTargetPid(targetPid)
+        return HotReloadSession.forTargetPid(targetPid, autoStart = false)
     }
     // Port not readable yet, but a pid-file property means HR is (or will be) present.
     val args =
@@ -534,7 +537,11 @@ private fun defaultHotReloadCapability(targetPid: Long): HotReloadCapability? {
             emptyList()
         }
     val pidFile = HotReloadPortDiscovery.parsePidFilePathFromJvmArgs(args) ?: return null
-    return HotReloadSession.forTargetPid(targetPid, explicitPidFile = pidFile)
+    return HotReloadSession.forTargetPid(
+        targetPid = targetPid,
+        explicitPidFile = pidFile,
+        autoStart = false,
+    )
 }
 
 private fun listJvmProcesses(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
@@ -73,7 +73,7 @@ internal constructor(
 
     /** Starts the reconnect loop. Safe to call once after construction. */
     public fun start() {
-        if (closed.get()) return
+        if (closed.get() || reconnectJob != null) return
         reconnectJob = scope.launch { runReconnectLoop() }
     }
 
@@ -121,8 +121,12 @@ internal constructor(
                 val message = channel.receiveCatching().getOrNull() ?: break
                 when (val event = message.toLifecycleEvent()) {
                     is ReloadLifecycleEvent.ReloadClassesResult -> {
-                        pendingSuccessfulRequestId =
-                            if (event.isSuccess) event.reloadRequestId else null
+                        if (event.isSuccess) {
+                            pendingSuccessfulRequestId = event.reloadRequestId
+                        } else if (event.reloadRequestId == pendingSuccessfulRequestId) {
+                            // Only clear when the failure is for the request we were tracking.
+                            pendingSuccessfulRequestId = null
+                        }
                     }
                     is ReloadLifecycleEvent.UIRendered -> {
                         val requestId = event.reloadRequestId
@@ -232,10 +236,16 @@ internal constructor(
         private const val CONNECT_POLL_MS: Long = 50
         private const val NANOS_PER_MS: Long = 1_000_000
 
-        /** Creates a session that discovers the port for [targetPid] on each reconnect attempt. */
+        /**
+         * Creates a session that discovers the port for [targetPid] on each reconnect attempt.
+         *
+         * When [autoStart] is false, the caller must invoke [start] after wiring listeners (#212)
+         * so the first connect does not race past an unregistered invalidation listener.
+         */
         public fun forTargetPid(
             targetPid: Long,
             explicitPidFile: java.nio.file.Path? = null,
+            autoStart: Boolean = true,
         ): HotReloadSession {
             val session =
                 HotReloadSession(
@@ -247,16 +257,16 @@ internal constructor(
                             ?.port
                     }
                 )
-            session.start()
+            if (autoStart) session.start()
             return session
         }
 
         /**
          * Creates a session pinned to a fixed [port] (tests and explicit orchestration endpoints).
          */
-        public fun forPort(port: Int): HotReloadSession {
+        public fun forPort(port: Int, autoStart: Boolean = true): HotReloadSession {
             val session = HotReloadSession(portProvider = { port })
-            session.start()
+            if (autoStart) session.start()
             return session
         }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
@@ -213,19 +213,28 @@ internal constructor(
         if (reconnectJob == null && handleRef.get() == null) {
             return ReloadSettleOutcome.Unavailable
         }
-        val startedNs = System.nanoTime()
-        val handle =
-            awaitConnection(timeoutMs)
-                ?: return when {
-                    closed.get() -> ReloadSettleOutcome.Cancelled
-                    // Reconnect was running but never produced a handle within the budget →
-                    // settle-timeout, not "HR unavailable" (session is still reload-aware).
-                    else -> ReloadSettleOutcome.TimedOut
-                }
-        val elapsedMs = (System.nanoTime() - startedNs) / NANOS_PER_MS
-        val remainingMs = (timeoutMs - elapsedMs).coerceAtLeast(0)
-        if (remainingMs == 0L) return ReloadSettleOutcome.TimedOut
-        return runBlocking { settleOn(handle, remainingMs) }
+        // Arm fan-out *before* awaitConnection so a reload that races connect → settle cannot
+        // fan out to an empty subscriber list and leave this waiter stuck in AwaitRequest.
+        val events = subscribeLifecycle()
+        try {
+            val startedNs = System.nanoTime()
+            val handle =
+                awaitConnection(timeoutMs)
+                    ?: return when {
+                        closed.get() -> ReloadSettleOutcome.Cancelled
+                        // Reconnect was running but never produced a handle within the budget →
+                        // settle-timeout, not "HR unavailable" (session is still reload-aware).
+                        else -> ReloadSettleOutcome.TimedOut
+                    }
+            val elapsedMs = (System.nanoTime() - startedNs) / NANOS_PER_MS
+            val remainingMs = (timeoutMs - elapsedMs).coerceAtLeast(0)
+            if (remainingMs == 0L) return ReloadSettleOutcome.TimedOut
+            // Pin the handle that is currently pumping into [events]; send Ping only on that
+            // same instance so reconnect cannot pair a dead send with a live receive.
+            return runBlocking { settleOn(handle, remainingMs, events) }
+        } finally {
+            events.cancel()
+        }
     }
 
     /**
@@ -256,33 +265,39 @@ internal constructor(
     }
 
     private suspend fun settleOn(
-        handle: OrchestrationHandle,
+        connectedHandle: OrchestrationHandle,
         timeoutMs: Long,
+        events: Channel<ReloadLifecycleEvent>,
     ): ReloadSettleOutcome {
         val machine = ReloadSettleStateMachine()
-        val events = subscribeLifecycle()
-        try {
-            val settled =
-                withTimeoutOrNull(timeoutMs) {
-                    while (true) {
-                        if (machine.needsPing()) {
-                            // Ping assigns its own messageId; match Ack against that id.
-                            val ping = OrchestrationMessage.Ping()
-                            handle.send(ping)
-                            machine.beginPingDrain(ping.messageId.toString())
+        val settled =
+            withTimeoutOrNull(timeoutMs) {
+                while (true) {
+                    if (machine.needsPing()) {
+                        // Only send on the same handle that was live when this waiter armed;
+                        // reconnect clears subscribers (channel closes → Cancelled) and replaces
+                        // handleRef, so a mismatched ref means this wait is already obsolete.
+                        val live = handleRef.get()
+                        if (live == null || live !== connectedHandle) {
+                            return@withTimeoutOrNull ReloadSettleOutcome.Cancelled
                         }
-                        val event =
-                            events.receiveCatching().getOrNull()
-                                ?: return@withTimeoutOrNull ReloadSettleOutcome.Cancelled
-                        val outcome = machine.onEvent(event)
-                        if (outcome != null) return@withTimeoutOrNull outcome
+                        val ping = OrchestrationMessage.Ping()
+                        try {
+                            live.send(ping)
+                        } catch (_: Exception) {
+                            return@withTimeoutOrNull ReloadSettleOutcome.Cancelled
+                        }
+                        machine.beginPingDrain(ping.messageId.toString())
                     }
-                    @Suppress("UNREACHABLE_CODE") ReloadSettleOutcome.TimedOut
+                    val event =
+                        events.receiveCatching().getOrNull()
+                            ?: return@withTimeoutOrNull ReloadSettleOutcome.Cancelled
+                    val outcome = machine.onEvent(event)
+                    if (outcome != null) return@withTimeoutOrNull outcome
                 }
-            return settled ?: machine.onTimeout()
-        } finally {
-            events.cancel()
-        }
+                @Suppress("UNREACHABLE_CODE") ReloadSettleOutcome.TimedOut
+            }
+        return settled ?: machine.onTimeout()
     }
 
     public companion object {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.cli.hotreload
 
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.CoroutineDispatcher
@@ -8,6 +9,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
@@ -52,6 +55,9 @@ public interface HotReloadCapability : AutoCloseable {
  * HR's own MCP), and exposes [waitForReloadSettled] for the full settle chain.
  *
  * Lifetime is owned by the daemon session: [close] on detach.
+ *
+ * Lifecycle messages are read by a **single** [asChannel] consumer per connected handle and fanned
+ * out to the invalidation observer and any concurrent [waitForReloadSettled] waiters (#212 Codex).
  */
 public class HotReloadSession
 internal constructor(
@@ -66,6 +72,11 @@ internal constructor(
     private val closed = AtomicBoolean(false)
     private val reloadSettledListener = AtomicReference<(() -> Unit)?>(null)
     private var reconnectJob: Job? = null
+    /**
+     * Active settle-wait subscribers for the current handle. Written only from the pump coroutine
+     * and subscribe/unsubscribe paths; CopyOnWrite so the pump can fan out without holding a lock.
+     */
+    private val lifecycleSubscribers = CopyOnWriteArrayList<SendChannel<ReloadLifecycleEvent>>()
 
     /** True when a live orchestration handle is connected. */
     public val isConnected: Boolean
@@ -95,51 +106,95 @@ internal constructor(
 
     private suspend fun awaitConnectedHandle(handle: OrchestrationHandle) {
         handleRef.set(handle)
-        val observer = scope.launch { observeReloadsForInvalidation(handle) }
+        // One reader for the handle; invalidation + waiters share fanned-out lifecycle events.
+        val pump = scope.launch { pumpLifecycle(handle) }
         try {
             // Suspend until the handle finishes (app exit / disconnect).
             handle.await()
         } catch (_: Exception) {
             // fall through to reconnect
         } finally {
-            observer.cancel()
+            pump.cancel()
+            clearLifecycleSubscribers()
             handleRef.compareAndSet(handle, null)
             runCatching { handle.close() }
         }
     }
 
     /**
-     * Background observation: after a successful class reload is rendered (`ReloadClassesResult`
-     * success + matching `UIRendered`), notify the invalidation listener so node keys are flushed
-     * (#212). Does not send Ping (avoids racing [waitForReloadSettled]).
+     * Single [asChannel] consumer: drives invalidation bookkeeping and fans every lifecycle event
+     * to concurrent [waitForReloadSettled] subscribers so they cannot steal messages from each
+     * other.
      */
-    private suspend fun observeReloadsForInvalidation(handle: OrchestrationHandle) {
+    private suspend fun pumpLifecycle(handle: OrchestrationHandle) {
         val channel = handle.asChannel()
         var pendingSuccessfulRequestId: String? = null
         try {
             while (scope.isActive && !closed.get()) {
-                val message = channel.receiveCatching().getOrNull() ?: break
-                when (val event = message.toLifecycleEvent()) {
-                    is ReloadLifecycleEvent.ReloadClassesResult -> {
-                        if (event.isSuccess) {
-                            pendingSuccessfulRequestId = event.reloadRequestId
-                        } else if (event.reloadRequestId == pendingSuccessfulRequestId) {
-                            // Only clear when the failure is for the request we were tracking.
-                            pendingSuccessfulRequestId = null
-                        }
-                    }
-                    is ReloadLifecycleEvent.UIRendered -> {
-                        val requestId = event.reloadRequestId
-                        if (requestId != null && requestId == pendingSuccessfulRequestId) {
-                            pendingSuccessfulRequestId = null
-                            reloadSettledListener.get()?.invoke()
-                        }
-                    }
-                    else -> Unit
+                val message = channel.receiveCatching().getOrNull()
+                if (message == null) {
+                    return
+                }
+                val event = message.toLifecycleEvent()
+                if (event != null) {
+                    pendingSuccessfulRequestId =
+                        updatePendingSuccess(pendingSuccessfulRequestId, event)
+                    fanOut(event)
                 }
             }
         } finally {
             channel.cancel()
+        }
+    }
+
+    /**
+     * Tracks successful reload → matching UIRendered for the invalidation listener. Does not send
+     * Ping (the settle waiter owns Ping/Ack drain).
+     */
+    private fun updatePendingSuccess(pending: String?, event: ReloadLifecycleEvent): String? =
+        when (event) {
+            is ReloadLifecycleEvent.ReloadClassesResult -> {
+                when {
+                    event.isSuccess -> event.reloadRequestId
+                    event.reloadRequestId == pending -> null
+                    else -> pending
+                }
+            }
+            is ReloadLifecycleEvent.UIRendered -> {
+                val requestId = event.reloadRequestId
+                if (requestId != null && requestId == pending) {
+                    reloadSettledListener.get()?.invoke()
+                    null
+                } else {
+                    pending
+                }
+            }
+            else -> pending
+        }
+
+    private fun fanOut(event: ReloadLifecycleEvent) {
+        for (subscriber in lifecycleSubscribers) {
+            // DROP when a waiter is not draining fast enough; settle timeout still covers misses.
+            subscriber.trySend(event)
+        }
+    }
+
+    /**
+     * Registers a buffered channel that receives every lifecycle event for the current connection.
+     * Caller must [Channel.cancel] when done; [invokeOnClose] removes the subscriber.
+     */
+    private fun subscribeLifecycle(): Channel<ReloadLifecycleEvent> {
+        val channel = Channel<ReloadLifecycleEvent>(Channel.BUFFERED)
+        lifecycleSubscribers.add(channel)
+        channel.invokeOnClose { lifecycleSubscribers.remove(channel) }
+        return channel
+    }
+
+    private fun clearLifecycleSubscribers() {
+        val snapshot = lifecycleSubscribers.toList()
+        lifecycleSubscribers.clear()
+        for (subscriber in snapshot) {
+            subscriber.close()
         }
     }
 
@@ -195,6 +250,7 @@ internal constructor(
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
         reconnectJob?.cancel()
+        clearLifecycleSubscribers()
         handleRef.getAndSet(null)?.let { runCatching { it.close() } }
         scope.cancel()
     }
@@ -204,7 +260,7 @@ internal constructor(
         timeoutMs: Long,
     ): ReloadSettleOutcome {
         val machine = ReloadSettleStateMachine()
-        val channel = handle.asChannel()
+        val events = subscribeLifecycle()
         try {
             val settled =
                 withTimeoutOrNull(timeoutMs) {
@@ -215,10 +271,9 @@ internal constructor(
                             handle.send(ping)
                             machine.beginPingDrain(ping.messageId.toString())
                         }
-                        val message =
-                            channel.receiveCatching().getOrNull()
+                        val event =
+                            events.receiveCatching().getOrNull()
                                 ?: return@withTimeoutOrNull ReloadSettleOutcome.Cancelled
-                        val event = message.toLifecycleEvent() ?: continue
                         val outcome = machine.onEvent(event)
                         if (outcome != null) return@withTimeoutOrNull outcome
                     }
@@ -226,7 +281,7 @@ internal constructor(
                 }
             return settled ?: machine.onTimeout()
         } finally {
-            channel.cancel()
+            events.cancel()
         }
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadSession.kt
@@ -35,6 +35,14 @@ public interface HotReloadCapability : AutoCloseable {
     public fun waitForReloadSettled(
         timeoutMs: Long = HotReloadSession.DEFAULT_SETTLE_TIMEOUT_MS
     ): ReloadSettleOutcome
+
+    /**
+     * Registers a listener invoked after a successful reload settles (matching `UIRendered` after a
+     * successful `ReloadClassesResult`). Used for tree/node-key invalidation (#212).
+     *
+     * Replaces any previous listener. Passing `null` clears the listener.
+     */
+    public fun setReloadSettledListener(listener: (() -> Unit)?)
 }
 
 /**
@@ -56,6 +64,7 @@ internal constructor(
     private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val handleRef = AtomicReference<OrchestrationHandle?>(null)
     private val closed = AtomicBoolean(false)
+    private val reloadSettledListener = AtomicReference<(() -> Unit)?>(null)
     private var reconnectJob: Job? = null
 
     /** True when a live orchestration handle is connected. */
@@ -66,6 +75,10 @@ internal constructor(
     public fun start() {
         if (closed.get()) return
         reconnectJob = scope.launch { runReconnectLoop() }
+    }
+
+    override fun setReloadSettledListener(listener: (() -> Unit)?) {
+        reloadSettledListener.set(listener)
     }
 
     private suspend fun runReconnectLoop() {
@@ -82,14 +95,47 @@ internal constructor(
 
     private suspend fun awaitConnectedHandle(handle: OrchestrationHandle) {
         handleRef.set(handle)
+        val observer = scope.launch { observeReloadsForInvalidation(handle) }
         try {
             // Suspend until the handle finishes (app exit / disconnect).
             handle.await()
         } catch (_: Exception) {
             // fall through to reconnect
         } finally {
+            observer.cancel()
             handleRef.compareAndSet(handle, null)
             runCatching { handle.close() }
+        }
+    }
+
+    /**
+     * Background observation: after a successful class reload is rendered (`ReloadClassesResult`
+     * success + matching `UIRendered`), notify the invalidation listener so node keys are flushed
+     * (#212). Does not send Ping (avoids racing [waitForReloadSettled]).
+     */
+    private suspend fun observeReloadsForInvalidation(handle: OrchestrationHandle) {
+        val channel = handle.asChannel()
+        var pendingSuccessfulRequestId: String? = null
+        try {
+            while (scope.isActive && !closed.get()) {
+                val message = channel.receiveCatching().getOrNull() ?: break
+                when (val event = message.toLifecycleEvent()) {
+                    is ReloadLifecycleEvent.ReloadClassesResult -> {
+                        pendingSuccessfulRequestId =
+                            if (event.isSuccess) event.reloadRequestId else null
+                    }
+                    is ReloadLifecycleEvent.UIRendered -> {
+                        val requestId = event.reloadRequestId
+                        if (requestId != null && requestId == pendingSuccessfulRequestId) {
+                            pendingSuccessfulRequestId = null
+                            reloadSettledListener.get()?.invoke()
+                        }
+                    }
+                    else -> Unit
+                }
+            }
+        } finally {
+            channel.cancel()
         }
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
@@ -11,19 +11,36 @@ package dev.sebastiano.spectre.cli.hotreload
  */
 public class ReloadAwareKeyGuard {
     private val lock = Any()
-    private var state: KeyState = KeyState.Untracked
+    /** Bumped on each [onReload]; only keys remembered for the current generation are accepted. */
+    private var generation: Long = 0L
+    /**
+     * Keys issued in [generation]. `null` means no tree has been issued in this generation yet —
+     * key ops still go to the live agent (same as pre-#212 behaviour for the first tree).
+     */
+    private var issuedKeys: Set<String>? = null
 
-    /** Records keys from a tree/find response and clears the post-reload invalidation flag. */
+    /** Records keys from a tree/find response for the current generation (unioning). */
     public fun rememberIssuedKeys(keys: Collection<String>) {
-        synchronized(lock) { state = KeyState.Tracked(keys.toSet()) }
+        synchronized(lock) {
+            val existing = issuedKeys
+            issuedKeys =
+                if (existing == null) {
+                    keys.toSet()
+                } else {
+                    existing + keys
+                }
+        }
     }
 
     /**
-     * Marks the session as post-reload: subsequent [accepts] calls fail until [rememberIssuedKeys]
-     * runs again.
+     * Marks the session as post-reload: subsequent [accepts] fail until [rememberIssuedKeys] runs
+     * for the new generation.
      */
     public fun onReload() {
-        synchronized(lock) { state = KeyState.Invalidated }
+        synchronized(lock) {
+            generation += 1
+            issuedKeys = null
+        }
     }
 
     /**
@@ -32,25 +49,17 @@ public class ReloadAwareKeyGuard {
      */
     public fun accepts(key: String): Boolean {
         synchronized(lock) {
-            return when (val current = state) {
-                KeyState.Untracked -> true
-                KeyState.Invalidated -> false
-                is KeyState.Tracked -> key in current.keys
-            }
+            val known = issuedKeys
+            // After reload and before the next tree, reject everything.
+            if (known == null) return generation == 0L
+            return key in known
         }
     }
 
     /** Test/diagnostics: whether a reload has invalidated keys awaiting a fresh tree. */
-    public fun isInvalidated(): Boolean = synchronized(lock) { state is KeyState.Invalidated }
+    public fun isInvalidated(): Boolean =
+        synchronized(lock) { issuedKeys == null && generation > 0 }
 
-    private sealed interface KeyState {
-        /** No tree has been issued yet — key ops still go to the live agent. */
-        data object Untracked : KeyState
-
-        /** Post-reload: every key is rejected until the next tree/find. */
-        data object Invalidated : KeyState
-
-        /** Keys from the last tree/find after attach or post-reload. */
-        data class Tracked(val keys: Set<String>) : KeyState
-    }
+    /** Test/diagnostics: current generation after reloads. */
+    public fun generation(): Long = synchronized(lock) { generation }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
@@ -77,27 +77,30 @@ public class ReloadAwareKeyGuard {
     /**
      * Validates zero, one, or two stamped keys and runs [op] under the same lock as [onReload]
      * (used by swipe so both keys stay valid for the IPC call).
+     *
+     * @return null when both keys were valid and [op] ran; otherwise the first stamped key that
+     *   failed resolution (so callers can name the stale key in `nodeNotFound`).
      */
     public fun dispatchKeys(
         first: String?,
         second: String?,
         op: (rawFirst: String?, rawSecond: String?) -> Unit,
-    ): Boolean {
+    ): String? {
         synchronized(lock) {
             val rawFirst =
                 if (first == null) {
                     null
                 } else {
-                    resolveUnlocked(first) ?: return false
+                    resolveUnlocked(first) ?: return first
                 }
             val rawSecond =
                 if (second == null) {
                     null
                 } else {
-                    resolveUnlocked(second) ?: return false
+                    resolveUnlocked(second) ?: return second
                 }
             op(rawFirst, rawSecond)
-            return true
+            return null
         }
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
@@ -74,6 +74,33 @@ public class ReloadAwareKeyGuard {
         }
     }
 
+    /**
+     * Validates zero, one, or two stamped keys and runs [op] under the same lock as [onReload]
+     * (used by swipe so both keys stay valid for the IPC call).
+     */
+    public fun dispatchKeys(
+        first: String?,
+        second: String?,
+        op: (rawFirst: String?, rawSecond: String?) -> Unit,
+    ): Boolean {
+        synchronized(lock) {
+            val rawFirst =
+                if (first == null) {
+                    null
+                } else {
+                    resolveUnlocked(first) ?: return false
+                }
+            val rawSecond =
+                if (second == null) {
+                    null
+                } else {
+                    resolveUnlocked(second) ?: return false
+                }
+            op(rawFirst, rawSecond)
+            return true
+        }
+    }
+
     public fun resolveForDispatch(stampedKey: String): String? =
         synchronized(lock) { resolveUnlocked(stampedKey) }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
@@ -1,62 +1,43 @@
 package dev.sebastiano.spectre.cli.hotreload
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+
 /**
  * Tracks node keys issued to clients for a reload-aware session (#212).
  *
- * After a hot reload, keys captured from pre-reload tree dumps are rejected with a defined
- * `nodeNotFound` failure instead of being resolved against a post-reload tree that may reuse
- * Compose node ids for different content.
+ * Keys returned to clients are **generation-stamped** (`g{n}:{rawKey}`). After a hot reload the
+ * generation advances, so pre-reload stamped keys fail closed as `nodeNotFound` even if Compose
+ * reuses node ids. Dispatch re-validates the stamp under the guard lock so a settle cannot race a
+ * click between check and IPC.
  *
  * Non-reload-aware sessions do not use this guard.
  */
+@OptIn(ExperimentalSpectreAgentApi::class)
 public class ReloadAwareKeyGuard {
     private val lock = Any()
-    /** Bumped on each [onReload]; only keys remembered for the current generation are accepted. */
     private var generation: Long = 0L
-    /**
-     * Keys issued in [generation]. `null` means no tree has been issued in this generation yet —
-     * key ops still go to the live agent (same as pre-#212 behaviour for the first tree).
-     */
+    /** Raw (unstamped) keys issued in [generation]. */
     private var issuedKeys: Set<String>? = null
 
     /**
-     * Snapshots the current generation. Pass the result to [rememberIssuedKeysIfGeneration] so a
-     * tree captured before [onReload] cannot re-arm pre-reload keys after settle.
+     * Records raw keys from a tree/find under the current generation and returns nodes with stamped
+     * keys for the client. Unions with keys already issued in this generation.
      */
-    public fun snapshotGeneration(): Long = synchronized(lock) { generation }
-
-    /**
-     * Records keys from a tree/find only when [expectedGeneration] still matches the live
-     * generation (unioning within that generation).
-     */
-    public fun rememberIssuedKeysIfGeneration(
-        expectedGeneration: Long,
-        keys: Collection<String>,
-    ): Boolean {
+    public fun issueNodes(nodes: List<NodeSnapshotDto>): List<NodeSnapshotDto> {
         synchronized(lock) {
-            if (expectedGeneration != generation) return false
-            val existing = issuedKeys
-            issuedKeys =
-                if (existing == null) {
-                    keys.toSet()
-                } else {
-                    existing + keys
-                }
-            return true
+            val rawKeys = nodes.map { it.key }
+            val prior = issuedKeys
+            issuedKeys = if (prior == null) rawKeys.toSet() else prior + rawKeys
+            val gen = generation
+            return nodes.map { node -> node.copy(key = stamp(gen, node.key)) }
         }
     }
 
-    /**
-     * Records keys for the current generation (unioning). Prefer [rememberIssuedKeysIfGeneration].
-     */
-    public fun rememberIssuedKeys(keys: Collection<String>) {
-        rememberIssuedKeysIfGeneration(snapshotGeneration(), keys)
-    }
+    /** Issues a single node key (e.g. waitForNode result) under the current generation. */
+    public fun issueNode(node: NodeSnapshotDto): NodeSnapshotDto = issueNodes(listOf(node)).single()
 
-    /**
-     * Marks the session as post-reload: subsequent [accepts] fail until [rememberIssuedKeys] runs
-     * for the new generation.
-     */
+    /** Advances generation and clears issued keys after a successful reload settle. */
     public fun onReload() {
         synchronized(lock) {
             generation += 1
@@ -65,22 +46,47 @@ public class ReloadAwareKeyGuard {
     }
 
     /**
-     * Returns true when [key] may be forwarded to the agent. False means the daemon should fail
-     * closed as `nodeNotFound` without contacting the target.
+     * Validates a client [stampedKey] and returns the raw key for agent dispatch, or `null` if the
+     * key is stale / unknown.
+     *
+     * When [issuedKeys] is still null in generation 0 (no tree yet), plain unstamped keys are
+     * accepted for compatibility with first-click-without-tree flows.
      */
-    public fun accepts(key: String): Boolean {
+    public fun resolveForDispatch(stampedKey: String): String? {
         synchronized(lock) {
+            val parsed = unstamp(stampedKey)
+            if (parsed == null) {
+                // Unstamped: only allow before any reload and before any tree (legacy path).
+                if (generation != 0L || issuedKeys != null) return null
+                return stampedKey
+            }
+            val (gen, raw) = parsed
+            if (gen != generation) return null
             val known = issuedKeys
-            // After reload and before the next tree, reject everything.
-            if (known == null) return generation == 0L
-            return key in known
+            if (known != null && raw !in known) return null
+            return raw
         }
     }
 
-    /** Test/diagnostics: whether a reload has invalidated keys awaiting a fresh tree. */
-    public fun isInvalidated(): Boolean =
-        synchronized(lock) { issuedKeys == null && generation > 0 }
+    /** @deprecated Prefer [resolveForDispatch]; kept for unit tests of stamp semantics. */
+    public fun accepts(stampedKey: String): Boolean = resolveForDispatch(stampedKey) != null
 
-    /** Test/diagnostics: current generation after reloads. */
+    public fun isInvalidated(): Boolean =
+        synchronized(lock) { issuedKeys == null && generation > 0L }
+
     public fun generation(): Long = synchronized(lock) { generation }
+
+    public companion object {
+        internal fun stamp(generation: Long, rawKey: String): String = "g$generation:$rawKey"
+
+        internal fun unstamp(stampedKey: String): Pair<Long, String>? {
+            if (!stampedKey.startsWith("g")) return null
+            val colon = stampedKey.indexOf(':')
+            if (colon <= 1) return null
+            val gen = stampedKey.substring(1, colon).toLongOrNull() ?: return null
+            val raw = stampedKey.substring(colon + 1)
+            if (raw.isEmpty()) return null
+            return gen to raw
+        }
+    }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
@@ -19,9 +19,22 @@ public class ReloadAwareKeyGuard {
      */
     private var issuedKeys: Set<String>? = null
 
-    /** Records keys from a tree/find response for the current generation (unioning). */
-    public fun rememberIssuedKeys(keys: Collection<String>) {
+    /**
+     * Snapshots the current generation. Pass the result to [rememberIssuedKeysIfGeneration] so a
+     * tree captured before [onReload] cannot re-arm pre-reload keys after settle.
+     */
+    public fun snapshotGeneration(): Long = synchronized(lock) { generation }
+
+    /**
+     * Records keys from a tree/find only when [expectedGeneration] still matches the live
+     * generation (unioning within that generation).
+     */
+    public fun rememberIssuedKeysIfGeneration(
+        expectedGeneration: Long,
+        keys: Collection<String>,
+    ): Boolean {
         synchronized(lock) {
+            if (expectedGeneration != generation) return false
             val existing = issuedKeys
             issuedKeys =
                 if (existing == null) {
@@ -29,7 +42,15 @@ public class ReloadAwareKeyGuard {
                 } else {
                     existing + keys
                 }
+            return true
         }
+    }
+
+    /**
+     * Records keys for the current generation (unioning). Prefer [rememberIssuedKeysIfGeneration].
+     */
+    public fun rememberIssuedKeys(keys: Collection<String>) {
+        rememberIssuedKeysIfGeneration(snapshotGeneration(), keys)
     }
 
     /**

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
@@ -7,9 +7,9 @@ import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
  * Tracks node keys issued to clients for a reload-aware session (#212).
  *
  * Keys returned to clients are **generation-stamped** (`g{n}:{rawKey}`). After a hot reload the
- * generation advances, so pre-reload stamped keys fail closed as `nodeNotFound` even if Compose
- * reuses node ids. Dispatch re-validates the stamp under the guard lock so a settle cannot race a
- * click between check and IPC.
+ * generation advances and the allowlist is cleared, so pre-reload stamped keys fail closed as
+ * `nodeNotFound`. Dispatch holds the same lock as [onReload] so a settle cannot race a click
+ * between validation and IPC.
  *
  * Non-reload-aware sessions do not use this guard.
  */
@@ -17,15 +17,23 @@ import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 public class ReloadAwareKeyGuard {
     private val lock = Any()
     private var generation: Long = 0L
-    /** Raw (unstamped) keys issued in [generation]. */
+    /** Raw (unstamped) keys issued in [generation]; null means none issued yet this generation. */
     private var issuedKeys: Set<String>? = null
 
+    /** Current generation (for pre-query snapshots). */
+    public fun snapshotGeneration(): Long = synchronized(lock) { generation }
+
     /**
-     * Records raw keys from a tree/find under the current generation and returns nodes with stamped
-     * keys for the client. Unions with keys already issued in this generation.
+     * Records raw keys under [expectedGeneration] (must still match live generation), unions with
+     * existing keys in that generation, and returns nodes with stamped keys. Returns null when the
+     * generation changed mid-query (caller should re-query).
      */
-    public fun issueNodes(nodes: List<NodeSnapshotDto>): List<NodeSnapshotDto> {
+    public fun issueNodesIfGeneration(
+        expectedGeneration: Long,
+        nodes: List<NodeSnapshotDto>,
+    ): List<NodeSnapshotDto>? {
         synchronized(lock) {
+            if (expectedGeneration != generation) return null
             val rawKeys = nodes.map { it.key }
             val prior = issuedKeys
             issuedKeys = if (prior == null) rawKeys.toSet() else prior + rawKeys
@@ -34,7 +42,14 @@ public class ReloadAwareKeyGuard {
         }
     }
 
-    /** Issues a single node key (e.g. waitForNode result) under the current generation. */
+    /** Issues nodes under the current generation (no mid-query race protection). */
+    public fun issueNodes(nodes: List<NodeSnapshotDto>): List<NodeSnapshotDto> {
+        synchronized(lock) {
+            return issueNodesIfGeneration(generation, nodes)
+                ?: error("generation advanced during locked issueNodes")
+        }
+    }
+
     public fun issueNode(node: NodeSnapshotDto): NodeSnapshotDto = issueNodes(listOf(node)).single()
 
     /** Advances generation and clears issued keys after a successful reload settle. */
@@ -46,35 +61,44 @@ public class ReloadAwareKeyGuard {
     }
 
     /**
-     * Validates a client [stampedKey] and returns the raw key for agent dispatch, or `null` if the
-     * key is stale / unknown.
+     * Validates [stampedKey] and runs [op] with the raw key under the same lock as [onReload], so a
+     * settle cannot interleave between validation and dispatch.
      *
-     * When [issuedKeys] is still null in generation 0 (no tree yet), plain unstamped keys are
-     * accepted for compatibility with first-click-without-tree flows.
+     * @return false when the key is stale / unknown (caller should return nodeNotFound).
      */
-    public fun resolveForDispatch(stampedKey: String): String? {
+    public fun dispatch(stampedKey: String, op: (rawKey: String) -> Unit): Boolean {
         synchronized(lock) {
-            val parsed = unstamp(stampedKey)
-            if (parsed == null) {
-                // Unstamped: only allow before any reload and before any tree (legacy path).
-                if (generation != 0L || issuedKeys != null) return null
-                return stampedKey
-            }
-            val (gen, raw) = parsed
-            if (gen != generation) return null
-            val known = issuedKeys
-            if (known != null && raw !in known) return null
-            return raw
+            val raw = resolveUnlocked(stampedKey) ?: return false
+            op(raw)
+            return true
         }
     }
 
-    /** @deprecated Prefer [resolveForDispatch]; kept for unit tests of stamp semantics. */
+    public fun resolveForDispatch(stampedKey: String): String? =
+        synchronized(lock) { resolveUnlocked(stampedKey) }
+
     public fun accepts(stampedKey: String): Boolean = resolveForDispatch(stampedKey) != null
 
     public fun isInvalidated(): Boolean =
         synchronized(lock) { issuedKeys == null && generation > 0L }
 
     public fun generation(): Long = synchronized(lock) { generation }
+
+    private fun resolveUnlocked(stampedKey: String): String? {
+        val parsed = unstamp(stampedKey)
+        if (parsed == null) {
+            // Unstamped keys: only before any reload and before any tree (legacy first-click).
+            if (generation != 0L || issuedKeys != null) return null
+            return stampedKey
+        }
+        val (gen, raw) = parsed
+        if (gen != generation) return null
+        val known = issuedKeys
+        // After reload (or before first tree in gen>0), reject everything until a tree is issued.
+        if (known == null) return null
+        if (raw !in known) return null
+        return raw
+    }
 
     public companion object {
         internal fun stamp(generation: Long, rawKey: String): String = "g$generation:$rawKey"

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuard.kt
@@ -1,0 +1,56 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+/**
+ * Tracks node keys issued to clients for a reload-aware session (#212).
+ *
+ * After a hot reload, keys captured from pre-reload tree dumps are rejected with a defined
+ * `nodeNotFound` failure instead of being resolved against a post-reload tree that may reuse
+ * Compose node ids for different content.
+ *
+ * Non-reload-aware sessions do not use this guard.
+ */
+public class ReloadAwareKeyGuard {
+    private val lock = Any()
+    private var state: KeyState = KeyState.Untracked
+
+    /** Records keys from a tree/find response and clears the post-reload invalidation flag. */
+    public fun rememberIssuedKeys(keys: Collection<String>) {
+        synchronized(lock) { state = KeyState.Tracked(keys.toSet()) }
+    }
+
+    /**
+     * Marks the session as post-reload: subsequent [accepts] calls fail until [rememberIssuedKeys]
+     * runs again.
+     */
+    public fun onReload() {
+        synchronized(lock) { state = KeyState.Invalidated }
+    }
+
+    /**
+     * Returns true when [key] may be forwarded to the agent. False means the daemon should fail
+     * closed as `nodeNotFound` without contacting the target.
+     */
+    public fun accepts(key: String): Boolean {
+        synchronized(lock) {
+            return when (val current = state) {
+                KeyState.Untracked -> true
+                KeyState.Invalidated -> false
+                is KeyState.Tracked -> key in current.keys
+            }
+        }
+    }
+
+    /** Test/diagnostics: whether a reload has invalidated keys awaiting a fresh tree. */
+    public fun isInvalidated(): Boolean = synchronized(lock) { state is KeyState.Invalidated }
+
+    private sealed interface KeyState {
+        /** No tree has been issued yet — key ops still go to the live agent. */
+        data object Untracked : KeyState
+
+        /** Post-reload: every key is rejected until the next tree/find. */
+        data object Invalidated : KeyState
+
+        /** Keys from the last tree/find after attach or post-reload. */
+        data class Tracked(val keys: Set<String>) : KeyState
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ControllableHotReloadCapability.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ControllableHotReloadCapability.kt
@@ -1,0 +1,23 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import java.util.Queue
+
+/** Shared test double for reload-aware daemon tests (#211/#212). */
+internal class ControllableHotReloadCapability(
+    private val outcomes: Queue<ReloadSettleOutcome> = java.util.concurrent.ConcurrentLinkedQueue()
+) : HotReloadCapability {
+    private var reloadListener: (() -> Unit)? = null
+
+    override fun waitForReloadSettled(timeoutMs: Long): ReloadSettleOutcome =
+        outcomes.poll() ?: ReloadSettleOutcome.Unavailable
+
+    override fun setReloadSettledListener(listener: (() -> Unit)?) {
+        reloadListener = listener
+    }
+
+    fun fireReloadSettled() {
+        reloadListener?.invoke()
+    }
+
+    override fun close() = Unit
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonKeyInvalidationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonKeyInvalidationTest.kt
@@ -23,6 +23,7 @@ class DaemonKeyInvalidationTest {
         val preKey = "main:0:1"
         val postKey = "main:0:99"
         var treeGeneration = 0
+        val clicked = mutableListOf<String>()
         val registry =
             DaemonSessionRegistry(
                 hotReloadSessionFactory = { hr },
@@ -32,11 +33,7 @@ class DaemonKeyInvalidationTest {
                             val key = if (treeGeneration == 0) preKey else postKey
                             listOf(sampleNode(key))
                         },
-                        clickAction = { key ->
-                            // Live resolve would still "find" post-reload nodes if we re-walked;
-                            // the guard must reject pre-reload keys before this runs.
-                            assertTrue(key == postKey, "stale key must not reach the automator")
-                        },
+                        clickAction = { key -> clicked += key },
                     )
                 },
             )
@@ -45,23 +42,29 @@ class DaemonKeyInvalidationTest {
 
         val tree =
             assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
-        assertEquals(preKey, tree.nodes.single().key)
+        val stampedPre = tree.nodes.single().key
+        assertTrue(stampedPre.startsWith("g0:"))
+        assertTrue(stampedPre.endsWith(preKey))
 
-        // Simulate HR settle → invalidation listener.
         hr.fireReloadSettled()
         treeGeneration = 1
 
         val rejected =
-            assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Click(sessionId, preKey)))
+            assertIs<DaemonResponse.Error>(
+                registry.handle(DaemonRequest.Click(sessionId, stampedPre))
+            )
         assertEquals(DaemonErrorCode.OperationFailed, rejected.code)
         assertEquals("nodeNotFound", rejected.category)
-        assertTrue(rejected.message.contains(preKey))
+        assertTrue(clicked.isEmpty())
 
-        // Fresh tree re-arms keys.
         val fresh =
             assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
-        assertEquals(postKey, fresh.nodes.single().key)
-        assertIs<DaemonResponse.Completed>(registry.handle(DaemonRequest.Click(sessionId, postKey)))
+        val stampedPost = fresh.nodes.single().key
+        assertTrue(stampedPost.startsWith("g1:"))
+        assertIs<DaemonResponse.Completed>(
+            registry.handle(DaemonRequest.Click(sessionId, stampedPost))
+        )
+        assertEquals(listOf(postKey), clicked)
     }
 
     @Test
@@ -78,7 +81,6 @@ class DaemonKeyInvalidationTest {
             )
         val sessionId =
             assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(1))).sessionId
-        // Click without a prior tree still works (no key guard).
         assertIs<DaemonResponse.Completed>(
             registry.handle(DaemonRequest.Click(sessionId, "never-issued"))
         )

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonKeyInvalidationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonKeyInvalidationTest.kt
@@ -1,0 +1,97 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.RectDto
+import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
+import dev.sebastiano.spectre.cli.daemon.DaemonRequest
+import dev.sebastiano.spectre.cli.daemon.DaemonResponse
+import dev.sebastiano.spectre.cli.daemon.DaemonSessionRegistry
+import dev.sebastiano.spectre.cli.daemon.TestDaemonSessionAutomator
+import java.util.concurrent.ConcurrentLinkedQueue
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalSpectreAgentApi::class)
+class DaemonKeyInvalidationTest {
+    @Test
+    fun `reload-aware session rejects pre-reload node keys with nodeNotFound`() {
+        val outcomes = ConcurrentLinkedQueue<ReloadSettleOutcome>()
+        val hr = ControllableHotReloadCapability(outcomes)
+        val preKey = "main:0:1"
+        val postKey = "main:0:99"
+        var treeGeneration = 0
+        val registry =
+            DaemonSessionRegistry(
+                hotReloadSessionFactory = { hr },
+                attachAutomator = {
+                    TestDaemonSessionAutomator(
+                        nodesResult = {
+                            val key = if (treeGeneration == 0) preKey else postKey
+                            listOf(sampleNode(key))
+                        },
+                        clickAction = { key ->
+                            // Live resolve would still "find" post-reload nodes if we re-walked;
+                            // the guard must reject pre-reload keys before this runs.
+                            assertTrue(key == postKey, "stale key must not reach the automator")
+                        },
+                    )
+                },
+            )
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(55))).sessionId
+
+        val tree =
+            assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
+        assertEquals(preKey, tree.nodes.single().key)
+
+        // Simulate HR settle → invalidation listener.
+        hr.fireReloadSettled()
+        treeGeneration = 1
+
+        val rejected =
+            assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Click(sessionId, preKey)))
+        assertEquals(DaemonErrorCode.OperationFailed, rejected.code)
+        assertEquals("nodeNotFound", rejected.category)
+        assertTrue(rejected.message.contains(preKey))
+
+        // Fresh tree re-arms keys.
+        val fresh =
+            assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
+        assertEquals(postKey, fresh.nodes.single().key)
+        assertIs<DaemonResponse.Completed>(registry.handle(DaemonRequest.Click(sessionId, postKey)))
+    }
+
+    @Test
+    fun `non-reload-aware session does not guard node keys`() {
+        val registry =
+            DaemonSessionRegistry(
+                hotReloadSessionFactory = { null },
+                attachAutomator = {
+                    TestDaemonSessionAutomator(
+                        nodesResult = { listOf(sampleNode("k1")) },
+                        clickAction = {},
+                    )
+                },
+            )
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(1))).sessionId
+        // Click without a prior tree still works (no key guard).
+        assertIs<DaemonResponse.Completed>(
+            registry.handle(DaemonRequest.Click(sessionId, "never-issued"))
+        )
+    }
+
+    private fun sampleNode(key: String): NodeSnapshotDto =
+        NodeSnapshotDto(
+            key = key,
+            testTag = "t",
+            texts = emptyList(),
+            role = "Text",
+            contentDescription = null,
+            isVisible = true,
+            bounds = RectDto(x = 0, y = 0, width = 10, height = 10),
+        )
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonKeyInvalidationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonKeyInvalidationTest.kt
@@ -8,10 +8,13 @@ import dev.sebastiano.spectre.cli.daemon.DaemonRequest
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
 import dev.sebastiano.spectre.cli.daemon.DaemonSessionRegistry
 import dev.sebastiano.spectre.cli.daemon.TestDaemonSessionAutomator
+import dev.sebastiano.spectre.cli.daemon.issueNodesAcrossReload
+import dev.sebastiano.spectre.cli.daemon.reloadRaceExhaustedError
 import java.util.concurrent.ConcurrentLinkedQueue
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalSpectreAgentApi::class)
@@ -84,6 +87,59 @@ class DaemonKeyInvalidationTest {
         assertIs<DaemonResponse.Completed>(
             registry.handle(DaemonRequest.Click(sessionId, "never-issued"))
         )
+    }
+
+    @Test
+    fun `swipe nodeNotFound names the stale to-key when from-key is still valid`() {
+        val hr = ControllableHotReloadCapability(ConcurrentLinkedQueue())
+        val registry =
+            DaemonSessionRegistry(
+                hotReloadSessionFactory = { hr },
+                attachAutomator = {
+                    TestDaemonSessionAutomator(
+                        nodesResult = { listOf(sampleNode("from"), sampleNode("to")) }
+                    )
+                },
+            )
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(7))).sessionId
+        val tree =
+            assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
+        val toKey = tree.nodes.first { it.key.endsWith(":to") }.key
+        // Advance generation and re-issue only "from" so the pre-reload to-key is uniquely stale.
+        hr.fireReloadSettled()
+        val reissued =
+            assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
+        val freshFrom = reissued.nodes.first { it.key.endsWith(":from") }.key
+        val rejected =
+            assertIs<DaemonResponse.Error>(
+                registry.handle(
+                    DaemonRequest.Swipe(
+                        sessionId = sessionId,
+                        fromNodeKey = freshFrom,
+                        toNodeKey = toKey,
+                    )
+                )
+            )
+        assertEquals("nodeNotFound", rejected.category)
+        assertTrue(
+            rejected.message.contains(toKey),
+            "expected stale to-key in message, got: ${rejected.message}",
+        )
+    }
+
+    @Test
+    fun `issueNodesAcrossReload returns null when generation keeps racing`() {
+        val guard = ReloadAwareKeyGuard()
+        val result =
+            issueNodesAcrossReload(keyGuard = guard, maxAttempts = 3) {
+                guard.onReload()
+                listOf(sampleNode("never-stamped"))
+            }
+        assertNull(result)
+        val wire = reloadRaceExhaustedError()
+        assertEquals(DaemonErrorCode.OperationFailed, wire.code)
+        assertEquals("reloadRace", wire.category)
     }
 
     private fun sampleNode(key: String): NodeSnapshotDto =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadSettleTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadSettleTest.kt
@@ -82,12 +82,3 @@ class DaemonReloadSettleTest {
         assertEquals(sessionId, settled.sessionId)
     }
 }
-
-private class ControllableHotReloadCapability(
-    private val outcomes: java.util.Queue<ReloadSettleOutcome>
-) : HotReloadCapability {
-    override fun waitForReloadSettled(timeoutMs: Long): ReloadSettleOutcome =
-        outcomes.poll() ?: ReloadSettleOutcome.Unavailable
-
-    override fun close() = Unit
-}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadInvalidationIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadInvalidationIntegrationTest.kt
@@ -5,7 +5,9 @@ package dev.sebastiano.spectre.cli.hotreload
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
@@ -62,6 +64,61 @@ class HotReloadInvalidationIntegrationTest {
             assertTrue(latch.await(10, TimeUnit.SECONDS), "invalidation listener did not fire")
             assertTrue(fired.get())
             // Spectre never called redefineClasses — coexistence premise.
+        } finally {
+            session.close()
+            appJob.cancel()
+            appScope.cancel()
+            server.close()
+        }
+    }
+
+    @Test
+    @Timeout(30)
+    fun `concurrent waitForReloadSettled and invalidation listener both observe the same settle`() {
+        val server = startOrchestrationServer()
+        val port = server.port.getBlocking(15.seconds).getOrThrow()
+        val appScope = applicationScope()
+        val appJob = startAckingApplicationClient(port, appScope)
+        val session = HotReloadSession.forPort(port)
+        val listenerFired = AtomicBoolean(false)
+        val listenerLatch = CountDownLatch(1)
+        session.setReloadSettledListener {
+            listenerFired.set(true)
+            listenerLatch.countDown()
+        }
+        try {
+            awaitConnected(session)
+            val outcomeRef = AtomicReference<ReloadSettleOutcome?>(null)
+            val waitLatch = CountDownLatch(1)
+            Thread(
+                    {
+                        outcomeRef.set(session.waitForReloadSettled(timeoutMs = 15_000))
+                        waitLatch.countDown()
+                    },
+                    "concurrent-settle-wait",
+                )
+                .start()
+            // Subscribe before broadcasting so the fan-out waiter is armed.
+            Thread.sleep(200)
+
+            val request = OrchestrationMessage.ReloadClassesRequest()
+            server sendBlocking request
+            server sendBlocking
+                OrchestrationMessage.ReloadClassesResult(
+                    reloadRequestId = request.messageId,
+                    isSuccess = true,
+                )
+            server sendBlocking
+                OrchestrationMessage.UIRendered(
+                    windowId = null,
+                    reloadRequestId = request.messageId,
+                    iteration = 1,
+                )
+
+            assertTrue(waitLatch.await(10, TimeUnit.SECONDS), "settle wait did not complete")
+            assertTrue(listenerLatch.await(10, TimeUnit.SECONDS), "listener did not fire")
+            assertEquals(ReloadSettleOutcome.Settled, outcomeRef.get())
+            assertTrue(listenerFired.get())
         } finally {
             session.close()
             appJob.cancel()

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadInvalidationIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadInvalidationIntegrationTest.kt
@@ -1,0 +1,101 @@
+@file:OptIn(org.jetbrains.compose.reload.DelicateHotReloadApi::class)
+
+package dev.sebastiano.spectre.cli.hotreload
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.reload.core.getBlocking
+import org.jetbrains.compose.reload.core.getOrThrow
+import org.jetbrains.compose.reload.orchestration.OrchestrationClientRole
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
+import org.jetbrains.compose.reload.orchestration.asChannel
+import org.jetbrains.compose.reload.orchestration.connectOrchestrationClient
+import org.jetbrains.compose.reload.orchestration.sendBlocking
+import org.jetbrains.compose.reload.orchestration.startOrchestrationServer
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Coexistence-style proof that Spectre's Tooling client can observe a real reload settle without
+ * class redefinition from Spectre (#212). Full `hotRun` fixture is blocked on #208; this drives the
+ * same orchestration surface production uses.
+ */
+class HotReloadInvalidationIntegrationTest {
+    @Test
+    @Timeout(30)
+    fun `reload settled listener fires after UIRendered without Spectre redefining classes`() {
+        val server = startOrchestrationServer()
+        val port = server.port.getBlocking(15.seconds).getOrThrow()
+        val appScope = applicationScope()
+        val appJob = startAckingApplicationClient(port, appScope)
+        val session = HotReloadSession.forPort(port)
+        val fired = AtomicBoolean(false)
+        val latch = CountDownLatch(1)
+        session.setReloadSettledListener {
+            fired.set(true)
+            latch.countDown()
+        }
+        try {
+            awaitConnected(session)
+            val request = OrchestrationMessage.ReloadClassesRequest()
+            server sendBlocking request
+            server sendBlocking
+                OrchestrationMessage.ReloadClassesResult(
+                    reloadRequestId = request.messageId,
+                    isSuccess = true,
+                )
+            server sendBlocking
+                OrchestrationMessage.UIRendered(
+                    windowId = null,
+                    reloadRequestId = request.messageId,
+                    iteration = 1,
+                )
+            assertTrue(latch.await(10, TimeUnit.SECONDS), "invalidation listener did not fire")
+            assertTrue(fired.get())
+            // Spectre never called redefineClasses — coexistence premise.
+        } finally {
+            session.close()
+            appJob.cancel()
+            appScope.cancel()
+            server.close()
+        }
+    }
+
+    private fun applicationScope(
+        dispatcher: CoroutineDispatcher = Dispatchers.Default
+    ): CoroutineScope = CoroutineScope(dispatcher)
+
+    private fun awaitConnected(session: HotReloadSession, timeoutMs: Long = 10_000) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (!session.isConnected && System.currentTimeMillis() < deadline) {
+            Thread.sleep(50)
+        }
+        assertTrue(session.isConnected, "Tooling client did not connect")
+    }
+
+    private fun startAckingApplicationClient(port: Int, scope: CoroutineScope): Job = scope.launch {
+        val client =
+            connectOrchestrationClient(OrchestrationClientRole.Application, port).getOrThrow()
+        val channel = client.asChannel()
+        try {
+            while (true) {
+                val message = channel.receiveCatching().getOrNull() ?: break
+                if (message is OrchestrationMessage.Ping) {
+                    client.send(OrchestrationMessage.Ack(message.messageId))
+                }
+            }
+        } finally {
+            channel.cancel()
+            client.close()
+        }
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
@@ -12,12 +12,14 @@ class ReloadAwareKeyGuardTest {
     }
 
     @Test
-    fun `after tree only issued keys are accepted`() {
+    fun `after tree only issued keys are accepted and finds union`() {
         val guard = ReloadAwareKeyGuard()
         guard.rememberIssuedKeys(listOf("a", "b"))
+        guard.rememberIssuedKeys(listOf("c"))
         assertTrue(guard.accepts("a"))
         assertTrue(guard.accepts("b"))
-        assertFalse(guard.accepts("c"))
+        assertTrue(guard.accepts("c"))
+        assertFalse(guard.accepts("d"))
     }
 
     @Test

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
@@ -1,0 +1,36 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ReloadAwareKeyGuardTest {
+    @Test
+    fun `before any tree keys pass through`() {
+        val guard = ReloadAwareKeyGuard()
+        assertTrue(guard.accepts("any-key"))
+    }
+
+    @Test
+    fun `after tree only issued keys are accepted`() {
+        val guard = ReloadAwareKeyGuard()
+        guard.rememberIssuedKeys(listOf("a", "b"))
+        assertTrue(guard.accepts("a"))
+        assertTrue(guard.accepts("b"))
+        assertFalse(guard.accepts("c"))
+    }
+
+    @Test
+    fun `reload invalidates until a new tree is issued`() {
+        val guard = ReloadAwareKeyGuard()
+        guard.rememberIssuedKeys(listOf("pre-reload"))
+        guard.onReload()
+        assertTrue(guard.isInvalidated())
+        assertFalse(guard.accepts("pre-reload"))
+        assertFalse(guard.accepts("anything"))
+        guard.rememberIssuedKeys(listOf("post-reload"))
+        assertFalse(guard.isInvalidated())
+        assertTrue(guard.accepts("post-reload"))
+        assertFalse(guard.accepts("pre-reload"))
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
@@ -1,38 +1,69 @@
 package dev.sebastiano.spectre.cli.hotreload
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.RectDto
 import kotlin.test.Test
-import kotlin.test.assertFalse
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalSpectreAgentApi::class)
 class ReloadAwareKeyGuardTest {
     @Test
-    fun `before any tree keys pass through`() {
+    fun `before any tree unstamped keys resolve for dispatch`() {
         val guard = ReloadAwareKeyGuard()
-        assertTrue(guard.accepts("any-key"))
+        assertEquals("any-key", guard.resolveForDispatch("any-key"))
     }
 
     @Test
-    fun `after tree only issued keys are accepted and finds union`() {
+    fun `issued keys are stamped and resolve to raw keys`() {
         val guard = ReloadAwareKeyGuard()
-        guard.rememberIssuedKeys(listOf("a", "b"))
-        guard.rememberIssuedKeys(listOf("c"))
-        assertTrue(guard.accepts("a"))
-        assertTrue(guard.accepts("b"))
-        assertTrue(guard.accepts("c"))
-        assertFalse(guard.accepts("d"))
+        val issued = guard.issueNodes(listOf(sample("a"), sample("b")))
+        assertEquals("g0:a", issued[0].key)
+        assertEquals("g0:b", issued[1].key)
+        assertEquals("a", guard.resolveForDispatch("g0:a"))
+        assertNull(guard.resolveForDispatch("g0:c"))
     }
 
     @Test
-    fun `reload invalidates until a new tree is issued`() {
+    fun `find unions keys within a generation`() {
         val guard = ReloadAwareKeyGuard()
-        guard.rememberIssuedKeys(listOf("pre-reload"))
+        guard.issueNodes(listOf(sample("a")))
+        guard.issueNodes(listOf(sample("b")))
+        assertEquals("a", guard.resolveForDispatch("g0:a"))
+        assertEquals("b", guard.resolveForDispatch("g0:b"))
+    }
+
+    @Test
+    fun `reload invalidates prior generation stamps`() {
+        val guard = ReloadAwareKeyGuard()
+        val pre = guard.issueNodes(listOf(sample("pre"))).single().key
+        assertEquals("g0:pre", pre)
         guard.onReload()
         assertTrue(guard.isInvalidated())
-        assertFalse(guard.accepts("pre-reload"))
-        assertFalse(guard.accepts("anything"))
-        guard.rememberIssuedKeys(listOf("post-reload"))
-        assertFalse(guard.isInvalidated())
-        assertTrue(guard.accepts("post-reload"))
-        assertFalse(guard.accepts("pre-reload"))
+        assertNull(guard.resolveForDispatch(pre))
+        assertNull(guard.resolveForDispatch("unstamped"))
+        val post = guard.issueNodes(listOf(sample("post"))).single().key
+        assertEquals("g1:post", post)
+        assertEquals("post", guard.resolveForDispatch(post))
+        assertNull(guard.resolveForDispatch(pre))
     }
+
+    @Test
+    fun `unstamp parses generation stamps`() {
+        assertEquals(2L to "main:0:1", ReloadAwareKeyGuard.unstamp("g2:main:0:1"))
+        assertNull(ReloadAwareKeyGuard.unstamp("main:0:1"))
+    }
+
+    private fun sample(key: String): NodeSnapshotDto =
+        NodeSnapshotDto(
+            key = key,
+            testTag = null,
+            texts = emptyList(),
+            role = null,
+            contentDescription = null,
+            isVisible = true,
+            bounds = RectDto(0, 0, 1, 1),
+        )
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
@@ -17,6 +17,15 @@ class ReloadAwareKeyGuardTest {
     }
 
     @Test
+    fun `after reload guessed stamps for current generation are rejected until tree`() {
+        val guard = ReloadAwareKeyGuard()
+        guard.issueNodes(listOf(sample("a")))
+        guard.onReload()
+        assertNull(guard.resolveForDispatch("g1:guessed"))
+        assertNull(guard.resolveForDispatch("g0:a"))
+    }
+
+    @Test
     fun `issued keys are stamped and resolve to raw keys`() {
         val guard = ReloadAwareKeyGuard()
         val issued = guard.issueNodes(listOf(sample("a"), sample("b")))

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ReloadAwareKeyGuardTest.kt
@@ -65,6 +65,18 @@ class ReloadAwareKeyGuardTest {
         assertNull(ReloadAwareKeyGuard.unstamp("main:0:1"))
     }
 
+    @Test
+    fun `dispatchKeys reports the first stale stamped key`() {
+        val guard = ReloadAwareKeyGuard()
+        val issued = guard.issueNodes(listOf(sample("from"), sample("to")))
+        val to = issued[1].key
+        guard.onReload()
+        val freshFrom = guard.issueNodes(listOf(sample("from"))).single().key
+        val stale = guard.dispatchKeys(freshFrom, to) { _, _ -> error("should not dispatch") }
+        assertEquals(to, stale)
+        assertNull(guard.dispatchKeys(freshFrom, null) { raw, _ -> assertEquals("from", raw) })
+    }
+
     private fun sample(key: String): NodeSnapshotDto =
         NodeSnapshotDto(
             key = key,


### PR DESCRIPTION
## Summary
- Daemon-side `ReloadAwareKeyGuard` tracks node keys from tree/find on reload-aware sessions.
- After successful HR settle (`ReloadClassesResult` success + matching `UIRendered`), keys are invalidated so pre-reload keys fail as `nodeNotFound` (#199 taxonomy).
- Non-reload-aware sessions keep prior behaviour (no key guard).
- Integration: real orchestration Tooling client fires invalidation without Spectre redefining classes (coexistence premise; full `hotRun` still blocked on #208).

Part of #210. Closes #212.

## Test plan
- [x] `./gradlew check`
- [x] Unit: key guard + daemon invalidation mapping
- [x] Integration: invalidation listener on real orchestration server
- [ ] CI green