### PR TITLE
Inject spectre-core when target has no preinstalled core (#209 M2)

### DIFF
--- a/agent-inject-runtime/build.gradle.kts
+++ b/agent-inject-runtime/build.gradle.kts
@@ -1,0 +1,119 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import java.util.zip.ZipFile
+
+plugins {
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.ktfmt)
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.shadow)
+    // Not published as a stand-alone Central artifact for the spike — nested inside
+    // spectre-agent-runtime as META-INF/spectre/inject-runtime.jar. POM fields remain for
+    // future publication if M5 promotes injection.
+}
+
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+}
+
+dependencies {
+    // Full core surface for inject bootstrap. Compose types stay external: the shadow jar
+    // excludes Compose / Skiko so the target JVM's classloaders supply them at runtime.
+    implementation(projects.core)
+
+    detektPlugins(libs.compose.rules.detekt)
+}
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }
+
+// Marker source so the module has a compile output even though payload is mostly core.
+tasks.named<Jar>("jar") {
+    archiveClassifier.set("thin")
+    enabled = true
+}
+
+tasks.named<ShadowJar>("shadowJar") {
+    archiveClassifier.set("")
+    archiveBaseName.set("spectre-agent-inject-runtime")
+    mergeServiceFiles()
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+    // Relocate kotlinx so IDE-shipped coroutines cannot collide with injected core.
+    relocate("kotlinx.coroutines", "dev.sebastiano.spectre.inject.relocated.kotlinx.coroutines")
+    // atomicfu is pulled transitively; relocate to keep inject payload self-contained.
+    relocate("kotlinx.atomicfu", "dev.sebastiano.spectre.inject.relocated.kotlinx.atomicfu")
+
+    dependencies {
+        // Compose / Skiko must come from the target — never shade.
+        exclude(dependency("org.jetbrains.compose.runtime:.*"))
+        exclude(dependency("org.jetbrains.compose.foundation:.*"))
+        exclude(dependency("org.jetbrains.compose.ui:.*"))
+        exclude(dependency("org.jetbrains.compose.animation:.*"))
+        exclude(dependency("org.jetbrains.compose.material3:.*"))
+        exclude(dependency("org.jetbrains.compose:.*"))
+        exclude(dependency("org.jetbrains.skiko:.*"))
+        // Kotlin stdlib is always on the target JVM (and IDE); keep out of inject jar.
+        exclude(dependency("org.jetbrains.kotlin:kotlin-stdlib.*"))
+        exclude(dependency("org.jetbrains.kotlin:kotlin-reflect.*"))
+        exclude(dependency("org.jetbrains:annotations"))
+    }
+
+    // Belt-and-suspenders: drop any Compose/Skiko/stdlib entries that slip past dependency exclude.
+    exclude("androidx/compose/**")
+    exclude("org/jetbrains/compose/**")
+    exclude("org/jetbrains/skiko/**")
+    exclude("kotlin/**")
+    exclude("META-INF/*.SF")
+    exclude("META-INF/*.DSA")
+    exclude("META-INF/*.RSA")
+}
+
+val verifyInjectRuntimeJarContents by tasks.registering {
+    description =
+        "Asserts inject runtime jar carries spectre-core + relocated kotlinx and never " +
+            "bundles Compose/Skiko."
+    group = "verification"
+
+    val jarFile = tasks.named<ShadowJar>("shadowJar").flatMap { it.archiveFile }
+    dependsOn(jarFile)
+    inputs.file(jarFile)
+
+    doLast {
+        val jar = jarFile.get().asFile
+        ZipFile(jar).use { zip ->
+            val names = zip.entries().asSequence().map { it.name }.toList()
+            fun has(prefix: String) = names.any { it.startsWith(prefix) }
+
+            require(has("dev/sebastiano/spectre/core/ComposeAutomator")) {
+                "Inject jar missing ComposeAutomator class"
+            }
+            require(has("dev/sebastiano/spectre/inject/relocated/kotlinx/coroutines/")) {
+                "Inject jar missing relocated kotlinx.coroutines " +
+                    "(got entries sample: ${names.filter { "coroutines" in it }.take(10)})"
+            }
+            val forbidden =
+                listOf(
+                    "androidx/compose/",
+                    "org/jetbrains/compose/",
+                    "org/jetbrains/skiko/",
+                    "kotlinx/coroutines/", // must be relocated, not original package
+                )
+            val leaks = names.filter { entry -> forbidden.any { entry.startsWith(it) } }
+            require(leaks.isEmpty()) {
+                "Inject jar contains forbidden entries:\n" +
+                    leaks.sorted().joinToString("\n") { "  - $it" }
+            }
+        }
+    }
+}
+
+tasks.named("check") { dependsOn(verifyInjectRuntimeJarContents, "shadowJar") }
+
+// Default assemble uses shadow jar as the consumable artifact.
+configurations.named("default") {
+    // Prefer shadow output when other modules depend on this project as files.
+}
+
+artifacts {
+    add("default", tasks.named<ShadowJar>("shadowJar")) { builtBy(tasks.named("shadowJar")) }
+}

--- a/agent-inject-runtime/gradle.properties
+++ b/agent-inject-runtime/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=spectre-agent-inject-runtime
+POM_NAME=Spectre Agent Inject Runtime
+POM_DESCRIPTION=Relocated Spectre core payload for agent injection into JVMs without preinstalled spectre-core. Compose is resolved against the target classloader and is not bundled.

--- a/agent-inject-runtime/src/main/kotlin/dev/sebastiano/spectre/inject/InjectRuntimeMarker.kt
+++ b/agent-inject-runtime/src/main/kotlin/dev/sebastiano/spectre/inject/InjectRuntimeMarker.kt
@@ -1,0 +1,10 @@
+package dev.sebastiano.spectre.inject
+
+/**
+ * Marker type packaged into the inject-runtime jar so tooling can detect the inject payload
+ * independently of `:core` classes (which live in the same jar after shadowing).
+ *
+ * The class has no behaviour — bootstrap loads `dev.sebastiano.spectre.core.ComposeAutomator` from
+ * this jar via [dev.sebastiano.spectre.agent.runtime.SpectreInjectClassLoader].
+ */
+public object InjectRuntimeMarker

--- a/agent-runtime/build.gradle.kts
+++ b/agent-runtime/build.gradle.kts
@@ -29,10 +29,7 @@ val runtimeClasspath = configurations.named("runtimeClasspath")
 // Nested inject payload (#209): relocated core + kotlinx, no Compose. Packaged as a resource
 // so the thin agent-runtime still forbids exploded core/ classes (verifyAgentRuntimeJarContents).
 val injectRuntimeJarTask = project(":agent-inject-runtime").tasks.named("shadowJar")
-val injectRuntimeJarFile =
-    injectRuntimeJarTask.map { task ->
-        task.outputs.files.singleFile
-    }
+val injectRuntimeJarFile = injectRuntimeJarTask.map { task -> task.outputs.files.singleFile }
 
 tasks.named<JvmJar>("jar") {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
@@ -67,61 +64,60 @@ tasks.named<JvmJar>("jar") {
     }
 }
 
