### PR TITLE
Launch harness front-ends: Gradle e2e, JUnit surface, spectre launch, docs (#208)

### DIFF
--- a/agent-test-fixture/build.gradle.kts
+++ b/agent-test-fixture/build.gradle.kts
@@ -23,10 +23,17 @@ dependencies {
     detektPlugins(libs.compose.rules.detekt)
 }
 
-// `./gradlew :agent-test-fixture:run` is intended only for manual verification of the
-// fixture — `AgentAttachIntegrationTest` spawns the fixture itself via `ProcessBuilder`.
+// `./gradlew :agent-test-fixture:run` is intended for manual verification and for the
+// launch-and-attach Gradle-path e2e (`LaunchAndAttachGradleIntegrationTest`). Direct
+// ProcessBuilder spawns in other agent tests still set their own JVM flags.
 // The `compose.desktop.application` block wires up the `run` task with the same JVM args
 // Compose Desktop would inject for a packaged native distribution.
 compose.desktop {
-    application { mainClass = "dev.sebastiano.spectre.agent.fixture.ComposeFixtureMainKt" }
+    application {
+        mainClass = "dev.sebastiano.spectre.agent.fixture.ComposeFixtureMainKt"
+        // So agent attach works without relying on JEP 451 stderr warnings when the
+        // launch harness drives `:agent-test-fixture:run` (Gradle cannot inject JVM args
+        // from outside the build).
+        jvmArgs += listOf("-XX:+EnableDynamicAgentLoading", "-Djava.awt.headless=false")
+    }
 }

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -208,7 +208,9 @@ public final class dev/sebastiano/spectre/agent/launch/LaunchAgentBootstrapExcep
 
 public final class dev/sebastiano/spectre/agent/launch/LaunchAndAttach {
 	public static final field INSTANCE Ldev/sebastiano/spectre/agent/launch/LaunchAndAttach;
-	public final fun launch (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;)Ldev/sebastiano/spectre/agent/launch/LaunchedSession;
+	public final fun getDEFAULT_WARNING_SINK ()Lkotlin/jvm/functions/Function1;
+	public final fun launch (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;)Ldev/sebastiano/spectre/agent/launch/LaunchedSession;
+	public static synthetic fun launch$default (Ldev/sebastiano/spectre/agent/launch/LaunchAndAttach;Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/launch/LaunchedSession;
 }
 
 public final class dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
@@ -26,14 +26,26 @@ public object LaunchAndAttach {
     /**
      * Start [spec], run staged readiness, and attach. On any stage failure the launched process
      * tree (or discovered app JVM for Gradle) is torn down before the exception propagates.
+     *
+     * @param warningSink receives loud operational warnings (e.g. Gradle-ish launch caveats).
+     *   Defaults to [System.err]. Warnings are also stored on [LaunchedSession.warnings].
      */
     @Throws(LaunchException::class, IOException::class)
-    public fun launch(spec: LaunchSpec): LaunchedSession {
+    public fun launch(
+        spec: LaunchSpec,
+        warningSink: (String) -> Unit = DEFAULT_WARNING_SINK,
+    ): LaunchedSession {
         require(spec.command.isNotEmpty()) { "command must not be empty" }
         val prepared = prepareLaunch(spec)
+        for (warning in prepared.warnings) {
+            warningSink(warning)
+        }
         val process = startProcess(prepared.command, spec, prepared.stdoutPath, prepared.stderrPath)
         return attachAfterStart(process, prepared, spec)
     }
+
+    /** Default warning destination — stderr so interactive tools and CI logs surface it. */
+    public val DEFAULT_WARNING_SINK: (String) -> Unit = { message -> System.err.println(message) }
 
     private data class PreparedLaunch(
         val command: List<String>,

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleIntegrationTest.kt
@@ -1,0 +1,152 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.AttachOptions
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.SpectreProcesses
+import dev.sebastiano.spectre.agent.fixture.TAG_LABEL
+import java.awt.GraphicsEnvironment
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * Issue #208 acceptance (b): Gradle-run launch through the harness.
+ *
+ * Asserts loud Gradle warning, app JVM discovery (not daemon), attach, exercise, and teardown that
+ * kills the app JVM while leaving any Gradle daemon alive.
+ *
+ * Gated like other agent UI e2es. Skips when no `gradlew` is found (e.g. incomplete checkout).
+ */
+@EnabledOnOs(OS.LINUX, OS.MAC)
+class LaunchAndAttachGradleIntegrationTest {
+
+    @Test
+    fun `gradle fixture run warns discovers app attaches and tears down without killing daemon`() {
+        assumeFalse(
+            GraphicsEnvironment.isHeadless(),
+            "Requires non-headless JVM for Compose Desktop fixture",
+        )
+        val agentJar = locateAgentJarOrSkip()
+        val repoRoot = locateRepoRootOrSkip()
+        val gradlew = repoRoot.resolve("gradlew")
+        assumeTrue(Files.isRegularFile(gradlew), "gradlew not found at $gradlew")
+        assumeTrue(Files.isExecutable(gradlew) || true, "gradlew present")
+
+        val daemonsBefore = gradleDaemonPids()
+        val captureDir = Files.createTempDirectory("spectre-launch-e2e-gradle-")
+        val warnings = mutableListOf<String>()
+        val attachedPid: Long
+
+        LaunchAndAttach.launch(
+                LaunchSpec(
+                    command = listOf(gradlew.toString(), ":agent-test-fixture:run", "-q"),
+                    workingDirectory = repoRoot,
+                    captureDirectory = captureDir,
+                    appJvmNameFilter = "ComposeFixtureMain",
+                    stageTimeouts =
+                        LaunchStageTimeouts(
+                            processAliveMs = 10_000,
+                            jvmAttachableMs = 120_000,
+                            agentBootstrapMs = 30_000,
+                            firstWindowMs = 60_000,
+                        ),
+                    attachOptions = AttachOptions(agentJarPath = agentJar, attachTimeoutMs = 15_000),
+                ),
+                warningSink = { warnings += it },
+            )
+            .use { session ->
+                assertTrue(session.gradleish, "expected Gradle-ish launch detection")
+                assertTrue(
+                    warnings.any { it.contains("Gradle-ish", ignoreCase = true) },
+                    "expected loud Gradle warning; got $warnings",
+                )
+                assertTrue(
+                    warnings.any { it.contains("daemon", ignoreCase = true) },
+                    "warning should mention daemon caveats",
+                )
+                // Attached pid must not be a Gradle daemon.
+                val attachedDisplay =
+                    SpectreProcesses.listJvmProcesses()
+                        .firstOrNull { it.pid == session.attachedPid }
+                        ?.displayName
+                        .orEmpty()
+                assertFalse(
+                    LaunchDescendantDiscovery.isGradleDaemonDisplayName(attachedDisplay),
+                    "must not attach to Gradle daemon; displayName='$attachedDisplay'",
+                )
+                assertTrue(
+                    session.attachedPid != session.launchedPid ||
+                        attachedDisplay.contains("ComposeFixture", ignoreCase = true),
+                    "attached pid should be the app JVM (displayName='$attachedDisplay')",
+                )
+
+                val windows = session.automator.windows()
+                assertTrue(windows.isNotEmpty(), "expected fixture windows after Gradle launch")
+                assertTrue(
+                    session.automator.findByTestTag(TAG_LABEL).isNotEmpty(),
+                    "expected fixture tag $TAG_LABEL",
+                )
+                attachedPid = session.attachedPid
+            }
+
+        assertFalse(
+            ProcessHandle.of(attachedPid).map { it.isAlive }.orElse(false),
+            "app JVM pid $attachedPid should be dead after session close",
+        )
+        // Daemons that existed before (or a daemon started for this run when not --no-daemon)
+        // must not all be wiped. With --no-daemon there may be none; with a pre-existing
+        // daemon pool, those PIDs should still be alive.
+        val daemonsAfter = gradleDaemonPids()
+        val stillAlive = daemonsBefore.filter { it in daemonsAfter }
+        if (daemonsBefore.isNotEmpty()) {
+            assertTrue(
+                stillAlive.isNotEmpty(),
+                "expected pre-existing Gradle daemon(s) to survive teardown; " +
+                    "before=$daemonsBefore after=$daemonsAfter",
+            )
+        }
+    }
+
+    private fun gradleDaemonPids(): Set<Long> =
+        runCatching { SpectreProcesses.listJvmProcesses() }
+            .getOrDefault(emptyList())
+            .filter { LaunchDescendantDiscovery.isGradleDaemonDisplayName(it.displayName) }
+            .map { it.pid }
+            .toSet()
+
+    private fun locateRepoRootOrSkip(): Path {
+        // Walk up from user.dir looking for settings.gradle.kts + gradlew.
+        var dir = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+        repeat(8) {
+            if (
+                Files.isRegularFile(dir.resolve("settings.gradle.kts")) &&
+                    Files.isRegularFile(dir.resolve("gradlew"))
+            ) {
+                return dir
+            }
+            dir = dir.parent ?: return@repeat
+        }
+        assumeTrue(false, "Could not locate repo root with gradlew from user.dir")
+        error("unreachable")
+    }
+
+    private fun locateAgentJarOrSkip(): Path {
+        val prop = System.getProperty("dev.sebastiano.spectre.agent.runtimeJar")
+        assumeFalse(
+            prop.isNullOrBlank(),
+            "Requires -Ddev.sebastiano.spectre.agent.runtimeJar; :agent:test sets it.",
+        )
+        val path = Paths.get(prop!!)
+        assumeFalse(!Files.isRegularFile(path), "Agent runtime JAR not found at $path")
+        return path
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleIntegrationTest.kt
@@ -39,7 +39,11 @@ class LaunchAndAttachGradleIntegrationTest {
         val repoRoot = locateRepoRootOrSkip()
         val gradlew = repoRoot.resolve("gradlew")
         assumeTrue(Files.isRegularFile(gradlew), "gradlew not found at $gradlew")
-        assumeTrue(Files.isExecutable(gradlew) || true, "gradlew present")
+        assumeTrue(
+            Files.isExecutable(gradlew) ||
+                System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true),
+            "gradlew not executable at $gradlew",
+        )
 
         val daemonsBefore = gradleDaemonPids()
         val captureDir = Files.createTempDirectory("spectre-launch-e2e-gradle-")

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachWarningTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachWarningTest.kt
@@ -1,0 +1,64 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Unit-level proof that Gradle-ish launches emit the loud warning through
+ * [LaunchAndAttach.launch]'s warning sink before process failure (no UI required).
+ */
+class LaunchAndAttachWarningTest {
+
+    @Test
+    fun `gradleish command emits warning via sink even when process fails fast`() {
+        val captureDir = Files.createTempDirectory("spectre-launch-warn-")
+        // Use a non-existent gradlew path so start fails or exits immediately — we only care
+        // that detection + warning fire before readiness completes.
+        val fakeGradlew =
+            Paths.get(captureDir.toString(), "gradlew").also {
+                Files.writeString(it, "#!/bin/sh\necho gradle-fake-stderr >&2\nexit 42\n")
+                it.toFile().setExecutable(true)
+            }
+        val warnings = mutableListOf<String>()
+        // Use an impossible nameFilter so discovery cannot attach to an unrelated daemon-child JVM
+        // on a busy developer machine; we only care that the warning fires.
+        val ex =
+            assertFailsWith<LaunchException> {
+                LaunchAndAttach.launch(
+                    LaunchSpec(
+                        command = listOf(fakeGradlew.toString(), ":app:run"),
+                        captureDirectory = captureDir,
+                        appJvmNameFilter = "NoSuchMainClass_issue208_warning_test",
+                        stageTimeouts =
+                            LaunchStageTimeouts(
+                                processAliveMs = 2_000,
+                                jvmAttachableMs = 2_000,
+                                agentBootstrapMs = 2_000,
+                                firstWindowMs = 2_000,
+                            ),
+                    ),
+                    warningSink = { warnings += it },
+                )
+            }
+        assertTrue(warnings.isNotEmpty(), "expected at least one warning before failure")
+        assertTrue(
+            warnings.any { it.contains("Gradle-ish", ignoreCase = true) },
+            "warnings=$warnings",
+        )
+        assertTrue(
+            warnings.any { it.contains("daemon", ignoreCase = true) },
+            "warnings should mention daemon; got $warnings",
+        )
+        // Stage may be PROCESS_ALIVE (script exits) or JVM_ATTACHABLE (no matching app JVM).
+        assertTrue(
+            ex.stage == LaunchStage.PROCESS_ALIVE || ex.stage == LaunchStage.JVM_ATTACHABLE,
+            "unexpected stage ${ex.stage}: ${ex.message}",
+        )
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/ProcessTreeTeardownTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/ProcessTreeTeardownTest.kt
@@ -46,6 +46,11 @@ class ProcessTreeTeardownTest {
         try {
             assertTrue(process.isAlive, "sleep helper should still be running")
             assertTrue(ProcessTreeTeardown.destroyTree(process.toHandle(), graceMs = 500))
+            // ProcessHandle may observe death slightly before Process.isAlive flips on some hosts.
+            assertTrue(
+                process.waitFor(2, TimeUnit.SECONDS),
+                "process should exit after destroyTree",
+            )
             assertFalse(process.isAlive, "process should be dead after destroyTree")
         } finally {
             if (process.isAlive) process.destroyForcibly()

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
@@ -58,8 +58,6 @@ internal class LaunchCommand(private val output: Appendable, private val errorOu
         if (command.isEmpty()) {
             throw CliktError("launch requires a command after --")
         }
-        // Released CLI packages embed agent-runtime; ensure AttachOptions can resolve it.
-        installEmbeddedAgentRuntimeForLaunch()
         val spec =
             LaunchSpec(
                 command = command,
@@ -67,6 +65,9 @@ internal class LaunchCommand(private val output: Appendable, private val errorOu
                 appJvmNameFilter = nameFilter,
             )
         try {
+            // Released CLI packages embed agent-runtime; ensure AttachOptions can resolve it.
+            // Kept inside try so install I/O failures report as launch I/O, not daemon errors.
+            installEmbeddedAgentRuntimeForLaunch()
             LaunchAndAttach.launch(spec) { warning ->
                     errorOutput.append(warning)
                     errorOutput.appendLine()

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
@@ -70,12 +70,19 @@ internal class LaunchCommand(private val output: Appendable, private val errorOu
         val shutdownHook =
             Thread(
                 {
-                    // Ctrl-C / JVM exit: do not rely on use{} unwinding during halt.
+                    // Ctrl-C / JVM exit: do not rely on finally{} unwinding during halt.
                     sessionRef.getAndSet(null)?.let { runCatching { it.close() } }
                 },
                 "spectre-launch-teardown",
             )
         try {
+            // Register the hook before launch so a Ctrl-C during launch still reaps if a session
+            // is published. IllegalStateException means the JVM is already shutting down.
+            try {
+                Runtime.getRuntime().addShutdownHook(shutdownHook)
+            } catch (ex: IllegalStateException) {
+                throw IOException("Cannot register launch teardown hook (JVM shutting down)", ex)
+            }
             // Released CLI packages embed agent-runtime; ensure AttachOptions can resolve it.
             // Kept inside try so install I/O failures report as launch I/O, not daemon errors.
             installEmbeddedAgentRuntimeForLaunch()
@@ -85,10 +92,7 @@ internal class LaunchCommand(private val output: Appendable, private val errorOu
                     errorOutput.appendLine()
                 }
             sessionRef.set(session)
-            // Always close the session if anything after launch fails (including hook
-            // registration).
             try {
-                runCatching { Runtime.getRuntime().addShutdownHook(shutdownHook) }
                 output.append("launchedPid=${session.launchedPid}")
                 output.append(" attachedPid=${session.attachedPid}")
                 output.append(" gradleish=${session.gradleish}")
@@ -112,7 +116,6 @@ internal class LaunchCommand(private val output: Appendable, private val errorOu
                 }
             } finally {
                 sessionRef.getAndSet(null)?.let { runCatching { it.close() } }
-                runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
             }
         } catch (ex: LaunchException) {
             errorOutput.append("Spectre launch error [${ex.stage}]: ${ex.message}")
@@ -122,6 +125,12 @@ internal class LaunchCommand(private val output: Appendable, private val errorOu
             errorOutput.append("Spectre launch I/O error: ${ex.message}")
             errorOutput.appendLine()
             throw ProgramResult(EXIT_ATTACH_FAILURE)
+        } finally {
+            // Drop the hook whether launch succeeded (normal teardown) or failed early.
+            runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
+            // If we aborted mid-flight without the inner finally, still close any published
+            // session.
+            sessionRef.getAndSet(null)?.let { runCatching { it.close() } }
         }
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
@@ -85,8 +85,10 @@ internal class LaunchCommand(private val output: Appendable, private val errorOu
                     errorOutput.appendLine()
                 }
             sessionRef.set(session)
-            Runtime.getRuntime().addShutdownHook(shutdownHook)
+            // Always close the session if anything after launch fails (including hook
+            // registration).
             try {
+                runCatching { Runtime.getRuntime().addShutdownHook(shutdownHook) }
                 output.append("launchedPid=${session.launchedPid}")
                 output.append(" attachedPid=${session.attachedPid}")
                 output.append(" gradleish=${session.gradleish}")

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
@@ -86,12 +86,14 @@ internal class LaunchCommand(private val output: Appendable, private val errorOu
             // Released CLI packages embed agent-runtime; ensure AttachOptions can resolve it.
             // Kept inside try so install I/O failures report as launch I/O, not daemon errors.
             installEmbeddedAgentRuntimeForLaunch()
+            // Publish into sessionRef in the same expression as launch returns so a Ctrl-C
+            // between "launch completed" and "ref assigned" cannot skip hook teardown.
             val session =
                 LaunchAndAttach.launch(spec) { warning ->
-                    errorOutput.append(warning)
-                    errorOutput.appendLine()
-                }
-            sessionRef.set(session)
+                        errorOutput.append(warning)
+                        errorOutput.appendLine()
+                    }
+                    .also { sessionRef.set(it) }
             try {
                 output.append("launchedPid=${session.launchedPid}")
                 output.append(" attachedPid=${session.attachedPid}")

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
@@ -1,0 +1,119 @@
+package dev.sebastiano.spectre.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.path
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.launch.LaunchAndAttach
+import dev.sebastiano.spectre.agent.launch.LaunchException
+import dev.sebastiano.spectre.agent.launch.LaunchSpec
+import dev.sebastiano.spectre.cli.daemon.EmbeddedAgentRuntime
+import java.io.IOException
+import java.nio.file.Path
+
+/**
+ * Launch a command, wait through staged readiness, attach Spectre, print a summary, then tear down
+ * when the command exits this process (or when `--once` finishes the first window check).
+ *
+ * Prefer prod-like launches. Gradle `run` / `hotRun` are supported but warn loudly.
+ *
+ * Examples:
+ * ```
+ * spectre launch -- java -jar app/build/libs/app.jar
+ * spectre launch -C /path/to/repo -- ./gradlew :app:run
+ * spectre launch --once -- java -cp fixture.jar FixtureMain
+ * ```
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal class LaunchCommand(private val output: Appendable, private val errorOutput: Appendable) :
+    CliktCommand(name = "launch") {
+    private val workingDirectory: Path? by
+        option("-C", "--directory", help = "Working directory for the launched process")
+            .path(mustExist = true, canBeFile = false, canBeDir = true)
+    private val nameFilter: String? by
+        option(
+            "--app-name",
+            help =
+                "Substring of the app JVM display name for Gradle-ish launches " +
+                    "(recommended when using ./gradlew)",
+        )
+    private val once: Boolean by
+        option(
+                "--once",
+                help =
+                    "Exit after staged readiness succeeds (print windows count) instead of holding " +
+                        "the session open until stdin EOF / interrupt",
+            )
+            .flag(default = false)
+    private val command: List<String> by
+        argument(help = "Command to launch; place after -- so flags are not consumed by spectre")
+            .multiple(required = true)
+
+    override fun run() {
+        if (command.isEmpty()) {
+            throw CliktError("launch requires a command after --")
+        }
+        // Released CLI packages embed agent-runtime; ensure AttachOptions can resolve it.
+        installEmbeddedAgentRuntimeForLaunch()
+        val spec =
+            LaunchSpec(
+                command = command,
+                workingDirectory = workingDirectory,
+                appJvmNameFilter = nameFilter,
+            )
+        try {
+            LaunchAndAttach.launch(spec) { warning ->
+                    errorOutput.append(warning)
+                    errorOutput.appendLine()
+                }
+                .use { session ->
+                    output.append("launchedPid=${session.launchedPid}")
+                    output.append(" attachedPid=${session.attachedPid}")
+                    output.append(" gradleish=${session.gradleish}")
+                    output.appendLine()
+                    output.append("stdout=${session.stdoutPath}")
+                    output.appendLine()
+                    output.append("stderr=${session.stderrPath}")
+                    output.appendLine()
+                    val windows = session.automator.windows()
+                    output.append("windows=${windows.size}")
+                    output.appendLine()
+                    if (!once) {
+                        output.append(
+                            "Session open — press Enter or send EOF to detach and tear down."
+                        )
+                        output.appendLine()
+                        // Hold the session for interactive use; teardown on close.
+                        try {
+                            System.`in`.read()
+                        } catch (_: IOException) {
+                            // stdin closed
+                        }
+                    }
+                }
+        } catch (ex: LaunchException) {
+            errorOutput.append("Spectre launch error [${ex.stage}]: ${ex.message}")
+            errorOutput.appendLine()
+            throw ProgramResult(EXIT_ATTACH_FAILURE)
+        } catch (ex: IOException) {
+            errorOutput.append("Spectre launch I/O error: ${ex.message}")
+            errorOutput.appendLine()
+            throw ProgramResult(EXIT_ATTACH_FAILURE)
+        }
+    }
+
+    private companion object {
+        const val EXIT_ATTACH_FAILURE: Int = 3
+    }
+}
+
+private fun installEmbeddedAgentRuntimeForLaunch() {
+    val prop = "dev.sebastiano.spectre.agent.runtimeJar"
+    if (System.getProperty(prop) != null) return
+    EmbeddedAgentRuntime.install()?.let { runtime -> System.setProperty(prop, runtime.toString()) }
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/LaunchCommand.kt
@@ -12,9 +12,11 @@ import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.launch.LaunchAndAttach
 import dev.sebastiano.spectre.agent.launch.LaunchException
 import dev.sebastiano.spectre.agent.launch.LaunchSpec
+import dev.sebastiano.spectre.agent.launch.LaunchedSession
 import dev.sebastiano.spectre.cli.daemon.EmbeddedAgentRuntime
 import java.io.IOException
 import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Launch a command, wait through staged readiness, attach Spectre, print a summary, then tear down
@@ -64,39 +66,52 @@ internal class LaunchCommand(private val output: Appendable, private val errorOu
                 workingDirectory = workingDirectory,
                 appJvmNameFilter = nameFilter,
             )
+        val sessionRef = AtomicReference<LaunchedSession?>(null)
+        val shutdownHook =
+            Thread(
+                {
+                    // Ctrl-C / JVM exit: do not rely on use{} unwinding during halt.
+                    sessionRef.getAndSet(null)?.let { runCatching { it.close() } }
+                },
+                "spectre-launch-teardown",
+            )
         try {
             // Released CLI packages embed agent-runtime; ensure AttachOptions can resolve it.
             // Kept inside try so install I/O failures report as launch I/O, not daemon errors.
             installEmbeddedAgentRuntimeForLaunch()
-            LaunchAndAttach.launch(spec) { warning ->
+            val session =
+                LaunchAndAttach.launch(spec) { warning ->
                     errorOutput.append(warning)
                     errorOutput.appendLine()
                 }
-                .use { session ->
-                    output.append("launchedPid=${session.launchedPid}")
-                    output.append(" attachedPid=${session.attachedPid}")
-                    output.append(" gradleish=${session.gradleish}")
+            sessionRef.set(session)
+            Runtime.getRuntime().addShutdownHook(shutdownHook)
+            try {
+                output.append("launchedPid=${session.launchedPid}")
+                output.append(" attachedPid=${session.attachedPid}")
+                output.append(" gradleish=${session.gradleish}")
+                output.appendLine()
+                output.append("stdout=${session.stdoutPath}")
+                output.appendLine()
+                output.append("stderr=${session.stderrPath}")
+                output.appendLine()
+                val windows = session.automator.windows()
+                output.append("windows=${windows.size}")
+                output.appendLine()
+                if (!once) {
+                    output.append("Session open — press Enter or send EOF to detach and tear down.")
                     output.appendLine()
-                    output.append("stdout=${session.stdoutPath}")
-                    output.appendLine()
-                    output.append("stderr=${session.stderrPath}")
-                    output.appendLine()
-                    val windows = session.automator.windows()
-                    output.append("windows=${windows.size}")
-                    output.appendLine()
-                    if (!once) {
-                        output.append(
-                            "Session open — press Enter or send EOF to detach and tear down."
-                        )
-                        output.appendLine()
-                        // Hold the session for interactive use; teardown on close.
-                        try {
-                            System.`in`.read()
-                        } catch (_: IOException) {
-                            // stdin closed
-                        }
+                    // Hold the session for interactive use; teardown on close or Ctrl-C.
+                    try {
+                        System.`in`.read()
+                    } catch (_: IOException) {
+                        // stdin closed
                     }
                 }
+            } finally {
+                sessionRef.getAndSet(null)?.let { runCatching { it.close() } }
+                runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
+            }
         } catch (ex: LaunchException) {
             errorOutput.append("Spectre launch error [${ex.stage}]: ${ex.message}")
             errorOutput.appendLine()

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -6,6 +6,7 @@ import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.parse
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -13,6 +14,9 @@ import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.long
 import com.github.ajalt.clikt.parameters.types.path
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.launch.LaunchAndAttach
+import dev.sebastiano.spectre.agent.launch.LaunchException
+import dev.sebastiano.spectre.agent.launch.LaunchSpec
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import dev.sebastiano.spectre.cli.daemon.CaptureSessionReport
@@ -56,7 +60,7 @@ public class SpectreCli(
 
     /** Parses and executes one CLI invocation, returning zero when it succeeds. */
     public fun run(arguments: List<String>): Int {
-        val command = RootCommand(request, shutdownRequest, output)
+        val command = RootCommand(request, shutdownRequest, output, errorOutput)
         return try {
             command.parse(arguments)
             EXIT_SUCCESS
@@ -127,11 +131,13 @@ private class RootCommand(
     request: (DaemonRequest) -> DaemonResponse,
     shutdownRequest: () -> DaemonResponse,
     output: Appendable,
+    errorOutput: Appendable,
 ) : CliktCommand(name = "spectre") {
     init {
         subcommands(
             AttachCommand(request, output),
             DetachCommand(request, output),
+            LaunchCommand(output, errorOutput),
             WindowsCommand(request, output),
             TreeCommand(request, output),
             FindCommand(request, output),
@@ -890,6 +896,92 @@ private class AttachCommand(
             output.append(humanSession(DaemonSessionSummary(session.sessionId, session.targetPid)))
         }
         output.appendLine()
+    }
+}
+
+/**
+ * Launch a command, wait through staged readiness, attach Spectre, print a summary, then tear down
+ * when the command exits this process (or when `--once` finishes the first window check).
+ *
+ * Prefer prod-like launches. Gradle `run` / `hotRun` are supported but warn loudly.
+ *
+ * Examples:
+ * ```
+ * spectre launch -- java -jar app/build/libs/app.jar
+ * spectre launch -C /path/to/repo -- ./gradlew :app:run
+ * spectre launch --once -- java -cp fixture.jar FixtureMain
+ * ```
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+private class LaunchCommand(private val output: Appendable, private val errorOutput: Appendable) :
+    CliktCommand(name = "launch") {
+    private val workingDirectory: Path? by
+        option("-C", "--directory", help = "Working directory for the launched process")
+            .path(mustExist = true, canBeFile = false, canBeDir = true)
+    private val nameFilter: String? by
+        option(
+            "--app-name",
+            help =
+                "Substring of the app JVM display name for Gradle-ish launches " +
+                    "(recommended when using ./gradlew)",
+        )
+    private val once: Boolean by
+        option(
+                "--once",
+                help =
+                    "Exit after staged readiness succeeds (print windows count) instead of holding " +
+                        "the session open until stdin EOF / interrupt",
+            )
+            .flag(default = false)
+    private val command: List<String> by
+        argument(help = "Command to launch; place after -- so flags are not consumed by spectre")
+            .multiple(required = true)
+
+    override fun run() {
+        if (command.isEmpty()) {
+            throw CliktError("launch requires a command after --")
+        }
+        val spec =
+            LaunchSpec(
+                command = command,
+                workingDirectory = workingDirectory,
+                appJvmNameFilter = nameFilter,
+            )
+        try {
+            LaunchAndAttach.launch(spec) { warning ->
+                    errorOutput.append(warning)
+                    errorOutput.appendLine()
+                }
+                .use { session ->
+                    output.append("launchedPid=${session.launchedPid}")
+                    output.append(" attachedPid=${session.attachedPid}")
+                    output.append(" gradleish=${session.gradleish}")
+                    output.appendLine()
+                    output.append("stdout=${session.stdoutPath}")
+                    output.appendLine()
+                    output.append("stderr=${session.stderrPath}")
+                    output.appendLine()
+                    val windows = session.automator.windows()
+                    output.append("windows=${windows.size}")
+                    output.appendLine()
+                    if (!once) {
+                        output.append(
+                            "Session open — press Enter or send EOF to detach and tear down."
+                        )
+                        output.appendLine()
+                        // Hold the session for interactive use; teardown on close.
+                        try {
+                            System.`in`.read()
+                        } catch (_: IOException) {
+                            // stdin closed
+                        }
+                    }
+                }
+        } catch (ex: LaunchException) {
+            errorOutput.append("Spectre launch error [${ex.stage}]: ${ex.message}")
+            errorOutput.appendLine()
+            throw ProgramResult(EXIT_ATTACH_FAILURE)
+        }
     }
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -941,6 +941,8 @@ private class LaunchCommand(private val output: Appendable, private val errorOut
         if (command.isEmpty()) {
             throw CliktError("launch requires a command after --")
         }
+        // Released CLI packages embed agent-runtime; ensure AttachOptions can resolve it.
+        installEmbeddedAgentRuntimeForLaunch()
         val spec =
             LaunchSpec(
                 command = command,
@@ -981,7 +983,19 @@ private class LaunchCommand(private val output: Appendable, private val errorOut
             errorOutput.append("Spectre launch error [${ex.stage}]: ${ex.message}")
             errorOutput.appendLine()
             throw ProgramResult(EXIT_ATTACH_FAILURE)
+        } catch (ex: IOException) {
+            errorOutput.append("Spectre launch I/O error: ${ex.message}")
+            errorOutput.appendLine()
+            throw ProgramResult(EXIT_ATTACH_FAILURE)
         }
+    }
+}
+
+private fun installEmbeddedAgentRuntimeForLaunch() {
+    val prop = "dev.sebastiano.spectre.agent.runtimeJar"
+    if (System.getProperty(prop) != null) return
+    dev.sebastiano.spectre.cli.daemon.EmbeddedAgentRuntime.install()?.let { runtime ->
+        System.setProperty(prop, runtime.toString())
     }
 }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -6,7 +6,6 @@ import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.parse
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
-import com.github.ajalt.clikt.parameters.arguments.multiple
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -14,9 +13,6 @@ import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.long
 import com.github.ajalt.clikt.parameters.types.path
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
-import dev.sebastiano.spectre.agent.launch.LaunchAndAttach
-import dev.sebastiano.spectre.agent.launch.LaunchException
-import dev.sebastiano.spectre.agent.launch.LaunchSpec
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import dev.sebastiano.spectre.cli.daemon.CaptureSessionReport
@@ -896,106 +892,6 @@ private class AttachCommand(
             output.append(humanSession(DaemonSessionSummary(session.sessionId, session.targetPid)))
         }
         output.appendLine()
-    }
-}
-
-/**
- * Launch a command, wait through staged readiness, attach Spectre, print a summary, then tear down
- * when the command exits this process (or when `--once` finishes the first window check).
- *
- * Prefer prod-like launches. Gradle `run` / `hotRun` are supported but warn loudly.
- *
- * Examples:
- * ```
- * spectre launch -- java -jar app/build/libs/app.jar
- * spectre launch -C /path/to/repo -- ./gradlew :app:run
- * spectre launch --once -- java -cp fixture.jar FixtureMain
- * ```
- */
-@OptIn(ExperimentalSpectreAgentApi::class)
-private class LaunchCommand(private val output: Appendable, private val errorOutput: Appendable) :
-    CliktCommand(name = "launch") {
-    private val workingDirectory: Path? by
-        option("-C", "--directory", help = "Working directory for the launched process")
-            .path(mustExist = true, canBeFile = false, canBeDir = true)
-    private val nameFilter: String? by
-        option(
-            "--app-name",
-            help =
-                "Substring of the app JVM display name for Gradle-ish launches " +
-                    "(recommended when using ./gradlew)",
-        )
-    private val once: Boolean by
-        option(
-                "--once",
-                help =
-                    "Exit after staged readiness succeeds (print windows count) instead of holding " +
-                        "the session open until stdin EOF / interrupt",
-            )
-            .flag(default = false)
-    private val command: List<String> by
-        argument(help = "Command to launch; place after -- so flags are not consumed by spectre")
-            .multiple(required = true)
-
-    override fun run() {
-        if (command.isEmpty()) {
-            throw CliktError("launch requires a command after --")
-        }
-        // Released CLI packages embed agent-runtime; ensure AttachOptions can resolve it.
-        installEmbeddedAgentRuntimeForLaunch()
-        val spec =
-            LaunchSpec(
-                command = command,
-                workingDirectory = workingDirectory,
-                appJvmNameFilter = nameFilter,
-            )
-        try {
-            LaunchAndAttach.launch(spec) { warning ->
-                    errorOutput.append(warning)
-                    errorOutput.appendLine()
-                }
-                .use { session ->
-                    output.append("launchedPid=${session.launchedPid}")
-                    output.append(" attachedPid=${session.attachedPid}")
-                    output.append(" gradleish=${session.gradleish}")
-                    output.appendLine()
-                    output.append("stdout=${session.stdoutPath}")
-                    output.appendLine()
-                    output.append("stderr=${session.stderrPath}")
-                    output.appendLine()
-                    val windows = session.automator.windows()
-                    output.append("windows=${windows.size}")
-                    output.appendLine()
-                    if (!once) {
-                        output.append(
-                            "Session open — press Enter or send EOF to detach and tear down."
-                        )
-                        output.appendLine()
-                        // Hold the session for interactive use; teardown on close.
-                        try {
-                            System.`in`.read()
-                        } catch (_: IOException) {
-                            // stdin closed
-                        }
-                    }
-                }
-        } catch (ex: LaunchException) {
-            errorOutput.append("Spectre launch error [${ex.stage}]: ${ex.message}")
-            errorOutput.appendLine()
-            throw ProgramResult(EXIT_ATTACH_FAILURE)
-        } catch (ex: IOException) {
-            errorOutput.append("Spectre launch I/O error: ${ex.message}")
-            errorOutput.appendLine()
-            throw ProgramResult(EXIT_ATTACH_FAILURE)
-        }
-    }
-}
-
-private fun installEmbeddedAgentRuntimeForLaunch() {
-    val prop = "dev.sebastiano.spectre.agent.runtimeJar"
-    if (System.getProperty(prop) != null) return
-    dev.sebastiano.spectre.cli.daemon.EmbeddedAgentRuntime.install()?.let { runtime ->
-        System.setProperty(prop, runtime.toString())
     }
 }
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliLaunchTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliLaunchTest.kt
@@ -1,0 +1,71 @@
+package dev.sebastiano.spectre.cli
+
+import dev.sebastiano.spectre.cli.daemon.DaemonRequest
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SpectreCliLaunchTest {
+
+    @Test
+    fun `launch help documents command form and options`() {
+        val output = StringBuilder()
+        val error = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { error("daemon should not be invoked for launch --help") },
+                output = output,
+                errorOutput = error,
+            )
+        // Clikt prints help to stderr via CliktError path with status 0 for --help.
+        val code = cli.run(listOf("launch", "--help"))
+        val combined = output.toString() + error.toString()
+        assertTrue(
+            code == 0 || combined.contains("launch", ignoreCase = true),
+            "help exit=$code out=$combined",
+        )
+        assertTrue(
+            combined.contains("launch") || combined.contains("Command"),
+            "expected launch help text: $combined",
+        )
+        assertTrue(
+            combined.contains("--once") ||
+                combined.contains("once") ||
+                combined.contains("directory"),
+            "expected launch options in help: $combined",
+        )
+    }
+
+    @Test
+    fun `launch once on java -version fails with attach-style exit and stage message`() {
+        val output = StringBuilder()
+        val error = StringBuilder()
+        val javaBin =
+            Paths.get(
+                    System.getProperty("java.home"),
+                    "bin",
+                    if (
+                        System.getProperty("os.name")
+                            .orEmpty()
+                            .startsWith("Windows", ignoreCase = true)
+                    )
+                        "java.exe"
+                    else "java",
+                )
+                .toString()
+        val cli =
+            SpectreCli(
+                request = { _: DaemonRequest -> error("daemon should not be called for launch") },
+                output = output,
+                errorOutput = error,
+            )
+        val code = cli.run(listOf("launch", "--once", "--", javaBin, "-version"))
+        assertEquals(3, code, "expected EXIT_ATTACH_FAILURE; err=$error out=$output")
+        assertTrue(
+            error.toString().contains("PROCESS_ALIVE") ||
+                error.toString().contains("launch error", ignoreCase = true),
+            "expected stage error on stderr: $error",
+        )
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -361,6 +361,13 @@ private fun spawnComposeFixture(): FixtureProcess {
         process.destroyForcibly()
         "Compose fixture did not emit $READY_SENTINEL"
     }
+    // READY is printed before the JVM is always attachable; give the target a short settle
+    // window so VirtualMachine.attach is less likely to race (macOS CI flakes).
+    Thread.sleep(FIXTURE_ATTACH_SETTLE_MS)
+    check(process.isAlive) {
+        process.destroyForcibly()
+        "Compose fixture exited immediately after $READY_SENTINEL"
+    }
     return FixtureProcess(process, reader, drainer)
 }
 
@@ -476,12 +483,14 @@ private fun attachWithRetry(
             is DaemonResponse.Attached -> return response
             is DaemonResponse.Error -> {
                 lastError = response
-                val notReady =
-                    response.message.contains("not ready to participate in attach handshake")
-                if (!notReady || attempt == ATTACH_RETRY_ATTEMPTS - 1) {
+                val retryable =
+                    response.message.contains("not ready to participate in attach handshake") ||
+                        response.message.contains("No such process") ||
+                        response.message.contains("AttachNotSupportedException")
+                if (!retryable || attempt == ATTACH_RETRY_ATTEMPTS - 1) {
                     return requireAttached(response)
                 }
-                Thread.sleep(ATTACH_RETRY_BACKOFF_MS * (attempt + 1))
+                Thread.sleep(ATTACH_RETRY_BACKOFF_MS * (attempt + 1L))
             }
             else -> return requireAttached(response)
         }
@@ -489,8 +498,9 @@ private fun attachWithRetry(
     return requireAttached(lastError ?: error("attach retry loop exited without a response"))
 }
 
-private const val ATTACH_RETRY_ATTEMPTS: Int = 5
-private const val ATTACH_RETRY_BACKOFF_MS: Long = 250
+private const val ATTACH_RETRY_ATTEMPTS: Int = 8
+private const val ATTACH_RETRY_BACKOFF_MS: Long = 400
+private const val FIXTURE_ATTACH_SETTLE_MS: Long = 750
 
 private suspend fun mcpText(client: Client, tool: String, arguments: Map<String, Any?>): String {
     val result = client.callTool(tool, arguments)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -179,17 +179,17 @@ class DaemonFixtureIntegrationTest {
         try {
             spawnComposeFixture().use { fixture ->
                 DaemonClient(socketPath).use { client ->
+                    // Target JVM can briefly refuse attach ("state is not ready to participate
+                    // in attach handshake") right after READY; retry before failing the suite.
                     val attached =
-                        requireAttached(
-                            client.requestOrStart(DaemonRequest.Attach(fixture.pid)) {
-                                daemon =
-                                    DaemonProcessLauncher(
-                                            socketPath = socketPath,
-                                            classPath = daemonFixtureRuntimeClassPath(),
-                                        )
-                                        .start()
-                            }
-                        )
+                        attachWithRetry(client, fixture.pid) {
+                            daemon =
+                                DaemonProcessLauncher(
+                                        socketPath = socketPath,
+                                        classPath = daemonFixtureRuntimeClassPath(),
+                                    )
+                                    .start()
+                        }
 
                     assertEquals(fixture.pid, attached.targetPid)
                     assertTrue(
@@ -463,6 +463,34 @@ private fun requireAttached(response: DaemonResponse): DaemonResponse.Attached =
             error("daemon attach failed: code=${response.code} message=${response.message}")
         else -> error("unexpected daemon response for attach: $response")
     }
+
+private fun attachWithRetry(
+    client: DaemonClient,
+    targetPid: Long,
+    startDaemon: () -> Unit,
+): DaemonResponse.Attached {
+    var lastError: DaemonResponse.Error? = null
+    repeat(ATTACH_RETRY_ATTEMPTS) { attempt ->
+        val response = client.requestOrStart(DaemonRequest.Attach(targetPid), start = startDaemon)
+        when (response) {
+            is DaemonResponse.Attached -> return response
+            is DaemonResponse.Error -> {
+                lastError = response
+                val notReady =
+                    response.message.contains("not ready to participate in attach handshake")
+                if (!notReady || attempt == ATTACH_RETRY_ATTEMPTS - 1) {
+                    return requireAttached(response)
+                }
+                Thread.sleep(ATTACH_RETRY_BACKOFF_MS * (attempt + 1))
+            }
+            else -> return requireAttached(response)
+        }
+    }
+    return requireAttached(lastError ?: error("attach retry loop exited without a response"))
+}
+
+private const val ATTACH_RETRY_ATTEMPTS: Int = 5
+private const val ATTACH_RETRY_BACKOFF_MS: Long = 250
 
 private suspend fun mcpText(client: Client, tool: String, arguments: Map<String, Any?>): String {
     val result = client.callTool(tool, arguments)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -180,14 +180,16 @@ class DaemonFixtureIntegrationTest {
             spawnComposeFixture().use { fixture ->
                 DaemonClient(socketPath).use { client ->
                     val attached =
-                        client.requestOrStart(DaemonRequest.Attach(fixture.pid)) {
-                            daemon =
-                                DaemonProcessLauncher(
-                                        socketPath = socketPath,
-                                        classPath = daemonFixtureRuntimeClassPath(),
-                                    )
-                                    .start()
-                        } as DaemonResponse.Attached
+                        requireAttached(
+                            client.requestOrStart(DaemonRequest.Attach(fixture.pid)) {
+                                daemon =
+                                    DaemonProcessLauncher(
+                                            socketPath = socketPath,
+                                            classPath = daemonFixtureRuntimeClassPath(),
+                                        )
+                                        .start()
+                            }
+                        )
 
                     assertEquals(fixture.pid, attached.targetPid)
                     assertTrue(
@@ -452,6 +454,15 @@ private fun startMcpBinary(daemonUser: String): Process {
         )
         .start()
 }
+
+/** Cast attach responses with a useful message when the daemon returns [DaemonResponse.Error]. */
+private fun requireAttached(response: DaemonResponse): DaemonResponse.Attached =
+    when (response) {
+        is DaemonResponse.Attached -> response
+        is DaemonResponse.Error ->
+            error("daemon attach failed: code=${response.code} message=${response.message}")
+        else -> error("unexpected daemon response for attach: $response")
+    }
 
 private suspend fun mcpText(client: Client, tool: String, arguments: Map<String, Any?>): String {
     val result = client.callTool(tool, arguments)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -326,6 +326,20 @@ private fun deleteDaemonSocketAndParent(socketPath: Path) {
 }
 
 private fun spawnComposeFixture(): FixtureProcess {
+    var lastError: String? = null
+    repeat(FIXTURE_SPAWN_ATTEMPTS) { attempt ->
+        try {
+            return spawnComposeFixtureOnce()
+        } catch (ex: IllegalStateException) {
+            lastError = ex.message
+            if (attempt == FIXTURE_SPAWN_ATTEMPTS - 1) throw ex
+            Thread.sleep(FIXTURE_ATTACH_SETTLE_MS * (attempt + 1L))
+        }
+    }
+    error(lastError ?: "Compose fixture failed to start")
+}
+
+private fun spawnComposeFixtureOnce(): FixtureProcess {
     val javaExe =
         if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) "java.exe"
         else "java"
@@ -501,6 +515,7 @@ private fun attachWithRetry(
 private const val ATTACH_RETRY_ATTEMPTS: Int = 8
 private const val ATTACH_RETRY_BACKOFF_MS: Long = 400
 private const val FIXTURE_ATTACH_SETTLE_MS: Long = 750
+private const val FIXTURE_SPAWN_ATTEMPTS: Int = 3
 
 private suspend fun mcpText(client: Client, tool: String, arguments: Map<String, Any?>): String {
     val result = client.callTool(tool, arguments)

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -34,11 +34,40 @@ authoritative reference for command arguments and options.
 
 The CLI follows a simple loop:
 
-1. Find a running JVM with `ps`.
-2. Attach it and retain the returned session ID.
+1. Find a running JVM with `ps`, **or** launch one with `spectre launch -- <command>`.
+2. Attach it and retain the returned session ID (or hold the launch session open).
 3. Inspect windows, the semantics tree, or nodes with a Compose test tag.
 4. Use a current node key to click or type, then inspect again.
 5. Capture a screenshot or recording when useful.
+
+### Launch and attach
+
+`spectre launch` starts a command, runs staged readiness (process alive → JVM attachable →
+agent bootstrap → first window), attaches Spectre, and tears the process tree down when the
+session ends. Prefer **prod-like** launches (`java -jar`, installDist, packaged apps). Gradle
+`./gradlew :app:run` / `hotRun` work but print a loud warning and require `--app-name` when the
+app JVM is daemon-spawned.
+
+```shell
+# Prod-like (recommended)
+spectre launch --once -- java -jar app/build/libs/app.jar
+
+# Gradle-ish (supported with warnings; name filter recommended)
+spectre launch --once --app-name ComposeFixtureMain -- ./gradlew :agent-test-fixture:run
+
+# Hold the session open until Enter / EOF, then tear down
+spectre launch -- java -jar app.jar
+```
+
+Options:
+
+- `-C` / `--directory` — working directory for the launched process
+- `--app-name` — substring of the app JVM display name (Gradle-ish descendant discovery)
+- `--once` — exit after readiness succeeds (print window count) instead of holding the session
+
+Stdout/stderr from the launched process are captured to files; their paths are printed on
+success. Stage failures print a taxonomy error such as `[PROCESS_ALIVE]` with exit code and
+stderr excerpt. See [Troubleshooting](troubleshooting.md#launch-and-attach-harness).
 
 For scripts and agents, add `--json` to a command that supports it. JSON output includes a
 format version and stable field names; use the returned session ID and node keys rather than

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -121,6 +121,26 @@ class LaunchedAppTest {
 }
 ```
 
+The extension implements `ParameterResolver`, so parallel-safe tests should take
+`LaunchedSession` or `AttachedAutomator` as method parameters (resolved from the
+per-invocation store). The `launchExt.automator` / `launchExt.launched` accessors return
+the most recent sequential session and can race under parallel execution:
+
+```kotlin
+@Test
+fun exercise(session: LaunchedSession) {
+    session.automator.windows()
+}
+
+@Test
+fun alsoFine(automator: AttachedAutomator) {
+    automator.windows()
+}
+```
+
+Because the extension needs a `LaunchSpec`, register it with `@RegisterExtension` (not
+`@ExtendWith`). Parameter injection still works for methods on the same test class.
+
 Prefer prod-like commands. For Gradle-ish launches, set `appJvmNameFilter` (main-class
 substring) so discovery can find the daemon-spawned app JVM without attaching an unrelated
 process. Direct `java` launches inject `-XX:+EnableDynamicAgentLoading` automatically.

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -127,6 +127,9 @@ The extension implements `ParameterResolver`, so when a class registers **one**
 `AttachedAutomator` as method parameters (resolved from the per-invocation store):
 
 ```kotlin
+import dev.sebastiano.spectre.agent.AttachedAutomator
+import dev.sebastiano.spectre.agent.launch.LaunchedSession
+
 @Test
 fun exercise(session: LaunchedSession) {
     session.automator.windows()

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -106,7 +106,8 @@ class LaunchedAppTest {
             LaunchSpec(
                 command =
                     listOf(
-                        javaBin,
+                        // java.home/bin/java (or java.exe on Windows)
+                        "${System.getProperty("java.home")}/bin/java",
                         "-jar",
                         "app/build/libs/app.jar",
                     )

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -82,6 +82,53 @@ class MyTest {
 getter, which is what JUnit 4 reflects on. Without the `get:` prefix Kotlin would put
 the annotation on the property itself and JUnit wouldn't see it.
 
+## Launch-and-attach harness
+
+When the UI under test is a **separate JVM** (prod-like `java -jar`, installDist, or even
+`./gradlew :app:run` with warnings), use `LaunchAndAttachExtension` (JUnit 5) or
+`LaunchAndAttachRule` (JUnit 4) from `:testing`. They call the shared agent launch core
+before each test and tear the process tree down after — the same lifecycle window
+`ComposeAutomatorExtension` / `ComposeAutomatorRule` use, so future failure-artifact
+hooks can compose freely.
+
+```kotlin
+import dev.sebastiano.spectre.agent.launch.LaunchSpec
+import dev.sebastiano.spectre.testing.LaunchAndAttachExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class LaunchedAppTest {
+
+    @JvmField
+    @RegisterExtension
+    val launchExt =
+        LaunchAndAttachExtension(
+            LaunchSpec(
+                command =
+                    listOf(
+                        javaBin,
+                        "-jar",
+                        "app/build/libs/app.jar",
+                    )
+            )
+        )
+
+    @Test
+    fun exercise() {
+        val windows = launchExt.automator.windows()
+        // …
+    }
+}
+```
+
+Prefer prod-like commands. For Gradle-ish launches, set `appJvmNameFilter` (main-class
+substring) so discovery can find the daemon-spawned app JVM without attaching an unrelated
+process. Direct `java` launches inject `-XX:+EnableDynamicAgentLoading` automatically.
+
+The full API lives in `dev.sebastiano.spectre.agent.launch` (`LaunchAndAttach`,
+`LaunchSpec`, stage exceptions). See [Agent attach](agent.md) and
+[Troubleshooting](troubleshooting.md#launch-and-attach-harness).
+
 ## Launching a Compose window from a test
 
 `application { Window(...) { ... } }` blocks until the app exits, so do not call it

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -121,10 +121,9 @@ class LaunchedAppTest {
 }
 ```
 
-The extension implements `ParameterResolver`, so parallel-safe tests should take
-`LaunchedSession` or `AttachedAutomator` as method parameters (resolved from the
-per-invocation store). The `launchExt.automator` / `launchExt.launched` accessors return
-the most recent sequential session and can race under parallel execution:
+The extension implements `ParameterResolver`, so when a class registers **one**
+`LaunchAndAttachExtension`, parallel-safe tests can take `LaunchedSession` or
+`AttachedAutomator` as method parameters (resolved from the per-invocation store):
 
 ```kotlin
 @Test
@@ -138,8 +137,14 @@ fun alsoFine(automator: AttachedAutomator) {
 }
 ```
 
+The `launchExt.automator` / `launchExt.launched` accessors are instance-specific and
+thread-local-backed, so they stay correct under parallel execution and when a class
+registers **two** launch extensions (app + helper). With two or more registrations,
+parameter injection is disabled to avoid competing resolvers — use the property
+accessors instead.
+
 Because the extension needs a `LaunchSpec`, register it with `@RegisterExtension` (not
-`@ExtendWith`). Parameter injection still works for methods on the same test class.
+`@ExtendWith`).
 
 Prefer prod-like commands. For Gradle-ish launches, set `appJvmNameFilter` (main-class
 substring) so discovery can find the daemon-spawned app JVM without attaching an unrelated

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -2,6 +2,37 @@
 
 Common surprises and their fixes, ordered roughly by how often they bite.
 
+## Launch-and-attach harness
+
+### "Launched process exited with code N before attach (PROCESS_ALIVE)"
+
+The process died before Spectre could attach. The exception message includes the exit
+code, paths to stdout/stderr capture files, and a stderr excerpt. Fix the app startup
+failure first (missing main class, bad classpath, AWT headless, etc.).
+
+### "No attachable JVM … (JVM_ATTACHABLE)" on a Gradle launch
+
+`./gradlew :app:run` spawns the app JVM from the **Gradle daemon**, not the `gradlew`
+client. Pass `LaunchSpec.appJvmNameFilter` / `spectre launch --app-name <MainClass>` so
+discovery can match the app among daemon children. Never kill the Gradle daemon to "fix"
+teardown — the harness only tears down the discovered app JVM.
+
+You will also see a loud **Gradle-ish** warning naming daemon, sandbox, and JEP 451
+caveats. Prefer a prod-like launch (`java -jar`, installDist) when you control the build.
+
+### "Agent bootstrap failed (AGENT_BOOTSTRAP)"
+
+The target JVM was found but the agent did not bind its UDS in time, or
+`ComposeAutomator` was not on the target classpath. Ensure the app depends on
+`spectre-core`, and for direct launches that Spectre injects
+`-XX:+EnableDynamicAgentLoading` (Gradle launches must set that flag in the build).
+
+### "Attached but no window (FIRST_WINDOW)"
+
+Attach succeeded but `windows()` stayed empty until timeout. The app may still be
+showing a splash screen, or the Compose tree never registered a window. Increase
+`LaunchStageTimeouts.firstWindowMs` or fix the UI startup path.
+
 ## "I called a wait helper from the EDT"
 
 ```

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -16,13 +16,16 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/jun
 	public final fun getAutomator ()Ldev/sebastiano/spectre/core/ComposeAutomator;
 }
 
-public final class dev/sebastiano/spectre/testing/LaunchAndAttachExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/BeforeEachCallback {
+public final class dev/sebastiano/spectre/testing/LaunchAndAttachExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/ParameterResolver {
 	public fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public final fun getAutomator ()Ldev/sebastiano/spectre/agent/AttachedAutomator;
 	public final fun getLaunched ()Ldev/sebastiano/spectre/agent/launch/LaunchedSession;
+	public final fun launchedFrom (Lorg/junit/jupiter/api/extension/ExtensionContext;)Ldev/sebastiano/spectre/agent/launch/LaunchedSession;
+	public fun resolveParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Ljava/lang/Object;
+	public fun supportsParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Z
 }
 
 public final class dev/sebastiano/spectre/testing/LaunchAndAttachRule : org/junit/rules/ExternalResource {

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -16,6 +16,24 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/jun
 	public final fun getAutomator ()Ldev/sebastiano/spectre/core/ComposeAutomator;
 }
 
+public final class dev/sebastiano/spectre/testing/LaunchAndAttachExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/BeforeEachCallback {
+	public fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
+	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
+	public final fun getAutomator ()Ldev/sebastiano/spectre/agent/AttachedAutomator;
+	public final fun getLaunched ()Ldev/sebastiano/spectre/agent/launch/LaunchedSession;
+}
+
+public final class dev/sebastiano/spectre/testing/LaunchAndAttachRule : org/junit/rules/ExternalResource {
+	public fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getAutomator ()Ldev/sebastiano/spectre/agent/AttachedAutomator;
+	public final fun getLaunched ()Ldev/sebastiano/spectre/agent/launch/LaunchedSession;
+	public final fun startSession ()V
+	public final fun stopSession ()V
+}
+
 public final class dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus {
 	public static final field INSTANCE Ldev/sebastiano/spectre/testing/contract/AutomatorContractCorpus;
 	public final fun run (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Ldev/sebastiano/spectre/testing/contract/AutomatorContractCorpus$RunResult;

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -17,6 +17,9 @@ kotlin {
 
 dependencies {
     api(projects.core)
+    // Launch-and-attach JUnit surface (#208) composes over the experimental agent launch API.
+    // Kept as `api` so consumers see `LaunchSpec` / `LaunchedSession` types from the extension.
+    api(projects.agent)
     // JUnit 4 and JUnit Jupiter are compileOnly so consumers pick whichever they're already
     // using; the testing module itself only references their public APIs.
     compileOnly(libs.junit4)
@@ -29,6 +32,8 @@ dependencies {
     testRuntimeOnly(libs.junit5.engine)
     // Lets us run the JUnit 4 rule via the JUnit Platform launcher in our own tests.
     testRuntimeOnly(libs.junit5.vintageEngine)
+    // Runtime jar path for attach e2es that launch fixtures via the harness.
+    testRuntimeOnly(projects.agentRuntime)
 }
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
@@ -1,0 +1,73 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.agent.AttachedAutomator
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.launch.LaunchAndAttach
+import dev.sebastiano.spectre.agent.launch.LaunchSpec
+import dev.sebastiano.spectre.agent.launch.LaunchedSession
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * JUnit 5 extension that launches a process via [LaunchAndAttach] before each test and tears it
+ * down afterwards.
+ *
+ * Composes with the same per-test lifecycle window as [ComposeAutomatorExtension] so future
+ * failure-artifact hooks (#205) can plug into after-each teardown without the launch harness owning
+ * that path.
+ *
+ * Usage:
+ * ```
+ * @JvmField
+ * @RegisterExtension
+ * val launchExt = LaunchAndAttachExtension(
+ *     LaunchSpec(command = listOf("java", "-jar", "app.jar"))
+ * )
+ *
+ * @Test fun exercise() {
+ *     launchExt.automator.windows()
+ * }
+ * ```
+ *
+ * Prefer a prod-like [LaunchSpec.command]. Gradle `run` / `hotRun` work but warn loudly.
+ */
+public class LaunchAndAttachExtension(
+    private val spec: LaunchSpec,
+    private val warningSink: (String) -> Unit = LaunchAndAttach.DEFAULT_WARNING_SINK,
+) : BeforeEachCallback, AfterEachCallback {
+
+    @Volatile private var session: LaunchedSession? = null
+
+    /** Live session for the current test; throws if accessed outside before/after. */
+    public val launched: LaunchedSession
+        get() =
+            checkNotNull(session) {
+                "LaunchAndAttachExtension.launched accessed outside of a running test"
+            }
+
+    /** Attached automator for the current test (same lifetime as [launched]). */
+    public val automator: AttachedAutomator
+        get() = launched.automator
+
+    override fun beforeEach(context: ExtensionContext) {
+        val launchedSession = LaunchAndAttach.launch(spec, warningSink)
+        context.getStore(NAMESPACE).put(STORE_KEY, launchedSession)
+        session = launchedSession
+    }
+
+    override fun afterEach(context: ExtensionContext) {
+        val stored = context.getStore(NAMESPACE).remove(STORE_KEY, LaunchedSession::class.java)
+        session = null
+        stored?.close()
+    }
+
+    private companion object {
+        val NAMESPACE: ExtensionContext.Namespace =
+            ExtensionContext.Namespace.create(LaunchAndAttachExtension::class.java)
+    }
+}
+
+private const val STORE_KEY: String = "launchedSession"

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
 import org.junit.jupiter.api.extension.ParameterResolver
+import org.junit.jupiter.api.extension.RegisterExtension
 
 /**
  * JUnit 5 extension that launches a process via [LaunchAndAttach] before each test and tears it
@@ -22,20 +23,24 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * failure-artifact hooks (#205) can plug into after-each teardown without the launch harness owning
  * that path.
  *
- * Sequential usage (`@RegisterExtension` property accessors):
+ * Sequential or multi-process usage (`@RegisterExtension` property accessors — instance-specific
+ * and parallel-safe via a thread-local):
  * ```
  * @JvmField
  * @RegisterExtension
- * val launchExt = LaunchAndAttachExtension(
- *     LaunchSpec(command = listOf("java", "-jar", "app.jar"))
- * )
+ * val app = LaunchAndAttachExtension(LaunchSpec(command = listOf("java", "-jar", "app.jar")))
+ *
+ * @JvmField
+ * @RegisterExtension
+ * val helper = LaunchAndAttachExtension(LaunchSpec(command = listOf("java", "-jar", "helper.jar")))
  *
  * @Test fun exercise() {
- *     launchExt.automator.windows()
+ *     app.automator.windows()
+ *     helper.automator.windows()
  * }
  * ```
  *
- * Parallel-safe usage (parameter injection from the per-invocation store):
+ * Single-extension parameter injection (parallel-safe from the per-invocation store):
  * ```
  * @JvmField
  * @RegisterExtension
@@ -55,8 +60,9 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * Prefer a prod-like [LaunchSpec.command]. Gradle `run` / `hotRun` work but warn loudly.
  *
  * Note: this extension requires a [LaunchSpec], so it is registered with `@RegisterExtension`
- * rather than `@ExtendWith`. [ParameterResolver] still applies to parameters of methods on the same
- * test class.
+ * rather than `@ExtendWith`. Parameter injection is enabled only when the test class registers a
+ * single [LaunchAndAttachExtension]; with two or more, use the property accessors so JUnit does not
+ * see competing [ParameterResolver]s.
  */
 public class LaunchAndAttachExtension(
     private val spec: LaunchSpec,
@@ -64,26 +70,28 @@ public class LaunchAndAttachExtension(
 ) : BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
     /**
-     * Live session for the **most recent** sequential `@RegisterExtension` test. Prefer parameter
-     * injection of [LaunchedSession] / [AttachedAutomator] (or [launchedFrom]) when running tests
-     * in parallel.
+     * Live session for the current test on this thread. Backed by a thread-local so parallel
+     * methods each see their own session even when multiple extension instances are registered.
+     * Prefer parameter injection of [LaunchedSession] / [AttachedAutomator] when a single extension
+     * is registered; prefer this accessor when multiple extensions share a class.
      */
     public val launched: LaunchedSession
         get() =
-            checkNotNull(lastSequentialSession) {
+            checkNotNull(threadSession.get() ?: lastSequentialSession) {
                 "LaunchAndAttachExtension.launched accessed outside of a running test"
             }
 
-    /** Attached automator for the current sequential test (same lifetime as [launched]). */
+    /** Attached automator for the current test (same lifetime as [launched]). */
     public val automator: AttachedAutomator
         get() = launched.automator
 
     @Volatile private var lastSequentialSession: LaunchedSession? = null
+    private val threadSession: ThreadLocal<LaunchedSession> = ThreadLocal()
 
     /**
      * Per-invocation session from [context] (parallel-safe). Prefer method-parameter injection of
-     * [LaunchedSession] / [AttachedAutomator] from test bodies; this accessor is for other
-     * extensions that already hold an [ExtensionContext].
+     * [LaunchedSession] / [AttachedAutomator] from test bodies when a single extension is
+     * registered; this accessor is for other extensions that already hold an [ExtensionContext].
      */
     public fun launchedFrom(context: ExtensionContext): LaunchedSession =
         checkNotNull(context.getStore(storeNamespace).get(STORE_KEY, LaunchedSession::class.java)) {
@@ -93,11 +101,15 @@ public class LaunchAndAttachExtension(
     override fun beforeEach(context: ExtensionContext) {
         val launchedSession = LaunchAndAttach.launch(spec, warningSink)
         context.getStore(storeNamespace).put(STORE_KEY, launchedSession)
+        threadSession.set(launchedSession)
         lastSequentialSession = launchedSession
     }
 
     override fun afterEach(context: ExtensionContext) {
         val stored = context.getStore(storeNamespace).remove(STORE_KEY, LaunchedSession::class.java)
+        if (threadSession.get() === stored) {
+            threadSession.remove()
+        }
         if (lastSequentialSession === stored) {
             lastSequentialSession = null
         }
@@ -112,6 +124,9 @@ public class LaunchAndAttachExtension(
         // Restrict resolution to per-test method invocations. Constructor parameters and
         // @BeforeAll / @AfterAll lifecycle hooks run outside the per-test window.
         if (!extensionContext.testMethod.isPresent) return false
+        // With two+ registered instances JUnit would see competing resolvers for the same types;
+        // refuse injection so callers use instance-specific property accessors instead.
+        if (!isSoleRegisteredExtension(extensionContext)) return false
         val type = parameterContext.parameter.type
         return type == LaunchedSession::class.java || type == AttachedAutomator::class.java
     }
@@ -138,6 +153,25 @@ public class LaunchAndAttachExtension(
      */
     private val storeNamespace: ExtensionContext.Namespace =
         ExtensionContext.Namespace.create(LaunchAndAttachExtension::class.java, this)
+
+    private companion object {
+        fun isSoleRegisteredExtension(context: ExtensionContext): Boolean {
+            val testClass = context.testClass.orElse(null) ?: return true
+            var count = 0
+            var cls: Class<*>? = testClass
+            while (cls != null && cls != Any::class.java) {
+                for (field in cls.declaredFields) {
+                    if (!field.isAnnotationPresent(RegisterExtension::class.java)) continue
+                    if (LaunchAndAttachExtension::class.java.isAssignableFrom(field.type)) {
+                        count++
+                        if (count > 1) return false
+                    }
+                }
+                cls = cls.superclass
+            }
+            return true
+        }
+    }
 }
 
 // File-level private constant rather than companion `const val` (which leaks into public ABI).

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
@@ -39,28 +39,39 @@ public class LaunchAndAttachExtension(
     private val warningSink: (String) -> Unit = LaunchAndAttach.DEFAULT_WARNING_SINK,
 ) : BeforeEachCallback, AfterEachCallback {
 
-    @Volatile private var session: LaunchedSession? = null
-
-    /** Live session for the current test; throws if accessed outside before/after. */
+    /**
+     * Live session for the **most recent** sequential `@RegisterExtension` test. Prefer
+     * [launchedFrom] when running tests in parallel.
+     */
     public val launched: LaunchedSession
         get() =
-            checkNotNull(session) {
+            checkNotNull(lastSequentialSession) {
                 "LaunchAndAttachExtension.launched accessed outside of a running test"
             }
 
-    /** Attached automator for the current test (same lifetime as [launched]). */
+    /** Attached automator for the current sequential test (same lifetime as [launched]). */
     public val automator: AttachedAutomator
         get() = launched.automator
+
+    @Volatile private var lastSequentialSession: LaunchedSession? = null
+
+    /** Per-invocation session from [context] (parallel-safe). */
+    public fun launchedFrom(context: ExtensionContext): LaunchedSession =
+        checkNotNull(context.getStore(NAMESPACE).get(STORE_KEY, LaunchedSession::class.java)) {
+            "No LaunchAndAttach session registered for this test invocation"
+        }
 
     override fun beforeEach(context: ExtensionContext) {
         val launchedSession = LaunchAndAttach.launch(spec, warningSink)
         context.getStore(NAMESPACE).put(STORE_KEY, launchedSession)
-        session = launchedSession
+        lastSequentialSession = launchedSession
     }
 
     override fun afterEach(context: ExtensionContext) {
         val stored = context.getStore(NAMESPACE).remove(STORE_KEY, LaunchedSession::class.java)
-        session = null
+        if (lastSequentialSession === stored) {
+            lastSequentialSession = null
+        }
         stored?.close()
     }
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
@@ -158,16 +158,22 @@ public class LaunchAndAttachExtension(
         fun isSoleRegisteredExtension(context: ExtensionContext): Boolean {
             val testClass = context.testClass.orElse(null) ?: return true
             var count = 0
-            var cls: Class<*>? = testClass
-            while (cls != null && cls != Any::class.java) {
-                for (field in cls.declaredFields) {
-                    if (!field.isAnnotationPresent(RegisterExtension::class.java)) continue
-                    if (LaunchAndAttachExtension::class.java.isAssignableFrom(field.type)) {
-                        count++
-                        if (count > 1) return false
+            // Walk this class, superclasses, and enclosing outer classes (@Nested inherits
+            // parent @RegisterExtension fields that still participate in resolution).
+            var nest: Class<*>? = testClass
+            while (nest != null && nest != Any::class.java) {
+                var cls: Class<*>? = nest
+                while (cls != null && cls != Any::class.java) {
+                    for (field in cls.declaredFields) {
+                        if (!field.isAnnotationPresent(RegisterExtension::class.java)) continue
+                        if (LaunchAndAttachExtension::class.java.isAssignableFrom(field.type)) {
+                            count++
+                            if (count > 1) return false
+                        }
                     }
+                    cls = cls.superclass
                 }
-                cls = cls.superclass
+                nest = nest.enclosingClass
             }
             return true
         }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
@@ -7,9 +7,12 @@ import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.launch.LaunchAndAttach
 import dev.sebastiano.spectre.agent.launch.LaunchSpec
 import dev.sebastiano.spectre.agent.launch.LaunchedSession
+import java.lang.reflect.Method
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.ParameterContext
+import org.junit.jupiter.api.extension.ParameterResolver
 
 /**
  * JUnit 5 extension that launches a process via [LaunchAndAttach] before each test and tears it
@@ -19,7 +22,7 @@ import org.junit.jupiter.api.extension.ExtensionContext
  * failure-artifact hooks (#205) can plug into after-each teardown without the launch harness owning
  * that path.
  *
- * Usage:
+ * Sequential usage (`@RegisterExtension` property accessors):
  * ```
  * @JvmField
  * @RegisterExtension
@@ -32,16 +35,38 @@ import org.junit.jupiter.api.extension.ExtensionContext
  * }
  * ```
  *
+ * Parallel-safe usage (parameter injection from the per-invocation store):
+ * ```
+ * @JvmField
+ * @RegisterExtension
+ * val launchExt = LaunchAndAttachExtension(
+ *     LaunchSpec(command = listOf("java", "-jar", "app.jar"))
+ * )
+ *
+ * @Test fun exercise(session: LaunchedSession) {
+ *     session.automator.windows()
+ * }
+ *
+ * @Test fun alsoFine(automator: AttachedAutomator) {
+ *     automator.windows()
+ * }
+ * ```
+ *
  * Prefer a prod-like [LaunchSpec.command]. Gradle `run` / `hotRun` work but warn loudly.
+ *
+ * Note: this extension requires a [LaunchSpec], so it is registered with `@RegisterExtension`
+ * rather than `@ExtendWith`. [ParameterResolver] still applies to parameters of methods on the same
+ * test class.
  */
 public class LaunchAndAttachExtension(
     private val spec: LaunchSpec,
     private val warningSink: (String) -> Unit = LaunchAndAttach.DEFAULT_WARNING_SINK,
-) : BeforeEachCallback, AfterEachCallback {
+) : BeforeEachCallback, AfterEachCallback, ParameterResolver {
 
     /**
-     * Live session for the **most recent** sequential `@RegisterExtension` test. Prefer
-     * [launchedFrom] when running tests in parallel.
+     * Live session for the **most recent** sequential `@RegisterExtension` test. Prefer parameter
+     * injection of [LaunchedSession] / [AttachedAutomator] (or [launchedFrom]) when running tests
+     * in parallel.
      */
     public val launched: LaunchedSession
         get() =
@@ -55,7 +80,11 @@ public class LaunchAndAttachExtension(
 
     @Volatile private var lastSequentialSession: LaunchedSession? = null
 
-    /** Per-invocation session from [context] (parallel-safe). */
+    /**
+     * Per-invocation session from [context] (parallel-safe). Prefer method-parameter injection of
+     * [LaunchedSession] / [AttachedAutomator] from test bodies; this accessor is for other
+     * extensions that already hold an [ExtensionContext].
+     */
     public fun launchedFrom(context: ExtensionContext): LaunchedSession =
         checkNotNull(context.getStore(NAMESPACE).get(STORE_KEY, LaunchedSession::class.java)) {
             "No LaunchAndAttach session registered for this test invocation"
@@ -73,6 +102,34 @@ public class LaunchAndAttachExtension(
             lastSequentialSession = null
         }
         stored?.close()
+    }
+
+    override fun supportsParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext,
+    ): Boolean {
+        if (parameterContext.declaringExecutable !is Method) return false
+        // Restrict resolution to per-test method invocations. Constructor parameters and
+        // @BeforeAll / @AfterAll lifecycle hooks run outside the per-test window.
+        if (!extensionContext.testMethod.isPresent) return false
+        val type = parameterContext.parameter.type
+        return type == LaunchedSession::class.java || type == AttachedAutomator::class.java
+    }
+
+    override fun resolveParameter(
+        parameterContext: ParameterContext,
+        extensionContext: ExtensionContext,
+    ): Any {
+        val session = launchedFrom(extensionContext)
+        return when (parameterContext.parameter.type) {
+            LaunchedSession::class.java -> session
+            AttachedAutomator::class.java -> session.automator
+            else ->
+                error(
+                    "LaunchAndAttachExtension cannot resolve parameter type " +
+                        parameterContext.parameter.type.name
+                )
+        }
     }
 
     private companion object {

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
@@ -86,18 +86,18 @@ public class LaunchAndAttachExtension(
      * extensions that already hold an [ExtensionContext].
      */
     public fun launchedFrom(context: ExtensionContext): LaunchedSession =
-        checkNotNull(context.getStore(NAMESPACE).get(STORE_KEY, LaunchedSession::class.java)) {
+        checkNotNull(context.getStore(storeNamespace).get(STORE_KEY, LaunchedSession::class.java)) {
             "No LaunchAndAttach session registered for this test invocation"
         }
 
     override fun beforeEach(context: ExtensionContext) {
         val launchedSession = LaunchAndAttach.launch(spec, warningSink)
-        context.getStore(NAMESPACE).put(STORE_KEY, launchedSession)
+        context.getStore(storeNamespace).put(STORE_KEY, launchedSession)
         lastSequentialSession = launchedSession
     }
 
     override fun afterEach(context: ExtensionContext) {
-        val stored = context.getStore(NAMESPACE).remove(STORE_KEY, LaunchedSession::class.java)
+        val stored = context.getStore(storeNamespace).remove(STORE_KEY, LaunchedSession::class.java)
         if (lastSequentialSession === stored) {
             lastSequentialSession = null
         }
@@ -132,10 +132,13 @@ public class LaunchAndAttachExtension(
         }
     }
 
-    private companion object {
-        val NAMESPACE: ExtensionContext.Namespace =
-            ExtensionContext.Namespace.create(LaunchAndAttachExtension::class.java)
-    }
+    /**
+     * Per-instance store namespace so two `@RegisterExtension` fields on the same test class do not
+     * overwrite each other's sessions under a shared class-level key.
+     */
+    private val storeNamespace: ExtensionContext.Namespace =
+        ExtensionContext.Namespace.create(LaunchAndAttachExtension::class.java, this)
 }
 
+// File-level private constant rather than companion `const val` (which leaks into public ABI).
 private const val STORE_KEY: String = "launchedSession"

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtension.kt
@@ -72,20 +72,23 @@ public class LaunchAndAttachExtension(
     /**
      * Live session for the current test on this thread. Backed by a thread-local so parallel
      * methods each see their own session even when multiple extension instances are registered.
+     * Capture the session (or [automator]) on the test thread before hopping to child threads —
+     * child threads do not inherit the thread-local.
+     *
      * Prefer parameter injection of [LaunchedSession] / [AttachedAutomator] when a single extension
      * is registered; prefer this accessor when multiple extensions share a class.
      */
     public val launched: LaunchedSession
         get() =
-            checkNotNull(threadSession.get() ?: lastSequentialSession) {
-                "LaunchAndAttachExtension.launched accessed outside of a running test"
+            checkNotNull(threadSession.get()) {
+                "LaunchAndAttachExtension.launched accessed outside of a running test " +
+                    "(or from a child thread that did not capture the session on the test thread)"
             }
 
     /** Attached automator for the current test (same lifetime as [launched]). */
     public val automator: AttachedAutomator
         get() = launched.automator
 
-    @Volatile private var lastSequentialSession: LaunchedSession? = null
     private val threadSession: ThreadLocal<LaunchedSession> = ThreadLocal()
 
     /**
@@ -102,17 +105,11 @@ public class LaunchAndAttachExtension(
         val launchedSession = LaunchAndAttach.launch(spec, warningSink)
         context.getStore(storeNamespace).put(STORE_KEY, launchedSession)
         threadSession.set(launchedSession)
-        lastSequentialSession = launchedSession
     }
 
     override fun afterEach(context: ExtensionContext) {
         val stored = context.getStore(storeNamespace).remove(STORE_KEY, LaunchedSession::class.java)
-        if (threadSession.get() === stored) {
-            threadSession.remove()
-        }
-        if (lastSequentialSession === stored) {
-            lastSequentialSession = null
-        }
+        threadSession.remove()
         stored?.close()
     }
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachRule.kt
@@ -1,0 +1,61 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.agent.AttachedAutomator
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.launch.LaunchAndAttach
+import dev.sebastiano.spectre.agent.launch.LaunchSpec
+import dev.sebastiano.spectre.agent.launch.LaunchedSession
+import org.junit.rules.ExternalResource
+
+/**
+ * JUnit 4 rule that launches a process via [LaunchAndAttach] before each test and tears it down
+ * afterwards.
+ *
+ * Prefer [LaunchAndAttachExtension] when using JUnit 5.
+ *
+ * Usage:
+ * ```
+ * @get:Rule
+ * val launchRule = LaunchAndAttachRule(
+ *     LaunchSpec(command = listOf("java", "-jar", "app.jar"))
+ * )
+ * ```
+ */
+public class LaunchAndAttachRule(
+    private val spec: LaunchSpec,
+    private val warningSink: (String) -> Unit = LaunchAndAttach.DEFAULT_WARNING_SINK,
+) : ExternalResource() {
+
+    private var session: LaunchedSession? = null
+
+    public val launched: LaunchedSession
+        get() =
+            checkNotNull(session) {
+                "LaunchAndAttachRule.launched accessed outside of a running test"
+            }
+
+    public val automator: AttachedAutomator
+        get() = launched.automator
+
+    override fun before() {
+        startSession()
+    }
+
+    override fun after() {
+        stopSession()
+    }
+
+    /** Starts the launch session (same as JUnit 4 `before`). Exposed for tests. */
+    public fun startSession() {
+        session = LaunchAndAttach.launch(spec, warningSink)
+    }
+
+    /** Tears down the launch session (same as JUnit 4 `after`). Exposed for tests. */
+    public fun stopSession() {
+        val toClose = session
+        session = null
+        toClose?.close()
+    }
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachRule.kt
@@ -49,6 +49,7 @@ public class LaunchAndAttachRule(
 
     /** Starts the launch session (same as JUnit 4 `before`). Exposed for tests. */
     public fun startSession() {
+        stopSession()
         session = LaunchAndAttach.launch(spec, warningSink)
     }
 

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtensionTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtensionTest.kt
@@ -34,6 +34,13 @@ class LaunchAndAttachExtensionTest {
     }
 
     @Test
+    fun `launched accessor rejects out-of-lifecycle use on extension`() {
+        val ext = LaunchAndAttachExtension(LaunchSpec(command = listOf(javaBin(), "-version")))
+        assertFailsWith<IllegalStateException> { ext.launched }
+        assertFailsWith<IllegalStateException> { ext.automator }
+    }
+
+    @Test
     fun `rule before launches and surfaces stage PROCESS_ALIVE for java -version`() {
         val captureDir = Files.createTempDirectory("spectre-testing-launch-rule-")
         val rule =

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtensionTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtensionTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ParameterResolver
 
 /**
  * Lifecycle tests for the JUnit launch surface. Full UI attach e2e lives in `:agent`
@@ -22,10 +23,14 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 class LaunchAndAttachExtensionTest {
 
     @Test
-    fun `extension implements before and after each callbacks`() {
-        val ext = LaunchAndAttachExtension(LaunchSpec(command = listOf(javaBin(), "-version")))
-        assertTrue(ext is BeforeEachCallback)
-        assertTrue(ext is AfterEachCallback)
+    fun `extension implements lifecycle callbacks and parameter resolver`() {
+        // Reflective assignability so the contracts stay asserted without always-true smart casts.
+        val extClass = LaunchAndAttachExtension::class.java
+        assertTrue(BeforeEachCallback::class.java.isAssignableFrom(extClass))
+        assertTrue(AfterEachCallback::class.java.isAssignableFrom(extClass))
+        assertTrue(ParameterResolver::class.java.isAssignableFrom(extClass))
+        // Constructor still callable with a minimal spec.
+        LaunchAndAttachExtension(LaunchSpec(command = listOf(javaBin(), "-version")))
     }
 
     @Test

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtensionTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/LaunchAndAttachExtensionTest.kt
@@ -1,0 +1,61 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.launch.LaunchSpec
+import dev.sebastiano.spectre.agent.launch.LaunchStage
+import dev.sebastiano.spectre.agent.launch.ProcessExitedBeforeAttachException
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+
+/**
+ * Lifecycle tests for the JUnit launch surface. Full UI attach e2e lives in `:agent`
+ * (`LaunchAndAttachIntegrationTest`).
+ */
+class LaunchAndAttachExtensionTest {
+
+    @Test
+    fun `extension implements before and after each callbacks`() {
+        val ext = LaunchAndAttachExtension(LaunchSpec(command = listOf(javaBin(), "-version")))
+        assertTrue(ext is BeforeEachCallback)
+        assertTrue(ext is AfterEachCallback)
+    }
+
+    @Test
+    fun `rule before launches and surfaces stage PROCESS_ALIVE for java -version`() {
+        val captureDir = Files.createTempDirectory("spectre-testing-launch-rule-")
+        val rule =
+            LaunchAndAttachRule(
+                LaunchSpec(command = listOf(javaBin(), "-version"), captureDirectory = captureDir)
+            )
+        val ex = assertFailsWith<ProcessExitedBeforeAttachException> { rule.startSession() }
+        assertEquals(LaunchStage.PROCESS_ALIVE, ex.stage)
+        assertTrue(Files.isRegularFile(ex.stderrPath))
+        // stop is safe when start never stored a session.
+        rule.stopSession()
+    }
+
+    @Test
+    fun `rule launched accessor rejects out-of-lifecycle use`() {
+        val rule = LaunchAndAttachRule(LaunchSpec(command = listOf(javaBin(), "-version")))
+        assertFailsWith<IllegalStateException> { rule.launched }
+        assertFailsWith<IllegalStateException> { rule.automator }
+    }
+
+    private fun javaBin(): String {
+        val exe =
+            if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) {
+                "java.exe"
+            } else {
+                "java"
+            }
+        return Paths.get(System.getProperty("java.home"), "bin", exe).toString()
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to #307 (core launch-and-attach harness). Completes #208 acceptance:

- **Gradle path**: loud `warningSink` (default stderr), `LaunchAndAttachGradleIntegrationTest` for `./gradlew :agent-test-fixture:run`, fixture run enables `-XX:+EnableDynamicAgentLoading`
- **`:testing`**: `LaunchAndAttachExtension` / `LaunchAndAttachRule` compose with JUnit lifecycle
- **CLI**: `spectre launch [--once] [-C dir] [--app-name …] -- <command>`
- **Docs**: `docs/guide/junit.md`, `cli.md`, `troubleshooting.md` (launch harness section)

## Test plan

- [x] `./gradlew :agent:check :testing:check`
- [x] Gradle e2e + warning unit tests
- [x] CLI launch help + fail-fast path
- [x] Manual `spectre launch --once -- java -version` (twice)

Closes #208