### PR TITLE
Close #212 coexistence acceptance gaps: attach/capture + no redefineClasses

### DIFF
--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ControllableHotReloadCapability.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/ControllableHotReloadCapability.kt
@@ -19,5 +19,10 @@ internal class ControllableHotReloadCapability(
         reloadListener?.invoke()
     }
 
+    /** Enqueue a controlled wait outcome (tests). */
+    fun enqueue(outcome: ReloadSettleOutcome) {
+        outcomes.add(outcome)
+    }
+
     override fun close() = Unit
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadCoexistenceTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadCoexistenceTest.kt
@@ -9,6 +9,7 @@ import dev.sebastiano.spectre.cli.daemon.DaemonRequest
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
 import dev.sebastiano.spectre.cli.daemon.DaemonSessionRegistry
 import dev.sebastiano.spectre.cli.daemon.TestDaemonSessionAutomator
+import java.nio.file.Files
 import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.Test
@@ -36,6 +37,7 @@ class DaemonReloadCoexistenceTest {
         val generation = AtomicInteger(0)
         val clicked = mutableListOf<String>()
         val captureCalls = AtomicInteger(0)
+        val outDir = Files.createTempDirectory("spectre-coexist-cap").toString()
 
         val registry =
             DaemonSessionRegistry(
@@ -75,9 +77,12 @@ class DaemonReloadCoexistenceTest {
         val preKey = preTree.nodes.single().key
         assertTrue(preKey.startsWith("g0:"), "expected stamped pre-reload key, got $preKey")
 
-        // Capture while attached and pre-reload.
+        // Capture while attached and pre-reload (isolated outDir — do not touch shared capture
+        // root).
         assertIs<DaemonResponse.Capture>(
-            registry.handle(DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0))
+            registry.handle(
+                DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0, outDir = outDir)
+            )
         )
         assertEquals(1, captureCalls.get())
 
@@ -100,22 +105,22 @@ class DaemonReloadCoexistenceTest {
 
         // Capture still works after reload settle (attach session still healthy).
         assertIs<DaemonResponse.Capture>(
-            registry.handle(DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0))
+            registry.handle(
+                DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0, outDir = outDir)
+            )
         )
         assertEquals(2, captureCalls.get())
 
         assertIs<DaemonResponse.Completed>(registry.handle(DaemonRequest.Click(sessionId, postKey)))
         assertEquals(listOf("main:0:1"), clicked)
 
-        // Explicit wait still works after coexistence path (controllable returns Unavailable when
-        // queue empty — proves the session still has an HR capability wired).
-        val wait =
-            assertIs<DaemonResponse.Error>(
-                registry.handle(
-                    DaemonRequest.WaitForReloadSettled(sessionId = sessionId, timeoutMs = 50)
-                )
+        // Session still has an HR capability: enqueue Settled and wait successfully.
+        hr.enqueue(ReloadSettleOutcome.Settled)
+        assertIs<DaemonResponse.Completed>(
+            registry.handle(
+                DaemonRequest.WaitForReloadSettled(sessionId = sessionId, timeoutMs = 1_000)
             )
-        assertEquals(DaemonErrorCode.HotReloadUnavailable, wait.code)
+        )
 
         registry.close()
     }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadCoexistenceTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadCoexistenceTest.kt
@@ -4,7 +4,6 @@ import dev.sebastiano.spectre.agent.AtomicCaptureResult
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.RectDto
-import dev.sebastiano.spectre.cli.daemon.CapturePruner
 import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
 import dev.sebastiano.spectre.cli.daemon.DaemonRequest
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
@@ -123,15 +122,9 @@ class DaemonReloadCoexistenceTest {
                 )
             )
         } finally {
-            CapturePruner.prune(
-                request =
-                    CapturePruner.Request(
-                        sessionId = "pid-4242",
-                        force = true,
-                        allowExplicitOutDir = true,
-                    ),
-                liveSessionIds = emptySet(),
-            )
+            // Match DaemonSessionRegistryTest capture isolation: explicit outDir + delete tree.
+            // CaptureArtifactStore still appends to the process ledger (same as sibling tests);
+            // we never force-prune the shared ledger (that would risk deleting real pid-4242 rows).
             outRoot.toFile().deleteRecursively()
             registry.close()
         }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadCoexistenceTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadCoexistenceTest.kt
