### PR TITLE
Clarify early Gradle client death as PROCESS_ALIVE (not name-filter miss)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -317,8 +317,9 @@ public final class dev/sebastiano/spectre/agent/launch/LaunchedSession : java/la
 }
 
 public final class dev/sebastiano/spectre/agent/launch/ProcessExitedBeforeAttachException : dev/sebastiano/spectre/agent/launch/LaunchException {
-	public fun <init> (ILjava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;)V
-	public synthetic fun <init> (ILjava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;Ljava/lang/String;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDetail ()Ljava/lang/String;
 	public final fun getExitCode ()I
 	public final fun getStderrExcerpt ()Ljava/lang/String;
 	public final fun getStderrPath ()Ljava/nio/file/Path;

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchExceptions.kt
@@ -33,6 +33,12 @@ public class ProcessExitedBeforeAttachException(
     public val stdoutPath: Path,
     public val stderrPath: Path,
     cause: Throwable? = null,
+    /**
+     * Optional context (e.g. Gradle client exited before an app JVM was discovered). Appended to
+     * the message so callers can distinguish wrapper death from a bare process exit without parsing
+     * free text for stage alone.
+     */
+    public val detail: String = "",
 ) :
     LaunchException(
         stage = LaunchStage.PROCESS_ALIVE,
@@ -40,6 +46,11 @@ public class ProcessExitedBeforeAttachException(
             buildString {
                 append("Launched process exited with code $exitCode before attach ")
                 append("(stage=${LaunchStage.PROCESS_ALIVE}). ")
+                if (detail.isNotBlank()) {
+                    append(detail.trim())
+                    if (!detail.trimEnd().endsWith('.')) append('.')
+                    append(' ')
+                }
                 append("stdout=$stdoutPath stderr=$stderrPath")
                 if (stderrExcerpt.isNotBlank()) {
                     append("\n--- captured stderr (excerpt) ---\n")

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -52,26 +52,47 @@ internal object LaunchReadiness {
     ): Long {
         val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
         while (System.nanoTime() < deadline) {
-            if (!process.isAlive && !gradleish) {
-                throw processExited(process, stdoutPath, stderrPath)
+            if (!process.isAlive) {
+                // Direct: client is the target. Gradle-ish: client is ./gradlew — if it died
+                // before we discovered an app JVM, surface client exit/stderr rather than a
+                // misleading name-filter miss at JVM_ATTACHABLE.
+                throw processExited(
+                    process = process,
+                    stdoutPath = stdoutPath,
+                    stderrPath = stderrPath,
+                    detail =
+                        if (gradleish) {
+                            GRADLE_CLIENT_DEAD_BEFORE_APP_JVM
+                        } else {
+                            ""
+                        },
+                )
             }
             if (!gradleish) {
                 // Direct launches already know the target PID. Stage PROCESS_ALIVE established
                 // the process is live; attach-by-pid works even when -XX:-UsePerfData hides the
                 // target from VirtualMachine.list() (see SpectreProcesses). Agent bootstrap's
                 // attachTimeoutMs covers "JVM not ready for loadAgent yet".
-                if (!process.isAlive) {
-                    throw processExited(process, stdoutPath, stderrPath)
-                }
                 return launchedPid
             }
             val pid = LaunchDescendantDiscovery.discoverAppJvm(launchedPid, nameFilter)
             if (pid != null) return pid
             sleepQuietly(POLL_MS)
         }
-        if (!process.isAlive && !gradleish) {
-            throw processExited(process, stdoutPath, stderrPath)
+        if (!process.isAlive) {
+            throw processExited(
+                process = process,
+                stdoutPath = stdoutPath,
+                stderrPath = stderrPath,
+                detail =
+                    if (gradleish) {
+                        GRADLE_CLIENT_DEAD_BEFORE_APP_JVM
+                    } else {
+                        ""
+                    },
+            )
         }
+        // Client still alive (or Gradle client still running) but no app JVM matched.
         throw JvmNotAttachableException(
             launchedPid = launchedPid,
             timeoutMs = timeoutMs,
@@ -79,15 +100,17 @@ internal object LaunchReadiness {
             stderrPath = stderrPath,
             detail =
                 if (gradleish) {
-                    "Gradle-ish launch: no daemon-child/client-descendant app JVM matched" +
+                    "Gradle-ish launch: client still running but no daemon-child/client-descendant " +
+                        "app JVM matched" +
                         (nameFilter?.let { " nameFilter='$it'" }.orEmpty()) +
                         (if (nameFilter.isNullOrBlank()) {
-                            " (set LaunchSpec.appJvmNameFilter to disambiguate daemon children)"
+                            " (set LaunchSpec.appJvmNameFilter / --app-name to disambiguate " +
+                                "daemon children)"
                         } else {
                             ""
                         })
                 } else {
-                    "pid $launchedPid exited before attach"
+                    "pid $launchedPid stayed alive but was not attachable within ${timeoutMs}ms"
                 },
         )
     }
@@ -207,6 +230,7 @@ internal object LaunchReadiness {
         process: Process,
         stdoutPath: Path,
         stderrPath: Path,
+        detail: String = "",
     ): ProcessExitedBeforeAttachException {
         val exitCode =
             try {
@@ -219,6 +243,7 @@ internal object LaunchReadiness {
             stderrExcerpt = readExcerpt(stderrPath),
             stdoutPath = stdoutPath,
             stderrPath = stderrPath,
+            detail = detail,
         )
     }
 
@@ -244,4 +269,13 @@ internal object LaunchReadiness {
     private const val POLL_MS: Long = 50
     private const val SETTLE_MS: Long = 250
     private const val STDERR_EXCERPT_CHARS: Int = 4_096
+
+    /**
+     * Surfaced when a Gradle-ish `./gradlew` client exits during descendant discovery before any
+     * app JVM is found. Prefer this over a name-filter [JvmNotAttachableException] so wrapper
+     * download / env failures are not misread as discovery misconfiguration.
+     */
+    internal const val GRADLE_CLIENT_DEAD_BEFORE_APP_JVM: String =
+        "Gradle client exited before any app JVM was discovered " +
+            "(wrapper download failure, bad env, or build error are common causes — see stderr)"
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -52,66 +52,61 @@ internal object LaunchReadiness {
     ): Long {
         val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
         while (System.nanoTime() < deadline) {
-            if (!process.isAlive) {
-                // Direct: client is the target. Gradle-ish: client is ./gradlew — if it died
-                // before we discovered an app JVM, surface client exit/stderr rather than a
-                // misleading name-filter miss at JVM_ATTACHABLE.
-                throw processExited(
-                    process = process,
-                    stdoutPath = stdoutPath,
-                    stderrPath = stderrPath,
-                    detail =
-                        if (gradleish) {
-                            GRADLE_CLIENT_DEAD_BEFORE_APP_JVM
-                        } else {
-                            ""
-                        },
-                )
-            }
             if (!gradleish) {
-                // Direct launches already know the target PID. Stage PROCESS_ALIVE established
-                // the process is live; attach-by-pid works even when -XX:-UsePerfData hides the
-                // target from VirtualMachine.list() (see SpectreProcesses). Agent bootstrap's
-                // attachTimeoutMs covers "JVM not ready for loadAgent yet".
+                // Direct: client is the target. Stage PROCESS_ALIVE established the process is
+                // live; attach-by-pid works even when -XX:-UsePerfData hides the target from
+                // VirtualMachine.list() (see SpectreProcesses).
+                if (!process.isAlive) {
+                    throw processExited(process, stdoutPath, stderrPath)
+                }
                 return launchedPid
             }
+            // Gradle-ish: keep discovering after the client exits. The app JVM is often a
+            // daemon child (not a ProcessHandle descendant of ./gradlew); tasks that fork and
+            // return still need the remaining stage budget to observe the app.
             val pid = LaunchDescendantDiscovery.discoverAppJvm(launchedPid, nameFilter)
             if (pid != null) return pid
             sleepQuietly(POLL_MS)
         }
+        if (!gradleish) {
+            if (!process.isAlive) {
+                throw processExited(process, stdoutPath, stderrPath)
+            }
+            throw JvmNotAttachableException(
+                launchedPid = launchedPid,
+                timeoutMs = timeoutMs,
+                stdoutPath = stdoutPath,
+                stderrPath = stderrPath,
+                detail =
+                    "pid $launchedPid stayed alive but was not attachable within ${timeoutMs}ms",
+            )
+        }
+        // Gradle-ish timeout: classify by whether the *client* is still running.
+        // Dead client + no app → surface client exit/stderr (wrapper/env failure).
+        // Live client + no app → true discovery / name-filter miss.
         if (!process.isAlive) {
             throw processExited(
                 process = process,
                 stdoutPath = stdoutPath,
                 stderrPath = stderrPath,
-                detail =
-                    if (gradleish) {
-                        GRADLE_CLIENT_DEAD_BEFORE_APP_JVM
-                    } else {
-                        ""
-                    },
+                detail = GRADLE_CLIENT_DEAD_BEFORE_APP_JVM,
             )
         }
-        // Client still alive (or Gradle client still running) but no app JVM matched.
         throw JvmNotAttachableException(
             launchedPid = launchedPid,
             timeoutMs = timeoutMs,
             stdoutPath = stdoutPath,
             stderrPath = stderrPath,
             detail =
-                if (gradleish) {
-                    "Gradle-ish launch: client still running but no daemon-child/client-descendant " +
-                        "app JVM matched" +
-                        (nameFilter?.let { " nameFilter='$it'" }.orEmpty()) +
-                        (if (nameFilter.isNullOrBlank()) {
-                            " (set LaunchSpec.appJvmNameFilter / --app-name to disambiguate " +
-                                "daemon children)"
-                        } else {
-                            ""
-                        })
-                } else {
-                    "pid $launchedPid stayed alive but was not attachable within ${timeoutMs}ms"
-                },
+                "Gradle-ish launch: client still running but no daemon-child/client-descendant " +
+                    "app JVM matched" +
+                    (nameFilter?.let { " nameFilter='$it'" }.orEmpty()) +
+                    (if (nameFilter.isNullOrBlank()) {
+                        " (set LaunchSpec.appJvmNameFilter / --app-name to disambiguate " +
+                            "daemon children)"
+                    } else {
+                        ""
+                    }),
         )
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
@@ -4,6 +4,7 @@ package dev.sebastiano.spectre.agent.launch
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,28 +16,19 @@ import kotlin.test.assertTrue
  * When a Gradle-ish `./gradlew` client dies before any app JVM is discovered (wrapper download
  * failure, bad env, etc.), the failure must surface client exit + stderr — not a misleading
  * [JvmNotAttachableException] / name-filter miss.
+ *
+ * Discovery still polls for the full [LaunchStageTimeouts.jvmAttachableMs] after the client exits
+ * (daemon-spawned apps), then classifies dead-client + no match as PROCESS_ALIVE.
  */
 class LaunchAndAttachGradleClientDeathTest {
 
     @Test
     fun `gradle client death during discovery is PROCESS_ALIVE with exit and stderr not name-filter`() {
         val captureDir = Files.createTempDirectory("spectre-launch-gradle-client-death-")
-        // Survive PROCESS_ALIVE settle (250ms), then die during JVM_ATTACHABLE discovery with
-        // a distinctive stderr line so we prove capture is surfaced.
-        val fakeGradlew =
-            Paths.get(captureDir.toString(), "gradlew").also {
-                Files.writeString(
-                    it,
-                    """
-                    #!/bin/sh
-                    echo 'spectre-gradle-client-death-stderr' 1>&2
-                    sleep 1
-                    exit 42
-                    """
-                        .trimIndent() + "\n",
-                )
-                it.toFile().setExecutable(true)
-            }
+        // Survive PROCESS_ALIVE settle (~250ms), die during discovery with distinctive stderr.
+        // jvmAttachable budget is intentionally longer than the client lifetime so classification
+        // happens after discovery had a chance to find a (non-matching) app JVM.
+        val fakeGradlew = writeFakeGradlewClient(captureDir)
 
         val ex =
             assertFailsWith<ProcessExitedBeforeAttachException> {
@@ -49,10 +41,7 @@ class LaunchAndAttachGradleClientDeathTest {
                         stageTimeouts =
                             LaunchStageTimeouts(
                                 processAliveMs = 500,
-                                // Short discovery budget: client dies at ~1s; we still poll until
-                                // this timeout before classifying (daemon apps may appear after
-                                // client exit — but with an impossible nameFilter none will).
-                                jvmAttachableMs = 1_500,
+                                jvmAttachableMs = 4_000,
                                 agentBootstrapMs = 2_000,
                                 firstWindowMs = 2_000,
                             ),
@@ -72,7 +61,6 @@ class LaunchAndAttachGradleClientDeathTest {
                 ex.message!!.contains("app JVM", ignoreCase = true),
             "message should explain gradle client died before app JVM; got: ${ex.message}",
         )
-        // Must not look like a name-filter miss on JVM_ATTACHABLE.
         assertFalse(
             ex.message!!.contains("nameFilter", ignoreCase = true),
             "must not blame nameFilter when the Gradle client already exited; got: ${ex.message}",
@@ -81,5 +69,39 @@ class LaunchAndAttachGradleClientDeathTest {
             ex.message!!.contains("JVM_ATTACHABLE", ignoreCase = true),
             "must not report stage JVM_ATTACHABLE; got: ${ex.message}",
         )
+    }
+
+    private fun writeFakeGradlewClient(captureDir: Path): Path {
+        val windows =
+            System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
+        return if (windows) {
+            Paths.get(captureDir.toString(), "gradlew.bat").also {
+                // ~1s delay then exit 42; stderr via stderr stream.
+                Files.writeString(
+                    it,
+                    """
+                    @echo off
+                    echo spectre-gradle-client-death-stderr 1>&2
+                    timeout /t 1 /nobreak >nul
+                    exit /b 42
+                    """
+                        .trimIndent() + "\r\n",
+                )
+            }
+        } else {
+            Paths.get(captureDir.toString(), "gradlew").also {
+                Files.writeString(
+                    it,
+                    """
+                    #!/bin/sh
+                    echo 'spectre-gradle-client-death-stderr' 1>&2
+                    sleep 1
+                    exit 42
+                    """
+                        .trimIndent() + "\n",
+                )
+                it.toFile().setExecutable(true)
+            }
+        }
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
@@ -49,7 +49,10 @@ class LaunchAndAttachGradleClientDeathTest {
                         stageTimeouts =
                             LaunchStageTimeouts(
                                 processAliveMs = 500,
-                                jvmAttachableMs = 5_000,
+                                // Short discovery budget: client dies at ~1s; we still poll until
+                                // this timeout before classifying (daemon apps may appear after
+                                // client exit — but with an impossible nameFilter none will).
+                                jvmAttachableMs = 1_500,
                                 agentBootstrapMs = 2_000,
                                 firstWindowMs = 2_000,
                             ),

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
@@ -79,10 +79,12 @@ class LaunchAndAttachGradleClientDeathTest {
                 // ~1s delay then exit 42; stderr via stderr stream.
                 Files.writeString(
                     it,
+                    // Prefer ping over `timeout`: under non-console redirected I/O, Windows
+                    // `timeout` can abort immediately (Bugbot/Windows CI).
                     """
                     @echo off
                     echo spectre-gradle-client-death-stderr 1>&2
-                    timeout /t 1 /nobreak >nul
+                    ping -n 2 127.0.0.1 >nul
                     exit /b 42
                     """
                         .trimIndent() + "\r\n",

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
@@ -1,0 +1,79 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * When a Gradle-ish `./gradlew` client dies before any app JVM is discovered (wrapper download
+ * failure, bad env, etc.), the failure must surface client exit + stderr — not a misleading
+ * [JvmNotAttachableException] / name-filter miss.
+ */
+class LaunchAndAttachGradleClientDeathTest {
+
+    @Test
+    fun `gradle client death during discovery is PROCESS_ALIVE with exit and stderr not name-filter`() {
+        val captureDir = Files.createTempDirectory("spectre-launch-gradle-client-death-")
+        // Survive PROCESS_ALIVE settle (250ms), then die during JVM_ATTACHABLE discovery with
+        // a distinctive stderr line so we prove capture is surfaced.
+        val fakeGradlew =
+            Paths.get(captureDir.toString(), "gradlew").also {
+                Files.writeString(
+                    it,
+                    """
+                    #!/bin/sh
+                    echo 'spectre-gradle-client-death-stderr' 1>&2
+                    sleep 1
+                    exit 42
+                    """
+                        .trimIndent() + "\n",
+                )
+                it.toFile().setExecutable(true)
+            }
+
+        val ex =
+            assertFailsWith<ProcessExitedBeforeAttachException> {
+                LaunchAndAttach.launch(
+                    LaunchSpec(
+                        command = listOf(fakeGradlew.toString(), ":app:run"),
+                        captureDirectory = captureDir,
+                        // Impossible filter so we never attach an unrelated daemon-child JVM.
+                        appJvmNameFilter = "NoSuchMainClass_issue208_client_death_test",
+                        stageTimeouts =
+                            LaunchStageTimeouts(
+                                processAliveMs = 500,
+                                jvmAttachableMs = 5_000,
+                                agentBootstrapMs = 2_000,
+                                firstWindowMs = 2_000,
+                            ),
+                    )
+                )
+            }
+
+        assertEquals(LaunchStage.PROCESS_ALIVE, ex.stage)
+        assertEquals(42, ex.exitCode)
+        assertTrue(
+            ex.stderrExcerpt.contains("spectre-gradle-client-death-stderr") ||
+                Files.readString(ex.stderrPath).contains("spectre-gradle-client-death-stderr"),
+            "expected client stderr in exception; excerpt='${ex.stderrExcerpt}' path=${ex.stderrPath}",
+        )
+        assertTrue(
+            ex.message!!.contains("Gradle client", ignoreCase = true) ||
+                ex.message!!.contains("app JVM", ignoreCase = true),
+            "message should explain gradle client died before app JVM; got: ${ex.message}",
+        )
+        // Must not look like a name-filter miss on JVM_ATTACHABLE.
+        assertFalse(ex is JvmNotAttachableException, "must not report as JvmNotAttachableException")
+        assertFalse(
+            ex.message!!.contains("nameFilter", ignoreCase = true),
+            "must not blame nameFilter when the Gradle client already exited; got: ${ex.message}",
+        )
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachGradleClientDeathTest.kt
@@ -73,10 +73,13 @@ class LaunchAndAttachGradleClientDeathTest {
             "message should explain gradle client died before app JVM; got: ${ex.message}",
         )
         // Must not look like a name-filter miss on JVM_ATTACHABLE.
-        assertFalse(ex is JvmNotAttachableException, "must not report as JvmNotAttachableException")
         assertFalse(
             ex.message!!.contains("nameFilter", ignoreCase = true),
             "must not blame nameFilter when the Gradle client already exited; got: ${ex.message}",
+        )
+        assertFalse(
+            ex.message!!.contains("JVM_ATTACHABLE", ignoreCase = true),
+            "must not report stage JVM_ATTACHABLE; got: ${ex.message}",
         )
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachWarningTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachWarningTest.kt
@@ -6,6 +6,7 @@ import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import java.nio.file.Files
 import java.nio.file.Paths
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
@@ -55,10 +56,9 @@ class LaunchAndAttachWarningTest {
             warnings.any { it.contains("daemon", ignoreCase = true) },
             "warnings should mention daemon; got $warnings",
         )
-        // Stage may be PROCESS_ALIVE (script exits) or JVM_ATTACHABLE (no matching app JVM).
-        assertTrue(
-            ex.stage == LaunchStage.PROCESS_ALIVE || ex.stage == LaunchStage.JVM_ATTACHABLE,
-            "unexpected stage ${ex.stage}: ${ex.message}",
-        )
+        // Client dies before any app JVM — should report PROCESS_ALIVE with exit, not a
+        // name-filter miss at JVM_ATTACHABLE.
+        assertEquals(LaunchStage.PROCESS_ALIVE, ex.stage, "unexpected stage: ${ex.message}")
+        assertTrue(ex is ProcessExitedBeforeAttachException, "expected process-exit taxonomy")
     }
 }

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -10,12 +10,19 @@ The process died before Spectre could attach. The exception message includes the
 code, paths to stdout/stderr capture files, and a stderr excerpt. Fix the app startup
 failure first (missing main class, bad classpath, AWT headless, etc.).
 
+On a **Gradle-ish** launch, if the `./gradlew` **client** exits before any app JVM is
+discovered (wrapper download failure, bad env, build script error), you get this same
+stage — often with detail that the Gradle client exited before an app JVM appeared —
+rather than a name-filter miss. Read the captured stderr first; do not assume
+`--app-name` is wrong until the client stays alive.
+
 ### "No attachable JVM … (JVM_ATTACHABLE)" on a Gradle launch
 
 `./gradlew :app:run` spawns the app JVM from the **Gradle daemon**, not the `gradlew`
-client. Pass `LaunchSpec.appJvmNameFilter` / `spectre launch --app-name <MainClass>` so
-discovery can match the app among daemon children. Never kill the Gradle daemon to "fix"
-teardown — the harness only tears down the discovered app JVM.
+client. This stage means the **client is still running** but no matching app JVM was
+found in time. Pass `LaunchSpec.appJvmNameFilter` / `spectre launch --app-name
+<MainClass>` so discovery can match the app among daemon children. Never kill the
+Gradle daemon to "fix" teardown — the harness only tears down the discovered app JVM.
 
 You will also see a loud **Gradle-ish** warning naming daemon, sandbox, and JEP 451
 caveats. Prefer a prod-like launch (`java -jar`, installDist) when you control the build.


### PR DESCRIPTION
## Summary
- When a Gradle-ish `./gradlew` client dies before any app JVM is discovered (wrapper download fail, bad env, build error), map the failure to **`ProcessExitedBeforeAttachException` / `PROCESS_ALIVE`** with exit code, stderr excerpt, and detail that the **Gradle client exited before an app JVM appeared**.
- Keep **`JVM_ATTACHABLE`** for the case where the **client is still running** but no matching app JVM was found (true name-filter / discovery miss).
- Troubleshooting note updated; ABI updated for optional `detail` on `ProcessExitedBeforeAttachException`.

## Test plan
- [x] `LaunchAndAttachGradleClientDeathTest` — client sleeps then exits 42 with stderr; asserts PROCESS_ALIVE, not nameFilter/JVM_ATTACHABLE
- [x] `LaunchAndAttachWarningTest` updated expectations
- [x] `./gradlew check` green locally

Feedback from perspective users after #208 (does not block use; debugging quality).