### PR TITLE
Developer ID sign + notarize + staple SpectreCaptureHelper.app (#191)

### DIFF
--- a/.agents/skills/spectre-release/SKILL.md
+++ b/.agents/skills/spectre-release/SKILL.md
@@ -64,6 +64,17 @@ If the release changes `CaptureDocument.SCHEMA_VERSION` / `capture.json`, bump t
 **`spectre-capture`** skill (`skills/spectre-capture/SKILL.md` + `package.json`) and the
 user-guide page `docs/guide/capture.md` in the same release.
 
+## macOS helper bundle signing (#191)
+
+Release tags must produce a **Developer ID signed, notarized, and stapled**
+`SpectreCaptureHelper.app` (not a bare Mach-O). Confirm:
+
+- [ ] `mac-helper` job ran with `-PnotarizeScreenCaptureKitHelper`
+- [ ] Artifact is the app tree under `SpectreCaptureHelper.app/`
+- [ ] Local or CI log shows `stapler staple` / `stapler validate` success
+- [ ] `codesign --verify --deep --strict` on the app
+- [ ] Docs: [docs/NOTARIZATION.md](../../../docs/NOTARIZATION.md) local-dev vs release table still accurate
+
 ## Finish
 
 After Central reports `PUBLISHED`, undraft the GitHub release:

--- a/docs/NOTARIZATION.md
+++ b/docs/NOTARIZATION.md
@@ -1,40 +1,53 @@
 # Notarization
 
-Spectre ships the macOS ScreenCaptureKit recorder as a small Swift helper packaged as
-`SpectreCaptureHelper.app` inside the `spectre-recording-macos` jar. Distribution builds must
-Developer ID sign and notarize that helper before the jar is published, otherwise macOS
-Gatekeeper can reject the extracted helper when a consumer starts `ScreenCaptureKitRecorder`.
+Spectre ships the macOS ScreenCaptureKit recorder as `SpectreCaptureHelper.app` inside the
+`spectre-recording-macos` jar. Distribution builds must **Developer ID sign, notarize, and
+staple the full app bundle** before the jar is published, otherwise macOS Gatekeeper can reject
+the extracted helper when a consumer starts `ScreenCaptureKitRecorder`.
 
-Issue #190 wraps the helper in a stable app bundle for TCC identity. Issue #191 extends
-signing/notarization/stapling to the full `.app` (today the pipeline still signs the universal
-Mach-O, then stages it into the app shell).
+TCC Screen Recording grants pin to **bundle ID + code signature**. Ad-hoc-signed local builds
+lose Settings grants on every rebuild; release builds keep the grant across versions when the
+same Developer ID identity and bundle id (`dev.sebastiano.spectre.screencapture`) are used.
 
 Local development builds do not need Apple credentials. The notarization path is opt-in and is
 only intended for release builds.
 
 ## What gets notarized
 
-The release build creates a universal `arm64` + `x86_64` helper binary at:
+The release build creates a universal `arm64` + `x86_64` helper binary, packages it as:
 
 ```text
-recording/build/generated/screenCaptureHelperUniversal/SpectreScreenCapture
+recording/build/generated/screenCaptureHelperUniversal/SpectreCaptureHelper.app
 ```
 
 Gradle then:
 
-1. Signs the helper with `codesign --options runtime --timestamp --force`.
-2. Archives the signed helper with `ditto -c -k --keepParent`.
-3. Submits the archive with `xcrun notarytool submit`.
-4. Waits for Apple to finish processing, bounded by a 30 minute timeout.
-5. Verifies the resulting Developer ID signature with `codesign --verify --strict --verbose=4`
-   before staging it into `native/macos/SpectreCaptureHelper.app` in the
-   `spectre-recording-macos` jar resources.
+1. Packages the universal Mach-O into `SpectreCaptureHelper.app` (Info.plist, `LSUIElement`,
+   icon, nested `Contents/MacOS/spectre-screencapture`).
+2. Developer ID signs the **bundle** with
+   `codesign --sign <identity> --options runtime --timestamp --force --deep`.
+3. Archives the signed app with `ditto -c -k --keepParent`.
+4. Submits the archive with `xcrun notarytool submit --wait` (30 minute timeout).
+5. Staples the ticket with `xcrun stapler staple` onto the `.app`.
+6. Verifies with `codesign --verify --deep --strict` and `xcrun stapler validate`.
+7. Best-effort `spctl -a -vv --type execute` (warn-only if the host policy database rejects it).
+8. Stages the signed+stapled app into
+   `native/macos/SpectreCaptureHelper.app` in the `spectre-recording-macos` jar resources.
 
-Apple's notary service can issue a ticket for a standalone binary inside the submitted archive,
-but `xcrun stapler` cannot currently staple tickets directly to bare command-line executables,
-and `spctl --assess --type execute` reports bare tools as valid code that is not an app.
-Spectre therefore notarizes the helper and verifies the Developer ID signature locally, but does
-not run `stapler` or use `spctl` as the Gradle gate for `SpectreScreenCapture`.
+Unlike bare command-line tools, app bundles support stapling and Gatekeeper assessment of the
+distributed artifact.
+
+## Local-dev signing story (ad-hoc vs release)
+
+| Build | Signature | TCC behaviour | When to use |
+|---|---|---|---|
+| Default `./gradlew :recording:jar` | Ad-hoc (`codesign -s -`) on the host-arch app | Grant may bind to path/ad-hoc identity; re-grant after clean rebuilds | Day-to-day development |
+| `-PuniversalHelper` without notarize | Ad-hoc universal app | Same as above | Fat-binary packaging smoke |
+| `-PuniversalHelper -PnotarizeScreenCaptureKitHelper` | Developer ID + notary + staple | Stable Settings row for **Spectre Capture Helper**; grant survives updates with the same identity | Release / release smoke |
+
+**Do not** Developer ID sign local iteration builds with a personal cert and then ship an ad-hoc
+rebuild under the same install path without expecting a re-prompt — keep release identity on the
+release path only.
 
 ## Local setup
 
@@ -83,15 +96,31 @@ compose.desktop.mac.notarization.keychainProfile=<notary-profile>
 Then run:
 
 ```bash
-./gradlew :recording-macos:jar -PuniversalHelper -PnotarizeScreenCaptureKitHelper
+./gradlew :recording:assembleScreenCaptureKitHelperUniversal \
+  -PuniversalHelper \
+  -PnotarizeScreenCaptureKitHelper
 ```
 
-If Apple accepts the submission, the build verifies the helper's signature and packages the jar.
-If Apple keeps the submission in `In Progress` past the timeout, the Gradle task fails locally but
-the submission continues processing on Apple's side. Query it with:
+If Apple accepts the submission, the build staples the ticket, verifies the app signature, and
+stages the app into jar resources. If Apple keeps the submission in `In Progress` past the
+timeout, the Gradle task fails locally but the submission continues processing on Apple's side.
+Query it with:
 
 ```bash
 xcrun notarytool info <submission-id> --keychain-profile <notary-profile>
+```
+
+### Quarantined Gatekeeper check
+
+After a successful local or CI notarization, validate as a user would:
+
+```bash
+APP=recording/build/generated/screenCaptureHelper/native/macos/SpectreCaptureHelper.app
+# Simulate download quarantine
+xattr -w com.apple.quarantine "0081;00000000;Safari;..." "$APP"   # or copy via browser/zip
+codesign --verify --deep --strict --verbose=2 "$APP"
+xcrun stapler validate "$APP"
+spctl -a -vv --type execute "$APP"
 ```
 
 ## CI release workflow
@@ -99,8 +128,8 @@ xcrun notarytool info <submission-id> --keychain-profile <notary-profile>
 The tag workflow at
 [`.github/workflows/release.yml`](https://github.com/rock3r/spectre/blob/main/.github/workflows/release.yml)
 builds the universal helper on `macos-latest`, imports the Developer ID certificate into a
-temporary keychain, signs and notarizes the helper, and uploads the notarized helper artifact
-for the publish job to package into `spectre-recording-macos`.
+temporary keychain, signs / notarizes / staples `SpectreCaptureHelper.app`, and uploads the
+notarized app artifact for the publish job to package into `spectre-recording-macos`.
 
 Set these repository secrets:
 
@@ -127,6 +156,8 @@ To rotate the Developer ID certificate:
 3. Base64-encode it with `base64 -i DeveloperID.p12 | pbcopy`.
 4. Update `APPLE_DEVELOPER_ID_P12`, `APPLE_DEVELOPER_ID_P12_PASSWORD`, and
    `APPLE_DEVELOPER_IDENTITY` in the repository secrets.
+5. Note: TCC grants bound to the old Team ID may require users to re-approve once after a
+   Team ID change.
 
 To rotate notarization credentials:
 
@@ -134,16 +165,18 @@ To rotate notarization credentials:
 2. Base64-encode the `.p8` file.
 3. Update `APPLE_NOTARY_API_KEY`, `APPLE_NOTARY_API_KEY_ID`, and
    `APPLE_NOTARY_API_ISSUER`.
-4. Push a test tag and verify the release workflow reaches the `codesign --verify` step.
+4. Push a test tag and verify the release workflow reaches the `stapler validate` step.
 
 ## Validation
 
 After a notarized release, validate on a fresh macOS user or machine:
 
 ```bash
-codesign --verify --strict --verbose=2 spectre-screencapture
+codesign --verify --deep --strict --verbose=2 SpectreCaptureHelper.app
+xcrun stapler validate SpectreCaptureHelper.app
+spctl -a -vv --type execute SpectreCaptureHelper.app
 ```
 
-Then run a small `ScreenCaptureKitRecorder` scenario from the released jar. The expected user
-experience is a normal Screen Recording permission prompt if the host process is not already
-trusted, and no Gatekeeper rejection for the extracted helper.
+Then run a small `ScreenCaptureKitRecorder` scenario (or `spectre permissions check`) from the
+released jar. The Settings row should show **Spectre Capture Helper**, and Gatekeeper should not
+reject the extracted app.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -34,10 +34,10 @@ Jobs on tag push (order simplified; see the workflow for the full graph):
    shape, runs `./gradlew check`, installs the docs dependencies, and runs
    `mkdocs build --strict`. Helper builds and publish wait for this gate.
 2. **`mac-helper`** (macOS runner, depends on `release-gate`) — builds the
-   arm64+x86_64 universal
-   `SpectreScreenCapture` Swift helper, codesigns it with the Developer ID, runs
-   `notarytool submit --wait`, and uploads the notarised binary as a GitHub
-   Actions artefact.
+   arm64+x86_64 universal helper, packages it as `SpectreCaptureHelper.app`,
+   Developer ID signs the **bundle**, runs `notarytool submit --wait`, staples
+   the ticket, verifies `codesign --deep --strict` + `stapler validate`, and
+   uploads the app as a GitHub Actions artefact (see [NOTARIZATION.md](NOTARIZATION.md)).
 3. **`linux-helpers`** (Linux runner, depends on `release-gate`) — cross-builds the
    `spectre-wayland-helper` Rust binary for `x86_64` and `aarch64` (same
    toolchain dance documented in [`ci.yml`][ci-yml]: dpkg multi-arch +
@@ -182,7 +182,8 @@ It additionally asserts:
 
 - every sources jar is free of generated `native/...` helper resources
 - `:recording` is API/common-only and contains no `native/...` resources
-- `:recording-macos` contains `native/macos/SpectreCaptureHelper.app`
+- `:recording-macos` contains the full `native/macos/SpectreCaptureHelper.app/` tree
+  (executable, Info.plist, PkgInfo, AppIcon.icns)
 - `:recording-linux` contains `native/linux/x86_64/spectre-wayland-helper` and
   `native/linux/aarch64/spectre-wayland-helper` when built with release helper inputs
 - `:recording-windows` contains `native/windows/x64/spectre-window-capture.exe` and
@@ -195,7 +196,7 @@ previous release-CI run), point at it instead of the stub:
 
 ```shell
 ./gradlew verifyMavenLocalPublication \
-    -PprebuiltMacHelperPath=/path/to/SpectreScreenCapture \
+    -PprebuiltMacHelperPath=/path/to/SpectreCaptureHelper.app \
     -PprebuiltLinuxHelpersDir=/path/to/linux-helpers \
     -PprebuiltWindowsHelpersDir=/path/to/windows-helpers
 ```

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -546,8 +546,18 @@ val assembleScreenCaptureKitHelperUniversal by tasks.registering {
         val dest = File(destPath)
         if (dest.exists()) dest.deleteRecursively()
         if (copyNotarizedApp) {
-            // Preserve Developer ID signature + staple; do not re-sign.
-            File(notarizedAppPath).copyRecursively(dest, overwrite = true)
+            // ditto preserves the stapled ticket file (Contents/CodeResources) and code
+            // signature metadata that Java File.copyRecursively can drop.
+            dest.parentFile?.mkdirs()
+            val process =
+                ProcessBuilder("ditto", notarizedAppPath, destPath)
+                    .redirectErrorStream(true)
+                    .start()
+            val output = process.inputStream.bufferedReader().readText()
+            val exit = process.waitFor()
+            if (exit != 0) {
+                throw GradleException("ditto copy of notarized app failed (exit $exit): $output")
+            }
             return@doLast
         }
         val contents = File(dest, "Contents")

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -987,16 +987,34 @@ val stagePrebuiltMacHelper by tasks.registering {
         val dest = File(destPath)
         if (dest.exists()) dest.deleteRecursively()
         if (source.isDirectory && source.name.endsWith(".app")) {
-            // ditto preserves staple ticket (Contents/CodeResources) and sealed metadata.
             dest.parentFile?.mkdirs()
-            val process =
-                ProcessBuilder("ditto", source.absolutePath, destPath)
-                    .redirectErrorStream(true)
-                    .start()
-            val output = process.inputStream.bufferedReader().readText()
-            val exit = process.waitFor()
-            if (exit != 0) {
-                throw GradleException("ditto copy of prebuilt app failed (exit $exit): $output")
+            // Prefer ditto on macOS (preserves Apple-specific metadata). Linux publish hosts
+            // do not have ditto — walk/copy every regular file so Contents/CodeResources
+            // (staple ticket) and _CodeSignature stay intact.
+            if (isMacOsHost) {
+                val process =
+                    ProcessBuilder("ditto", source.absolutePath, destPath)
+                        .redirectErrorStream(true)
+                        .start()
+                val output = process.inputStream.bufferedReader().readText()
+                val exit = process.waitFor()
+                if (exit != 0) {
+                    throw GradleException("ditto copy of prebuilt app failed (exit $exit): $output")
+                }
+            } else {
+                source.walkTopDown().forEach { file ->
+                    val rel = file.relativeTo(source)
+                    val target = dest.resolve(rel.path)
+                    if (file.isDirectory) {
+                        target.mkdirs()
+                    } else {
+                        target.parentFile?.mkdirs()
+                        file.copyTo(target, overwrite = true)
+                        if (file.canExecute()) {
+                            target.setExecutable(true, false)
+                        }
+                    }
+                }
             }
         } else {
             dest.mkdirs()

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -979,6 +979,8 @@ val stagePrebuiltMacHelper by tasks.registering {
     val infoPlistPath = helperAppInfoPlistAbsolutePath
     val pkgInfoPath = helperAppPkgInfoAbsolutePath
     val iconPath = helperAppIconAbsolutePath
+    // Capture Boolean into task action (config-cache safe; do not close over script receiver).
+    val hostIsMac = isMacOsHost
     doLast {
         val source = File(sourcePath)
         if (!source.exists()) {
@@ -991,7 +993,7 @@ val stagePrebuiltMacHelper by tasks.registering {
             // Prefer ditto on macOS (preserves Apple-specific metadata). Linux publish hosts
             // do not have ditto — walk/copy every regular file so Contents/CodeResources
             // (staple ticket) and _CodeSignature stay intact.
-            if (isMacOsHost) {
+            if (hostIsMac) {
                 val process =
                     ProcessBuilder("ditto", source.absolutePath, destPath)
                         .redirectErrorStream(true)

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -986,10 +986,20 @@ val stagePrebuiltMacHelper by tasks.registering {
         }
         val dest = File(destPath)
         if (dest.exists()) dest.deleteRecursively()
-        dest.mkdirs()
         if (source.isDirectory && source.name.endsWith(".app")) {
-            source.copyRecursively(dest, overwrite = true)
+            // ditto preserves staple ticket (Contents/CodeResources) and sealed metadata.
+            dest.parentFile?.mkdirs()
+            val process =
+                ProcessBuilder("ditto", source.absolutePath, destPath)
+                    .redirectErrorStream(true)
+                    .start()
+            val output = process.inputStream.bufferedReader().readText()
+            val exit = process.waitFor()
+            if (exit != 0) {
+                throw GradleException("ditto copy of prebuilt app failed (exit $exit): $output")
+            }
         } else {
+            dest.mkdirs()
             val contents = File(dest, "Contents")
             File(contents, "MacOS").mkdirs()
             File(contents, "Resources").mkdirs()

--- a/recording/build.gradle.kts
+++ b/recording/build.gradle.kts
@@ -166,8 +166,13 @@ val perArchSwiftBuildTasks = universalArchitectures.map { arch ->
 // vals that goes with it (Gradle's configuration cache refuses to serialise that).
 val universalHelperBinary =
     layout.buildDirectory.file("generated/screenCaptureHelperUniversal/SpectreScreenCapture")
+// Release path packages + signs + notarizes the full app bundle (issue #191), not a bare Mach-O.
+val universalHelperAppBundle =
+    layout.buildDirectory.dir("generated/screenCaptureHelperUniversal/SpectreCaptureHelper.app")
 val universalHelperNotaryArchive =
-    layout.buildDirectory.file("generated/screenCaptureHelperUniversal/SpectreScreenCapture.zip")
+    layout.buildDirectory.file(
+        "generated/screenCaptureHelperUniversal/SpectreCaptureHelper.app.zip"
+    )
 
 // Precompute everything as plain String/File outside the task action bodies. Capturing
 // `swiftHelperSource` / `universalHelperBinary` (which are Gradle Layout types) inside an
@@ -180,6 +185,7 @@ val perArchOutputFiles = universalArchitectures.map { arch ->
 }
 val perArchOutputAbsolutePaths = perArchOutputFiles.map { it.asFile.absolutePath }
 val universalHelperAbsolutePath = universalHelperBinary.get().asFile.absolutePath
+val universalHelperAppBundleAbsolutePath = universalHelperAppBundle.get().asFile.absolutePath
 val universalHelperNotaryArchiveAbsolutePath =
     universalHelperNotaryArchive.get().asFile.absolutePath
 val shouldNotarizeScreenCaptureKitHelper =
@@ -297,12 +303,57 @@ val verifyUniversalScreenCaptureKitHelper by
         inputs.file(universalHelperBinary)
     }
 
+// Absolute template paths used by both host-arch assemble and the release app package
+// (declared early so notarization tasks can reference them without forward refs).
+val helperAppInfoPlistAbsolutePathEarly =
+    File(helperAppBundleTemplateAbsolutePath, "Info.plist").absolutePath
+val helperAppPkgInfoAbsolutePathEarly =
+    File(helperAppBundleTemplateAbsolutePath, "PkgInfo").absolutePath
+val helperAppIconAbsolutePathEarly =
+    File(helperAppBundleTemplateAbsolutePath, "Resources/AppIcon.icns").absolutePath
+
+/**
+ * Packages the universal Mach-O into an unsigned SpectreCaptureHelper.app ready for Developer ID
+ * signing. Used only on the `-PnotarizeScreenCaptureKitHelper` path; local host-arch builds keep
+ * the ad-hoc-signed assemble task.
+ */
+val packageUniversalHelperAppBundle by tasks.registering {
+    description =
+        "Packages the universal helper binary as an unsigned SpectreCaptureHelper.app " +
+            "for Developer ID signing and notarization (#191)."
+    group = "build"
+    enabled = notarizationTaskEnabled
+    dependsOn(verifyUniversalScreenCaptureKitHelper)
+    inputs.file(universalHelperAbsolutePath)
+    inputs.file(helperAppInfoPlistAbsolutePathEarly)
+    inputs.file(helperAppPkgInfoAbsolutePathEarly)
+    inputs.file(helperAppIconAbsolutePathEarly)
+    outputs.dir(universalHelperAppBundleAbsolutePath)
+    val destPath = universalHelperAppBundleAbsolutePath
+    val binaryPath = universalHelperAbsolutePath
+    val infoPlistPath = helperAppInfoPlistAbsolutePathEarly
+    val pkgInfoPath = helperAppPkgInfoAbsolutePathEarly
+    val iconPath = helperAppIconAbsolutePathEarly
+    doLast {
+        val dest = File(destPath)
+        if (dest.exists()) dest.deleteRecursively()
+        val contents = File(dest, "Contents")
+        File(contents, "MacOS").mkdirs()
+        File(contents, "Resources").mkdirs()
+        File(infoPlistPath).copyTo(File(contents, "Info.plist"), overwrite = true)
+        File(pkgInfoPath).copyTo(File(contents, "PkgInfo"), overwrite = true)
+        File(iconPath).copyTo(File(contents, "Resources/AppIcon.icns"), overwrite = true)
+        File(binaryPath).copyTo(File(contents, "MacOS/spectre-screencapture"), overwrite = true)
+        File(contents, "MacOS/spectre-screencapture").setExecutable(true, false)
+    }
+}
+
 val signScreenCaptureKitHelper by
     tasks.registering(Exec::class) {
-        description = "Codesigns the universal ScreenCaptureKit helper for distribution."
+        description = "Developer ID codesigns SpectreCaptureHelper.app for distribution (#191)."
         group = "build"
         enabled = notarizationTaskEnabled
-        dependsOn(verifyUniversalScreenCaptureKitHelper)
+        dependsOn(packageUniversalHelperAppBundle)
         commandLine(
             "codesign",
             "--sign",
@@ -311,15 +362,16 @@ val signScreenCaptureKitHelper by
             "runtime",
             "--timestamp",
             "--force",
-            universalHelperAbsolutePath,
+            "--deep",
+            universalHelperAppBundleAbsolutePath,
         )
-        inputs.file(universalHelperBinary)
-        outputs.file(universalHelperBinary)
+        inputs.dir(universalHelperAppBundleAbsolutePath)
+        outputs.dir(universalHelperAppBundleAbsolutePath)
     }
 
 val zipScreenCaptureKitHelperForNotarization by
     tasks.registering(Exec::class) {
-        description = "Archives the signed ScreenCaptureKit helper for Apple notarization."
+        description = "Archives the signed SpectreCaptureHelper.app for Apple notarization."
         group = "build"
         enabled = notarizationTaskEnabled
         dependsOn(signScreenCaptureKitHelper)
@@ -328,16 +380,16 @@ val zipScreenCaptureKitHelperForNotarization by
             "-c",
             "-k",
             "--keepParent",
-            universalHelperAbsolutePath,
+            universalHelperAppBundleAbsolutePath,
             universalHelperNotaryArchiveAbsolutePath,
         )
-        inputs.file(universalHelperBinary)
+        inputs.dir(universalHelperAppBundleAbsolutePath)
         outputs.file(universalHelperNotaryArchive)
     }
 
 val notarizeScreenCaptureKitHelper by
     tasks.registering(Exec::class) {
-        description = "Submits the signed ScreenCaptureKit helper archive to Apple notarization."
+        description = "Submits the signed SpectreCaptureHelper.app archive to Apple notarization."
         group = "build"
         enabled = notarizationTaskEnabled
         dependsOn(zipScreenCaptureKitHelperForNotarization)
@@ -354,28 +406,69 @@ val notarizeScreenCaptureKitHelper by
         inputs.file(universalHelperNotaryArchive)
     }
 
-val verifyNotarizedScreenCaptureKitHelper by
+val stapleScreenCaptureKitHelper by
     tasks.registering(Exec::class) {
-        description = "Verifies the signed and notarized ScreenCaptureKit helper's code signature."
-        group = "verification"
+        description = "Staples the Apple notarization ticket to SpectreCaptureHelper.app (#191)."
+        group = "build"
         enabled = notarizationTaskEnabled
         dependsOn(notarizeScreenCaptureKitHelper)
-        commandLine("codesign", "--verify", "--strict", "--verbose=4", universalHelperAbsolutePath)
-        inputs.file(universalHelperBinary)
+        commandLine("xcrun", "stapler", "staple", universalHelperAppBundleAbsolutePath)
+        inputs.dir(universalHelperAppBundleAbsolutePath)
+        outputs.dir(universalHelperAppBundleAbsolutePath)
     }
 
+val verifyNotarizedScreenCaptureKitHelper by tasks.registering {
+    description = "Verifies Developer ID signature + staple on SpectreCaptureHelper.app (#191)."
+    group = "verification"
+    enabled = notarizationTaskEnabled
+    dependsOn(stapleScreenCaptureKitHelper)
+    inputs.dir(universalHelperAppBundleAbsolutePath)
+    val appPath = universalHelperAppBundleAbsolutePath
+    doLast {
+        fun runOrFail(vararg args: String) {
+            val process = ProcessBuilder(*args).redirectErrorStream(true).start()
+            val output = process.inputStream.bufferedReader().readText()
+            val exit = process.waitFor()
+            if (exit != 0) {
+                throw GradleException(
+                    "Command failed (exit $exit): ${args.joinToString(" ")}\n$output"
+                )
+            }
+            logger.lifecycle(output.trim())
+        }
+        runOrFail("codesign", "--verify", "--deep", "--strict", "--verbose=4", appPath)
+        runOrFail("xcrun", "stapler", "validate", appPath)
+        // spctl assess is best-effort: some CI images lack a full Gatekeeper policy
+        // database. Prefer success; warn-and-continue only if spctl is missing.
+        val spctl =
+            ProcessBuilder("spctl", "-a", "-vv", "--type", "execute", appPath)
+                .redirectErrorStream(true)
+                .start()
+        val spctlOut = spctl.inputStream.bufferedReader().readText()
+        val spctlExit = spctl.waitFor()
+        if (spctlExit != 0) {
+            logger.warn(
+                "spctl assessment did not pass (exit $spctlExit); " +
+                    "codesign+stapler already verified. Output:\n$spctlOut"
+            )
+        } else {
+            logger.lifecycle(spctlOut.trim())
+        }
+    }
+}
+
 // Absolute template paths — config-cache safe (plain String/File, no script captures).
-val helperAppInfoPlistAbsolutePath =
-    File(helperAppBundleTemplateAbsolutePath, "Info.plist").absolutePath
-val helperAppPkgInfoAbsolutePath = File(helperAppBundleTemplateAbsolutePath, "PkgInfo").absolutePath
-val helperAppIconAbsolutePath =
-    File(helperAppBundleTemplateAbsolutePath, "Resources/AppIcon.icns").absolutePath
+// Reuse the early paths declared for the notarization package task.
+val helperAppInfoPlistAbsolutePath = helperAppInfoPlistAbsolutePathEarly
+val helperAppPkgInfoAbsolutePath = helperAppPkgInfoAbsolutePathEarly
+val helperAppIconAbsolutePath = helperAppIconAbsolutePathEarly
 val hostHelperBinaryAbsolutePath = swiftHelperBinary.asFile.absolutePath
 val isMacOsHost = OperatingSystem.current().isMacOsX
 
 // Layout (must match HelperAppBundle Kotlin constants):
 // SpectreCaptureHelper.app/Contents/{Info.plist,PkgInfo,MacOS/spectre-screencapture,Resources/AppIcon.icns}
-// Local builds ad-hoc sign (`codesign -s -`). Full Developer ID on the .app is #191.
+// Local builds ad-hoc sign (`codesign -s -`). Release builds Developer ID sign + notarize +
+// staple the full .app (#191).
 
 val assembleScreenCaptureKitHelper by tasks.registering {
     description = "Stages the host-arch ScreenCaptureKit helper as SpectreCaptureHelper.app."
@@ -423,30 +516,40 @@ val assembleScreenCaptureKitHelperUniversal by tasks.registering {
     description =
         "Stages the universal arm64+x86_64 ScreenCaptureKit helper as " +
             "SpectreCaptureHelper.app (opt-in for distribution builds; slower than the " +
-            "host-arch task). Wire into processResources by passing -PuniversalHelper."
+            "host-arch task). Wire into processResources by passing -PuniversalHelper. " +
+            "With -PnotarizeScreenCaptureKitHelper, copies the Developer ID signed, " +
+            "notarized, and stapled app bundle (#191)."
     group = "build"
     enabled = isMacOsHost
     dependsOn(
         if (shouldNotarizeScreenCaptureKitHelper) verifyNotarizedScreenCaptureKitHelper
         else verifyUniversalScreenCaptureKitHelper
     )
-    inputs.file(universalHelperAbsolutePath)
     inputs.file(helperAppInfoPlistAbsolutePath)
     inputs.file(helperAppPkgInfoAbsolutePath)
     inputs.file(helperAppIconAbsolutePath)
+    if (shouldNotarizeScreenCaptureKitHelper) {
+        inputs.dir(universalHelperAppBundleAbsolutePath)
+    } else {
+        inputs.file(universalHelperAbsolutePath)
+    }
     outputs.dir(helperAppBundleStagingAbsolutePath)
     val destPath = helperAppBundleStagingAbsolutePath
     val binaryPath = universalHelperAbsolutePath
     val infoPlistPath = helperAppInfoPlistAbsolutePath
     val pkgInfoPath = helperAppPkgInfoAbsolutePath
     val iconPath = helperAppIconAbsolutePath
-    // Never ad-hoc re-sign after Developer ID notarization — that would wipe the nested
-    // Mach-O ticket. Full `.app` Developer ID sign is #191; until then the nested binary
-    // keeps its notarized signature and the app shell stays unsigned on the release path.
+    val notarizedAppPath = universalHelperAppBundleAbsolutePath
+    val copyNotarizedApp = shouldNotarizeScreenCaptureKitHelper
     val adHocSign = isMacOsHost && !shouldNotarizeScreenCaptureKitHelper
     doLast {
         val dest = File(destPath)
         if (dest.exists()) dest.deleteRecursively()
+        if (copyNotarizedApp) {
+            // Preserve Developer ID signature + staple; do not re-sign.
+            File(notarizedAppPath).copyRecursively(dest, overwrite = true)
+            return@doLast
+        }
         val contents = File(dest, "Contents")
         File(contents, "MacOS").mkdirs()
         File(contents, "Resources").mkdirs()

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
@@ -226,15 +226,15 @@ internal class HelperBinaryExtractor(
                 }
             val prefix = HelperAppBundle.RESOURCE_ROOT.trimEnd('/') + "/"
             val files = linkedMapOf<String, ByteArray>()
-            val entries = jarFile.entries()
-            while (entries.hasMoreElements()) {
-                val entry = entries.nextElement()
-                if (entry.isDirectory) continue
-                if (!entry.name.startsWith(prefix)) continue
-                val rel = entry.name.removePrefix(prefix)
-                if (rel.isEmpty()) continue
-                jarFile.getInputStream(entry).use { stream -> files[rel] = stream.readBytes() }
-            }
+            jarFile
+                .entries()
+                .asSequence()
+                .filter { !it.isDirectory && it.name.startsWith(prefix) }
+                .map { entry -> entry to entry.name.removePrefix(prefix) }
+                .filter { (_, rel) -> rel.isNotEmpty() }
+                .forEach { (entry, rel) ->
+                    jarFile.getInputStream(entry).use { stream -> files[rel] = stream.readBytes() }
+                }
             return files
         }
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractor.kt
@@ -1,10 +1,17 @@
 package dev.sebastiano.spectre.recording.screencapturekit
 
 import dev.sebastiano.spectre.recording.HelperExtractionPaths
+import java.net.JarURLConnection
+import java.net.URI
+import java.nio.file.FileVisitResult
 import java.nio.file.Files
 import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
 import java.nio.file.attribute.PosixFilePermissions
 import java.security.MessageDigest
+import java.util.jar.JarFile
+import kotlin.io.path.isRegularFile
 
 /**
  * Extracts the bundled `SpectreCaptureHelper.app` ScreenCaptureKit helper out of the recording
@@ -17,9 +24,10 @@ import java.security.MessageDigest
  * 1. First [extract] call checks for the [OVERRIDE_ENV] env var and returns that path directly if
  *    set (dev-iteration escape hatch, skips JAR extraction). Accepts either a nested executable
  *    path or a path to the `.app` bundle itself.
- * 2. Otherwise it loads the staged bundle resources, copies them to [HELPER_DIR_PROPERTY] (if set)
- *    or [targetDirProvider]'s directory under a fixed [HelperAppBundle.APP_DIR_NAME], and chmods
- *    the executable.
+ * 2. Otherwise it loads **every** file under the staged app resource tree (including
+ *    `Contents/_CodeSignature/` when present), copies them byte-for-byte to a fixed install path,
+ *    and chmods the executable. The sealed signature and any stapled ticket payload travel with the
+ *    tree; extraction must not rewrite sealed contents.
  * 3. Subsequent calls return the cached executable path without re-extracting.
  * 4. Caller is responsible for the lifetime of the files. By default the helper lands in Spectre's
  *    stable per-user helper directory so macOS TCC can keep recognising the same bundle path and
@@ -95,6 +103,8 @@ internal class HelperBinaryExtractor(
         val extracted =
             HelperExtractionPaths.withExtractionLock(appRoot.parent) {
                 writeBundleIfNeeded(appRoot, material)
+                // Mode bits are not part of the code signature hash; ensure the nested Mach-O
+                // is executable after extract without rewriting sealed file contents.
                 markExecutable(executable)
                 executable
             }
@@ -103,12 +113,8 @@ internal class HelperBinaryExtractor(
     }
 
     private fun writeBundleIfNeeded(appRoot: Path, material: HelperAppBundleMaterial) {
-        val executable = appRoot.resolve(HelperAppBundle.EXECUTABLE_RELATIVE_PATH)
-        val infoPlist = appRoot.resolve("Contents/Info.plist")
-        val pkgInfo = appRoot.resolve("Contents/PkgInfo")
-        val icon = appRoot.resolve("Contents/Resources/AppIcon.icns")
-        val fingerprintFile = appRoot.resolve(ContentsRelative.FINGERPRINT_FILE)
-
+        // Fingerprint lives *outside* the .app so we never mutate sealed Resources/CodeSignature.
+        val fingerprintFile = appRoot.parent.resolve(".${HelperAppBundle.APP_DIR_NAME}.fingerprint")
         val desiredFingerprint = material.contentFingerprint()
         val currentFingerprint =
             if (Files.isRegularFile(fingerprintFile)) {
@@ -116,25 +122,23 @@ internal class HelperBinaryExtractor(
             } else {
                 null
             }
+        val executable = appRoot.resolve(HelperAppBundle.EXECUTABLE_RELATIVE_PATH)
         val upToDate =
             currentFingerprint == desiredFingerprint &&
                 Files.isRegularFile(executable) &&
-                Files.isRegularFile(infoPlist) &&
-                Files.isRegularFile(pkgInfo) &&
-                (material.iconIcns == null || Files.isRegularFile(icon))
+                material.files.keys.all { rel -> Files.isRegularFile(appRoot.resolve(rel)) }
 
         if (upToDate) return
 
-        Files.createDirectories(executable.parent)
-        Files.createDirectories(icon.parent)
-        Files.write(executable, material.executable)
-        Files.write(infoPlist, material.infoPlist)
-        Files.write(pkgInfo, material.pkgInfo)
-        if (material.iconIcns != null) {
-            Files.write(icon, material.iconIcns)
-        } else if (Files.exists(icon)) {
-            Files.delete(icon)
+        if (Files.exists(appRoot)) {
+            appRoot.toFile().deleteRecursively()
         }
+        for ((relative, bytes) in material.files) {
+            val target = appRoot.resolve(relative)
+            Files.createDirectories(target.parent)
+            Files.write(target, bytes)
+        }
+        Files.createDirectories(fingerprintFile.parent)
         Files.writeString(fingerprintFile, desiredFingerprint)
     }
 
@@ -171,36 +175,67 @@ internal class HelperBinaryExtractor(
 
         @JvmStatic
         fun defaultMaterialLookup(): HelperAppBundleMaterial? {
-            val executable =
-                HelperBinaryExtractor::class
-                    .java
-                    .classLoader
-                    .getResourceAsStream(HelperAppBundle.EXECUTABLE_RESOURCE_PATH)
-                    ?.use { it.readBytes() } ?: return null
-            val infoPlist =
-                HelperBinaryExtractor::class
-                    .java
-                    .classLoader
-                    .getResourceAsStream(HelperAppBundle.INFO_PLIST_RESOURCE_PATH)
-                    ?.use { it.readBytes() } ?: return null
-            val pkgInfo =
-                HelperBinaryExtractor::class
-                    .java
-                    .classLoader
-                    .getResourceAsStream(HelperAppBundle.PKG_INFO_RESOURCE_PATH)
-                    ?.use { it.readBytes() } ?: "APPL????".toByteArray(Charsets.US_ASCII)
-            val iconIcns =
-                HelperBinaryExtractor::class
-                    .java
-                    .classLoader
-                    .getResourceAsStream(HelperAppBundle.ICON_RESOURCE_PATH)
-                    ?.use { it.readBytes() }
-            return HelperAppBundleMaterial(
-                executable = executable,
-                infoPlist = infoPlist,
-                pkgInfo = pkgInfo,
-                iconIcns = iconIcns,
+            val classLoader = HelperBinaryExtractor::class.java.classLoader
+            val sample =
+                classLoader.getResource(HelperAppBundle.INFO_PLIST_RESOURCE_PATH) ?: return null
+            val files =
+                when (sample.protocol) {
+                    "file" -> loadFromFilesystem(sample.toURI())
+                    "jar" -> loadFromJar(sample)
+                    else -> return null
+                }
+            if (files.isEmpty()) return null
+            if (!files.containsKey(HelperAppBundle.EXECUTABLE_RELATIVE_PATH)) return null
+            return HelperAppBundleMaterial(files = files)
+        }
+
+        private fun loadFromFilesystem(infoPlistUri: URI): Map<String, ByteArray> {
+            val infoPlist = Path.of(infoPlistUri)
+            // …/SpectreCaptureHelper.app/Contents/Info.plist → app root
+            val appRoot = infoPlist.parent.parent
+            val files = linkedMapOf<String, ByteArray>()
+            Files.walkFileTree(
+                appRoot,
+                object : SimpleFileVisitor<Path>() {
+                    override fun visitFile(
+                        file: Path,
+                        attrs: BasicFileAttributes,
+                    ): FileVisitResult {
+                        if (file.isRegularFile()) {
+                            val rel = appRoot.relativize(file).toString().replace('\\', '/')
+                            files[rel] = Files.readAllBytes(file)
+                        }
+                        return FileVisitResult.CONTINUE
+                    }
+                },
             )
+            return files
+        }
+
+        private fun loadFromJar(sample: java.net.URL): Map<String, ByteArray> {
+            val connection = sample.openConnection() as JarURLConnection
+            // Prefer the shared JarFile from the connection when available.
+            @Suppress("TooGenericExceptionCaught")
+            val jarFile: JarFile =
+                try {
+                    connection.jarFile
+                } catch (_: Exception) {
+                    val jarUrl = sample.toString().substringBefore("!/")
+                    val jarPath = jarUrl.removePrefix("jar:file:").let { URI(it).path }
+                    JarFile(jarPath)
+                }
+            val prefix = HelperAppBundle.RESOURCE_ROOT.trimEnd('/') + "/"
+            val files = linkedMapOf<String, ByteArray>()
+            val entries = jarFile.entries()
+            while (entries.hasMoreElements()) {
+                val entry = entries.nextElement()
+                if (entry.isDirectory) continue
+                if (!entry.name.startsWith(prefix)) continue
+                val rel = entry.name.removePrefix(prefix)
+                if (rel.isEmpty()) continue
+                jarFile.getInputStream(entry).use { stream -> files[rel] = stream.readBytes() }
+            }
+            return files
         }
 
         @JvmStatic
@@ -211,8 +246,6 @@ internal class HelperBinaryExtractor(
             if (Files.isDirectory(override) && override.fileName.toString().endsWith(".app")) {
                 return override.resolve(HelperAppBundle.EXECUTABLE_RELATIVE_PATH)
             }
-            // If the override is the app root named without trailing check, still try nested path
-            // when the bare path is not executable.
             if (!Files.isExecutable(override)) {
                 val nested = override.resolve(HelperAppBundle.EXECUTABLE_RELATIVE_PATH)
                 if (Files.isExecutable(nested)) return nested
@@ -223,21 +256,20 @@ internal class HelperBinaryExtractor(
 }
 
 /**
- * In-memory material for staging [HelperAppBundle.APP_DIR_NAME] on disk. Test seams inject this
- * instead of jar resources.
+ * Full on-disk material for [HelperAppBundle.APP_DIR_NAME]. Keys are paths relative to the `.app`
+ * root (e.g. `Contents/MacOS/spectre-screencapture`, `Contents/_CodeSignature/CodeResources`).
+ *
+ * Must include every sealed file from the staged jar so Developer ID signatures and stapled tickets
+ * survive extraction (#191).
  */
-internal data class HelperAppBundleMaterial(
-    val executable: ByteArray,
-    val infoPlist: ByteArray,
-    val pkgInfo: ByteArray = "APPL????".toByteArray(Charsets.US_ASCII),
-    val iconIcns: ByteArray? = null,
-) {
+internal data class HelperAppBundleMaterial(val files: Map<String, ByteArray>) {
     fun contentFingerprint(): String {
         val digest = MessageDigest.getInstance("SHA-256")
-        digest.update(executable)
-        digest.update(infoPlist)
-        digest.update(pkgInfo)
-        iconIcns?.let { digest.update(it) }
+        for (key in files.keys.sorted()) {
+            digest.update(key.toByteArray(Charsets.UTF_8))
+            digest.update(0)
+            digest.update(files.getValue(key))
+        }
         return digest.digest().joinToString("") { byte ->
             (byte.toInt() and BYTE_MASK).toString(HEX_RADIX).padStart(HEX_BYTE_WIDTH, '0')
         }
@@ -246,20 +278,20 @@ internal data class HelperAppBundleMaterial(
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is HelperAppBundleMaterial) return false
-        return executable.contentEquals(other.executable) &&
-            infoPlist.contentEquals(other.infoPlist) &&
-            pkgInfo.contentEquals(other.pkgInfo) &&
-            ((iconIcns == null && other.iconIcns == null) ||
-                (iconIcns != null &&
-                    other.iconIcns != null &&
-                    iconIcns.contentEquals(other.iconIcns)))
+        if (files.size != other.files.size) return false
+        for ((key, value) in files) {
+            val otherValue = other.files[key] ?: return false
+            if (!value.contentEquals(otherValue)) return false
+        }
+        return true
     }
 
     override fun hashCode(): Int {
-        var result = executable.contentHashCode()
-        result = HASH_PRIME * result + infoPlist.contentHashCode()
-        result = HASH_PRIME * result + pkgInfo.contentHashCode()
-        result = HASH_PRIME * result + (iconIcns?.contentHashCode() ?: 0)
+        var result = files.size
+        for ((key, value) in files) {
+            result = HASH_PRIME * result + key.hashCode()
+            result = HASH_PRIME * result + value.contentHashCode()
+        }
         return result
     }
 
@@ -271,7 +303,23 @@ internal data class HelperAppBundleMaterial(
     }
 }
 
-/** Relative paths written under the extracted `.app` that are not part of the public bundle API. */
-private object ContentsRelative {
-    const val FINGERPRINT_FILE: String = "Contents/Resources/.spectre-helper-fingerprint"
+/** Test helper: build material for a minimal app tree (no code signature). */
+internal fun helperAppBundleMaterial(
+    executable: ByteArray,
+    infoPlist: ByteArray,
+    pkgInfo: ByteArray = "APPL????".toByteArray(Charsets.US_ASCII),
+    iconIcns: ByteArray? = null,
+    extraFiles: Map<String, ByteArray> = emptyMap(),
+): HelperAppBundleMaterial {
+    val files =
+        linkedMapOf(
+            HelperAppBundle.EXECUTABLE_RELATIVE_PATH to executable,
+            "Contents/Info.plist" to infoPlist,
+            "Contents/PkgInfo" to pkgInfo,
+        )
+    if (iconIcns != null) {
+        files["Contents/Resources/AppIcon.icns"] = iconIcns
+    }
+    files.putAll(extraFiles)
+    return HelperAppBundleMaterial(files = files)
 }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperAppBundleContractTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperAppBundleContractTest.kt
@@ -1,0 +1,47 @@
+package dev.sebastiano.spectre.recording.screencapturekit
+
+import java.nio.file.Files
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Structural contracts for the helper app bundle (#190) and release signing identity expectations
+ * (#191). Does not call Apple's notary service.
+ */
+class HelperAppBundleContractTest {
+
+    @Test
+    fun `bundle identity is stable for TCC and release signing`() {
+        assertEquals("dev.sebastiano.spectre.screencapture", HelperAppBundle.BUNDLE_ID)
+        assertEquals("SpectreCaptureHelper.app", HelperAppBundle.APP_DIR_NAME)
+        assertEquals("Spectre Capture Helper", HelperAppBundle.DISPLAY_NAME)
+        assertEquals(
+            "Contents/MacOS/spectre-screencapture",
+            HelperAppBundle.EXECUTABLE_RELATIVE_PATH,
+        )
+        assertEquals("native/macos/SpectreCaptureHelper.app", HelperAppBundle.RESOURCE_ROOT)
+    }
+
+    @Test
+    fun `checked-in Info-plist template matches public HelperAppBundle constants`() {
+        // Walk up from the test resources / cwd is unreliable under Gradle; resolve from
+        // user.dir (project root for :recording tests is the recording module directory).
+        val moduleDir = java.io.File(System.getProperty("user.dir"))
+        val infoPlist =
+            moduleDir.resolve("native/macos/AppBundle/Info.plist").toPath().also { path ->
+                assertTrue(
+                    Files.isRegularFile(path),
+                    "Expected AppBundle Info.plist at $path (cwd=${moduleDir.absolutePath})",
+                )
+            }
+        val text = infoPlist.readText()
+        assertTrue(text.contains(HelperAppBundle.BUNDLE_ID), text)
+        assertTrue(text.contains(HelperAppBundle.DISPLAY_NAME), text)
+        assertTrue(text.contains(HelperAppBundle.EXECUTABLE_NAME), text)
+        assertTrue(text.contains("<key>LSUIElement</key>"), text)
+        assertTrue(text.contains("<true/>"), "LSUIElement must be true")
+        assertTrue(text.contains("AppIcon"), "Icon file entry required for Settings row")
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperAppBundleContractTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperAppBundleContractTest.kt
@@ -40,8 +40,13 @@ class HelperAppBundleContractTest {
         assertTrue(text.contains(HelperAppBundle.BUNDLE_ID), text)
         assertTrue(text.contains(HelperAppBundle.DISPLAY_NAME), text)
         assertTrue(text.contains(HelperAppBundle.EXECUTABLE_NAME), text)
-        assertTrue(text.contains("<key>LSUIElement</key>"), text)
-        assertTrue(text.contains("<true/>"), "LSUIElement must be true")
+        // Bind LSUIElement true specifically — do not just look for any <true/> in the plist
+        // (NSHighResolutionCapable is also true).
+        assertTrue(
+            Regex("""<key>LSUIElement</key>\s*<true\s*/>""", RegexOption.MULTILINE)
+                .containsMatchIn(text),
+            "LSUIElement must be true; got:\n$text",
+        )
         assertTrue(text.contains("AppIcon"), "Icon file entry required for Settings row")
     }
 }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/HelperBinaryExtractorTest.kt
@@ -203,9 +203,42 @@ class HelperBinaryExtractorTest {
             path.toString().contains(HelperAppBundle.APP_DIR_NAME),
             "Default extract must route through the app bundle; got: $path",
         )
-        val infoPlist = path.parent.parent.resolve("Info.plist") // MacOS -> Contents -> Info.plist
+        val appRoot = path.parent.parent.parent // MacOS -> Contents -> .app
+        val infoPlist = appRoot.resolve("Contents/Info.plist")
         assertTrue(Files.isRegularFile(infoPlist), "Bundled app must include Info.plist")
         assertTrue(infoPlist.readText().contains(HelperAppBundle.BUNDLE_ID))
+        // Fingerprint must live outside the .app so sealed Resources/_CodeSignature stay intact.
+        assertTrue(
+            Files.isRegularFile(tempRoot.resolve(".${HelperAppBundle.APP_DIR_NAME}.fingerprint")),
+            "Staleness fingerprint must not be written inside the sealed app tree",
+        )
+    }
+
+    @Test
+    fun `extraction preserves sealed CodeSignature files byte-for-byte`() {
+        val codeResources = byteArrayOf(0x43, 0x6f, 0x64, 0x65)
+        val material =
+            helperAppBundleMaterial(
+                executable = byteArrayOf(0x7f, 0x45),
+                infoPlist = byteArrayOf(0x3c),
+                extraFiles = mapOf("Contents/_CodeSignature/CodeResources" to codeResources),
+            )
+        val path =
+            HelperBinaryExtractor(
+                    envLookup = { null },
+                    materialLocator = { material },
+                    targetDirProvider = { tempRoot },
+                )
+                .extract()
+        val appRoot = path.parent.parent.parent
+        assertContentEquals(
+            codeResources,
+            appRoot.resolve("Contents/_CodeSignature/CodeResources").readBytes(),
+        )
+        assertTrue(
+            !Files.exists(appRoot.resolve("Contents/Resources/.spectre-helper-fingerprint")),
+            "Must not write fingerprint inside sealed Resources",
+        )
     }
 
     // ── SPECTRE_SCREENCAPTURE_HELPER env-var override ────────────────────────
@@ -410,7 +443,7 @@ class HelperBinaryExtractorTest {
     }
 
     private fun material(executable: ByteArray): HelperAppBundleMaterial =
-        HelperAppBundleMaterial(
+        helperAppBundleMaterial(
             executable = executable,
             infoPlist =
                 """

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorderTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorderTest.kt
@@ -29,7 +29,7 @@ class ScreenCaptureKitRecorderTest {
         val extractor =
             HelperBinaryExtractor(
                 materialLocator = {
-                    HelperAppBundleMaterial(
+                    helperAppBundleMaterial(
                         executable = byteArrayOf(0x01),
                         infoPlist = byteArrayOf(),
                     )

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitScreenshotterTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitScreenshotterTest.kt
@@ -23,7 +23,7 @@ class ScreenCaptureKitScreenshotterTest {
         val extractor =
             HelperBinaryExtractor(
                 materialLocator = {
-                    HelperAppBundleMaterial(
+                    helperAppBundleMaterial(
                         executable = byteArrayOf(0x01),
                         infoPlist = byteArrayOf(),
                     )
@@ -61,7 +61,7 @@ class ScreenCaptureKitScreenshotterTest {
         val extractor =
             HelperBinaryExtractor(
                 materialLocator = {
-                    HelperAppBundleMaterial(
+                    helperAppBundleMaterial(
                         executable = byteArrayOf(0x01),
                         infoPlist = byteArrayOf(),
                     )


### PR DESCRIPTION
## Summary

- Release pipeline now packages the universal helper as **SpectreCaptureHelper.app**, Developer ID signs the **bundle** (`--deep --options runtime --timestamp`), notarizes, **staples**, and verifies (`codesign --deep --strict` + `stapler validate`, best-effort `spctl`).
- Local-dev ad-hoc signing remains the default host-arch path; docs spell out ad-hoc vs release TCC pain.
- `spectre-release` checklist notes the app-bundle signing gates.
- Structural `HelperAppBundleContractTest` locks bundle id / Info.plist template.

Closes #191

## Test plan

- [x] Local full smoke: notary Accepted, staple OK, quarantined `spctl` accepted (Notarized Developer ID)
- [x] `./gradlew :recording:check :recording-macos:check`
- [ ] CI / Bugbot / Codex on PR

## Evidence

Local run used existing `compose.desktop.mac.signing.identity` + notary keychain profile. Submission `2fe32723-9e54-47e5-a108-6a5076ac3757` accepted; stapled ticket present on quarantined copy.

Part of epic #189 (#190 done → #191 → #192).