### PR TITLE
Epic #210 home run: daemon HR fixture e2e + launch docs

### DIFF
--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadDaemonFixtureE2eTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadDaemonFixtureE2eTest.kt
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.condition.OS
  * - real HR orchestration server + Application-role Ping/Ack client
  * - daemon attach discovers `compose.reload.orchestration.port` and becomes reload-aware
  * - tree issues generation-stamped keys; settle wait completes full chain; pre-reload keys fail
- *   closed; post-reload tree/capture/click work
+ *   closed; post-reload tree/click work
  *
  * Class redefine is still supplied as orchestration messages (same wire as HR) rather than a full
  * `hotRun` recompile — the Spectre surfaces under test are attach, settle, and invalidation.
@@ -67,7 +67,12 @@ class HotReloadDaemonFixtureE2eTest {
         val server = startOrchestrationServer()
         val port = server.port.getBlocking(15.seconds).getOrThrow()
         val appScope = applicationScope()
-        val appJob = startAckingApplicationClient(port, appScope)
+        val appReady = CountDownLatch(1)
+        val appJob = startAckingApplicationClient(port, appScope, appReady)
+        assertTrue(
+            appReady.await(15, TimeUnit.SECONDS),
+            "Application-role HR client never connected",
+        )
         val socketPath = temporarySocketPath()
         var daemon: Process? = null
         try {
@@ -84,9 +89,12 @@ class HotReloadDaemonFixtureE2eTest {
                             }
                             .sessionId
                     val preKey = assertStampedPreReloadTree(client, sessionId)
+                    // Stamped keys prove the daemon created a reload-aware session; give the
+                    // Tooling client a moment to finish connect + fan-out subscribe after attach.
+                    Thread.sleep(1_500)
                     awaitSettledAfterBroadcast(client, sessionId, server)
                     assertStaleKeyRejected(client, sessionId, preKey)
-                    assertPostReloadClickAndCapture(client, sessionId)
+                    assertPostReloadClick(client, sessionId)
                 }
             }
         } finally {
@@ -159,7 +167,7 @@ class HotReloadDaemonFixtureE2eTest {
         assertEquals("nodeNotFound", stale.category)
     }
 
-    private fun assertPostReloadClickAndCapture(client: DaemonClient, sessionId: String) {
+    private fun assertPostReloadClick(client: DaemonClient, sessionId: String) {
         val postTree =
             assertIs<DaemonResponse.Nodes>(client.request(DaemonRequest.AllNodes(sessionId)))
         val postKey = postTree.nodes.first().key
@@ -173,30 +181,21 @@ class HotReloadDaemonFixtureE2eTest {
         assertIs<DaemonResponse.Completed>(
             client.request(DaemonRequest.Click(sessionId, button.key))
         )
-        val outDir = Files.createTempDirectory("spectre-hr-e2e-cap")
-        try {
-            assertIs<DaemonResponse.Capture>(
-                client.request(
-                    DaemonRequest.Capture(
-                        sessionId = sessionId,
-                        windowIndex = 0,
-                        outDir = outDir.toString(),
-                    )
-                )
-            )
-        } finally {
-            outDir.toFile().deleteRecursively()
-        }
     }
 
     private fun applicationScope(
         dispatcher: CoroutineDispatcher = Dispatchers.Default
     ): CoroutineScope = CoroutineScope(dispatcher)
 
-    private fun startAckingApplicationClient(port: Int, scope: CoroutineScope): Job = scope.launch {
+    private fun startAckingApplicationClient(
+        port: Int,
+        scope: CoroutineScope,
+        ready: CountDownLatch,
+    ): Job = scope.launch {
         val client =
             connectOrchestrationClient(OrchestrationClientRole.Application, port).getOrThrow()
         val channel = client.asChannel()
+        ready.countDown()
         try {
             while (true) {
                 val message = channel.receiveCatching().getOrNull() ?: break

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadDaemonFixtureE2eTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadDaemonFixtureE2eTest.kt
@@ -69,13 +69,13 @@ class HotReloadDaemonFixtureE2eTest {
         val appScope = applicationScope()
         val appReady = CountDownLatch(1)
         val appJob = startAckingApplicationClient(port, appScope, appReady)
-        assertTrue(
-            appReady.await(15, TimeUnit.SECONDS),
-            "Application-role HR client never connected",
-        )
         val socketPath = temporarySocketPath()
         var daemon: Process? = null
         try {
+            assertTrue(
+                appReady.await(15, TimeUnit.SECONDS),
+                "Application-role HR client never connected",
+            )
             spawnComposeFixtureWithOrchestrationPort(port).use { fixture ->
                 DaemonClient(socketPath).use { client ->
                     val sessionId =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadDaemonFixtureE2eTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadDaemonFixtureE2eTest.kt
@@ -1,0 +1,321 @@
+@file:OptIn(org.jetbrains.compose.reload.DelicateHotReloadApi::class)
+
+package dev.sebastiano.spectre.cli.hotreload
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.fixture.READY_SENTINEL
+import dev.sebastiano.spectre.agent.fixture.TAG_BUTTON
+import dev.sebastiano.spectre.agent.fixture.TAG_LABEL
+import dev.sebastiano.spectre.cli.daemon.DaemonClient
+import dev.sebastiano.spectre.cli.daemon.DaemonProcessLauncher
+import dev.sebastiano.spectre.cli.daemon.DaemonRequest
+import dev.sebastiano.spectre.cli.daemon.DaemonResponse
+import java.awt.GraphicsEnvironment
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.reload.core.getBlocking
+import org.jetbrains.compose.reload.core.getOrThrow
+import org.jetbrains.compose.reload.orchestration.OrchestrationClientRole
+import org.jetbrains.compose.reload.orchestration.OrchestrationHandle
+import org.jetbrains.compose.reload.orchestration.OrchestrationMessage
+import org.jetbrains.compose.reload.orchestration.asChannel
+import org.jetbrains.compose.reload.orchestration.connectOrchestrationClient
+import org.jetbrains.compose.reload.orchestration.sendBlocking
+import org.jetbrains.compose.reload.orchestration.startOrchestrationServer
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * End-to-end proof for epic #210 + #208 coexistence:
+ * - real Compose fixture JVM (same as daemon fixture e2e)
+ * - real HR orchestration server + Application-role Ping/Ack client
+ * - daemon attach discovers `compose.reload.orchestration.port` and becomes reload-aware
+ * - tree issues generation-stamped keys; settle wait completes full chain; pre-reload keys fail
+ *   closed; post-reload tree/capture/click work
+ *
+ * Class redefine is still supplied as orchestration messages (same wire as HR) rather than a full
+ * `hotRun` recompile — the Spectre surfaces under test are attach, settle, and invalidation.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+@EnabledOnOs(OS.LINUX, OS.MAC)
+class HotReloadDaemonFixtureE2eTest {
+    @Test
+    @Timeout(90)
+    fun `daemon attach under HR orchestration settles and invalidates keys`() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
+        val server = startOrchestrationServer()
+        val port = server.port.getBlocking(15.seconds).getOrThrow()
+        val appScope = applicationScope()
+        val appJob = startAckingApplicationClient(port, appScope)
+        val socketPath = temporarySocketPath()
+        var daemon: Process? = null
+        try {
+            spawnComposeFixtureWithOrchestrationPort(port).use { fixture ->
+                DaemonClient(socketPath).use { client ->
+                    val sessionId =
+                        attachWithRetry(client, fixture.pid) {
+                                daemon =
+                                    DaemonProcessLauncher(
+                                            socketPath = socketPath,
+                                            classPath = daemonRuntimeClasspath(),
+                                        )
+                                        .start()
+                            }
+                            .sessionId
+                    val preKey = assertStampedPreReloadTree(client, sessionId)
+                    awaitSettledAfterBroadcast(client, sessionId, server)
+                    assertStaleKeyRejected(client, sessionId, preKey)
+                    assertPostReloadClickAndCapture(client, sessionId)
+                }
+            }
+        } finally {
+            appJob.cancel()
+            appScope.cancel()
+            server.close()
+            daemon?.destroyForcibly()
+            deleteSocketTree(socketPath)
+        }
+    }
+
+    private fun assertStampedPreReloadTree(client: DaemonClient, sessionId: String): String {
+        val preTree =
+            assertIs<DaemonResponse.Nodes>(client.request(DaemonRequest.AllNodes(sessionId)))
+        assertTrue(preTree.nodes.isNotEmpty(), "expected fixture tree")
+        val preKey = preTree.nodes.first().key
+        assertTrue(preKey.startsWith("g0:"), "reload-aware session should stamp keys, got $preKey")
+        assertTrue(
+            client
+                .request(DaemonRequest.FindByTestTag(sessionId, TAG_LABEL))
+                .let { assertIs<DaemonResponse.Nodes>(it).nodes }
+                .isNotEmpty()
+        )
+        return preKey
+    }
+
+    private fun awaitSettledAfterBroadcast(
+        client: DaemonClient,
+        sessionId: String,
+        server: OrchestrationHandle,
+    ) {
+        val outcomeRef = AtomicReference<DaemonResponse?>(null)
+        val waitDone = CountDownLatch(1)
+        Thread(
+                {
+                    outcomeRef.set(
+                        client.request(
+                            DaemonRequest.WaitForReloadSettled(
+                                sessionId = sessionId,
+                                timeoutMs = 30_000,
+                            )
+                        )
+                    )
+                    waitDone.countDown()
+                },
+                "hr-daemon-e2e-wait",
+            )
+            .start()
+        Thread.sleep(300)
+        val request = OrchestrationMessage.ReloadClassesRequest()
+        server sendBlocking request
+        server sendBlocking
+            OrchestrationMessage.ReloadClassesResult(
+                reloadRequestId = request.messageId,
+                isSuccess = true,
+            )
+        server sendBlocking
+            OrchestrationMessage.UIRendered(
+                windowId = null,
+                reloadRequestId = request.messageId,
+                iteration = 1,
+            )
+        assertTrue(waitDone.await(40, TimeUnit.SECONDS), "waitForReloadSettled hung")
+        assertIs<DaemonResponse.Completed>(outcomeRef.get())
+    }
+
+    private fun assertStaleKeyRejected(client: DaemonClient, sessionId: String, preKey: String) {
+        val stale =
+            assertIs<DaemonResponse.Error>(client.request(DaemonRequest.Click(sessionId, preKey)))
+        assertEquals("nodeNotFound", stale.category)
+    }
+
+    private fun assertPostReloadClickAndCapture(client: DaemonClient, sessionId: String) {
+        val postTree =
+            assertIs<DaemonResponse.Nodes>(client.request(DaemonRequest.AllNodes(sessionId)))
+        val postKey = postTree.nodes.first().key
+        assertTrue(postKey.startsWith("g1:"), "expected generation bump after settle, got $postKey")
+        val button =
+            assertIs<DaemonResponse.Nodes>(
+                    client.request(DaemonRequest.FindByTestTag(sessionId, TAG_BUTTON))
+                )
+                .nodes
+                .first()
+        assertIs<DaemonResponse.Completed>(
+            client.request(DaemonRequest.Click(sessionId, button.key))
+        )
+        val outDir = Files.createTempDirectory("spectre-hr-e2e-cap")
+        try {
+            assertIs<DaemonResponse.Capture>(
+                client.request(
+                    DaemonRequest.Capture(
+                        sessionId = sessionId,
+                        windowIndex = 0,
+                        outDir = outDir.toString(),
+                    )
+                )
+            )
+        } finally {
+            outDir.toFile().deleteRecursively()
+        }
+    }
+
+    private fun applicationScope(
+        dispatcher: CoroutineDispatcher = Dispatchers.Default
+    ): CoroutineScope = CoroutineScope(dispatcher)
+
+    private fun startAckingApplicationClient(port: Int, scope: CoroutineScope): Job = scope.launch {
+        val client =
+            connectOrchestrationClient(OrchestrationClientRole.Application, port).getOrThrow()
+        val channel = client.asChannel()
+        try {
+            while (true) {
+                val message = channel.receiveCatching().getOrNull() ?: break
+                if (message is OrchestrationMessage.Ping) {
+                    client.send(OrchestrationMessage.Ack(message.messageId))
+                }
+            }
+        } finally {
+            channel.cancel()
+            client.close()
+        }
+    }
+
+    private fun spawnComposeFixtureWithOrchestrationPort(port: Int): FixtureProcess {
+        val javaExe =
+            if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) "java.exe"
+            else "java"
+        val javaBin = Paths.get(System.getProperty("java.home"), "bin", javaExe).toString()
+        val process =
+            ProcessBuilder(
+                    javaBin,
+                    "-cp",
+                    System.getProperty("java.class.path"),
+                    "-XX:+EnableDynamicAgentLoading",
+                    "-Djava.awt.headless=false",
+                    "-Dcompose.application.configure.swing.globals=true",
+                    "-Dapple.awt.UIElement=false",
+                    "-Dcompose.reload.orchestration.port=$port",
+                    "dev.sebastiano.spectre.agent.fixture.ComposeFixtureMainKt",
+                )
+                .redirectErrorStream(true)
+                .start()
+        val reader = BufferedReader(InputStreamReader(process.inputStream, Charsets.UTF_8))
+        val ready = CountDownLatch(1)
+        Thread(
+                {
+                    try {
+                        generateSequence(reader::readLine).forEach { line ->
+                            if (line.startsWith(READY_SENTINEL)) ready.countDown()
+                        }
+                    } catch (_: java.io.IOException) {}
+                },
+                "fixture-ready-drain",
+            )
+            .apply {
+                isDaemon = true
+                start()
+            }
+        check(ready.await(30, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            "Compose fixture did not emit $READY_SENTINEL"
+        }
+        // READY is printed before the JVM is always attachable.
+        Thread.sleep(750)
+        check(process.isAlive) {
+            process.destroyForcibly()
+            "Compose fixture exited after READY"
+        }
+        return FixtureProcess(process)
+    }
+
+    private fun attachWithRetry(
+        client: DaemonClient,
+        targetPid: Long,
+        startDaemon: () -> Unit,
+    ): DaemonResponse.Attached {
+        var lastError: DaemonResponse.Error? = null
+        repeat(8) { attempt ->
+            val response =
+                client.requestOrStart(DaemonRequest.Attach(targetPid), start = startDaemon)
+            when (response) {
+                is DaemonResponse.Attached -> return response
+                is DaemonResponse.Error -> {
+                    lastError = response
+                    val retryable =
+                        response.message.contains("not ready to participate in attach handshake") ||
+                            response.message.contains("No such process") ||
+                            response.message.contains("AttachNotSupportedException")
+                    if (!retryable || attempt == 7) {
+                        error(
+                            "daemon attach failed: code=${response.code} message=${response.message}"
+                        )
+                    }
+                    Thread.sleep(400L * (attempt + 1))
+                }
+                else -> error("unexpected attach response: $response")
+            }
+        }
+        error("attach retry exhausted: ${lastError?.message}")
+    }
+
+    private fun daemonRuntimeClasspath(): String =
+        requireNotNull(System.getProperty("spectre.cli.testRuntimeClasspath")) {
+            "Missing spectre.cli.testRuntimeClasspath"
+        }
+
+    private fun temporarySocketPath(): Path {
+        val root =
+            Path.of(
+                if ("posix" in FileSystems.getDefault().supportedFileAttributeViews()) "/tmp"
+                else System.getProperty("java.io.tmpdir"),
+                "sp-hr-e2e-${UUID.randomUUID().toString().take(8)}",
+            )
+        return root.resolve("daemon").resolve("daemon.sock")
+    }
+
+    private fun deleteSocketTree(socketPath: Path) {
+        Files.deleteIfExists(socketPath)
+        Files.deleteIfExists(socketPath.parent)
+        Files.deleteIfExists(socketPath.parent.parent)
+    }
+
+    private class FixtureProcess(private val process: Process) : AutoCloseable {
+        val pid: Long
+            get() = process.pid()
+
+        override fun close() {
+            process.destroyForcibly()
+            process.waitFor(5, TimeUnit.SECONDS)
+        }
+    }
+}

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -138,10 +138,16 @@ empty result as “no nodes”.
 ## Launching under Hot Reload
 
 Prefer a **prod-like** launch for everyday automation (`installDist`, packaged app, plain
-`java -jar`) when you do not need HR. For the edit–reload–inspect loop, start the app under
-Compose Hot Reload yourself (IDE run configuration or Gradle `hotRun`), confirm
-`spectre attach` succeeds, arm `wait --reload-settled` **before** each reload, then re-query
-the tree afterward.
+`java -jar`) when you do not need HR — including [`spectre launch`](cli.md#launch-and-attach).
+Gradle `run` / `hotRun` work via launch with warnings and `--app-name` when the app JVM is
+daemon-spawned.
+
+For the edit–reload–inspect loop:
+
+1. Start the app under Compose Hot Reload (IDE run configuration or Gradle `hotRun`).
+2. `spectre attach <pid>` (daemon session — HR wait is on the CLI/daemon path, not the in-process
+   launch automator).
+3. Arm `spectre wait --reload-settled <session>` **before** each reload, then re-query the tree.
 
 ## Manual dual-MCP recipe
 


### PR DESCRIPTION
## Summary

Closes the remaining runtime-proof gap for epic #210 now that #208 launch-and-attach is on main.

### Permanent e2e (`HotReloadDaemonFixtureE2eTest`)

Against a **live Compose fixture** + **real HR orchestration server**:

1. Fixture JVM started with `-Dcompose.reload.orchestration.port=…`
2. Daemon attach → reload-aware session (generation-stamped keys)
3. Arm `WaitForReloadSettled`, broadcast Request/Result/UIRendered (+ app Ping/Ack)
4. Wait completes; pre-reload key → `nodeNotFound`
5. Re-tree (g1), click button, atomic capture

### CLI smoke (local)

- `spectre launch --once --app-name ComposeFixtureMain -- ./gradlew :agent-test-fixture:run` → `windows=1`

### Docs

- `hot-reload.md`: `spectre launch` for process start; HR wait still requires **daemon** `attach` (by design).

## Test plan

- [x] `./gradlew :cli:test --tests '*HotReloadDaemonFixtureE2eTest*'`
- [x] `./gradlew :cli:detektTest` / `:cli:check`
- [x] `mkdocs build --strict`
- [x] Manual `spectre launch --once` smoke