### PR TITLE
Fix inject e2e classpath strip on Windows (doubled separators)

### DIFF
--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -87,6 +87,13 @@ tasks.withType<Test>().configureEach {
             .orElse(providers.environmentVariable("SPECTRE_FIXTURE_JAVA_HOME"))
             .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.fixtureJavaHome"))
 
+    // Physical Windows desktop inject e2e opt-in (#209). Forward into the test JVM the same
+    // way as fixtureJavaHome — Gradle CLI `-D` alone does not reach workers.
+    val allowWindowsInjectE2e =
+        providers
+            .gradleProperty("spectre.agent.injectE2e.allowWindows")
+            .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.injectE2e.allowWindows"))
+
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
             buildList {
@@ -97,6 +104,10 @@ tasks.withType<Test>().configureEach {
                 val home = fixtureJavaHome.orNull?.takeIf { it.isNotBlank() }
                 if (home != null) {
                     add("-Ddev.sebastiano.spectre.agent.fixtureJavaHome=$home")
+                }
+                val allowWin = allowWindowsInjectE2e.orNull?.takeIf { it.isNotBlank() }
+                if (allowWin != null) {
+                    add("-Ddev.sebastiano.spectre.agent.injectE2e.allowWindows=$allowWin")
                 }
             }
         }

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -87,13 +87,6 @@ tasks.withType<Test>().configureEach {
             .orElse(providers.environmentVariable("SPECTRE_FIXTURE_JAVA_HOME"))
             .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.fixtureJavaHome"))
 
-    // Physical Windows desktop inject e2e opt-in (#209). Forward into the test JVM the same
-    // way as fixtureJavaHome — Gradle CLI `-D` alone does not reach workers.
-    val allowWindowsInjectE2e =
-        providers
-            .gradleProperty("spectre.agent.injectE2e.allowWindows")
-            .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.injectE2e.allowWindows"))
-
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
             buildList {
@@ -104,10 +97,6 @@ tasks.withType<Test>().configureEach {
                 val home = fixtureJavaHome.orNull?.takeIf { it.isNotBlank() }
                 if (home != null) {
                     add("-Ddev.sebastiano.spectre.agent.fixtureJavaHome=$home")
-                }
-                val allowWin = allowWindowsInjectE2e.orNull?.takeIf { it.isNotBlank() }
-                if (allowWin != null) {
-                    add("-Ddev.sebastiano.spectre.agent.injectE2e.allowWindows=$allowWin")
                 }
             }
         }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
@@ -18,6 +18,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 
@@ -27,9 +28,11 @@ import org.junit.jupiter.api.condition.OS
  * `META-INF/spectre/inject-runtime.jar`.
  *
  * Drives the real attach/UDS path ([AgentAttach.attach]) — not a re-implementation.
+ *
+ * **OS gate:** default is Linux/macOS. Hosted Windows CI lacks a reliable interactive desktop (same
+ * as [AgentAttachIntegrationTest]); set
+ * `-Ddev.sebastiano.spectre.agent.injectE2e.allowWindows=true` for physical Windows desktops.
  */
-// Physical Windows desktops can exercise inject; CI Windows runners stay unreliable for Robot UI
-// and will still skip on headless GraphicsEnvironment.
 @EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
 class AgentInjectAttachIntegrationTest {
 
@@ -39,6 +42,13 @@ class AgentInjectAttachIntegrationTest {
             GraphicsEnvironment.isHeadless(),
             "Requires non-headless JVM for Compose Desktop",
         )
+        if (isWindows()) {
+            assumeTrue(
+                System.getProperty(ALLOW_WINDOWS_PROP) == "true",
+                "Windows inject e2e is opt-in (hosted CI has no reliable interactive desktop). " +
+                    "Pass -D$ALLOW_WINDOWS_PROP=true on a physical desktop.",
+            )
+        }
         val agentJar = locateAgentJarOrSkip()
 
         spawnInjectFixture().use { fixture ->
@@ -165,7 +175,11 @@ class AgentInjectAttachIntegrationTest {
         }
     }
 
+    private fun isWindows(): Boolean =
+        System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
+
     private companion object {
         const val FIXTURE_READY_TIMEOUT_MS: Long = 30_000
+        const val ALLOW_WINDOWS_PROP: String = "dev.sebastiano.spectre.agent.injectE2e.allowWindows"
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
@@ -28,7 +28,9 @@ import org.junit.jupiter.api.condition.OS
  *
  * Drives the real attach/UDS path ([AgentAttach.attach]) — not a re-implementation.
  */
-@EnabledOnOs(OS.LINUX, OS.MAC)
+// Physical Windows desktops can exercise inject; CI Windows runners stay unreliable for Robot UI
+// and will still skip on headless GraphicsEnvironment.
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
 class AgentInjectAttachIntegrationTest {
 
     @Test
@@ -142,20 +144,12 @@ class AgentInjectAttachIntegrationTest {
     /**
      * Spectre `:core` module outputs only — never `kotlinx-coroutines-core` or other `*-core`
      * artifacts.
+     *
+     * Uses [java.io.File.invariantSeparatorsPath] so Windows `\` classpaths match the same
+     * `/core/build/...` markers as POSIX (inject e2e on physical Windows).
      */
-    private fun isSpectreCoreClasspathEntry(entry: String): Boolean {
-        val n = entry.replace('\\', '/')
-        val base = n.substringAfterLast('/')
-        // Compiled classes / resources of the :core project (any checkout path).
-        if (n.contains("/core/build/classes/") || n.contains("/core/build/resources/")) return true
-        // Project jar under core/build/libs/core-*.jar (not kotlinx-coroutines-core-*.jar).
-        if (n.contains("/core/build/libs/") && base.startsWith("core-") && base.endsWith(".jar")) {
-            return true
-        }
-        if (base.startsWith("spectre-core-") && base.endsWith(".jar")) return true
-        if (base == "spectre-core.jar") return true
-        return false
-    }
+    private fun isSpectreCoreClasspathEntry(entry: String): Boolean =
+        InjectClasspathStrip.isSpectreCoreClasspathEntry(entry)
 
     private class FixtureProcess(
         private val process: Process,

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
@@ -175,11 +175,7 @@ class AgentInjectAttachIntegrationTest {
         }
     }
 
-    private fun isWindows(): Boolean =
-        System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
-
     private companion object {
         const val FIXTURE_READY_TIMEOUT_MS: Long = 30_000
-        const val ALLOW_WINDOWS_PROP: String = "dev.sebastiano.spectre.agent.injectE2e.allowWindows"
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentInjectAttachIntegrationTest.kt
@@ -18,7 +18,6 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeFalse
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 
@@ -29,11 +28,11 @@ import org.junit.jupiter.api.condition.OS
  *
  * Drives the real attach/UDS path ([AgentAttach.attach]) — not a re-implementation.
  *
- * **OS gate:** default is Linux/macOS. Hosted Windows CI lacks a reliable interactive desktop (same
- * as [AgentAttachIntegrationTest]); set
- * `-Ddev.sebastiano.spectre.agent.injectE2e.allowWindows=true` for physical Windows desktops.
+ * **OS gate:** Linux and macOS via `@EnabledOnOs` (same policy as [AgentAttachIntegrationTest]).
+ * Hosted Windows CI has no reliable interactive desktop; physical Windows inject e2e was validated
+ * on Mattone. Windows classpath shapes are covered by [InjectClasspathStripTest].
  */
-@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
+@EnabledOnOs(OS.LINUX, OS.MAC)
 class AgentInjectAttachIntegrationTest {
 
     @Test
@@ -42,13 +41,6 @@ class AgentInjectAttachIntegrationTest {
             GraphicsEnvironment.isHeadless(),
             "Requires non-headless JVM for Compose Desktop",
         )
-        if (isWindows()) {
-            assumeTrue(
-                System.getProperty(ALLOW_WINDOWS_PROP) == "true",
-                "Windows inject e2e is opt-in (hosted CI has no reliable interactive desktop). " +
-                    "Pass -D$ALLOW_WINDOWS_PROP=true on a physical desktop.",
-            )
-        }
         val agentJar = locateAgentJarOrSkip()
 
         spawnInjectFixture().use { fixture ->

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/InjectClasspathStrip.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/InjectClasspathStrip.kt
@@ -1,0 +1,35 @@
+package dev.sebastiano.spectre.agent
+
+/**
+ * Classpath filtering helpers for inject e2e: strip Spectre `:core` outputs from a child JVM
+ * classpath so bootstrap must use the nested inject-runtime jar.
+ *
+ * Package-visible for unit tests (Windows path shapes must match).
+ */
+internal object InjectClasspathStrip {
+    /**
+     * Spectre `:core` module outputs only — never `kotlinx-coroutines-core` or other `*-core`
+     * artifacts.
+     *
+     * Normalizes `\` → `/` on every platform (do not use [java.io.File] path APIs for foreign
+     * Windows paths when running tests on Unix — [java.io.File] only treats the host separator as
+     * special).
+     */
+    fun isSpectreCoreClasspathEntry(entry: String): Boolean {
+        val n = normalizeClasspathEntry(entry)
+        val base = n.substringAfterLast('/')
+        // Compiled classes / resources of the :core project (any checkout path).
+        if ("/core/build/classes/" in n || "/core/build/resources/" in n) return true
+        // Project jar under core/build/libs/core-*.jar (not kotlinx-coroutines-core-*.jar).
+        if ("/core/build/libs/" in n && isCoreProjectJarName(base)) return true
+        if (base.startsWith("spectre-core-") && base.endsWith(".jar")) return true
+        if (base == "spectre-core.jar") return true
+        return false
+    }
+
+    /** `core-0.1.0-SNAPSHOT.jar` / `core.jar` — not `kotlinx-coroutines-core-*.jar`. */
+    fun isCoreProjectJarName(base: String): Boolean =
+        base == "core.jar" || (base.startsWith("core-") && base.endsWith(".jar"))
+
+    fun normalizeClasspathEntry(entry: String): String = entry.trim().replace('\\', '/')
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/InjectClasspathStrip.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/InjectClasspathStrip.kt
@@ -31,5 +31,10 @@ internal object InjectClasspathStrip {
     fun isCoreProjectJarName(base: String): Boolean =
         base == "core.jar" || (base.startsWith("core-") && base.endsWith(".jar"))
 
-    fun normalizeClasspathEntry(entry: String): String = entry.trim().replace('\\', '/')
+    /**
+     * Windows Gradle worker classpaths sometimes embed doubled backslashes (`C:\\Users\\...`).
+     * After `\`→`/` that becomes `//`, which would miss `/core/build/libs/` markers — collapse.
+     */
+    fun normalizeClasspathEntry(entry: String): String =
+        entry.trim().replace('\\', '/').replace(Regex("/+"), "/")
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/InjectClasspathStripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/InjectClasspathStripTest.kt
@@ -1,0 +1,77 @@
+package dev.sebastiano.spectre.agent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InjectClasspathStripTest {
+
+    @Test
+    fun `detects unix core build outputs`() {
+        assertTrue(
+            InjectClasspathStrip.isSpectreCoreClasspathEntry(
+                "/Users/seb/src/spectre/core/build/libs/core-0.1.0-SNAPSHOT.jar"
+            )
+        )
+        assertTrue(
+            InjectClasspathStrip.isSpectreCoreClasspathEntry(
+                "/Users/seb/src/spectre/core/build/classes/kotlin/main"
+            )
+        )
+        assertTrue(
+            InjectClasspathStrip.isSpectreCoreClasspathEntry(
+                "/Users/seb/src/spectre/core/build/resources/main"
+            )
+        )
+    }
+
+    @Test
+    fun `detects windows core build outputs with backslashes`() {
+        assertTrue(
+            InjectClasspathStrip.isSpectreCoreClasspathEntry(
+                """C:\Users\rock3r\src\spectre\core\build\libs\core-0.1.0-SNAPSHOT.jar"""
+            )
+        )
+        assertTrue(
+            InjectClasspathStrip.isSpectreCoreClasspathEntry(
+                """C:\Users\rock3r\src\spectre\core\build\classes\kotlin\main"""
+            )
+        )
+    }
+
+    @Test
+    fun `does not match kotlinx coroutines core jar`() {
+        assertFalse(
+            InjectClasspathStrip.isSpectreCoreClasspathEntry(
+                "/home/seb/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlinx/" +
+                    "kotlinx-coroutines-core-jvm/1.10.2/xxx/kotlinx-coroutines-core-jvm-1.10.2.jar"
+            )
+        )
+        assertFalse(
+            InjectClasspathStrip.isSpectreCoreClasspathEntry(
+                """C:\Users\rock3r\.gradle\caches\modules-2\files-2.1\org.jetbrains.kotlinx\""" +
+                    """kotlinx-coroutines-core\1.10.2\xxx\kotlinx-coroutines-core-1.10.2.jar"""
+            )
+        )
+    }
+
+    @Test
+    fun `core project jar name rules`() {
+        assertTrue(InjectClasspathStrip.isCoreProjectJarName("core-0.1.0-SNAPSHOT.jar"))
+        assertTrue(InjectClasspathStrip.isCoreProjectJarName("core.jar"))
+        assertFalse(InjectClasspathStrip.isCoreProjectJarName("kotlinx-coroutines-core-1.10.2.jar"))
+        assertFalse(
+            InjectClasspathStrip.isCoreProjectJarName("agent-test-fixture-0.1.0-SNAPSHOT.jar")
+        )
+    }
+
+    @Test
+    fun `published spectre-core coordinates`() {
+        assertTrue(InjectClasspathStrip.isSpectreCoreClasspathEntry("/repo/spectre-core-0.3.0.jar"))
+        assertEquals(
+            false,
+            InjectClasspathStrip.isSpectreCoreClasspathEntry("/repo/spectre-agent-0.3.0.jar"),
+        )
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/InjectClasspathStripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/InjectClasspathStripTest.kt
@@ -41,6 +41,18 @@ class InjectClasspathStripTest {
     }
 
     @Test
+    fun `detects windows paths with doubled backslashes from Gradle workers`() {
+        // Real java.class.path shape observed on physical Windows (code points 92,92).
+        val doubled =
+            "C:\\\\Users\\\\rock3r\\\\src\\\\spectre\\\\core\\\\build\\\\libs\\\\core-0.1.0-SNAPSHOT.jar"
+        assertTrue(InjectClasspathStrip.isSpectreCoreClasspathEntry(doubled))
+        assertEquals(
+            "C:/Users/rock3r/src/spectre/core/build/libs/core-0.1.0-SNAPSHOT.jar",
+            InjectClasspathStrip.normalizeClasspathEntry(doubled),
+        )
+    }
+
+    @Test
     fun `does not match kotlinx coroutines core jar`() {
         assertFalse(
             InjectClasspathStrip.isSpectreCoreClasspathEntry(

--- a/docs/spikes/209-injection/user-recipe.md
+++ b/docs/spikes/209-injection/user-recipe.md
@@ -2,13 +2,14 @@
 
 ## Automated path (CI / developer)
 
-**Prerequisites:** Linux or macOS with a non-headless display (or `xvfb-run -a` on Linux).
-The test is `@EnabledOnOs(LINUX, MAC)` and assumes `!GraphicsEnvironment.isHeadless()` — on
-Windows and headless Linux CI it **skips** (green Gradle with no attach/tree evidence). Do not
-treat a skipped run as inject proof.
+**Prerequisites:** Linux, macOS, or **Windows** with a non-headless display (or `xvfb-run -a` on
+Linux). The test is `@EnabledOnOs(LINUX, MAC, WINDOWS)` and assumes
+`!GraphicsEnvironment.isHeadless()` — headless CI (including Linux without Xvfb and Windows
+runners without an interactive desktop) **skips** (green Gradle with no attach/tree evidence).
+Do not treat a skipped run as inject proof.
 
 ```bash
-# macOS / interactive Linux:
+# macOS / interactive Linux / interactive Windows:
 ./gradlew :agent:test --tests '*AgentInjectAttachIntegrationTest*'
 
 # headless Linux with a virtual display:

--- a/docs/spikes/209-injection/user-recipe.md
+++ b/docs/spikes/209-injection/user-recipe.md
@@ -2,18 +2,22 @@
 
 ## Automated path (CI / developer)
 
-**Prerequisites:** Linux, macOS, or **Windows** with a non-headless display (or `xvfb-run -a` on
-Linux). The test is `@EnabledOnOs(LINUX, MAC, WINDOWS)` and assumes
-`!GraphicsEnvironment.isHeadless()` — headless CI (including Linux without Xvfb and Windows
-runners without an interactive desktop) **skips** (green Gradle with no attach/tree evidence).
-Do not treat a skipped run as inject proof.
+**Prerequisites:** Linux or macOS with a non-headless display (or `xvfb-run -a` on Linux). The test
+assumes `!GraphicsEnvironment.isHeadless()`. On **Windows**, inject e2e is **opt-in** (hosted CI
+has no reliable interactive desktop): pass
+`-Ddev.sebastiano.spectre.agent.injectE2e.allowWindows=true` on a physical desktop. Headless or
+non-opt-in runs **skip** — do not treat a skip as inject proof.
 
 ```bash
-# macOS / interactive Linux / interactive Windows:
+# macOS / interactive Linux:
 ./gradlew :agent:test --tests '*AgentInjectAttachIntegrationTest*'
 
 # headless Linux with a virtual display:
 xvfb-run -a ./gradlew :agent:test --tests '*AgentInjectAttachIntegrationTest*'
+
+# physical Windows desktop only (opt-in; not default CI):
+./gradlew :agent:test --tests '*AgentInjectAttachIntegrationTest*' \
+  -Pspectre.agent.injectE2e.allowWindows=true
 ```
 
 What it does when it **runs** (real shipped APIs):

--- a/docs/spikes/209-injection/user-recipe.md
+++ b/docs/spikes/209-injection/user-recipe.md
@@ -3,10 +3,10 @@
 ## Automated path (CI / developer)
 
 **Prerequisites:** Linux or macOS with a non-headless display (or `xvfb-run -a` on Linux). The test
-assumes `!GraphicsEnvironment.isHeadless()`. On **Windows**, inject e2e is **opt-in** (hosted CI
-has no reliable interactive desktop): pass
-`-Ddev.sebastiano.spectre.agent.injectE2e.allowWindows=true` on a physical desktop. Headless or
-non-opt-in runs **skip** — do not treat a skip as inject proof.
+is `@EnabledOnOs(LINUX, MAC)` and assumes `!GraphicsEnvironment.isHeadless()` — headless CI
+**skips** (not inject proof). Physical **Windows** was validated on Mattone; the default test
+stays off hosted Windows CI (same policy as the non-inject attach e2e). Windows path stripping is
+covered by `InjectClasspathStripTest`.
 
 ```bash
 # macOS / interactive Linux:
@@ -14,10 +14,6 @@ non-opt-in runs **skip** — do not treat a skip as inject proof.
 
 # headless Linux with a virtual display:
 xvfb-run -a ./gradlew :agent:test --tests '*AgentInjectAttachIntegrationTest*'
-
-# physical Windows desktop only (opt-in; not default CI):
-./gradlew :agent:test --tests '*AgentInjectAttachIntegrationTest*' \
-  -Pspectre.agent.injectE2e.allowWindows=true
 ```
 
 What it does when it **runs** (real shipped APIs):


### PR DESCRIPTION
## Summary

Physical Windows validation of `AgentInjectAttachIntegrationTest` failed because Gradle worker `java.class.path` entries embed **literal doubled backslashes** (`C:\\Users\\...`). After `\`→`/` normalize that becomes `//`, so `/core/build/libs/` never matched and the inject e2e thought `:core` was absent.

- Extract `InjectClasspathStrip` with `//` collapse after separator normalize
- Unit tests for single- and doubled-backslash Windows path shapes
- Inject UI e2e stays `@EnabledOnOs(LINUX, MAC)` only (same policy as non-inject attach e2e; hosted Windows has no reliable interactive desktop)

## Validation

| Host | Path | Result |
|------|------|--------|
| **Windows** Mattone (`rock3r@192.168.1.8`) | direct SSH | inject e2e + strip tests green (~8.7s) |
| **Linux** sebnux (Hyper-V) | two-hop via Windows (Mac cannot SSH VM directly) | inject e2e under `xvfb-run` + strip green (~2.3s) |
| **macOS** (local) | direct | inject e2e green earlier |

## Test plan

- [x] `InjectClasspathStripTest` (Windows path shapes)
- [x] `AgentInjectAttachIntegrationTest` on Windows physical + Linux VM (two-hop)
- [ ] CI (macOS may flake on unrelated CLI/agent UI tests also red on `main` — track separately)