-val verifyAgentRuntimeJarContents by
-    tasks.registering {
-        description =
-            "Asserts the agent runtime JAR is loadable by the Attach API and stays thin: no " +
-                "exploded Compose, Skiko, Kotlin stdlib, coroutines, or Spectre core classes. " +
-                "Nested META-INF/spectre/inject-runtime.jar is required for #209 injection."
-        group = "verification"
+val verifyAgentRuntimeJarContents by tasks.registering {
+    description =
+        "Asserts the agent runtime JAR is loadable by the Attach API and stays thin: no " +
+            "exploded Compose, Skiko, Kotlin stdlib, coroutines, or Spectre core classes. " +
+            "Nested META-INF/spectre/inject-runtime.jar is required for #209 injection."
+    group = "verification"
 
-        val jarFile = tasks.named<JvmJar>("jar").flatMap { it.archiveFile }
-        dependsOn(jarFile)
-        inputs.file(jarFile)
+    val jarFile = tasks.named<JvmJar>("jar").flatMap { it.archiveFile }
+    dependsOn(jarFile)
+    inputs.file(jarFile)
 
-        doLast {
-            val jar = jarFile.get().asFile
-            ZipFile(jar).use { zip ->
-                val manifest =
-                    zip.getInputStream(zip.getEntry("META-INF/MANIFEST.MF")).use { input ->
-                        Manifest(input)
-                    }
-                val attrs = manifest.mainAttributes
-                val expectedAgentClass = "dev.sebastiano.spectre.agent.runtime.SpectreAgent"
-                require(attrs.getValue("Agent-Class") == expectedAgentClass) {
-                    "Agent runtime jar is missing Agent-Class=$expectedAgentClass"
+    doLast {
+        val jar = jarFile.get().asFile
+        ZipFile(jar).use { zip ->
+            val manifest =
+                zip.getInputStream(zip.getEntry("META-INF/MANIFEST.MF")).use { input ->
+                    Manifest(input)
                 }
-                require(attrs.getValue("Premain-Class") == expectedAgentClass) {
-                    "Agent runtime jar is missing Premain-Class=$expectedAgentClass"
-                }
+            val attrs = manifest.mainAttributes
+            val expectedAgentClass = "dev.sebastiano.spectre.agent.runtime.SpectreAgent"
+            require(attrs.getValue("Agent-Class") == expectedAgentClass) {
+                "Agent runtime jar is missing Agent-Class=$expectedAgentClass"
+            }
+            require(attrs.getValue("Premain-Class") == expectedAgentClass) {
+                "Agent runtime jar is missing Premain-Class=$expectedAgentClass"
+            }
 
-                val injectEntry = zip.getEntry("META-INF/spectre/inject-runtime.jar")
-                require(injectEntry != null && injectEntry.size > 0L) {
-                    "Agent runtime jar missing nested META-INF/spectre/inject-runtime.jar (#209)"
-                }
+            val injectEntry = zip.getEntry("META-INF/spectre/inject-runtime.jar")
+            require(injectEntry != null && injectEntry.size > 0L) {
+                "Agent runtime jar missing nested META-INF/spectre/inject-runtime.jar (#209)"
+            }
 
-                val forbiddenPrefixes =
-                    listOf(
-                        "androidx/compose/",
-                        "org/jetbrains/compose/",
-                        "org/jetbrains/skiko/",
-                        "dev/sebastiano/spectre/core/",
-                        "kotlin/Pair.class",
-                        "kotlinx/coroutines/",
-                    )
-                val leaks =
-                    zip.entries()
-                        .asSequence()
-                        .map { it.name }
-                        .filter { entry -> forbiddenPrefixes.any { entry.startsWith(it) } }
-                val leakList = leaks.toList()
-                require(leakList.isEmpty()) {
-                    "Agent runtime jar contains forbidden classes:\n" +
-                        leakList.sorted().joinToString("\n") { "  - $it" }
-                }
+            val forbiddenPrefixes =
+                listOf(
+                    "androidx/compose/",
+                    "org/jetbrains/compose/",
+                    "org/jetbrains/skiko/",
+                    "dev/sebastiano/spectre/core/",
+                    "kotlin/Pair.class",
+                    "kotlinx/coroutines/",
+                )
+            val leaks =
+                zip.entries()
+                    .asSequence()
+                    .map { it.name }
+                    .filter { entry -> forbiddenPrefixes.any { entry.startsWith(it) } }
+            val leakList = leaks.toList()
+            require(leakList.isEmpty()) {
+                "Agent runtime jar contains forbidden classes:\n" +
+                    leakList.sorted().joinToString("\n") { "  - $it" }
             }
         }
     }
+}
 
 tasks.named("check") { dependsOn(verifyAgentRuntimeJarContents) }
 

--- a/agent-runtime/build.gradle.kts
+++ b/agent-runtime/build.gradle.kts
@@ -2,6 +2,7 @@ import java.io.File
 import java.util.jar.Attributes
 import java.util.jar.Manifest
 import java.util.zip.ZipFile
+import org.gradle.jvm.tasks.Jar as JvmJar
 
 plugins {
     alias(libs.plugins.detekt)
@@ -25,8 +26,18 @@ tasks.withType<Test>().configureEach { useJUnitPlatform() }
 
 val runtimeClasspath = configurations.named("runtimeClasspath")
 
-tasks.named<Jar>("jar") {
+// Nested inject payload (#209): relocated core + kotlinx, no Compose. Packaged as a resource
+// so the thin agent-runtime still forbids exploded core/ classes (verifyAgentRuntimeJarContents).
+val injectRuntimeJarTask = project(":agent-inject-runtime").tasks.named("shadowJar")
+val injectRuntimeJarFile =
+    injectRuntimeJarTask.map { task ->
+        task.outputs.files.singleFile
+    }
+
+tasks.named<JvmJar>("jar") {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    dependsOn(injectRuntimeJarTask)
+    inputs.file(injectRuntimeJarFile)
 
     manifest {
         attributes(
@@ -48,56 +59,69 @@ tasks.named<Jar>("jar") {
         exclude("META-INF/*.RSA")
         exclude("META-INF/INDEX.LIST")
     }
+
+    // Nested jar resource — not exploded core classes.
+    from(injectRuntimeJarFile) {
+        into("META-INF/spectre")
+        rename { "inject-runtime.jar" }
+    }
 }
 
-val verifyAgentRuntimeJarContents by tasks.registering {
-    description =
-        "Asserts the agent runtime JAR is loadable by the Attach API and stays thin: no " +
-            "Compose, Skiko, Kotlin stdlib, coroutines, or Spectre core classes."
-    group = "verification"
+val verifyAgentRuntimeJarContents by
+    tasks.registering {
+        description =
+            "Asserts the agent runtime JAR is loadable by the Attach API and stays thin: no " +
+                "exploded Compose, Skiko, Kotlin stdlib, coroutines, or Spectre core classes. " +
+                "Nested META-INF/spectre/inject-runtime.jar is required for #209 injection."
+        group = "verification"
 
-    val jarFile = tasks.named<Jar>("jar").flatMap { it.archiveFile }
-    dependsOn(jarFile)
-    inputs.file(jarFile)
+        val jarFile = tasks.named<JvmJar>("jar").flatMap { it.archiveFile }
+        dependsOn(jarFile)
+        inputs.file(jarFile)
 
-    doLast {
-        val jar = jarFile.get().asFile
-        ZipFile(jar).use { zip ->
-            val manifest =
-                zip.getInputStream(zip.getEntry("META-INF/MANIFEST.MF")).use { input ->
-                    Manifest(input)
+        doLast {
+            val jar = jarFile.get().asFile
+            ZipFile(jar).use { zip ->
+                val manifest =
+                    zip.getInputStream(zip.getEntry("META-INF/MANIFEST.MF")).use { input ->
+                        Manifest(input)
+                    }
+                val attrs = manifest.mainAttributes
+                val expectedAgentClass = "dev.sebastiano.spectre.agent.runtime.SpectreAgent"
+                require(attrs.getValue("Agent-Class") == expectedAgentClass) {
+                    "Agent runtime jar is missing Agent-Class=$expectedAgentClass"
                 }
-            val attrs = manifest.mainAttributes
-            val expectedAgentClass = "dev.sebastiano.spectre.agent.runtime.SpectreAgent"
-            require(attrs.getValue("Agent-Class") == expectedAgentClass) {
-                "Agent runtime jar is missing Agent-Class=$expectedAgentClass"
-            }
-            require(attrs.getValue("Premain-Class") == expectedAgentClass) {
-                "Agent runtime jar is missing Premain-Class=$expectedAgentClass"
-            }
+                require(attrs.getValue("Premain-Class") == expectedAgentClass) {
+                    "Agent runtime jar is missing Premain-Class=$expectedAgentClass"
+                }
 
-            val forbiddenPrefixes =
-                listOf(
-                    "androidx/compose/",
-                    "org/jetbrains/compose/",
-                    "org/jetbrains/skiko/",
-                    "dev/sebastiano/spectre/core/",
-                    "kotlin/Pair.class",
-                    "kotlinx/coroutines/",
-                )
-            val leaks =
-                zip.entries()
-                    .asSequence()
-                    .map { it.name }
-                    .filter { entry -> forbiddenPrefixes.any { entry.startsWith(it) } }
-            val leakList = leaks.toList()
-            require(leakList.isEmpty()) {
-                "Agent runtime jar contains forbidden classes:\n" +
-                    leakList.sorted().joinToString("\n") { "  - $it" }
+                val injectEntry = zip.getEntry("META-INF/spectre/inject-runtime.jar")
+                require(injectEntry != null && injectEntry.size > 0L) {
+                    "Agent runtime jar missing nested META-INF/spectre/inject-runtime.jar (#209)"
+                }
+
+                val forbiddenPrefixes =
+                    listOf(
+                        "androidx/compose/",
+                        "org/jetbrains/compose/",
+                        "org/jetbrains/skiko/",
+                        "dev/sebastiano/spectre/core/",
+                        "kotlin/Pair.class",
+                        "kotlinx/coroutines/",
+                    )
+                val leaks =
+                    zip.entries()
+                        .asSequence()
+                        .map { it.name }
+                        .filter { entry -> forbiddenPrefixes.any { entry.startsWith(it) } }
+                val leakList = leaks.toList()
+                require(leakList.isEmpty()) {
+                    "Agent runtime jar contains forbidden classes:\n" +
+                        leakList.sorted().joinToString("\n") { "  - $it" }
+                }
             }
         }
     }
-}
 
 tasks.named("check") { dependsOn(verifyAgentRuntimeJarContents) }
 
@@ -108,6 +132,9 @@ private fun includeInAgentRuntimeJar(file: File): Boolean {
         name.startsWith("kotlin-reflect") -> false
         name.startsWith("kotlinx-coroutines") -> false
         name.startsWith("annotations-") -> false
+        // Never explode the inject payload into the agent-runtime root.
+        name.startsWith("spectre-agent-inject-runtime") -> false
+        name.startsWith("agent-inject-runtime") -> false
         else -> true
     }
 }

--- a/agent-test-fixture/src/main/kotlin/dev/sebastiano/spectre/agent/fixture/InjectComposeFixtureMain.kt
+++ b/agent-test-fixture/src/main/kotlin/dev/sebastiano/spectre/agent/fixture/InjectComposeFixtureMain.kt
@@ -37,7 +37,7 @@ fun injectMain() {
         val frame =
             JFrame(SPECTRE_FIXTURE_WINDOW_TITLE).apply {
                 defaultCloseOperation = WindowConstants.EXIT_ON_CLOSE
-                size = Dimension(320, 240)
+                size = Dimension(FIXTURE_WIDTH_PX, FIXTURE_HEIGHT_PX)
                 setLocationRelativeTo(null)
                 isAlwaysOnTop = true
             }
@@ -47,7 +47,7 @@ fun injectMain() {
                 setContent {
                     var typed by remember { mutableStateOf("") }
                     MaterialTheme {
-                        Column(modifier = Modifier.padding(16.dp)) {
+                        Column(modifier = Modifier.padding(FIXTURE_PADDING_DP.dp)) {
                             Text(
                                 text = "Spectre inject fixture",
                                 modifier = Modifier.testTag(TAG_LABEL),
@@ -76,12 +76,12 @@ fun injectMain() {
     }
 
     val panel = panelRef.get()
-    val deadline = System.currentTimeMillis() + 15_000L
+    val deadline = System.currentTimeMillis() + READY_POLL_TIMEOUT_MS
     while (injectSemanticsOwnerCountOnEdt(panel) == 0) {
         check(System.currentTimeMillis() < deadline) {
-            "Compose semantics tree did not populate within 15000ms"
+            "Compose semantics tree did not populate within ${READY_POLL_TIMEOUT_MS}ms"
         }
-        Thread.sleep(25L)
+        Thread.sleep(READY_POLL_INTERVAL_MS)
     }
     System.err.println("[inject-fixture] semantics ready; emitting READY")
     System.err.flush()
@@ -98,6 +98,12 @@ fun injectMain() {
 fun main() {
     injectMain()
 }
+
+private const val FIXTURE_PADDING_DP: Int = 16
+private const val FIXTURE_WIDTH_PX: Int = 320
+private const val FIXTURE_HEIGHT_PX: Int = 240
+private const val READY_POLL_INTERVAL_MS: Long = 25
+private const val READY_POLL_TIMEOUT_MS: Long = 15_000
 
 @OptIn(ExperimentalComposeUiApi::class)
 private fun injectSemanticsOwnerCountOnEdt(panel: ComposePanel): Int {

--- a/agent-test-fixture/src/main/kotlin/dev/sebastiano/spectre/agent/fixture/InjectComposeFixtureMain.kt
+++ b/agent-test-fixture/src/main/kotlin/dev/sebastiano/spectre/agent/fixture/InjectComposeFixtureMain.kt
@@ -1,0 +1,107 @@
+@file:Suppress("MatchingDeclarationName")
+
+package dev.sebastiano.spectre.agent.fixture
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.awt.ComposePanel
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import java.awt.Dimension
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+import javax.swing.WindowConstants
+
+/**
+ * Compose-only fixture for #209 injection e2e: same tagged UI as [main] but **never** references
+ * `dev.sebastiano.spectre.core` so the target JVM can run without spectre-core on its classpath.
+ * The agent injects relocated core at attach time.
+ */
+@OptIn(ExperimentalComposeUiApi::class)
+fun injectMain() {
+    System.err.println("[inject-fixture] entered injectMain() pid=${ProcessHandle.current().pid()}")
+    System.err.flush()
+
+    val panelRef = java.util.concurrent.atomic.AtomicReference<ComposePanel>()
+    SwingUtilities.invokeAndWait {
+        val frame =
+            JFrame(SPECTRE_FIXTURE_WINDOW_TITLE).apply {
+                defaultCloseOperation = WindowConstants.EXIT_ON_CLOSE
+                size = Dimension(320, 240)
+                setLocationRelativeTo(null)
+                isAlwaysOnTop = true
+            }
+
+        val composePanel =
+            ComposePanel().apply {
+                setContent {
+                    var typed by remember { mutableStateOf("") }
+                    MaterialTheme {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text(
+                                text = "Spectre inject fixture",
+                                modifier = Modifier.testTag(TAG_LABEL),
+                            )
+                            TextField(
+                                value = typed,
+                                onValueChange = { typed = it },
+                                modifier = Modifier.testTag(TAG_TEXT_FIELD),
+                            )
+                            Button(
+                                onClick = { typed = "$BUTTON_CLICKED_PREFIX$typed" },
+                                modifier = Modifier.testTag(TAG_BUTTON),
+                            ) {
+                                Text(text = "Click me")
+                            }
+                        }
+                    }
+                }
+            }
+
+        frame.contentPane.add(composePanel)
+        frame.isVisible = true
+        frame.toFront()
+        frame.requestFocus()
+        panelRef.set(composePanel)
+    }
+
+    val panel = panelRef.get()
+    val deadline = System.currentTimeMillis() + 15_000L
+    while (injectSemanticsOwnerCountOnEdt(panel) == 0) {
+        check(System.currentTimeMillis() < deadline) {
+            "Compose semantics tree did not populate within 15000ms"
+        }
+        Thread.sleep(25L)
+    }
+    System.err.println("[inject-fixture] semantics ready; emitting READY")
+    System.err.flush()
+
+    val pid = ProcessHandle.current().pid()
+    // Explicitly does NOT touch ComposeAutomator — that is the whole point of this fixture.
+    println("$READY_SENTINEL pid=$pid inject=true")
+    System.out.flush()
+
+    Thread.currentThread().join()
+}
+
+/** JVM entry point for ProcessBuilder (`…InjectComposeFixtureMainKt`). */
+fun main() {
+    injectMain()
+}
+
+@OptIn(ExperimentalComposeUiApi::class)
+private fun injectSemanticsOwnerCountOnEdt(panel: ComposePanel): Int {
+    val box = IntArray(1)
+    SwingUtilities.invokeAndWait { box[0] = panel.semanticsOwners.size }
+    return box[0]
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
@@ -1,9 +1,20 @@
 package dev.sebastiano.spectre.agent.runtime
 
 import java.lang.instrument.Instrumentation
+import java.nio.file.Path
 
 internal const val COMPOSE_AUTOMATOR_FQN = "dev.sebastiano.spectre.core.ComposeAutomator"
 internal const val PLUGIN_CLASS_LOADER_FQN = "com.intellij.ide.plugins.cl.PluginClassLoader"
+
+/**
+ * Public Compose Desktop markers used to locate a host classloader when Spectre is not installed.
+ */
+internal val COMPOSE_HOST_MARKER_FQNS: List<String> =
+    listOf(
+        "androidx.compose.ui.awt.ComposeWindow",
+        "androidx.compose.ui.awt.ComposePanel",
+        "androidx.compose.ui.semantics.SemanticsOwner",
+    )
 
 /**
  * Locates the Spectre `core` library on the target JVM's classpath and returns the [ClassLoader]
@@ -14,6 +25,10 @@ internal const val PLUGIN_CLASS_LOADER_FQN = "com.intellij.ide.plugins.cl.Plugin
  * inside a plugin's [PLUGIN_CLASS_LOADER_FQN]), the plugin's loader wins. If no clear winner
  * exists, fail loudly with [AmbiguousSpectreClasspathException] rather than silently picking the
  * wrong one.
+ *
+ * **Injection (#209):** when `ComposeAutomator` is absent, [findSpectreClassLoader] falls back to
+ * loading the nested inject-runtime jar (relocated kotlinx + core, no Compose) against a Compose
+ * host classloader discovered via [COMPOSE_HOST_MARKER_FQNS] / D-14.
  *
  * Designed as `internal object` so callers go through the agent entry points ([SpectreAgent])
  * rather than reaching directly into the bootstrap machinery.
@@ -29,8 +44,13 @@ internal object AgentBootstrap {
      * hands-off UI app that doesn't itself call `ComposeAutomator.inProcess()`). Sample-desktop is
      * the canonical example.
      *
-     * @throws SpectreNotOnClasspathException when neither the loaded-class scan nor the force-load
-     *   fallback turns up `ComposeAutomator`.
+     * If that also fails, attempts **injection**: extract the nested inject-runtime jar and load
+     * Spectre core via [SpectreInjectClassLoader] parented on a Compose host loader.
+     *
+     * @throws SpectreNotOnClasspathException when neither preinstalled core nor inject payload can
+     *   supply `ComposeAutomator` (e.g. inject resource missing).
+     * @throws ComposeNotOnClasspathException when inject is attempted but the target has no
+     *   Compose.
      * @throws AmbiguousSpectreClasspathException when multiple candidates exist and no winner
      *   emerges from the selection rule.
      */
@@ -38,7 +58,55 @@ internal object AgentBootstrap {
         val initialCandidates = collectCandidateClassLoaders(instrumentation, COMPOSE_AUTOMATOR_FQN)
         if (initialCandidates.isNotEmpty()) return selectClassLoader(initialCandidates)
 
-        return forceLoadFromSystemLoader() ?: throw SpectreNotOnClasspathException()
+        forceLoadFromSystemLoader()?.let {
+            return it
+        }
+
+        return injectSpectreClassLoader(instrumentation) ?: throw SpectreNotOnClasspathException()
+    }
+
+    /**
+     * Builds an inject [ClassLoader] that owns Spectre core from [injectJar] while resolving
+     * Compose against [composeHost]. Exposed for unit tests.
+     */
+    fun openInjectClassLoader(injectJar: Path, composeHost: ClassLoader): ClassLoader {
+        val urls = arrayOf(injectJar.toUri().toURL())
+        return SpectreInjectClassLoader(urls, composeHost)
+    }
+
+    /**
+     * Locates a Compose-capable host classloader for injection (D-14 when multiple).
+     *
+     * @throws ComposeNotOnClasspathException when no Compose marker class is loadable.
+     * @throws AmbiguousSpectreClasspathException when multiple hosts match and D-14 cannot pick
+     *   one.
+     */
+    fun findComposeHostClassLoader(instrumentation: Instrumentation): ClassLoader {
+        val candidates =
+            COMPOSE_HOST_MARKER_FQNS.flatMap { fqn ->
+                    collectCandidateClassLoaders(instrumentation, fqn)
+                }
+                .distinct()
+        if (candidates.isNotEmpty()) {
+            return selectClassLoader(candidates) { throw ComposeNotOnClasspathException() }
+        }
+        forceLoadComposeHostFromSystemLoader()?.let {
+            return it
+        }
+        throw ComposeNotOnClasspathException()
+    }
+
+    private fun injectSpectreClassLoader(instrumentation: Instrumentation): ClassLoader? {
+        val injectJar = InjectRuntimeLocator.extractInjectJar() ?: return null
+        System.err.println(
+            "[spectre-agent] spectre-core not on target classpath; injecting from $injectJar"
+        )
+        val composeHost = findComposeHostClassLoader(instrumentation)
+        System.err.println("[spectre-agent] Compose host classloader: $composeHost")
+        val injectLoader = openInjectClassLoader(injectJar, composeHost)
+        // Prove ComposeAutomator resolves from the inject jar before returning.
+        injectLoader.loadClass(COMPOSE_AUTOMATOR_FQN)
+        return injectLoader
     }
 }
 
@@ -67,6 +135,21 @@ private fun forceLoadFromSystemLoader(): ClassLoader? =
         null
     }
 
+private fun forceLoadComposeHostFromSystemLoader(): ClassLoader? {
+    val system = ClassLoader.getSystemClassLoader()
+    for (fqn in COMPOSE_HOST_MARKER_FQNS) {
+        try {
+            val loaded = Class.forName(fqn, false, system)
+            return loaded.classLoader ?: system
+        } catch (_: ClassNotFoundException) {
+            // try next marker
+        } catch (_: NoClassDefFoundError) {
+            // try next marker
+        }
+    }
+    return null
+}
+
 /**
  * Filters [Instrumentation.getAllLoadedClasses] down to classes whose [Class.getName] equals
  * [targetFqn], then collects the distinct [ClassLoader]s that own them.
@@ -88,7 +171,7 @@ internal fun collectCandidateClassLoaders(
 /**
  * Applies the D-14 selection rule to the [candidates] list:
  *
- * 1. If [candidates] is empty → throw [SpectreNotOnClasspathException].
+ * 1. If [candidates] is empty → throw via [onEmpty].
  * 2. If [candidates] has exactly one entry → return it.
  * 3. If multiple candidates exist, prefer the one whose class-loader hierarchy chain reaches
  *    [PLUGIN_CLASS_LOADER_FQN].
@@ -99,8 +182,11 @@ internal fun collectCandidateClassLoaders(
  * wrong loader would produce confusing downstream bugs (the agent's reflective calls would target a
  * `ComposeAutomator` the app isn't actually using).
  */
-internal fun selectClassLoader(candidates: List<ClassLoader>): ClassLoader {
-    if (candidates.isEmpty()) throw SpectreNotOnClasspathException()
+internal fun selectClassLoader(
+    candidates: List<ClassLoader>,
+    onEmpty: () -> Nothing = { throw SpectreNotOnClasspathException() },
+): ClassLoader {
+    if (candidates.isEmpty()) onEmpty()
     if (candidates.size == 1) return candidates.single()
 
     val pluginCandidates = candidates.filter { it.hasPluginClassLoaderInHierarchy() }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
@@ -122,10 +122,11 @@ internal object AgentBootstrap {
         System.err.println(
             "[spectre-agent] spectre-core not on target classpath; injecting from $injectJar"
         )
+        var injectLoader: SpectreInjectClassLoader? = null
         return try {
             val composeHost = findComposeHostClassLoader(instrumentation)
             System.err.println("[spectre-agent] Compose host classloader: $composeHost")
-            val injectLoader = openInjectClassLoader(injectJar, composeHost)
+            injectLoader = openInjectClassLoader(injectJar, composeHost)
             // Prove ComposeAutomator resolves from the inject jar before returning.
             injectLoader.loadClass(COMPOSE_AUTOMATOR_FQN)
             SpectreBootstrapResult(
@@ -134,6 +135,8 @@ internal object AgentBootstrap {
                 injectClassLoader = injectLoader,
             )
         } catch (t: Throwable) {
+            // Close loader before delete so Windows can unlink the jar file.
+            runCatching { injectLoader?.close() }
             runCatching { java.nio.file.Files.deleteIfExists(injectJar) }
             throw t
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
@@ -134,11 +134,11 @@ internal object AgentBootstrap {
                 injectJar = injectJar,
                 injectClassLoader = injectLoader,
             )
-        } catch (t: Throwable) {
+        } catch (error: Exception) {
             // Close loader before delete so Windows can unlink the jar file.
             runCatching { injectLoader?.close() }
             runCatching { java.nio.file.Files.deleteIfExists(injectJar) }
-            throw t
+            throw error
         }
     }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
@@ -134,7 +134,10 @@ internal object AgentBootstrap {
                 injectJar = injectJar,
                 injectClassLoader = injectLoader,
             )
-        } catch (error: Exception) {
+        } catch (@Suppress("TooGenericExceptionCaught") error: Exception) {
+            // Cleanup must run for any failure after extract (classloader open, Compose host
+            // selection, loadClass). Specific typed catches would miss LinkageError-derived
+            // RuntimeExceptions from the target Compose stack.
             // Close loader before delete so Windows can unlink the jar file.
             runCatching { injectLoader?.close() }
             runCatching { java.nio.file.Files.deleteIfExists(injectJar) }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrap.kt
@@ -26,13 +26,28 @@ internal val COMPOSE_HOST_MARKER_FQNS: List<String> =
  * exists, fail loudly with [AmbiguousSpectreClasspathException] rather than silently picking the
  * wrong one.
  *
- * **Injection (#209):** when `ComposeAutomator` is absent, [findSpectreClassLoader] falls back to
- * loading the nested inject-runtime jar (relocated kotlinx + core, no Compose) against a Compose
- * host classloader discovered via [COMPOSE_HOST_MARKER_FQNS] / D-14.
+ * **Injection (#209):** when `ComposeAutomator` is absent, [findSpectre] falls back to loading the
+ * nested inject-runtime jar (relocated kotlinx + core, no Compose) against a Compose host
+ * classloader discovered via [COMPOSE_HOST_MARKER_FQNS] / D-14.
  *
  * Designed as `internal object` so callers go through the agent entry points ([SpectreAgent])
  * rather than reaching directly into the bootstrap machinery.
  */
+/**
+ * Result of [AgentBootstrap.findSpectre] so callers can release inject payload resources on detach
+ * (close [SpectreInjectClassLoader], delete extracted jar).
+ */
+internal data class SpectreBootstrapResult(
+    val classLoader: ClassLoader,
+    val injectJar: Path? = null,
+    val injectClassLoader: SpectreInjectClassLoader? = null,
+) {
+    fun releaseInjectResources() {
+        runCatching { injectClassLoader?.close() }
+        injectJar?.let { path -> runCatching { java.nio.file.Files.deleteIfExists(path) } }
+    }
+}
+
 internal object AgentBootstrap {
     /**
      * Walks the target JVM's loaded classes via [Instrumentation.getAllLoadedClasses], filters to
@@ -54,22 +69,28 @@ internal object AgentBootstrap {
      * @throws AmbiguousSpectreClasspathException when multiple candidates exist and no winner
      *   emerges from the selection rule.
      */
-    fun findSpectreClassLoader(instrumentation: Instrumentation): ClassLoader {
+    fun findSpectre(instrumentation: Instrumentation): SpectreBootstrapResult {
         val initialCandidates = collectCandidateClassLoaders(instrumentation, COMPOSE_AUTOMATOR_FQN)
-        if (initialCandidates.isNotEmpty()) return selectClassLoader(initialCandidates)
-
-        forceLoadFromSystemLoader()?.let {
-            return it
+        if (initialCandidates.isNotEmpty()) {
+            return SpectreBootstrapResult(selectClassLoader(initialCandidates))
         }
 
-        return injectSpectreClassLoader(instrumentation) ?: throw SpectreNotOnClasspathException()
+        forceLoadFromSystemLoader()?.let {
+            return SpectreBootstrapResult(it)
+        }
+
+        return injectSpectre(instrumentation) ?: throw SpectreNotOnClasspathException()
     }
+
+    /** Convenience for tests and call sites that only need the [ClassLoader]. */
+    fun findSpectreClassLoader(instrumentation: Instrumentation): ClassLoader =
+        findSpectre(instrumentation).classLoader
 
     /**
      * Builds an inject [ClassLoader] that owns Spectre core from [injectJar] while resolving
      * Compose against [composeHost]. Exposed for unit tests.
      */
-    fun openInjectClassLoader(injectJar: Path, composeHost: ClassLoader): ClassLoader {
+    fun openInjectClassLoader(injectJar: Path, composeHost: ClassLoader): SpectreInjectClassLoader {
         val urls = arrayOf(injectJar.toUri().toURL())
         return SpectreInjectClassLoader(urls, composeHost)
     }
@@ -96,17 +117,26 @@ internal object AgentBootstrap {
         throw ComposeNotOnClasspathException()
     }
 
-    private fun injectSpectreClassLoader(instrumentation: Instrumentation): ClassLoader? {
+    private fun injectSpectre(instrumentation: Instrumentation): SpectreBootstrapResult? {
         val injectJar = InjectRuntimeLocator.extractInjectJar() ?: return null
         System.err.println(
             "[spectre-agent] spectre-core not on target classpath; injecting from $injectJar"
         )
-        val composeHost = findComposeHostClassLoader(instrumentation)
-        System.err.println("[spectre-agent] Compose host classloader: $composeHost")
-        val injectLoader = openInjectClassLoader(injectJar, composeHost)
-        // Prove ComposeAutomator resolves from the inject jar before returning.
-        injectLoader.loadClass(COMPOSE_AUTOMATOR_FQN)
-        return injectLoader
+        return try {
+            val composeHost = findComposeHostClassLoader(instrumentation)
+            System.err.println("[spectre-agent] Compose host classloader: $composeHost")
+            val injectLoader = openInjectClassLoader(injectJar, composeHost)
+            // Prove ComposeAutomator resolves from the inject jar before returning.
+            injectLoader.loadClass(COMPOSE_AUTOMATOR_FQN)
+            SpectreBootstrapResult(
+                classLoader = injectLoader,
+                injectJar = injectJar,
+                injectClassLoader = injectLoader,
+            )
+        } catch (t: Throwable) {
+            runCatching { java.nio.file.Files.deleteIfExists(injectJar) }
+            throw t
+        }
     }
 }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/Exceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/Exceptions.kt
@@ -20,11 +20,25 @@ internal sealed class SpectreAgentBootstrapException(message: String) : RuntimeE
 internal class SpectreNotOnClasspathException :
     SpectreAgentBootstrapException(
         "No `dev.sebastiano.spectre.core.ComposeAutomator` class found in the target JVM's " +
-            "loaded classes. The Spectre agent requires the target application to include " +
-            "`dev.sebastiano.spectre:spectre-core` on its classpath. The agent JAR itself is " +
-            "supplied by the attaching JVM via `VirtualMachine.loadAgent`, not added as a target-side " +
-            "dependency. See https://github.com/rock3r/spectre/issues/153 for the thin-agent " +
-            "design rationale."
+            "loaded classes, and inject-runtime bootstrap was unavailable or failed to load " +
+            "core. Either add `dev.sebastiano.spectre:spectre-core` to the target classpath, " +
+            "or use a spectre-agent-runtime build that embeds META-INF/spectre/inject-runtime.jar " +
+            "(#209). The agent JAR itself is supplied by the attaching JVM via " +
+            "`VirtualMachine.loadAgent`. See https://github.com/rock3r/spectre/issues/209."
+    )
+
+/**
+ * Thrown when injection is attempted but the target JVM has no loadable Compose Desktop types
+ * (`ComposeWindow` / `ComposePanel` / `SemanticsOwner`). Injection resolves Compose against the
+ * target's classloaders and cannot proceed without them.
+ */
+internal class ComposeNotOnClasspathException :
+    SpectreAgentBootstrapException(
+        "No Compose Desktop host types " +
+            "(ComposeWindow / ComposePanel / SemanticsOwner) were found in the target JVM. " +
+            "Agent injection (#209) requires the target to already load Compose so injected " +
+            "spectre-core can resolve UI types against the target's classloaders. Compose is " +
+            "never bundled in the inject jar."
     )
 
 /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/InjectRuntimeLocator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/InjectRuntimeLocator.kt
@@ -1,0 +1,35 @@
+package dev.sebastiano.spectre.agent.runtime
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption
+
+/**
+ * Resolves the nested inject-runtime jar packaged inside `spectre-agent-runtime` at
+ * [INJECT_RUNTIME_RESOURCE].
+ *
+ * Extraction is to a temp file because [SpectreInjectClassLoader] needs a filesystem URL; nested
+ * jar URLs are awkward and brittle under the Attach-loaded agent classloader.
+ */
+internal object InjectRuntimeLocator {
+    const val INJECT_RUNTIME_RESOURCE: String = "META-INF/spectre/inject-runtime.jar"
+
+    /**
+     * Extracts the inject jar resource from [loader] (typically the agent runtime's loader) to a
+     * temp file. Returns `null` when the resource is missing (older agent runtimes / thin-only
+     * builds).
+     */
+    fun extractInjectJar(
+        loader: ClassLoader = InjectRuntimeLocator::class.java.classLoader
+    ): Path? {
+        val stream = loader.getResourceAsStream(INJECT_RUNTIME_RESOURCE) ?: return null
+        return stream.use { input ->
+            val target =
+                Files.createTempFile("spectre-inject-runtime-", ".jar").also { path ->
+                    path.toFile().deleteOnExit()
+                }
+            Files.copy(input, target, StandardCopyOption.REPLACE_EXISTING)
+            target
+        }
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
@@ -85,73 +85,81 @@ public object SpectreAgent {
         // JVM agent layer which surfaces them at the attaching `VirtualMachine.loadAgent` call
         // site.
         val bootstrap = AgentBootstrap.findSpectre(instrumentation)
-        val loader = bootstrap.classLoader
-        System.err.println("[spectre-agent] found Spectre via $loader")
+        // When AgentState is published successfully, detach/shutdown owns inject cleanup.
+        // Until then (or on any failure path), we release in the finally below.
+        var injectOwnedByAgentState = false
+        try {
+            val loader = bootstrap.classLoader
+            System.err.println("[spectre-agent] found Spectre via $loader")
 
-        // Open AWT peer packages so core window-identity can resolve host HWND/NSWindow*/XID for
-        // embedded ComposePanel surfaces (Compose windowHandle is 0 there). Best-effort: failures
-        // are logged and identity falls back to null handles.
-        AwtPeerModuleOpener.openFor(loader, instrumentation)
+            // Open AWT peer packages so core window-identity can resolve host HWND/NSWindow*/XID
+            // for embedded ComposePanel surfaces (Compose windowHandle is 0 there). Best-effort:
+            // failures are logged and identity falls back to null handles.
+            AwtPeerModuleOpener.openFor(loader, instrumentation)
 
-        val automator = createAutomatorReflectively(loader)
-        System.err.println("[spectre-agent] ComposeAutomator ready: $automator")
+            val automator = createAutomatorReflectively(loader)
+            System.err.println("[spectre-agent] ComposeAutomator ready: $automator")
 
-        val udsPath = agentArgs.takeUnless { it.isNullOrBlank() }?.let(Path::of)
-        if (udsPath == null) {
-            // No UDS path means manual diagnostic mode: report window count to stderr so a user
-            // can verify Spectre is correctly on a target's classpath.
-            val count = invokeWindowsCountReflectively(automator)
+            val udsPath = agentArgs.takeUnless { it.isNullOrBlank() }?.let(Path::of)
+            if (udsPath == null) {
+                // No UDS path means manual diagnostic mode: report window count to stderr so a
+                // user can verify Spectre is correctly on a target's classpath.
+                val count = invokeWindowsCountReflectively(automator)
+                System.err.println(
+                    "[spectre-agent] no UDS path provided; spike mode reports " +
+                        "getWindows().size = $count"
+                )
+                return
+            }
+
+            // IpcServer's constructor throws IOException on bind failure (path too long,
+            // permission issue, …). Let it propagate.
+            val handler = ReflectiveAutomatorHandler(automator)
+            val server =
+                IpcServer(udsPath = udsPath, handler = handler, onDetach = ::onClientDetach)
+
+            // Register the shutdown hook BEFORE publishing AgentState so a crash between here and
+            // CAS leaves no orphans. We carry the hook Thread in AgentState so onClientDetach can
+            // unregister it.
+            val shutdownHook =
+                Thread(
+                    {
+                        // Path B — crash safety. close() handles its own idempotency.
+                        runCatching { server.close() }
+                        bootstrap.releaseInjectResources()
+                    },
+                    SHUTDOWN_HOOK_NAME,
+                )
+            Runtime.getRuntime().addShutdownHook(shutdownHook)
+
+            val newState =
+                AgentState(
+                    server = server,
+                    udsPath = udsPath,
+                    shutdownHook = shutdownHook,
+                    bootstrap = bootstrap,
+                )
+            if (!agentState.compareAndSet(null, newState)) {
+                // Idempotency race: someone bootstrapped between our earlier `get()` check and now.
+                // Roll back: close our just-created server and remove our hook so the existing
+                // state remains the source of truth.
+                runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
+                runCatching { server.close() }
+                System.err.println(
+                    "[spectre-agent] lost idempotency race; rolled back duplicate IPC server"
+                )
+                return
+            }
+
+            injectOwnedByAgentState = true
             System.err.println(
-                "[spectre-agent] no UDS path provided; spike mode reports getWindows().size = $count"
+                "[spectre-agent] IPC server listening on $udsPath — ready for client connections"
             )
-            // Spike mode still releases inject payload so repeated attachSpike runs do not pile
-            // temp jars while the target stays alive.
-            bootstrap.releaseInjectResources()
-            return
+        } finally {
+            if (!injectOwnedByAgentState) {
+                bootstrap.releaseInjectResources()
+            }
         }
-
-        // IpcServer's constructor throws IOException on bind failure (path too long,
-        // permission issue, …). Let it propagate.
-        val handler = ReflectiveAutomatorHandler(automator)
-        val server = IpcServer(udsPath = udsPath, handler = handler, onDetach = ::onClientDetach)
-
-        // Register the shutdown hook BEFORE publishing AgentState so a crash between here and
-        // CAS leaves no orphans. We carry the hook Thread in AgentState so onClientDetach can
-        // unregister it.
-        val shutdownHook =
-            Thread(
-                {
-                    // Path B — crash safety. close() handles its own idempotency.
-                    runCatching { server.close() }
-                    bootstrap.releaseInjectResources()
-                },
-                SHUTDOWN_HOOK_NAME,
-            )
-        Runtime.getRuntime().addShutdownHook(shutdownHook)
-
-        val newState =
-            AgentState(
-                server = server,
-                udsPath = udsPath,
-                shutdownHook = shutdownHook,
-                bootstrap = bootstrap,
-            )
-        if (!agentState.compareAndSet(null, newState)) {
-            // Idempotency race: someone bootstrapped between our earlier `get()` check and now.
-            // Roll back: close our just-created server and remove our hook so the existing
-            // state remains the source of truth.
-            runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
-            runCatching { server.close() }
-            bootstrap.releaseInjectResources()
-            System.err.println(
-                "[spectre-agent] lost idempotency race; rolled back duplicate IPC server"
-            )
-            return
-        }
-
-        System.err.println(
-            "[spectre-agent] IPC server listening on $udsPath — ready for client connections"
-        )
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
@@ -79,11 +79,13 @@ public object SpectreAgent {
             return
         }
 
-        // findSpectreClassLoader throws SpectreNotOnClasspathException or
-        // AmbiguousSpectreClasspathException; createAutomatorReflectively throws
-        // ReflectiveOperationException. Both propagate to the JVM agent layer which surfaces
-        // them at the attaching `VirtualMachine.loadAgent` call site.
-        val loader = AgentBootstrap.findSpectreClassLoader(instrumentation)
+        // findSpectre throws SpectreNotOnClasspathException /
+        // AmbiguousSpectreClasspathException / ComposeNotOnClasspathException;
+        // createAutomatorReflectively throws ReflectiveOperationException. Both propagate to the
+        // JVM agent layer which surfaces them at the attaching `VirtualMachine.loadAgent` call
+        // site.
+        val bootstrap = AgentBootstrap.findSpectre(instrumentation)
+        val loader = bootstrap.classLoader
         System.err.println("[spectre-agent] found Spectre via $loader")
 
         // Open AWT peer packages so core window-identity can resolve host HWND/NSWindow*/XID for
@@ -102,6 +104,9 @@ public object SpectreAgent {
             System.err.println(
                 "[spectre-agent] no UDS path provided; spike mode reports getWindows().size = $count"
             )
+            // Spike mode still releases inject payload so repeated attachSpike runs do not pile
+            // temp jars while the target stays alive.
+            bootstrap.releaseInjectResources()
             return
         }
 
@@ -118,18 +123,26 @@ public object SpectreAgent {
                 {
                     // Path B — crash safety. close() handles its own idempotency.
                     runCatching { server.close() }
+                    bootstrap.releaseInjectResources()
                 },
                 SHUTDOWN_HOOK_NAME,
             )
         Runtime.getRuntime().addShutdownHook(shutdownHook)
 
-        val newState = AgentState(server = server, udsPath = udsPath, shutdownHook = shutdownHook)
+        val newState =
+            AgentState(
+                server = server,
+                udsPath = udsPath,
+                shutdownHook = shutdownHook,
+                bootstrap = bootstrap,
+            )
         if (!agentState.compareAndSet(null, newState)) {
             // Idempotency race: someone bootstrapped between our earlier `get()` check and now.
             // Roll back: close our just-created server and remove our hook so the existing
             // state remains the source of truth.
             runCatching { Runtime.getRuntime().removeShutdownHook(shutdownHook) }
             runCatching { server.close() }
+            bootstrap.releaseInjectResources()
             System.err.println(
                 "[spectre-agent] lost idempotency race; rolled back duplicate IPC server"
             )
@@ -143,7 +156,8 @@ public object SpectreAgent {
 
     /**
      * Called by [IpcServer] when it processes an `AgentRequest.Detach`. Performs the full D-7 Path
-     * A cleanup: clears the global slot, closes the server (idempotent), removes the shutdown hook.
+     * A cleanup: clears the global slot, closes the server (idempotent), removes the shutdown hook,
+     * and releases inject payload resources when the attach used injection (#209).
      *
      * The server has *already* set its `running` flag to false before invoking this; the `close()`
      * here ensures the ServerSocketChannel native fd is released and the UDS path unlinked. Without
@@ -153,6 +167,7 @@ public object SpectreAgent {
         val state = agentState.getAndSet(null) ?: return
         runCatching { state.server.close() }
         runCatching { Runtime.getRuntime().removeShutdownHook(state.shutdownHook) }
+        state.bootstrap.releaseInjectResources()
         System.err.println("[spectre-agent] detached cleanly; resources released")
     }
 
@@ -195,5 +210,6 @@ public object SpectreAgent {
         val server: IpcServer,
         val udsPath: Path,
         val shutdownHook: Thread,
+        val bootstrap: SpectreBootstrapResult,
     )
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreInjectClassLoader.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreInjectClassLoader.kt
@@ -1,0 +1,51 @@
+package dev.sebastiano.spectre.agent.runtime
+
+import java.net.URL
+import java.net.URLClassLoader
+
+/**
+ * Child-first classloader for the #209 inject payload.
+ *
+ * Loads Spectre core, inject marker, relocated kotlinx, and other bundled non-Compose deps from the
+ * inject jar first so they never collide with IDE-shipped kotlinx. Everything else (Compose, Kotlin
+ * stdlib, JDK) delegates to [parent] — the target's Compose-capable loader.
+ */
+internal class SpectreInjectClassLoader(urls: Array<URL>, parent: ClassLoader) :
+    URLClassLoader(urls, parent) {
+
+    override fun loadClass(name: String, resolve: Boolean): Class<*> {
+        synchronized(getClassLoadingLock(name)) {
+            findLoadedClass(name)?.let { loaded ->
+                if (resolve) resolveClass(loaded)
+                return loaded
+            }
+            if (loadFromInjectJar(name)) {
+                try {
+                    val fromInject = findClass(name)
+                    if (resolve) resolveClass(fromInject)
+                    return fromInject
+                } catch (_: ClassNotFoundException) {
+                    // Fall through to parent.
+                }
+            }
+            val fromParent = parent.loadClass(name)
+            if (resolve) resolveClass(fromParent)
+            return fromParent
+        }
+    }
+
+    internal companion object {
+        /**
+         * Packages owned by the inject jar. Must stay in sync with `:agent-inject-runtime` shadow
+         * relocation prefixes.
+         */
+        fun loadFromInjectJar(name: String): Boolean =
+            name.startsWith("dev.sebastiano.spectre.") ||
+                name.startsWith("androidx.tracing.") ||
+                name.startsWith("androidx.collection.") ||
+                name.startsWith("androidx.annotation.") ||
+                name.startsWith("okio.") ||
+                name.startsWith("com.squareup.wire.") ||
+                name.startsWith("com.squareup.okio.")
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
@@ -63,11 +63,6 @@ class AgentInjectAttachIntegrationTest {
             else "java"
         val javaBin = Paths.get(System.getProperty("java.home"), "bin", javaExe).toString()
         val classpath = classpathWithoutSpectreCore()
-        // Sanity: core must not be on the child CP.
-        assumeFalse(
-            classpath.split(java.io.File.pathSeparator).any { isSpectreCoreClasspathEntry(it) },
-            "Failed to strip spectre-core from fixture classpath",
-        )
 
         val process =
             ProcessBuilder(
@@ -123,24 +118,43 @@ class AgentInjectAttachIntegrationTest {
 
     private fun classpathWithoutSpectreCore(): String {
         val sep = java.io.File.pathSeparator
-        return System.getProperty("java.class.path")
-            .split(sep)
-            .filterNot { isSpectreCoreClasspathEntry(it) }
-            .joinToString(sep)
+        val original = System.getProperty("java.class.path").split(sep)
+        val coreEntries = original.filter { isSpectreCoreClasspathEntry(it) }
+        // Prove the attacher JVM actually had :core to strip — otherwise the child might still
+        // inherit core and forceLoadFromSystemLoader would hide a broken inject path.
+        assertTrue(
+            coreEntries.isNotEmpty(),
+            "Expected spectre :core on the test classpath so inject e2e can strip it; " +
+                "entries sample=${original.take(8)}",
+        )
+        val stripped = original.filterNot { isSpectreCoreClasspathEntry(it) }
+        assertTrue(
+            stripped.none { isSpectreCoreClasspathEntry(it) },
+            "Strip left residual core entries: ${stripped.filter { isSpectreCoreClasspathEntry(it) }}",
+        )
+        assertTrue(
+            stripped.size < original.size,
+            "Classpath strip did not remove any entries (original size=${original.size})",
+        )
+        return stripped.joinToString(sep)
     }
 
+    /**
+     * Spectre `:core` module outputs only — never `kotlinx-coroutines-core` or other `*-core`
+     * artifacts.
+     */
     private fun isSpectreCoreClasspathEntry(entry: String): Boolean {
         val n = entry.replace('\\', '/')
-        // Only Spectre's `:core` module outputs — never kotlinx-coroutines-core etc.
-        return n.contains("/spectre/core/build/classes/") ||
-            n.contains("/spectre/core/build/libs/") ||
-            n.contains("/.worktrees/") && n.contains("/core/build/classes/") ||
-            n.contains("/.worktrees/") && n.contains("/core/build/libs/") ||
-            n.contains("spectre-core-") ||
-            n.endsWith("/spectre-core.jar") ||
-            // Gradle project jar name for :core (e.g. core-0.1.0-SNAPSHOT.jar) when path ends
-            // with /core/build/libs/…
-            (n.contains("/core/build/libs/") && n.substringAfterLast('/').startsWith("core-"))
+        val base = n.substringAfterLast('/')
+        // Compiled classes / resources of the :core project (any checkout path).
+        if (n.contains("/core/build/classes/") || n.contains("/core/build/resources/")) return true
+        // Project jar under core/build/libs/core-*.jar (not kotlinx-coroutines-core-*.jar).
+        if (n.contains("/core/build/libs/") && base.startsWith("core-") && base.endsWith(".jar")) {
+            return true
+        }
+        if (base.startsWith("spectre-core-") && base.endsWith(".jar")) return true
+        if (base == "spectre-core.jar") return true
+        return false
     }
 
     private class FixtureProcess(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
@@ -1,0 +1,163 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import dev.sebastiano.spectre.agent.fixture.READY_SENTINEL
+import dev.sebastiano.spectre.agent.fixture.SPECTRE_FIXTURE_WINDOW_TITLE
+import dev.sebastiano.spectre.agent.fixture.TAG_BUTTON
+import dev.sebastiano.spectre.agent.fixture.TAG_LABEL
+import dev.sebastiano.spectre.agent.fixture.TAG_TEXT_FIELD
+import java.awt.GraphicsEnvironment
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * #209 / #313: attach + tree dump against a Compose target that does **not** have spectre-core on
+ * its classpath. The agent runtime injects relocated core from
+ * `META-INF/spectre/inject-runtime.jar`.
+ *
+ * Drives the real attach/UDS path ([AgentAttach.attach]) — not a re-implementation.
+ */
+@EnabledOnOs(OS.LINUX, OS.MAC)
+class AgentInjectAttachIntegrationTest {
+
+    @Test
+    fun `inject attach dumps semantics tree without preinstalled spectre-core`() {
+        assumeFalse(
+            GraphicsEnvironment.isHeadless(),
+            "Requires non-headless JVM for Compose Desktop",
+        )
+        val agentJar = locateAgentJarOrSkip()
+
+        spawnInjectFixture().use { fixture ->
+            AgentAttach.attach(pid = fixture.pid, options = AttachOptions(agentJarPath = agentJar))
+                .use { automator ->
+                    val windows = automator.windows()
+                    assertTrue(
+                        windows.any { it.title == SPECTRE_FIXTURE_WINDOW_TITLE },
+                        "expected fixture window in $windows",
+                    )
+                    val nodes = automator.allNodes()
+                    assertTrue(nodes.isNotEmpty(), "expected non-empty tree dump after inject")
+                    assertTrue(automator.findByTestTag(TAG_LABEL).isNotEmpty())
+                    assertTrue(automator.findByTestTag(TAG_BUTTON).isNotEmpty())
+                    assertTrue(automator.findByTestTag(TAG_TEXT_FIELD).isNotEmpty())
+                }
+        }
+    }
+
+    private fun spawnInjectFixture(): FixtureProcess {
+        val javaExe =
+            if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
+                "java.exe"
+            else "java"
+        val javaBin = Paths.get(System.getProperty("java.home"), "bin", javaExe).toString()
+        val classpath = classpathWithoutSpectreCore()
+        // Sanity: core must not be on the child CP.
+        assumeFalse(
+            classpath.split(java.io.File.pathSeparator).any { isSpectreCoreClasspathEntry(it) },
+            "Failed to strip spectre-core from fixture classpath",
+        )
+
+        val process =
+            ProcessBuilder(
+                    javaBin,
+                    "-cp",
+                    classpath,
+                    "-XX:+EnableDynamicAgentLoading",
+                    "-Djava.awt.headless=false",
+                    "-Dcompose.application.configure.swing.globals=true",
+                    "-Dapple.awt.UIElement=false",
+                    "dev.sebastiano.spectre.agent.fixture.InjectComposeFixtureMainKt",
+                )
+                .redirectErrorStream(true)
+                .start()
+
+        val reader = BufferedReader(InputStreamReader(process.inputStream, Charsets.UTF_8))
+        val readyLatch = CountDownLatch(1)
+        val drainerThread =
+            Thread({
+                    try {
+                        generateSequence(reader::readLine).forEach { line ->
+                            if (line.startsWith(READY_SENTINEL) && readyLatch.count > 0) {
+                                readyLatch.countDown()
+                            }
+                        }
+                    } catch (_: java.io.IOException) {
+                        // pipe closed
+                    }
+                })
+                .apply {
+                    isDaemon = true
+                    name = "inject-fixture-stdout-drainer"
+                    start()
+                }
+
+        if (!readyLatch.await(FIXTURE_READY_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+            process.destroyForcibly()
+            error(
+                "Inject fixture did not emit $READY_SENTINEL within ${FIXTURE_READY_TIMEOUT_MS} ms"
+            )
+        }
+
+        return FixtureProcess(process, process.pid(), reader, drainerThread)
+    }
+
+    private fun locateAgentJarOrSkip(): Path {
+        val prop = System.getProperty("dev.sebastiano.spectre.agent.runtimeJar")
+        assumeFalse(prop.isNullOrBlank(), "Requires -Ddev.sebastiano.spectre.agent.runtimeJar")
+        val path = Paths.get(prop!!)
+        assumeFalse(!Files.isRegularFile(path), "Agent runtime JAR not found at $path")
+        return path
+    }
+
+    private fun classpathWithoutSpectreCore(): String {
+        val sep = java.io.File.pathSeparator
+        return System.getProperty("java.class.path")
+            .split(sep)
+            .filterNot { isSpectreCoreClasspathEntry(it) }
+            .joinToString(sep)
+    }
+
+    private fun isSpectreCoreClasspathEntry(entry: String): Boolean {
+        val n = entry.replace('\\', '/')
+        // Only Spectre's `:core` module outputs — never kotlinx-coroutines-core etc.
+        return n.contains("/spectre/core/build/classes/") ||
+            n.contains("/spectre/core/build/libs/") ||
+            n.contains("/.worktrees/") && n.contains("/core/build/classes/") ||
+            n.contains("/.worktrees/") && n.contains("/core/build/libs/") ||
+            n.contains("spectre-core-") ||
+            n.endsWith("/spectre-core.jar") ||
+            // Gradle project jar name for :core (e.g. core-0.1.0-SNAPSHOT.jar) when path ends
+            // with /core/build/libs/…
+            (n.contains("/core/build/libs/") && n.substringAfterLast('/').startsWith("core-"))
+    }
+
+    private class FixtureProcess(
+        private val process: Process,
+        val pid: Long,
+        private val reader: BufferedReader,
+        private val drainer: Thread,
+    ) : AutoCloseable {
+        override fun close() {
+            process.destroyForcibly()
+            runCatching { process.waitFor(5, TimeUnit.SECONDS) }
+            runCatching { reader.close() }
+            runCatching { drainer.join(1_000) }
+        }
+    }
+
+    private companion object {
+        const val FIXTURE_READY_TIMEOUT_MS: Long = 30_000
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/InjectRuntimeLocatorTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/InjectRuntimeLocatorTest.kt
@@ -1,0 +1,42 @@
+package dev.sebastiano.spectre.agent.runtime
+
+import java.net.URLClassLoader
+import java.nio.file.Files
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class InjectRuntimeLocatorTest {
+
+    @Test
+    fun `extractInjectJar returns null when resource missing`() {
+        val emptyLoader = URLClassLoader(emptyArray(), null)
+        assertNull(InjectRuntimeLocator.extractInjectJar(emptyLoader))
+    }
+
+    @Test
+    fun `extractInjectJar copies nested resource to a readable temp file`() {
+        val nested = Files.createTempFile("nested-inject-", ".jar")
+        JarOutputStream(Files.newOutputStream(nested)).use { jar ->
+            jar.putNextEntry(ZipEntry("marker.txt"))
+            jar.write("inject-payload".toByteArray(Charsets.UTF_8))
+            jar.closeEntry()
+        }
+
+        val carrier = Files.createTempFile("agent-runtime-carrier-", ".jar")
+        JarOutputStream(Files.newOutputStream(carrier)).use { jar ->
+            jar.putNextEntry(ZipEntry(InjectRuntimeLocator.INJECT_RUNTIME_RESOURCE))
+            jar.write(Files.readAllBytes(nested))
+            jar.closeEntry()
+        }
+
+        val loader = URLClassLoader(arrayOf(carrier.toUri().toURL()), null)
+        val extracted = InjectRuntimeLocator.extractInjectJar(loader)
+        assertNotNull(extracted)
+        assertTrue(Files.isRegularFile(extracted))
+        assertTrue(Files.size(extracted) > 0L)
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreInjectClassLoaderTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreInjectClassLoaderTest.kt
@@ -1,0 +1,59 @@
+package dev.sebastiano.spectre.agent.runtime
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class SpectreInjectClassLoaderTest {
+
+    @Test
+    fun `loadFromInjectJar owns spectre and relocated packages but not Compose`() {
+        assertTrue(
+            SpectreInjectClassLoader.loadFromInjectJar(
+                "dev.sebastiano.spectre.core.ComposeAutomator"
+            )
+        )
+        assertTrue(
+            SpectreInjectClassLoader.loadFromInjectJar(
+                "dev.sebastiano.spectre.inject.relocated.kotlinx.coroutines.Dispatchers"
+            )
+        )
+        assertTrue(SpectreInjectClassLoader.loadFromInjectJar("androidx.tracing.Trace"))
+        assertEquals(
+            false,
+            SpectreInjectClassLoader.loadFromInjectJar("androidx.compose.ui.awt.ComposeWindow"),
+        )
+        assertEquals(false, SpectreInjectClassLoader.loadFromInjectJar("java.lang.String"))
+    }
+
+    @Test
+    fun `inject classloader prefers jar for spectre packages and parent for others`() {
+        val injectJar = writeJarWithTextResource()
+        val parent = object : ClassLoader(ClassLoader.getSystemClassLoader()) {}
+        val loader = SpectreInjectClassLoader(arrayOf(injectJar.toUri().toURL()), parent)
+
+        // Resource from inject jar is visible via findResource (URLClassLoader).
+        val resource = loader.findResource("inject-marker.txt")
+        assertTrue(resource != null, "expected inject-marker.txt on inject jar")
+
+        // JDK class always from parent hierarchy.
+        val stringClass = loader.loadClass("java.lang.String")
+        assertSame(java.lang.String::class.java, stringClass)
+    }
+
+    private fun writeJarWithTextResource(): Path {
+        val path = Files.createTempFile("spectre-inject-test-", ".jar")
+        JarOutputStream(Files.newOutputStream(path)).use { jar ->
+            jar.putNextEntry(ZipEntry("inject-marker.txt"))
+            jar.write("ok".toByteArray(Charsets.UTF_8))
+            jar.closeEntry()
+        }
+        path.toFile().deleteOnExit()
+        return path
+    }
+}

--- a/docs/spikes/209-injection/inject-packaging.md
+++ b/docs/spikes/209-injection/inject-packaging.md
@@ -1,0 +1,30 @@
+# #209 inject-runtime packaging (M2 / #313)
+
+## Artifacts
+
+| Artifact | Contents | Compose |
+| --- | --- | --- |
+| `spectre-agent-runtime` | Thin agent + IPC + nested inject jar resource | Not bundled |
+| nested `META-INF/spectre/inject-runtime.jar` | `:core` + relocated kotlinx (+ tracing/okio/wire) | **Not** bundled |
+
+## Relocation
+
+Shadow relocates:
+
+- `kotlinx.coroutines` → `dev.sebastiano.spectre.inject.relocated.kotlinx.coroutines`
+- `kotlinx.atomicfu` → `dev.sebastiano.spectre.inject.relocated.kotlinx.atomicfu`
+
+Compose / Skiko / Kotlin stdlib are excluded from the inject jar and resolve against the
+**target** classloader (parent of `SpectreInjectClassLoader`).
+
+## Bootstrap
+
+1. Prefer preinstalled `ComposeAutomator` (existing thin-agent path, D-14).
+2. Else extract nested inject jar → `SpectreInjectClassLoader(parent = Compose host)`.
+3. Compose host discovery uses `ComposeWindow` / `ComposePanel` / `SemanticsOwner` + D-14.
+
+## Verification
+
+- `:agent-inject-runtime:verifyInjectRuntimeJarContents`
+- `:agent-runtime:verifyAgentRuntimeJarContents` (nested resource present; no exploded core)
+- `AgentInjectAttachIntegrationTest` — attach + tree dump with spectre-core stripped from target CP

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -96,6 +96,9 @@ include(":agent")
 
 include(":agent-runtime")
 
+// Relocated :core payload nested inside agent-runtime for #209 injection (no Compose bundled).
+include(":agent-inject-runtime")
+
 include(":cli")
 
 // Tiny non-publishable Compose Desktop app used only as a target for `:agent`'s integration


### PR DESCRIPTION
## Summary

- New `:agent-inject-runtime` Shadow jar: `:core` + relocated kotlinx, **no Compose**.
- Nested into `spectre-agent-runtime` as `META-INF/spectre/inject-runtime.jar`.
- Bootstrap inject path via `SpectreInjectClassLoader` when `ComposeAutomator` is absent; Compose host selected with D-14 rules.
- E2E: `AgentInjectAttachIntegrationTest` attaches to a Compose fixture **without** spectre-core on the target classpath and dumps a non-empty semantics tree.

Closes #313 (parent #209). Also covers the core of #314 e2e path.

## Test plan

- [x] `./gradlew :agent-inject-runtime:verifyInjectRuntimeJarContents`
- [x] `./gradlew :agent-runtime:verifyAgentRuntimeJarContents`
- [x] `./gradlew :agent:test --tests '*Inject*' --tests '*AgentBootstrap*'`
- [x] `AgentInjectAttachIntegrationTest` green twice
- [ ] CI `check`

## Review notes

Spike packaging — not production CLI `attach --inject`. Stock IDE attempt remains M4.