@@ -4,6 +4,7 @@ import dev.sebastiano.spectre.agent.AtomicCaptureResult
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.RectDto
+import dev.sebastiano.spectre.cli.daemon.CapturePruner
 import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
 import dev.sebastiano.spectre.cli.daemon.DaemonRequest
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
@@ -24,10 +25,10 @@ import kotlin.test.assertTrue
  * - pre-reload stamped keys fail closed as nodeNotFound
  * - a fresh tree after settle yields usable keys for input
  *
- * Full class-redefine + JdwpTracker coexistence needs a live HR `hotRun` process (#208 still open).
- * This test exercises the Spectre-owned path that product code actually runs after orchestration
- * reports settle: key flush + attach/capture stay healthy without Spectre calling
- * `Instrumentation.redefineClasses` (see [SpectreDoesNotRedefineClassesContractTest]).
+ * Full class-redefine + JdwpTracker coexistence needs a live HR hotRun process (#208 still open).
+ * This test exercises the Spectre-owned path after orchestration reports settle: key flush +
+ * attach/capture stay healthy without Spectre calling Instrumentation.redefineClasses (see
+ * SpectreDoesNotRedefineClassesContractTest).
  */
 @OptIn(ExperimentalSpectreAgentApi::class)
 class DaemonReloadCoexistenceTest {
@@ -37,8 +38,8 @@ class DaemonReloadCoexistenceTest {
         val generation = AtomicInteger(0)
         val clicked = mutableListOf<String>()
         val captureCalls = AtomicInteger(0)
-        val outDir = Files.createTempDirectory("spectre-coexist-cap").toString()
-
+        val outRoot = Files.createTempDirectory("spectre-coexist-cap")
+        val outDir = outRoot.toString()
         val registry =
             DaemonSessionRegistry(
                 hotReloadSessionFactory = { hr },
@@ -69,60 +70,71 @@ class DaemonReloadCoexistenceTest {
                 },
             )
 
-        val sessionId =
-            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(4242))).sessionId
+        try {
+            val sessionId =
+                assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(4242)))
+                    .sessionId
 
-        val preTree =
-            assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
-        val preKey = preTree.nodes.single().key
-        assertTrue(preKey.startsWith("g0:"), "expected stamped pre-reload key, got $preKey")
+            val preTree =
+                assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
+            val preKey = preTree.nodes.single().key
+            assertTrue(preKey.startsWith("g0:"), "expected stamped pre-reload key, got $preKey")
 
-        // Capture while attached and pre-reload (isolated outDir — do not touch shared capture
-        // root).
-        assertIs<DaemonResponse.Capture>(
-            registry.handle(
-                DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0, outDir = outDir)
+            assertIs<DaemonResponse.Capture>(
+                registry.handle(
+                    DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0, outDir = outDir)
+                )
             )
-        )
-        assertEquals(1, captureCalls.get())
+            assertEquals(1, captureCalls.get())
 
-        // Simulated HR settle (orchestration already drained in production by HotReloadSession).
-        hr.fireReloadSettled()
-        generation.set(1)
+            hr.fireReloadSettled()
+            generation.set(1)
 
-        val stale =
-            assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Click(sessionId, preKey)))
-        assertEquals(DaemonErrorCode.OperationFailed, stale.code)
-        assertEquals("nodeNotFound", stale.category)
-        assertTrue(clicked.isEmpty(), "stale key must not dispatch click")
+            val stale =
+                assertIs<DaemonResponse.Error>(
+                    registry.handle(DaemonRequest.Click(sessionId, preKey))
+                )
+            assertEquals(DaemonErrorCode.OperationFailed, stale.code)
+            assertEquals("nodeNotFound", stale.category)
+            assertTrue(clicked.isEmpty(), "stale key must not dispatch click")
 
-        // Tree re-read after reload.
-        val postTree =
-            assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
-        val postKey = postTree.nodes.single().key
-        assertTrue(postKey.startsWith("g1:"), "expected new generation stamp, got $postKey")
-        assertTrue(postKey != preKey)
+            val postTree =
+                assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
+            val postKey = postTree.nodes.single().key
+            assertTrue(postKey.startsWith("g1:"), "expected new generation stamp, got $postKey")
+            assertTrue(postKey != preKey)
 
-        // Capture still works after reload settle (attach session still healthy).
-        assertIs<DaemonResponse.Capture>(
-            registry.handle(
-                DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0, outDir = outDir)
+            assertIs<DaemonResponse.Capture>(
+                registry.handle(
+                    DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0, outDir = outDir)
+                )
             )
-        )
-        assertEquals(2, captureCalls.get())
+            assertEquals(2, captureCalls.get())
 
