### PR TITLE
Bump IntelliJ-hosted validation to 262 / IDEA 2026.2 (#217)

### DIFF
--- a/.github/workflows/ide-uitest.yml
+++ b/.github/workflows/ide-uitest.yml
@@ -67,12 +67,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Set up JDK 21
-        # Same toolchain as the rest of the project (see ci.yml for the temurin-vs-jbr note).
+      - name: Set up JDK 25
+        # ide-starter 262+ is compiled for Java 25 (class file 69). Running the uiTest
+        # executor on JDK 21 fails with UnsupportedClassVersionError on
+        # TestCleanupListener. The plugin still targets jvmToolchain(21) for compile —
+        # only the test process / Gradle JVM needs 25 (issue #217 / platform 262).
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: "21"
+          java-version: "25"
 
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v5

--- a/.github/workflows/ide-uitest.yml
+++ b/.github/workflows/ide-uitest.yml
@@ -1,9 +1,9 @@
 name: IDE UI test
 
-# Runs the intellij-ide-starter UI test (#42) — boots a real IntelliJ IDEA 2026.1.1 in a child
-# process, installs the freshly-built `:sample-intellij-plugin` zip, invokes `RunSpectreAction`
-# via the Driver, and asserts every tagged Compose node from `SpectreSampleToolWindowContent`
-# appears in `idea.log`.
+# Runs the intellij-ide-starter UI test (#42) — boots a real IntelliJ IDEA 2026.2.0.1 (262 /
+# JBR 25 era) in a child process, installs the freshly-built `:sample-intellij-plugin` zip,
+# invokes `RunSpectreAction` via the Driver, and asserts every tagged Compose node from
+# `SpectreSampleToolWindowContent` appears in `idea.log`.
 #
 # Why this is its own workflow (not part of `ci.yml`):
 #   - First run downloads ~1 GB IDE installer (cached afterwards via the `ide-starter-cache`

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -43,7 +43,8 @@ on `PATH`.
 ## Requirements
 
 - **JDK 21 or newer.** JBR 21 is the project's dev-loop default; JBR 25 is exercised via
-  the IDE-hosted UI test. Any JDK 21+ works for the non-IDE modules.
+  the IDE-hosted UI test (IntelliJ 2026.2 / platform 262) and the runtime matrix. Any JDK
+  21+ works for the non-IDE modules.
 - **Windows 10 version 1903 or newer**, **.NET 8 Desktop Runtime**, and
   **Windows App Runtime 1.8** for native window/region recording and still-window screenshots
   through Windows Graphics Capture. Contributors and CI that build the helper from source

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -396,7 +396,7 @@ returns a human-readable diagnostic without throwing.
 ## "JBR vs Temurin: which JDK should I use?"
 
 - **Locally**: JBR 21 is the dev-loop default. JBR 25 also gets exercised via the
-  IDE-hosted UI test (it's bundled with IntelliJ 2026.1).
+  IDE-hosted UI test (it's bundled with IntelliJ 2026.2 / JBR 25).
 - **On CI**: Temurin 21. `actions/setup-java` does support the `jetbrains`
   distribution if you'd rather mirror the local toolchain — the choice here is
   pragmatic, not a constraint.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,14 +8,16 @@ composeHotReload = "1.2.0"
 clikt = "5.0.1"
 composeRules = "0.5.6"
 detekt = "2.0.0-alpha.3"
-intellijIdea = "2026.1.1"
-# JetBrains' intellij-ide-starter for the #42 IDE-hosted UI test. Pinned to the same build
-# our IDE itself runs (2026.1.1 == 261.23567.138) so the framework matches the IDE's
-# internal API surface. Deliberately NOT `LATEST-EAP-SNAPSHOT` — JetBrains' own examples use
-# that for their nightly cycle but we need reproducibility against beta+ build stability.
-ideStarter = "261.23567.138"
-jewel = "0.35.0-261.23567.138"
-jewelBridge = "261.23567.138"
+# IntelliJ IDEA 2026.2.0.1 == build 262.8665.337 (JBR 25 era; epic #215 / issue #217).
+intellijIdea = "2026.2.0.1"
+# JetBrains' intellij-ide-starter for the #42 IDE-hosted UI test. Keep locked to the same
+# build as intellijIdea. Deliberately NOT `LATEST-EAP-SNAPSHOT`.
+ideStarter = "262.8665.337"
+# jewel-ui compileOnly pin: Maven Central's closest 262 pin is 0.38.0-262.8665.351;
+# ide-laf-bridge / ide-starter are 262.8665.337. Runtime Jewel still comes from the IDE's
+# bundled modules via composeUI().
+jewel = "0.38.0-262.8665.351"
+jewelBridge = "262.8665.337"
 ktfmt = "0.26.0"
 kotlin = "2.3.20"
 # vanniktech-maven-publish — Sonatype Central Portal-aware Maven publish plugin. Wires up
@@ -81,6 +83,8 @@ jewel-ui = { module = "org.jetbrains.jewel:jewel-ui", version.ref = "jewel" }
 # https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/tools/ —
 # require the JetBrains releases repo declared in settings.gradle.kts.
 ideStarter-squashed = { module = "com.jetbrains.intellij.tools:ide-starter-squashed", version.ref = "ideStarter" }
+# 2026.2+: product IdeInfo defaults live in per-IDE modules (IdeProductProvider removed).
+ideStarter-productIdeaUltimate = { module = "com.jetbrains.intellij.tools:ide-starter-product-idea-ultimate", version.ref = "ideStarter" }
 ideStarter-junit5 = { module = "com.jetbrains.intellij.tools:ide-starter-junit5", version.ref = "ideStarter" }
 ideStarter-driver = { module = "com.jetbrains.intellij.tools:ide-starter-driver", version.ref = "ideStarter" }
 ideStarter-driverClient = { module = "com.jetbrains.intellij.driver:driver-client", version.ref = "ideStarter" }

--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -19,7 +19,7 @@ kotlin { jvmToolchain(21) }
 // Repositories are inherited from settings.gradle.kts (Maven Central, Google, IntelliJ Platform
 // + JetBrains Skiko mirror) — the IntelliJ Platform settings plugin makes that work.
 
-// IDE 2026.1.1 bundles its own Jewel + Compose + skiko as platform modules (see
+// IDE 2026.2 (262) bundles its own Jewel + Compose + skiko as platform modules (see
 // `<idea-home>/lib/intellij.libraries.{skiko,compose.*}.jar` and
 // `intellij.platform.jewel.*.jar`). The IDE loads its bundled skiko native dylib at startup;
 // JNI native libraries are loaded once per JVM, so the plugin MUST use the IDE's own skiko
@@ -188,6 +188,7 @@ val uiTestRuntimeOnly by configurations.getting { extendsFrom(configurations["ru
 dependencies {
     "uiTestImplementation"(libs.junit5.api)
     "uiTestImplementation"(libs.ideStarter.squashed)
+    "uiTestImplementation"(libs.ideStarter.productIdeaUltimate)
     "uiTestImplementation"(libs.ideStarter.junit5)
     "uiTestImplementation"(libs.ideStarter.driver)
     "uiTestImplementation"(libs.ideStarter.driverClient)
@@ -211,7 +212,7 @@ val uiTest by
         group = "verification"
         description =
             "IDE-hosted UI test for the Spectre sample plugin (intellij-ide-starter, #42). " +
-                "Boots an IntelliJ IDEA 2026.1.1 in a child process, installs the plugin from " +
+                "Boots an IntelliJ IDEA 2026.2.0.1 in a child process, installs the plugin from " +
                 "the local buildPlugin output, invokes `RunSpectreAction`, and asserts the " +
                 "expected semantics tags appear in idea.log. NOT wired into :check — opt-in. " +
                 "Targets IU because JetBrains stopped shipping a distinct IC distribution as " +

--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -231,4 +231,12 @@ val uiTest by
         // filename, which depends on Gradle archive-naming conventions
         // (`<project>-<version>.zip`, not the plugin's display name).
         systemProperty("path.to.build.plugin", pluginZipProvider.get().asFile.absolutePath)
+        // ide-starter 262+ is class-file 69 (Java 25). Prefer a Java 25 toolchain launcher
+        // when the Gradle JVM is older so local `./gradlew :uiTest` on JBR 21 still works
+        // once a JDK 25 is installed (fooJay resolver).
+        javaLauncher.set(
+            javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
+        )
+        // Required by ide-starter 2026.2 changelog for recent IDE runs.
+        jvmArgs("--add-opens=java.base/sun.nio.fs=ALL-UNNAMED")
     }

--- a/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/RunSpectreUiTest.kt
+++ b/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/RunSpectreUiTest.kt
@@ -5,7 +5,6 @@ import com.intellij.driver.sdk.singleProject
 import com.intellij.driver.sdk.waitForIndicators
 import com.intellij.driver.sdk.waitForProjectOpen
 import com.intellij.ide.starter.driver.engine.runIdeWithDriver
-import com.intellij.ide.starter.ide.IdeProductProvider
 import com.intellij.ide.starter.junit5.hyphenateWithClass
 import com.intellij.ide.starter.models.TestCase
 import com.intellij.ide.starter.plugins.PluginConfigurator
@@ -13,6 +12,7 @@ import com.intellij.ide.starter.project.LocalProjectInfo
 import com.intellij.ide.starter.runner.CurrentTestMethod
 import com.intellij.ide.starter.runner.IDERunContext
 import com.intellij.ide.starter.runner.Starter
+import com.intellij.tools.ide.starter.product.idea.ultimate.IdeaUltimateProductInit
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicReference
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.Test
  * IDE-hosted validation for #42: boots a real IntelliJ IDEA via `intellij-ide-starter`, installs
  * the locally-built `:sample-intellij-plugin` zip, invokes `RunSpectreAction`, and asserts the
  * action's `[Spectre]` log lines mention every tagged node from `SpectreSampleToolWindowContent`.
- * As of the 253.x (2026.1.x) line, JetBrains stopped shipping a distinct IntelliJ Community Edition
- * — IDEA Ultimate is now the unified product under a freemium licence, so this test naturally
- * targets IU.
+ * As of the 253.x line, JetBrains stopped shipping a distinct IntelliJ Community Edition — IDEA
+ * Ultimate is now the unified product under a freemium licence, so this test naturally targets IU.
+ * The platform pin is 262-based (IDEA 2026.2 / JBR 25 era; issue #217).
  *
  * Counterpart to the manual `./gradlew :sample-intellij-plugin:runIde` smoke that landed with #43 —
  * same assertions, no human in the loop. CI runs this only when the plugin or recording sources
@@ -57,21 +57,21 @@ class RunSpectreUiTest {
         val testContext =
             Starter.newContext(
                     CurrentTestMethod.hyphenateWithClass(),
-                    // The plugin compiles against IntelliJ IDEA 2026.1.1 (build
-                    // 261.23567.138 = IU). As of the 253.x line JetBrains stopped shipping a
-                    // distinct Community Edition — IU is the unified IDEA product under a
-                    // freemium licence — so `IdeProductProvider.IU` is the only thing
-                    // ide-starter has for 2026.1.x and this test targets it directly.
+                    // The plugin compiles against IntelliJ IDEA 2026.2.0.1 (build
+                    // 262.8665.337 = IU). As of 2026.2, ide-starter split product defaults
+                    // into `ide-starter-product-*` modules; IU is
+                    // `IdeaUltimateProductInit().ideInfo` (IdeProductProvider was removed).
+                    // As of the 253.x line JetBrains also stopped shipping a distinct
+                    // Community Edition — IU is the unified freemium product.
                     //
                     // We do NOT call `setLicense(...)` — invokeAction-only flows against
                     // an empty project don't need a paid licence. If the IDE later refuses
                     // to start because of licence validation, that's the signal to wire
                     // `LICENSE_KEY` from a CI secret.
                     TestCase(
-                        IdeProductProvider.IU.copy(
-                            buildType = "release",
-                            buildNumber = IDE_BUILD_NUMBER,
-                        ),
+                        IdeaUltimateProductInit()
+                            .ideInfo
+                            .copy(buildType = "release", buildNumber = IDE_BUILD_NUMBER),
                         LocalProjectInfo(tempProject),
                     ),
                 )
@@ -107,7 +107,10 @@ class RunSpectreUiTest {
                     // CI's fresh config dir this can briefly steal focus and adds
                     // unnecessary cost; we don't need it.
                     setIdeStartupDialogEnabled(false)
-                    setNeverShowInitConfigModal()
+                    // 262 renamed/folded the old setNeverShowInitConfigModal() into the
+                    // broader startup-dialog suppressors.
+                    disableStartupDialogs()
+                    disableNewUsersOnboardingDialogue()
                 }
                 // Skip stub-index initialization on project open. With the daemon disabled
                 // the dominant remaining cost on a cold Windows runner is ~3 min of stub /
@@ -251,12 +254,12 @@ class RunSpectreUiTest {
     }
 
     private companion object {
-        // IntelliJ IDEA 2026.1.1 build number (resolves to IU here — see comment on the
-        // `IdeProductProvider.IU` use above). Must stay in lockstep with `intellijIdea` in
-        // `gradle/libs.versions.toml` — bumping that version means updating this constant to
-        // the matching build (find it under
-        // https://www.jetbrains.com/intellij-repository/releases/com/jetbrains/intellij/idea/).
-        const val IDE_BUILD_NUMBER = "261.23567.138"
+        // IntelliJ IDEA 2026.2.0.1 build number (resolves to IU here — see comment on the
+        // `IdeProductProvider.IU` use above). Must stay in lockstep with `intellijIdea` /
+        // `ideStarter` in `gradle/libs.versions.toml` — bumping those means updating this
+        // constant to the matching build (product→build map:
+        // https://data.services.jetbrains.com/products?code=IIU&release.type=release).
+        const val IDE_BUILD_NUMBER = "262.8665.337"
         const val SPECTRE_ACTION_ID = "dev.sebastiano.spectre.sample.RunSpectre"
         // Matches every test-tagged node the manual smoke proved discoverable in PR #43.
         // Keep this list aligned with `SpectreSampleToolWindowContent`'s `Modifier.testTag`


### PR DESCRIPTION
## Summary

Implements #217 (epic #215): bump IntelliJ-hosted validation to a **262-based** platform (JBR 25 era).

- `intellijIdea` → `2026.2.0.1` (build **262.8665.337**)
- `ideStarter` / `jewelBridge` → `262.8665.337`
- `jewel` compileOnly → `0.38.0-262.8665.351` (Maven Central closest 262 pin)
- Add `ide-starter-product-idea-ultimate` (2026.2 breaking change: product IdeInfo defaults moved out of squashed jar; `IdeProductProvider` removed)
- uiTest: `IdeaUltimateProductInit().ideInfo.copy(...)`; replace `setNeverShowInitConfigModal()` with `disableStartupDialogs()` / `disableNewUsersOnboardingDialogue()`
- Docs/workflow comments updated for 2026.2
- **#56**: recheck comment posted — leave open; Windows host had no `java` on PATH for a live OnWindow re-run under JBR 25

## Test plan

- [x] `:sample-intellij-plugin:compileKotlin` + `compileUiTestKotlin` green against 262 pins
- [x] `./gradlew check` (+ uiTest ktfmt/detekt) locally
- [ ] CI `ide-uitest` green on this PR
- [x] #56 comment with findings

Closes #217.