### PR TITLE
Document #209 injection practicalities, decision, and recipe

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -34,4 +34,28 @@ dependencies {
     testImplementation(libs.kotlinx.coroutines.test)
 }
 
-tasks.withType<Test>().configureEach { useJUnitPlatform() }
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    // Docs contract tests read repo-root markdown at runtime; register them as inputs so
+    // :core:test is not UP-TO-DATE/cache-hit after spike/guide docs change (#209).
+    val docsRoot = rootProject.layout.projectDirectory.dir("docs")
+    inputs
+        .files(
+            docsRoot.file("spikes/209-injection/api-audit.md"),
+            docsRoot.file("spikes/209-injection/decision.md"),
+            docsRoot.file("spikes/209-injection/practicalities.md"),
+            docsRoot.file("spikes/209-injection/user-recipe.md"),
+            docsRoot.file("spikes/209-injection/inject-packaging.md"),
+            docsRoot.file("guide/getting-started.md"),
+            docsRoot.file("guide/junit.md"),
+            docsRoot.file("guide/troubleshooting.md"),
+            docsRoot.file("guide/selectors.md"),
+            docsRoot.file("guide/interactions.md"),
+        )
+        .withPropertyName("docsContractInputs")
+        .optional()
+    inputs
+        .file(rootProject.layout.projectDirectory.file("skills/spectre/SKILL.md"))
+        .withPropertyName("skillContractInput")
+        .optional()
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InjectionSpikeDocsContractTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InjectionSpikeDocsContractTest.kt
@@ -1,0 +1,39 @@
+package dev.sebastiano.spectre.core
+
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/** Pins #209 spike docs required by acceptance criteria (audit + practicalities + decision). */
+class InjectionSpikeDocsContractTest {
+
+    @Test
+    fun `spike docs cover audit practicalities decision and user recipe`() {
+        for (name in
+            listOf(
+                "api-audit.md",
+                "practicalities.md",
+                "decision.md",
+                "user-recipe.md",
+                "inject-packaging.md",
+            )) {
+            val path = root.resolve("docs/spikes/209-injection/$name")
+            assertTrue(path.exists(), "missing $path")
+            assertTrue(path.readText().isNotBlank())
+        }
+        val decision = root.resolve("docs/spikes/209-injection/decision.md").readText()
+        assertTrue(decision.contains("Instrumented-only"))
+        assertTrue(decision.contains("Read-only injection"))
+        assertTrue(decision.contains("STABILITY"))
+        val practicalities = root.resolve("docs/spikes/209-injection/practicalities.md").readText()
+        assertTrue(practicalities.contains("EnableDynamicAgentLoading"))
+        assertTrue(practicalities.contains("adapter"))
+        assertTrue(practicalities.contains("classloader") || practicalities.contains("Metaspace"))
+    }
+
+    private companion object {
+        val root: Path = Path.of("..").toAbsolutePath().normalize()
+    }
+}

