### PR TITLE
Launch-and-attach harness core + direct e2e (#208 P1)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -179,6 +179,164 @@ public final class dev/sebastiano/spectre/agent/SpectreProcesses {
 	public final fun listJvmProcesses ()Ljava/util/List;
 }
 
+public final class dev/sebastiano/spectre/agent/launch/FirstWindowTimeoutException : dev/sebastiano/spectre/agent/launch/LaunchException {
+	public fun <init> (JJLjava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (JJLjava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAttachedPid ()J
+	public final fun getStderrPath ()Ljava/nio/file/Path;
+	public final fun getStdoutPath ()Ljava/nio/file/Path;
+	public final fun getTimeoutMs ()J
+}
+
+public final class dev/sebastiano/spectre/agent/launch/JvmNotAttachableException : dev/sebastiano/spectre/agent/launch/LaunchException {
+	public fun <init> (JJLjava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;)V
+	public synthetic fun <init> (JJLjava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDetail ()Ljava/lang/String;
+	public final fun getLaunchedPid ()J
+	public final fun getStderrPath ()Ljava/nio/file/Path;
+	public final fun getStdoutPath ()Ljava/nio/file/Path;
+	public final fun getTimeoutMs ()J
+}
+
+public final class dev/sebastiano/spectre/agent/launch/LaunchAgentBootstrapException : dev/sebastiano/spectre/agent/launch/LaunchException {
+	public fun <init> (JLjava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (JLjava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAttachedPid ()J
+	public final fun getStderrPath ()Ljava/nio/file/Path;
+	public final fun getStdoutPath ()Ljava/nio/file/Path;
+}
+
+public final class dev/sebastiano/spectre/agent/launch/LaunchAndAttach {
+	public static final field INSTANCE Ldev/sebastiano/spectre/agent/launch/LaunchAndAttach;
+	public final fun launch (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;)Ldev/sebastiano/spectre/agent/launch/LaunchedSession;
+}
+
+public final class dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter {
+	public static final field DYNAMIC_AGENT_LOADING_FLAG Ljava/lang/String;
+	public static final field INSTANCE Ldev/sebastiano/spectre/agent/launch/LaunchCommandRewriter;
+	public final fun classpathContainsSpectreCore (Ljava/lang/String;)Z
+	public final fun extractClasspath (Ljava/util/List;)Ljava/lang/String;
+	public final fun gradleLaunchWarning ()Ljava/lang/String;
+	public final fun hasDynamicAgentLoadingFlag (Ljava/util/List;)Z
+	public final fun isDirectJvmLaunch (Ljava/util/List;)Z
+	public final fun isGradleishLaunch (Ljava/util/List;)Z
+	public final fun rewriteDirectJvmCommand (Ljava/util/List;Ljava/util/List;Z)Ljava/util/List;
+	public static synthetic fun rewriteDirectJvmCommand$default (Ldev/sebastiano/spectre/agent/launch/LaunchCommandRewriter;Ljava/util/List;Ljava/util/List;ZILjava/lang/Object;)Ljava/util/List;
+}
+
+public final class dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery {
+	public static final field INSTANCE Ldev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery;
+	public final fun discoverAppJvm (JLjava/lang/String;)Ljava/lang/Long;
+	public final fun isGradleDaemonDisplayName (Ljava/lang/String;)Z
+}
+
+public abstract class dev/sebastiano/spectre/agent/launch/LaunchException : java/lang/RuntimeException {
+	public synthetic fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchStage;Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchStage;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getStage ()Ldev/sebastiano/spectre/agent/launch/LaunchStage;
+}
+
+public final class dev/sebastiano/spectre/agent/launch/LaunchSpec {
+	public fun <init> (Ljava/util/List;Ljava/nio/file/Path;Ljava/util/Map;Ljava/util/List;Ljava/nio/file/Path;Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;Ldev/sebastiano/spectre/agent/AttachOptions;Ljava/lang/String;ZZ)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/nio/file/Path;Ljava/util/Map;Ljava/util/List;Ljava/nio/file/Path;Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;Ldev/sebastiano/spectre/agent/AttachOptions;Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Z
+	public final fun component2 ()Ljava/nio/file/Path;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/nio/file/Path;
+	public final fun component6 ()Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;
+	public final fun component7 ()Ldev/sebastiano/spectre/agent/AttachOptions;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/util/List;Ljava/nio/file/Path;Ljava/util/Map;Ljava/util/List;Ljava/nio/file/Path;Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;Ldev/sebastiano/spectre/agent/AttachOptions;Ljava/lang/String;ZZ)Ldev/sebastiano/spectre/agent/launch/LaunchSpec;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Ljava/util/List;Ljava/nio/file/Path;Ljava/util/Map;Ljava/util/List;Ljava/nio/file/Path;Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;Ldev/sebastiano/spectre/agent/AttachOptions;Ljava/lang/String;ZZILjava/lang/Object;)Ldev/sebastiano/spectre/agent/launch/LaunchSpec;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppJvmNameFilter ()Ljava/lang/String;
+	public final fun getAttachOptions ()Ldev/sebastiano/spectre/agent/AttachOptions;
+	public final fun getCaptureDirectory ()Ljava/nio/file/Path;
+	public final fun getCommand ()Ljava/util/List;
+	public final fun getEnvironment ()Ljava/util/Map;
+	public final fun getExtraJvmArgs ()Ljava/util/List;
+	public final fun getInjectDynamicAgentLoading ()Z
+	public final fun getRequireSpectreCoreOnClasspath ()Z
+	public final fun getStageTimeouts ()Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;
+	public final fun getWorkingDirectory ()Ljava/nio/file/Path;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/agent/launch/LaunchStage : java/lang/Enum {
+	public static final field AGENT_BOOTSTRAP Ldev/sebastiano/spectre/agent/launch/LaunchStage;
+	public static final field FIRST_WINDOW Ldev/sebastiano/spectre/agent/launch/LaunchStage;
+	public static final field JVM_ATTACHABLE Ldev/sebastiano/spectre/agent/launch/LaunchStage;
+	public static final field PROCESS_ALIVE Ldev/sebastiano/spectre/agent/launch/LaunchStage;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/launch/LaunchStage;
+	public static fun values ()[Ldev/sebastiano/spectre/agent/launch/LaunchStage;
+}
+
+public final class dev/sebastiano/spectre/agent/launch/LaunchStageTimeouts {
+	public static final field Companion Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts$Companion;
+	public static final field DEFAULT_AGENT_BOOTSTRAP_MS J
+	public static final field DEFAULT_FIRST_WINDOW_MS J
+	public static final field DEFAULT_JVM_ATTACHABLE_MS J
+	public static final field DEFAULT_PROCESS_ALIVE_MS J
+	public fun <init> ()V
+	public fun <init> (JJJJ)V
+	public synthetic fun <init> (JJJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()J
+	public final fun component2 ()J
+	public final fun component3 ()J
+	public final fun component4 ()J
+	public final fun copy (JJJJ)Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;JJJJILjava/lang/Object;)Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAgentBootstrapMs ()J
+	public final fun getFirstWindowMs ()J
+	public final fun getJvmAttachableMs ()J
+	public final fun getProcessAliveMs ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/agent/launch/LaunchStageTimeouts$Companion {
+}
+
+public final class dev/sebastiano/spectre/agent/launch/LaunchedSession : java/lang/AutoCloseable {
+	public fun close ()V
+	public final fun getAttachedPid ()J
+	public final fun getAutomator ()Ldev/sebastiano/spectre/agent/AttachedAutomator;
+	public final fun getGradleish ()Z
+	public final fun getLaunchedPid ()J
+	public final fun getStderrPath ()Ljava/nio/file/Path;
+	public final fun getStdoutPath ()Ljava/nio/file/Path;
+	public final fun getWarnings ()Ljava/util/List;
+}
+
+public final class dev/sebastiano/spectre/agent/launch/ProcessExitedBeforeAttachException : dev/sebastiano/spectre/agent/launch/LaunchException {
+	public fun <init> (ILjava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getExitCode ()I
+	public final fun getStderrExcerpt ()Ljava/lang/String;
+	public final fun getStderrPath ()Ljava/nio/file/Path;
+	public final fun getStdoutPath ()Ljava/nio/file/Path;
+}
+
+public final class dev/sebastiano/spectre/agent/launch/ProcessTreeTeardown {
+	public static final field DEFAULT_GRACE_MS J
+	public static final field INSTANCE Ldev/sebastiano/spectre/agent/launch/ProcessTreeTeardown;
+	public final fun destroyTree (Ljava/lang/ProcessHandle;J)Z
+	public static synthetic fun destroyTree$default (Ldev/sebastiano/spectre/agent/launch/ProcessTreeTeardown;Ljava/lang/ProcessHandle;JILjava/lang/Object;)Z
+	public final fun destroyTreeByPid (JJ)Z
+	public static synthetic fun destroyTreeByPid$default (Ldev/sebastiano/spectre/agent/launch/ProcessTreeTeardown;JJILjava/lang/Object;)Z
+}
+
+public final class dev/sebastiano/spectre/agent/launch/SpectreCoreMissingOnClasspathException : dev/sebastiano/spectre/agent/launch/LaunchException {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getClasspath ()Ljava/lang/String;
+}
+
 public final class dev/sebastiano/spectre/agent/runtime/SpectreAgent {
 	public static final field INSTANCE Ldev/sebastiano/spectre/agent/runtime/SpectreAgent;
 	public static final fun agentmain (Ljava/lang/String;Ljava/lang/instrument/Instrumentation;)V

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
@@ -1,0 +1,208 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.AttachedAutomator
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Launch a command, wait through staged readiness, attach Spectre, and return a [LaunchedSession]
+ * that tears the app down on [AutoCloseable.close].
+ *
+ * Stages (each with its own timeout and failure type):
+ * 1. [LaunchStage.PROCESS_ALIVE] — process still running after start
+ * 2. [LaunchStage.JVM_ATTACHABLE] — target JVM visible to the Attach API
+ * 3. [LaunchStage.AGENT_BOOTSTRAP] — agent load + ComposeAutomator bootstrap + UDS
+ * 4. [LaunchStage.FIRST_WINDOW] — `windows()` non-empty
+ *
+ * Direct `java` launches inject `-XX:+EnableDynamicAgentLoading` (unless disabled). Gradle-ish
+ * commands emit [LaunchCommandRewriter.gradleLaunchWarning] and discover the app JVM among
+ * descendants of the client process.
+ */
+@ExperimentalSpectreAgentApi
+public object LaunchAndAttach {
+
+    /**
+     * Start [spec], run staged readiness, and attach. On any stage failure the launched process
+     * tree (or discovered app JVM for Gradle) is torn down before the exception propagates.
+     */
+    @Throws(LaunchException::class, IOException::class)
+    public fun launch(spec: LaunchSpec): LaunchedSession {
+        require(spec.command.isNotEmpty()) { "command must not be empty" }
+        val prepared = prepareLaunch(spec)
+        val process = startProcess(prepared.command, spec, prepared.stdoutPath, prepared.stderrPath)
+        return attachAfterStart(process, prepared, spec)
+    }
+
+    private data class PreparedLaunch(
+        val command: List<String>,
+        val gradleish: Boolean,
+        val warnings: List<String>,
+        val stdoutPath: Path,
+        val stderrPath: Path,
+    )
+
+    private fun prepareLaunch(spec: LaunchSpec): PreparedLaunch {
+        val gradleish = LaunchCommandRewriter.isGradleishLaunch(spec.command)
+        val warnings =
+            if (gradleish) listOf(LaunchCommandRewriter.gradleLaunchWarning()) else emptyList()
+        val command = rewriteCommand(spec)
+        maybeRequireSpectreCore(spec, command)
+        val captureDir =
+            (spec.captureDirectory ?: Files.createTempDirectory("spectre-launch-")).also {
+                Files.createDirectories(it)
+            }
+        return PreparedLaunch(
+            command = command,
+            gradleish = gradleish,
+            warnings = warnings,
+            stdoutPath = captureDir.resolve("stdout.log"),
+            stderrPath = captureDir.resolve("stderr.log"),
+        )
+    }
+
+    private fun rewriteCommand(spec: LaunchSpec): List<String> =
+        if (LaunchCommandRewriter.isDirectJvmLaunch(spec.command)) {
+            LaunchCommandRewriter.rewriteDirectJvmCommand(
+                command = spec.command,
+                extraJvmArgs = spec.extraJvmArgs,
+                inject = spec.injectDynamicAgentLoading,
+            )
+        } else {
+            spec.command
+        }
+
+    private fun maybeRequireSpectreCore(spec: LaunchSpec, command: List<String>) {
+        if (!spec.requireSpectreCoreOnClasspath) return
+        if (!LaunchCommandRewriter.isDirectJvmLaunch(command)) return
+        val cp = LaunchCommandRewriter.extractClasspath(command) ?: return
+        if (!LaunchCommandRewriter.classpathContainsSpectreCore(cp)) {
+            throw SpectreCoreMissingOnClasspathException(cp)
+        }
+    }
+
+    private fun startProcess(
+        command: List<String>,
+        spec: LaunchSpec,
+        stdoutPath: Path,
+        stderrPath: Path,
+    ): Process {
+        val builder = ProcessBuilder(command)
+        if (spec.workingDirectory != null) {
+            builder.directory(spec.workingDirectory.toFile())
+        }
+        if (spec.environment.isNotEmpty()) {
+            builder.environment().putAll(spec.environment)
+        }
+        builder.redirectOutput(stdoutPath.toFile())
+        builder.redirectError(stderrPath.toFile())
+        return try {
+            builder.start()
+        } catch (ex: IOException) {
+            throw ProcessExitedBeforeAttachException(
+                exitCode = -1,
+                stderrExcerpt = "Failed to start process: ${ex.message}",
+                stdoutPath = stdoutPath,
+                stderrPath = stderrPath,
+                cause = ex,
+            )
+        }
+    }
+
+    private fun attachAfterStart(
+        process: Process,
+        prepared: PreparedLaunch,
+        spec: LaunchSpec,
+    ): LaunchedSession {
+        val launchedPid = process.pid()
+        var attachedPid: Long? = null
+        var automator: AttachedAutomator? = null
+        var ready = false
+        try {
+            LaunchReadiness.awaitProcessAlive(
+                process,
+                spec.stageTimeouts.processAliveMs,
+                prepared.stdoutPath,
+                prepared.stderrPath,
+            )
+            attachedPid =
+                LaunchReadiness.awaitJvmAttachable(
+                    process = process,
+                    launchedPid = launchedPid,
+                    gradleish = prepared.gradleish,
+                    nameFilter = spec.appJvmNameFilter,
+                    timeoutMs = spec.stageTimeouts.jvmAttachableMs,
+                    stdoutPath = prepared.stdoutPath,
+                    stderrPath = prepared.stderrPath,
+                )
+            automator =
+                LaunchReadiness.awaitAgentBootstrap(
+                    process = process,
+                    attachedPid = attachedPid,
+                    gradleish = prepared.gradleish,
+                    attachOptions = spec.attachOptions,
+                    bootstrapTimeoutMs = spec.stageTimeouts.agentBootstrapMs,
+                    stdoutPath = prepared.stdoutPath,
+                    stderrPath = prepared.stderrPath,
+                )
+            LaunchReadiness.awaitFirstWindow(
+                automator = automator,
+                attachedPid = attachedPid,
+                timeoutMs = spec.stageTimeouts.firstWindowMs,
+                stdoutPath = prepared.stdoutPath,
+                stderrPath = prepared.stderrPath,
+            )
+            ready = true
+            return LaunchedSession(
+                launchedPid = launchedPid,
+                attachedPid = attachedPid,
+                automator = automator,
+                stdoutPath = prepared.stdoutPath,
+                stderrPath = prepared.stderrPath,
+                gradleish = prepared.gradleish,
+                warnings = prepared.warnings,
+                onClose = { teardownApp(process, prepared.gradleish, launchedPid, attachedPid) },
+            )
+        } finally {
+            if (!ready) {
+                runCatching { automator?.close() }
+                teardownApp(process, prepared.gradleish, launchedPid, attachedPid)
+            }
+        }
+    }
+
+    private fun teardownApp(
+        process: Process,
+        gradleish: Boolean,
+        launchedPid: Long,
+        attachedPid: Long?,
+    ) {
+        if (gradleish) {
+            // Prefer the discovered app JVM. Never kill a Gradle daemon by display name.
+            if (attachedPid != null) {
+                ProcessTreeTeardown.destroyTreeByPid(attachedPid)
+            }
+            // If we never discovered an app JVM, destroy only the *launched client* process
+            // (./gradlew wrapper). Do not walk its descendants blindly — that graph can include
+            // the long-lived daemon on some layouts.
+            if (attachedPid == null && process.isAlive) {
+                runCatching { process.destroy() }
+                if (process.isAlive) {
+                    process.waitFor(
+                        ProcessTreeTeardown.DEFAULT_GRACE_MS,
+                        java.util.concurrent.TimeUnit.MILLISECONDS,
+                    )
+                }
+                if (process.isAlive) {
+                    process.destroyForcibly()
+                }
+            }
+            return
+        }
+        ProcessTreeTeardown.destroyTreeByPid(launchedPid)
+        if (process.isAlive) {
+            process.destroyForcibly()
+        }
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
@@ -75,11 +75,25 @@ public object LaunchCommandRewriter {
         return result
     }
 
-    /** True when [command] already sets `±EnableDynamicAgentLoading`. */
-    public fun hasDynamicAgentLoadingFlag(command: List<String>): Boolean = command.any { token ->
-        token == DYNAMIC_AGENT_LOADING_FLAG ||
-            token == "-XX:-EnableDynamicAgentLoading" ||
-            token.contains("EnableDynamicAgentLoading")
+    /**
+     * True when [command] already sets `±EnableDynamicAgentLoading` as a **launcher** JVM flag
+     * (before `-jar` / main class). Unrelated tokens such as `-Dfeature=EnableDynamicAgentLoading`
+     * do not count.
+     */
+    public fun hasDynamicAgentLoadingFlag(command: List<String>): Boolean {
+        if (!isDirectJvmLaunch(command)) return false
+        var i = 1
+        while (i < command.size) {
+            val token = command[i]
+            when {
+                token == "-jar" -> return false
+                token == DYNAMIC_AGENT_LOADING_FLAG || token == "-XX:-EnableDynamicAgentLoading" ->
+                    return true
+                token.startsWith("-") -> i++
+                else -> return false // main class boundary
+            }
+        }
+        return false
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
@@ -1,0 +1,134 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+
+/**
+ * Pure rewrites applied to [LaunchSpec.command] before [ProcessBuilder] starts the process.
+ *
+ * Kept free of I/O so unit tests cover injection and Gradle detection without spawning.
+ */
+@ExperimentalSpectreAgentApi
+public object LaunchCommandRewriter {
+
+    /** True when [command] looks like a direct HotSpot/`java` launcher invocation. */
+    public fun isDirectJvmLaunch(command: List<String>): Boolean {
+        if (command.isEmpty()) return false
+        val executable = basename(command.first())
+        return executable.equals("java", ignoreCase = true) ||
+            executable.equals("java.exe", ignoreCase = true)
+    }
+
+    /**
+     * True when [command] is Gradle-client shaped (`gradlew`, `gradle`, or a clearly Gradle-driven
+     * Compose Hot Reload `hotRun` task). These launches spawn the app JVM from the Gradle daemon,
+     * so readiness/teardown must use descendant discovery rather than the client PID.
+     */
+    public fun isGradleishLaunch(command: List<String>): Boolean {
+        if (command.isEmpty()) return false
+        val basenames = command.map { basename(it).lowercase() }
+        if (
+            basenames.any {
+                it == "gradlew" || it == "gradlew.bat" || it == "gradle" || it == "gradle.bat"
+            }
+        ) {
+            return true
+        }
+        // Compose Hot Reload task names appear as Gradle task args on an otherwise normal command.
+        return command.any { token ->
+            val lower = token.lowercase()
+            lower.contains("hotrun") || lower.contains("hotrunjvm")
+        }
+    }
+
+    /**
+     * Loud multi-line warning for Gradle-ish launches. Callers should print this to the harness
+     * warning sink before readiness begins.
+     */
+    public fun gradleLaunchWarning(): String =
+        """
+        |WARNING: Spectre launch detected a Gradle-ish command (./gradlew …:run / hotRun / gradle).
+        |  • The app JVM is typically spawned by the Gradle daemon, not the gradlew client.
+        |  • Teardown targets the discovered app JVM only — never the Gradle daemon.
+        |  • External JVM-arg injection is not possible; start the app with
+        |    -XX:+EnableDynamicAgentLoading inside the build if JEP 451 warns.
+        |  • Agent-sandboxed Gradle daemons can leave attach/UDS failures that look like Spectre bugs.
+        |Prefer a prod-like launch (java -jar, installDist, packaged app) when you control the build.
+        """
+            .trimMargin()
+
+    /**
+     * For direct JVM launches, insert `-XX:+EnableDynamicAgentLoading` immediately after the `java`
+     * binary when [inject] is true and the flag is not already present. Also inserts [extraJvmArgs]
+     * after the injected flag (or after `java` when injection is skipped).
+     *
+     * Non-direct launches are returned unchanged ( [extraJvmArgs] are not applied ).
+     */
+    public fun rewriteDirectJvmCommand(
+        command: List<String>,
+        extraJvmArgs: List<String> = emptyList(),
+        inject: Boolean = true,
+    ): List<String> {
+        if (!isDirectJvmLaunch(command)) return command
+        val result = command.toMutableList()
+        var insertAt = 1
+        if (inject && !hasDynamicAgentLoadingFlag(command)) {
+            result.add(insertAt, DYNAMIC_AGENT_LOADING_FLAG)
+            insertAt++
+        }
+        if (extraJvmArgs.isNotEmpty()) {
+            result.addAll(insertAt, extraJvmArgs)
+        }
+        return result
+    }
+
+    /** True when [command] already sets `±EnableDynamicAgentLoading`. */
+    public fun hasDynamicAgentLoadingFlag(command: List<String>): Boolean = command.any { token ->
+        token == DYNAMIC_AGENT_LOADING_FLAG ||
+            token == "-XX:-EnableDynamicAgentLoading" ||
+            token.contains("EnableDynamicAgentLoading")
+    }
+
+    /**
+     * Best-effort scan of a direct JVM command line for a `-cp` / `-classpath` value. Returns null
+     * when no classpath is present on the command line.
+     */
+    public fun extractClasspath(command: List<String>): String? {
+        if (!isDirectJvmLaunch(command)) return null
+        var i = 1
+        while (i < command.size) {
+            val token = command[i]
+            when {
+                token == "-cp" || token == "-classpath" -> return command.getOrNull(i + 1)
+                token.startsWith("-cp=") -> return token.removePrefix("-cp=")
+                token.startsWith("-classpath=") -> return token.removePrefix("-classpath=")
+                else -> i++
+            }
+        }
+        return null
+    }
+
+    /** True when [classpath] contains a path segment that looks like a spectre-core jar. */
+    public fun classpathContainsSpectreCore(classpath: String): Boolean {
+        // Split on both Unix (:) and Windows (;) classpath separators without a spread operator.
+        val entries = classpath.replace(';', ':').split(':')
+        return entries.any { entry ->
+            val lower = entry.lowercase()
+            val name = basename(entry).lowercase()
+            name.startsWith("spectre-core") ||
+                lower.contains("/spectre-core") ||
+                lower.contains("\\spectre-core") ||
+                // In-repo module output: .../core/build/libs/core-*.jar
+                lower.contains("/core/build/") ||
+                lower.contains("\\core\\build\\")
+        }
+    }
+
+    internal fun basename(path: String): String {
+        val slash = path.lastIndexOf('/')
+        val backslash = path.lastIndexOf('\\')
+        val cut = maxOf(slash, backslash)
+        return if (cut < 0) path else path.substring(cut + 1)
+    }
+
+    public const val DYNAMIC_AGENT_LOADING_FLAG: String = "-XX:+EnableDynamicAgentLoading"
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
@@ -65,7 +65,10 @@ public object LaunchCommandRewriter {
         if (!isDirectJvmLaunch(command)) return command
         val result = command.toMutableList()
         var insertAt = 1
-        if (inject && !hasDynamicAgentLoadingFlag(command)) {
+        val alreadyPresent =
+            hasDynamicAgentLoadingFlag(command) ||
+                extraJvmArgs.any { isExactDynamicAgentLoadingFlag(it) }
+        if (inject && !alreadyPresent) {
             result.add(insertAt, DYNAMIC_AGENT_LOADING_FLAG)
             insertAt++
         }
@@ -78,7 +81,7 @@ public object LaunchCommandRewriter {
     /**
      * True when [command] already sets `±EnableDynamicAgentLoading` as a **launcher** JVM flag
      * (before `-jar` / main class). Unrelated tokens such as `-Dfeature=EnableDynamicAgentLoading`
-     * do not count.
+     * do not count. Tokens that take a value (`-cp` / `-classpath`) skip their following argument.
      */
     public fun hasDynamicAgentLoadingFlag(command: List<String>): Boolean {
         if (!isDirectJvmLaunch(command)) return false
@@ -87,14 +90,17 @@ public object LaunchCommandRewriter {
             val token = command[i]
             when {
                 token == "-jar" -> return false
-                token == DYNAMIC_AGENT_LOADING_FLAG || token == "-XX:-EnableDynamicAgentLoading" ->
-                    return true
+                isExactDynamicAgentLoadingFlag(token) -> return true
+                token == "-cp" || token == "-classpath" -> i += 2 // skip classpath value
                 token.startsWith("-") -> i++
                 else -> return false // main class boundary
             }
         }
         return false
     }
+
+    private fun isExactDynamicAgentLoadingFlag(token: String): Boolean =
+        token == DYNAMIC_AGENT_LOADING_FLAG || token == "-XX:-EnableDynamicAgentLoading"
 
     /**
      * Best-effort scan of a direct JVM command line for a `-cp` / `-classpath` value among

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
@@ -115,19 +115,47 @@ public object LaunchCommandRewriter {
         var i = 1
         while (i < command.size) {
             val token = command[i]
+            classpathValueFromToken(token, command, i)?.let {
+                return it
+            }
             when {
-                token == "-jar" -> return null // remaining tokens are jar path + app args
-                token == "-cp" || token == "-classpath" || token == "--class-path" ->
-                    return command.getOrNull(i + 1)
-                token.startsWith("-cp=") -> return token.removePrefix("-cp=")
-                token.startsWith("-classpath=") -> return token.removePrefix("-classpath=")
-                token.startsWith("--class-path=") -> return token.removePrefix("--class-path=")
-                token.startsWith("-") -> i++ // other JVM launcher option
+                token == "-jar" -> return null
+                isLauncherOptionTakingValue(token) -> i += 2
+                token.startsWith("-") -> i++
                 else -> return null // main class — end of launcher options
             }
         }
         return null
     }
+
+    private fun classpathValueFromToken(token: String, command: List<String>, index: Int): String? =
+        when {
+            token == "-cp" || token == "-classpath" || token == "--class-path" ->
+                command.getOrNull(index + 1)
+            token.startsWith("-cp=") -> token.removePrefix("-cp=")
+            token.startsWith("-classpath=") -> token.removePrefix("-classpath=")
+            token.startsWith("--class-path=") -> token.removePrefix("--class-path=")
+            else -> null
+        }
+
+    private fun isLauncherOptionTakingValue(token: String): Boolean =
+        token in LAUNCHER_OPTIONS_WITH_VALUE
+
+    private val LAUNCHER_OPTIONS_WITH_VALUE: Set<String> =
+        setOf(
+            "-p",
+            "--module-path",
+            "--upgrade-module-path",
+            "--add-modules",
+            "--limit-modules",
+            "--add-exports",
+            "--add-opens",
+            "--add-reads",
+            "--patch-module",
+            "-cp",
+            "-classpath",
+            "--class-path",
+        )
 
     /** True when [classpath] contains a path segment that looks like a spectre-core jar. */
     public fun classpathContainsSpectreCore(classpath: String): Boolean {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
@@ -89,8 +89,11 @@ public object LaunchCommandRewriter {
     }
 
     /**
-     * Best-effort scan of a direct JVM command line for a `-cp` / `-classpath` value. Returns null
-     * when no classpath is present on the command line.
+     * Best-effort scan of a direct JVM command line for a `-cp` / `-classpath` value among
+     * **launcher** options only. Stops at `-jar <file>` or the first non-option token (main class)
+     * so application arguments like `java -jar app.jar -cp user-value` are not misread.
+     *
+     * Returns null when no classpath is present on the command line.
      */
     public fun extractClasspath(command: List<String>): String? {
         if (!isDirectJvmLaunch(command)) return null
@@ -98,10 +101,12 @@ public object LaunchCommandRewriter {
         while (i < command.size) {
             val token = command[i]
             when {
+                token == "-jar" -> return null // remaining tokens are jar path + app args
                 token == "-cp" || token == "-classpath" -> return command.getOrNull(i + 1)
                 token.startsWith("-cp=") -> return token.removePrefix("-cp=")
                 token.startsWith("-classpath=") -> return token.removePrefix("-classpath=")
-                else -> i++
+                token.startsWith("-") -> i++ // other JVM launcher option
+                else -> return null // main class — end of launcher options
             }
         }
         return null

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
@@ -119,7 +119,11 @@ public object LaunchCommandRewriter {
                 return it
             }
             when {
-                token == "-jar" -> return null
+                token == "-jar" ||
+                    token == "-m" ||
+                    token == "--module" ||
+                    token.startsWith("-m=") ||
+                    token.startsWith("--module=") -> return null // app boundary
                 isLauncherOptionTakingValue(token) -> i += 2
                 token.startsWith("-") -> i++
                 else -> return null // main class — end of launcher options

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
@@ -19,25 +19,19 @@ public object LaunchCommandRewriter {
     }
 
     /**
-     * True when [command] is Gradle-client shaped (`gradlew`, `gradle`, or a clearly Gradle-driven
-     * Compose Hot Reload `hotRun` task). These launches spawn the app JVM from the Gradle daemon,
-     * so readiness/teardown must use descendant discovery rather than the client PID.
+     * True when [command] is Gradle-client shaped (`gradlew` / `gradle` as the executable).
+     *
+     * Only the **launcher** basename is used — a direct `java -jar hotrun-tools.jar` (or a main arg
+     * containing `hotRun`) must stay a direct JVM launch so readiness attaches to the launched PID.
+     * Compose Hot Reload `hotRun` tasks are still covered when invoked via `./gradlew …`.
      */
     public fun isGradleishLaunch(command: List<String>): Boolean {
         if (command.isEmpty()) return false
-        val basenames = command.map { basename(it).lowercase() }
-        if (
-            basenames.any {
-                it == "gradlew" || it == "gradlew.bat" || it == "gradle" || it == "gradle.bat"
-            }
-        ) {
-            return true
-        }
-        // Compose Hot Reload task names appear as Gradle task args on an otherwise normal command.
-        return command.any { token ->
-            val lower = token.lowercase()
-            lower.contains("hotrun") || lower.contains("hotrunjvm")
-        }
+        val launcher = basename(command.first()).lowercase()
+        return launcher == "gradlew" ||
+            launcher == "gradlew.bat" ||
+            launcher == "gradle" ||
+            launcher == "gradle.bat"
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter.kt
@@ -91,7 +91,8 @@ public object LaunchCommandRewriter {
             when {
                 token == "-jar" -> return false
                 isExactDynamicAgentLoadingFlag(token) -> return true
-                token == "-cp" || token == "-classpath" -> i += 2 // skip classpath value
+                token == "-cp" || token == "-classpath" || token == "--class-path" ->
+                    i += 2 // skip classpath value
                 token.startsWith("-") -> i++
                 else -> return false // main class boundary
             }
@@ -116,9 +117,11 @@ public object LaunchCommandRewriter {
             val token = command[i]
             when {
                 token == "-jar" -> return null // remaining tokens are jar path + app args
-                token == "-cp" || token == "-classpath" -> return command.getOrNull(i + 1)
+                token == "-cp" || token == "-classpath" || token == "--class-path" ->
+                    return command.getOrNull(i + 1)
                 token.startsWith("-cp=") -> return token.removePrefix("-cp=")
                 token.startsWith("-classpath=") -> return token.removePrefix("-classpath=")
+                token.startsWith("--class-path=") -> return token.removePrefix("--class-path=")
                 token.startsWith("-") -> i++ // other JVM launcher option
                 else -> return null // main class — end of launcher options
             }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -51,12 +51,13 @@ public object LaunchDescendantDiscovery {
                 it.displayName.contains(nameFilter, ignoreCase = true)
             }
             if (nameMatched.isEmpty()) return null
-            // Prefer daemon children and client descendants among name matches.
-            val preferred =
-                nameMatched.filter { it.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() } +
-                    nameMatched.filter { it.pid in clientDescendants } +
-                    nameMatched
-            return preferred.distinctBy { it.pid }.maxByOrNull { it.pid }?.pid
+            // Restrict to structural signals only — never fall back to an arbitrary
+            // machine-wide name match (could be another developer's IDE / leftover process).
+            val structuralNameMatches = nameMatched.filter { info ->
+                info.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() ||
+                    info.pid in clientDescendants
+            }
+            return structuralNameMatches.maxByOrNull { it.pid }?.pid
         }
 
         // No name filter: only structural signals (never "any non-daemon JVM").

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -9,15 +9,15 @@ import kotlin.streams.asSequence
  * Locates the real app JVM for Gradle-ish launches (readiness + teardown).
  *
  * Layout reality: `./gradlew :app:run` typically has the **Gradle daemon** spawn the app JVM, so
- * the app is **not** a ProcessHandle descendant of the gradlew client. Discovery therefore
- * combines:
- * 1. optional [nameFilter] against [JvmProcessInfo.displayName] (required for daemon-child apps
- *    when the client graph does not contain the app)
- * 2. JVMs parented by a known Gradle daemon (from the attach list)
- * 3. ProcessHandle descendants of the client (covers `--no-daemon` / rare layouts)
+ * the app is **not** a ProcessHandle descendant of the gradlew client.
  *
- * Never returns a Gradle daemon display-name match, and never falls back to an arbitrary
- * machine-wide JVM without one of the signals above.
+ * Safety rules:
+ * - Never returns a Gradle daemon display-name match.
+ * - Never returns an arbitrary machine-wide JVM.
+ * - Daemon-child candidates are only considered when [nameFilter] is set (shared daemons often host
+ *   unrelated app JVMs).
+ * - Without [nameFilter], only ProcessHandle descendants of the client are considered
+ *   (`--no-daemon` and rare layouts).
  */
 @ExperimentalSpectreAgentApi
 public object LaunchDescendantDiscovery {
@@ -25,9 +25,8 @@ public object LaunchDescendantDiscovery {
     /**
      * Find an attachable app JVM for a Gradle-ish launch started as [clientPid].
      *
-     * @param nameFilter optional case-insensitive substring of the app's main-class display name.
-     *   Strongly recommended for multi-project machines. When set and no listed JVM matches,
-     *   returns null (does not fall through to unrelated JVMs).
+     * @param nameFilter case-insensitive substring of the app's main-class display name. Required
+     *   to safely pick among daemon children on machines with concurrent Gradle apps.
      */
     public fun discoverAppJvm(clientPid: Long, nameFilter: String?): Long? {
         val listed = runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList())
@@ -51,18 +50,15 @@ public object LaunchDescendantDiscovery {
                 it.displayName.contains(nameFilter, ignoreCase = true)
             }
             if (nameMatched.isEmpty()) return null
-            // Restrict to structural signals only — never fall back to an arbitrary
-            // machine-wide name match (could be another developer's IDE / leftover process).
-            val structuralNameMatches = nameMatched.filter { info ->
+            val structural = nameMatched.filter { info ->
                 info.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() ||
                     info.pid in clientDescendants
             }
-            return structuralNameMatches.maxByOrNull { it.pid }?.pid
+            return structural.maxByOrNull { it.pid }?.pid
         }
 
-        // No name filter: only structural signals (never "any non-daemon JVM").
-        val structural = childOfDaemon + nonDaemon.filter { it.pid in clientDescendants }
-        return structural.distinctBy { it.pid }.maxByOrNull { it.pid }?.pid
+        // No name filter: only client descendants (never unfiltered daemon children).
+        return nonDaemon.filter { it.pid in clientDescendants }.maxByOrNull { it.pid }?.pid
     }
 
     /** True when [displayName] looks like a Gradle daemon JVM banner from `jps` / Attach list. */
@@ -74,13 +70,7 @@ public object LaunchDescendantDiscovery {
             lower.contains("gradle-daemon")
     }
 
-    /**
-     * True when [pid] is visible to the Attach API via `VirtualMachine.list()`.
-     *
-     * Intentionally does **not** treat a mere live `java` ProcessHandle as attach-ready — that
-     * races with hsperfdata registration and turns early attach failures into bootstrap errors
-     * instead of waiting out the JVM-attachable stage.
-     */
+    /** True when [pid] is visible to the Attach API via `VirtualMachine.list()`. */
     internal fun isJvmAttachable(pid: Long): Boolean {
         val listed = runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList())
         return listed.any { it.pid == pid }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -92,13 +92,23 @@ public object LaunchDescendantDiscovery {
                 addAll(daemonPids)
             }
         }
+        val daemonPidSet = daemonPids // roots may include daemon pids as walk roots only
         return roots
             .asSequence()
             .flatMap { root -> descendantPidsOf(root).asSequence() }
             .filter { pid -> pid != clientPid }
+            .filter { pid -> pid !in daemonPidSet }
             .filter { pid -> looksLikeJavaProcess(pid) }
+            .filter { pid -> !commandLineLooksLikeGradleDaemon(pid) }
             .filter { pid -> nameFilter.isNullOrBlank() || commandLineContains(pid, nameFilter) }
             .maxOrNull()
+    }
+
+    private fun commandLineLooksLikeGradleDaemon(pid: Long): Boolean {
+        val handle = ProcessHandle.of(pid).orElse(null) ?: return false
+        val cmd = handle.info().command().orElse("")
+        val args = handle.info().arguments().orElse(emptyArray()).joinToString(" ")
+        return isGradleDaemonDisplayName("$cmd $args")
     }
 
     private fun looksLikeJavaProcess(pid: Long): Boolean {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -49,16 +49,75 @@ public object LaunchDescendantDiscovery {
             val nameMatched = nonDaemon.filter {
                 it.displayName.contains(nameFilter, ignoreCase = true)
             }
-            if (nameMatched.isEmpty()) return null
             val structural = nameMatched.filter { info ->
                 info.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() ||
                     info.pid in clientDescendants
             }
-            return structural.maxByOrNull { it.pid }?.pid
+            structural
+                .maxByOrNull { it.pid }
+                ?.pid
+                ?.let {
+                    return it
+                }
+            // Native process-tree fallback: hsperfdata/list can lag behind spawn. Walk daemon
+            // children and client descendants via ProcessHandle and match command/args.
+            return discoverByNativeTree(
+                clientPid = clientPid,
+                daemonPids = daemonPids,
+                nameFilter = nameFilter,
+            )
         }
 
         // No name filter: only client descendants (never unfiltered daemon children).
         return nonDaemon.filter { it.pid in clientDescendants }.maxByOrNull { it.pid }?.pid
+            ?: discoverByNativeTree(
+                clientPid = clientPid,
+                daemonPids = emptySet(), // no unfiltered daemon walk without nameFilter
+                nameFilter = null,
+            )
+    }
+
+    /**
+     * Walk [ProcessHandle] descendants when Attach list is incomplete. With [nameFilter], also walk
+     * daemon children; without it, only [clientPid] descendants.
+     */
+    private fun discoverByNativeTree(
+        clientPid: Long,
+        daemonPids: Set<Long>,
+        nameFilter: String?,
+    ): Long? {
+        val roots = buildList {
+            add(clientPid)
+            if (!nameFilter.isNullOrBlank()) {
+                addAll(daemonPids)
+            }
+        }
+        val candidates = mutableListOf<Long>()
+        for (root in roots) {
+            for (pid in descendantPidsOf(root)) {
+                if (pid == clientPid) continue
+                if (!looksLikeJavaProcess(pid)) continue
+                if (nameFilter.isNullOrBlank() || commandLineContains(pid, nameFilter)) {
+                    candidates.add(pid)
+                }
+            }
+        }
+        return candidates.maxOrNull()
+    }
+
+    private fun looksLikeJavaProcess(pid: Long): Boolean {
+        val handle = ProcessHandle.of(pid).orElse(null) ?: return false
+        if (!handle.isAlive) return false
+        val cmd = handle.info().command().orElse("")
+        val base = LaunchCommandRewriter.basename(cmd)
+        return base.equals("java", ignoreCase = true) || base.equals("java.exe", ignoreCase = true)
+    }
+
+    private fun commandLineContains(pid: Long, needle: String): Boolean {
+        val handle = ProcessHandle.of(pid).orElse(null) ?: return false
+        val cmd = handle.info().command().orElse("")
+        val args = handle.info().arguments().orElse(emptyArray()).joinToString(" ")
+        return cmd.contains(needle, ignoreCase = true) || args.contains(needle, ignoreCase = true)
     }
 
     /** True when [displayName] looks like a Gradle daemon JVM banner from `jps` / Attach list. */

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -1,47 +1,67 @@
 package dev.sebastiano.spectre.agent.launch
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.JvmProcessInfo
 import dev.sebastiano.spectre.agent.SpectreProcesses
 import kotlin.streams.asSequence
 
 /**
- * Locates the real app JVM among a Gradle client's descendants for readiness and teardown.
+ * Locates the real app JVM for Gradle-ish launches (readiness + teardown).
  *
- * Never returns a JVM whose display name looks like a Gradle daemon — teardown must not kill the
- * daemon. Never returns an arbitrary machine-wide JVM when no descendants are known yet — that
- * would risk attaching to / killing an unrelated process.
+ * Layout reality: `./gradlew :app:run` typically has the **Gradle daemon** spawn the app JVM, so
+ * the app is **not** a ProcessHandle descendant of the gradlew client. Discovery therefore
+ * combines:
+ * 1. optional [nameFilter] against [JvmProcessInfo.displayName] (required for daemon-child apps
+ *    when the client graph does not contain the app)
+ * 2. JVMs parented by a known Gradle daemon (from the attach list)
+ * 3. ProcessHandle descendants of the client (covers `--no-daemon` / rare layouts)
+ *
+ * Never returns a Gradle daemon display-name match, and never falls back to an arbitrary
+ * machine-wide JVM without one of the signals above.
  */
 @ExperimentalSpectreAgentApi
 public object LaunchDescendantDiscovery {
 
     /**
-     * Find an attachable JVM that is a **ProcessHandle descendant** of [clientPid].
+     * Find an attachable app JVM for a Gradle-ish launch started as [clientPid].
      *
-     * Returns null when:
-     * - the client handle is missing,
-     * - no descendants are visible yet (keep polling),
-     * - no listed JVM is both a descendant and non-daemon (and matches [nameFilter] if set).
-     *
-     * Does **not** fall back to “any JVM on the machine.”
+     * @param nameFilter optional case-insensitive substring of the app's main-class display name.
+     *   Strongly recommended for multi-project machines. When set and no listed JVM matches,
+     *   returns null (does not fall through to unrelated JVMs).
      */
     public fun discoverAppJvm(clientPid: Long, nameFilter: String?): Long? {
-        val clientHandle = ProcessHandle.of(clientPid).orElse(null) ?: return null
-        val descendantPids: Set<Long> =
-            try {
-                clientHandle.descendants().asSequence().map { it.pid() }.toSet()
-            } catch (_: UnsupportedOperationException) {
-                emptySet()
-            }
-        if (descendantPids.isEmpty()) return null
-
         val listed = runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList())
-        val candidates = listed.filter { info ->
-            info.pid in descendantPids &&
-                !isGradleDaemonDisplayName(info.displayName) &&
-                (nameFilter == null || info.displayName.contains(nameFilter, ignoreCase = true))
+        if (listed.isEmpty()) return null
+
+        val daemonPids =
+            listed.filter { isGradleDaemonDisplayName(it.displayName) }.map { it.pid }.toSet()
+        val nonDaemon = listed.filter { info ->
+            info.pid != clientPid && !isGradleDaemonDisplayName(info.displayName)
         }
-        // Prefer the highest PID among matches (typically the most recently spawned app JVM).
-        return candidates.maxByOrNull { it.pid }?.pid
+        if (nonDaemon.isEmpty()) return null
+
+        val clientDescendants = descendantPidsOf(clientPid)
+        val childOfDaemon = nonDaemon.filter { info ->
+            val parent = parentPid(info.pid) ?: return@filter false
+            parent in daemonPids
+        }
+
+        if (!nameFilter.isNullOrBlank()) {
+            val nameMatched = nonDaemon.filter {
+                it.displayName.contains(nameFilter, ignoreCase = true)
+            }
+            if (nameMatched.isEmpty()) return null
+            // Prefer daemon children and client descendants among name matches.
+            val preferred =
+                nameMatched.filter { it.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() } +
+                    nameMatched.filter { it.pid in clientDescendants } +
+                    nameMatched
+            return preferred.distinctBy { it.pid }.maxByOrNull { it.pid }?.pid
+        }
+
+        // No name filter: only structural signals (never "any non-daemon JVM").
+        val structural = childOfDaemon + nonDaemon.filter { it.pid in clientDescendants }
+        return structural.distinctBy { it.pid }.maxByOrNull { it.pid }?.pid
     }
 
     /** True when [displayName] looks like a Gradle daemon JVM banner from `jps` / Attach list. */
@@ -64,4 +84,16 @@ public object LaunchDescendantDiscovery {
         val listed = runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList())
         return listed.any { it.pid == pid }
     }
+
+    private fun descendantPidsOf(clientPid: Long): Set<Long> {
+        val clientHandle = ProcessHandle.of(clientPid).orElse(null) ?: return emptySet()
+        return try {
+            clientHandle.descendants().asSequence().map { it.pid() }.toSet()
+        } catch (_: UnsupportedOperationException) {
+            emptySet()
+        }
+    }
+
+    private fun parentPid(pid: Long): Long? =
+        ProcessHandle.of(pid).flatMap { it.parent() }.map { it.pid() }.orElse(null)
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -1,0 +1,67 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.SpectreProcesses
+import kotlin.streams.asSequence
+
+/**
+ * Locates the real app JVM among a Gradle client's descendants for readiness and teardown.
+ *
+ * Never returns a JVM whose display name looks like a Gradle daemon — teardown must not kill the
+ * daemon. Never returns an arbitrary machine-wide JVM when no descendants are known yet — that
+ * would risk attaching to / killing an unrelated process.
+ */
+@ExperimentalSpectreAgentApi
+public object LaunchDescendantDiscovery {
+
+    /**
+     * Find an attachable JVM that is a **ProcessHandle descendant** of [clientPid].
+     *
+     * Returns null when:
+     * - the client handle is missing,
+     * - no descendants are visible yet (keep polling),
+     * - no listed JVM is both a descendant and non-daemon (and matches [nameFilter] if set).
+     *
+     * Does **not** fall back to “any JVM on the machine.”
+     */
+    public fun discoverAppJvm(clientPid: Long, nameFilter: String?): Long? {
+        val clientHandle = ProcessHandle.of(clientPid).orElse(null) ?: return null
+        val descendantPids: Set<Long> =
+            try {
+                clientHandle.descendants().asSequence().map { it.pid() }.toSet()
+            } catch (_: UnsupportedOperationException) {
+                emptySet()
+            }
+        if (descendantPids.isEmpty()) return null
+
+        val listed = runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList())
+        val candidates = listed.filter { info ->
+            info.pid in descendantPids &&
+                !isGradleDaemonDisplayName(info.displayName) &&
+                (nameFilter == null || info.displayName.contains(nameFilter, ignoreCase = true))
+        }
+        // Prefer the highest PID among matches (typically the most recently spawned app JVM).
+        return candidates.maxByOrNull { it.pid }?.pid
+    }
+
+    /** True when [displayName] looks like a Gradle daemon JVM banner from `jps` / Attach list. */
+    public fun isGradleDaemonDisplayName(displayName: String): Boolean {
+        val lower = displayName.lowercase()
+        return lower.contains("gradle daemon") ||
+            lower.contains("gradledaemon") ||
+            lower.contains("org.gradle.launcher.daemon") ||
+            lower.contains("gradle-daemon")
+    }
+
+    /**
+     * True when [pid] is visible to the Attach API via `VirtualMachine.list()`.
+     *
+     * Intentionally does **not** treat a mere live `java` ProcessHandle as attach-ready — that
+     * races with hsperfdata registration and turns early attach failures into bootstrap errors
+     * instead of waiting out the JVM-attachable stage.
+     */
+    internal fun isJvmAttachable(pid: Long): Boolean {
+        val listed = runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList())
+        return listed.any { it.pid == pid }
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -92,17 +92,13 @@ public object LaunchDescendantDiscovery {
                 addAll(daemonPids)
             }
         }
-        val candidates = mutableListOf<Long>()
-        for (root in roots) {
-            for (pid in descendantPidsOf(root)) {
-                if (pid == clientPid) continue
-                if (!looksLikeJavaProcess(pid)) continue
-                if (nameFilter.isNullOrBlank() || commandLineContains(pid, nameFilter)) {
-                    candidates.add(pid)
-                }
-            }
-        }
-        return candidates.maxOrNull()
+        return roots
+            .asSequence()
+            .flatMap { root -> descendantPidsOf(root).asSequence() }
+            .filter { pid -> pid != clientPid }
+            .filter { pid -> looksLikeJavaProcess(pid) }
+            .filter { pid -> nameFilter.isNullOrBlank() || commandLineContains(pid, nameFilter) }
+            .maxOrNull()
     }
 
     private fun looksLikeJavaProcess(pid: Long): Boolean {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -49,18 +49,23 @@ public object LaunchDescendantDiscovery {
             val nameMatched = nonDaemon.filter {
                 it.displayName.contains(nameFilter, ignoreCase = true)
             }
-            val structural = nameMatched.filter { info ->
-                info.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() ||
-                    info.pid in clientDescendants
-            }
-            structural
+            // Prefer client descendants over arbitrary daemon children so concurrent Gradle
+            // apps with the same main class are not stolen from another launch.
+            nameMatched
+                .filter { it.pid in clientDescendants }
                 .maxByOrNull { it.pid }
                 ?.pid
                 ?.let {
                     return it
                 }
-            // Native process-tree fallback: hsperfdata/list can lag behind spawn. Walk daemon
-            // children and client descendants via ProcessHandle and match command/args.
+            nameMatched
+                .filter { it.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() }
+                .maxByOrNull { it.pid }
+                ?.pid
+                ?.let {
+                    return it
+                }
+            // Native process-tree fallback: hsperfdata/list can lag behind spawn.
             return discoverByNativeTree(
                 clientPid = clientPid,
                 daemonPids = daemonPids,

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchExceptions.kt
@@ -1,0 +1,133 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Path
+
+/**
+ * Base for launch-and-attach readiness failures. Each subclass binds a distinct [stage] so callers
+ * can branch without parsing free-text messages.
+ *
+ * Lives outside the [dev.sebastiano.spectre.agent.SpectreAttachException] sealed hierarchy so
+ * launch-stage taxonomy stays independent of attach-only failure types (and Kotlin sealed
+ * subclasses must share a package with their parent).
+ */
+@ExperimentalSpectreAgentApi
+public sealed class LaunchException(
+    public val stage: LaunchStage,
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
+
+/**
+ * Stage [LaunchStage.PROCESS_ALIVE]: the launched process exited before it became attachable.
+ *
+ * @property exitCode process exit value (may be non-zero or zero).
+ * @property stderrExcerpt truncated contents of the stderr capture file at failure time.
+ * @property stdoutPath absolute path of the stdout capture file for this launch.
+ * @property stderrPath absolute path of the stderr capture file for this launch.
+ */
+@ExperimentalSpectreAgentApi
+public class ProcessExitedBeforeAttachException(
+    public val exitCode: Int,
+    public val stderrExcerpt: String,
+    public val stdoutPath: Path,
+    public val stderrPath: Path,
+    cause: Throwable? = null,
+) :
+    LaunchException(
+        stage = LaunchStage.PROCESS_ALIVE,
+        message =
+            buildString {
+                append("Launched process exited with code $exitCode before attach ")
+                append("(stage=${LaunchStage.PROCESS_ALIVE}). ")
+                append("stdout=$stdoutPath stderr=$stderrPath")
+                if (stderrExcerpt.isNotBlank()) {
+                    append("\n--- captured stderr (excerpt) ---\n")
+                    append(stderrExcerpt)
+                    if (!stderrExcerpt.endsWith("\n")) append('\n')
+                    append("--- end stderr ---")
+                }
+            },
+        cause = cause,
+    )
+
+/**
+ * Stage [LaunchStage.JVM_ATTACHABLE]: the process stayed alive but no attachable JVM was found
+ * within the stage timeout (direct PID or Gradle descendant discovery).
+ */
+@ExperimentalSpectreAgentApi
+public class JvmNotAttachableException(
+    public val launchedPid: Long,
+    public val timeoutMs: Long,
+    public val stdoutPath: Path,
+    public val stderrPath: Path,
+    public val detail: String = "",
+) :
+    LaunchException(
+        stage = LaunchStage.JVM_ATTACHABLE,
+        message =
+            buildString {
+                append("No attachable JVM for launched pid=$launchedPid within ${timeoutMs}ms ")
+                append("(stage=${LaunchStage.JVM_ATTACHABLE}). ")
+                append("stdout=$stdoutPath stderr=$stderrPath")
+                if (detail.isNotBlank()) append(" $detail")
+            },
+    )
+
+/**
+ * Stage [LaunchStage.AGENT_BOOTSTRAP]: the target JVM was attachable but agent load / bootstrap /
+ * UDS connect failed.
+ */
+@ExperimentalSpectreAgentApi
+public class LaunchAgentBootstrapException(
+    public val attachedPid: Long,
+    public val stdoutPath: Path,
+    public val stderrPath: Path,
+    cause: Throwable? = null,
+) :
+    LaunchException(
+        stage = LaunchStage.AGENT_BOOTSTRAP,
+        message =
+            "Agent bootstrap failed for pid=$attachedPid " +
+                "(stage=${LaunchStage.AGENT_BOOTSTRAP}). " +
+                "stdout=$stdoutPath stderr=$stderrPath" +
+                (cause?.message?.let { ": $it" }.orEmpty()),
+        cause = cause,
+    )
+
+/**
+ * Stage [LaunchStage.FIRST_WINDOW]: attach succeeded but no windows appeared within the stage
+ * timeout.
+ */
+@ExperimentalSpectreAgentApi
+public class FirstWindowTimeoutException(
+    public val attachedPid: Long,
+    public val timeoutMs: Long,
+    public val stdoutPath: Path,
+    public val stderrPath: Path,
+    cause: Throwable? = null,
+) :
+    LaunchException(
+        stage = LaunchStage.FIRST_WINDOW,
+        message =
+            "Attached pid=$attachedPid but no window appeared within ${timeoutMs}ms " +
+                "(stage=${LaunchStage.FIRST_WINDOW}). " +
+                "stdout=$stdoutPath stderr=$stderrPath",
+        cause = cause,
+    )
+
+/**
+ * Pre-flight failure: a direct JVM launch's classpath does not include `spectre-core` and
+ * [LaunchSpec.requireSpectreCoreOnClasspath] is true.
+ */
+@ExperimentalSpectreAgentApi
+public class SpectreCoreMissingOnClasspathException(public val classpath: String) :
+    LaunchException(
+        stage = LaunchStage.PROCESS_ALIVE,
+        message =
+            "LaunchSpec.requireSpectreCoreOnClasspath is true but the target classpath does " +
+                "not contain a spectre-core jar entry. Classpath excerpt: " +
+                classpath.take(CLASSPATH_EXCERPT_CHARS),
+    )
+
+private const val CLASSPATH_EXCERPT_CHARS: Int = 512

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -1,9 +1,17 @@
 package dev.sebastiano.spectre.agent.launch
 
 import dev.sebastiano.spectre.agent.AgentAttach
+import dev.sebastiano.spectre.agent.AgentBootstrapTimeoutException
+import dev.sebastiano.spectre.agent.AgentJarNotFoundException
+import dev.sebastiano.spectre.agent.AttachInterruptedException
 import dev.sebastiano.spectre.agent.AttachOptions
+import dev.sebastiano.spectre.agent.AttachPermissionDeniedException
+import dev.sebastiano.spectre.agent.AttachPlatformUnsupportedException
+import dev.sebastiano.spectre.agent.AttachUnsupportedException
 import dev.sebastiano.spectre.agent.AttachedAutomator
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.JavaVersionUnsupportedException
+import dev.sebastiano.spectre.agent.SpectreAgentException
 import dev.sebastiano.spectre.agent.SpectreAttachException
 import java.io.IOException
 import java.nio.charset.StandardCharsets
@@ -114,6 +122,23 @@ internal object LaunchReadiness {
             }
             try {
                 return AgentAttach.attach(attachedPid, options)
+            } catch (ex: AttachInterruptedException) {
+                // Cooperative cancellation must not be retried for the full stage budget.
+                Thread.currentThread().interrupt()
+                throw LaunchAgentBootstrapException(
+                    attachedPid = attachedPid,
+                    stdoutPath = stdoutPath,
+                    stderrPath = stderrPath,
+                    cause = ex,
+                )
+            } catch (ex: SpectreAgentException) {
+                // Protocol/handshake taxonomy from the wire — terminal for this launch.
+                throw LaunchAgentBootstrapException(
+                    attachedPid = attachedPid,
+                    stdoutPath = stdoutPath,
+                    stderrPath = stderrPath,
+                    cause = ex,
+                )
             } catch (ex: SpectreAttachException) {
                 lastFailure = ex
                 if (!isRetriableAttachFailure(ex)) {
@@ -125,6 +150,8 @@ internal object LaunchReadiness {
                     )
                 }
             } catch (ex: IOException) {
+                // Generic connect races (UDS not ready yet) are retriable; protocol errors are
+                // SpectreAgentException (caught above).
                 lastFailure = ex
             }
             sleepQuietly(POLL_MS)
@@ -183,16 +210,18 @@ internal object LaunchReadiness {
     }
 
     /**
-     * Permission / platform / jar-missing failures are terminal; bootstrap timeouts and generic
-     * connect races are retried within the stage budget.
+     * Bootstrap timeouts are retriable (agent may still be loading). Permission / platform /
+     * interrupt / jar-missing failures are terminal.
      */
     private fun isRetriableAttachFailure(ex: SpectreAttachException): Boolean =
         when (ex) {
-            is dev.sebastiano.spectre.agent.AttachPermissionDeniedException,
-            is dev.sebastiano.spectre.agent.AttachPlatformUnsupportedException,
-            is dev.sebastiano.spectre.agent.AttachUnsupportedException,
-            is dev.sebastiano.spectre.agent.JavaVersionUnsupportedException,
-            is dev.sebastiano.spectre.agent.AgentJarNotFoundException -> false
+            is AgentBootstrapTimeoutException -> true
+            is AttachInterruptedException,
+            is AttachPermissionDeniedException,
+            is AttachPlatformUnsupportedException,
+            is AttachUnsupportedException,
+            is JavaVersionUnsupportedException,
+            is AgentJarNotFoundException -> false
             else -> true
         }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -58,7 +58,11 @@ internal object LaunchReadiness {
             val pid =
                 if (gradleish) {
                     LaunchDescendantDiscovery.discoverAppJvm(launchedPid, nameFilter)
-                } else if (LaunchDescendantDiscovery.isJvmAttachable(launchedPid)) {
+                } else if (isDirectJvmReady(launchedPid, process)) {
+                    // Direct launches already know the target PID. Prefer VirtualMachine.list()
+                    // when available; if the process is still alive accept the launched PID even
+                    // when -XX:-UsePerfData hides it from list() (attach by explicit pid still
+                    // works — see SpectreProcesses docs).
                     launchedPid
                 } else {
                     null
@@ -76,12 +80,21 @@ internal object LaunchReadiness {
             stderrPath = stderrPath,
             detail =
                 if (gradleish) {
-                    "Gradle-ish launch: no descendant app JVM matched" +
+                    "Gradle-ish launch: no daemon-child/client-descendant app JVM matched" +
                         (nameFilter?.let { " nameFilter='$it'" }.orEmpty())
                 } else {
-                    "pid $launchedPid never appeared in VirtualMachine.list()"
+                    "pid $launchedPid is not attachable (process dead or not a live JVM)"
                 },
         )
+    }
+
+    /**
+     * Direct path: listed in Attach API, or still-alive process (covers -XX:-UsePerfData where
+     * list() omits the target but attach-by-pid still works).
+     */
+    private fun isDirectJvmReady(launchedPid: Long, process: Process): Boolean {
+        if (LaunchDescendantDiscovery.isJvmAttachable(launchedPid)) return true
+        return process.isAlive && ProcessHandle.of(launchedPid).map { it.isAlive }.orElse(false)
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -1,0 +1,223 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.AgentAttach
+import dev.sebastiano.spectre.agent.AttachOptions
+import dev.sebastiano.spectre.agent.AttachedAutomator
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.SpectreAttachException
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/** Per-stage readiness polls for [LaunchAndAttach]. */
+@ExperimentalSpectreAgentApi
+internal object LaunchReadiness {
+
+    /**
+     * Stage [LaunchStage.PROCESS_ALIVE]: the process must still be running after start. Polls for
+     * up to [timeoutMs] so an early crash is attributed here rather than a later stage.
+     */
+    fun awaitProcessAlive(process: Process, timeoutMs: Long, stdoutPath: Path, stderrPath: Path) {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+        // Minimum settle so a process that dies mid-classload still surfaces as stage-1 even when
+        // the caller passes a very small timeout.
+        val settleDeadline =
+            System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(minOf(timeoutMs, SETTLE_MS))
+        while (System.nanoTime() < deadline) {
+            if (!process.isAlive) {
+                throw processExited(process, stdoutPath, stderrPath)
+            }
+            // After the short settle window, process-alive is satisfied; remaining budget is for
+            // "still alive when we leave this stage", not for waiting the full timeout on success.
+            if (System.nanoTime() >= settleDeadline) return
+            sleepQuietly(POLL_MS)
+        }
+        if (!process.isAlive) {
+            throw processExited(process, stdoutPath, stderrPath)
+        }
+    }
+
+    fun awaitJvmAttachable(
+        process: Process,
+        launchedPid: Long,
+        gradleish: Boolean,
+        nameFilter: String?,
+        timeoutMs: Long,
+        stdoutPath: Path,
+        stderrPath: Path,
+    ): Long {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+        while (System.nanoTime() < deadline) {
+            if (!process.isAlive && !gradleish) {
+                throw processExited(process, stdoutPath, stderrPath)
+            }
+            val pid =
+                if (gradleish) {
+                    LaunchDescendantDiscovery.discoverAppJvm(launchedPid, nameFilter)
+                } else if (LaunchDescendantDiscovery.isJvmAttachable(launchedPid)) {
+                    launchedPid
+                } else {
+                    null
+                }
+            if (pid != null) return pid
+            sleepQuietly(POLL_MS)
+        }
+        if (!process.isAlive && !gradleish) {
+            throw processExited(process, stdoutPath, stderrPath)
+        }
+        throw JvmNotAttachableException(
+            launchedPid = launchedPid,
+            timeoutMs = timeoutMs,
+            stdoutPath = stdoutPath,
+            stderrPath = stderrPath,
+            detail =
+                if (gradleish) {
+                    "Gradle-ish launch: no descendant app JVM matched" +
+                        (nameFilter?.let { " nameFilter='$it'" }.orEmpty())
+                } else {
+                    "pid $launchedPid never appeared in VirtualMachine.list()"
+                },
+        )
+    }
+
+    /**
+     * Stage [LaunchStage.AGENT_BOOTSTRAP]: poll [AgentAttach.attach] until success, a terminal
+     * attach failure, process death, or [bootstrapTimeoutMs].
+     *
+     * Transient "agent not ready yet" failures are retried within the stage budget so a slow
+     * ComposeAutomator load does not fail the whole launch on the first attempt.
+     */
+    fun awaitAgentBootstrap(
+        process: Process,
+        attachedPid: Long,
+        gradleish: Boolean,
+        attachOptions: AttachOptions,
+        bootstrapTimeoutMs: Long,
+        stdoutPath: Path,
+        stderrPath: Path,
+    ): AttachedAutomator {
+        val options =
+            if (bootstrapTimeoutMs != attachOptions.attachTimeoutMs) {
+                attachOptions.copy(attachTimeoutMs = minOf(bootstrapTimeoutMs, ATTACH_ATTEMPT_MS))
+            } else {
+                attachOptions.copy(
+                    attachTimeoutMs = minOf(attachOptions.attachTimeoutMs, ATTACH_ATTEMPT_MS)
+                )
+            }
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(bootstrapTimeoutMs)
+        var lastFailure: Exception? = null
+        while (System.nanoTime() < deadline) {
+            if (!process.isAlive && !gradleish) {
+                throw processExited(process, stdoutPath, stderrPath)
+            }
+            try {
+                return AgentAttach.attach(attachedPid, options)
+            } catch (ex: SpectreAttachException) {
+                lastFailure = ex
+                if (!isRetriableAttachFailure(ex)) {
+                    throw LaunchAgentBootstrapException(
+                        attachedPid = attachedPid,
+                        stdoutPath = stdoutPath,
+                        stderrPath = stderrPath,
+                        cause = ex,
+                    )
+                }
+            } catch (ex: IOException) {
+                lastFailure = ex
+            }
+            sleepQuietly(POLL_MS)
+        }
+        throw LaunchAgentBootstrapException(
+            attachedPid = attachedPid,
+            stdoutPath = stdoutPath,
+            stderrPath = stderrPath,
+            cause = lastFailure,
+        )
+    }
+
+    fun awaitFirstWindow(
+        automator: AttachedAutomator,
+        attachedPid: Long,
+        timeoutMs: Long,
+        stdoutPath: Path,
+        stderrPath: Path,
+    ) {
+        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+        var lastError: IOException? = null
+        while (System.nanoTime() < deadline) {
+            try {
+                if (automator.windows().isNotEmpty()) return
+            } catch (ex: IOException) {
+                lastError = ex
+            }
+            sleepQuietly(POLL_MS)
+        }
+        throw FirstWindowTimeoutException(
+            attachedPid = attachedPid,
+            timeoutMs = timeoutMs,
+            stdoutPath = stdoutPath,
+            stderrPath = stderrPath,
+            cause = lastError,
+        )
+    }
+
+    fun processExited(
+        process: Process,
+        stdoutPath: Path,
+        stderrPath: Path,
+    ): ProcessExitedBeforeAttachException {
+        val exitCode =
+            try {
+                process.exitValue()
+            } catch (_: IllegalThreadStateException) {
+                -1
+            }
+        return ProcessExitedBeforeAttachException(
+            exitCode = exitCode,
+            stderrExcerpt = readExcerpt(stderrPath),
+            stdoutPath = stdoutPath,
+            stderrPath = stderrPath,
+        )
+    }
+
+    /**
+     * Permission / platform / jar-missing failures are terminal; bootstrap timeouts and generic
+     * connect races are retried within the stage budget.
+     */
+    private fun isRetriableAttachFailure(ex: SpectreAttachException): Boolean =
+        when (ex) {
+            is dev.sebastiano.spectre.agent.AttachPermissionDeniedException,
+            is dev.sebastiano.spectre.agent.AttachPlatformUnsupportedException,
+            is dev.sebastiano.spectre.agent.AttachUnsupportedException,
+            is dev.sebastiano.spectre.agent.JavaVersionUnsupportedException,
+            is dev.sebastiano.spectre.agent.AgentJarNotFoundException -> false
+            else -> true
+        }
+
+    private fun readExcerpt(path: Path, maxChars: Int = STDERR_EXCERPT_CHARS): String {
+        if (!Files.isRegularFile(path)) return ""
+        return try {
+            val text = Files.readString(path, StandardCharsets.UTF_8)
+            if (text.length <= maxChars) text else text.take(maxChars) + "\n…(truncated)…"
+        } catch (_: IOException) {
+            ""
+        }
+    }
+
+    private fun sleepQuietly(ms: Long) {
+        try {
+            Thread.sleep(ms)
+        } catch (ex: InterruptedException) {
+            Thread.currentThread().interrupt()
+            throw ex
+        }
+    }
+
+    private const val POLL_MS: Long = 50
+    private const val SETTLE_MS: Long = 250
+    /** Per-attempt attach budget so the outer stage can retry within [bootstrapTimeoutMs]. */
+    private const val ATTACH_ATTEMPT_MS: Long = 2_000
+    private const val STDERR_EXCERPT_CHARS: Int = 4_096
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -1,16 +1,10 @@
 package dev.sebastiano.spectre.agent.launch
 
 import dev.sebastiano.spectre.agent.AgentAttach
-import dev.sebastiano.spectre.agent.AgentBootstrapTimeoutException
-import dev.sebastiano.spectre.agent.AgentJarNotFoundException
 import dev.sebastiano.spectre.agent.AttachInterruptedException
 import dev.sebastiano.spectre.agent.AttachOptions
-import dev.sebastiano.spectre.agent.AttachPermissionDeniedException
-import dev.sebastiano.spectre.agent.AttachPlatformUnsupportedException
-import dev.sebastiano.spectre.agent.AttachUnsupportedException
 import dev.sebastiano.spectre.agent.AttachedAutomator
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
-import dev.sebastiano.spectre.agent.JavaVersionUnsupportedException
 import dev.sebastiano.spectre.agent.SpectreAgentException
 import dev.sebastiano.spectre.agent.SpectreAttachException
 import java.io.IOException
@@ -91,11 +85,13 @@ internal object LaunchReadiness {
     }
 
     /**
-     * Stage [LaunchStage.AGENT_BOOTSTRAP]: poll [AgentAttach.attach] until success, a terminal
-     * attach failure, process death, or [bootstrapTimeoutMs].
+     * Stage [LaunchStage.AGENT_BOOTSTRAP]: a **single** [AgentAttach.attach] with the stage budget
+     * as `attachTimeoutMs`.
      *
-     * Transient "agent not ready yet" failures are retried within the stage budget so a slow
-     * ComposeAutomator load does not fail the whole launch on the first attempt.
+     * Retries are intentionally avoided: each attach call may `loadAgent` with a UDS path, and a
+     * second attempt with a freshly generated path would wait forever while the already-loaded
+     * agent remains bound to the first socket (Codex P1). Stage 2 already waits for the JVM to
+     * appear in the Attach list before we get here.
      */
     fun awaitAgentBootstrap(
         process: Process,
@@ -106,62 +102,44 @@ internal object LaunchReadiness {
         stdoutPath: Path,
         stderrPath: Path,
     ): AttachedAutomator {
-        val options =
-            if (bootstrapTimeoutMs != attachOptions.attachTimeoutMs) {
-                attachOptions.copy(attachTimeoutMs = minOf(bootstrapTimeoutMs, ATTACH_ATTEMPT_MS))
-            } else {
-                attachOptions.copy(
-                    attachTimeoutMs = minOf(attachOptions.attachTimeoutMs, ATTACH_ATTEMPT_MS)
-                )
-            }
-        val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(bootstrapTimeoutMs)
-        var lastFailure: Exception? = null
-        while (System.nanoTime() < deadline) {
-            if (!process.isAlive && !gradleish) {
-                throw processExited(process, stdoutPath, stderrPath)
-            }
-            try {
-                return AgentAttach.attach(attachedPid, options)
-            } catch (ex: AttachInterruptedException) {
-                // Cooperative cancellation must not be retried for the full stage budget.
-                Thread.currentThread().interrupt()
-                throw LaunchAgentBootstrapException(
-                    attachedPid = attachedPid,
-                    stdoutPath = stdoutPath,
-                    stderrPath = stderrPath,
-                    cause = ex,
-                )
-            } catch (ex: SpectreAgentException) {
-                // Protocol/handshake taxonomy from the wire — terminal for this launch.
-                throw LaunchAgentBootstrapException(
-                    attachedPid = attachedPid,
-                    stdoutPath = stdoutPath,
-                    stderrPath = stderrPath,
-                    cause = ex,
-                )
-            } catch (ex: SpectreAttachException) {
-                lastFailure = ex
-                if (!isRetriableAttachFailure(ex)) {
-                    throw LaunchAgentBootstrapException(
-                        attachedPid = attachedPid,
-                        stdoutPath = stdoutPath,
-                        stderrPath = stderrPath,
-                        cause = ex,
-                    )
-                }
-            } catch (ex: IOException) {
-                // Generic connect races (UDS not ready yet) are retriable; protocol errors are
-                // SpectreAgentException (caught above).
-                lastFailure = ex
-            }
-            sleepQuietly(POLL_MS)
+        if (!process.isAlive && !gradleish) {
+            throw processExited(process, stdoutPath, stderrPath)
         }
-        throw LaunchAgentBootstrapException(
-            attachedPid = attachedPid,
-            stdoutPath = stdoutPath,
-            stderrPath = stderrPath,
-            cause = lastFailure,
-        )
+        // Pin UDS path for the whole stage (even if a future retry is reintroduced).
+        val udsPath = attachOptions.udsPath ?: AttachOptions.defaultUdsPath(attachedPid)
+        val options = attachOptions.copy(udsPath = udsPath, attachTimeoutMs = bootstrapTimeoutMs)
+        return try {
+            AgentAttach.attach(attachedPid, options)
+        } catch (ex: AttachInterruptedException) {
+            Thread.currentThread().interrupt()
+            throw LaunchAgentBootstrapException(
+                attachedPid = attachedPid,
+                stdoutPath = stdoutPath,
+                stderrPath = stderrPath,
+                cause = ex,
+            )
+        } catch (ex: SpectreAgentException) {
+            throw LaunchAgentBootstrapException(
+                attachedPid = attachedPid,
+                stdoutPath = stdoutPath,
+                stderrPath = stderrPath,
+                cause = ex,
+            )
+        } catch (ex: SpectreAttachException) {
+            throw LaunchAgentBootstrapException(
+                attachedPid = attachedPid,
+                stdoutPath = stdoutPath,
+                stderrPath = stderrPath,
+                cause = ex,
+            )
+        } catch (ex: IOException) {
+            throw LaunchAgentBootstrapException(
+                attachedPid = attachedPid,
+                stdoutPath = stdoutPath,
+                stderrPath = stderrPath,
+                cause = ex,
+            )
+        }
     }
 
     fun awaitFirstWindow(
@@ -209,22 +187,6 @@ internal object LaunchReadiness {
         )
     }
 
-    /**
-     * Bootstrap timeouts are retriable (agent may still be loading). Permission / platform /
-     * interrupt / jar-missing failures are terminal.
-     */
-    private fun isRetriableAttachFailure(ex: SpectreAttachException): Boolean =
-        when (ex) {
-            is AgentBootstrapTimeoutException -> true
-            is AttachInterruptedException,
-            is AttachPermissionDeniedException,
-            is AttachPlatformUnsupportedException,
-            is AttachUnsupportedException,
-            is JavaVersionUnsupportedException,
-            is AgentJarNotFoundException -> false
-            else -> true
-        }
-
     private fun readExcerpt(path: Path, maxChars: Int = STDERR_EXCERPT_CHARS): String {
         if (!Files.isRegularFile(path)) return ""
         return try {
@@ -246,7 +208,5 @@ internal object LaunchReadiness {
 
     private const val POLL_MS: Long = 50
     private const val SETTLE_MS: Long = 250
-    /** Per-attempt attach budget so the outer stage can retry within [bootstrapTimeoutMs]. */
-    private const val ATTACH_ATTEMPT_MS: Long = 2_000
     private const val STDERR_EXCERPT_CHARS: Int = 4_096
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -160,6 +160,18 @@ internal object LaunchReadiness {
         val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
         var lastError: IOException? = null
         while (System.nanoTime() < deadline) {
+            if (!ProcessHandle.of(attachedPid).map { it.isAlive }.orElse(false)) {
+                throw FirstWindowTimeoutException(
+                    attachedPid = attachedPid,
+                    timeoutMs = timeoutMs,
+                    stdoutPath = stdoutPath,
+                    stderrPath = stderrPath,
+                    cause =
+                        IllegalStateException(
+                            "Attached pid=$attachedPid exited before any window appeared"
+                        ),
+                )
+            }
             try {
                 if (automator.windows().isNotEmpty()) return
             } catch (ex: IOException) {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -127,6 +127,7 @@ internal object LaunchReadiness {
                 cause = ex,
             )
         } catch (ex: SpectreAgentException) {
+            rethrowIfProcessDied(process, gradleish, stdoutPath, stderrPath)
             throw LaunchAgentBootstrapException(
                 attachedPid = attachedPid,
                 stdoutPath = stdoutPath,
@@ -134,6 +135,7 @@ internal object LaunchReadiness {
                 cause = ex,
             )
         } catch (ex: SpectreAttachException) {
+            rethrowIfProcessDied(process, gradleish, stdoutPath, stderrPath)
             throw LaunchAgentBootstrapException(
                 attachedPid = attachedPid,
                 stdoutPath = stdoutPath,
@@ -141,12 +143,25 @@ internal object LaunchReadiness {
                 cause = ex,
             )
         } catch (ex: IOException) {
+            rethrowIfProcessDied(process, gradleish, stdoutPath, stderrPath)
             throw LaunchAgentBootstrapException(
                 attachedPid = attachedPid,
                 stdoutPath = stdoutPath,
                 stderrPath = stderrPath,
                 cause = ex,
             )
+        }
+    }
+
+    /** Prefer stage PROCESS_ALIVE when the process died during attach (race with early exit). */
+    private fun rethrowIfProcessDied(
+        process: Process,
+        gradleish: Boolean,
+        stdoutPath: Path,
+        stderrPath: Path,
+    ) {
+        if (!gradleish && !process.isAlive) {
+            throw processExited(process, stdoutPath, stderrPath)
         }
     }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -55,18 +55,17 @@ internal object LaunchReadiness {
             if (!process.isAlive && !gradleish) {
                 throw processExited(process, stdoutPath, stderrPath)
             }
-            val pid =
-                if (gradleish) {
-                    LaunchDescendantDiscovery.discoverAppJvm(launchedPid, nameFilter)
-                } else if (isDirectJvmReady(launchedPid, process)) {
-                    // Direct launches already know the target PID. Prefer VirtualMachine.list()
-                    // when available; if the process is still alive accept the launched PID even
-                    // when -XX:-UsePerfData hides it from list() (attach by explicit pid still
-                    // works — see SpectreProcesses docs).
-                    launchedPid
-                } else {
-                    null
+            if (!gradleish) {
+                // Direct launches already know the target PID. Stage PROCESS_ALIVE established
+                // the process is live; attach-by-pid works even when -XX:-UsePerfData hides the
+                // target from VirtualMachine.list() (see SpectreProcesses). Agent bootstrap's
+                // attachTimeoutMs covers "JVM not ready for loadAgent yet".
+                if (!process.isAlive) {
+                    throw processExited(process, stdoutPath, stderrPath)
                 }
+                return launchedPid
+            }
+            val pid = LaunchDescendantDiscovery.discoverAppJvm(launchedPid, nameFilter)
             if (pid != null) return pid
             sleepQuietly(POLL_MS)
         }
@@ -81,20 +80,16 @@ internal object LaunchReadiness {
             detail =
                 if (gradleish) {
                     "Gradle-ish launch: no daemon-child/client-descendant app JVM matched" +
-                        (nameFilter?.let { " nameFilter='$it'" }.orEmpty())
+                        (nameFilter?.let { " nameFilter='$it'" }.orEmpty()) +
+                        (if (nameFilter.isNullOrBlank()) {
+                            " (set LaunchSpec.appJvmNameFilter to disambiguate daemon children)"
+                        } else {
+                            ""
+                        })
                 } else {
-                    "pid $launchedPid is not attachable (process dead or not a live JVM)"
+                    "pid $launchedPid exited before attach"
                 },
         )
-    }
-
-    /**
-     * Direct path: listed in Attach API, or still-alive process (covers -XX:-UsePerfData where
-     * list() omits the target but attach-by-pid still works).
-     */
-    private fun isDirectJvmReady(launchedPid: Long, process: Process): Boolean {
-        if (LaunchDescendantDiscovery.isJvmAttachable(launchedPid)) return true
-        return process.isAlive && ProcessHandle.of(launchedPid).map { it.isAlive }.orElse(false)
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchSpec.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchSpec.kt
@@ -1,0 +1,51 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.AttachOptions
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Path
+
+/**
+ * Specification for starting a process and attaching Spectre to its app JVM.
+ *
+ * Prefer **prod-like** launches (`java -jar …`, installDist binaries, packaged apps). Gradle `run`
+ * / `hotRun` are supported but detected and warned about — see
+ * [LaunchCommandRewriter.isGradleishLaunch] and [LaunchCommandRewriter.gradleLaunchWarning].
+ *
+ * @property command argv to start (first token is the executable).
+ * @property workingDirectory optional cwd for the process; null keeps the attacher's cwd.
+ * @property environment extra environment entries merged over the current process env.
+ * @property extraJvmArgs JVM flags inserted after the `java` binary for direct JVM launches (after
+ *   any automatic `-XX:+EnableDynamicAgentLoading` injection). Ignored for non-JVM command lines.
+ * @property captureDirectory directory for stdout/stderr capture files; created if missing. When
+ *   null, a fresh temp directory is allocated under `java.io.tmpdir`.
+ * @property stageTimeouts per-stage readiness budgets.
+ * @property attachOptions agent JAR / UDS / attach-timeout options used at the bootstrap stage.
+ * @property appJvmNameFilter optional case-insensitive substring of
+ *   [dev.sebastiano.spectre.agent.JvmProcessInfo.displayName] used when discovering a Gradle-
+ *   spawned app JVM among descendants. When null on a Gradle-ish launch, any JVM descendant of the
+ *   client process (excluding the Gradle daemon) is considered.
+ * @property injectDynamicAgentLoading when true (default), direct `java` launches get
+ *   `-XX:+EnableDynamicAgentLoading` injected unless the flag is already present.
+ * @property requireSpectreCoreOnClasspath when true, direct JVM launches whose command line exposes
+ *   a classpath are rejected early if no `spectre-core` jar entry is found.
+ */
+@ExperimentalSpectreAgentApi
+public data class LaunchSpec(
+    public val command: List<String>,
+    public val workingDirectory: Path? = null,
+    public val environment: Map<String, String> = emptyMap(),
+    public val extraJvmArgs: List<String> = emptyList(),
+    public val captureDirectory: Path? = null,
+    public val stageTimeouts: LaunchStageTimeouts = LaunchStageTimeouts(),
+    public val attachOptions: AttachOptions = AttachOptions(),
+    public val appJvmNameFilter: String? = null,
+    public val injectDynamicAgentLoading: Boolean = true,
+    public val requireSpectreCoreOnClasspath: Boolean = false,
+) {
+    init {
+        require(command.isNotEmpty()) { "LaunchSpec.command must not be empty" }
+        require(command.first().isNotBlank()) {
+            "LaunchSpec.command[0] (executable) must not be blank"
+        }
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchStage.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchStage.kt
@@ -1,0 +1,24 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+
+/**
+ * Ordered readiness stages for [LaunchAndAttach.launch].
+ *
+ * Each stage failing produces a distinct [LaunchException] so callers can distinguish "exited
+ * before attach" from "attached but no window" without parsing free text.
+ */
+@ExperimentalSpectreAgentApi
+public enum class LaunchStage {
+    /** The launched OS process is still alive after start. */
+    PROCESS_ALIVE,
+
+    /** The target JVM is visible to the JDK Attach API (or discovered as a descendant). */
+    JVM_ATTACHABLE,
+
+    /** Agent load + bootstrap found `ComposeAutomator` and bound the UDS. */
+    AGENT_BOOTSTRAP,
+
+    /** At least one window is visible through the attached automator. */
+    FIRST_WINDOW,
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchStageTimeouts.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchStageTimeouts.kt
@@ -1,0 +1,28 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+
+/**
+ * Per-stage timeouts for [LaunchAndAttach.launch] readiness.
+ *
+ * Defaults favour CI-friendly Compose Desktop fixture boots without sleep-and-pray polling of the
+ * whole pipeline as one opaque budget.
+ */
+@ExperimentalSpectreAgentApi
+public data class LaunchStageTimeouts(
+    /** How long the process may take to stay alive after [ProcessBuilder.start]. */
+    public val processAliveMs: Long = DEFAULT_PROCESS_ALIVE_MS,
+    /** How long to wait for the target JVM to appear in Attach-API listings. */
+    public val jvmAttachableMs: Long = DEFAULT_JVM_ATTACHABLE_MS,
+    /** How long agent load + bootstrap + UDS connect may take. */
+    public val agentBootstrapMs: Long = DEFAULT_AGENT_BOOTSTRAP_MS,
+    /** How long after attach to wait for a non-empty `AttachedAutomator.windows()` list. */
+    public val firstWindowMs: Long = DEFAULT_FIRST_WINDOW_MS,
+) {
+    public companion object {
+        public const val DEFAULT_PROCESS_ALIVE_MS: Long = 5_000
+        public const val DEFAULT_JVM_ATTACHABLE_MS: Long = 15_000
+        public const val DEFAULT_AGENT_BOOTSTRAP_MS: Long = 15_000
+        public const val DEFAULT_FIRST_WINDOW_MS: Long = 30_000
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchedSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchedSession.kt
@@ -1,0 +1,42 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.AttachedAutomator
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * A process launched by [LaunchAndAttach] with a live [automator] session.
+ *
+ * Closing detaches the agent and tears down the app process tree (never the Gradle daemon on
+ * Gradle-ish launches). Capture files under [stdoutPath] / [stderrPath] are left in place for
+ * failure diagnostics.
+ *
+ * @property launchedPid OS pid of the process started from [LaunchSpec.command] (gradlew client on
+ *   Gradle-ish launches).
+ * @property attachedPid OS pid of the JVM Spectre attached to (equals [launchedPid] for direct
+ *   launches; the discovered app JVM for Gradle-ish launches).
+ * @property gradleish true when the launch was treated as Gradle-driven.
+ * @property warnings human-readable warnings emitted for this launch (e.g. Gradle caveats).
+ */
+@ExperimentalSpectreAgentApi
+public class LaunchedSession
+internal constructor(
+    public val launchedPid: Long,
+    public val attachedPid: Long,
+    public val automator: AttachedAutomator,
+    public val stdoutPath: Path,
+    public val stderrPath: Path,
+    public val gradleish: Boolean,
+    public val warnings: List<String>,
+    private val onClose: () -> Unit,
+) : AutoCloseable {
+
+    private val closed = AtomicBoolean(false)
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        runCatching { automator.close() }
+        onClose()
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/ProcessTreeTeardown.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/ProcessTreeTeardown.kt
@@ -1,0 +1,87 @@
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.util.concurrent.TimeUnit
+import kotlin.streams.asSequence
+
+/**
+ * Grace-then-force process-tree teardown via [ProcessHandle].
+ *
+ * For **direct** launches, [destroyTree] is invoked on the launched process root so children are
+ * reaped too. For **Gradle-ish** launches, call [destroyTree] only on the discovered app JVM —
+ * never on the Gradle client or daemon.
+ */
+@ExperimentalSpectreAgentApi
+public object ProcessTreeTeardown {
+
+    public const val DEFAULT_GRACE_MS: Long = 2_000
+
+    /**
+     * Destroy [root] and all of its live descendants: first [ProcessHandle.destroy] (graceful),
+     * wait up to [graceMs], then [ProcessHandle.destroyForcibly] on anything still alive.
+     *
+     * Descendants are signalled before the root so a parent waiting on children can exit cleanly
+     * during the grace window when the OS allows it.
+     *
+     * @return true when [root] is no longer alive after the force pass (or was already dead).
+     */
+    public fun destroyTree(root: ProcessHandle, graceMs: Long = DEFAULT_GRACE_MS): Boolean {
+        if (!root.isAlive) return true
+        val descendants =
+            try {
+                root.descendants().asSequence().toList()
+            } catch (_: UnsupportedOperationException) {
+                emptyList()
+            }
+        for (child in descendants) {
+            if (child.isAlive) {
+                runCatching { child.destroy() }
+            }
+        }
+        runCatching { root.destroy() }
+
+        val deadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(graceMs)
+        while (System.nanoTime() < deadlineNs) {
+            if (!root.isAlive && descendants.none { it.isAlive }) {
+                return true
+            }
+            sleepQuietly(POLL_MS)
+        }
+
+        for (child in descendants) {
+            if (child.isAlive) {
+                runCatching { child.destroyForcibly() }
+            }
+        }
+        if (root.isAlive) {
+            runCatching { root.destroyForcibly() }
+        }
+        // Brief wait for force kills to register.
+        val forceDeadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(FORCE_WAIT_MS)
+        while (System.nanoTime() < forceDeadlineNs && root.isAlive) {
+            sleepQuietly(POLL_MS)
+        }
+        return !root.isAlive
+    }
+
+    /**
+     * Destroy a single process tree identified by [pid] when the handle is still resolvable.
+     *
+     * @return true when the pid is gone (or was never resolvable as alive).
+     */
+    public fun destroyTreeByPid(pid: Long, graceMs: Long = DEFAULT_GRACE_MS): Boolean {
+        val handle = ProcessHandle.of(pid).orElse(null) ?: return true
+        return destroyTree(handle, graceMs)
+    }
+
+    private fun sleepQuietly(ms: Long) {
+        try {
+            Thread.sleep(ms)
+        } catch (ex: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
+
+    private const val POLL_MS: Long = 50
+    private const val FORCE_WAIT_MS: Long = 500
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachIntegrationTest.kt
@@ -1,0 +1,203 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.AttachOptions
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.fixture.TAG_LABEL
+import java.awt.GraphicsEnvironment
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * Issue #208 acceptance e2es for the launch-and-attach harness.
+ *
+ * (a) Direct `java` launch of `:agent-test-fixture` — staged readiness, exercise, teardown. (c)
+ * Binary that exits immediately → stage-1 taxonomy error with exit code + stderr.
+ *
+ * Gating matches [dev.sebastiano.spectre.agent.AgentAttachIntegrationTest]: Linux/macOS,
+ * non-headless, agent runtime jar property set by `:agent:test`.
+ */
+@EnabledOnOs(OS.LINUX, OS.MAC)
+class LaunchAndAttachIntegrationTest {
+
+    @Test
+    fun `direct java launch of fixture completes staged readiness exercise and tears down`() {
+        assumeFalse(
+            GraphicsEnvironment.isHeadless(),
+            "Requires non-headless JVM for Compose Desktop fixture",
+        )
+        val agentJar = locateAgentJarOrSkip()
+        val captureDir = Files.createTempDirectory("spectre-launch-e2e-direct-")
+        val attachedPid: Long
+
+        LaunchAndAttach.launch(
+                LaunchSpec(
+                    command = fixtureJavaCommand(),
+                    captureDirectory = captureDir,
+                    stageTimeouts =
+                        LaunchStageTimeouts(
+                            processAliveMs = 5_000,
+                            jvmAttachableMs = 15_000,
+                            agentBootstrapMs = 20_000,
+                            firstWindowMs = 30_000,
+                        ),
+                    attachOptions = AttachOptions(agentJarPath = agentJar, attachTimeoutMs = 20_000),
+                )
+            )
+            .use { session ->
+                assertFalse(session.gradleish)
+                assertEquals(session.launchedPid, session.attachedPid)
+                assertTrue(Files.isRegularFile(session.stdoutPath))
+                assertTrue(Files.isRegularFile(session.stderrPath))
+
+                val windows = session.automator.windows()
+                assertTrue(
+                    windows.isNotEmpty(),
+                    "expected fixture window after staged readiness; got $windows",
+                )
+                val labels = session.automator.findByTestTag(TAG_LABEL)
+                assertTrue(
+                    labels.isNotEmpty(),
+                    "expected fixture tag $TAG_LABEL after launch+attach",
+                )
+                attachedPid = session.attachedPid
+            }
+
+        // After close, the fixture process tree must be gone.
+        assertFalse(
+            ProcessHandle.of(attachedPid).map { it.isAlive }.orElse(false),
+            "fixture pid $attachedPid should be dead after LaunchedSession.close()",
+        )
+    }
+
+    @Test
+    fun `command that exits immediately fails stage PROCESS_ALIVE with exit code and stderr`() {
+        val captureDir = Files.createTempDirectory("spectre-launch-e2e-fail-")
+        val javaBin = javaBin()
+        // Force a non-zero exit with a diagnostic on stderr.
+        val command =
+            listOf(
+                javaBin,
+                "-cp",
+                "this-classpath-does-not-exist-xyz",
+                "dev.sebastiano.spectre.DoesNotExistMain",
+            )
+
+        val ex =
+            assertFailsWith<ProcessExitedBeforeAttachException> {
+                LaunchAndAttach.launch(
+                    LaunchSpec(
+                        command = command,
+                        captureDirectory = captureDir,
+                        // Disable injection so the failure is purely "bad classpath / exit".
+                        injectDynamicAgentLoading = true,
+                        stageTimeouts =
+                            LaunchStageTimeouts(
+                                processAliveMs = 5_000,
+                                jvmAttachableMs = 5_000,
+                                agentBootstrapMs = 5_000,
+                                firstWindowMs = 5_000,
+                            ),
+                    )
+                )
+            }
+
+        assertEquals(LaunchStage.PROCESS_ALIVE, ex.stage)
+        assertTrue(ex.exitCode != 0, "expected non-zero exit, got ${ex.exitCode}")
+        assertTrue(
+            Files.isRegularFile(ex.stdoutPath),
+            "stdout capture file must exist: ${ex.stdoutPath}",
+        )
+        assertTrue(
+            Files.isRegularFile(ex.stderrPath),
+            "stderr capture file must exist: ${ex.stderrPath}",
+        )
+        // JVM writes Error: Could not find or load main class… to stderr for bad main/cp.
+        val stderr = Files.readString(ex.stderrPath)
+        assertTrue(
+            stderr.isNotBlank() || ex.stderrExcerpt.isNotBlank(),
+            "expected captured stderr content; path=${ex.stderrPath} excerpt='${ex.stderrExcerpt}'",
+        )
+        assertTrue(
+            ex.message!!.contains("exit") || ex.message!!.contains("${ex.exitCode}"),
+            "message should carry exit code: ${ex.message}",
+        )
+        assertTrue(
+            ex.message!!.contains("PROCESS_ALIVE") ||
+                ex.message!!.contains(LaunchStage.PROCESS_ALIVE.name),
+            "message should identify stage: ${ex.message}",
+        )
+    }
+
+    @Test
+    fun `java -version exits as stage PROCESS_ALIVE with stderr capture files`() {
+        // Complements the rewriter unit tests that assert -XX:+EnableDynamicAgentLoading injection
+        // on the command line. This path proves capture files + stage taxonomy for a fast-exit
+        // java tool (exit code may be 0).
+        val captureDir = Files.createTempDirectory("spectre-launch-inject-")
+        val javaBin = javaBin()
+        val ex =
+            assertFailsWith<ProcessExitedBeforeAttachException> {
+                LaunchAndAttach.launch(
+                    LaunchSpec(
+                        command = listOf(javaBin, "-version"),
+                        captureDirectory = captureDir,
+                        injectDynamicAgentLoading = true,
+                    )
+                )
+            }
+        assertEquals(LaunchStage.PROCESS_ALIVE, ex.stage)
+        assertTrue(Files.isRegularFile(ex.stderrPath))
+        assertTrue(
+            Files.size(ex.stderrPath) > 0 || ex.stderrExcerpt.isNotBlank(),
+            "java -version should have produced stderr capture",
+        )
+    }
+
+    private fun fixtureJavaCommand(): List<String> {
+        val javaBin = javaBin()
+        val classpath = System.getProperty("java.class.path")
+        return listOf(
+            javaBin,
+            "-cp",
+            classpath,
+            // Harness injects EnableDynamicAgentLoading; do not set it here so e2e proves
+            // injection.
+            "-Djava.awt.headless=false",
+            "-Dcompose.application.configure.swing.globals=true",
+            "-Dapple.awt.UIElement=false",
+            "dev.sebastiano.spectre.agent.fixture.ComposeFixtureMainKt",
+        )
+    }
+
+    private fun javaBin(): String {
+        val exe =
+            if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) {
+                "java.exe"
+            } else {
+                "java"
+            }
+        return Paths.get(System.getProperty("java.home"), "bin", exe).toString()
+    }
+
+    private fun locateAgentJarOrSkip(): Path {
+        val prop = System.getProperty("dev.sebastiano.spectre.agent.runtimeJar")
+        assumeFalse(
+            prop.isNullOrBlank(),
+            "Requires -Ddev.sebastiano.spectre.agent.runtimeJar; :agent:test sets it.",
+        )
+        val path = Paths.get(prop!!)
+        assumeFalse(!Files.isRegularFile(path), "Agent runtime JAR not found at $path")
+        return path
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachIntegrationTest.kt
@@ -83,15 +83,10 @@ class LaunchAndAttachIntegrationTest {
     @Test
     fun `command that exits immediately fails stage PROCESS_ALIVE with exit code and stderr`() {
         val captureDir = Files.createTempDirectory("spectre-launch-e2e-fail-")
-        val javaBin = javaBin()
-        // Force a non-zero exit with a diagnostic on stderr.
+        // Use a non-JVM binary that exits immediately with stderr — avoids races where a dying
+        // HotSpot process is briefly attachable and fails as bootstrap instead of PROCESS_ALIVE.
         val command =
-            listOf(
-                javaBin,
-                "-cp",
-                "this-classpath-does-not-exist-xyz",
-                "dev.sebastiano.spectre.DoesNotExistMain",
-            )
+            listOf("/bin/sh", "-c", "echo 'spectre-launch-fail-fast-stderr' 1>&2; exit 17")
 
         val ex =
             assertFailsWith<ProcessExitedBeforeAttachException> {
@@ -99,8 +94,6 @@ class LaunchAndAttachIntegrationTest {
                     LaunchSpec(
                         command = command,
                         captureDirectory = captureDir,
-                        // Disable injection so the failure is purely "bad classpath / exit".
-                        injectDynamicAgentLoading = true,
                         stageTimeouts =
                             LaunchStageTimeouts(
                                 processAliveMs = 5_000,
@@ -113,7 +106,7 @@ class LaunchAndAttachIntegrationTest {
             }
 
         assertEquals(LaunchStage.PROCESS_ALIVE, ex.stage)
-        assertTrue(ex.exitCode != 0, "expected non-zero exit, got ${ex.exitCode}")
+        assertEquals(17, ex.exitCode)
         assertTrue(
             Files.isRegularFile(ex.stdoutPath),
             "stdout capture file must exist: ${ex.stdoutPath}",
@@ -122,14 +115,14 @@ class LaunchAndAttachIntegrationTest {
             Files.isRegularFile(ex.stderrPath),
             "stderr capture file must exist: ${ex.stderrPath}",
         )
-        // JVM writes Error: Could not find or load main class… to stderr for bad main/cp.
         val stderr = Files.readString(ex.stderrPath)
         assertTrue(
-            stderr.isNotBlank() || ex.stderrExcerpt.isNotBlank(),
+            stderr.contains("spectre-launch-fail-fast-stderr") ||
+                ex.stderrExcerpt.contains("spectre-launch-fail-fast-stderr"),
             "expected captured stderr content; path=${ex.stderrPath} excerpt='${ex.stderrExcerpt}'",
         )
         assertTrue(
-            ex.message!!.contains("exit") || ex.message!!.contains("${ex.exitCode}"),
+            ex.message!!.contains("17") || ex.message!!.contains("exit"),
             "message should carry exit code: ${ex.message}",
         )
         assertTrue(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriterTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriterTest.kt
@@ -28,7 +28,7 @@ class LaunchCommandRewriterTest {
     }
 
     @Test
-    fun `isGradleishLaunch detects gradlew gradle and hotRun`() {
+    fun `isGradleishLaunch detects gradlew and gradle launchers only`() {
         assertTrue(LaunchCommandRewriter.isGradleishLaunch(listOf("./gradlew", ":app:run")))
         assertTrue(LaunchCommandRewriter.isGradleishLaunch(listOf("gradlew.bat", "run")))
         assertTrue(LaunchCommandRewriter.isGradleishLaunch(listOf("/opt/gradle/bin/gradle", "run")))
@@ -37,16 +37,14 @@ class LaunchCommandRewriterTest {
                 listOf("./gradlew", ":sample-desktop:hotRunJvm")
             )
         )
-        assertTrue(
-            LaunchCommandRewriter.isGradleishLaunch(listOf("java", "-jar", "wrapper.jar", "hotRun"))
-        )
+        // Direct java must not become Gradle-ish just because an arg mentions hotRun.
         assertFalse(
-            LaunchCommandRewriter.isDirectJvmLaunch(listOf("./gradlew", ":app:run")).let {
-                // gradle is not a direct JVM launch
-                it
-            }
+            LaunchCommandRewriter.isGradleishLaunch(
+                listOf("java", "-jar", "hotrun-tools.jar", "hotRun")
+            )
         )
         assertFalse(LaunchCommandRewriter.isGradleishLaunch(listOf("java", "-jar", "app.jar")))
+        assertFalse(LaunchCommandRewriter.isDirectJvmLaunch(listOf("./gradlew", ":app:run")))
     }
 
     @Test

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriterTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriterTest.kt
@@ -1,0 +1,151 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LaunchCommandRewriterTest {
+
+    @Test
+    fun `isDirectJvmLaunch recognizes java basenames and absolute paths`() {
+        assertTrue(LaunchCommandRewriter.isDirectJvmLaunch(listOf("java", "-version")))
+        assertTrue(
+            LaunchCommandRewriter.isDirectJvmLaunch(listOf("/usr/bin/java", "-jar", "app.jar"))
+        )
+        assertTrue(
+            LaunchCommandRewriter.isDirectJvmLaunch(
+                listOf("""C:\Program Files\Java\bin\java.exe""", "-cp", "a.jar", "Main")
+            )
+        )
+        assertFalse(LaunchCommandRewriter.isDirectJvmLaunch(listOf("./gradlew", ":app:run")))
+        assertFalse(LaunchCommandRewriter.isDirectJvmLaunch(listOf("/usr/bin/python3", "app.py")))
+        assertFalse(LaunchCommandRewriter.isDirectJvmLaunch(emptyList()))
+    }
+
+    @Test
+    fun `isGradleishLaunch detects gradlew gradle and hotRun`() {
+        assertTrue(LaunchCommandRewriter.isGradleishLaunch(listOf("./gradlew", ":app:run")))
+        assertTrue(LaunchCommandRewriter.isGradleishLaunch(listOf("gradlew.bat", "run")))
+        assertTrue(LaunchCommandRewriter.isGradleishLaunch(listOf("/opt/gradle/bin/gradle", "run")))
+        assertTrue(
+            LaunchCommandRewriter.isGradleishLaunch(
+                listOf("./gradlew", ":sample-desktop:hotRunJvm")
+            )
+        )
+        assertTrue(
+            LaunchCommandRewriter.isGradleishLaunch(listOf("java", "-jar", "wrapper.jar", "hotRun"))
+        )
+        assertFalse(
+            LaunchCommandRewriter.isDirectJvmLaunch(listOf("./gradlew", ":app:run")).let {
+                // gradle is not a direct JVM launch
+                it
+            }
+        )
+        assertFalse(LaunchCommandRewriter.isGradleishLaunch(listOf("java", "-jar", "app.jar")))
+    }
+
+    @Test
+    fun `rewriteDirectJvmCommand injects EnableDynamicAgentLoading after java`() {
+        val rewritten =
+            LaunchCommandRewriter.rewriteDirectJvmCommand(
+                listOf("java", "-cp", "app.jar", "Main"),
+                extraJvmArgs = emptyList(),
+                inject = true,
+            )
+        assertEquals(
+            listOf(
+                "java",
+                LaunchCommandRewriter.DYNAMIC_AGENT_LOADING_FLAG,
+                "-cp",
+                "app.jar",
+                "Main",
+            ),
+            rewritten,
+        )
+    }
+
+    @Test
+    fun `rewriteDirectJvmCommand does not double-inject the flag`() {
+        val input = listOf("java", "-XX:+EnableDynamicAgentLoading", "-cp", "app.jar", "Main")
+        assertEquals(input, LaunchCommandRewriter.rewriteDirectJvmCommand(input, inject = true))
+    }
+
+    @Test
+    fun `rewriteDirectJvmCommand inserts extraJvmArgs after injected flag`() {
+        val rewritten =
+            LaunchCommandRewriter.rewriteDirectJvmCommand(
+                listOf("java", "-jar", "app.jar"),
+                extraJvmArgs = listOf("-Xmx512m", "-Dfoo=bar"),
+                inject = true,
+            )
+        assertEquals(
+            listOf(
+                "java",
+                LaunchCommandRewriter.DYNAMIC_AGENT_LOADING_FLAG,
+                "-Xmx512m",
+                "-Dfoo=bar",
+                "-jar",
+                "app.jar",
+            ),
+            rewritten,
+        )
+    }
+
+    @Test
+    fun `rewriteDirectJvmCommand leaves non-java commands unchanged`() {
+        val input = listOf("./gradlew", ":app:run")
+        assertEquals(
+            input,
+            LaunchCommandRewriter.rewriteDirectJvmCommand(
+                input,
+                extraJvmArgs = listOf("-Xmx1g"),
+                inject = true,
+            ),
+        )
+    }
+
+    @Test
+    fun `extractClasspath reads -cp and -classpath forms`() {
+        assertEquals(
+            "a.jar:b.jar",
+            LaunchCommandRewriter.extractClasspath(listOf("java", "-cp", "a.jar:b.jar", "Main")),
+        )
+        assertEquals(
+            "a.jar",
+            LaunchCommandRewriter.extractClasspath(listOf("java", "-classpath", "a.jar", "Main")),
+        )
+        assertNull(LaunchCommandRewriter.extractClasspath(listOf("java", "-jar", "app.jar")))
+        assertNull(LaunchCommandRewriter.extractClasspath(listOf("./gradlew", "run")))
+    }
+
+    @Test
+    fun `classpathContainsSpectreCore matches jar names and in-repo layout`() {
+        assertTrue(
+            LaunchCommandRewriter.classpathContainsSpectreCore(
+                "/repo/spectre-core-0.1.0.jar:/other/lib.jar"
+            )
+        )
+        assertTrue(
+            LaunchCommandRewriter.classpathContainsSpectreCore(
+                "/Users/seb/src/spectre/core/build/libs/core-0.1.0-SNAPSHOT.jar"
+            )
+        )
+        assertFalse(
+            LaunchCommandRewriter.classpathContainsSpectreCore("/only/agent-runtime.jar:/foo.jar")
+        )
+    }
+
+    @Test
+    fun `gradleLaunchWarning names the caveats`() {
+        val warning = LaunchCommandRewriter.gradleLaunchWarning()
+        assertTrue(warning.contains("Gradle-ish", ignoreCase = true))
+        assertTrue(warning.contains("daemon", ignoreCase = true))
+        assertTrue(warning.contains("EnableDynamicAgentLoading"))
+        assertTrue(warning.contains("prod-like", ignoreCase = true))
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriterTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchCommandRewriterTest.kt
@@ -121,6 +121,12 @@ class LaunchCommandRewriterTest {
         )
         assertNull(LaunchCommandRewriter.extractClasspath(listOf("java", "-jar", "app.jar")))
         assertNull(LaunchCommandRewriter.extractClasspath(listOf("./gradlew", "run")))
+        // Application args after -jar must not be read as launcher classpath.
+        assertNull(
+            LaunchCommandRewriter.extractClasspath(
+                listOf("java", "-jar", "app.jar", "-cp", "user-value")
+            )
+        )
     }
 
     @Test

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
@@ -1,0 +1,42 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class LaunchDescendantDiscoveryTest {
+
+    @Test
+    fun `isGradleDaemonDisplayName matches common daemon banners`() {
+        assertTrue(LaunchDescendantDiscovery.isGradleDaemonDisplayName("GradleDaemon 8.14"))
+        assertTrue(
+            LaunchDescendantDiscovery.isGradleDaemonDisplayName(
+                "org.gradle.launcher.daemon.bootstrap.GradleDaemon"
+            )
+        )
+        assertTrue(LaunchDescendantDiscovery.isGradleDaemonDisplayName("gradle-daemon"))
+        assertFalse(
+            LaunchDescendantDiscovery.isGradleDaemonDisplayName(
+                "dev.sebastiano.spectre.agent.fixture.ComposeFixtureMainKt"
+            )
+        )
+        assertFalse(LaunchDescendantDiscovery.isGradleDaemonDisplayName("SampleDesktopKt"))
+    }
+
+    @Test
+    fun `discoverAppJvm returns null when client pid has no descendants`() {
+        // Current process has no child JVMs in a normal unit-test run; must not fall back to
+        // attaching an arbitrary machine-wide JVM (e.g. the lowest listed PID).
+        val self = ProcessHandle.current().pid()
+        assertNull(LaunchDescendantDiscovery.discoverAppJvm(self, nameFilter = null))
+    }
+
+    @Test
+    fun `discoverAppJvm returns null for missing client pid`() {
+        assertNull(LaunchDescendantDiscovery.discoverAppJvm(Long.MAX_VALUE / 3, nameFilter = null))
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
@@ -28,15 +28,29 @@ class LaunchDescendantDiscoveryTest {
     }
 
     @Test
-    fun `discoverAppJvm returns null when client pid has no descendants`() {
-        // Current process has no child JVMs in a normal unit-test run; must not fall back to
-        // attaching an arbitrary machine-wide JVM (e.g. the lowest listed PID).
+    fun `discoverAppJvm returns null for impossible nameFilter`() {
         val self = ProcessHandle.current().pid()
-        assertNull(LaunchDescendantDiscovery.discoverAppJvm(self, nameFilter = null))
+        assertNull(
+            LaunchDescendantDiscovery.discoverAppJvm(
+                clientPid = self,
+                nameFilter = "DefinitelyNotARealMainClass_issue208_xyz",
+            )
+        )
     }
 
     @Test
-    fun `discoverAppJvm returns null for missing client pid`() {
-        assertNull(LaunchDescendantDiscovery.discoverAppJvm(Long.MAX_VALUE / 3, nameFilter = null))
+    fun `discoverAppJvm never returns a Gradle daemon pid`() {
+        val self = ProcessHandle.current().pid()
+        val found = LaunchDescendantDiscovery.discoverAppJvm(self, nameFilter = null)
+        if (found != null) {
+            // If structural discovery found something on this machine, it must not be a daemon.
+            val listed = dev.sebastiano.spectre.agent.SpectreProcesses.listJvmProcesses()
+            val display = listed.firstOrNull { it.pid == found }?.displayName.orEmpty()
+            assertFalse(
+                LaunchDescendantDiscovery.isGradleDaemonDisplayName(display),
+                "discoverAppJvm returned daemon pid=$found displayName='$display'",
+            )
+            assertTrue(found != self, "must not return the client pid itself")
+        }
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/ProcessTreeTeardownTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/ProcessTreeTeardownTest.kt
@@ -1,0 +1,61 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Paths
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+class ProcessTreeTeardownTest {
+
+    @Test
+    fun `destroyTreeByPid is no-op when handle is missing`() {
+        // Extremely unlikely to be a live process; of() empty → treated as already dead.
+        assertTrue(ProcessTreeTeardown.destroyTreeByPid(pid = Long.MAX_VALUE / 4))
+    }
+
+    @Test
+    fun `destroyTree is idempotent for a process that already exited`() {
+        val javaBin =
+            Paths.get(System.getProperty("java.home"), "bin", javaExecutableName()).toString()
+        val process =
+            ProcessBuilder(javaBin, "-version")
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+        process.waitFor(5, TimeUnit.SECONDS)
+        assertFalse(process.isAlive)
+        assertTrue(ProcessTreeTeardown.destroyTree(process.toHandle()))
+    }
+
+    @Test
+    fun `destroyTree kills a long-running process`() {
+        assumeTrue(
+            !System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true),
+            "Uses /bin/sleep; Windows path covered by integration teardown e2e",
+        )
+        val process =
+            ProcessBuilder("/bin/sleep", "3600")
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.DISCARD)
+                .start()
+        try {
+            assertTrue(process.isAlive, "sleep helper should still be running")
+            assertTrue(ProcessTreeTeardown.destroyTree(process.toHandle(), graceMs = 500))
+            assertFalse(process.isAlive, "process should be dead after destroyTree")
+        } finally {
+            if (process.isAlive) process.destroyForcibly()
+        }
+    }
+
+    private fun javaExecutableName(): String =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) {
+            "java.exe"
+        } else {
+            "java"
+        }
+}


### PR DESCRIPTION
## Summary

- Adds `LaunchAndAttach` in `:agent` (`dev.sebastiano.spectre.agent.launch`) as the core for issue #208: start a command, staged readiness, attach, tear down.
- Stages with distinct failures: process alive → JVM attachable → agent bootstrap → first window.
- Captures stdout/stderr to files from process start; stage-1 early exits include exit code + stderr excerpt.
- Direct `java` launches inject `-XX:+EnableDynamicAgentLoading`.
- ProcessHandle process-tree teardown (grace then force). Gradle-ish detection + safe descendant discovery (no machine-wide JVM fallback; never targets the Gradle daemon).
- E2E: direct fixture launch + fail-fast exit path. Unit tests for rewriter, discovery, teardown.

## Test plan

- [x] `./gradlew :agent:check` (ktfmt, detekt, ABI, tests including launch e2e)
- [x] `LaunchAndAttachIntegrationTest` — direct fixture + process-alive fail-fast
- [x] `LaunchCommandRewriterTest`, `LaunchDescendantDiscoveryTest`, `ProcessTreeTeardownTest`

## Out of scope (later phases)

- Full Gradle-run e2e / louder warning wiring in front-ends (P2 polish)
- `:testing` JUnit surface (P3)
- `spectre launch` CLI + guide docs (P4)

Closes nothing alone — tracks #208 phased delivery.