### PR TITLE
SwiftUI guided Screen Recording permission window (#192)

### DIFF
--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -38,13 +38,14 @@ routers that pick the right one per call.
     actionable error. `ffmpeg` on `PATH` is only relevant if you instantiate the explicit
     legacy ffmpeg backends.
 
-!!! note "macOS TCC preflight (v1)"
-    Capture and recording **never** pop the Screen Recording TCC prompt implicitly.
-    The helper preflights with `CGPreflightScreenCaptureAccess` and fails fast with a
-    structured error (Settings path + deep link) when access is missing. Agents cannot
-    click TCC prompts. With a human present, run `spectre permissions check` or
-    `spectre permissions request` (the only path that may call
-    `CGRequestScreenCaptureAccess`).
+!!! note "macOS TCC preflight + guided grant"
+    Capture and recording **never** open the Screen Recording prompt or guide UI
+    implicitly. They preflight with `CGPreflightScreenCaptureAccess` and fail fast with a
+    structured error when access is missing. Agents cannot click TCC prompts.
+    With a human present, run `spectre permissions check` or
+    `spectre permissions request` — **request** opens the Spectre Capture Helper guide
+    window (explain → Open Settings → drag icon → live re-check) when the grant is
+    missing.
 
 ## Still Window Screenshots
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -321,18 +321,24 @@ Look for patterns such as `Sandbox: java(...) deny(1) mach-lookup`,
 
 ## "macOS recording errors out or produces no file"
 
-- **Screen Recording permission.** macOS gates screen capture behind an explicit
-  grant. Open System Settings → Privacy & Security → Screen Recording and toggle on
-  the responsible parent process — see the next bullet for what that actually means.
-- **TCC attaches to the launching app, not to `java`.** macOS attributes
-  Screen Recording (and Accessibility) to whichever binary opened the JVM
-  process: IntelliJ IDEA when you run tests from the IDE, Terminal.app or iTerm
-  when you `./gradlew test` from a shell, a third-party launcher otherwise. If
-  the wrong app is granted, capture still fails. Check the entry that's actually
-  ticked in the Screen Recording list; it should match the icon you launched.
-- **TCC doesn't refresh live.** After granting, fully quit and relaunch the
-  parent app — not just the JVM child. macOS only picks up the new entitlement on
-  process start.
+- **Screen Recording permission for Spectre Capture Helper.** Capture uses the
+  bundled helper app (`SpectreCaptureHelper.app`, display name **Spectre Capture
+  Helper**). With a human present, run:
+
+  ```bash
+  spectre permissions check
+  spectre permissions request   # guided window if not granted
+  ```
+
+  The request command opens a small guide: Open Settings (Screen Recording deep
+  link), drag the helper icon into the list if missing, wait until the UI shows
+  **Done ✓**, then close. Capture/record paths never open this guide themselves —
+  they fail fast with a structured error agents can relay.
+- **Settings row should say Spectre Capture Helper**, not Terminal/IntelliJ/java.
+  If you only see the spawning app, upgrade Spectre and unset
+  `SPECTRE_SCREENCAPTURE_HELPER` so the bundled app is used.
+- **macOS may re-prompt after updates.** Run `spectre permissions request` again;
+  the guide uses re-approval copy when you re-open it after a prior grant lapsed.
 - **The SCK helper artifact is missing.** If `spectre-recording-macos` is not on the
   runtime classpath, the Swift helper is not present and `AutoRecorder.startWindow(...)`
   throws instead of silently switching capture modes. Add the helper artifact as

--- a/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
+++ b/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
@@ -1,30 +1,17 @@
-import Foundation
 import SpectreScreenCaptureCore
 
 @main
 enum SpectreScreenCapture {
-    /// Async entry for capture modes. Guide mode transfers permanently to the AppKit main
-    /// run loop without parking `DispatchGroup.wait()` on the main actor (Codex P1).
+    /// Async entry for capture modes. Guide mode hops to `@MainActor` and enters
+    /// `NSApplication.run()` there (process exits from the guide UI — no main-thread
+    /// `DispatchGroup.wait()` parking for normal modes).
     static func main() async {
         let argv = CommandLine.arguments
         if isGuidePermissionsInvocation(argv) {
             let binary = argv.first ?? "spectre-screencapture"
             let reapproval = argv.contains("--reapproval")
-            if Thread.isMainThread {
-                MainActor.assumeIsolated {
-                    PermissionGuideApp.run(binaryPath: binary, reapproval: reapproval)
-                }
-            } else {
-                // Hand off to the main queue and never return; guide exits the process.
-                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
-                    DispatchQueue.main.async {
-                        // cont intentionally never resumed — PermissionGuideApp.run ends in exit().
-                        _ = cont
-                        MainActor.assumeIsolated {
-                            PermissionGuideApp.run(binaryPath: binary, reapproval: reapproval)
-                        }
-                    }
-                }
+            await MainActor.run {
+                PermissionGuideApp.run(binaryPath: binary, reapproval: reapproval)
             }
             return
         }

--- a/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
+++ b/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
@@ -1,8 +1,35 @@
 import SpectreScreenCaptureCore
 
 @main
-struct SpectreScreenCapture {
-    static func main() async {
-        await SpectreScreenCaptureCommand.main()
+enum SpectreScreenCapture {
+    /// Sync entry so guide mode runs on the real AppKit main thread.
+    /// Capture/recording still use the async CLI path via a Task.
+    static func main() {
+        let argv = CommandLine.arguments
+        if isGuidePermissionsInvocation(argv) {
+            // @main without `async` is already on the main thread — safe for NSApplication.
+            PermissionGuideApp.run(
+                binaryPath: argv.first ?? "spectre-screencapture",
+                reapproval: argv.contains("--reapproval")
+            )
+            return
+        }
+        let group = DispatchGroup()
+        group.enter()
+        Task {
+            defer { group.leave() }
+            await SpectreScreenCaptureCommand.main(argv)
+        }
+        group.wait()
+    }
+
+    private static func isGuidePermissionsInvocation(_ argv: [String]) -> Bool {
+        if argv.contains("--guide-permissions") {
+            return true
+        }
+        if let modeIndex = argv.firstIndex(of: "--mode"), modeIndex + 1 < argv.count {
+            return argv[modeIndex + 1] == "guide-permissions"
+        }
+        return false
     }
 }

--- a/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
+++ b/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
@@ -1,30 +1,34 @@
-import Dispatch
 import Foundation
 import SpectreScreenCaptureCore
 
 @main
 enum SpectreScreenCapture {
-    /// Sync entry so guide mode runs on the real AppKit main thread.
-    /// Capture/recording still use the async CLI path via a Task.
-    static func main() {
+    /// Async entry for capture modes. Guide mode transfers permanently to the AppKit main
+    /// run loop without parking `DispatchGroup.wait()` on the main actor (Codex P1).
+    static func main() async {
         let argv = CommandLine.arguments
         if isGuidePermissionsInvocation(argv) {
-            // @main without `async` is already on the main thread — safe for NSApplication.
-            MainActor.assumeIsolated {
-                PermissionGuideApp.run(
-                    binaryPath: argv.first ?? "spectre-screencapture",
-                    reapproval: argv.contains("--reapproval")
-                )
+            let binary = argv.first ?? "spectre-screencapture"
+            let reapproval = argv.contains("--reapproval")
+            if Thread.isMainThread {
+                MainActor.assumeIsolated {
+                    PermissionGuideApp.run(binaryPath: binary, reapproval: reapproval)
+                }
+            } else {
+                // Hand off to the main queue and never return; guide exits the process.
+                await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+                    DispatchQueue.main.async {
+                        // cont intentionally never resumed — PermissionGuideApp.run ends in exit().
+                        _ = cont
+                        MainActor.assumeIsolated {
+                            PermissionGuideApp.run(binaryPath: binary, reapproval: reapproval)
+                        }
+                    }
+                }
             }
             return
         }
-        let group = DispatchGroup()
-        group.enter()
-        Task {
-            defer { group.leave() }
-            await SpectreScreenCaptureCommand.main(argv)
-        }
-        group.wait()
+        await SpectreScreenCaptureCommand.main(argv)
     }
 
     private static func isGuidePermissionsInvocation(_ argv: [String]) -> Bool {

--- a/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
+++ b/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
@@ -1,3 +1,5 @@
+import Dispatch
+import Foundation
 import SpectreScreenCaptureCore
 
 @main

--- a/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
+++ b/recording/native/macos/Sources/SpectreScreenCapture/SpectreScreenCaptureMain.swift
@@ -8,10 +8,12 @@ enum SpectreScreenCapture {
         let argv = CommandLine.arguments
         if isGuidePermissionsInvocation(argv) {
             // @main without `async` is already on the main thread — safe for NSApplication.
-            PermissionGuideApp.run(
-                binaryPath: argv.first ?? "spectre-screencapture",
-                reapproval: argv.contains("--reapproval")
-            )
+            MainActor.assumeIsolated {
+                PermissionGuideApp.run(
+                    binaryPath: argv.first ?? "spectre-screencapture",
+                    reapproval: argv.contains("--reapproval")
+                )
+            }
             return
         }
         let group = DispatchGroup()

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
@@ -95,10 +95,8 @@ enum PermissionGuideApp {
         model.onFinished = { granted in
             let result = ScreenCaptureAccess.result(granted: granted, binaryPath: binaryPath)
             FileHandle.standardOutput.write(Data(result.jsonLine.utf8))
-            // Exit after the current runloop turn so the UI can dismiss cleanly.
-            DispatchQueue.main.async {
-                exit(granted ? 0 : 6)
-            }
+            // Exit synchronously on the AppKit run-loop thread (no nested main.async).
+            exit(granted ? 0 : 6)
         }
 
         NotificationCenter.default.addObserver(
@@ -117,18 +115,21 @@ enum PermissionGuideApp {
         exit(6)
     }
 
-    /// Entry from the async CLI main: hop to the main actor if needed, then never return.
+    /// Entry from the async CLI main. Never wraps `NSApplication.run()` in
+    /// `DispatchQueue.main.sync` (that would block timers / UI callbacks).
     nonisolated static func runAndExit(binaryPath: String, reapproval: Bool) -> Never {
-        if Thread.isMainThread {
+        let start: () -> Void = {
             MainActor.assumeIsolated {
                 run(binaryPath: binaryPath, reapproval: reapproval)
             }
+        }
+        if Thread.isMainThread {
+            start()
         } else {
-            DispatchQueue.main.sync {
-                MainActor.assumeIsolated {
-                    run(binaryPath: binaryPath, reapproval: reapproval)
-                }
-            }
+            // Schedule onto the main queue without holding it in a sync block, then
+            // become the main queue processor so AppKit timers and buttons can run.
+            DispatchQueue.main.async(execute: start)
+            dispatchMain()
         }
         exit(6)
     }
@@ -164,8 +165,9 @@ final class PermissionGuideModel: ObservableObject {
         timer?.invalidate()
         // Immediate check, then every 500ms until granted.
         tick()
+        // Timer already fires on the main run loop — call tick() directly (no Task hop).
         timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
-            Task { @MainActor in self?.tick() }
+            self?.tick()
         }
     }
 

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
@@ -56,11 +56,11 @@ public struct PermissionGuidePollState: Equatable {
     }
 }
 
-enum PermissionGuideApp {
+public enum PermissionGuideApp {
     /// Runs the guide UI on the main thread until the user finishes, then exits the process.
     /// Caller must be on the AppKit main thread (`@main` without async).
     @MainActor
-    static func run(binaryPath: String, reapproval: Bool) {
+    public static func run(binaryPath: String, reapproval: Bool) {
         let app = NSApplication.shared
         // LSUIElement is set in Info.plist; accessory keeps us out of the Dock.
         app.setActivationPolicy(.accessory)

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
@@ -56,9 +56,10 @@ public struct PermissionGuidePollState: Equatable {
     }
 }
 
-@MainActor
 enum PermissionGuideApp {
     /// Runs the guide UI on the main thread until the user finishes, then exits the process.
+    /// Caller must be on the AppKit main thread (`@main` without async).
+    @MainActor
     static func run(binaryPath: String, reapproval: Bool) {
         let app = NSApplication.shared
         // LSUIElement is set in Info.plist; accessory keeps us out of the Dock.
@@ -147,9 +148,10 @@ final class PermissionGuideModel: ObservableObject {
         timer?.invalidate()
         // Immediate check, then every 500ms until granted.
         tick()
-        // Timer already fires on the main run loop — call tick() directly (no Task hop).
+        // Timer fires on the main run loop; hop explicitly for MainActor isolation.
         timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
-            self?.tick()
+            guard let self else { return }
+            MainActor.assumeIsolated { self.tick() }
         }
     }
 

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
@@ -1,0 +1,267 @@
+import AppKit
+import CoreGraphics
+import Foundation
+import SwiftUI
+
+// MARK: - Guided Screen Recording permission UI (#192)
+//
+// Human-only path: `spectre permissions request` launches
+// `spectre-screencapture --mode guide-permissions`. Capture/record paths never
+// enter this mode (they stay fail-fast preflight from #187).
+
+/// Pure copy selection so unit tests do not need a display.
+public enum PermissionGuideCopy {
+    public static let windowTitle = "Spectre Capture Helper"
+
+    public static let firstRunHeadline = "Allow Screen Recording"
+    public static let reapprovalHeadline = "Re-enable Screen Recording"
+
+    public static let firstRunBody =
+        "Spectre uses this helper only when you or an agent asks to capture a window or screen. "
+        + "Grant Screen & System Audio Recording to Spectre Capture Helper in System Settings."
+
+    public static let reapprovalBody =
+        "macOS sometimes asks again after updates or when a previous grant lapses. "
+        + "Turn Spectre Capture Helper back on in System Settings (same list as first-time setup)."
+
+    public static let openSettingsLabel = "Open Settings"
+    public static let dragHint = "Drag this icon into the Screen Recording list if it is missing."
+    public static let waitingLabel = "Waiting for permission…"
+    public static let grantedLabel = "Done ✓ Screen Recording granted"
+    public static let closeLabel = "Close"
+    public static let doneLabel = "Done"
+
+    public static func headline(reapproval: Bool) -> String {
+        reapproval ? reapprovalHeadline : firstRunHeadline
+    }
+
+    public static func body(reapproval: Bool) -> String {
+        reapproval ? reapprovalBody : firstRunBody
+    }
+}
+
+/// Polling state machine for live preflight checks (testable without AppKit run loop).
+public struct PermissionGuidePollState: Equatable {
+    public var granted: Bool
+    public var pollCount: Int
+
+    public init(granted: Bool = false, pollCount: Int = 0) {
+        self.granted = granted
+        self.pollCount = pollCount
+    }
+
+    public mutating func applyPreflight(_ isGranted: Bool) {
+        pollCount += 1
+        granted = isGranted
+    }
+}
+
+@MainActor
+enum PermissionGuideApp {
+    /// Runs the guide UI on the main thread until the user finishes, then exits the process.
+    static func run(binaryPath: String, reapproval: Bool) {
+        let app = NSApplication.shared
+        // LSUIElement is set in Info.plist; accessory keeps us out of the Dock.
+        app.setActivationPolicy(.accessory)
+
+        let model = PermissionGuideModel(
+            binaryPath: binaryPath,
+            reapproval: reapproval,
+            preflight: { CGPreflightScreenCaptureAccess() },
+            openSettings: {
+                if let url = URL(string: ScreenCaptureAccess.deepLink) {
+                    NSWorkspace.shared.open(url)
+                }
+            },
+            appURL: Bundle.main.bundleURL
+        )
+        model.startPolling()
+
+        let rootView = PermissionGuideView(model: model)
+        let hosting = NSHostingController(rootView: rootView)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 360),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = PermissionGuideCopy.windowTitle
+        window.contentViewController = hosting
+        window.isReleasedWhenClosed = false
+        window.center()
+        window.makeKeyAndOrderFront(nil)
+        app.activate(ignoringOtherApps: true)
+
+        model.onFinished = { granted in
+            let result = ScreenCaptureAccess.result(granted: granted, binaryPath: binaryPath)
+            FileHandle.standardOutput.write(Data(result.jsonLine.utf8))
+            // Exit after the current runloop turn so the UI can dismiss cleanly.
+            DispatchQueue.main.async {
+                exit(granted ? 0 : 6)
+            }
+        }
+
+        NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { _ in
+            let granted = CGPreflightScreenCaptureAccess()
+            let result = ScreenCaptureAccess.result(granted: granted, binaryPath: binaryPath)
+            FileHandle.standardOutput.write(Data(result.jsonLine.utf8))
+            exit(granted ? 0 : 6)
+        }
+
+        app.run()
+        // Fallback if the run loop ends without an explicit exit.
+        exit(6)
+    }
+
+    /// Entry from the async CLI main: hop to the main actor if needed, then never return.
+    nonisolated static func runAndExit(binaryPath: String, reapproval: Bool) -> Never {
+        if Thread.isMainThread {
+            MainActor.assumeIsolated {
+                run(binaryPath: binaryPath, reapproval: reapproval)
+            }
+        } else {
+            DispatchQueue.main.sync {
+                MainActor.assumeIsolated {
+                    run(binaryPath: binaryPath, reapproval: reapproval)
+                }
+            }
+        }
+        exit(6)
+    }
+}
+
+@MainActor
+final class PermissionGuideModel: ObservableObject {
+    @Published var poll = PermissionGuidePollState()
+    let reapproval: Bool
+    let binaryPath: String
+    let appURL: URL
+    var onFinished: ((Bool) -> Void)?
+
+    private let preflight: () -> Bool
+    private let openSettings: () -> Void
+    private var timer: Timer?
+
+    init(
+        binaryPath: String,
+        reapproval: Bool,
+        preflight: @escaping () -> Bool,
+        openSettings: @escaping () -> Void,
+        appURL: URL
+    ) {
+        self.binaryPath = binaryPath
+        self.reapproval = reapproval
+        self.preflight = preflight
+        self.openSettings = openSettings
+        self.appURL = appURL
+    }
+
+    func startPolling() {
+        timer?.invalidate()
+        // Immediate check, then every 500ms until granted.
+        tick()
+        timer = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tick() }
+        }
+    }
+
+    func tick() {
+        let granted = preflight()
+        poll.applyPreflight(granted)
+        if granted {
+            timer?.invalidate()
+            timer = nil
+        }
+    }
+
+    func openSystemSettings() {
+        openSettings()
+    }
+
+    func finish() {
+        timer?.invalidate()
+        timer = nil
+        onFinished?(poll.granted)
+    }
+}
+
+struct PermissionGuideView: View {
+    @ObservedObject var model: PermissionGuideModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(PermissionGuideCopy.headline(reapproval: model.reapproval))
+                .font(.title2.weight(.semibold))
+                .accessibilityAddTraits(.isHeader)
+
+            Text(PermissionGuideCopy.body(reapproval: model.reapproval))
+                .font(.body)
+                .fixedSize(horizontal: false, vertical: true)
+                .foregroundStyle(.primary)
+
+            Button(PermissionGuideCopy.openSettingsLabel) {
+                model.openSystemSettings()
+            }
+            .keyboardShortcut(.defaultAction)
+            .accessibilityLabel(PermissionGuideCopy.openSettingsLabel)
+            .accessibilityHint("Opens System Settings to Screen Recording privacy")
+
+            HStack(spacing: 12) {
+                AppIconDragView(appURL: model.appURL)
+                    .frame(width: 64, height: 64)
+                    .accessibilityLabel("Spectre Capture Helper icon")
+                    .accessibilityHint(PermissionGuideCopy.dragHint)
+                Text(PermissionGuideCopy.dragHint)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.vertical, 4)
+
+            HStack {
+                if model.poll.granted {
+                    Text(PermissionGuideCopy.grantedLabel)
+                        .font(.headline)
+                        .foregroundStyle(.green)
+                        .accessibilityLabel(PermissionGuideCopy.grantedLabel)
+                } else {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(PermissionGuideCopy.waitingLabel)
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+
+            HStack {
+                Spacer()
+                Button(model.poll.granted ? PermissionGuideCopy.doneLabel : PermissionGuideCopy.closeLabel) {
+                    model.finish()
+                }
+                .keyboardShortcut(.cancelAction)
+            }
+        }
+        .padding(24)
+        .frame(minWidth: 400, minHeight: 320)
+    }
+}
+
+/// Draggable app-icon affordance for Settings' add-to-list gesture.
+struct AppIconDragView: View {
+    let appURL: URL
+
+    var body: some View {
+        Image(nsImage: NSWorkspace.shared.icon(forFile: appURL.path))
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .onDrag {
+                NSItemProvider(contentsOf: appURL) ?? NSItemProvider()
+            }
+    }
+}
+

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/PermissionGuide.swift
@@ -115,24 +115,6 @@ enum PermissionGuideApp {
         exit(6)
     }
 
-    /// Entry from the async CLI main. Never wraps `NSApplication.run()` in
-    /// `DispatchQueue.main.sync` (that would block timers / UI callbacks).
-    nonisolated static func runAndExit(binaryPath: String, reapproval: Bool) -> Never {
-        let start: () -> Void = {
-            MainActor.assumeIsolated {
-                run(binaryPath: binaryPath, reapproval: reapproval)
-            }
-        }
-        if Thread.isMainThread {
-            start()
-        } else {
-            // Schedule onto the main queue without holding it in a sync block, then
-            // become the main queue processor so AppKit timers and buttons can run.
-            DispatchQueue.main.async(execute: start)
-            dispatchMain()
-        }
-        exit(6)
-    }
 }
 
 @MainActor

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
@@ -69,13 +69,14 @@ public enum SpectreScreenCaptureCommand {
                 FileHandle.standardOutput.write(Data(result.jsonLine.utf8))
                 exit(result.granted ? 0 : 6)
             case .guidePermissions:
-                // Guide mode is handled in SpectreScreenCaptureMain before this async path
-                // so AppKit always starts on the real main thread. Keep a defensive fallback.
-                PermissionGuideApp.run(
-                    binaryPath: argv.first ?? "spectre-screencapture",
-                    reapproval: args.reapproval
+                // Handled in SpectreScreenCaptureMain on the real main thread before any Task.
+                FileHandle.standardError.write(
+                    Data(
+                        "spectre-screencapture: guide-permissions must be entered from the process main thread\n"
+                            .utf8
+                    )
                 )
-                exit(6)
+                exit(2)
             case .recording, .screenshot:
                 let recorder = Recorder(arguments: args)
                 try await recorder.run()

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
@@ -69,11 +69,13 @@ public enum SpectreScreenCaptureCommand {
                 FileHandle.standardOutput.write(Data(result.jsonLine.utf8))
                 exit(result.granted ? 0 : 6)
             case .guidePermissions:
-                // Blocks on NSApplication run loop until the user finishes the guide.
-                PermissionGuideApp.runAndExit(
+                // Guide mode is handled in SpectreScreenCaptureMain before this async path
+                // so AppKit always starts on the real main thread. Keep a defensive fallback.
+                PermissionGuideApp.run(
                     binaryPath: argv.first ?? "spectre-screencapture",
                     reapproval: args.reapproval
                 )
+                exit(6)
             case .recording, .screenshot:
                 let recorder = Recorder(arguments: args)
                 try await recorder.run()

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
@@ -11,10 +11,11 @@ import UniformTypeIdentifiers
 // MARK: - CLI contract
 //
 // spectre-screencapture
-//   --mode <recording|screenshot|preflight|request>
+//   --mode <recording|screenshot|preflight|request|guide-permissions>
 //                              Optional. Default recording.
 //                              preflight: CGPreflightScreenCaptureAccess only (never prompts).
 //                              request:   CGRequestScreenCaptureAccess (human-invoked only).
+//                              guide-permissions: SwiftUI guided Settings flow (#192).
 //   --source <window|region>   Optional. Default window. Ignored for preflight/request.
 //   --pid <jvm pid>            Required for window source. Filters CGWindowList by owner PID so we never
 //                              capture another process's window matching the discriminator.
@@ -67,6 +68,12 @@ public enum SpectreScreenCaptureCommand {
                 let result = ScreenCaptureAccess.request(binaryPath: argv.first ?? "spectre-screencapture")
                 FileHandle.standardOutput.write(Data(result.jsonLine.utf8))
                 exit(result.granted ? 0 : 6)
+            case .guidePermissions:
+                // Blocks on NSApplication run loop until the user finishes the guide.
+                PermissionGuideApp.runAndExit(
+                    binaryPath: argv.first ?? "spectre-screencapture",
+                    reapproval: args.reapproval
+                )
             case .recording, .screenshot:
                 let recorder = Recorder(arguments: args)
                 try await recorder.run()
@@ -131,7 +138,7 @@ enum ScreenCaptureAccess {
         return result(granted: granted, binaryPath: binaryPath)
     }
 
-    private static func result(granted: Bool, binaryPath: String) -> ScreenCaptureAccessResult {
+    static func result(granted: Bool, binaryPath: String) -> ScreenCaptureAccessResult {
         let guidance: String
         if granted {
             guidance =
@@ -173,6 +180,8 @@ struct Arguments {
     let captureCursor: Bool
     let fileType: RecordingFileType
     let discoveryTimeoutMs: Int
+    /// When true, guide UI uses re-approval copy (#192).
+    let reapproval: Bool
 
     static func parse(_ argv: [String]) throws -> Arguments {
         var mode = CaptureMode.recording
@@ -187,6 +196,7 @@ struct Arguments {
         var cursor = true
         var fileType: RecordingFileType?
         var discoveryTimeoutMs = 2000
+        var reapproval = false
 
         var i = 1
         while i < argv.count {
@@ -202,6 +212,16 @@ struct Arguments {
                 i += 1
                 continue
             }
+            if key == "--guide-permissions" {
+                mode = .guidePermissions
+                i += 1
+                continue
+            }
+            if key == "--reapproval" {
+                reapproval = true
+                i += 1
+                continue
+            }
             guard i + 1 < argv.count else {
                 throw CLIError(code: 2, message: "missing value for \(key)")
             }
@@ -211,7 +231,9 @@ struct Arguments {
                 guard let parsed = CaptureMode(rawValue: value) else {
                     throw CLIError(
                         code: 2,
-                        message: "--mode must be recording, screenshot, preflight, or request")
+                        message:
+                            "--mode must be recording, screenshot, preflight, request, or guide-permissions"
+                    )
                 }
                 mode = parsed
             case "--source":
@@ -263,8 +285,8 @@ struct Arguments {
             i += 2
         }
 
-        if mode == .preflight || mode == .request {
-            // Dummy output — preflight/request never open the file.
+        if mode == .preflight || mode == .request || mode == .guidePermissions {
+            // Dummy output — preflight/request/guide never open the file.
             let dummy = URL(fileURLWithPath: "/dev/null")
             return Arguments(
                 mode: mode,
@@ -278,7 +300,8 @@ struct Arguments {
                 fps: fps,
                 captureCursor: cursor,
                 fileType: fileType ?? .mp4,
-                discoveryTimeoutMs: discoveryTimeoutMs
+                discoveryTimeoutMs: discoveryTimeoutMs,
+                reapproval: reapproval
             )
         }
 
@@ -316,7 +339,8 @@ struct Arguments {
             fps: fps,
             captureCursor: cursor,
             fileType: fileType ?? RecordingFileType.forOutput(outputUrl),
-            discoveryTimeoutMs: discoveryTimeoutMs
+            discoveryTimeoutMs: discoveryTimeoutMs,
+            reapproval: reapproval
         )
     }
 }
@@ -326,6 +350,7 @@ enum CaptureMode: String {
     case screenshot
     case preflight
     case request
+    case guidePermissions = "guide-permissions"
 }
 
 enum CaptureSource: String {

--- a/recording/native/macos/Tests/SpectreScreenCaptureCoreTests/PermissionGuideTests.swift
+++ b/recording/native/macos/Tests/SpectreScreenCaptureCoreTests/PermissionGuideTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import SpectreScreenCaptureCore
+
+final class PermissionGuideTests: XCTestCase {
+    func testGuidePermissionsModeFromFlag() throws {
+        let args = try Arguments.parse([
+            "spectre-screencapture",
+            "--guide-permissions",
+        ])
+        XCTAssertEqual(args.mode, .guidePermissions)
+        XCTAssertFalse(args.reapproval)
+    }
+
+    func testGuidePermissionsModeFromModeValue() throws {
+        let args = try Arguments.parse([
+            "spectre-screencapture",
+            "--mode",
+            "guide-permissions",
+            "--reapproval",
+        ])
+        XCTAssertEqual(args.mode, .guidePermissions)
+        XCTAssertTrue(args.reapproval)
+    }
+
+    func testGuideCopyDiffersForReapproval() {
+        XCTAssertNotEqual(
+            PermissionGuideCopy.headline(reapproval: false),
+            PermissionGuideCopy.headline(reapproval: true)
+        )
+        XCTAssertNotEqual(
+            PermissionGuideCopy.body(reapproval: false),
+            PermissionGuideCopy.body(reapproval: true)
+        )
+        XCTAssertFalse(PermissionGuideCopy.openSettingsLabel.isEmpty)
+        XCTAssertFalse(PermissionGuideCopy.dragHint.isEmpty)
+        XCTAssertFalse(PermissionGuideCopy.grantedLabel.isEmpty)
+    }
+
+    func testPollStateMachineFlipsToGranted() {
+        var state = PermissionGuidePollState()
+        state.applyPreflight(false)
+        XCTAssertFalse(state.granted)
+        XCTAssertEqual(state.pollCount, 1)
+        state.applyPreflight(true)
+        XCTAssertTrue(state.granted)
+        XCTAssertEqual(state.pollCount, 2)
+    }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
@@ -220,11 +220,22 @@ public object MacOsScreenCaptureAccess {
     internal const val GUIDE_MODE: String = "guide-permissions"
 
     /**
-     * Sidecar next to the extracted helper executable: records that Screen Recording was once
-     * granted so a later lapsed grant can open the guide with re-approval copy (#192).
+     * Sidecar **outside** the `.app` tree: records that Screen Recording was once granted so a
+     * later lapsed grant can open the guide with re-approval copy (#192). Must not write inside
+     * `Contents/` or codesign/staple is invalidated.
      */
-    private fun grantMarker(helperPath: Path): Path =
-        helperPath.parent.resolve(".spectre-screen-recording-granted")
+    private fun grantMarker(helperPath: Path): Path {
+        var cursor: Path? = helperPath
+        while (cursor != null) {
+            val name = cursor.fileName?.toString().orEmpty()
+            if (name.endsWith(".app")) {
+                return cursor.parent.resolve(".$name.screen-recording-granted")
+            }
+            cursor = cursor.parent
+        }
+        // Bare-binary override path: marker next to the executable is fine.
+        return helperPath.parent.resolve(".spectre-screen-recording-granted")
+    }
 
     private fun wasPreviouslyGranted(helperPath: Path): Boolean =
         try {
@@ -235,8 +246,9 @@ public object MacOsScreenCaptureAccess {
 
     private fun markPreviouslyGranted(helperPath: Path) {
         try {
-            Files.createDirectories(helperPath.parent)
-            Files.writeString(grantMarker(helperPath), "1")
+            val marker = grantMarker(helperPath)
+            Files.createDirectories(marker.parent)
+            Files.writeString(marker, "1")
         } catch (_: Exception) {
             // Best-effort; missing marker only affects copy choice, not grant itself.
         }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.recording.screencapturekit
 
 import java.io.IOException
+import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import kotlinx.serialization.SerialName
@@ -73,16 +74,25 @@ public object MacOsScreenCaptureAccess {
     ): ScreenCaptureAccessResult {
         if (!isMacOs()) return ScreenCaptureAccessResult.notApplicable()
         // Prefer the guided SwiftUI flow (#192). If already granted, skip the window.
+        val helperPath = helperExtractor.extract()
         val existing = preflight(helperExtractor, processFactory, isMacOs)
-        if (existing.granted) return existing
-        return runHelper(
-            mode = GUIDE_MODE,
-            helperPath = helperExtractor.extract(),
-            processFactory = processFactory,
-            // Guide window blocks until the human closes it or grants permission.
-            timeoutSeconds = REQUEST_TIMEOUT_SECONDS,
-            extraArgs = emptyList(),
-        )
+        if (existing.granted) {
+            markPreviouslyGranted(helperPath)
+            return existing
+        }
+        // Re-approval copy when a prior successful grant was recorded for this helper install.
+        val reapproval = wasPreviouslyGranted(helperPath)
+        val result =
+            runHelper(
+                mode = GUIDE_MODE,
+                helperPath = helperPath,
+                processFactory = processFactory,
+                // Guide window blocks until the human closes it or grants permission.
+                timeoutSeconds = REQUEST_TIMEOUT_SECONDS,
+                extraArgs = if (reapproval) listOf("--reapproval") else emptyList(),
+            )
+        if (result.granted) markPreviouslyGranted(helperPath)
+        return result
     }
 
     /**
@@ -208,6 +218,29 @@ public object MacOsScreenCaptureAccess {
 
     /** Helper mode for the SwiftUI guide (#192). Never used by capture fail-fast preflight. */
     internal const val GUIDE_MODE: String = "guide-permissions"
+
+    /**
+     * Sidecar next to the extracted helper executable: records that Screen Recording was once
+     * granted so a later lapsed grant can open the guide with re-approval copy (#192).
+     */
+    private fun grantMarker(helperPath: Path): Path =
+        helperPath.parent.resolve(".spectre-screen-recording-granted")
+
+    private fun wasPreviouslyGranted(helperPath: Path): Boolean =
+        try {
+            Files.isRegularFile(grantMarker(helperPath))
+        } catch (_: Exception) {
+            false
+        }
+
+    private fun markPreviouslyGranted(helperPath: Path) {
+        try {
+            Files.createDirectories(helperPath.parent)
+            Files.writeString(grantMarker(helperPath), "1")
+        } catch (_: Exception) {
+            // Best-effort; missing marker only affects copy choice, not grant itself.
+        }
+    }
 }
 
 /** Result of a Screen Recording TCC preflight or request. */

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccess.kt
@@ -31,8 +31,9 @@ public object MacOsScreenCaptureAccess {
         preflight(HelperBinaryExtractor(), DefaultProcessFactory)
 
     /**
-     * Trigger the system permission flow (may prompt). **Human-invoked only** — never call from
-     * automated capture/recording paths.
+     * Human-only guided permission flow (#192). Launches the helper's SwiftUI guide window when
+     * Screen Recording is missing; returns immediately if already granted. **Never call from
+     * automated capture/recording paths** — those must use [requireGranted] / [preflight] only.
      */
     public fun request(): ScreenCaptureAccessResult =
         request(HelperBinaryExtractor(), DefaultProcessFactory)
@@ -71,11 +72,33 @@ public object MacOsScreenCaptureAccess {
         isMacOs: () -> Boolean = ::isMacOs,
     ): ScreenCaptureAccessResult {
         if (!isMacOs()) return ScreenCaptureAccessResult.notApplicable()
+        // Prefer the guided SwiftUI flow (#192). If already granted, skip the window.
+        val existing = preflight(helperExtractor, processFactory, isMacOs)
+        if (existing.granted) return existing
+        return runHelper(
+            mode = GUIDE_MODE,
+            helperPath = helperExtractor.extract(),
+            processFactory = processFactory,
+            // Guide window blocks until the human closes it or grants permission.
+            timeoutSeconds = REQUEST_TIMEOUT_SECONDS,
+            extraArgs = emptyList(),
+        )
+    }
+
+    /**
+     * Explicit legacy system-dialog path (CGRequestScreenCaptureAccess). Prefer [request] which
+     * opens the guided Settings flow. Kept for tests that inject a fake helper.
+     */
+    internal fun requestSystemDialog(
+        helperExtractor: HelperBinaryExtractor,
+        processFactory: ProcessFactory,
+        isMacOs: () -> Boolean = ::isMacOs,
+    ): ScreenCaptureAccessResult {
+        if (!isMacOs()) return ScreenCaptureAccessResult.notApplicable()
         return runHelper(
             mode = "request",
             helperPath = helperExtractor.extract(),
             processFactory = processFactory,
-            // CGRequestScreenCaptureAccess blocks on the system dialog until a human responds.
             timeoutSeconds = REQUEST_TIMEOUT_SECONDS,
         )
     }
@@ -95,8 +118,14 @@ public object MacOsScreenCaptureAccess {
         helperPath: Path,
         processFactory: ProcessFactory,
         timeoutSeconds: Long,
+        extraArgs: List<String> = emptyList(),
     ): ScreenCaptureAccessResult {
-        val argv = listOf(helperPath.toString(), "--mode", mode)
+        val argv = buildList {
+            add(helperPath.toString())
+            add("--mode")
+            add(mode)
+            addAll(extraArgs)
+        }
         val process =
             try {
                 processFactory.start(argv)
@@ -172,10 +201,13 @@ public object MacOsScreenCaptureAccess {
     private const val PREFLIGHT_TIMEOUT_SECONDS: Long = 15
 
     /**
-     * Request may block on the TCC system dialog until a human responds. Five minutes is long
+     * Guided permission window may stay open until a human finishes Settings. Five minutes is long
      * enough for a deliberate grant without hanging CI forever if a fake process never exits.
      */
     private const val REQUEST_TIMEOUT_SECONDS: Long = 300
+
+    /** Helper mode for the SwiftUI guide (#192). Never used by capture fail-fast preflight. */
+    internal const val GUIDE_MODE: String = "guide-permissions"
 }
 
 /** Result of a Screen Recording TCC preflight or request. */

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccessTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccessTest.kt
@@ -56,20 +56,71 @@ class MacOsScreenCaptureAccessTest {
     }
 
     @Test
-    fun `request mode invokes helper with --mode request`() {
+    fun `request launches guide-permissions when preflight is denied`() {
+        val denied =
+            """{"granted":false,"api":"CGPreflightScreenCaptureAccess","binary":"/h","settings_path":"s","deep_link":"d","guidance":"denied"}"""
+        val granted =
+            """{"granted":true,"api":"CGPreflightScreenCaptureAccess","binary":"/h","settings_path":"s","deep_link":"d","guidance":"ok"}"""
+        val argvs = mutableListOf<List<String>>()
+        var call = 0
+        val factory = MacOsScreenCaptureAccess.ProcessFactory { args ->
+            argvs += args
+            call += 1
+            if (call == 1) {
+                FakeProcess(stdout = denied + "\n", exitCode = 6)
+            } else {
+                FakeProcess(stdout = granted + "\n", exitCode = 0)
+            }
+        }
+        val result =
+            MacOsScreenCaptureAccess.request(
+                helperExtractor = stubExtractor(),
+                processFactory = factory,
+                isMacOs = { true },
+            )
+        assertTrue(result.granted)
+        assertEquals(2, argvs.size)
+        assertEquals("preflight", argvs[0][argvs[0].indexOf("--mode") + 1])
+        assertEquals(MacOsScreenCaptureAccess.GUIDE_MODE, argvs[1][argvs[1].indexOf("--mode") + 1])
+    }
+
+    @Test
+    fun `request skips guide when preflight already granted`() {
+        val granted =
+            """{"granted":true,"api":"CGPreflightScreenCaptureAccess","binary":"/h","settings_path":"s","deep_link":"d","guidance":"ok"}"""
+        var calls = 0
+        val factory = MacOsScreenCaptureAccess.ProcessFactory {
+            calls += 1
+            FakeProcess(stdout = granted + "\n", exitCode = 0)
+        }
+        val result =
+            MacOsScreenCaptureAccess.request(
+                helperExtractor = stubExtractor(),
+                processFactory = factory,
+                isMacOs = { true },
+            )
+        assertTrue(result.granted)
+        assertEquals(1, calls, "must not open the guide window when already granted")
+    }
+
+    @Test
+    fun `capture fail-fast never uses guide-permissions mode`() {
+        val denied =
+            """{"granted":false,"api":"CGPreflightScreenCaptureAccess","binary":"/h","settings_path":"s","deep_link":"d","guidance":"denied"}"""
         var argv: List<String> = emptyList()
-        val json =
-            """{"granted":true,"api":"CGPreflightScreenCaptureAccess","binary":"/h","settings_path":"s","deep_link":"d","guidance":"g"}"""
         val factory = MacOsScreenCaptureAccess.ProcessFactory { args ->
             argv = args
-            FakeProcess(stdout = json + "\n", exitCode = 0)
+            FakeProcess(stdout = denied + "\n", exitCode = 6)
         }
-        MacOsScreenCaptureAccess.request(
-            helperExtractor = stubExtractor(),
-            processFactory = factory,
-            isMacOs = { true },
-        )
-        assertEquals("request", argv[argv.indexOf("--mode") + 1])
+        assertFailsWith<ScreenCaptureAccessDeniedException> {
+            MacOsScreenCaptureAccess.requireGranted(
+                helperExtractor = stubExtractor(),
+                processFactory = factory,
+                isMacOs = { true },
+            )
+        }
+        assertEquals("preflight", argv[argv.indexOf("--mode") + 1])
+        assertFalse(argv.contains(MacOsScreenCaptureAccess.GUIDE_MODE))
     }
 
     @Test

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccessTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/screencapturekit/MacOsScreenCaptureAccessTest.kt
@@ -82,6 +82,39 @@ class MacOsScreenCaptureAccessTest {
         assertEquals(2, argvs.size)
         assertEquals("preflight", argvs[0][argvs[0].indexOf("--mode") + 1])
         assertEquals(MacOsScreenCaptureAccess.GUIDE_MODE, argvs[1][argvs[1].indexOf("--mode") + 1])
+        assertFalse(argvs[1].contains("--reapproval"), "first grant must not use reapproval copy")
+    }
+
+    @Test
+    fun `request passes reapproval after a prior grant marker exists`() {
+        val denied =
+            """{"granted":false,"api":"CGPreflightScreenCaptureAccess","binary":"/h","settings_path":"s","deep_link":"d","guidance":"denied"}"""
+        val granted =
+            """{"granted":true,"api":"CGPreflightScreenCaptureAccess","binary":"/h","settings_path":"s","deep_link":"d","guidance":"ok"}"""
+        val extractor = stubExtractor()
+        // Seed a prior grant so the guide uses re-approval copy.
+        MacOsScreenCaptureAccess.request(
+            helperExtractor = extractor,
+            processFactory = { FakeProcess(stdout = granted + "\n", exitCode = 0) },
+            isMacOs = { true },
+        )
+        val argvs = mutableListOf<List<String>>()
+        var call = 0
+        MacOsScreenCaptureAccess.request(
+            helperExtractor = extractor,
+            processFactory = { args ->
+                argvs += args
+                call += 1
+                if (call == 1) FakeProcess(stdout = denied + "\n", exitCode = 6)
+                else FakeProcess(stdout = granted + "\n", exitCode = 0)
+            },
+            isMacOs = { true },
+        )
+        assertEquals(2, argvs.size)
+        assertTrue(
+            argvs[1].contains("--reapproval"),
+            "lapsed grant must pass --reapproval to the guide",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Helper mode `guide-permissions` (also `--guide-permissions` / `--reapproval`) shows a SwiftUI window: explanation, Open Settings deep link, draggable app icon, live preflight polling, Done/Close.
- `MacOsScreenCaptureAccess.request()` / `spectre permissions request` launches the guide when Screen Recording is missing; already-granted returns immediately.
- Capture/`requireGranted` stay fail-fast preflight only (no implicit guide).
- Docs for recording + troubleshooting updated; unit tests for arg parse, poll state, CLI routing.

Closes #192

## Test plan

- [x] Swift build + Kotlin `MacOsScreenCaptureAccessTest` / recording check
- [x] Manual: `spectre-screencapture --mode guide-permissions` keeps process alive (UI path)
- [ ] CI / Bugbot / Codex

Part of epic #189.