-        assertIs<DaemonResponse.Completed>(registry.handle(DaemonRequest.Click(sessionId, postKey)))
-        assertEquals(listOf("main:0:1"), clicked)
-
-        // Session still has an HR capability: enqueue Settled and wait successfully.
-        hr.enqueue(ReloadSettleOutcome.Settled)
-        assertIs<DaemonResponse.Completed>(
-            registry.handle(
-                DaemonRequest.WaitForReloadSettled(sessionId = sessionId, timeoutMs = 1_000)
+            assertIs<DaemonResponse.Completed>(
+                registry.handle(DaemonRequest.Click(sessionId, postKey))
             )
-        )
+            assertEquals(listOf("main:0:1"), clicked)
 
-        registry.close()
+            hr.enqueue(ReloadSettleOutcome.Settled)
+            assertIs<DaemonResponse.Completed>(
+                registry.handle(
+                    DaemonRequest.WaitForReloadSettled(sessionId = sessionId, timeoutMs = 1_000)
+                )
+            )
+        } finally {
+            CapturePruner.prune(
+                request =
+                    CapturePruner.Request(
+                        sessionId = "pid-4242",
+                        force = true,
+                        allowExplicitOutDir = true,
+                    ),
+                liveSessionIds = emptySet(),
+            )
+            outRoot.toFile().deleteRecursively()
+            registry.close()
+        }
     }
 
     private fun sampleNode(rawKey: String, tag: String): NodeSnapshotDto =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadCoexistenceTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/DaemonReloadCoexistenceTest.kt
