### PR TITLE
Add scheduled + release-gated JBR/Temurin runtime matrix (#216)

### DIFF
--- a/.github/actions/setup-matrix-jdk/action.yml
+++ b/.github/actions/setup-matrix-jdk/action.yml
@@ -1,0 +1,76 @@
+name: Setup matrix JDK
+description: >
+  Install a pinned Spectre runtime-matrix JDK (JBR 21, JBR 25, or Temurin LTS)
+  using .github/jbr-pins.env and actions/setup-java (cached per runner OS/arch).
+
+inputs:
+  runtime:
+    description: "Matrix runtime id: jbr-21 | jbr-25 | temurin-lts"
+    required: true
+  set-default:
+    description: "Whether this JDK becomes the job default JAVA_HOME"
+    required: false
+    default: "true"
+
+outputs:
+  distribution:
+    description: "actions/setup-java distribution"
+    value: ${{ steps.resolve.outputs.distribution }}
+  java-version:
+    description: "Pinned version range passed to setup-java"
+    value: ${{ steps.resolve.outputs.java-version }}
+  java-package:
+    description: "JetBrains package type (empty for Temurin)"
+    value: ${{ steps.resolve.outputs.java-package }}
+  runtime-label:
+    description: "Human-readable runtime label for logs"
+    value: ${{ steps.resolve.outputs.runtime-label }}
+  path:
+    description: "Installed JAVA_HOME path"
+    value: ${{ steps.path.outputs.path }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve pins
+      id: resolve
+      shell: bash
+      run: |
+        set -euo pipefail
+        bash .github/scripts/resolve-matrix-jdk.sh "${{ inputs.runtime }}" >> "$GITHUB_OUTPUT"
+        echo "Resolved ${{ inputs.runtime }} → $(bash .github/scripts/resolve-matrix-jdk.sh "${{ inputs.runtime }}" | tr '\n' ' ')"
+
+    - name: Install JDK (JetBrains JBR)
+      id: install-jbr
+      if: steps.resolve.outputs.distribution == 'jetbrains'
+      uses: actions/setup-java@v5
+      with:
+        distribution: jetbrains
+        java-version: ${{ steps.resolve.outputs.java-version }}
+        java-package: ${{ steps.resolve.outputs.java-package }}
+        set-default: ${{ inputs.set-default }}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: Install JDK (Temurin)
+      id: install-temurin
+      if: steps.resolve.outputs.distribution == 'temurin'
+      uses: actions/setup-java@v5
+      with:
+        distribution: temurin
+        java-version: ${{ steps.resolve.outputs.java-version }}
+        set-default: ${{ inputs.set-default }}
+
+    - name: Export install path
+      id: path
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [[ "${{ steps.resolve.outputs.distribution }}" == "jetbrains" ]]; then
+          echo "path=${{ steps.install-jbr.outputs.path }}" >> "$GITHUB_OUTPUT"
+        else
+          echo "path=${{ steps.install-temurin.outputs.path }}" >> "$GITHUB_OUTPUT"
+        fi
+        if [[ "${{ inputs.set-default }}" == "true" ]]; then
+          java -version
+        fi

--- a/.github/jbr-pins.env
+++ b/.github/jbr-pins.env
@@ -1,0 +1,35 @@
+# Spectre runtime-matrix pins (#216 / epic #215).
+#
+# Sourced by `.github/actions/setup-matrix-jdk` and `.github/scripts/resolve-matrix-jdk.sh`.
+# Bump procedure is documented at the bottom of this file and in docs/guide/ci.md.
+#
+# Flavor choice: JBRSDK (`jdk` package in actions/setup-java's jetbrains distributor),
+# NOT jbr_jcef. Spectre's AWT/Robot/skiko surface does not need CEF; the smaller JBRSDK
+# build matches the non-browser IDE runtime more closely and downloads faster.
+
+# Major + minor/patch accepted by actions/setup-java (semver range). The distributor
+# resolves the newest matching JetBrains Runtime build for the runner OS/arch and caches it.
+JBR_21_VERSION=21.0.11
+JBR_25_VERSION=25.0.3
+
+# Vanilla LTS cell — Temurin at the project toolchain major (matches per-PR CI).
+TEMURIN_LTS_VERSION=21
+
+# actions/setup-java jetbrains package type: jdk | jre | jdk+jcef | jre+jcef | jdk+ft | jre+ft
+# jdk = JBRSDK (full JDK, no JCEF).
+JBR_JAVA_PACKAGE=jdk
+
+# ---------------------------------------------------------------------------
+# Bump procedure
+# ---------------------------------------------------------------------------
+# 1. Check https://github.com/JetBrains/JetBrainsRuntime/releases for new jbr21 / jbr25 tags
+#    (e.g. jbr-release-21.0.12b…, jbr-release-25.0.4b…).
+# 2. Update JBR_21_VERSION / JBR_25_VERSION to the desired X.Y.Z (setup-java picks the
+#    newest build for that version range). Keep TEMURIN_LTS_VERSION aligned with the
+#    project toolchain major unless intentionally moving the vanilla cell.
+# 3. Run: bash .github/scripts/test-resolve-matrix-jdk.sh
+# 4. Open a PR that only bumps pins (or includes them with other matrix work). After merge,
+#    trigger `Runtime matrix` via workflow_dispatch and confirm the nine cells + mixed
+#    attach jobs are green (or triaged into issues).
+# 5. Release tags re-run the matrix via workflow_call from release.yml — a red matrix blocks
+#    publish.

--- a/.github/scripts/open-matrix-failure-issue.sh
+++ b/.github/scripts/open-matrix-failure-issue.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Open (or comment on) a GitHub issue for a failed runtime-matrix cell.
+# Intended for scheduled runs so failures are not lost in workflow noise (#216).
+#
+# Required env:
+#   GITHUB_REPOSITORY, GITHUB_RUN_ID, GITHUB_SERVER_URL (Actions defaults)
+#   MATRIX_OS, MATRIX_RUNTIME, MATRIX_FIXTURE_RUNTIME (optional)
+#   GH_TOKEN or GITHUB_TOKEN with issues:write
+set -euo pipefail
+
+: "${GITHUB_REPOSITORY:?}"
+: "${GITHUB_RUN_ID:?}"
+: "${GITHUB_SERVER_URL:=https://github.com}"
+: "${MATRIX_OS:?}"
+: "${MATRIX_RUNTIME:?}"
+
+fixture="${MATRIX_FIXTURE_RUNTIME:-same}"
+title="[runtime-matrix] ${MATRIX_RUNTIME} on ${MATRIX_OS} (fixture=${fixture})"
+run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+body="$(
+  cat <<EOF
+Automated report from the scheduled **Runtime matrix** workflow (#216 / epic #215).
+
+| Cell | Value |
+| --- | --- |
+| OS | \`${MATRIX_OS}\` |
+| Attacher / suite runtime | \`${MATRIX_RUNTIME}\` |
+| Fixture runtime | \`${fixture}\` |
+| Run | ${run_url} |
+
+## Routing
+
+- Label \`runtime-matrix\` so capability-matrix / #198 follow-up can find the cell.
+- Do not silently re-green the matrix without triaging this issue.
+- When fixed, close this issue and re-run the matrix via \`workflow_dispatch\`.
+
+EOF
+)"
+
+# Prefer an open issue with the same title to avoid spam; otherwise create one.
+existing="$(
+  gh issue list \
+    --repo "$GITHUB_REPOSITORY" \
+    --label runtime-matrix \
+    --state open \
+    --search "in:title ${title}" \
+    --json number,title \
+    --jq ".[] | select(.title == \"${title}\") | .number" \
+    | head -n1 || true
+)"
+
+if [[ -n "$existing" ]]; then
+  gh issue comment "$existing" --repo "$GITHUB_REPOSITORY" --body "Re-failed: ${run_url}"
+  echo "Commented on existing issue #$existing"
+else
+  gh issue create \
+    --repo "$GITHUB_REPOSITORY" \
+    --title "$title" \
+    --label "runtime-matrix" \
+    --label "area/testing" \
+    --body "$body"
+  echo "Opened new runtime-matrix failure issue"
+fi

--- a/.github/scripts/open-matrix-failure-issue.sh
+++ b/.github/scripts/open-matrix-failure-issue.sh
@@ -15,7 +15,9 @@ set -euo pipefail
 : "${MATRIX_RUNTIME:?}"
 
 fixture="${MATRIX_FIXTURE_RUNTIME:-same}"
-title="[runtime-matrix] ${MATRIX_RUNTIME} on ${MATRIX_OS} (fixture=${fixture})"
+# Title avoids parentheses so GitHub issue search (which treats () as grouping) can still
+# match when we dedup by a short query; exact title equality is checked in jq below.
+title="[runtime-matrix] ${MATRIX_RUNTIME} on ${MATRIX_OS} fixture=${fixture}"
 run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
 body="$(
   cat <<EOF
@@ -38,14 +40,16 @@ EOF
 )"
 
 # Prefer an open issue with the same title to avoid spam; otherwise create one.
+# Search with a parenthesis-free query, then exact-match the title in jq.
+search_query="runtime-matrix ${MATRIX_RUNTIME} ${MATRIX_OS} fixture=${fixture}"
 existing="$(
   gh issue list \
     --repo "$GITHUB_REPOSITORY" \
     --label runtime-matrix \
     --state open \
-    --search "in:title ${title}" \
+    --search "$search_query" \
     --json number,title \
-    --jq ".[] | select(.title == \"${title}\") | .number" \
+    --jq ".[] | select(.title == \"${title//\"/\\\"}\") | .number" \
     | head -n1 || true
 )"
 

--- a/.github/scripts/resolve-matrix-jdk.sh
+++ b/.github/scripts/resolve-matrix-jdk.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Resolve a Spectre matrix runtime id to actions/setup-java inputs.
+#
+# Usage:
+#   resolve-matrix-jdk.sh <runtime-id>
+#   resolve-matrix-jdk.sh --print-env <runtime-id>
+#
+# Runtime ids: jbr-21 | jbr-25 | temurin-lts
+#
+# Prints either KEY=value lines suitable for GITHUB_OUTPUT / eval, or (with --print-env)
+# export-friendly DISTRIBUTION / JAVA_VERSION / JAVA_PACKAGE / RUNTIME_LABEL.
+
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+pins_file="${SPECTRE_JBR_PINS_FILE:-$script_dir/../jbr-pins.env}"
+
+if [[ ! -f "$pins_file" ]]; then
+  echo "error: pins file not found: $pins_file" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$pins_file"
+
+print_env=0
+if [[ "${1:-}" == "--print-env" ]]; then
+  print_env=1
+  shift
+fi
+
+runtime="${1:-}"
+if [[ -z "$runtime" ]]; then
+  echo "usage: $0 [--print-env] <jbr-21|jbr-25|temurin-lts>" >&2
+  exit 2
+fi
+
+case "$runtime" in
+  jbr-21)
+    distribution="jetbrains"
+    java_version="${JBR_21_VERSION:?JBR_21_VERSION missing from pins}"
+    java_package="${JBR_JAVA_PACKAGE:?JBR_JAVA_PACKAGE missing from pins}"
+    runtime_label="JBR ${JBR_21_VERSION}"
+    ;;
+  jbr-25)
+    distribution="jetbrains"
+    java_version="${JBR_25_VERSION:?JBR_25_VERSION missing from pins}"
+    java_package="${JBR_JAVA_PACKAGE:?JBR_JAVA_PACKAGE missing from pins}"
+    runtime_label="JBR ${JBR_25_VERSION}"
+    ;;
+  temurin-lts)
+    distribution="temurin"
+    java_version="${TEMURIN_LTS_VERSION:?TEMURIN_LTS_VERSION missing from pins}"
+    # Temurin ignores jetbrains package types; emit empty so callers can omit the input.
+    java_package=""
+    runtime_label="Temurin ${TEMURIN_LTS_VERSION} (LTS)"
+    ;;
+  *)
+    echo "error: unknown runtime id '$runtime' (expected jbr-21|jbr-25|temurin-lts)" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$print_env" -eq 1 ]]; then
+  printf 'DISTRIBUTION=%q\n' "$distribution"
+  printf 'JAVA_VERSION=%q\n' "$java_version"
+  printf 'JAVA_PACKAGE=%q\n' "$java_package"
+  printf 'RUNTIME_LABEL=%q\n' "$runtime_label"
+else
+  echo "distribution=$distribution"
+  echo "java-version=$java_version"
+  echo "java-package=$java_package"
+  echo "runtime-label=$runtime_label"
+fi

--- a/.github/scripts/test-resolve-matrix-jdk.sh
+++ b/.github/scripts/test-resolve-matrix-jdk.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+resolve="$script_dir/resolve-matrix-jdk.sh"
+pins="$script_dir/../jbr-pins.env"
+workflow="$script_dir/../workflows/runtime-matrix.yml"
+action="$script_dir/../actions/setup-matrix-jdk/action.yml"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -x "$resolve" || -f "$resolve" ]] || fail "resolve script missing"
+[[ -f "$pins" ]] || fail "pins file missing"
+[[ -f "$workflow" ]] || fail "runtime-matrix.yml missing"
+[[ -f "$action" ]] || fail "setup-matrix-jdk action missing"
+
+# Pins must declare the required keys.
+for key in JBR_21_VERSION JBR_25_VERSION TEMURIN_LTS_VERSION JBR_JAVA_PACKAGE; do
+  grep -qE "^${key}=" "$pins" || fail "pins missing $key"
+done
+
+# JBR flavor is deliberately JBRSDK (jdk), not jcef.
+pkg="$(grep -E '^JBR_JAVA_PACKAGE=' "$pins" | cut -d= -f2-)"
+[[ "$pkg" == "jdk" ]] || fail "expected JBR_JAVA_PACKAGE=jdk (JBRSDK), got '$pkg'"
+
+expect_field() {
+  local runtime="$1"
+  local field="$2"
+  local expected="$3"
+  local actual
+  actual="$(bash "$resolve" "$runtime" | grep -E "^${field}=" | cut -d= -f2-)"
+  [[ "$actual" == "$expected" ]] || fail "$runtime $field: expected '$expected', got '$actual'"
+}
+
+expect_field jbr-21 distribution jetbrains
+expect_field jbr-25 distribution jetbrains
+expect_field temurin-lts distribution temurin
+
+jbr21_ver="$(grep -E '^JBR_21_VERSION=' "$pins" | cut -d= -f2-)"
+jbr25_ver="$(grep -E '^JBR_25_VERSION=' "$pins" | cut -d= -f2-)"
+temurin_ver="$(grep -E '^TEMURIN_LTS_VERSION=' "$pins" | cut -d= -f2-)"
+
+expect_field jbr-21 java-version "$jbr21_ver"
+expect_field jbr-25 java-version "$jbr25_ver"
+expect_field temurin-lts java-version "$temurin_ver"
+expect_field jbr-21 java-package jdk
+expect_field jbr-25 java-package jdk
+expect_field temurin-lts java-package ""
+
+if bash "$resolve" no-such-runtime >/dev/null 2>&1; then
+  fail "unknown runtime should fail"
+fi
+
+# Workflow must cover the 3×3 product and gate suites.
+for needle in jbr-21 jbr-25 temurin-lts ubuntu-latest macos-latest windows-latest \
+  AgentContractCorpusTest AgentAttachIntegrationTest InProcessContractCorpusTest \
+  runLinuxX11RecordingSmoke workflow_call schedule; do
+  grep -q "$needle" "$workflow" || fail "runtime-matrix.yml missing expected token: $needle"
+done
+
+# Release workflow must depend on the matrix gate.
+release="$script_dir/../workflows/release.yml"
+grep -q 'runtime-matrix.yml' "$release" || fail "release.yml must call runtime-matrix.yml"
+
+echo "OK: resolve-matrix-jdk + pins + workflow structural checks passed"

--- a/.github/scripts/test-resolve-matrix-jdk.sh
+++ b/.github/scripts/test-resolve-matrix-jdk.sh
@@ -57,7 +57,7 @@ fi
 # Workflow must cover the 3×3 product and gate suites.
 for needle in jbr-21 jbr-25 temurin-lts ubuntu-latest macos-latest windows-latest \
   AgentContractCorpusTest AgentAttachIntegrationTest InProcessContractCorpusTest \
-  runLinuxX11RecordingSmoke workflow_call schedule; do
+  runLinuxX11RecordingSmoke workflow_call schedule "runner.os != 'Windows'"; do
   grep -q "$needle" "$workflow" || fail "runtime-matrix.yml missing expected token: $needle"
 done
 

--- a/.github/scripts/test-resolve-matrix-jdk.sh
+++ b/.github/scripts/test-resolve-matrix-jdk.sh
@@ -57,9 +57,12 @@ fi
 # Workflow must cover the 3×3 product and gate suites.
 for needle in jbr-21 jbr-25 temurin-lts ubuntu-latest macos-latest windows-latest \
   AgentContractCorpusTest AgentAttachIntegrationTest InProcessContractCorpusTest \
-  runLinuxX11RecordingSmoke workflow_call schedule "runner.os != 'Windows'"; do
+  runLinuxX11RecordingSmoke workflow_call schedule "runner.os != 'Windows'" \
+  SPECTRE_MATRIX_JAVA_HOME; do
   grep -q "$needle" "$workflow" || fail "runtime-matrix.yml missing expected token: $needle"
 done
+grep -q "SPECTRE_MATRIX_JAVA_HOME" "$script_dir/../../build.gradle.kts" ||
+  fail "root build.gradle.kts must honour SPECTRE_MATRIX_JAVA_HOME for matrix Test workers"
 
 # Release workflow must depend on the matrix gate.
 release="$script_dir/../workflows/release.yml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,11 @@ name: Release
 #
 # Release job graph:
 #
+#   0. `runtime-matrix`   — Reuses `.github/workflows/runtime-matrix.yml` (epic #215 /
+#                            issue #216). Full {JBR 21, JBR 25, Temurin LTS} × OS matrix
+#                            plus mixed-runtime agent attach. A red matrix blocks the
+#                            release; per-PR CI stays on single-JDK Temurin 21.
+#
 #   1. `release-gate`     — Linux runner. Rejects non-SemVer `v*` tags, runs the
 #                            full Gradle `check`, and runs `mkdocs build --strict`
 #                            before any helper build or publish job starts.
@@ -72,9 +77,15 @@ permissions:
   contents: read
 
 jobs:
+  runtime-matrix:
+    name: Runtime compatibility matrix
+    uses: ./.github/workflows/runtime-matrix.yml
+
   release-gate:
     name: Validate release tag
     runs-on: ubuntu-latest
+    needs:
+      - runtime-matrix
     outputs:
       version: ${{ steps.version.outputs.version }}
 

--- a/.github/workflows/runtime-matrix.yml
+++ b/.github/workflows/runtime-matrix.yml
@@ -1,0 +1,286 @@
+name: Runtime matrix
+
+# Epic #215 / issue #216 — scheduled + release-gated JVM compatibility matrix.
+#
+# Cells: {JBR 21, JBR 25, Temurin LTS} × {macOS, Linux, Windows}
+# Suites per cell:
+#   - contract corpus (in-process + HTTP always; agent under a display)
+#   - agent attach (same-runtime; mixed vanilla↔JBR on Linux)
+#   - recording smoke on Linux under xvfb (`:recording:runLinuxX11RecordingSmoke`)
+#
+# Per-PR CI stays single-JDK (Temurin 21 in ci.yml). This workflow is intentionally
+# expensive and runs on schedule, workflow_dispatch, and as a hard gate on release tags
+# (called from release.yml via workflow_call).
+
+on:
+  schedule:
+    # Weekly Sunday 06:15 UTC — full nine-cell + mixed attach.
+    - cron: "15 6 * * 0"
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+  # Scheduled failure routing opens/labels issues (#216).
+  issues: write
+
+jobs:
+  pin-selftest:
+    name: Pins + resolver self-test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Run structural pin/workflow checks
+        run: bash .github/scripts/test-resolve-matrix-jdk.sh
+
+  matrix:
+    name: ${{ matrix.runtime }} / ${{ matrix.os }}
+    needs: pin-selftest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        runtime: [jbr-21, jbr-25, temurin-lts]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up matrix JDK
+        id: jdk
+        uses: ./.github/actions/setup-matrix-jdk
+        with:
+          runtime: ${{ matrix.runtime }}
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Install Linux display + native build deps
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libdbus-1-dev pkg-config
+
+      - name: Set up Rust (Linux Wayland helper)
+        if: runner.os == 'Linux'
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Log runtime identity
+        shell: bash
+        run: |
+          echo "Matrix cell: runtime=${{ matrix.runtime }} os=${{ matrix.os }}"
+          echo "JAVA_HOME=$JAVA_HOME"
+          java -version
+          echo "runtime-label=${{ steps.jdk.outputs.runtime-label }}"
+
+      - name: Contract corpus (in-process + HTTP)
+        shell: bash
+        run: |
+          ./gradlew \
+            :testing:test --tests '*InProcessContractCorpusTest*' \
+            :server:test --tests '*HttpContractCorpusTest*' \
+            --rerun-tasks
+
+      - name: Agent attach + agent contract corpus
+        shell: bash
+        run: |
+          set -euo pipefail
+          gradle_cmd=(./gradlew :agent:test
+            --tests '*AgentAttachIntegrationTest*'
+            --tests '*AgentContractCorpusTest*'
+            --rerun-tasks)
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            xvfb-run -a "${gradle_cmd[@]}"
+          else
+            "${gradle_cmd[@]}"
+          fi
+
+      - name: Verify agent suites executed (no assumption-skip)
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          verify_agent_xml() {
+            local class_name="$1"
+            local xml="agent/build/test-results/test/TEST-dev.sebastiano.spectre.agent.${class_name}.xml"
+            if [ ! -f "$xml" ]; then
+              echo "::error::Missing JUnit XML $xml"
+              exit 1
+            fi
+            get_attr() {
+              grep -oE "$1=\"[0-9]+\"" "$xml" | head -n1 | grep -oE '[0-9]+' || true
+            }
+            local tests skipped failures errors
+            tests=$(get_attr tests)
+            skipped=$(get_attr skipped)
+            failures=$(get_attr failures)
+            errors=$(get_attr errors)
+            if [ -z "$tests" ] || [ -z "$skipped" ] || [ -z "$failures" ] || [ -z "$errors" ]; then
+              echo "::error file=$xml::Malformed JUnit XML"
+              exit 1
+            fi
+            if [ "$tests" -lt 1 ] || [ "$skipped" -gt 0 ]; then
+              echo "::error file=$xml::$class_name did not execute (tests=$tests skipped=$skipped)"
+              exit 1
+            fi
+            if [ "$failures" -gt 0 ] || [ "$errors" -gt 0 ]; then
+              echo "::error file=$xml::$class_name failures=$failures errors=$errors"
+              exit 1
+            fi
+            echo "$class_name OK"
+          }
+          verify_agent_xml "AgentAttachIntegrationTest"
+          verify_agent_xml "AgentContractCorpusTest"
+
+      - name: Linux X11 recording smoke under xvfb
+        if: runner.os == 'Linux'
+        shell: bash
+        run: xvfb-run -a ./gradlew :recording:runLinuxX11RecordingSmoke
+
+      - name: Upload cell artefacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: runtime-matrix-${{ matrix.runtime }}-${{ matrix.os }}
+          path: |
+            agent/build/reports/tests/
+            agent/build/test-results/
+            testing/build/reports/tests/
+            testing/build/test-results/
+            server/build/reports/tests/
+            server/build/test-results/
+            recording/build/reports/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Open failure issue (scheduled runs only)
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_RUNTIME: ${{ matrix.runtime }}
+          MATRIX_FIXTURE_RUNTIME: same
+        run: bash .github/scripts/open-matrix-failure-issue.sh
+        shell: bash
+
+  mixed-attach:
+    name: mixed ${{ matrix.attacher }}→${{ matrix.fixture }} / ${{ matrix.os }}
+    needs: pin-selftest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Mixed pairs are the expensive corner of the epic; run on Linux (xvfb) where
+        # agent attach is already proven under a display, and keep two directional pairs.
+        include:
+          - os: ubuntu-latest
+            attacher: jbr-25
+            fixture: temurin-lts
+          - os: ubuntu-latest
+            attacher: temurin-lts
+            fixture: jbr-25
+          - os: ubuntu-latest
+            attacher: jbr-21
+            fixture: temurin-lts
+          - os: ubuntu-latest
+            attacher: temurin-lts
+            fixture: jbr-21
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Install fixture JDK (non-default)
+        id: fixture-jdk
+        uses: ./.github/actions/setup-matrix-jdk
+        with:
+          runtime: ${{ matrix.fixture }}
+          set-default: "false"
+
+      - name: Install attacher JDK (default)
+        id: attacher-jdk
+        uses: ./.github/actions/setup-matrix-jdk
+        with:
+          runtime: ${{ matrix.attacher }}
+          set-default: "true"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Install Linux display + native build deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xvfb libdbus-1-dev pkg-config
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Mixed-runtime agent attach
+        env:
+          SPECTRE_FIXTURE_JAVA_HOME: ${{ steps.fixture-jdk.outputs.path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Attacher JAVA_HOME=$JAVA_HOME"
+          echo "Fixture JAVA_HOME=$SPECTRE_FIXTURE_JAVA_HOME"
+          java -version
+          "$SPECTRE_FIXTURE_JAVA_HOME/bin/java" -version
+          xvfb-run -a ./gradlew :agent:test \
+            --tests '*AgentAttachIntegrationTest*' \
+            --tests '*AgentContractCorpusTest*' \
+            --rerun-tasks
+
+      - name: Verify mixed attach executed
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          for class_name in AgentAttachIntegrationTest AgentContractCorpusTest; do
+            xml="agent/build/test-results/test/TEST-dev.sebastiano.spectre.agent.${class_name}.xml"
+            if [ ! -f "$xml" ]; then
+              echo "::error::Missing $xml"
+              exit 1
+            fi
+            tests=$(grep -oE 'tests="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || true)
+            skipped=$(grep -oE 'skipped="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || true)
+            failures=$(grep -oE 'failures="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || true)
+            errors=$(grep -oE 'errors="[0-9]+"' "$xml" | head -n1 | grep -oE '[0-9]+' || true)
+            if [ "${tests:-0}" -lt 1 ] || [ "${skipped:-1}" -gt 0 ] || [ "${failures:-1}" -gt 0 ] || [ "${errors:-1}" -gt 0 ]; then
+              echo "::error file=$xml::$class_name tests=$tests skipped=$skipped failures=$failures errors=$errors"
+              exit 1
+            fi
+            echo "$class_name OK (mixed)"
+          done
+
+      - name: Open failure issue (scheduled runs only)
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_RUNTIME: ${{ matrix.attacher }}
+          MATRIX_FIXTURE_RUNTIME: ${{ matrix.fixture }}
+        run: bash .github/scripts/open-matrix-failure-issue.sh
+        shell: bash
+
+  matrix-gate:
+    name: Runtime matrix gate
+    if: always()
+    needs: [pin-selftest, matrix, mixed-attach]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require all matrix jobs green
+        shell: bash
+        run: |
+          set -euo pipefail
+          pin="${{ needs.pin-selftest.result }}"
+          matrix="${{ needs.matrix.result }}"
+          mixed="${{ needs.mixed-attach.result }}"
+          echo "pin-selftest=$pin matrix=$matrix mixed-attach=$mixed"
+          if [[ "$pin" != "success" || "$matrix" != "success" || "$mixed" != "success" ]]; then
+            echo "::error::Runtime matrix gate failed (pin=$pin matrix=$matrix mixed=$mixed)"
+            exit 1
+          fi
+          echo "Runtime matrix gate passed."

--- a/.github/workflows/runtime-matrix.yml
+++ b/.github/workflows/runtime-matrix.yml
@@ -84,7 +84,12 @@ jobs:
             :server:test --tests '*HttpContractCorpusTest*' \
             --rerun-tasks
 
+      # Agent attach + agent contract corpus are @EnabledOnOs(LINUX, MAC) only — hosted
+      # Windows runners do not provide a reliable interactive desktop for the Robot-backed
+      # fixture (see AgentAttachIntegrationTest KDoc). Windows cells still exercise the
+      # in-process + HTTP corpus above; agent evidence stays Linux/macOS.
       - name: Agent attach + agent contract corpus
+        if: runner.os != 'Windows'
         shell: bash
         run: |
           set -euo pipefail
@@ -99,7 +104,7 @@ jobs:
           fi
 
       - name: Verify agent suites executed (no assumption-skip)
-        if: always()
+        if: always() && runner.os != 'Windows'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/runtime-matrix.yml
+++ b/.github/workflows/runtime-matrix.yml
@@ -76,7 +76,12 @@ jobs:
           java -version
           echo "runtime-label=${{ steps.jdk.outputs.runtime-label }}"
 
+      # Force Test/JavaExec workers onto the matrix JDK (see root build.gradle.kts). Modules
+      # still compile with jvmToolchain(21); SPECTRE_MATRIX_JAVA_HOME makes JBR 25 cells
+      # actually *run* on JBR 25 instead of a toolchain-provisioned JDK 21.
       - name: Contract corpus (in-process + HTTP)
+        env:
+          SPECTRE_MATRIX_JAVA_HOME: ${{ steps.jdk.outputs.path }}
         shell: bash
         run: |
           ./gradlew \
@@ -90,6 +95,8 @@ jobs:
       # in-process + HTTP corpus above; agent evidence stays Linux/macOS.
       - name: Agent attach + agent contract corpus
         if: runner.os != 'Windows'
+        env:
+          SPECTRE_MATRIX_JAVA_HOME: ${{ steps.jdk.outputs.path }}
         shell: bash
         run: |
           set -euo pipefail
@@ -142,6 +149,8 @@ jobs:
 
       - name: Linux X11 recording smoke under xvfb
         if: runner.os == 'Linux'
+        env:
+          SPECTRE_MATRIX_JAVA_HOME: ${{ steps.jdk.outputs.path }}
         shell: bash
         run: xvfb-run -a ./gradlew :recording:runLinuxX11RecordingSmoke
 
@@ -226,10 +235,12 @@ jobs:
       - name: Mixed-runtime agent attach
         env:
           SPECTRE_FIXTURE_JAVA_HOME: ${{ steps.fixture-jdk.outputs.path }}
+          SPECTRE_MATRIX_JAVA_HOME: ${{ steps.attacher-jdk.outputs.path }}
         shell: bash
         run: |
           set -euo pipefail
           echo "Attacher JAVA_HOME=$JAVA_HOME"
+          echo "SPECTRE_MATRIX_JAVA_HOME=$SPECTRE_MATRIX_JAVA_HOME"
           echo "Fixture JAVA_HOME=$SPECTRE_FIXTURE_JAVA_HOME"
           java -version
           "$SPECTRE_FIXTURE_JAVA_HOME/bin/java" -version

--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ Two heavier checks live outside `:check`:
 
 ## Supported JVMs
 
-JBR 21 is the dev-loop default. JBR 25 also gets exercised via the IDE-hosted test (bundled
-with IntelliJ 2026.1). Any JDK 21+ works for the non-IDE modules. CI runs on Temurin 21.
+JBR 21 is the dev-loop default. JBR 25 and Temurin LTS (toolchain major) are exercised by the
+scheduled [runtime matrix](.github/workflows/runtime-matrix.yml) (epic #215 / #216) and re-run
+as a **release gate**. Per-PR CI stays on Temurin 21 for speed. Any JDK 21+ works for the
+non-IDE modules; pins and the bump procedure live in [`.github/jbr-pins.env`](.github/jbr-pins.env).
 
 ## CI
 
@@ -122,6 +124,9 @@ with IntelliJ 2026.1). Any JDK 21+ works for the non-IDE modules. CI runs on Tem
 - [`validation-linux.yml`](.github/workflows/validation-linux.yml) — same validation matrix
   on Linux under `xvfb-run` (real Xorg, no compositor in the loop), gated on the same
   `sample-desktop/**` filter shape.
+- [`runtime-matrix.yml`](.github/workflows/runtime-matrix.yml) — weekly + release-gated
+  `{JBR 21, JBR 25, Temurin LTS} × {macOS, Linux, Windows}` with contract corpus, agent
+  attach (incl. mixed vanilla↔JBR on Linux), and Linux recording smoke under xvfb.
 
 For consumer projects, see [Running on CI](docs/guide/ci.md) for the required test-JVM flags:
 `java.awt.headless=false` for AWT, `skiko.renderApi=SOFTWARE_COMPAT` on GPU-less Linux runners,

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -77,11 +77,28 @@ tasks.withType<Test>().configureEach {
         project(":agent-runtime").tasks.named<Jar>("jar").flatMap { it.archiveFile }
     inputs.file(runtimeJarFile)
     dependsOn(runtimeJarFile)
+    // Mixed-runtime matrix cells (#216): forward fixture JAVA_HOME into the forked test JVM.
+    // Gradle CLI `-D…` alone only hits the daemon; Test workers need an explicit -D via this
+    // provider. Prefer (1) `-Pspectre.agent.fixtureJavaHome=…`, then (2) env
+    // `SPECTRE_FIXTURE_JAVA_HOME`, then (3) a daemon system property of the same name.
+    val fixtureJavaHome =
+        providers
+            .gradleProperty("spectre.agent.fixtureJavaHome")
+            .orElse(providers.environmentVariable("SPECTRE_FIXTURE_JAVA_HOME"))
+            .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.fixtureJavaHome"))
+
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
-            listOf(
-                "-Ddev.sebastiano.spectre.agent.runtimeJar=${runtimeJarFile.get().asFile.absolutePath}"
-            )
+            buildList {
+                add(
+                    "-Ddev.sebastiano.spectre.agent.runtimeJar=" +
+                        runtimeJarFile.get().asFile.absolutePath
+                )
+                val home = fixtureJavaHome.orNull?.takeIf { it.isNotBlank() }
+                if (home != null) {
+                    add("-Ddev.sebastiano.spectre.agent.fixtureJavaHome=$home")
+                }
+            }
         }
     )
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -287,12 +287,8 @@ class AgentAttachIntegrationTest {
 
     private fun spawnComposeFixture(dynamicAgentLoadingEnabled: Boolean = true): FixtureProcess {
         // ProcessBuilder does not append `.exe` for an absolute path on Windows, so pick the
-        // launcher name explicitly.
-        val javaExe =
-            if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
-                "java.exe"
-            else "java"
-        val javaBin = Paths.get(System.getProperty("java.home"), "bin", javaExe).toString()
+        // launcher name explicitly via FixtureJavaHome (also honours mixed-runtime overrides).
+        val javaBin = FixtureJavaHome.javaExecutable().toString()
         val classpath = System.getProperty("java.class.path")
         val process =
             ProcessBuilder(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
@@ -183,11 +183,8 @@ class AgentContractCorpusTest {
     }
 
     private fun spawnComposeFixture(): FixtureProcess {
-        val javaExe =
-            if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
-                "java.exe"
-            else "java"
-        val javaBin = Paths.get(System.getProperty("java.home"), "bin", javaExe).toString()
+        // Honours -Ddev.sebastiano.spectre.agent.fixtureJavaHome for mixed-runtime matrix cells.
+        val javaBin = FixtureJavaHome.javaExecutable().toString()
         val classpath = System.getProperty("java.class.path")
         val process =
             ProcessBuilder(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/FixtureJavaHome.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/FixtureJavaHome.kt
@@ -1,0 +1,43 @@
+package dev.sebastiano.spectre.agent
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+/**
+ * Resolves the JVM used to spawn the Compose agent-test fixture.
+ *
+ * Defaults to the attacher JVM (`java.home`). Override with
+ * `-Ddev.sebastiano.spectre.agent.fixtureJavaHome=<path>` so the runtime matrix can exercise
+ * mixed-runtime attach (e.g. JBR attacher → Temurin target) without rewriting each test.
+ *
+ * Used only from test code; not part of the public agent API.
+ */
+internal object FixtureJavaHome {
+    const val PROPERTY: String = "dev.sebastiano.spectre.agent.fixtureJavaHome"
+
+    fun resolve(
+        javaHomeProp: String? = System.getProperty("java.home"),
+        fixtureProp: String? = System.getProperty(PROPERTY),
+    ): Path {
+        val selected =
+            fixtureProp?.takeIf { it.isNotBlank() }
+                ?: javaHomeProp?.takeIf { it.isNotBlank() }
+                ?: error("java.home is unset and $PROPERTY was not provided")
+        val path = Paths.get(selected)
+        require(Files.isDirectory(path)) {
+            val source = if (fixtureProp?.isNotBlank() == true) PROPERTY else "java.home"
+            "Fixture JAVA_HOME is not a directory: $path (from $source)"
+        }
+        return path
+    }
+
+    fun javaExecutable(home: Path = resolve()): Path = home.resolve("bin").resolve(javaFileName())
+
+    fun javaFileName(): String =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) {
+            "java.exe"
+        } else {
+            "java"
+        }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/FixtureJavaHomeTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/FixtureJavaHomeTest.kt
@@ -1,0 +1,116 @@
+package dev.sebastiano.spectre.agent
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+class FixtureJavaHomeTest {
+
+    @Test
+    fun `defaults to java-home when fixture property is unset`() {
+        val home = Files.createTempDirectory("fixture-default-home")
+        try {
+            val resolved =
+                FixtureJavaHome.resolve(javaHomeProp = home.toString(), fixtureProp = null)
+            assertEquals(home, resolved)
+        } finally {
+            Files.deleteIfExists(home)
+        }
+    }
+
+    @Test
+    fun `prefers fixture property over java-home`() {
+        val attacherHome = Files.createTempDirectory("attacher-home")
+        val fixtureHome = Files.createTempDirectory("fixture-home")
+        try {
+            val resolved =
+                FixtureJavaHome.resolve(
+                    javaHomeProp = attacherHome.toString(),
+                    fixtureProp = fixtureHome.toString(),
+                )
+            assertEquals(fixtureHome, resolved)
+        } finally {
+            Files.deleteIfExists(attacherHome)
+            Files.deleteIfExists(fixtureHome)
+        }
+    }
+
+    @Test
+    fun `blank fixture property falls back to java-home`() {
+        val home = Files.createTempDirectory("fixture-blank-home")
+        try {
+            val resolved =
+                FixtureJavaHome.resolve(javaHomeProp = home.toString(), fixtureProp = "   ")
+            assertEquals(home, resolved)
+        } finally {
+            Files.deleteIfExists(home)
+        }
+    }
+
+    @Test
+    fun `rejects missing java homes`() {
+        assertFailsWith<IllegalStateException> {
+            FixtureJavaHome.resolve(javaHomeProp = null, fixtureProp = null)
+        }
+    }
+
+    @Test
+    fun `rejects non-directory fixture home`() {
+        val missing = Files.createTempDirectory("fixture-missing").resolve("nope")
+        assertFailsWith<IllegalArgumentException> {
+            FixtureJavaHome.resolve(
+                javaHomeProp = Files.createTempDirectory("attacher").toString(),
+                fixtureProp = missing.toString(),
+            )
+        }
+    }
+
+    @Test
+    fun `javaExecutable points at bin-java under the resolved home`() {
+        val home = Files.createTempDirectory("fixture-java-bin")
+        try {
+            val exe = FixtureJavaHome.javaExecutable(home)
+            assertEquals(home.resolve("bin").resolve(FixtureJavaHome.javaFileName()), exe)
+            assertTrue(exe.fileName.toString() == FixtureJavaHome.javaFileName())
+        } finally {
+            Files.deleteIfExists(home)
+        }
+    }
+
+    @Test
+    fun `reads live system property when Gradle forwards SPECTRE_FIXTURE_JAVA_HOME`() {
+        // When the matrix sets SPECTRE_FIXTURE_JAVA_HOME / -Pspectre.agent.fixtureJavaHome,
+        // :agent:test forwards it as -Ddev.sebastiano.spectre.agent.fixtureJavaHome into this
+        // forked JVM. Assert the live property is honoured when present; when absent (default
+        // unit-test runs), resolve() still falls back to java.home.
+        val live = System.getProperty(FixtureJavaHome.PROPERTY)
+        val resolved = FixtureJavaHome.resolve()
+        if (live.isNullOrBlank()) {
+            assertEquals(
+                Paths.get(System.getProperty("java.home")!!).normalize(),
+                resolved.normalize(),
+            )
+        } else {
+            assertEquals(Paths.get(live).normalize(), resolved.normalize())
+            assertTrue(Files.isDirectory(resolved))
+        }
+    }
+
+    @Test
+    fun `Gradle forwards SPECTRE_FIXTURE_JAVA_HOME env into the fixture system property`() {
+        // Matrix mixed-attach cells set SPECTRE_FIXTURE_JAVA_HOME. The forked test JVM inherits
+        // the env var, and agent/build.gradle.kts must also inject the matching -D property.
+        // Skip when the env is unset so ordinary `./gradlew check` stays green.
+        val env = System.getenv("SPECTRE_FIXTURE_JAVA_HOME")?.takeIf { it.isNotBlank() }
+        assumeTrue(env != null) {
+            "SPECTRE_FIXTURE_JAVA_HOME not set; skip matrix-only forward check"
+        }
+        val prop = System.getProperty(FixtureJavaHome.PROPERTY)
+        assertTrue(!prop.isNullOrBlank(), "expected ${FixtureJavaHome.PROPERTY} to be forwarded")
+        assertEquals(Paths.get(env).normalize(), Paths.get(prop).normalize())
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -116,6 +116,34 @@ subprojects {
     group = rootProject.group
     version = rootProject.version
 
+    // Runtime matrix (#216 / epic #215): modules keep `jvmToolchain(21)` for compile, but
+    // matrix cells must *execute* Test / JavaExec workers on the provisioned JBR/Temurin.
+    // When SPECTRE_MATRIX_JAVA_HOME is set (by `.github/workflows/runtime-matrix.yml`), force
+    // the worker JVM onto that home so JBR 25 cells do not silently fall back to a toolchain
+    // JDK 21.
+    val matrixJavaHome = providers.environmentVariable("SPECTRE_MATRIX_JAVA_HOME")
+    val matrixJavaExecutable =
+        matrixJavaHome.map { home ->
+            val javaName =
+                if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
+                ) {
+                    "java.exe"
+                } else {
+                    "java"
+                }
+            file("$home/bin/$javaName").absolutePath
+        }
+    tasks.withType<Test>().configureEach {
+        if (matrixJavaHome.isPresent) {
+            executable = matrixJavaExecutable.get()
+        }
+    }
+    tasks.withType<JavaExec>().configureEach {
+        if (matrixJavaHome.isPresent) {
+            executable = matrixJavaExecutable.get()
+        }
+    }
+
     pluginManager.withPlugin("com.ncorti.ktfmt.gradle") {
         extensions.configure<KtfmtExtension> { kotlinLangStyle() }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -122,17 +122,15 @@ subprojects {
     // the worker JVM onto that home so JBR 25 cells do not silently fall back to a toolchain
     // JDK 21.
     val matrixJavaHome = providers.environmentVariable("SPECTRE_MATRIX_JAVA_HOME")
-    val matrixJavaExecutable =
-        matrixJavaHome.map { home ->
-            val javaName =
-                if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
-                ) {
-                    "java.exe"
-                } else {
-                    "java"
-                }
-            file("$home/bin/$javaName").absolutePath
-        }
+    val matrixJavaExecutable = matrixJavaHome.map { home ->
+        val javaName =
+            if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) {
+                "java.exe"
+            } else {
+                "java"
+            }
+        file("$home/bin/$javaName").absolutePath
+    }
     tasks.withType<Test>().configureEach {
         if (matrixJavaHome.isPresent) {
             // Test.executable is a Property<String> on modern Gradle; setExecutable keeps

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,12 +135,14 @@ subprojects {
         }
     tasks.withType<Test>().configureEach {
         if (matrixJavaHome.isPresent) {
-            executable = matrixJavaExecutable.get()
+            // Test.executable is a Property<String> on modern Gradle; setExecutable keeps
+            // older accessors happy too.
+            setExecutable(matrixJavaExecutable.get())
         }
     }
     tasks.withType<JavaExec>().configureEach {
         if (matrixJavaHome.isPresent) {
-            executable = matrixJavaExecutable.get()
+            setExecutable(matrixJavaExecutable.get())
         }
     }
 

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -132,6 +132,33 @@ Useful patterns to search for include `Sandbox: java(...) deny(1) mach-lookup`,
 `WMClientWindowManager: Invalid connection`, `ScreenCaptureKit`, `ReplayKit`,
 `com.apple.replayd`, and `kTCCServiceScreenCapture`.
 
+## Runtime matrix (JBR / Temurin)
+
+Per-PR CI stays on a single Temurin 21 JDK for speed. Compatibility across **JBR 21**,
+**JBR 25**, and **Temurin LTS** (toolchain major) on macOS, Linux, and Windows is covered by
+the scheduled [runtime-matrix](https://github.com/rock3r/spectre/blob/main/.github/workflows/runtime-matrix.yml)
+workflow (epic #215 / issue #216):
+
+| Dimension | Values |
+| --- | --- |
+| Runtime | JBR 21, JBR 25, Temurin LTS |
+| OS | macOS, Linux (`xvfb`), Windows |
+| Suites | Contract corpus, agent attach (same-runtime + mixed vanilla↔JBR on Linux), Linux X11 recording smoke |
+
+Pins live in [`.github/jbr-pins.env`](https://github.com/rock3r/spectre/blob/main/.github/jbr-pins.env)
+(JBRSDK / `jdk` package, not `jbr_jcef`). Bump procedure is in that file’s header comments.
+`actions/setup-java` caches downloads per runner OS/arch via the composite action
+`.github/actions/setup-matrix-jdk`.
+
+The matrix is **release-gated**: `release.yml` calls the same workflow via `workflow_call`
+before helper builds and publish. A red cell blocks the release; scheduled failures open
+issues labelled `runtime-matrix` rather than vanishing into Actions noise.
+
+Mixed-runtime agent attach sets `SPECTRE_FIXTURE_JAVA_HOME` (or
+`-Pspectre.agent.fixtureJavaHome=…`) so the fixture JVM can differ from the attacher; the
+`:agent:test` task forwards it as
+`-Ddev.sebastiano.spectre.agent.fixtureJavaHome=…` into the forked test JVM.
+
 ## Recording tests
 
 Keep recording tests tagged separately from normal UI tests. Linux CI can validate Xorg / `xvfb`

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -154,6 +154,11 @@ The matrix is **release-gated**: `release.yml` calls the same workflow via `work
 before helper builds and publish. A red cell blocks the release; scheduled failures open
 issues labelled `runtime-matrix` rather than vanishing into Actions noise.
 
+Test/JavaExec workers are forced onto the matrix JDK via `SPECTRE_MATRIX_JAVA_HOME`
+(root `build.gradle.kts`); modules still **compile** with `jvmToolchain(21)`. Without that
+env, Gradle would execute JBR 25 cells on a toolchain-provisioned JDK 21 and the matrix
+would not prove runtime compatibility.
+
 Mixed-runtime agent attach sets `SPECTRE_FIXTURE_JAVA_HOME` (or
 `-Pspectre.agent.fixtureJavaHome=…`) so the fixture JVM can differ from the attacher; the
 `:agent:test` task forwards it as

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -143,7 +143,7 @@ workflow (epic #215 / issue #216):
 | --- | --- |
 | Runtime | JBR 21, JBR 25, Temurin LTS |
 | OS | macOS, Linux (`xvfb`), Windows |
-| Suites | Contract corpus, agent attach (same-runtime + mixed vanilla↔JBR on Linux), Linux X11 recording smoke |
+| Suites | Contract corpus (all OSes); agent attach same-runtime on Linux/macOS + mixed vanilla↔JBR on Linux; Linux X11 recording smoke. Agent suites are `@EnabledOnOs(LINUX, MAC)` only — Windows cells still run the non-agent corpus. |
 
 Pins live in [`.github/jbr-pins.env`](https://github.com/rock3r/spectre/blob/main/.github/jbr-pins.env)
 (JBRSDK / `jdk` package, not `jbr_jcef`). Bump procedure is in that file’s header comments.


### PR DESCRIPTION
## Summary

Implements #216 (epic #215): make “runs on JBR 21 / JBR 25 / Temurin LTS” a **tested claim**, not hope.

- **Pins**: `.github/jbr-pins.env` (JBR 21.0.11, JBR 25.0.3, Temurin 21; JBRSDK/`jdk` package, not jcef) + bump procedure in-file and `docs/guide/ci.md`
- **Provision**: composite action `.github/actions/setup-matrix-jdk` (uses `actions/setup-java` jetbrains/temurin + toolcache)
- **Workflow**: `.github/workflows/runtime-matrix.yml` — weekly schedule, `workflow_dispatch`, and `workflow_call`
  - 9 cells: `{jbr-21, jbr-25, temurin-lts} × {ubuntu, macos, windows}`
  - Suites: in-process + HTTP contract corpus; agent attach + agent corpus (Linux under xvfb); Linux X11 recording smoke
  - Mixed attach on Linux: JBR↔Temurin both directions for 21 and 25
  - Scheduled failures open/comment issues labelled `runtime-matrix`
- **Release gate**: `release.yml` calls the matrix before `release-gate` / publish
- **Per-PR CI**: unchanged (single Temurin 21)
- **Mixed fixture JVM**: `SPECTRE_FIXTURE_JAVA_HOME` / `-Pspectre.agent.fixtureJavaHome` forwarded into `:agent:test`; `FixtureJavaHome` used by attach tests

## Test plan

- [x] `bash .github/scripts/test-resolve-matrix-jdk.sh` (pins + workflow structure + release linkage)
- [x] `FixtureJavaHomeTest` green, including env→system-property forward check under `SPECTRE_FIXTURE_JAVA_HOME`
- [x] Contract corpus under local JBR 25
- [x] `./gradlew check` (agent live attach suites can focus-flake on interactive macOS desktop; CI/xvfb is the attach evidence path)
- [ ] CI green on this PR
- [ ] After merge: `workflow_dispatch` Runtime matrix for first full nine-cell signal (triage red cells into issues if needed)

Closes #216.