### PR TITLE
Install GStreamer for Linux runtime-matrix recording smoke (#326)

### DIFF
--- a/.github/scripts/test-resolve-matrix-jdk.sh
+++ b/.github/scripts/test-resolve-matrix-jdk.sh
@@ -59,7 +59,8 @@ for needle in jbr-21 jbr-25 temurin-lts ubuntu-latest macos-latest windows-lates
   AgentContractCorpusTest AgentAttachIntegrationTest InProcessContractCorpusTest \
   runLinuxX11RecordingSmoke workflow_call schedule "runner.os != 'Windows'" \
   SPECTRE_MATRIX_JAVA_HOME gstreamer1.0-tools gstreamer1.0-plugins-base \
-  gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly x11-utils; do
+  gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly gstreamer1.0-plugins-bad \
+  x11-utils; do
   grep -q "$needle" "$workflow" || fail "runtime-matrix.yml missing expected token: $needle"
 done
 grep -q "SPECTRE_MATRIX_JAVA_HOME" "$script_dir/../../build.gradle.kts" ||

--- a/.github/scripts/test-resolve-matrix-jdk.sh
+++ b/.github/scripts/test-resolve-matrix-jdk.sh
@@ -58,7 +58,8 @@ fi
 for needle in jbr-21 jbr-25 temurin-lts ubuntu-latest macos-latest windows-latest \
   AgentContractCorpusTest AgentAttachIntegrationTest InProcessContractCorpusTest \
   runLinuxX11RecordingSmoke workflow_call schedule "runner.os != 'Windows'" \
-  SPECTRE_MATRIX_JAVA_HOME; do
+  SPECTRE_MATRIX_JAVA_HOME gstreamer1.0-tools gstreamer1.0-plugins-base \
+  gstreamer1.0-plugins-good gstreamer1.0-plugins-ugly x11-utils; do
   grep -q "$needle" "$workflow" || fail "runtime-matrix.yml missing expected token: $needle"
 done
 grep -q "SPECTRE_MATRIX_JAVA_HOME" "$script_dir/../../build.gradle.kts" ||

--- a/.github/workflows/runtime-matrix.yml
+++ b/.github/workflows/runtime-matrix.yml
@@ -75,6 +75,7 @@ jobs:
             gstreamer1.0-plugins-base \
             gstreamer1.0-plugins-good \
             gstreamer1.0-plugins-ugly \
+            gstreamer1.0-plugins-bad \
             x11-utils
 
       - name: Set up Rust (Linux Wayland helper)
@@ -91,6 +92,10 @@ jobs:
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             command -v gst-launch-1.0
             gst-launch-1.0 --version | head -n1
+            # Fail early if the X11 recording pipeline elements are missing (h264parse
+            # ships in plugins-bad; x264enc in plugins-ugly).
+            gst-inspect-1.0 h264parse >/dev/null
+            gst-inspect-1.0 x264enc >/dev/null
           fi
 
       # Force Test/JavaExec workers onto the matrix JDK (see root build.gradle.kts). Modules

--- a/.github/workflows/runtime-matrix.yml
+++ b/.github/workflows/runtime-matrix.yml
@@ -61,8 +61,21 @@ jobs:
       - name: Install Linux display + native build deps
         if: runner.os == 'Linux'
         run: |
+          # xvfb: display for Compose/Robot. libdbus/pkg-config: Wayland helper Rust build.
+          # GStreamer + x11-utils: required by :recording:runLinuxX11RecordingSmoke
+          # (gst-launch-1.0 + ximagesrc/x264enc stack — see docs/guide/recording.md).
+          # Without these packages the smoke fails with gst-launch ENOENT after agent suites
+          # already passed (first dispatch 30049909702 / issue #326).
           sudo apt-get update
-          sudo apt-get install -y xvfb libdbus-1-dev pkg-config
+          sudo apt-get install -y \
+            xvfb \
+            libdbus-1-dev \
+            pkg-config \
+            gstreamer1.0-tools \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-ugly \
+            x11-utils
 
       - name: Set up Rust (Linux Wayland helper)
         if: runner.os == 'Linux'
@@ -75,6 +88,10 @@ jobs:
           echo "JAVA_HOME=$JAVA_HOME"
           java -version
           echo "runtime-label=${{ steps.jdk.outputs.runtime-label }}"
+          if [[ "${{ runner.os }}" == "Linux" ]]; then
+            command -v gst-launch-1.0
+            gst-launch-1.0 --version | head -n1
+          fi
 
       # Force Test/JavaExec workers onto the matrix JDK (see root build.gradle.kts). Modules
       # still compile with jvmToolchain(21); SPECTRE_MATRIX_JAVA_HOME makes JBR 25 cells


### PR DESCRIPTION
## Summary

Fixes the deterministic Linux runtime-matrix failures tracked in #326.

Linux cells already ran agent attach successfully; they then failed
`:recording:runLinuxX11RecordingSmoke` with `gst-launch-1.0: No such file or directory`.
Install the Xorg recording stack from `docs/guide/recording.md`:

- `gstreamer1.0-tools`
- `gstreamer1.0-plugins-base` / `good` / `ugly`
- `x11-utils`

Plus a log-step check that `gst-launch-1.0` is on PATH.

## Test plan

- [x] `bash .github/scripts/test-resolve-matrix-jdk.sh` (requires gstreamer packages in workflow)
- [ ] Re-dispatch Runtime matrix after merge; Linux cells should pass recording smoke
- [x] Correct #326 triage (agent was green; missing GStreamer was the failure)

Closes #326.