### PR TITLE
Document Compose Hot Reload awareness and HR vs Spectre division of labor (#213)

### DIFF
--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -449,7 +449,17 @@ Restart Claude Code after changing the configuration. It can then use these tool
 3. `tree` or `find` to retrieve current node keys, then `click` or `type_text` to interact.
 4. `screenshot` to receive a window-scoped PNG as MCP image content (optional `window_index` /
    `surface_id` / `fullscreen`), rather than a file path.
+5. When the target runs under Compose Hot Reload: `wait_for_reload_settled` after a code reload,
+   then re-run `tree` / `find` before further input.
 
 Node keys are short-lived: get a fresh key with `tree` or `find` after an interaction changes the
-UI. Use `spectre daemon kill` to stop the shared daemon and discard its sessions when you are
+UI. On reload-aware sessions, keys are also invalidated after a successful hot reload settle —
+see [Compose Hot Reload awareness](hot-reload.md).
+
+If the agent also has Compose Hot Reload’s MCP configured, do not alternate randomly:
+
+> If you have HR available and want quick sanity checks while iterating on a live app, use the
+> HR MCP; in any other case, Spectre is the right choice.
+
+Use `spectre daemon kill` to stop the shared daemon and discard its sessions when you are
 finished.

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -449,8 +449,9 @@ Restart Claude Code after changing the configuration. It can then use these tool
 3. `tree` or `find` to retrieve current node keys, then `click` or `type_text` to interact.
 4. `screenshot` to receive a window-scoped PNG as MCP image content (optional `window_index` /
    `surface_id` / `fullscreen`), rather than a file path.
-5. When the target runs under Compose Hot Reload: `wait_for_reload_settled` after a code reload,
-   then re-run `tree` / `find` before further input.
+5. When the target runs under Compose Hot Reload: call `wait_for_reload_settled` **before**
+   triggering a code reload (it must observe the settle chain), then re-run `tree` / `find`
+   before further input.
 
 Node keys are short-lived: get a fresh key with `tree` or `find` after an interaction changes the
 UI. On reload-aware sessions, keys are also invalidated after a successful hot reload settle —

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -37,9 +37,13 @@ The skill covers:
 - schemaVersion **1** field reference
 - ready-made `jq` recipes (clickable nodes by text, bounds by test tag, tree diffs)
 - capture → act → capture → diff workflow
-- node-key lifetime (re-capture after navigation / re-attach)
+- node-key lifetime (re-capture after navigation / re-attach / hot reload settle)
+- division of labor when both Compose Hot Reload MCP and Spectre are configured
 - `spectre captures prune` cleanup guidance
 - a manual find-click-verify recipe against a live fixture
+
+For reload settle and generation-stamped keys, see
+[Compose Hot Reload awareness](hot-reload.md).
 
 ## Schema versioning
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -68,6 +68,9 @@ spectre capture <session-id> --json
 spectre captures list
 # Prune closed-session captures on the default root (never touches live sessions without --force).
 spectre captures prune --keep 20
+# When the target runs under Compose Hot Reload: wait for a full settle, then re-tree.
+spectre wait --reload-settled <session-id>
+spectre tree <session-id> --json
 spectre record start <session-id> --output ./interaction.mp4
 # Window is default (index 0); --fullscreen is opt-in full primary display.
 spectre record start <session-id> --window 0 --output ./window.mp4
@@ -105,8 +108,13 @@ them.
 ## MCP
 
 Run `spectre mcp` when an MCP client should drive the UI. It exposes process discovery, attach,
-window/tree lookup, test-tag lookup, click, text input, screenshots, and recording as tools.
-Screenshots are returned to MCP clients as inline PNG images.
+window/tree lookup, test-tag lookup, click, text input, screenshots, recording, atomic capture,
+and optional Compose Hot Reload settle (`wait_for_reload_settled`) as tools. Screenshots are
+returned to MCP clients as inline PNG images.
+
+When an agent also has Compose Hot Reload’s own MCP configured, follow the division of labor in
+[Compose Hot Reload awareness](hot-reload.md): HR MCP for quick reload-native sanity checks;
+Spectre for tree, input, capture, and evidence.
 
 For example, configure a client with the absolute executable path:
 
@@ -136,7 +144,11 @@ writes banners or logs to standard output.
 - `click` and `type` send real operating-system input to the target UI. They can move focus and
   change application state.
 - Node keys are short-lived. After an interaction changes the UI, run `tree` or `find` again
-  before using another node key.
+  before using another node key. On **reload-aware** sessions (Compose Hot Reload detected at
+  attach), keys are also invalidated after `wait --reload-settled` completes — always re-query.
+- `spectre wait --reload-settled <session-id>` is meaningful only when the attached process is
+  running under Compose Hot Reload; otherwise it fails closed with `hotReloadUnavailable`. See
+  [Compose Hot Reload awareness](hot-reload.md).
 - The CLI attaches only to JVMs. It does not make a non-Compose or non-Spectre application
   inspectable.
 

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -1,0 +1,149 @@
+# Compose Hot Reload awareness
+
+Spectre can build on [Compose Hot Reload](https://github.com/JetBrains/compose-hot-reload)
+**when the target app is already running under HR**. It never assumes HR is present: the same
+CLI, daemon, and MCP surfaces work on ordinary JVM targets, and HR-only waits fail closed with a
+clear error.
+
+Reload awareness lives in the **interactive** tier only (`spectre` CLI / daemon / MCP). It is
+**not** part of the `:testing` / JUnit surface. A test that needs hot reload to pass is not a
+reliable test.
+
+## Division of labor
+
+If you configure both Compose Hot Reload’s MCP server and Spectre’s MCP (or CLI) in the same
+agent session, use this rule — do not flip a coin per call:
+
+> **If you have HR available and want quick sanity checks while iterating on a live app, use the
+> HR MCP; in any other case, Spectre is the right choice.**
+
+| Goal | Prefer |
+|---|---|
+| Quick “did this recompose?” / HR-native reload plumbing while editing | Compose Hot Reload MCP |
+| Semantics tree, node keys, real input, screenshots, recording, capture, attach to any Spectre-enabled JVM | Spectre |
+| Wait until a reload has fully settled, then re-inspect with Spectre | Spectre `wait --reload-settled` / `wait_for_reload_settled` |
+| Repeatable automated tests | Spectre **without** HR (`:testing` / JUnit) |
+
+The same rule is repeated in the shipped **`spectre-capture`** agent skill so dual-MCP agents see
+it next to capture workflows.
+
+## When reload awareness activates
+
+On `spectre attach` (and the MCP `attach` tool), the daemon tries to discover an HR orchestration
+endpoint for that process:
+
+1. HR pid file (`compose.reload.pidFile` / default discovery) carrying `orchestration.port`
+2. JVM system property `compose.reload.orchestration.port` in the target’s arguments
+
+If a port is found, the daemon opens a **Tooling**-role orchestration client (same public
+`hot-reload-orchestration` surface HR’s own tooling uses). That session is **reload-aware**:
+
+- `spectre wait --reload-settled <session>` / MCP `wait_for_reload_settled` wait for a full settle
+- Node keys returned by `tree` / `find` / capture are **generation-stamped** and invalidated after
+  a successful reload settles
+
+If no HR orchestration is found, attach still succeeds. The session is ordinary Spectre: all
+non-HR commands work; reload wait fails immediately with category `hotReloadUnavailable`.
+
+## Version range
+
+Spectre pins and tests against Compose Hot Reload **1.2.0-rc01** on the CLI classpath. The
+supported line starts at **1.2.0-alpha+211** (the findings baseline for the Tooling client and
+settle chain). Older HR builds may omit newer orchestration messages; Spectre fails closed rather
+than guessing.
+
+Keep the app’s HR plugin/runtime on a version in that range when you want reload awareness.
+
+## `waitForReloadSettled`
+
+Spectre mirrors HR’s own settle chain (not a simple “reload state” poll):
+
+`ReloadClassesRequest` → matching `ReloadClassesResult` → matching `UIRendered` → `Ping` / `Ack`
+drain.
+
+### CLI
+
+```shell
+spectre attach <pid> --json
+# …trigger a hot reload in the app / IDE…
+spectre wait --reload-settled <session-id>
+# optional:
+spectre wait --reload-settled <session-id> --timeout-ms 60000 --json
+```
+
+On success the command prints that the reload settled (or JSON completion with the session id).
+
+### MCP
+
+Tool name: **`wait_for_reload_settled`**
+
+| Argument | Required | Default |
+|---|---|---|
+| `session_id` | yes | — |
+| `timeout_ms` | no | `60000` |
+
+### Error categories
+
+| Category | Meaning |
+|---|---|
+| `hotReloadUnavailable` | Session is not reload-aware (no HR orchestration for this process), or HR was never connectable for this attach |
+| `reloadFailed` | HR reported an unsuccessful class reload (`ReloadClassesResult` with failure) |
+| `timeout` | Settle chain did not complete within `--timeout-ms` / `timeout_ms` |
+| `cancelled` | Session closed or the orchestration connection dropped while waiting |
+
+## Node keys after reload
+
+On reload-aware sessions, node keys clients see are **stamped** with a generation prefix
+(`g{n}:…`). After a successful reload settle:
+
+1. Spectre advances the generation and clears the issued-key allowlist.
+2. Pre-reload keys fail closed as `nodeNotFound` (including guessed stamps for the new generation
+   until a fresh tree is issued).
+3. Call `tree`, `find`, or `capture` again, then use the new keys for input.
+
+On non-reload-aware sessions, keys stay unstamped and behave as before: still short-lived across
+UI changes, but not generation-gated by HR.
+
+If a tree query races a settle so hard that Spectre cannot stamp a consistent generation, the
+daemon fails closed with category `reloadRace` — re-run `tree` / `find` rather than treating an
+empty result as “no nodes”.
+
+## Layering rules (non-negotiable)
+
+- **HR is a capability, not a dependency.** Semantics reading, attach, input, capture, and
+  recording work without it.
+- **HR is dev-loop only.** Debug runs, no production guarantee, no CI repeatability contract.
+- **Banned from `:testing`.** There is no `waitForReloadSettled` on `ComposeAutomator` / JUnit
+  extensions. Use `waitForNode` / `waitForIdle` / `waitForVisualIdle` in tests.
+- **Spectre never redefines classes.** Coexistence with HR’s agent is intentional: Spectre does
+  not trip HR’s external-reload trackers.
+
+## Launching with `hotRun`
+
+Prefer a **prod-like** launch for everyday automation (`installDist`, packaged app, plain
+`java -jar`). Gradle `run` / Compose Hot Reload `hotRun` launches are useful in the
+edit–reload–inspect loop but need extra care for attach timing and JVM args.
+
+A first-class **launch-and-attach** harness (CLI + testing) is the place that will document
+Gradle/`hotRun` warnings in detail as that surface ships. Until then: start the app under HR
+yourself, confirm attach, then use `wait --reload-settled` between reloads.
+
+## Manual dual-MCP recipe
+
+Use this when validating an agent that has **both** HR MCP and Spectre configured:
+
+1. Start the Compose app under Hot Reload (IDE run configuration or `hotRun`).
+2. Confirm Spectre can see it: `spectre ps --json` → `spectre attach <pid> --json`.
+3. For a **quick HR-native sanity check** (reload plumbing only), use the HR MCP tools.
+4. For **tree / click / capture / screenshot**, use Spectre only — do not alternate randomly.
+5. After an intentional code reload: `spectre wait --reload-settled <session>`, then
+   `spectre tree` / `spectre capture` and act on **new** keys.
+6. Detach when finished; prune captures if you used atomic capture.
+
+## Related
+
+- [CLI](cli.md) — `wait --reload-settled`, attach, tree, capture
+- [Agent attach](agent.md) — attach model and MCP tool list
+- [Synchronization](synchronization.md) — in-process waits (no HR wait on `:testing`)
+- [Atomic capture](capture.md) and skill **`spectre-capture`**
+- [Troubleshooting](troubleshooting.md#compose-hot-reload)

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -63,15 +63,21 @@ drain.
 
 ### CLI
 
+The wait only observes reloads that start **while it is running** (it must see
+`ReloadClassesRequest` through the settle chain). Start the wait **before** you save/reload,
+not after:
+
 ```shell
 spectre attach <pid> --json
-# …trigger a hot reload in the app / IDE…
+# Terminal A — arm the wait first (blocks until settle or timeout):
 spectre wait --reload-settled <session-id>
-# optional:
-spectre wait --reload-settled <session-id> --timeout-ms 60000 --json
+# optional: --timeout-ms 60000 --json
+# Terminal B / IDE — then trigger the hot reload (save, apply changes, etc.)
 ```
 
-On success the command prints that the reload settled (or JSON completion with the session id).
+On success the wait prints that the reload settled (or JSON completion with the session id).
+If you reload first and only then call `wait`, a fast settle can finish before the waiter
+subscribes and the command will sit until the **next** reload or time out.
 
 ### MCP
 
@@ -93,13 +99,19 @@ Tool name: **`wait_for_reload_settled`**
 
 ## Node keys after reload
 
-On reload-aware sessions, node keys clients see are **stamped** with a generation prefix
-(`g{n}:…`). After a successful reload settle:
+On reload-aware sessions, node keys from **`tree` / `find`** (and wait-for-node) are **stamped**
+with a generation prefix (`g{n}:…`). After a successful reload settle:
 
 1. Spectre advances the generation and clears the issued-key allowlist.
 2. Pre-reload keys fail closed as `nodeNotFound` (including guessed stamps for the new generation
    until a fresh tree is issued).
-3. Call `tree`, `find`, or `capture` again, then use the new keys for input.
+3. Call `tree` or `find` again, then use the new stamped keys for input.
+
+**Atomic capture** still writes the window PNG and a full semantics tree for inspection, but
+`capture.json` node keys are the raw tree keys — they are **not** generation-stamped for click
+dispatch on reload-aware sessions. After a reload settle, resolve keys with `tree` / `find`
+(or MCP equivalents) before clicking; use capture for evidence and `jq` recipes, not as the
+source of post-reload click keys.
 
 On non-reload-aware sessions, keys stay unstamped and behave as before: still short-lived across
 UI changes, but not generation-gated by HR.
@@ -118,15 +130,13 @@ empty result as “no nodes”.
 - **Spectre never redefines classes.** Coexistence with HR’s agent is intentional: Spectre does
   not trip HR’s external-reload trackers.
 
-## Launching with `hotRun`
+## Launching under Hot Reload
 
 Prefer a **prod-like** launch for everyday automation (`installDist`, packaged app, plain
-`java -jar`). Gradle `run` / Compose Hot Reload `hotRun` launches are useful in the
-edit–reload–inspect loop but need extra care for attach timing and JVM args.
-
-A first-class **launch-and-attach** harness (CLI + testing) is the place that will document
-Gradle/`hotRun` warnings in detail as that surface ships. Until then: start the app under HR
-yourself, confirm attach, then use `wait --reload-settled` between reloads.
+`java -jar`) when you do not need HR. For the edit–reload–inspect loop, start the app under
+Compose Hot Reload yourself (IDE run configuration or Gradle `hotRun`), confirm
+`spectre attach` succeeds, arm `wait --reload-settled` **before** each reload, then re-query
+the tree afterward.
 
 ## Manual dual-MCP recipe
 
@@ -135,9 +145,12 @@ Use this when validating an agent that has **both** HR MCP and Spectre configure
 1. Start the Compose app under Hot Reload (IDE run configuration or `hotRun`).
 2. Confirm Spectre can see it: `spectre ps --json` → `spectre attach <pid> --json`.
 3. For a **quick HR-native sanity check** (reload plumbing only), use the HR MCP tools.
-4. For **tree / click / capture / screenshot**, use Spectre only — do not alternate randomly.
-5. After an intentional code reload: `spectre wait --reload-settled <session>`, then
-   `spectre tree` / `spectre capture` and act on **new** keys.
+4. For **tree / click / screenshot / capture-as-evidence**, use Spectre only — do not alternate
+   randomly.
+5. Before an intentional code reload: start `spectre wait --reload-settled <session>` (blocking
+   call), then trigger the reload; when wait returns, run `spectre tree` / `spectre find` and
+   act on **new** stamped keys. Use `capture` for screenshots and `jq` inspection if useful —
+   not for post-reload click keys.
 6. Detach when finished; prune captures if you used atomic capture.
 
 ## Related

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -30,17 +30,22 @@ it next to capture workflows.
 ## When reload awareness activates
 
 On `spectre attach` (and the MCP `attach` tool), the daemon tries to discover an HR orchestration
-endpoint for that process:
+endpoint for that process from the target’s JVM arguments (and an optional explicit pid-file path
+used by tests / advanced callers):
 
-1. HR pid file (`compose.reload.pidFile` / default discovery) carrying `orchestration.port`
-2. JVM system property `compose.reload.orchestration.port` in the target’s arguments
+1. System property `compose.reload.orchestration.port` on the process command line
+2. System property `compose.reload.pidFile` pointing at HR’s pid file, which must contain
+   `orchestration.port` (and, when present, a matching `pid`)
+
+There is **no** scan of a default filesystem location for a pid file — only the property-backed
+path (or an explicit override) is read.
 
 If a port is found, the daemon opens a **Tooling**-role orchestration client (same public
 `hot-reload-orchestration` surface HR’s own tooling uses). That session is **reload-aware**:
 
 - `spectre wait --reload-settled <session>` / MCP `wait_for_reload_settled` wait for a full settle
-- Node keys returned by `tree` / `find` / capture are **generation-stamped** and invalidated after
-  a successful reload settles
+- Node keys returned by `tree` / `find` (and wait-for-node) are **generation-stamped** and
+  invalidated after a successful reload settles
 
 If no HR orchestration is found, attach still succeeds. The session is ordinary Spectre: all
 non-HR commands work; reload wait fails immediately with category `hotReloadUnavailable`.

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -97,9 +97,9 @@ Tool name: **`wait_for_reload_settled`**
 
 | Category | Meaning |
 |---|---|
-| `hotReloadUnavailable` | Session is not reload-aware (no HR orchestration for this process), or HR was never connectable for this attach |
+| `hotReloadUnavailable` | Session is **not** reload-aware: attach found no HR orchestration port/pid-file properties, so no Hot Reload client was created |
 | `reloadFailed` | HR reported an unsuccessful class reload (`ReloadClassesResult` with failure) |
-| `timeout` | Settle chain did not complete within `--timeout-ms` / `timeout_ms` |
+| `timeout` | Settle chain did not complete within `--timeout-ms` / `timeout_ms`. Also returned when the session is reload-aware (properties present) but the Tooling client never connects or the settle events never arrive — including stale/unreachable advertised ports |
 | `cancelled` | Session closed or the orchestration connection dropped while waiting |
 
 ## Node keys after reload

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -19,8 +19,12 @@ The guide walks through using Spectre end-to-end:
 11. **[Agent attach](agent.md)** — attach to a running Spectre-instrumented JVM.
 12. **[Capability matrix](capability-matrix.md)** — ops × transports × platforms, with
     fail-closed CI evidence for every Supported cell.
-13. **[IntelliJ-hosted Compose](intellij.md)** — Jewel-on-IntelliJ tool windows.
-14. **[Troubleshooting](troubleshooting.md)** — platform-specific gotchas.
+13. **[CLI](cli.md)** — interactive `spectre` command and MCP server.
+14. **[Atomic capture](capture.md)** — window PNG + versioned tree for agents.
+15. **[Compose Hot Reload](hot-reload.md)** — optional reload settle wait and key
+    invalidation when the target runs under HR (CLI/MCP only).
+16. **[IntelliJ-hosted Compose](intellij.md)** — Jewel-on-IntelliJ tool windows.
+17. **[Troubleshooting](troubleshooting.md)** — platform-specific gotchas.
 
 If you're new to Spectre, start with [Installation](installation.md) and
 [Getting started](getting-started.md), then read [The automator](automator.md) before

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -4,6 +4,14 @@ Spectre deliberately doesn't wrap reads and actions in an implicit idle barrier.
 flip side is that you have a small but explicit set of wait helpers, and you decide
 where to put them. This page covers all three.
 
+## Interactive-only: Compose Hot Reload settle
+
+JUnit / `:testing` has **no** hot-reload wait. For the CLI and MCP attach path only, Spectre
+exposes `wait --reload-settled` / `wait_for_reload_settled` when the target process is already
+running under Compose Hot Reload. That wait is optional, fails closed without HR, and is
+documented under [Compose Hot Reload awareness](hot-reload.md). Prefer
+`waitForNode` / `waitForIdle` / `waitForVisualIdle` in automated tests.
+
 ## The EDT rule
 
 All three wait helpers — `waitForNode`, `waitForIdle`, and `waitForVisualIdle` — refuse

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -122,17 +122,18 @@ clipboard, so none of the paste-specific caveats apply.
 
 ### "`wait --reload-settled` says hotReloadUnavailable"
 
-The attached session is not reload-aware. Common causes:
+The attached session is **not** reload-aware: attach did not find HR orchestration properties on
+the process, so no Hot Reload client was created. Common causes:
 
 1. **The target is not running under Compose Hot Reload** — ordinary `run` / packaged launches
-   are fine for Spectre; reload wait only activates when HR orchestration is discoverable.
-2. **Port discovery failed** — Spectre reads `compose.reload.orchestration.port` and/or
+   are fine for Spectre; reload wait only activates when HR properties are discoverable.
+2. **Port discovery found nothing** — Spectre reads `compose.reload.orchestration.port` and/or
    `compose.reload.pidFile` from the **target process’s JVM arguments**, then the pid file’s
    `orchestration.port` field. Confirm the app was started by an HR-aware run configuration that
    still exposes those properties.
-3. **Orchestration never connected within the wait budget** — a very short `--timeout-ms` right
-   after attach can report timeout rather than “unavailable”; give the Tooling client a moment
-   after attach, or increase the timeout.
+
+If properties **are** present but the orchestration server is down or the port is stale, wait
+returns **`timeout`**, not `hotReloadUnavailable` (the session is still treated as reload-aware).
 
 See [Compose Hot Reload awareness](hot-reload.md).
 
@@ -142,9 +143,9 @@ See [Compose Hot Reload awareness](hot-reload.md).
   example a redefine error). Fix the reload in the app/IDE; Spectre is only reporting HR’s
   outcome.
 - **`timeout`** — the settle chain (`Request` → `Result` → `UIRendered` → `Ping`/`Ack`) did not
-  finish in time. The reload may still be running, UI may not have rendered, or the connection
-  dropped mid-wait. Retry with a larger `--timeout-ms`, confirm HR is healthy, then re-query the
-  tree.
+  finish in time, **or** a reload-aware session never connected to orchestration (stale port,
+  HR not listening yet). Retry with a larger `--timeout-ms`, confirm HR is healthy and still
+  advertising a live port, then re-query the tree.
 
 ### "Clicks fail with nodeNotFound after a hot reload"
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -147,10 +147,11 @@ See [Compose Hot Reload awareness](hot-reload.md).
 
 ### "Clicks fail with nodeNotFound after a hot reload"
 
-On reload-aware sessions, node keys are generation-stamped and cleared after a successful
-reload settle. Pre-reload keys (and guessed `g{n}:…` stamps before a fresh tree) return
-`nodeNotFound`. Run `spectre wait --reload-settled <session>`, then `tree` / `find` / `capture`
-again and use the new keys.
+On reload-aware sessions, node keys from `tree` / `find` are generation-stamped and cleared
+after a successful reload settle. Pre-reload keys (and guessed `g{n}:…` stamps before a fresh
+tree) return `nodeNotFound`. Arm `spectre wait --reload-settled <session>` **before** the
+reload, then `tree` / `find` again and use the new stamped keys. Do not reuse keys from an
+older `capture.json` for clicks after settle — capture writes raw keys for inspection.
 
 ### "Older Hot Reload builds"
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -118,6 +118,46 @@ Use `pressKey(...)` for individual key events (modifier shortcuts, navigation ke
 `<kbd>Tab</kbd>`, `<kbd>Esc</kbd>`) — those go through the AWT key map, not the
 clipboard, so none of the paste-specific caveats apply.
 
+## Compose Hot Reload {#compose-hot-reload}
+
+### "`wait --reload-settled` says hotReloadUnavailable"
+
+The attached session is not reload-aware. Common causes:
+
+1. **The target is not running under Compose Hot Reload** — ordinary `run` / packaged launches
+   are fine for Spectre; reload wait only activates when HR orchestration is discoverable.
+2. **Port discovery failed** — Spectre looks for HR’s pid file (`orchestration.port`) and the
+   `compose.reload.orchestration.port` JVM property. Confirm the app was started by an HR-aware
+   run configuration and that the pid file is still present for that process.
+3. **Orchestration never connected within the wait budget** — a very short `--timeout-ms` right
+   after attach can report timeout rather than “unavailable”; give the Tooling client a moment
+   after attach, or increase the timeout.
+
+See [Compose Hot Reload awareness](hot-reload.md).
+
+### "`reloadFailed` vs `timeout`"
+
+- **`reloadFailed`** — HR completed a `ReloadClassesResult` with `isSuccess = false` (for
+  example a redefine error). Fix the reload in the app/IDE; Spectre is only reporting HR’s
+  outcome.
+- **`timeout`** — the settle chain (`Request` → `Result` → `UIRendered` → `Ping`/`Ack`) did not
+  finish in time. The reload may still be running, UI may not have rendered, or the connection
+  dropped mid-wait. Retry with a larger `--timeout-ms`, confirm HR is healthy, then re-query the
+  tree.
+
+### "Clicks fail with nodeNotFound after a hot reload"
+
+On reload-aware sessions, node keys are generation-stamped and cleared after a successful
+reload settle. Pre-reload keys (and guessed `g{n}:…` stamps before a fresh tree) return
+`nodeNotFound`. Run `spectre wait --reload-settled <session>`, then `tree` / `find` / `capture`
+again and use the new keys.
+
+### "Older Hot Reload builds"
+
+Spectre tests against the Compose Hot Reload **1.2** line (pinned **1.2.0-rc01**, minimum
+**1.2.0-alpha+211**). Older orchestration servers may omit message types Spectre needs; upgrade
+HR rather than expecting settle wait to work.
+
 ## "The JVM is headless"
 
 Spectre input and screenshots need AWT. If the JVM is launched with

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -126,9 +126,10 @@ The attached session is not reload-aware. Common causes:
 
 1. **The target is not running under Compose Hot Reload** — ordinary `run` / packaged launches
    are fine for Spectre; reload wait only activates when HR orchestration is discoverable.
-2. **Port discovery failed** — Spectre looks for HR’s pid file (`orchestration.port`) and the
-   `compose.reload.orchestration.port` JVM property. Confirm the app was started by an HR-aware
-   run configuration and that the pid file is still present for that process.
+2. **Port discovery failed** — Spectre reads `compose.reload.orchestration.port` and/or
+   `compose.reload.pidFile` from the **target process’s JVM arguments**, then the pid file’s
+   `orchestration.port` field. Confirm the app was started by an HR-aware run configuration that
+   still exposes those properties.
 3. **Orchestration never connected within the wait budget** — a very short `--timeout-ms` right
    after attach can report timeout rather than “unavailable”; give the Tooling client a moment
    after attach, or increase the timeout.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,6 +104,7 @@ nav:
       - Capability matrix: guide/capability-matrix.md
       - CLI: guide/cli.md
       - Atomic capture: guide/capture.md
+      - Compose Hot Reload: guide/hot-reload.md
       - IntelliJ-hosted Compose: guide/intellij.md
       - Troubleshooting: guide/troubleshooting.md
   - Reference:

--- a/skills/spectre-capture/SKILL.md
+++ b/skills/spectre-capture/SKILL.md
@@ -4,12 +4,29 @@ description: >
   Use when working with Spectre atomic captures — capture.json + screenshot.png written by
   `spectre capture`, the capture MCP tool, or ComposeAutomator.capture. Covers the versioned
   capture schema, jq recipes over the tree, capture → act → capture → diff verification,
-  node-key lifetime, and captures prune cleanup.
+  node-key lifetime (including Compose Hot Reload invalidation), division of labor vs the
+  Hot Reload MCP, and captures prune cleanup.
 license: Apache-2.0
 compatibility: Requires the Spectre CLI (or in-process capture API) and schemaVersion 1 captures.
 ---
 
 # Spectre capture output
+
+## Division of labor (HR MCP vs Spectre)
+
+If this agent also has Compose Hot Reload’s MCP server configured, **do not flip a coin per
+call**. Use this rule verbatim:
+
+> **If you have HR available and want quick sanity checks while iterating on a live app, use the
+> HR MCP; in any other case, Spectre is the right choice.**
+
+- **HR MCP** — quick reload-native sanity checks while iterating on a live HR run.
+- **Spectre** (CLI / MCP / capture) — semantics tree, node keys, real input, screenshots,
+  recording, atomic capture, attach to any Spectre-enabled JVM, and
+  `wait --reload-settled` / `wait_for_reload_settled` when you need settle + re-inspect.
+
+Reload awareness is **optional** and **dev-loop only**. It is not part of Spectre’s JUnit
+`:testing` surface. Full user guide: <https://spectre.sebastiano.dev/guide/hot-reload/>
 
 Atomic capture freezes one Compose window into:
 
@@ -159,6 +176,11 @@ jq '.summary' "$CAP"
 - Keys are valid for the **current attach session** and the tree they came from.
 - After navigation, re-composition, or re-attach, **re-capture** and re-resolve keys.
 - Do not cache keys across detach/attach cycles.
+- **Compose Hot Reload:** on reload-aware attaches, keys are generation-stamped and cleared after
+  a successful reload settle. After you (or the IDE) hot-reloads code:
+  1. `spectre wait --reload-settled <session-id>` (or MCP `wait_for_reload_settled`)
+  2. **Re-capture** (or `tree` / `find`) and resolve keys from the **new** tree
+  3. Never reuse pre-reload keys — they fail as `nodeNotFound`
 
 ## Capture from MCP / CLI / library
 
@@ -191,4 +213,5 @@ With only this skill + the Spectre CLI (no source reading):
 
 - User guide CLI: <https://spectre.sebastiano.dev/guide/cli/>
 - Capture skill page: <https://spectre.sebastiano.dev/guide/capture/>
+- Compose Hot Reload awareness: <https://spectre.sebastiano.dev/guide/hot-reload/>
 - General UI automation skill: `spectre-ui-automation` / `spectre`

--- a/skills/spectre-capture/SKILL.md
+++ b/skills/spectre-capture/SKILL.md
@@ -176,11 +176,15 @@ jq '.summary' "$CAP"
 - Keys are valid for the **current attach session** and the tree they came from.
 - After navigation, re-composition, or re-attach, **re-capture** and re-resolve keys.
 - Do not cache keys across detach/attach cycles.
-- **Compose Hot Reload:** on reload-aware attaches, keys are generation-stamped and cleared after
-  a successful reload settle. After you (or the IDE) hot-reloads code:
-  1. `spectre wait --reload-settled <session-id>` (or MCP `wait_for_reload_settled`)
-  2. **Re-capture** (or `tree` / `find`) and resolve keys from the **new** tree
+- **Compose Hot Reload:** on reload-aware attaches, keys from **`tree` / `find`** are
+  generation-stamped and cleared after a successful reload settle. Workflow:
+  1. Start `spectre wait --reload-settled <session-id>` (or MCP `wait_for_reload_settled`)
+     **before** triggering the reload (the wait must be armed to observe the settle chain)
+  2. Trigger the reload; when wait returns, run **`tree` / `find`** and resolve keys from that
+     response
   3. Never reuse pre-reload keys — they fail as `nodeNotFound`
+  4. `capture.json` remains useful for evidence and `jq`, but its keys are **not** stamped for
+     post-reload click dispatch on reload-aware sessions — prefer `tree` / `find` for input keys
 
 ## Capture from MCP / CLI / library
 

--- a/skills/spectre-capture/package.json
+++ b/skills/spectre-capture/package.json
@@ -1,8 +1,8 @@
 {
   "name": "spectre-capture",
-  "version": "1.0.0",
-  "description": "Agent skill for querying Spectre atomic capture output (capture.json schema v1)",
-  "keywords": ["claude-skill", "spectre", "capture", "compose-desktop", "jq", "ui-automation"],
+  "version": "1.1.0",
+  "description": "Agent skill for querying Spectre atomic capture output (capture.json schema v1), including Hot Reload key invalidation and HR vs Spectre division of labor",
+  "keywords": ["claude-skill", "spectre", "capture", "compose-desktop", "jq", "ui-automation", "hot-reload"],
   "author": "Sebastiano Poggi <poggos@gmail.com>",
   "license": "Apache-2.0",
   "files": ["SKILL.md"]

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -21,8 +21,19 @@ Use the published docs as the source of truth when answering setup questions:
 - Installation and coordinates: <https://spectre.sebastiano.dev/guide/installation/>
 - Agent attach: <https://spectre.sebastiano.dev/guide/agent/>
 - Cross-JVM HTTP transport: <https://spectre.sebastiano.dev/guide/cross-jvm/>
+- Compose Hot Reload awareness (CLI/MCP only): <https://spectre.sebastiano.dev/guide/hot-reload/>
 
 In the Spectre repository, the same pages live under `docs/guide/`.
+
+## Division of labor vs Compose Hot Reload MCP
+
+When an agent has **both** Compose Hot Reload’s MCP and Spectre configured:
+
+> **If you have HR available and want quick sanity checks while iterating on a live app, use the
+> HR MCP; in any other case, Spectre is the right choice.**
+
+Do **not** use HR for repeatable tests. Spectre’s `:testing` / JUnit surface has no
+`waitForReloadSettled` — that wait exists only on the interactive CLI/daemon/MCP tier.
 
 ## The 30-second mental model
 


### PR DESCRIPTION
## Summary

- New user-guide page for optional Compose Hot Reload awareness (settle wait, activation, version range, key invalidation, layering rules, dual-MCP recipe).
- Cross-links from CLI, agent attach, synchronization, capture, troubleshooting, and guide index; nav entry in `mkdocs.yml`.
- **Division of labor** rule (verbatim) in docs and in shipped **`spectre-capture`** + **`spectre`** skills so dual-MCP agents do not flip a coin per call.
- `spectre-capture` skill bumped to **1.1.0** (HR key lifetime + division of labor).

Closes #213.

## Acceptance (#213)

- [x] Guide section: what reload awareness is, when it activates, `waitForReloadSettled` usage, HR version range, layering (never assumed, dev-loop only, banned from `:testing`)
- [x] Division-of-labor rule in docs **and** capture skill
- [x] Troubleshooting: HR present but connect fails; version range; reloadFailed vs timeout; post-reload nodeNotFound
- [x] Cross-link from launch/hotRun guidance (prod-like launch preferred; launch-and-attach harness is the future home for Gradle warnings — no issue-number noise in public prose)
- [x] `mkdocs build --strict` passes
- [x] Manual dual-MCP recipe on the guide page; CLI `spectre wait --help` verified against installed dist

## Test plan

- [x] `python3 -m mkdocs build --strict`
- [x] `./gradlew :cli:installDist` + `spectre wait --help` matches documented flags
- [ ] CI docs workflow (if present) + babysit bots