--- a/docs/spikes/209-injection/decision.md
+++ b/docs/spikes/209-injection/decision.md
@@ -1,0 +1,51 @@
+# #209 decision: injection for Spectre 1.0 (M5 / #316)
+
+## Recommendation for 1.0
+
+**Read-only injection: experimental / optional path**  
+**Full injection (Robot input via inject): deferred**  
+**Instrumented-only (preinstalled `spectre-core`): remains the supported production attach path**
+
+### Why
+
+1. **API audit** shows the primary semantics read path is public Compose Desktop API — inject is
+   architecturally sound for tree dump/inspect without shading Compose.
+2. **Prototype succeeded** against a no-core Compose fixture over real attach/UDS
+   (`AgentInjectAttachIntegrationTest`, PR #319).
+3. **Maintenance cost** for main-scene read is low; full overlay/recomposer parity and multi-IDE
+   Compose lines raise adapter cost into STABILITY experimental territory.
+4. **Metaspace leak** after inject means unbounded attach/detach on stock IDEs is a product risk
+   if advertised as production.
+5. **Stock IDE** was not fully proven in the delivery environment — keep the feature experimental
+   until a documented stock-IDE recipe is green in CI or release QA.
+
+## Mapping to `docs/STABILITY.md` tiers
+
+| Surface | Tier | Notes |
+| --- | --- | --- |
+| Agent attach with preinstalled core | `@ExperimentalSpectreAgentApi` (existing) | Unchanged |
+| Inject packaging + bootstrap | Experimental (same marker) | Nested inject jar inside agent-runtime |
+| Production CLI `spectre attach --inject` | **Out of 1.0** | Requires re-approval (non-goal of #209) |
+| Version adapter matrix for every IDE major | Not shipped | Estimate only (see practicalities) |
+
+## Modes compared
+
+| Mode | 1.0 status | Rationale |
+| --- | --- | --- |
+| Instrumented-only | **Supported experimental attach** | Existing path; no leak; CI e2e mature |
+| Read-only injection | **Spike-proven; experimental** | Tree dump works; document leak + EnableDynamicAgentLoading |
+| Full injection (Robot) | **Technically viable** after geometry | Same inject payload; defer product UX until stock-IDE QA |
+
+## Follow-up issues (filed from this decision)
+
+Filed after decision (not before):
+
+1. **#320** — Stock IDE attach recipe + QA (vmoptions + IntelliJ 2026.2 Jewel tags).
+2. **#321** — Decide 1.0 fate of nested inject-runtime packaging (promote / keep experimental / strip).
+3. **#322** — OverlayLayerInspector multi-version adapter policy.
+
+## Closes
+
+This decision, the API audit, practicalities, packaging prototype, and fixture e2e evidence
+together **close spike #209** even without a stock-IDE screenshot: negative stock-IDE automation
+is environmental and documented.

--- a/docs/spikes/209-injection/practicalities.md
+++ b/docs/spikes/209-injection/practicalities.md
@@ -1,0 +1,71 @@
+# #209 practicalities (M4 / #315)
+
+## 1. Enabling `-XX:+EnableDynamicAgentLoading` on a stock IDE
+
+JetBrains IDEs expose **Help → Edit Custom VM Options…**, which opens (or creates) a
+per-product `*.vmoptions` file under the IDE config directory. Append:
+
+```text
+-XX:+EnableDynamicAgentLoading
+```
+
+Then fully restart the IDE. Without the flag, JDK 21+ prints a JEP 451 stderr warning on
+dynamic attach; a future JDK may reject attach entirely. Spectre's launch harness injects the
+flag for direct `java` launches automatically (`LaunchCommandRewriter`); stock IDEs must be
+edited by the user/operator.
+
+**Config path examples (macOS):**
+`~/Library/Application Support/JetBrains/IntelliJIdea2026.2/idea.vmoptions`
+
+## 2. Compose / Jewel adapter-matrix estimate
+
+| Surface | Public vs internal | Adapter pressure |
+| --- | --- | --- |
+| Main-scene `ComposeWindow` / `ComposePanel.semanticsOwners` | Public (`@ExperimentalComposeUiApi`) | Low — track experimental opt-in + Desktop release notes |
+| Semantics tree walk / properties | Public Compose UI | Low–medium if property keys rename |
+| OnWindow overlay popups (`OverlayLayerInspector`) | **Internal reflection** | High per Compose Desktop minor if host fields rename |
+| `RecomposerInspector` / recomposition monitor | Internal reflection | High; optional for inspect mode |
+| Robot geometry input | Public AWT only | None for Compose skew |
+
+**Estimate across supported IDE majors (2024.3 → 2026.2):**
+
+- **Read-only main scene:** expect **0–1 adapter** if experimental public API stays stable; otherwise
+  a thin shims package per Compose Desktop line used by an IDE major.
+- **Overlay popups + recomposer:** **1–3 reflective adapter variants** over that window if full
+  parity is required — concentrate in `OverlayLayerInspector` / `RecomposerInspector` only.
+- **Jewel version:** Jewel is theming/UI; Spectre reads semantics, not Jewel widgets. Jewel skew
+  does not require Spectre adapters unless Jewel embeds Compose through a non-standard host
+  (none known for stock tool windows).
+
+Spike prototype does **not** ship a multi-version adapter matrix; it validates the inject packaging
+and bootstrap against the project's pinned Compose Desktop line.
+
+## 3. Detach / classloader-leak acceptability (inspect mode)
+
+Injected classes **cannot be unloaded** once defined. Spectre now:
+
+- extracts inject jar to a temp file
+- closes `SpectreInjectClassLoader` and deletes the temp jar on detach / failed bootstrap
+  (handles/files reclaimable)
+
+But **loaded classes remain in Metaspace** for the target process lifetime. For **inspect-mode**
+(attach, dump tree, detach) on a long-lived IDE:
+
+- **Acceptable** if attach is rare (debug sessions): small metaspace growth per attach cycle
+  that used a new inject loader.
+- **Not acceptable** as an unbounded attach loop without process restart.
+
+**Implication for 1.0:** prefer **instrumented-only** (preinstalled core) for production CI
+targets; treat injection as **experimental inspect** with documented leak semantics — or
+instrument once via `-javaagent` at IDE start to avoid repeated inject classloader creation.
+
+## 4. Stock IDE proving status
+
+Automated stock IntelliJ 2026.2 attach was **not** executed in the agent delivery environment
+(no reliable stock IDE launch path). Evidence path used instead:
+
+- `AgentInjectAttachIntegrationTest` — real attach + UDS + tree dump against Compose fixture
+  **without** preinstalled `spectre-core` on the target classpath (injection exercised).
+
+Stock-IDE gap is environmental, not a prototype packaging failure. Optional remote
+Windows/Linux hosts were not required for packaging validation.

--- a/docs/spikes/209-injection/practicalities.md
+++ b/docs/spikes/209-injection/practicalities.md
@@ -42,22 +42,27 @@ and bootstrap against the project's pinned Compose Desktop line.
 
 ## 3. Detach / classloader-leak acceptability (inspect mode)
 
-Injected classes **cannot be unloaded** once defined. Spectre now:
+Spectre:
 
 - extracts inject jar to a temp file
 - closes `SpectreInjectClassLoader` and deletes the temp jar on detach / failed bootstrap
-  (handles/files reclaimable)
+  (file handles reclaimable)
 
-But **loaded classes remain in Metaspace** for the target process lifetime. For **inspect-mode**
-(attach, dump tree, detach) on a long-lived IDE:
+Injected classes are defined by that **child** `URLClassLoader`. After detach releases the
+loader (and no other strong references remain), those classes are **eligible for unloading**
+when the GC reclaims the loader — timing is **not guaranteed**, and any retained reference
+(stale automator, IDE-held stack frame, etc.) can keep the loader alive.
 
-- **Acceptable** if attach is rare (debug sessions): small metaspace growth per attach cycle
-  that used a new inject loader.
-- **Not acceptable** as an unbounded attach loop without process restart.
+For **inspect-mode** (attach, dump tree, detach) on a long-lived IDE:
 
-**Implication for 1.0:** prefer **instrumented-only** (preinstalled core) for production CI
-targets; treat injection as **experimental inspect** with documented leak semantics — or
-instrument once via `-javaagent` at IDE start to avoid repeated inject classloader creation.
+- **Usually fine** for rare debug sessions: close/delete of the inject jar is deterministic;
+  metaspace retention is GC-dependent, not a guaranteed permanent per-attach leak.
+- **Still prefer instrumented-only** for high-frequency CI attach loops so product behaviour
+  does not depend on GC class-unloading behaviour.
+
+**Implication for 1.0:** keep injection as **experimental inspect**; production CI targets
+should keep preinstalled core (or a single `-javaagent` at process start) rather than
+relying on unbounded inject attach/detach cycles.
 
 ## 4. Stock IDE proving status
 

--- a/docs/spikes/209-injection/user-recipe.md
+++ b/docs/spikes/209-injection/user-recipe.md
@@ -1,0 +1,34 @@
+# #209 user-like inject attach recipe (M3)
+
+## Automated path (CI / developer)
+
+```bash
+./gradlew :agent:test --tests '*AgentInjectAttachIntegrationTest*'
+```
+
+What it does (real shipped APIs):
+
+1. Builds `spectre-agent-runtime` with nested `META-INF/spectre/inject-runtime.jar`.
+2. Spawns `InjectComposeFixtureMain` on a child JVM **without** `spectre-core` on its classpath.
+3. Calls `AgentAttach.attach(pid)` → UDS → `windows()` / `allNodes()` / `findByTestTag(...)`.
+4. Asserts non-empty tree and fixture tags.
+
+## Manual recipe (same components)
+
+```bash
+# Terminal A — target without spectre-core (filter core off the classpath yourself,
+# or run a Compose app that does not depend on spectre-core):
+./gradlew :agent-test-fixture:jar :agent-inject-runtime:shadowJar :agent-runtime:jar
+# Construct a CP of Compose + agent-test-fixture classes only, then:
+java -cp "$COMPOSE_AND_FIXTURE_CP" \
+  -XX:+EnableDynamicAgentLoading \
+  dev.sebastiano.spectre.agent.fixture.InjectComposeFixtureMainKt
+
+# Terminal B — attach with the agent runtime that embeds inject-runtime:
+./gradlew :agent:attachSpike -Ppid=<pid-from-jps>
+# or from a test/tool using AgentAttach.attach(pid, AttachOptions(agentJarPath = ...))
+```
+
+Success signal: non-empty `windows()` / `allNodes()` / fixture tags. Failure signal: bootstrap
+exceptions (`SpectreNotOnClasspathException`, `ComposeNotOnClasspathException`, attach timeouts)
+with the same categories documented in agent guide + decision doc.

--- a/docs/spikes/209-injection/user-recipe.md
+++ b/docs/spikes/209-injection/user-recipe.md
@@ -15,18 +15,39 @@ What it does (real shipped APIs):
 
 ## Manual recipe (same components)
 
+`./gradlew :agent:attachSpike` only loads the agent in diagnostic mode (window count on the
+**target** stderr) — it does **not** return an `AttachedAutomator` or print a tree. Prefer the
+Gradle e2e above for a full tree dump. For an interactive attach that queries the tree:
+
 ```bash
-# Terminal A — target without spectre-core (filter core off the classpath yourself,
-# or run a Compose app that does not depend on spectre-core):
-./gradlew :agent-test-fixture:jar :agent-inject-runtime:shadowJar :agent-runtime:jar
-# Construct a CP of Compose + agent-test-fixture classes only, then:
+# Terminal A — target without spectre-core:
+./gradlew :agent-test-fixture:jar :agent-runtime:jar
+# Build a classpath of Compose + agent-test-fixture only (no spectre-core), then:
 java -cp "$COMPOSE_AND_FIXTURE_CP" \
   -XX:+EnableDynamicAgentLoading \
   dev.sebastiano.spectre.agent.fixture.InjectComposeFixtureMainKt
+```
 
-# Terminal B — attach with the agent runtime that embeds inject-runtime:
-./gradlew :agent:attachSpike -Ppid=<pid-from-jps>
-# or from a test/tool using AgentAttach.attach(pid, AttachOptions(agentJarPath = ...))
+```kotlin
+// Terminal B — attacher JVM (spectre-agent + spectre-agent-runtime on CP):
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+import dev.sebastiano.spectre.agent.AgentAttach
+import dev.sebastiano.spectre.agent.AttachOptions
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Path
+
+AgentAttach.attach(
+    pid = targetPid, // from jps / SpectreProcesses
+    options =
+        AttachOptions(
+            agentJarPath = Path.of("agent-runtime/build/libs/…spectre-agent-runtime….jar"),
+        ),
+).use { automator ->
+    println(automator.windows())
+    println(automator.allNodes().map { it.testTag })
+    println(automator.findByTestTag("agent-fixture-label"))
+}
 ```
 
 Success signal: non-empty `windows()` / `allNodes()` / fixture tags. Failure signal: bootstrap

--- a/docs/spikes/209-injection/user-recipe.md
+++ b/docs/spikes/209-injection/user-recipe.md
@@ -2,11 +2,20 @@
 
 ## Automated path (CI / developer)
 
+**Prerequisites:** Linux or macOS with a non-headless display (or `xvfb-run -a` on Linux).
+The test is `@EnabledOnOs(LINUX, MAC)` and assumes `!GraphicsEnvironment.isHeadless()` — on
+Windows and headless Linux CI it **skips** (green Gradle with no attach/tree evidence). Do not
+treat a skipped run as inject proof.
+
 ```bash
+# macOS / interactive Linux:
 ./gradlew :agent:test --tests '*AgentInjectAttachIntegrationTest*'
+
+# headless Linux with a virtual display:
+xvfb-run -a ./gradlew :agent:test --tests '*AgentInjectAttachIntegrationTest*'
 ```
 
-What it does (real shipped APIs):
+What it does when it **runs** (real shipped APIs):
 
 1. Builds `spectre-agent-runtime` with nested `META-INF/spectre/inject-runtime.jar`.
 2. Spawns `InjectComposeFixtureMain` on a child JVM **without** `spectre-core` on its classpath.


### PR DESCRIPTION
## Summary

- Practicalities: EnableDynamicAgentLoading on stock IDE, adapter-matrix estimate, detach/leak.
- Decision: instrumented-only remains supported experimental attach; read-only inject spike-proven experimental; full product inject CLI out of 1.0.
- User recipe for inject e2e / manual attach.
- Follow-ups filed from decision: #320 #321 #322.
- Contract test pins spike docs presence.

Closes #314 #315 #316. Parent spike #209 can close with this + #317/#319 evidence.

## Test plan

- [x] `InjectionSpikeDocsContractTest` / `InjectionApiAuditContractTest`
- [x] Inject e2e twice (local evidence under implementer scratch)
- [ ] CI check