@@ -1,0 +1,133 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import dev.sebastiano.spectre.agent.AtomicCaptureResult
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.RectDto
+import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
+import dev.sebastiano.spectre.cli.daemon.DaemonRequest
+import dev.sebastiano.spectre.cli.daemon.DaemonResponse
+import dev.sebastiano.spectre.cli.daemon.DaemonSessionRegistry
+import dev.sebastiano.spectre.cli.daemon.TestDaemonSessionAutomator
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * #212 coexistence contract at the daemon session boundary:
+ * - attach remains usable across a simulated reload settle
+ * - atomic capture succeeds before and after settle
+ * - pre-reload stamped keys fail closed as nodeNotFound
+ * - a fresh tree after settle yields usable keys for input
+ *
+ * Full class-redefine + JdwpTracker coexistence needs a live HR `hotRun` process (#208 still open).
+ * This test exercises the Spectre-owned path that product code actually runs after orchestration
+ * reports settle: key flush + attach/capture stay healthy without Spectre calling
+ * `Instrumentation.redefineClasses` (see [SpectreDoesNotRedefineClassesContractTest]).
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+class DaemonReloadCoexistenceTest {
+    @Test
+    fun `attach tree capture survives reload settle and rejects stale keys`() {
+        val hr = ControllableHotReloadCapability(ConcurrentLinkedQueue())
+        val generation = AtomicInteger(0)
+        val clicked = mutableListOf<String>()
+        val captureCalls = AtomicInteger(0)
+
+        val registry =
+            DaemonSessionRegistry(
+                hotReloadSessionFactory = { hr },
+                attachAutomator = {
+                    TestDaemonSessionAutomator(
+                        nodesResult = {
+                            val gen = generation.get()
+                            listOf(sampleNode(rawKey = "main:0:$gen", tag = "CounterValue"))
+                        },
+                        clickAction = { key -> clicked += key },
+                        captureResult = { windowIndex ->
+                            captureCalls.incrementAndGet()
+                            AtomicCaptureResult(
+                                windowIndex = windowIndex,
+                                schemaVersion = 1,
+                                captureJson =
+                                    """{"schemaVersion":1,"nodes":[{"key":"raw-in-json"}]}""",
+                                pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47),
+                                nodeCount = 1,
+                                taggedNodeCount = 1,
+                                textedNodeCount = 0,
+                                imageWidth = 10,
+                                imageHeight = 10,
+                                captureDurationMs = 1,
+                            )
+                        },
+                    )
+                },
+            )
+
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(4242))).sessionId
+
+        val preTree =
+            assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
+        val preKey = preTree.nodes.single().key
+        assertTrue(preKey.startsWith("g0:"), "expected stamped pre-reload key, got $preKey")
+
+        // Capture while attached and pre-reload.
+        assertIs<DaemonResponse.Capture>(
+            registry.handle(DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0))
+        )
+        assertEquals(1, captureCalls.get())
+
+        // Simulated HR settle (orchestration already drained in production by HotReloadSession).
+        hr.fireReloadSettled()
+        generation.set(1)
+
+        val stale =
+            assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Click(sessionId, preKey)))
+        assertEquals(DaemonErrorCode.OperationFailed, stale.code)
+        assertEquals("nodeNotFound", stale.category)
+        assertTrue(clicked.isEmpty(), "stale key must not dispatch click")
+
+        // Tree re-read after reload.
+        val postTree =
+            assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionId)))
+        val postKey = postTree.nodes.single().key
+        assertTrue(postKey.startsWith("g1:"), "expected new generation stamp, got $postKey")
+        assertTrue(postKey != preKey)
+
+        // Capture still works after reload settle (attach session still healthy).
+        assertIs<DaemonResponse.Capture>(
+            registry.handle(DaemonRequest.Capture(sessionId = sessionId, windowIndex = 0))
+        )
+        assertEquals(2, captureCalls.get())
+
+        assertIs<DaemonResponse.Completed>(registry.handle(DaemonRequest.Click(sessionId, postKey)))
+        assertEquals(listOf("main:0:1"), clicked)
+
+        // Explicit wait still works after coexistence path (controllable returns Unavailable when
+        // queue empty — proves the session still has an HR capability wired).
+        val wait =
+            assertIs<DaemonResponse.Error>(
+                registry.handle(
+                    DaemonRequest.WaitForReloadSettled(sessionId = sessionId, timeoutMs = 50)
+                )
+            )
+        assertEquals(DaemonErrorCode.HotReloadUnavailable, wait.code)
+
+        registry.close()
+    }
+
+    private fun sampleNode(rawKey: String, tag: String): NodeSnapshotDto =
+        NodeSnapshotDto(
+            key = rawKey,
+            testTag = tag,
+            texts = emptyList(),
+            role = "Text",
+            contentDescription = null,
+            isVisible = true,
+            bounds = RectDto(x = 0, y = 0, width = 10, height = 10),
+        )
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -64,13 +64,20 @@ class SpectreDoesNotRedefineClassesContractTest {
 
     private fun resolveRepoRoot(): Path {
         var dir = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize()
-        repeat(8) {
+        var hops = 0
+        while (hops < 8) {
             val settings = dir.resolve("settings.gradle.kts")
             val cli = dir.resolve("cli")
-            if (Files.isRegularFile(settings) && Files.isDirectory(cli)) {
+            val found = Files.isRegularFile(settings) && Files.isDirectory(cli)
+            if (found) {
                 return dir
             }
-            dir = dir.parent ?: fail("walked off filesystem from ${System.getProperty("user.dir")}")
+            val parent = dir.parent
+            if (parent == null) {
+                break
+            }
+            dir = parent
+            hops += 1
         }
         fail(
             "could not find Spectre repo root from " +

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -48,8 +48,8 @@ class SpectreDoesNotRedefineClassesContractTest {
     }
 
     /**
-     * Walks the repo for `**/src/main` directories that look like production modules (skip
-     * `build/`, `.git/`, worktrees under nested `.worktrees` if present).
+     * Walks the repo for production `src/main` directories (skip `build/`, `.git/`, nested
+     * `.worktrees` if present).
      */
     private fun discoverProductionMainSourceRoots(repoRoot: Path): List<Path> {
         val found = mutableListOf<Path>()

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -52,17 +52,16 @@ class SpectreDoesNotRedefineClassesContractTest {
      * `.worktrees` if present).
      */
     private fun discoverProductionMainSourceRoots(repoRoot: Path): List<Path> {
-        val found = mutableListOf<Path>()
+        val found = ArrayList<Path>()
         Files.walk(repoRoot, 6).use { stream ->
-            stream
-                .asSequence()
-                .filter { Files.isDirectory(it) && it.fileName.toString() == "main" }
-                .filter { it.parent?.fileName?.toString() == "src" }
-                .filter { path ->
-                    val s = path.toString().replace('\\', '/')
-                    "/build/" !in s && "/.git/" !in s && "/.worktrees/" !in s
-                }
-                .forEach { found += it }
+            stream.forEach { path ->
+                if (!Files.isDirectory(path)) return@forEach
+                if (path.fileName.toString() != "main") return@forEach
+                if (path.parent?.fileName?.toString() != "src") return@forEach
+                val s = path.toString().replace('\\', '/')
+                if ("/build/" in s || "/.git/" in s || "/.worktrees/" in s) return@forEach
+                found.add(path)
+            }
         }
         return found.sortedBy { it.toString() }
     }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -1,0 +1,72 @@
+package dev.sebastiano.spectre.cli.hotreload
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.extension
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import kotlin.streams.asSequence
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+/**
+ * Coexistence premise with Compose Hot Reload's JdwpTracker (#212): Spectre must not call
+ * [java.lang.instrument.Instrumentation.redefineClasses], which would look like an external
+ * redefine and trip HR's tracker.
+ *
+ * Scans production Kotlin sources under `cli/`, `agent/`, `agent-runtime/`, and `core/` for the
+ * forbidden call site. `redefineModule` (module opens at attach) is allowed and is a different API.
+ */
+class SpectreDoesNotRedefineClassesContractTest {
+    @Test
+    fun `production sources never call Instrumentation redefineClasses`() {
+        val repoRoot = resolveRepoRoot()
+        val roots = listOf("cli", "agent", "agent-runtime", "core").map { repoRoot.resolve(it) }
+        val hits = mutableListOf<String>()
+        for (root in roots) {
+            assertTrue(Files.isDirectory(root), "expected module directory $root")
+            val mainSrc = root.resolve("src/main")
+            if (!Files.isDirectory(mainSrc)) continue
+            Files.walk(mainSrc).use { stream ->
+                stream
+                    .asSequence()
+                    .filter { it.isRegularFile() && it.extension == "kt" }
+                    .forEach { path ->
+                        val text = path.readText()
+                        if (REDEFINE_CLASSES_CALL.containsMatchIn(text)) {
+                            hits += path.toString()
+                        }
+                    }
+            }
+        }
+        assertTrue(
+            hits.isEmpty(),
+            "Spectre must not call Instrumentation.redefineClasses (HR coexistence). Hits:\n" +
+                hits.joinToString("\n"),
+        )
+    }
+
+    private fun resolveRepoRoot(): Path {
+        var dir = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize()
+        repeat(6) {
+            if (
+                Files.isRegularFile(dir.resolve("settings.gradle.kts")) &&
+                    Files.isDirectory(dir.resolve("cli"))
+            ) {
+                return dir
+            }
+            dir = dir.parent ?: fail("walked off filesystem from ${System.getProperty("user.dir")}")
+        }
+        fail(
+            "could not find Spectre repo root (settings.gradle.kts) from " +
+                System.getProperty("user.dir") +
+                " (cwd name=${Path.of(System.getProperty("user.dir")).name})"
+        )
+    }
+
+    companion object {
+        private val REDEFINE_CLASSES_CALL = Regex("""\bredefineClasses\s*\(""")
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -3,7 +3,9 @@ package dev.sebastiano.spectre.cli.hotreload
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
 import kotlin.io.path.isRegularFile
+import kotlin.io.path.listDirectoryEntries
 import kotlin.io.path.name
 import kotlin.io.path.readText
 import kotlin.streams.asSequence
@@ -16,16 +18,21 @@ import kotlin.test.fail
  * [java.lang.instrument.Instrumentation.redefineClasses], which would look like an external
  * redefine and trip HR's tracker.
  *
- * Scans every production `src/main` Kotlin tree under the Spectre repo (all modules, not a
- * hard-coded subset) for the forbidden call site. `redefineModule` (module opens at attach) is
- * allowed and is a different API.
+ * Scans every production `src/main` Kotlin tree under the Spectre repo (all modules that have a
+ * `build.gradle.kts` + `src/main`) for the forbidden call site. `redefineModule` (module opens at
+ * attach) is allowed and is a different API.
  */
 class SpectreDoesNotRedefineClassesContractTest {
     @Test
     fun `production sources never call Instrumentation redefineClasses`() {
         val repoRoot = resolveRepoRoot()
         val mainSrcRoots = discoverProductionMainSourceRoots(repoRoot)
-        assertTrue(mainSrcRoots.isNotEmpty(), "expected at least one src/main tree under $repoRoot")
+        assertTrue(
+            mainSrcRoots.isNotEmpty(),
+            "expected at least one src/main tree under $repoRoot (user.dir=" +
+                System.getProperty("user.dir") +
+                ")",
+        )
         val hits = mutableListOf<String>()
         for (mainSrc in mainSrcRoots) {
             Files.walk(mainSrc).use { stream ->
@@ -33,8 +40,7 @@ class SpectreDoesNotRedefineClassesContractTest {
                     .asSequence()
                     .filter { it.isRegularFile() && it.extension == "kt" }
                     .forEach { path ->
-                        val text = path.readText()
-                        if (REDEFINE_CLASSES_CALL.containsMatchIn(text)) {
+                        if (REDEFINE_CLASSES_CALL.containsMatchIn(path.readText())) {
                             hits += path.toString()
                         }
                     }
@@ -48,27 +54,32 @@ class SpectreDoesNotRedefineClassesContractTest {
     }
 
     /**
-     * Walks the repo for production `src/main` directories (skip `build/`, `.git/`, nested
-     * `.worktrees` if present).
+     * Finds production modules by looking for immediate child directories (and recording/*) that
+     * have both `build.gradle.kts` and `src/main`.
      */
     private fun discoverProductionMainSourceRoots(repoRoot: Path): List<Path> {
-        val found = ArrayList<Path>()
-        Files.walk(repoRoot, 6).use { stream ->
-            stream.forEach { path ->
-                if (!Files.isDirectory(path)) return@forEach
-                if (path.fileName.toString() != "main") return@forEach
-                if (path.parent?.fileName?.toString() != "src") return@forEach
-                val s = path.toString().replace('\\', '/')
-                if ("/build/" in s || "/.git/" in s || "/.worktrees/" in s) return@forEach
-                found.add(path)
-            }
+        val roots = ArrayList<Path>()
+        fun consider(moduleDir: Path) {
+            if (!moduleDir.isDirectory()) return
+            if (!Files.isRegularFile(moduleDir.resolve("build.gradle.kts"))) return
+            val main = moduleDir.resolve("src/main")
+            if (main.isDirectory()) roots.add(main)
         }
-        return found.sortedBy { it.toString() }
+        // Top-level modules
+        repoRoot.listDirectoryEntries().forEach { consider(it) }
+        // Nested platform recording modules
+        val recording = repoRoot.resolve("recording")
+        if (recording.isDirectory()) {
+            recording.listDirectoryEntries().forEach { consider(it) }
+        }
+        // Also consider recording itself
+        consider(recording)
+        return roots.sortedBy { it.toString() }
     }
 
     private fun resolveRepoRoot(): Path {
         var dir = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize()
-        repeat(6) {
+        repeat(8) {
             if (
                 Files.isRegularFile(dir.resolve("settings.gradle.kts")) &&
                     Files.isDirectory(dir.resolve("cli"))

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -47,20 +47,15 @@ class SpectreDoesNotRedefineClassesContractTest {
     }
 
     private fun discoverProductionMainSourceRoots(repoRoot: Path): List<Path> {
+        // Top-level Gradle modules only (recording-macos/linux/windows are siblings of recording/).
         val roots = ArrayList<Path>()
-        fun consider(moduleDir: Path) {
-            if (!moduleDir.isDirectory()) return
-            if (!Files.isRegularFile(moduleDir.resolve("build.gradle.kts"))) return
+        for (moduleDir in repoRoot.listDirectoryEntries()) {
+            if (!moduleDir.isDirectory()) continue
+            if (!Files.isRegularFile(moduleDir.resolve("build.gradle.kts"))) continue
             val main = moduleDir.resolve("src").resolve("main")
             if (main.isDirectory()) {
                 roots.add(main)
             }
-        }
-        repoRoot.listDirectoryEntries().forEach { consider(it) }
-        val recording = repoRoot.resolve("recording")
-        if (recording.isDirectory()) {
-            recording.listDirectoryEntries().forEach { consider(it) }
-            consider(recording)
         }
         return roots.sortedBy { it.toString() }
     }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -50,42 +50,29 @@ class SpectreDoesNotRedefineClassesContractTest {
 
     private fun discoverProductionMainSourceRoots(repoRoot: Path): List<Path> {
         // Top-level Gradle modules only (recording-macos/linux/windows are siblings of recording/).
-        val roots = ArrayList<Path>()
-        for (moduleDir in repoRoot.listDirectoryEntries()) {
-            if (!moduleDir.isDirectory()) continue
-            if (!Files.isRegularFile(moduleDir.resolve("build.gradle.kts"))) continue
-            val main = moduleDir.resolve("src").resolve("main")
-            if (main.isDirectory()) {
-                roots.add(main)
-            }
-        }
-        return roots.sortedBy { it.toString() }
+        return repoRoot
+            .listDirectoryEntries()
+            .filter { it.isDirectory() }
+            .filter { Files.isRegularFile(it.resolve("build.gradle.kts")) }
+            .map { it.resolve("src").resolve("main") }
+            .filter { it.isDirectory() }
+            .sortedBy { it.toString() }
     }
 
     private fun resolveRepoRoot(): Path {
-        var dir = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize()
-        var hops = 0
-        while (hops < 8) {
-            val settings = dir.resolve("settings.gradle.kts")
-            val cli = dir.resolve("cli")
-            val found = Files.isRegularFile(settings) && Files.isDirectory(cli)
-            if (found) {
-                return dir
-            }
-            val parent = dir.parent
-            if (parent == null) {
-                break
-            }
-            dir = parent
-            hops += 1
+        val start = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize()
+        val ancestors = generateSequence(start) { it.parent }.take(8).toList()
+        return ancestors.firstOrNull { dir ->
+            Files.isRegularFile(dir.resolve("settings.gradle.kts")) &&
+                Files.isDirectory(dir.resolve("cli"))
         }
-        fail(
-            "could not find Spectre repo root from " +
-                System.getProperty("user.dir") +
-                " (cwd name=" +
-                Path.of(System.getProperty("user.dir")).name +
-                ")"
-        )
+            ?: fail(
+                "could not find Spectre repo root from " +
+                    System.getProperty("user.dir") +
+                    " (cwd name=" +
+                    Path.of(System.getProperty("user.dir")).name +
+                    ")"
+            )
     }
 
     companion object {

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -31,7 +31,9 @@ class SpectreDoesNotRedefineClassesContractTest {
             Files.walk(mainSrc).use { stream ->
                 stream
                     .asSequence()
-                    .filter { it.isRegularFile() && it.extension == "kt" }
+                    .filter {
+                        it.isRegularFile() && (it.extension == "kt" || it.extension == "java")
+                    }
                     .forEach { path ->
                         if (REDEFINE_CLASSES_CALL.containsMatchIn(path.readText())) {
                             hits += path.toString()

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -13,15 +13,8 @@ import kotlin.test.Test
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
-/**
- * Coexistence premise with Compose Hot Reload's JdwpTracker (#212): Spectre must not call
- * [java.lang.instrument.Instrumentation.redefineClasses], which would look like an external
- * redefine and trip HR's tracker.
- *
- * Scans every production `src/main` Kotlin tree under the Spectre repo (all modules that have a
- * `build.gradle.kts` + `src/main`) for the forbidden call site. `redefineModule` (module opens at
- * attach) is allowed and is a different API.
- */
+// HR coexistence: Spectre must never call Instrumentation.redefineClasses (JdwpTracker tripwire).
+// redefineModule for attach-time module opens is a different API and is allowed.
 class SpectreDoesNotRedefineClassesContractTest {
     @Test
     fun `production sources never call Instrumentation redefineClasses`() {
@@ -53,45 +46,41 @@ class SpectreDoesNotRedefineClassesContractTest {
         )
     }
 
-    /**
-     * Finds production modules by looking for immediate child directories (and recording/*) that
-     * have both `build.gradle.kts` and `src/main`.
-     */
     private fun discoverProductionMainSourceRoots(repoRoot: Path): List<Path> {
         val roots = ArrayList<Path>()
         fun consider(moduleDir: Path) {
             if (!moduleDir.isDirectory()) return
             if (!Files.isRegularFile(moduleDir.resolve("build.gradle.kts"))) return
-            val main = moduleDir.resolve("src/main")
-            if (main.isDirectory()) roots.add(main)
+            val main = moduleDir.resolve("src").resolve("main")
+            if (main.isDirectory()) {
+                roots.add(main)
+            }
         }
-        // Top-level modules
         repoRoot.listDirectoryEntries().forEach { consider(it) }
-        // Nested platform recording modules
         val recording = repoRoot.resolve("recording")
         if (recording.isDirectory()) {
             recording.listDirectoryEntries().forEach { consider(it) }
+            consider(recording)
         }
-        // Also consider recording itself
-        consider(recording)
         return roots.sortedBy { it.toString() }
     }
 
     private fun resolveRepoRoot(): Path {
         var dir = Path.of(System.getProperty("user.dir")).toAbsolutePath().normalize()
         repeat(8) {
-            if (
-                Files.isRegularFile(dir.resolve("settings.gradle.kts")) &&
-                    Files.isDirectory(dir.resolve("cli"))
-            ) {
+            val settings = dir.resolve("settings.gradle.kts")
+            val cli = dir.resolve("cli")
+            if (Files.isRegularFile(settings) && Files.isDirectory(cli)) {
                 return dir
             }
             dir = dir.parent ?: fail("walked off filesystem from ${System.getProperty("user.dir")}")
         }
         fail(
-            "could not find Spectre repo root (settings.gradle.kts) from " +
+            "could not find Spectre repo root from " +
                 System.getProperty("user.dir") +
-                " (cwd name=${Path.of(System.getProperty("user.dir")).name})"
+                " (cwd name=" +
+                Path.of(System.getProperty("user.dir")).name +
+                ")"
         )
     }
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/SpectreDoesNotRedefineClassesContractTest.kt
@@ -16,19 +16,18 @@ import kotlin.test.fail
  * [java.lang.instrument.Instrumentation.redefineClasses], which would look like an external
  * redefine and trip HR's tracker.
  *
- * Scans production Kotlin sources under `cli/`, `agent/`, `agent-runtime/`, and `core/` for the
- * forbidden call site. `redefineModule` (module opens at attach) is allowed and is a different API.
+ * Scans every production `src/main` Kotlin tree under the Spectre repo (all modules, not a
+ * hard-coded subset) for the forbidden call site. `redefineModule` (module opens at attach) is
+ * allowed and is a different API.
  */
 class SpectreDoesNotRedefineClassesContractTest {
     @Test
     fun `production sources never call Instrumentation redefineClasses`() {
         val repoRoot = resolveRepoRoot()
-        val roots = listOf("cli", "agent", "agent-runtime", "core").map { repoRoot.resolve(it) }
+        val mainSrcRoots = discoverProductionMainSourceRoots(repoRoot)
+        assertTrue(mainSrcRoots.isNotEmpty(), "expected at least one src/main tree under $repoRoot")
         val hits = mutableListOf<String>()
-        for (root in roots) {
-            assertTrue(Files.isDirectory(root), "expected module directory $root")
-            val mainSrc = root.resolve("src/main")
-            if (!Files.isDirectory(mainSrc)) continue
+        for (mainSrc in mainSrcRoots) {
             Files.walk(mainSrc).use { stream ->
                 stream
                     .asSequence()
@@ -46,6 +45,26 @@ class SpectreDoesNotRedefineClassesContractTest {
             "Spectre must not call Instrumentation.redefineClasses (HR coexistence). Hits:\n" +
                 hits.joinToString("\n"),
         )
+    }
+
+    /**
+     * Walks the repo for `**/src/main` directories that look like production modules (skip
+     * `build/`, `.git/`, worktrees under nested `.worktrees` if present).
+     */
+    private fun discoverProductionMainSourceRoots(repoRoot: Path): List<Path> {
+        val found = mutableListOf<Path>()
+        Files.walk(repoRoot, 6).use { stream ->
+            stream
+                .asSequence()
+                .filter { Files.isDirectory(it) && it.fileName.toString() == "main" }
+                .filter { it.parent?.fileName?.toString() == "src" }
+                .filter { path ->
+                    val s = path.toString().replace('\\', '/')
+                    "/build/" !in s && "/.git/" !in s && "/.worktrees/" !in s
+                }
+                .forEach { found += it }
+        }
+        return found.sortedBy { it.toString() }
     }
 
     private fun resolveRepoRoot(): Path {


### PR DESCRIPTION
## Summary

Follow-up to #304 / #212 to make the coexistence acceptance criteria explicit in tests:

1. **`DaemonReloadCoexistenceTest`** — reload-aware daemon session: attach → tree → **capture** → simulated settle → pre-reload key → `nodeNotFound` → re-tree → **capture again** → click with new stamped key.
2. **`SpectreDoesNotRedefineClassesContractTest`** — production sources under `cli`/`agent`/`agent-runtime`/`core` never call `Instrumentation.redefineClasses` (HR JdwpTracker tripwire premise). `redefineModule` remains allowed.

### Honest #208 gap

A live **class redefine** + full `hotRun` attach/capture across real HR is still blocked on open **#208** (launch-and-attach / Gradle hotRun harness). This PR does **not** absorb #208. Orchestration integration tests from #211/#304 remain the real TCP settle chain; this PR locks the Spectre-owned attach/invalidation/capture contract and the redefineClasses invariant.

## Test plan

- [x] `./gradlew :cli:test --tests '*DaemonReloadCoexistence*' --tests '*DoesNotRedefine*'`
- [x] `./gradlew :cli:check`
- [x] `./gradlew check` (after clean fixture state)
- [x] User smoke: live non-HR fixture attach → `wait --reload-settled` → “hot reload is not available for this session”