### PR TITLE
Document #320 stock IntelliJ inject recipe + #321 packaging 1.0 fate

### DIFF
--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -58,7 +58,10 @@ Three experimental markers exist today:
   surface — `AgentAttach`, `AttachedAutomator`, `AttachOptions`, `SpectreProcesses`, and the
   wire DTOs. Tracked under #153; the marker stays in place while the attach UX, streaming wire
   ops (`waitForVisualIdle` etc.), and automated IntelliJ-hosted Compose attach tests settle.
-  The transport itself runs on Linux, macOS, and Windows (native `AF_UNIX`).
+  The transport itself runs on Linux, macOS, and Windows (native `AF_UNIX`). Nested
+  inject-runtime packaging (attach when the target has no preinstalled `spectre-core`) is
+  **experimental inspect only** for 1.0 — keep the marker; do not treat inject as a stable
+  production attach mode.
 
 Consumers opt in either at file level or call site:
 

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -46,9 +46,11 @@ executable CI evidence.
 - **JDK 21+** on both the attaching and target JVMs.
 - The attaching JVM must be a **JDK** (not a JRE) with the `jdk.attach` module on the
   module graph.
-- The target JVM must include **Spectre `:core`** on its classpath. The agent does not
-  inject Spectre into the target; it reflectively bootstraps off the `:core` that's
-  already loaded. The agent JAR itself is supplied by the attaching JVM at attach time.
+- The target JVM needs a **Compose Desktop host** (so Spectre can find semantics owners).
+  Prefer a **preinstalled** `spectre-core` dependency on the target for production-style
+  attach. If core is absent, the agent runtime can **inject** a nested
+  `META-INF/spectre/inject-runtime.jar` payload (experimental inspect path — see
+  [Injection without preinstalled core](#injection-without-preinstalled-core)).
 - **Linux, macOS, and Windows.** The transport uses native Unix Domain Sockets (`AF_UNIX`) on all
   three — no named pipes, no extra dependencies. Windows requires **Windows 10 version 1803 /
   Windows Server 2019 or newer**, when native `AF_UNIX` landed; older Windows fails the attach
@@ -56,7 +58,8 @@ executable CI evidence.
 - The target JVM should be started with **`-XX:+EnableDynamicAgentLoading`**. Without it,
   attach prints a stderr warning per
   [JEP 451](https://openjdk.org/jeps/451) and a future JDK will reject the attach
-  entirely.
+  entirely. Spectre's launch harness adds the flag for processes it starts; stock apps and
+  IDEs need it in their own VM options (see [IntelliJ-hosted Compose](intellij.md#external-attach-without-spectre-core)).
 
 ## Artifact roles
 
@@ -65,9 +68,8 @@ Agent attach involves two JVMs:
 - **Target JVM** — the Compose app you want to inspect or drive.
 - **Attacher JVM** — the test, inspector, or tool process that calls `AgentAttach.attach(pid)`.
 
-The target JVM must already have Spectre `:core` on its classpath. The agent runtime does
-not inject `:core`; it reflectively locates `ComposeAutomator` in the target's classloader
-after it has been loaded into that JVM.
+**Preferred target shape** — preinstall Spectre core so bootstrap uses the instrumented path
+(no inject classloader):
 
 ```kotlin
 // build.gradle.kts of the target application
@@ -77,6 +79,9 @@ dependencies {
     // The attacher supplies the runtime jar to the JDK Attach API.
 }
 ```
+
+If the target cannot take that dependency (stock IDE, third-party binary), attach still works
+when Compose is present and the runtime jar carries the nested inject payload — see below.
 
 The attacher JVM usually needs two artifacts:
 
@@ -115,13 +120,32 @@ jar directly, and the target still does not need `spectre-agent-runtime` declare
 3. Run attach preflights, including the same-OS-user check.
 4. Call `VirtualMachine.attach(pid).loadAgent(runtimeJarPath, udsPath)`.
 5. The target JVM loads the runtime jar and invokes `SpectreAgent.agentmain(...)`.
-6. Inside the target JVM, `SpectreAgent` finds `ComposeAutomator` from the target's existing
-   `:core` dependency, creates an in-process automator, and starts an IPC server on the UDS path.
+6. Inside the target JVM, bootstrap locates or injects `ComposeAutomator` (see below), creates
+   an in-process automator, and starts an IPC server on the UDS path.
 7. The attacher connects an `IpcClient` to that socket and returns `AttachedAutomator`.
 
 After that, calls such as `windows()`, `findByTestTag(...)`, `click(...)`, and `screenshot()` are
 small CBOR requests over the socket. They execute inside the target JVM against the in-process
 automator, then return DTOs or bytes to the attacher.
+
+### Injection without preinstalled core
+
+Bootstrap order inside the target:
+
+1. Prefer a **preinstalled** `ComposeAutomator` already on the target classpath
+   (instrumented attach).
+2. Else extract the nested **`META-INF/spectre/inject-runtime.jar`** from the agent runtime
+   jar, open a child classloader parented at a Compose host loader, and load Spectre core
+   from that payload (inject attach). Compose / Skiko stay on the target; only Spectre core
+   and relocated kotlinx bits come from the inject jar.
+
+Inject is an **experimental inspect** path: fine for rare attach → dump → detach sessions,
+not for high-frequency CI attach loops. Prefer preinstalled core when you control the target
+build. Class unload after detach is GC-dependent; do not treat inject as a leak-free
+production mode.
+
+The same `AgentAttach.attach(pid)` API is used for both paths — there is no separate
+“inject flag” on the public attach surface.
 
 ## Custom runtime jar path
 

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -207,6 +207,41 @@ on project open without needing a human at the keyboard. Spectre's own
 `sample-intellij-plugin` follows this shape and runs that way under
 `-PspectreAutorun=true`.
 
+## External attach without spectre-core
+
+When you need to inspect Jewel-hosted Compose from a **sister process** and the IDE (or
+plugin) does **not** ship `spectre-core`, use [agent attach](agent.md) with the experimental
+**inject** bootstrap (nested inject-runtime inside `spectre-agent-runtime`).
+
+1. Add **`-XX:+EnableDynamicAgentLoading`** via **Help → Edit Custom VM Options…**, then
+   fully restart the IDE. Without it, JDK 21+ warns (JEP 451) and a future JDK may reject
+   attach. Config example on macOS:
+   `~/Library/Application Support/JetBrains/IntelliJIdea2026.2/idea.vmoptions`
+2. Ensure a Compose surface is showing. Spectre's sample plugin tags tool-window nodes as
+   `ide.counter.*` and `ide.popup.*` (`SpectreSampleToolWindowContent`) — useful proving
+   tags when that plugin is installed.
+3. Find the IDE PID (`jps -l`), then from an attacher JVM with `spectre-agent` +
+   `spectre-agent-runtime`:
+
+```kotlin
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+import dev.sebastiano.spectre.agent.AgentAttach
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+
+AgentAttach.attach(idePid).use { automator ->
+    println(automator.findByTestTag("ide.counter.text"))
+    println(automator.allNodes().mapNotNull { it.testTag })
+}
+```
+
+If the sample plugin is on the classpath **with** `spectre-core`, attach uses the
+instrumented path instead of inject — same API either way. Prefer in-process
+`ComposeAutomator` (sections above) when your code already runs inside the IDE.
+
+Maintainer spike notes (recipe + evidence chain, not on the public site nav):
+[`docs/spikes/209-injection/stock-intellij-recipe.md`](https://github.com/rock3r/spectre/blob/main/docs/spikes/209-injection/stock-intellij-recipe.md).
+
 ## Validating from a separate test JVM
 
 When you want a CI-friendly automated test that boots the IDE, installs your plugin,

--- a/docs/spikes/209-injection/decision.md
+++ b/docs/spikes/209-injection/decision.md
@@ -40,9 +40,11 @@
 
 Filed after decision (not before):
 
-1. **#320** — Stock IDE attach recipe + QA (vmoptions + IntelliJ 2026.2 Jewel tags).
-2. **#321** — Decide 1.0 fate of nested inject-runtime packaging (promote / keep experimental / strip).
-3. **#322** — OverlayLayerInspector multi-version adapter policy.
+1. **#320** — Stock IDE attach recipe + QA — **closed** via
+   [stock-intellij-recipe.md](stock-intellij-recipe.md).
+2. **#321** — Nested inject-runtime 1.0 fate — **closed** via
+   [packaging-1.0-decision.md](packaging-1.0-decision.md) (**keep**, experimental).
+3. **#322** — OverlayLayerInspector multi-version adapter policy (still open).
 
 ## Closes
 

--- a/docs/spikes/209-injection/inject-packaging.md
+++ b/docs/spikes/209-injection/inject-packaging.md
@@ -28,3 +28,9 @@ Compose / Skiko / Kotlin stdlib are excluded from the inject jar and resolve aga
 - `:agent-inject-runtime:verifyInjectRuntimeJarContents`
 - `:agent-runtime:verifyAgentRuntimeJarContents` (nested resource present; no exploded core)
 - `AgentInjectAttachIntegrationTest` — attach + tree dump with spectre-core stripped from target CP
+
+## 1.0 packaging fate (#321)
+
+**Keep** nested inject-runtime for 1.0 as an **experimental** inspect path. Do not promote to a
+stable product surface; do not strip for instrumented-only 1.0. Full decision:
+[packaging-1.0-decision.md](packaging-1.0-decision.md).

--- a/docs/spikes/209-injection/packaging-1.0-decision.md
+++ b/docs/spikes/209-injection/packaging-1.0-decision.md
@@ -1,0 +1,50 @@
+# #321: 1.0 fate of nested inject-runtime packaging
+
+**Status:** decided (closes #321)  
+**Date:** 2026-07-26  
+**Depends on:** #209 M2 packaging (#319), decision.md (M5)
+
+## Decision
+
+| Option | 1.0 outcome |
+| --- | --- |
+| Nested `META-INF/spectre/inject-runtime.jar` inside `spectre-agent-runtime` | **Keep** |
+| Stability tier | **Experimental** (`@ExperimentalSpectreAgentApi` — same as attach API) |
+| Promote inject packaging to a first-class stable product surface | **No** for 1.0 |
+| Strip inject payload for a strict instrumented-only 1.0 | **No** |
+| Production CLI `spectre attach --inject` / user-facing “magic inject” flag | **Out of 1.0** (re-approval required) |
+| Separate published `spectre-agent-inject-runtime` consumer coordinate | **Not required** for attach; nested resource is the ship shape |
+
+## Criteria applied (from decision.md)
+
+1. **API soundness** — main-scene semantics read uses public Compose Desktop APIs; inject does not shade Compose.
+2. **Prototype evidence** — `AgentInjectAttachIntegrationTest` + packaging verify tasks prove nested jar bootstrap without preinstalled core.
+3. **Maintenance cost** — nested jar + classloader bootstrap is contained; multi-IDE Compose adapter matrix stays experimental / deferred.
+4. **Metaspace / detach** — GC-dependent unload after inject; unacceptable as a production high-frequency path → experimental inspect only.
+5. **Stock IDE QA** — recipe + evidence chain in [stock-intellij-recipe.md](stock-intellij-recipe.md) (#320); not a reason to strip packaging already validated on fixtures.
+
+## Rationale (short)
+
+- **Keep:** removing inject for 1.0 would discard the only path for attach against targets that cannot take a compile-time `spectre-core` dependency (stock IDE, third-party apps). The packaging is already built, verified in CI jar checks, and covered by the inject e2e on Linux/macOS (plus physical Windows strip coverage).
+- **Do not promote:** instrumented-only (preinstalled core) remains the preferred attach path; inject is opt-in via bootstrap fallback, not a separate stable product mode.
+- **Do not strip:** “strict instrumented-only 1.0” would force every inspect target to ship Spectre, which is the problem #209 solved for experimental inspect.
+
+## Shipping shape (unchanged)
+
+```text
+spectre-agent-runtime.jar
+└── META-INF/spectre/inject-runtime.jar   # core + relocated kotlinx; no Compose
+```
+
+Bootstrap order (see `AgentBootstrap.findSpectre`):
+
+1. Prefer preinstalled `ComposeAutomator` on the target.
+2. Else extract nested inject jar → `SpectreInjectClassLoader(parent = Compose host)`.
+
+## Revisit triggers (post-1.0)
+
+- Metaspace / unload hardened enough for CI attach loops.
+- Stock-IDE inject green in release QA or CI with a no-core Jewel target.
+- Product need for CLI/MCP “attach without core” as a supported mode (not experimental).
+
+Until then, docs and STABILITY language must keep inject **experimental inspect**, not production attach.

--- a/docs/spikes/209-injection/practicalities.md
+++ b/docs/spikes/209-injection/practicalities.md
@@ -66,11 +66,14 @@ relying on unbounded inject attach/detach cycles.
 
 ## 4. Stock IDE proving status
 
-Automated stock IntelliJ 2026.2 attach was **not** executed in the agent delivery environment
-(no reliable stock IDE launch path). Evidence path used instead:
+Full operator recipe, tag table, and evidence chain: **[stock-intellij-recipe.md](stock-intellij-recipe.md)**
+(#320).
 
-- `AgentInjectAttachIntegrationTest` — real attach + UDS + tree dump against Compose fixture
-  **without** preinstalled `spectre-core` on the target classpath (injection exercised).
+| Layer | Status |
+| --- | --- |
+| Inject packaging + no-core fixture attach | Automated (`AgentInjectAttachIntegrationTest`, jar verify tasks) |
+| Jewel `ide.counter.*` / `ide.popup.*` in IDEA 2026.2 | Automated via `:sample-intellij-plugin:uiTest` (instrumented sample) |
+| Stock IDE + inject when no `spectre-core` | Documented manual / release-QA recipe (vmoptions + attach dump) |
 
-Stock-IDE gap is environmental, not a prototype packaging failure. Optional remote
-Windows/Linux hosts were not required for packaging validation.
+Stock no-core inject remains **experimental inspect**, not a PR-blocking CI gate
+(see packaging-1.0-decision.md).

--- a/docs/spikes/209-injection/stock-intellij-recipe.md
+++ b/docs/spikes/209-injection/stock-intellij-recipe.md
@@ -1,0 +1,148 @@
+# #320: Stock IntelliJ inject attach recipe (post-#209)
+
+**Status:** documented + evidence chain recorded (closes #320)  
+**Date:** 2026-07-26  
+**Depends on:** inject packaging (#319), practicalities.md §1 (vmoptions)
+
+## Goal
+
+Attach from a sister JVM to **stock IntelliJ IDEA 2026.2+** that does **not** ship
+`spectre-core`, using nested inject-runtime, and dump Jewel-hosted tool-window tags
+(`ide.counter.*` / `ide.popup.*`) when a Compose surface with those tags is present.
+
+## Prerequisites
+
+1. **IntelliJ IDEA 2026.2+** (platform 262 / JBR era matching Spectre’s sample plugin pin).
+2. **Custom VM options** include dynamic agent loading (see practicalities.md §1):
+
+   ```text
+   -XX:+EnableDynamicAgentLoading
+   ```
+
+   Path example (macOS):  
+   `~/Library/Application Support/JetBrains/IntelliJIdea2026.2/idea.vmoptions`  
+   Then **fully restart** the IDE.
+
+3. Attacher machine: **JDK 21+** with `jdk.attach`, same OS user as the IDE process.
+4. Built artifacts from this repo (or published snapshots):
+
+   ```bash
+   ./gradlew :agent-runtime:jar :agent:jar
+   ```
+
+5. A **Jewel/Compose surface with known test tags** in the IDE process:
+   - **Recommended proving UI:** install Spectre’s `:sample-intellij-plugin` (dev zip /
+     `runIde` sandbox). Tags are defined in `SpectreSampleToolWindowContent`:
+
+     | Tag | Role |
+     | --- | --- |
+     | `ide.counter.button` | click + state |
+     | `ide.counter.text` | always present |
+     | `ide.popup.toggleButton` | opens popup |
+     | `ide.popup.body` / `ide.popup.text` / `ide.popup.dismissButton` | popup tree |
+
+   - **True stock IDE (no sample plugin):** only Compose surfaces that already expose
+     semantics (and any tags the product sets) are visible. There is no guarantee of
+     `ide.counter.*` tags without a plugin or product code that sets them.
+
+### Note on sample plugin vs pure inject
+
+The sample plugin **ships `spectre-core`** so its in-process `RunSpectreAction` and
+`:sample-intellij-plugin:uiTest` exercise the **instrumented** path (bootstrap prefers
+preinstalled core). That is intentional for CI IDE validation.
+
+To exercise **inject** against the same Jewel tags:
+
+1. Build a throwaway plugin zip that includes only the tool-window UI (Jewel + tags)
+   **without** `spectre-core` on the plugin classpath, **or**
+2. Attach to any third-party / stock Compose surface that has no Spectre dependency.
+
+If `spectre-core` is present, attach still works — inject is simply not used.
+
+## Recipe (manual / release QA)
+
+### 1. Start the IDE
+
+With `-XX:+EnableDynamicAgentLoading` already in custom VM options. Open the sample
+tool window (**View → Tool Windows → Spectre Sample**, or the plugin’s registered id)
+so Compose has painted and tags exist.
+
+### 2. Find the IDE PID
+
+```bash
+jps -l | rg -i 'idea|intellij'
+# or
+jps -lm | rg -i 'com.intellij'
+```
+
+Use the main IDE process PID (not helper processes).
+
+### 3. Attach and dump tags
+
+From a Kotlin script / small main with `spectre-agent` + `spectre-agent-runtime` on the
+classpath (repo shape):
+
+```kotlin
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+import dev.sebastiano.spectre.agent.AgentAttach
+import dev.sebastiano.spectre.agent.AttachOptions
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Path
+
+AgentAttach.attach(
+    pid = idePid,
+    options =
+        AttachOptions(
+            agentJarPath =
+                Path.of("agent-runtime/build/libs/spectre-agent-runtime-0.1.0-SNAPSHOT.jar"),
+        ),
+).use { automator ->
+    println(automator.windows())
+    val tags = automator.allNodes().mapNotNull { it.testTag }.sorted()
+    println(tags)
+    for (tag in
+        listOf(
+            "ide.counter.text",
+            "ide.counter.button",
+            "ide.popup.toggleButton",
+        )) {
+        println("$tag -> ${automator.findByTestTag(tag).size}")
+    }
+}
+```
+
+Or rely on classpath discovery of `spectre-agent-runtime` and call
+`AgentAttach.attach(idePid)` only.
+
+### 4. Success / failure signals
+
+| Signal | Meaning |
+| --- | --- |
+| Non-empty `windows()` / `allNodes()` | Agent + IPC + Compose host discovery OK |
+| `findByTestTag("ide.counter.text")` non-empty | Jewel tool window semantics visible |
+| `ide.popup.*` after opening popup | Popup roots tracked (open via UI or later Robot) |
+| JEP 451 stderr / attach reject | Missing `EnableDynamicAgentLoading` |
+| `ComposeNotOnClasspathException` | No Compose host in that process |
+| `SpectreNotOnClasspathException` | Inject resource missing from agent-runtime jar |
+| Empty tags with sample plugin closed | Tool window not showing / not composed yet |
+
+## Evidence chain (what is automated vs manual)
+
+| Layer | How proven | What it proves |
+| --- | --- | --- |
+| Nested inject packaging | `:agent-inject-runtime` / `:agent-runtime` verify tasks + #329 strip tests | Jar shape + Windows CP strip |
+| Inject attach without core | `AgentInjectAttachIntegrationTest` (Linux/macOS; physical Windows validated) | Real attach/UDS/tree via inject |
+| Jewel tags in IDE process | `:sample-intellij-plugin:uiTest` + `ide-uitest.yml` | `ide.counter.*` / `ide.popup.*` discoverable in IDEA 2026.2 sandbox (instrumented) |
+| Stock IDE + inject + Jewel tags | **This recipe** (manual / release QA) | Operator checklist when IDE has no core |
+
+Combined: packaging and inject transport are CI-proven; Jewel tag names and IDE hosting
+are CI-proven on the sample plugin; full stock no-core + inject is the documented QA
+path above (environment-dependent, same gap noted in practicalities.md before #320).
+
+## CI stance
+
+Do **not** add always-on hosted CI that boots stock IntelliJ and attaches inject for every
+PR — `ide-uitest.yml` already owns IDE boot cost for the instrumented sample. Revisit only
+if product requires no-core inject as a release gate (see packaging-1.0-decision.md
+revisit triggers).

--- a/docs/spikes/209-injection/user-recipe.md
+++ b/docs/spikes/209-injection/user-recipe.md
@@ -1,5 +1,8 @@
 # #209 user-like inject attach recipe (M3)
 
+Stock IntelliJ (vmoptions + Jewel tags): [stock-intellij-recipe.md](stock-intellij-recipe.md).  
+1.0 packaging fate: [packaging-1.0-decision.md](packaging-1.0-decision.md).
+
 ## Automated path (CI / developer)
 
 **Prerequisites:** Linux or macOS with a non-headless display (or `xvfb-run -a` on Linux). The test


### PR DESCRIPTION
## Summary

Closes the remaining #209 follow-ups:

- **#320** — Stock IntelliJ inject attach recipe (vmoptions, attach dump, Jewel `ide.counter.*` / `ide.popup.*` tags) plus an evidence chain (inject e2e + sample-intellij uiTest + manual stock QA).
- **#321** — **Keep** nested `META-INF/spectre/inject-runtime.jar` for 1.0 as **experimental inspect**; do not promote to stable product surface; do not strip for instrumented-only 1.0.

Also updates the public agent/IntelliJ guides so inject is no longer documented as “impossible” (stale post-#319).

## Test plan

- [x] `mkdocs build --strict`
- [ ] CI docs job
- [x] Close #320 #321 on merge