### PR TITLE
Bump Compose Hot Reload to 1.2.0

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadVersions.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/hotreload/HotReloadVersions.kt
@@ -9,13 +9,13 @@ package dev.sebastiano.spectre.cli.hotreload
  */
 public object HotReloadVersions {
     /** Exact artifact version resolved by Spectre's CLI/daemon dependency. */
-    public const val PINNED: String = "1.2.0-rc01"
+    public const val PINNED: String = "1.2.0"
 
     /** Inclusive lower bound of the supported 1.2 line (findings verified from alpha+211). */
     public const val MIN_SUPPORTED: String = "1.2.0-alpha+211"
 
     /** Inclusive upper bound of the currently tested range. */
-    public const val MAX_TESTED: String = "1.2.0-rc01"
+    public const val MAX_TESTED: String = "1.2.0"
 
     /** System property / env key for the orchestration TCP port (HR's own key). */
     public const val ORCHESTRATION_PORT_PROPERTY: String = "compose.reload.orchestration.port"

--- a/docs/guide/hot-reload.md
+++ b/docs/guide/hot-reload.md
@@ -52,7 +52,7 @@ non-HR commands work; reload wait fails immediately with category `hotReloadUnav
 
 ## Version range
 
-Spectre pins and tests against Compose Hot Reload **1.2.0-rc01** on the CLI classpath. The
+Spectre pins and tests against Compose Hot Reload **1.2.0** on the CLI classpath. The
 supported line starts at **1.2.0-alpha+211** (the findings baseline for the Tooling client and
 settle chain). Older HR builds may omit newer orchestration messages; Spectre fails closed rather
 than guessing.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -195,7 +195,7 @@ older `capture.json` for clicks after settle — capture writes raw keys for ins
 
 ### "Older Hot Reload builds"
 
-Spectre tests against the Compose Hot Reload **1.2** line (pinned **1.2.0-rc01**, minimum
+Spectre tests against the Compose Hot Reload **1.2** line (pinned **1.2.0**, minimum
 **1.2.0-alpha+211**). Older orchestration servers may omit message types Spectre needs; upgrade
 HR rather than expecting settle wait to work.
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ androidx-tracing = "2.0.0-alpha06"
 composeMultiplatform = "1.10.3"
 # Compose Hot Reload orchestration client for daemon-side reload awareness (#211).
 # Keep aligned with cli HotReloadVersions.PINNED.
-composeHotReload = "1.2.0-rc01"
+composeHotReload = "1.2.0"
 clikt = "5.0.1"
 composeRules = "0.5.6"
 detekt = "2.0.0-alpha.3"


### PR DESCRIPTION
## Summary
- Bump Compose Hot Reload from `1.2.0-rc01` → `1.2.0` on the CLI/daemon classpath (`libs.versions.toml` + `HotReloadVersions.PINNED` / `MAX_TESTED`).
- Update user-facing pin text in `docs/guide/hot-reload.md` and `docs/guide/troubleshooting.md`.
- Supported floor remains `1.2.0-alpha+211`.

No production API changes; this is a dependency + docs pin update for the stable HR release.

## Test plan
- [x] `./gradlew :cli:test --tests '*HotReload*' --tests '*hotreload*'`
- [x] `./gradlew :cli:dependencies` resolves `hot-reload-*:1.2.0`
- [x] `./gradlew check` (one flaky `:agent:test` pass on retry; failures were focus/bootstrap, unrelated to HR pin)
- [ ] CI green