### PR TITLE
Codify supported JVM runtimes in STABILITY platform tiers (#218)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,10 +103,11 @@ Two heavier checks live outside `:check`:
 
 ## Supported JVMs
 
-JBR 21 is the dev-loop default. JBR 25 and Temurin LTS (toolchain major) are exercised by the
-scheduled [runtime matrix](.github/workflows/runtime-matrix.yml) (epic #215 / #216) and re-run
-as a **release gate**. Per-PR CI stays on Temurin 21 for speed. Any JDK 21+ works for the
-non-IDE modules; pins and the bump procedure live in [`.github/jbr-pins.env`](.github/jbr-pins.env).
+JBR 21 (dev-loop default), JBR 25, and Temurin LTS (toolchain major) are the codified
+supported set — see [docs/STABILITY.md](docs/STABILITY.md#jvm-runtime-support-tiers).
+They are exercised by the scheduled [runtime matrix](.github/workflows/runtime-matrix.yml)
+and re-run as a **release gate**. Per-PR CI stays on Temurin 21 for speed. Pins and the
+bump procedure live in [`.github/jbr-pins.env`](.github/jbr-pins.env).
 
 ## CI
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -23,11 +23,16 @@ published library module.
 
 [release-yml]: https://github.com/rock3r/spectre/blob/main/.github/workflows/release.yml
 
-Five jobs run on tag push:
+Jobs on tag push (order simplified; see the workflow for the full graph):
 
-1. **`release-gate`** (Linux runner) — validates the tag shape, runs
-   `./gradlew check`, installs the docs dependencies, and runs
-   `mkdocs build --strict`. Nothing else starts until this gate passes.
+0. **`runtime-matrix`** (reusable workflow) — full
+   `{JBR 21, JBR 25, Temurin LTS} × {macOS, Linux, Windows}` compatibility matrix
+   (epic #215 / #216). A red matrix **blocks** the release; this is the executable
+   evidence for the supported JVM set in [Stability policy](STABILITY.md). Per-PR CI
+   stays on single-JDK Temurin 21.
+1. **`release-gate`** (Linux runner, depends on `runtime-matrix`) — validates the tag
+   shape, runs `./gradlew check`, installs the docs dependencies, and runs
+   `mkdocs build --strict`. Helper builds and publish wait for this gate.
 2. **`mac-helper`** (macOS runner, depends on `release-gate`) — builds the
    arm64+x86_64 universal
    `SpectreScreenCapture` Swift helper, codesigns it with the Developer ID, runs

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -26,10 +26,10 @@ published library module.
 Jobs on tag push (order simplified; see the workflow for the full graph):
 
 0. **`runtime-matrix`** (reusable workflow) — full
-   `{JBR 21, JBR 25, Temurin LTS} × {macOS, Linux, Windows}` compatibility matrix
-   (epic #215 / #216). A red matrix **blocks** the release; this is the executable
-   evidence for the supported JVM set in [Stability policy](STABILITY.md). Per-PR CI
-   stays on single-JDK Temurin 21.
+   `{JBR 21, JBR 25, Temurin LTS} × {macOS, Linux, Windows}` compatibility matrix.
+   A red matrix **blocks** the release; this is the executable evidence for the
+   supported JVM set in [Stability policy](STABILITY.md). Per-PR CI stays on
+   single-JDK Temurin 21.
 1. **`release-gate`** (Linux runner, depends on `runtime-matrix`) — validates the tag
    shape, runs `./gradlew check`, installs the docs dependencies, and runs
    `mkdocs build --strict`. Helper builds and publish wait for this gate.

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -146,7 +146,7 @@ Spectre is JVM-first and targets desktop OSes.
 
 Spectre is a JVM library and CLI. **Supported JVM runtimes** are the set we claim work
 for non-IDE modules; claims are fail-closed on **executable evidence** (same rule as the
-[capability matrix](guide/capability-matrix.md) / epic #198).
+[capability matrix](guide/capability-matrix.md)).
 
 | Runtime | Tier | Evidence / notes |
 | --- | --- | --- |

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -142,6 +142,43 @@ Spectre is JVM-first and targets desktop OSes.
 | **Linux Wayland** | Best-effort | Portal-mediated capture via `WaylandPortalRecorder`, `WaylandPortalWindowRecorder`, and `LinuxNativeScreenshotter`. **Validated on GNOME/Mutter only**; KDE / sway / wlroots compositors may behave differently and are not exercised in CI. Real Robot input is unavailable on Wayland — use the synthetic adapter for tests. |
 | **BSD** | Unsupported | Not built or tested. |
 
+## JVM runtime support tiers
+
+Spectre is a JVM library and CLI. **Supported JVM runtimes** are the set we claim work
+for non-IDE modules; claims are fail-closed on **executable evidence** (same rule as the
+[capability matrix](guide/capability-matrix.md) / epic #198).
+
+| Runtime | Tier | Evidence / notes |
+| --- | --- | --- |
+| **JBR 21** (JetBrains Runtime, JBRSDK pin) | Primary (dev-loop default) | Local default; scheduled [runtime matrix](https://github.com/rock3r/spectre/blob/main/.github/workflows/runtime-matrix.yml) cell. Pins: [`.github/jbr-pins.env`](https://github.com/rock3r/spectre/blob/main/.github/jbr-pins.env). |
+| **JBR 25** | Full | Runtime matrix cell; IntelliJ-hosted validation on platform **262** / IDEA 2026.2 (IDE-bundled JBR 25). |
+| **Temurin LTS** (Eclipse Temurin at project toolchain major, currently **21**) | Full | Per-PR CI (`ci.yml` / macos-check / windows) and runtime matrix vanilla cell. |
+| **Other vanilla LTS JDKs ≥ toolchain** (e.g. other Temurin/Zulu majors ≥ 21) | Best-effort | Not every vendor/major is matrixed. Expect to work for non-IDE modules; regressions should be filed. |
+| **JVM &lt; 21** | Unsupported | Toolchain and published bytecode target 21. |
+
+### What “supported” means operationally
+
+1. **Exercised** by the scheduled + release-gated runtime matrix
+   (`runtime-matrix.yml`: contract corpus, agent attach where applicable, Linux recording
+   smoke under xvfb) and/or by the IDE UI test path for JBR 25 in the IDE process.
+2. **Release-blocking**: a red matrix **blocks** the tag-driven release pipeline
+   (`release.yml` calls the matrix via `workflow_call` before helper builds / publish).
+3. **Not per-PR**: everyday PRs stay on single-JDK Temurin 21 for speed. Compatibility
+   signal is scheduled + release-gated, not every PR.
+4. **Failures are triaged, not silent**: scheduled cell failures open issues labelled
+   `runtime-matrix` rather than vanishing into Actions noise.
+
+### Adding or dropping a runtime
+
+- **Add**: pin the runtime in `.github/jbr-pins.env` (or Temurin major), extend the matrix
+  include list, prove the cell green (or open a tracked triage issue), then document it
+  here as Supported only when evidence exists.
+- **Drop**: remove matrix cells first (or mark them Unsupported with a linked issue), then
+  update this table. Do not claim Supported without a green (or explicitly triaged)
+  matrix path.
+- **Bump JBR pins**: follow the bump procedure in `.github/jbr-pins.env` and re-run the
+  matrix via `workflow_dispatch`.
+
 ## AndroidX-style stability expectations
 
 Spectre adopts the cultural convention pioneered by [AndroidX](https://developer.android.com/jetpack/androidx):

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -42,9 +42,11 @@ on `PATH`.
 
 ## Requirements
 
-- **JDK 21 or newer.** JBR 21 is the project's dev-loop default; JBR 25 is exercised via
-  the IDE-hosted UI test (IntelliJ 2026.2 / platform 262) and the runtime matrix. Any JDK
-  21+ works for the non-IDE modules.
+- **JDK 21 or newer.** JBR 21 is the project's dev-loop default; JBR 25 and Temurin LTS
+  are matrix-exercised (see [Stability policy](../STABILITY.md#jvm-runtime-support-tiers)
+  and the [runtime matrix](https://github.com/rock3r/spectre/blob/main/.github/workflows/runtime-matrix.yml)).
+  Any JDK 21+ works for the non-IDE modules; IntelliJ-hosted Compose uses the IDE’s
+  bundled JBR.
 - **Windows 10 version 1903 or newer**, **.NET 8 Desktop Runtime**, and
   **Windows App Runtime 1.8** for native window/region recording and still-window screenshots
   through Windows Graphics Capture. Contributors and CI that build the helper from source

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -404,9 +404,10 @@ returns a human-readable diagnostic without throwing.
   set and what “supported” means operationally live in
   [Stability policy — JVM runtime support tiers](../STABILITY.md#jvm-runtime-support-tiers).
 
-**Agent attach** requires a real JDK (not a JRE-only image) on both attacher and target.
-**IntelliJ-hosted Compose** always implies the IDE’s bundled JBR — do not ship a second
-skiko into the plugin classloader (see [IntelliJ guide](intellij.md)).
+**Agent attach** needs a real JDK (with `jdk.attach`) on the **attacher** process; the
+target only needs to allow dynamic agent loading. **IntelliJ-hosted Compose** always
+implies the IDE’s bundled JBR — do not ship a second skiko into the plugin classloader
+(see [IntelliJ guide](intellij.md)).
 
 The sample IntelliJ plugin module configures its sandbox JDK via the IntelliJ Platform
 Gradle plugin; you do not pick Temurin for that path.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -395,15 +395,21 @@ returns a human-readable diagnostic without throwing.
 
 ## "JBR vs Temurin: which JDK should I use?"
 
-- **Locally**: JBR 21 is the dev-loop default. JBR 25 also gets exercised via the
-  IDE-hosted UI test (it's bundled with IntelliJ 2026.2 / JBR 25).
-- **On CI**: Temurin 21. `actions/setup-java` does support the `jetbrains`
-  distribution if you'd rather mirror the local toolchain — the choice here is
-  pragmatic, not a constraint.
-- **For consumers**: any JDK 21+ works for the non-IDE modules.
+- **Locally**: JBR 21 is the dev-loop default. JBR 25 is exercised by the scheduled
+  [runtime matrix](https://github.com/rock3r/spectre/blob/main/.github/workflows/runtime-matrix.yml)
+  and by the IDE-hosted UI test (IntelliJ 2026.2 / platform 262 bundles JBR 25).
+- **On CI (per-PR)**: Temurin 21 for speed. The full JBR/Temurin × OS matrix is
+  scheduled and **release-gated**, not per-PR.
+- **For consumers**: any JDK **21+** works for non-IDE modules. The codified supported
+  set and what “supported” means operationally live in
+  [Stability policy — JVM runtime support tiers](../STABILITY.md#jvm-runtime-support-tiers).
 
-The IntelliJ plugin module needs JBR specifically for its sandbox JDK; the Gradle build
-configures that automatically.
+**Agent attach** requires a real JDK (not a JRE-only image) on both attacher and target.
+**IntelliJ-hosted Compose** always implies the IDE’s bundled JBR — do not ship a second
+skiko into the plugin classloader (see [IntelliJ guide](intellij.md)).
+
+The sample IntelliJ plugin module configures its sandbox JDK via the IntelliJ Platform
+Gradle plugin; you do not pick Temurin for that path.
 
 ## Still stuck?
 


### PR DESCRIPTION
## Summary

Implements #218 (epic #215): codify the supported JVM runtime contract.

- **`docs/STABILITY.md`**: new **JVM runtime support tiers** table (JBR 21, JBR 25, Temurin LTS, best-effort other LTS ≥ 21, unsupported &lt; 21) plus operational meaning (matrix evidence, release gate, not per-PR, failure triage) and add/drop policy.
- **`docs/PUBLISHING.md`**: release job graph step 0 documents `runtime-matrix` as a hard gate before `release-gate`.
- **README / installation / troubleshooting**: point at STABILITY + matrix; agent attach / IntelliJ-hosted notes where runtime choice matters.
- `mkdocs build --strict` green locally.

## Test plan

- [x] `python3 -m mkdocs build --strict`
- [x] Internal links under `docs/` resolve relative to `docs/`
- [ ] CI docs build green on PR

Closes #218.