### PR TITLE
Failure artifact path layout + capture helpers (#205)

### DIFF
--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -31,16 +31,18 @@ public final class dev/sebastiano/spectre/testing/FailureArtifactPaths {
 
 public final class dev/sebastiano/spectre/testing/FailureArtifactsConfig {
 	public fun <init> ()V
-	public fun <init> (ZLjava/nio/file/Path;Ljava/lang/Integer;)V
-	public synthetic fun <init> (ZLjava/nio/file/Path;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZLjava/nio/file/Path;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (ZLjava/nio/file/Path;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Ljava/nio/file/Path;
 	public final fun component3 ()Ljava/lang/Integer;
-	public final fun copy (ZLjava/nio/file/Path;Ljava/lang/Integer;)Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;
-	public static synthetic fun copy$default (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;ZLjava/nio/file/Path;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (ZLjava/nio/file/Path;Ljava/lang/Integer;Ljava/lang/String;)Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;ZLjava/nio/file/Path;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttemptIndex ()Ljava/lang/Integer;
 	public final fun getEnabled ()Z
+	public final fun getInvocationId ()Ljava/lang/String;
 	public final fun getReportsRoot ()Ljava/nio/file/Path;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -16,6 +16,36 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/jun
 	public final fun getAutomator ()Ldev/sebastiano/spectre/core/ComposeAutomator;
 }
 
+public final class dev/sebastiano/spectre/testing/FailureArtifactCapture {
+	public static final field INSTANCE Ldev/sebastiano/spectre/testing/FailureArtifactCapture;
+	public final fun captureAllWindows (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/nio/file/Path;)Ljava/util/List;
+	public final fun captureWindows (Ljava/nio/file/Path;ILkotlin/jvm/functions/Function1;)Ljava/util/List;
+}
+
+public final class dev/sebastiano/spectre/testing/FailureArtifactPaths {
+	public static final field INSTANCE Ldev/sebastiano/spectre/testing/FailureArtifactPaths;
+	public final fun defaultReportsRoot ()Ljava/nio/file/Path;
+	public final fun methodDirectory (Ljava/lang/String;Ljava/lang/String;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)Ljava/nio/file/Path;
+	public final fun windowDirectory (Ljava/nio/file/Path;I)Ljava/nio/file/Path;
+}
+
+public final class dev/sebastiano/spectre/testing/FailureArtifactsConfig {
+	public fun <init> ()V
+	public fun <init> (ZLjava/nio/file/Path;Ljava/lang/Integer;)V
+	public synthetic fun <init> (ZLjava/nio/file/Path;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/nio/file/Path;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (ZLjava/nio/file/Path;Ljava/lang/Integer;)Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;ZLjava/nio/file/Path;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttemptIndex ()Ljava/lang/Integer;
+	public final fun getEnabled ()Z
+	public final fun getReportsRoot ()Ljava/nio/file/Path;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class dev/sebastiano/spectre/testing/LaunchAndAttachExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/ParameterResolver {
 	public fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/agent/launch/LaunchSpec;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -44,17 +44,40 @@ public object FailureArtifactCapture {
     /**
      * Convenience for production: capture every currently tracked window via [ComposeAutomator].
      * Refreshes the window list first so indices match a live UI at failure time.
+     *
+     * Window discovery failures are swallowed (empty list) for the same reason as per-window
+     * capture errors: the original test failure must remain the primary failure signal.
      */
     public fun captureAllWindows(
         automator: ComposeAutomator,
         methodDirectory: Path,
+    ): List<CaptureArtifactPaths> =
+        captureFromDiscovery(
+            methodDirectory = methodDirectory,
+            discoverWindowCount = {
+                automator.refreshWindows()
+                automator.surfaceIds().size
+            },
+            captureWindow = { index -> automator.capture(index) },
+        )
+
+    /**
+     * Shared best-effort path for production and tests: if [discoverWindowCount] throws, returns an
+     * empty list instead of propagating.
+     */
+    internal fun captureFromDiscovery(
+        methodDirectory: Path,
+        discoverWindowCount: () -> Int,
+        captureWindow: (windowIndex: Int) -> AtomicCapture,
     ): List<CaptureArtifactPaths> {
-        automator.refreshWindows()
-        val count = automator.surfaceIds().size
+        val count =
+            runCatching(discoverWindowCount).getOrElse {
+                return emptyList()
+            }
         return captureWindows(
             methodDirectory = methodDirectory,
             windowCount = count,
-            captureWindow = { index -> automator.capture(index) },
+            captureWindow = captureWindow,
         )
     }
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -31,6 +31,9 @@ public object FailureArtifactCapture {
         val written = ArrayList<CaptureArtifactPaths>(windowCount)
         for (index in 0 until windowCount) {
             val directory = FailureArtifactPaths.windowDirectory(methodDirectory, index)
+            // Drop any stale window-N from a prior failure in the same method dir so a capture
+            // failure later cannot leave old artifacts looking like this attempt's evidence.
+            deleteRecursivelyQuietly(directory)
             val paths =
                 runCatching {
                         val capture = captureWindow(index)

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -30,10 +30,18 @@ public object FailureArtifactCapture {
         // Drop every prior window-* under this method dir (including higher indices than the
         // current windowCount) so CI cannot publish stale captures from a previous failure.
         clearStaleWindowDirectories(methodDirectory)
+        // If OS locks prevent full cleanup, write under a unique run-* subdir so this attempt's
+        // artifacts cannot interleave with undeletable leftovers.
+        val writeRoot =
+            if (listWindowDirectories(methodDirectory).isEmpty()) {
+                methodDirectory
+            } else {
+                methodDirectory.resolve("run-${System.nanoTime()}")
+            }
         if (windowCount <= 0) return emptyList()
         val written = ArrayList<CaptureArtifactPaths>(windowCount)
         for (index in 0 until windowCount) {
-            val directory = FailureArtifactPaths.windowDirectory(methodDirectory, index)
+            val directory = FailureArtifactPaths.windowDirectory(writeRoot, index)
             val paths =
                 runCatching {
                         val capture = captureWindow(index)
@@ -46,17 +54,24 @@ public object FailureArtifactCapture {
     }
 
     private fun clearStaleWindowDirectories(methodDirectory: Path) {
-        if (!methodDirectory.exists()) return
-        runCatching {
-            Files.list(methodDirectory).use { stream ->
-                stream
-                    .asSequence()
-                    .filter {
-                        Files.isDirectory(it) && it.fileName.toString().startsWith("window-")
-                    }
-                    .forEach { deleteRecursivelyQuietly(it) }
-            }
+        for (dir in listWindowDirectories(methodDirectory)) {
+            deleteRecursivelyQuietly(dir)
         }
+    }
+
+    private fun listWindowDirectories(methodDirectory: Path): List<Path> {
+        if (!methodDirectory.exists()) return emptyList()
+        return runCatching {
+                Files.list(methodDirectory).use { stream ->
+                    stream
+                        .asSequence()
+                        .filter {
+                            Files.isDirectory(it) && it.fileName.toString().startsWith("window-")
+                        }
+                        .toList()
+                }
+            }
+            .getOrDefault(emptyList())
     }
 
     /**

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -1,0 +1,60 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.capture.AtomicCapture
+import dev.sebastiano.spectre.core.capture.CaptureArtifactPaths
+import dev.sebastiano.spectre.core.capture.CaptureArtifactsWriter
+import java.nio.file.Path
+
+/**
+ * Writes one atomic capture directory per known window under a test-method report folder.
+ *
+ * Pure relative to the capture function: production callers pass `{ automator.capture(it) }`; unit
+ * tests inject stubs so path + write behavior is covered without a live Compose UI.
+ *
+ * Capture failures for individual windows are swallowed so a flaky screenshot cannot mask the
+ * original test failure. Callers still receive the successfully written paths.
+ */
+public object FailureArtifactCapture {
+
+    public fun captureWindows(
+        methodDirectory: Path,
+        windowCount: Int,
+        captureWindow: (windowIndex: Int) -> AtomicCapture,
+    ): List<CaptureArtifactPaths> {
+        if (windowCount <= 0) return emptyList()
+        val written = ArrayList<CaptureArtifactPaths>(windowCount)
+        for (index in 0 until windowCount) {
+            val paths =
+                runCatching {
+                        val capture = captureWindow(index)
+                        CaptureArtifactsWriter.write(
+                            directory =
+                                FailureArtifactPaths.windowDirectory(methodDirectory, index),
+                            document = capture.document,
+                            pngBytes = capture.pngBytes,
+                        )
+                    }
+                    .getOrNull()
+            if (paths != null) written += paths
+        }
+        return written
+    }
+
+    /**
+     * Convenience for production: capture every currently tracked window via [ComposeAutomator].
+     * Refreshes the window list first so indices match a live UI at failure time.
+     */
+    public fun captureAllWindows(
+        automator: ComposeAutomator,
+        methodDirectory: Path,
+    ): List<CaptureArtifactPaths> {
+        automator.refreshWindows()
+        val count = automator.surfaceIds().size
+        return captureWindows(
+            methodDirectory = methodDirectory,
+            windowCount = count,
+            captureWindow = { index -> automator.capture(index) },
+        )
+    }
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -33,7 +33,7 @@ public object FailureArtifactCapture {
         // If OS locks prevent full cleanup, write under a unique run-* subdir so this attempt's
         // artifacts cannot interleave with undeletable leftovers.
         val writeRoot =
-            if (listWindowDirectories(methodDirectory).isEmpty()) {
+            if (listStaleArtifactDirectories(methodDirectory).isEmpty()) {
                 methodDirectory
             } else {
                 methodDirectory.resolve("run-${System.nanoTime()}")
@@ -79,11 +79,6 @@ public object FailureArtifactCapture {
             }
             .getOrDefault(emptyList())
     }
-
-    private fun listWindowDirectories(methodDirectory: Path): List<Path> =
-        listStaleArtifactDirectories(methodDirectory).filter {
-            it.fileName.toString().startsWith("window-")
-        }
 
     /**
      * Convenience for production: capture every currently tracked window via [ComposeAutomator].

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -27,13 +27,13 @@ public object FailureArtifactCapture {
         windowCount: Int,
         captureWindow: (windowIndex: Int) -> AtomicCapture,
     ): List<CaptureArtifactPaths> {
+        // Drop every prior window-* under this method dir (including higher indices than the
+        // current windowCount) so CI cannot publish stale captures from a previous failure.
+        clearStaleWindowDirectories(methodDirectory)
         if (windowCount <= 0) return emptyList()
         val written = ArrayList<CaptureArtifactPaths>(windowCount)
         for (index in 0 until windowCount) {
             val directory = FailureArtifactPaths.windowDirectory(methodDirectory, index)
-            // Drop any stale window-N from a prior failure in the same method dir so a capture
-            // failure later cannot leave old artifacts looking like this attempt's evidence.
-            deleteRecursivelyQuietly(directory)
             val paths =
                 runCatching {
                         val capture = captureWindow(index)
@@ -43,6 +43,20 @@ public object FailureArtifactCapture {
             if (paths != null) written += paths
         }
         return written
+    }
+
+    private fun clearStaleWindowDirectories(methodDirectory: Path) {
+        if (!methodDirectory.exists()) return
+        runCatching {
+            Files.list(methodDirectory).use { stream ->
+                stream
+                    .asSequence()
+                    .filter {
+                        Files.isDirectory(it) && it.fileName.toString().startsWith("window-")
+                    }
+                    .forEach { deleteRecursivelyQuietly(it) }
+            }
+        }
     }
 
     /**

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -4,7 +4,11 @@ import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.capture.AtomicCapture
 import dev.sebastiano.spectre.core.capture.CaptureArtifactPaths
 import dev.sebastiano.spectre.core.capture.CaptureArtifactsWriter
+import java.io.IOException
+import java.nio.file.Files
 import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.streams.asSequence
 
 /**
  * Writes one atomic capture directory per known window under a test-method report folder.
@@ -13,7 +17,8 @@ import java.nio.file.Path
  * tests inject stubs so path + write behavior is covered without a live Compose UI.
  *
  * Capture failures for individual windows are swallowed so a flaky screenshot cannot mask the
- * original test failure. Callers still receive the successfully written paths.
+ * original test failure. Callers still receive the successfully written paths. Partial directories
+ * from a failed write are removed so CI globs never upload a half-written capture.
  */
 public object FailureArtifactCapture {
 
@@ -25,15 +30,11 @@ public object FailureArtifactCapture {
         if (windowCount <= 0) return emptyList()
         val written = ArrayList<CaptureArtifactPaths>(windowCount)
         for (index in 0 until windowCount) {
+            val directory = FailureArtifactPaths.windowDirectory(methodDirectory, index)
             val paths =
                 runCatching {
                         val capture = captureWindow(index)
-                        CaptureArtifactsWriter.write(
-                            directory =
-                                FailureArtifactPaths.windowDirectory(methodDirectory, index),
-                            document = capture.document,
-                            pngBytes = capture.pngBytes,
-                        )
+                        writeCaptureAtomically(directory, capture)
                     }
                     .getOrNull()
             if (paths != null) written += paths
@@ -43,7 +44,10 @@ public object FailureArtifactCapture {
 
     /**
      * Convenience for production: capture every currently tracked window via [ComposeAutomator].
-     * Refreshes the window list first so indices match a live UI at failure time.
+     *
+     * Snapshots [ComposeAutomator.surfaceIds] once, then re-resolves each surface by id before
+     * capturing so a window that closes mid-loop does not shift later indices onto the wrong
+     * surface (best-effort: a closed surface is skipped).
      *
      * Window discovery failures are swallowed (empty list) for the same reason as per-window
      * capture errors: the original test failure must remain the primary failure signal.
@@ -51,15 +55,27 @@ public object FailureArtifactCapture {
     public fun captureAllWindows(
         automator: ComposeAutomator,
         methodDirectory: Path,
-    ): List<CaptureArtifactPaths> =
-        captureFromDiscovery(
+    ): List<CaptureArtifactPaths> {
+        val surfaceIds =
+            runCatching {
+                    automator.refreshWindows()
+                    automator.surfaceIds()
+                }
+                .getOrElse {
+                    return emptyList()
+                }
+        return captureWindows(
             methodDirectory = methodDirectory,
-            discoverWindowCount = {
+            windowCount = surfaceIds.size,
+            captureWindow = { index ->
+                val surfaceId = surfaceIds[index]
                 automator.refreshWindows()
-                automator.surfaceIds().size
+                val liveIndex = automator.surfaceIds().indexOf(surfaceId)
+                check(liveIndex >= 0) { "Window surface $surfaceId no longer tracked" }
+                automator.capture(liveIndex)
             },
-            captureWindow = { index -> automator.capture(index) },
         )
+    }
 
     /**
      * Shared best-effort path for production and tests: if [discoverWindowCount] throws, returns an
@@ -79,5 +95,33 @@ public object FailureArtifactCapture {
             windowCount = count,
             captureWindow = captureWindow,
         )
+    }
+
+    private fun writeCaptureAtomically(
+        directory: Path,
+        capture: AtomicCapture,
+    ): CaptureArtifactPaths {
+        return try {
+            CaptureArtifactsWriter.write(
+                directory = directory,
+                document = capture.document,
+                pngBytes = capture.pngBytes,
+            )
+        } catch (error: IOException) {
+            deleteRecursivelyQuietly(directory)
+            throw error
+        }
+    }
+
+    private fun deleteRecursivelyQuietly(directory: Path) {
+        if (!directory.exists()) return
+        runCatching {
+            Files.walk(directory).use { stream ->
+                stream
+                    .asSequence()
+                    .sortedByDescending { it.nameCount }
+                    .forEach { path -> runCatching { Files.deleteIfExists(path) } }
+            }
+        }
     }
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -27,17 +27,11 @@ public object FailureArtifactCapture {
         windowCount: Int,
         captureWindow: (windowIndex: Int) -> AtomicCapture,
     ): List<CaptureArtifactPaths> {
-        // Drop every prior window-* under this method dir (including higher indices than the
-        // current windowCount) so CI cannot publish stale captures from a previous failure.
+        // Best-effort purge of prior window-*/run-* trees. Always write under a fresh run-*
+        // directory so this attempt cannot share or interleave paths with residual OS-locked
+        // leftovers (CI still may upload undeletable leftovers; that is an OS edge case).
         clearStaleWindowDirectories(methodDirectory)
-        // If OS locks prevent full cleanup, write under a unique run-* subdir so this attempt's
-        // artifacts cannot interleave with undeletable leftovers.
-        val writeRoot =
-            if (listStaleArtifactDirectories(methodDirectory).isEmpty()) {
-                methodDirectory
-            } else {
-                methodDirectory.resolve("run-${System.nanoTime()}")
-            }
+        val writeRoot = methodDirectory.resolve("run-${System.nanoTime()}")
         if (windowCount <= 0) return emptyList()
         val written = ArrayList<CaptureArtifactPaths>(windowCount)
         for (index in 0 until windowCount) {

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -72,7 +72,14 @@ public object FailureArtifactCapture {
                 automator.refreshWindows()
                 val liveIndex = automator.surfaceIds().indexOf(surfaceId)
                 check(liveIndex >= 0) { "Window surface $surfaceId no longer tracked" }
-                automator.capture(liveIndex)
+                val capture = automator.capture(liveIndex)
+                // capture() refreshes again; reject a drifted surface so we never write the wrong
+                // window into window-N (skip this slot via runCatching instead).
+                check(capture.document.window.surfaceId == surfaceId) {
+                    "Capture drifted to surface ${capture.document.window.surfaceId}, " +
+                        "wanted $surfaceId"
+                }
+                capture
             },
         )
     }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -54,25 +54,36 @@ public object FailureArtifactCapture {
     }
 
     private fun clearStaleWindowDirectories(methodDirectory: Path) {
-        for (dir in listWindowDirectories(methodDirectory)) {
+        for (dir in listStaleArtifactDirectories(methodDirectory)) {
             deleteRecursivelyQuietly(dir)
         }
     }
 
-    private fun listWindowDirectories(methodDirectory: Path): List<Path> {
+    /**
+     * Prior capture slots under a method directory: top-level `window-*` and any leftover `run-*`
+     * isolation trees from earlier lock-conflict captures.
+     */
+    private fun listStaleArtifactDirectories(methodDirectory: Path): List<Path> {
         if (!methodDirectory.exists()) return emptyList()
         return runCatching {
                 Files.list(methodDirectory).use { stream ->
                     stream
                         .asSequence()
-                        .filter {
-                            Files.isDirectory(it) && it.fileName.toString().startsWith("window-")
+                        .filter { path ->
+                            if (!Files.isDirectory(path)) return@filter false
+                            val name = path.fileName.toString()
+                            name.startsWith("window-") || name.startsWith("run-")
                         }
                         .toList()
                 }
             }
             .getOrDefault(emptyList())
     }
+
+    private fun listWindowDirectories(methodDirectory: Path): List<Path> =
+        listStaleArtifactDirectories(methodDirectory).filter {
+            it.fileName.toString().startsWith("window-")
+        }
 
     /**
      * Convenience for production: capture every currently tracked window via [ComposeAutomator].

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCapture.kt
@@ -79,6 +79,9 @@ public object FailureArtifactCapture {
                     automator.surfaceIds()
                 }
                 .getOrElse {
+                    // Still purge prior window-* so discovery failure cannot leave stale captures
+                    // looking like evidence for this failure.
+                    clearStaleWindowDirectories(methodDirectory)
                     return emptyList()
                 }
         return captureWindows(

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -67,6 +67,9 @@ public object FailureArtifactPaths {
                 }
                 .joinToString("")
                 .replace(Regex("_+"), "_")
+                // Windows rejects/normalizes trailing dots and spaces; strip them so the
+                // segment is a real directory name. Lossy vs raw → hash below.
+                .trimEnd('.', ' ')
                 .trim('_')
         val base =
             when {
@@ -117,32 +120,28 @@ public object FailureArtifactPaths {
         Integer.toUnsignedString(value.hashCode(), HASH_RADIX).padStart(HASH_WIDTH, '0')
 
     /**
-     * Longest UTF-8 prefix of [bytes] whose length is at most [maxBytes] and ends on a char
-     * boundary.
+     * Longest UTF-8 prefix of [bytes] whose length is at most [maxBytes] and ends on a complete
+     * character boundary (never retains a multi-byte lead without its continuation bytes).
      */
     private fun utf8Prefix(bytes: ByteArray, maxBytes: Int): ByteArray {
-        var end = minOf(maxBytes, bytes.size)
-        // Walk back over UTF-8 continuation bytes (10xxxxxx).
-        while (
-            end > 0 &&
-                (bytes[end - 1].toInt() and UTF8_CONTINUATION_MASK) == UTF8_CONTINUATION_VALUE
-        ) {
-            end--
-        }
-        // If we stopped on a multi-byte lead that no longer has its full sequence, drop the lead.
-        if (end > 0) {
-            val last = bytes[end - 1].toInt() and 0xFF
-            val need =
+        var end = 0
+        var index = 0
+        while (index < bytes.size) {
+            val lead = bytes[index].toInt() and 0xFF
+            val charLen =
                 when {
-                    last and 0x80 == 0 -> 1
-                    last and 0xE0 == 0xC0 -> 2
-                    last and 0xF0 == 0xE0 -> 3
-                    last and 0xF8 == 0xF0 -> 4
+                    lead and 0x80 == 0 -> 1
+                    lead and 0xE0 == 0xC0 -> 2
+                    lead and 0xF0 == 0xE0 -> 3
+                    lead and 0xF8 == 0xF0 -> 4
                     else -> 1
                 }
-            if (end - 1 + need > maxBytes) end--
+            if (index + charLen > bytes.size) break
+            if (end + charLen > maxBytes) break
+            end += charLen
+            index += charLen
         }
-        return bytes.copyOf(end.coerceAtLeast(0))
+        return bytes.copyOf(end)
     }
 
     private val RESERVED_WINDOWS_DEVICE_NAMES: Set<String> = buildSet {
@@ -155,6 +154,4 @@ public object FailureArtifactPaths {
 
     private const val HASH_RADIX: Int = 16
     private const val HASH_WIDTH: Int = 8
-    private const val UTF8_CONTINUATION_MASK: Int = 0xC0
-    private const val UTF8_CONTINUATION_VALUE: Int = 0x80
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -28,11 +28,17 @@ public object FailureArtifactPaths {
         config: FailureArtifactsConfig,
     ): Path {
         val classSeg = sanitizePathSegment(testClassName)
-        val methodSeg =
-            sanitizePathSegment(testMethodName).let { base ->
-                val attempt = config.attemptIndex
-                if (attempt != null && attempt > 1) "$base-attempt-$attempt" else base
+        // Fold attempt into the label *before* sanitize/bound so `-attempt-N` cannot push a
+        // max-length method segment over the filesystem component limit.
+        val methodLabel = buildString {
+            append(testMethodName)
+            val attempt = config.attemptIndex
+            if (attempt != null && attempt > 1) {
+                append("-attempt-")
+                append(attempt)
             }
+        }
+        val methodSeg = sanitizePathSegment(methodLabel)
         return config.reportsRoot.resolve(classSeg).resolve(methodSeg)
     }
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -16,6 +16,9 @@ import kotlin.io.path.absolute
  */
 public object FailureArtifactPaths {
 
+    /** Common filesystem per-component limit (bytes). */
+    internal const val MAX_SEGMENT_BYTES: Int = 255
+
     public fun defaultReportsRoot(): Path =
         Path.of("build", "reports", "spectre").absolute().normalize()
 
@@ -42,7 +45,11 @@ public object FailureArtifactPaths {
      * when the input had any content. Reserved Windows device names (`CON`, `NUL`, `COM1`, …) get
      * an underscore after the **stem** so `createDirectories` does not fail on Windows — including
      * dotted forms (`nul.txt` → `nul_.txt`), because Windows keys off the stem before the first
-     * `.`.
+     * `.`. Dot-only names (`.` / `..`) become literal `dot` / `dotdot` so they cannot navigate out
+     * of the reports root. When sanitization changes the original string (lossy replacements,
+     * reserved-name escape, etc.), a stable hash of the original is appended so distinct names that
+     * only differ in replaced punctuation do not collide. Overlong segments are truncated with
+     * another hash suffix so parameterized display names still fit filesystem limits.
      */
     internal fun sanitizePathSegment(raw: String): String {
         val cleaned =
@@ -55,8 +62,22 @@ public object FailureArtifactPaths {
                 .joinToString("")
                 .replace(Regex("_+"), "_")
                 .trim('_')
-        val base = cleaned.ifEmpty { "unnamed" }
-        return escapeReservedWindowsDeviceName(base)
+        val base =
+            when {
+                cleaned.isEmpty() -> "unnamed"
+                cleaned == "." -> "dot"
+                cleaned == ".." -> "dotdot"
+                else -> cleaned
+            }
+        val escaped = escapeReservedWindowsDeviceName(base)
+        // Preserve uniqueness when the sanitize path was lossy relative to the original label.
+        val unique =
+            if (escaped == raw) {
+                escaped
+            } else {
+                "${escaped}_${shortHash(raw)}"
+            }
+        return boundSegmentLength(unique)
     }
 
     /**
@@ -71,6 +92,53 @@ public object FailureArtifactPaths {
         return "${stem}_$extension"
     }
 
+    /**
+     * Keeps [segment] within [MAX_SEGMENT_BYTES] UTF-8 bytes. When truncated, appends `_<hex>` of
+     * the original segment's hash so distinct long names do not collapse to the same prefix.
+     */
+    private fun boundSegmentLength(segment: String): String {
+        val utf8 = segment.toByteArray(Charsets.UTF_8)
+        if (utf8.size <= MAX_SEGMENT_BYTES) return segment
+        val hash = shortHash(segment)
+        val suffix = "_$hash"
+        val suffixBytes = suffix.toByteArray(Charsets.UTF_8)
+        val budget = (MAX_SEGMENT_BYTES - suffixBytes.size).coerceAtLeast(1)
+        val prefix = utf8Prefix(utf8, budget).toString(Charsets.UTF_8)
+        return prefix + suffix
+    }
+
+    private fun shortHash(value: String): String =
+        Integer.toUnsignedString(value.hashCode(), HASH_RADIX).padStart(HASH_WIDTH, '0')
+
+    /**
+     * Longest UTF-8 prefix of [bytes] whose length is at most [maxBytes] and ends on a char
+     * boundary.
+     */
+    private fun utf8Prefix(bytes: ByteArray, maxBytes: Int): ByteArray {
+        var end = minOf(maxBytes, bytes.size)
+        // Walk back over UTF-8 continuation bytes (10xxxxxx).
+        while (
+            end > 0 &&
+                (bytes[end - 1].toInt() and UTF8_CONTINUATION_MASK) == UTF8_CONTINUATION_VALUE
+        ) {
+            end--
+        }
+        // If we stopped on a multi-byte lead that no longer has its full sequence, drop the lead.
+        if (end > 0) {
+            val last = bytes[end - 1].toInt() and 0xFF
+            val need =
+                when {
+                    last and 0x80 == 0 -> 1
+                    last and 0xE0 == 0xC0 -> 2
+                    last and 0xF0 == 0xE0 -> 3
+                    last and 0xF8 == 0xF0 -> 4
+                    else -> 1
+                }
+            if (end - 1 + need > maxBytes) end--
+        }
+        return bytes.copyOf(end.coerceAtLeast(0))
+    }
+
     private val RESERVED_WINDOWS_DEVICE_NAMES: Set<String> = buildSet {
         addAll(listOf("con", "prn", "aux", "nul"))
         for (n in 0..9) {
@@ -78,4 +146,9 @@ public object FailureArtifactPaths {
             add("lpt$n")
         }
     }
+
+    private const val HASH_RADIX: Int = 16
+    private const val HASH_WIDTH: Int = 8
+    private const val UTF8_CONTINUATION_MASK: Int = 0xC0
+    private const val UTF8_CONTINUATION_VALUE: Int = 0x80
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -8,11 +8,12 @@ import kotlin.io.path.absolute
  *
  * Layout:
  * ```
- * <reportsRoot>/<test-class>/<test-method>[-attempt-N]/window-<i>/{capture.json,screenshot.png}
+ * <reportsRoot>/<test-class>/<test-method>[/attempt-N]/window-<i>/{capture.json,screenshot.png}
  * ```
  *
  * Each `window-<i>` directory matches the atomic-capture layout from #181 so `spectre-capture` `jq`
- * recipes work unchanged.
+ * recipes work unchanged. Retry attempts use a nested `attempt-N` directory (not a method-name
+ * suffix) so they cannot collide with a test literally named `…-attempt-N`.
  */
 public object FailureArtifactPaths {
 
@@ -28,18 +29,14 @@ public object FailureArtifactPaths {
         config: FailureArtifactsConfig,
     ): Path {
         val classSeg = sanitizePathSegment(testClassName)
-        // Fold attempt into the label *before* sanitize/bound so `-attempt-N` cannot push a
-        // max-length method segment over the filesystem component limit.
-        val methodLabel = buildString {
-            append(testMethodName)
-            val attempt = config.attemptIndex
-            if (attempt != null && attempt > 1) {
-                append("-attempt-")
-                append(attempt)
-            }
+        val methodSeg = sanitizePathSegment(testMethodName)
+        val methodDir = config.reportsRoot.resolve(classSeg).resolve(methodSeg)
+        val attempt = config.attemptIndex
+        return if (attempt != null && attempt > 1) {
+            methodDir.resolve("attempt-$attempt")
+        } else {
+            methodDir
         }
-        val methodSeg = sanitizePathSegment(methodLabel)
-        return config.reportsRoot.resolve(classSeg).resolve(methodSeg)
     }
 
     public fun windowDirectory(methodDirectory: Path, windowIndex: Int): Path =
@@ -80,13 +77,11 @@ public object FailureArtifactPaths {
                     core.trimEnd('.', ' ').trim('_').ifEmpty { "unnamed" }
             }
         val escaped = escapeReservedWindowsDeviceName(base)
-        // Preserve uniqueness when the sanitize path was lossy relative to the original label.
-        val unique =
-            if (escaped == raw) {
-                escaped
-            } else {
-                "${escaped}_${shortHash(raw)}"
-            }
+        // Preserve uniqueness when the sanitize path was lossy relative to the original label,
+        // or when the label has uppercase letters (case-insensitive volumes would otherwise alias
+        // `caseA` and `CaseA` onto the same directory).
+        val needsHash = escaped != raw || raw.any { it.isUpperCase() }
+        val unique = if (needsHash) "${escaped}_${shortHash(raw)}" else escaped
         return boundSegmentLength(unique)
     }
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -40,7 +40,9 @@ public object FailureArtifactPaths {
      * Replaces characters that are hostile on common filesystems or ambiguous in shell globs.
      * Collapses runs of replacements to a single `_` and trims edges so segments stay non-empty
      * when the input had any content. Reserved Windows device names (`CON`, `NUL`, `COM1`, …) get
-     * an underscore suffix so `createDirectories` does not fail on Windows.
+     * an underscore after the **stem** so `createDirectories` does not fail on Windows — including
+     * dotted forms (`nul.txt` → `nul_.txt`), because Windows keys off the stem before the first
+     * `.`.
      */
     internal fun sanitizePathSegment(raw: String): String {
         val cleaned =
@@ -54,16 +56,19 @@ public object FailureArtifactPaths {
                 .replace(Regex("_+"), "_")
                 .trim('_')
         val base = cleaned.ifEmpty { "unnamed" }
-        return if (isReservedWindowsDeviceName(base)) "${base}_" else base
+        return escapeReservedWindowsDeviceName(base)
     }
 
     /**
-     * True when [name] is a Windows reserved device name (case-insensitive), including optional
-     * extension forms such as `nul.txt` / `COM1.anything`.
+     * If the stem (text before the first `.`) is a Windows reserved device name, insert `_` after
+     * the stem so the resulting stem is no longer reserved (`NUL` → `NUL_`, `nul.txt` →
+     * `nul_.txt`).
      */
-    private fun isReservedWindowsDeviceName(name: String): Boolean {
-        val stem = name.substringBefore('.').lowercase()
-        return stem in RESERVED_WINDOWS_DEVICE_NAMES
+    private fun escapeReservedWindowsDeviceName(name: String): String {
+        val stem = name.substringBefore('.')
+        if (stem.lowercase() !in RESERVED_WINDOWS_DEVICE_NAMES) return name
+        val extension = name.removePrefix(stem) // empty, or ".something"
+        return "${stem}_$extension"
     }
 
     private val RESERVED_WINDOWS_DEVICE_NAMES: Set<String> = buildSet {

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -39,7 +39,8 @@ public object FailureArtifactPaths {
     /**
      * Replaces characters that are hostile on common filesystems or ambiguous in shell globs.
      * Collapses runs of replacements to a single `_` and trims edges so segments stay non-empty
-     * when the input had any content.
+     * when the input had any content. Reserved Windows device names (`CON`, `NUL`, `COM1`, …) get
+     * an underscore suffix so `createDirectories` does not fail on Windows.
      */
     internal fun sanitizePathSegment(raw: String): String {
         val cleaned =
@@ -52,6 +53,24 @@ public object FailureArtifactPaths {
                 .joinToString("")
                 .replace(Regex("_+"), "_")
                 .trim('_')
-        return cleaned.ifEmpty { "unnamed" }
+        val base = cleaned.ifEmpty { "unnamed" }
+        return if (isReservedWindowsDeviceName(base)) "${base}_" else base
+    }
+
+    /**
+     * True when [name] is a Windows reserved device name (case-insensitive), including optional
+     * extension forms such as `nul.txt` / `COM1.anything`.
+     */
+    private fun isReservedWindowsDeviceName(name: String): Boolean {
+        val stem = name.substringBefore('.').lowercase()
+        return stem in RESERVED_WINDOWS_DEVICE_NAMES
+    }
+
+    private val RESERVED_WINDOWS_DEVICE_NAMES: Set<String> = buildSet {
+        addAll(listOf("con", "prn", "aux", "nul"))
+        for (n in 0..9) {
+            add("com$n")
+            add("lpt$n")
+        }
     }
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -6,14 +6,16 @@ import kotlin.io.path.absolute
 /**
  * Path layout for JUnit failure artifacts under `build/reports/spectre/`.
  *
- * Layout:
+ * Layout (as written by [FailureArtifactCapture]):
  * ```
- * <reportsRoot>/<test-class>/<test-method>[/attempt-N]/window-<i>/{capture.json,screenshot.png}
+ * <reportsRoot>/<test-class>/<test-method>[/<invocationId>][/attempt-N]/run-<nano>/window-<i>/{capture.json,screenshot.png}
  * ```
  *
  * Each `window-<i>` directory matches the atomic-capture layout from #181 so `spectre-capture` `jq`
  * recipes work unchanged. Retry attempts use a nested `attempt-N` directory (not a method-name
- * suffix) so they cannot collide with a test literally named `…-attempt-N`.
+ * suffix) so they cannot collide with a test literally named `…-attempt-N`. Optional
+ * [FailureArtifactsConfig.invocationId] distinguishes parallel invocations. Captures always land
+ * under a unique `run-*` tree so concurrent/locked leftovers cannot interleave files.
  */
 public object FailureArtifactPaths {
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -121,7 +121,7 @@ public object FailureArtifactPaths {
         // distinct display names that sanitize to the same base.
         var hash = FNV_OFFSET_BASIS
         for (byte in value.toByteArray(Charsets.UTF_8)) {
-            hash = hash xor (byte.toLong() and 0xFFL)
+            hash = hash xor (byte.toLong() and BYTE_MASK)
             hash *= FNV_PRIME
         }
         return java.lang.Long.toUnsignedString(hash, HASH_RADIX).padStart(HASH_WIDTH, '0')
@@ -162,6 +162,7 @@ public object FailureArtifactPaths {
 
     private const val HASH_RADIX: Int = 16
     private const val HASH_WIDTH: Int = 16
+    private const val BYTE_MASK: Long = 0xFFL
     private const val FNV_OFFSET_BASIS: Long = -0x340d631b7bdddcdbL // 0xcbf29ce484222325
     private const val FNV_PRIME: Long = 0x100000001b3L
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -30,7 +30,11 @@ public object FailureArtifactPaths {
     ): Path {
         val classSeg = sanitizePathSegment(testClassName)
         val methodSeg = sanitizePathSegment(testMethodName)
-        val methodDir = config.reportsRoot.resolve(classSeg).resolve(methodSeg)
+        var methodDir = config.reportsRoot.resolve(classSeg).resolve(methodSeg)
+        val invocation = config.invocationId?.takeIf { it.isNotBlank() }
+        if (invocation != null) {
+            methodDir = methodDir.resolve(sanitizePathSegment(invocation))
+        }
         val attempt = config.attemptIndex
         return if (attempt != null && attempt > 1) {
             methodDir.resolve("attempt-$attempt")

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -67,16 +67,17 @@ public object FailureArtifactPaths {
                 }
                 .joinToString("")
                 .replace(Regex("_+"), "_")
-                // Windows rejects/normalizes trailing dots and spaces; strip them so the
-                // segment is a real directory name. Lossy vs raw → hash below.
-                .trimEnd('.', ' ')
-                .trim('_')
+        val core = cleaned.trim('_')
         val base =
             when {
-                cleaned.isEmpty() -> "unnamed"
-                cleaned == "." -> "dot"
-                cleaned == ".." -> "dotdot"
-                else -> cleaned
+                core.isEmpty() -> "unnamed"
+                // Pure-dot labels (before stripping trailing dots for Windows) map to literals
+                // so they never navigate `..` out of the reports root.
+                core.all { it == '.' } -> if (core.length == 1) "dot" else "dotdot"
+                else ->
+                    // Windows rejects/normalizes trailing dots and spaces; strip them so the
+                    // segment is a real directory name. Lossy vs raw → hash below.
+                    core.trimEnd('.', ' ').trim('_').ifEmpty { "unnamed" }
             }
         val escaped = escapeReservedWindowsDeviceName(base)
         // Preserve uniqueness when the sanitize path was lossy relative to the original label.
@@ -136,8 +137,8 @@ public object FailureArtifactPaths {
                     lead and 0xF8 == 0xF0 -> 4
                     else -> 1
                 }
-            if (index + charLen > bytes.size) break
-            if (end + charLen > maxBytes) break
+            val fits = index + charLen <= bytes.size && end + charLen <= maxBytes
+            if (!fits) break
             end += charLen
             index += charLen
         }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -1,0 +1,57 @@
+package dev.sebastiano.spectre.testing
+
+import java.nio.file.Path
+import kotlin.io.path.absolute
+
+/**
+ * Path layout for JUnit failure artifacts under `build/reports/spectre/`.
+ *
+ * Layout:
+ * ```
+ * <reportsRoot>/<test-class>/<test-method>[-attempt-N]/window-<i>/{capture.json,screenshot.png}
+ * ```
+ *
+ * Each `window-<i>` directory matches the atomic-capture layout from #181 so `spectre-capture` `jq`
+ * recipes work unchanged.
+ */
+public object FailureArtifactPaths {
+
+    public fun defaultReportsRoot(): Path =
+        Path.of("build", "reports", "spectre").absolute().normalize()
+
+    public fun methodDirectory(
+        testClassName: String,
+        testMethodName: String,
+        config: FailureArtifactsConfig,
+    ): Path {
+        val classSeg = sanitizePathSegment(testClassName)
+        val methodSeg =
+            sanitizePathSegment(testMethodName).let { base ->
+                val attempt = config.attemptIndex
+                if (attempt != null && attempt > 1) "$base-attempt-$attempt" else base
+            }
+        return config.reportsRoot.resolve(classSeg).resolve(methodSeg)
+    }
+
+    public fun windowDirectory(methodDirectory: Path, windowIndex: Int): Path =
+        methodDirectory.resolve("window-$windowIndex")
+
+    /**
+     * Replaces characters that are hostile on common filesystems or ambiguous in shell globs.
+     * Collapses runs of replacements to a single `_` and trims edges so segments stay non-empty
+     * when the input had any content.
+     */
+    internal fun sanitizePathSegment(raw: String): String {
+        val cleaned =
+            raw.map { ch ->
+                    when {
+                        ch.isLetterOrDigit() || ch == '.' || ch == '-' || ch == '_' -> ch
+                        else -> '_'
+                    }
+                }
+                .joinToString("")
+                .replace(Regex("_+"), "_")
+                .trim('_')
+        return cleaned.ifEmpty { "unnamed" }
+    }
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -77,11 +77,11 @@ public object FailureArtifactPaths {
                     core.trimEnd('.', ' ').trim('_').ifEmpty { "unnamed" }
             }
         val escaped = escapeReservedWindowsDeviceName(base)
-        // Preserve uniqueness when the sanitize path was lossy relative to the original label,
-        // or when the label has uppercase letters (case-insensitive volumes would otherwise alias
-        // `caseA` and `CaseA` onto the same directory).
-        val needsHash = escaped != raw || raw.any { it.isUpperCase() }
-        val unique = if (needsHash) "${escaped}_${shortHash(raw)}" else escaped
+        // Always append a stable hash of the original label so distinct raw names that alias after
+        // sanitize (punctuation, case folding, Unicode case folds on case-insensitive volumes)
+        // never
+        // share a directory.
+        val unique = "${escaped}_${shortHash(raw)}"
         return boundSegmentLength(unique)
     }
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -78,9 +78,9 @@ public object FailureArtifactPaths {
                 // so they never navigate `..` out of the reports root.
                 core.all { it == '.' } -> if (core.length == 1) "dot" else "dotdot"
                 else ->
-                    // Windows rejects/normalizes trailing dots and spaces; strip them so the
-                    // segment is a real directory name. Lossy vs raw → hash below.
-                    core.trimEnd('.', ' ').trim('_').ifEmpty { "unnamed" }
+                    // Windows rejects/normalizes leading/trailing dots and spaces; strip them so
+                    // the segment is a real directory name. Lossy vs raw → hash below.
+                    core.trim('.', ' ').trim('_').ifEmpty { "unnamed" }
             }
         val escaped = escapeReservedWindowsDeviceName(base)
         // Always append a stable hash of the original label so distinct raw names that alias after

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPaths.kt
@@ -116,8 +116,16 @@ public object FailureArtifactPaths {
         return prefix + suffix
     }
 
-    private fun shortHash(value: String): String =
-        Integer.toUnsignedString(value.hashCode(), HASH_RADIX).padStart(HASH_WIDTH, '0')
+    private fun shortHash(value: String): String {
+        // FNV-1a 64-bit hex (16 chars) — more collision-resistant than String.hashCode for
+        // distinct display names that sanitize to the same base.
+        var hash = FNV_OFFSET_BASIS
+        for (byte in value.toByteArray(Charsets.UTF_8)) {
+            hash = hash xor (byte.toLong() and 0xFFL)
+            hash *= FNV_PRIME
+        }
+        return java.lang.Long.toUnsignedString(hash, HASH_RADIX).padStart(HASH_WIDTH, '0')
+    }
 
     /**
      * Longest UTF-8 prefix of [bytes] whose length is at most [maxBytes] and ends on a complete
@@ -153,5 +161,7 @@ public object FailureArtifactPaths {
     }
 
     private const val HASH_RADIX: Int = 16
-    private const val HASH_WIDTH: Int = 8
+    private const val HASH_WIDTH: Int = 16
+    private const val FNV_OFFSET_BASIS: Long = -0x340d631b7bdddcdbL // 0xcbf29ce484222325
+    private const val FNV_PRIME: Long = 0x100000001b3L
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactsConfig.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactsConfig.kt
@@ -12,12 +12,18 @@ import java.nio.file.Path
  * `user.dir`) so Gradle `clean` and a single CI `upload-artifact` glob own their lifecycle —
  * deliberately not the `$TMPDIR` capture root used by the CLI/agent.
  *
- * [attemptIndex] is 1-based. When greater than 1, the method directory is suffixed with
- * `-attempt-<n>` so retries do not overwrite prior attempt captures (and stay out of the way of
- * future `runSpectreTest` paths — see #110).
+ * [attemptIndex] is **1-based**. When greater than 1, artifacts nest under an `attempt-<n>`
+ * directory so retries do not overwrite prior attempt captures and do not collide with a test
+ * literally named `…-attempt-N` (see #110 / future `runSpectreTest`).
  */
 public data class FailureArtifactsConfig(
     public val enabled: Boolean = true,
     public val reportsRoot: Path = FailureArtifactPaths.defaultReportsRoot(),
     public val attemptIndex: Int? = null,
-)
+) {
+    init {
+        require(attemptIndex == null || attemptIndex >= 1) {
+            "attemptIndex must be null or >= 1 (1-based), was $attemptIndex"
+        }
+    }
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactsConfig.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactsConfig.kt
@@ -1,0 +1,23 @@
+package dev.sebastiano.spectre.testing
+
+import java.nio.file.Path
+
+/**
+ * Configuration for writing atomic capture artifacts when a Spectre-driven JUnit test fails.
+ *
+ * Default is **enabled**. Opt out with `FailureArtifactsConfig(enabled = false)` when wiring the
+ * JUnit extension/rule (see epic #205).
+ *
+ * Artifacts land under [reportsRoot] (default `build/reports/spectre` under the test JVM's
+ * `user.dir`) so Gradle `clean` and a single CI `upload-artifact` glob own their lifecycle —
+ * deliberately not the `$TMPDIR` capture root used by the CLI/agent.
+ *
+ * [attemptIndex] is 1-based. When greater than 1, the method directory is suffixed with
+ * `-attempt-<n>` so retries do not overwrite prior attempt captures (and stay out of the way of
+ * future `runSpectreTest` paths — see #110).
+ */
+public data class FailureArtifactsConfig(
+    public val enabled: Boolean = true,
+    public val reportsRoot: Path = FailureArtifactPaths.defaultReportsRoot(),
+    public val attemptIndex: Int? = null,
+)

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactsConfig.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactsConfig.kt
@@ -15,11 +15,16 @@ import java.nio.file.Path
  * [attemptIndex] is **1-based**. When greater than 1, artifacts nest under an `attempt-<n>`
  * directory so retries do not overwrite prior attempt captures and do not collide with a test
  * literally named `…-attempt-N` (see #110 / future `runSpectreTest`).
+ *
+ * [invocationId] distinguishes parallel or repeated invocations of the same class/method that share
+ * a null attempt index (JUnit 5 unique id / display name). When non-null/blank it becomes an extra
+ * path segment under the method directory.
  */
 public data class FailureArtifactsConfig(
     public val enabled: Boolean = true,
     public val reportsRoot: Path = FailureArtifactPaths.defaultReportsRoot(),
     public val attemptIndex: Int? = null,
+    public val invocationId: String? = null,
 ) {
     init {
         require(attemptIndex == null || attemptIndex >= 1) {

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
@@ -29,14 +29,15 @@ class FailureArtifactCaptureTest {
 
         assertEquals(2, captures.size)
         for (index in 0..1) {
-            val windowDir = methodDir.resolve("window-$index")
+            val windowDir = captures[index].directory
+            assertTrue(windowDir.parent.fileName.toString().startsWith("run-"))
+            assertEquals("window-$index", windowDir.fileName.toString())
             val json = windowDir.resolve(CaptureArtifactsWriter.CAPTURE_JSON_NAME)
             val png = windowDir.resolve(CaptureArtifactsWriter.SCREENSHOT_PNG_NAME)
             assertTrue(Files.isRegularFile(json), "missing $json")
             assertTrue(Files.isRegularFile(png), "missing $png")
             assertTrue(Files.size(json) > 0)
             assertTrue(Files.size(png) > 0)
-            assertEquals(windowDir, captures[index].directory)
         }
     }
 
@@ -66,9 +67,11 @@ class FailureArtifactCaptureTest {
                 },
             )
         assertEquals(2, captures.size)
-        assertTrue(Files.isRegularFile(methodDir.resolve("window-0").resolve("capture.json")))
-        assertFalse(Files.exists(methodDir.resolve("window-1")))
-        assertTrue(Files.isRegularFile(methodDir.resolve("window-2").resolve("capture.json")))
+        val runDir = captures.first().directory.parent
+        assertTrue(runDir.fileName.toString().startsWith("run-"))
+        assertTrue(Files.isRegularFile(runDir.resolve("window-0").resolve("capture.json")))
+        assertFalse(Files.exists(runDir.resolve("window-1")))
+        assertTrue(Files.isRegularFile(runDir.resolve("window-2").resolve("capture.json")))
     }
 
     @Test

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
@@ -108,6 +108,22 @@ class FailureArtifactCaptureTest {
         assertFalse(Files.exists(methodDir.resolve("window-9")))
     }
 
+    @Test
+    fun `successful captures land under a run subdir`(@TempDir temp: Path) {
+        val methodDir = temp.resolve("com.example.T").resolve("ok")
+        val captures =
+            FailureArtifactCapture.captureWindows(
+                methodDirectory = methodDir,
+                windowCount = 1,
+                captureWindow = { fakeAtomicCapture(windowIndex = 0) },
+            )
+        assertEquals(1, captures.size)
+        val dir = captures.single().directory
+        assertTrue(dir.parent.fileName.toString().startsWith("run-"))
+        assertEquals("window-0", dir.fileName.toString())
+        assertTrue(Files.isRegularFile(dir.resolve("capture.json")))
+    }
+
     private fun fakeAtomicCapture(windowIndex: Int): AtomicCapture {
         val image = BufferedImage(4, 4, BufferedImage.TYPE_INT_ARGB)
         val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47) // minimal non-empty stub

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
@@ -85,14 +85,16 @@ class FailureArtifactCaptureTest {
     }
 
     @Test
-    fun `clears stale window dir before capturing`(@TempDir temp: Path) {
+    fun `clears all stale window dirs before capturing`(@TempDir temp: Path) {
         val methodDir = temp.resolve("com.example.T").resolve("stale")
-        val windowDir = methodDir.resolve("window-0")
-        Files.createDirectories(windowDir)
-        val stale = windowDir.resolve("capture.json")
-        Files.writeString(stale, "stale-from-previous-failure")
+        val stale0 = methodDir.resolve("window-0").resolve("capture.json")
+        val stale9 = methodDir.resolve("window-9").resolve("capture.json")
+        Files.createDirectories(stale0.parent)
+        Files.createDirectories(stale9.parent)
+        Files.writeString(stale0, "stale-0")
+        Files.writeString(stale9, "stale-9")
 
-        // Capture fails before write — stale dir must still be gone so CI cannot publish it.
+        // Only one window this run — higher-index leftovers must still be purged.
         val captures =
             FailureArtifactCapture.captureWindows(
                 methodDirectory = methodDir,
@@ -100,8 +102,10 @@ class FailureArtifactCaptureTest {
                 captureWindow = { error("capture boom") },
             )
         assertTrue(captures.isEmpty())
-        assertFalse(Files.exists(stale))
-        assertFalse(Files.exists(windowDir))
+        assertFalse(Files.exists(stale0))
+        assertFalse(Files.exists(stale9))
+        assertFalse(Files.exists(methodDir.resolve("window-0")))
+        assertFalse(Files.exists(methodDir.resolve("window-9")))
     }
 
     private fun fakeAtomicCapture(windowIndex: Int): AtomicCapture {

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
@@ -71,6 +71,19 @@ class FailureArtifactCaptureTest {
         assertTrue(Files.isRegularFile(methodDir.resolve("window-2").resolve("capture.json")))
     }
 
+    @Test
+    fun `returns empty list when window discovery throws`(@TempDir temp: Path) {
+        val methodDir = temp.resolve("com.example.T").resolve("discovery")
+        val captures =
+            FailureArtifactCapture.captureFromDiscovery(
+                methodDirectory = methodDir,
+                discoverWindowCount = { error("EDT died during refresh") },
+                captureWindow = { error("should not capture") },
+            )
+        assertTrue(captures.isEmpty())
+        assertFalse(Files.exists(methodDir))
+    }
+
     private fun fakeAtomicCapture(windowIndex: Int): AtomicCapture {
         val image = BufferedImage(4, 4, BufferedImage.TYPE_INT_ARGB)
         val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47) // minimal non-empty stub

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
@@ -84,6 +84,29 @@ class FailureArtifactCaptureTest {
         assertFalse(Files.exists(methodDir))
     }
 
+    @Test
+    fun `removes partial window directory when write fails after capture`(@TempDir temp: Path) {
+        val methodDir = temp.resolve("com.example.T").resolve("partial-write")
+        // Pre-create a stale half-written capture dir that a failed write would leave behind
+        // if cleanup did not run; the capture lambda succeeds but we force write failure by
+        // making the window path a *file* so createDirectories fails.
+        val blocker = methodDir.resolve("window-0")
+        Files.createDirectories(methodDir)
+        Files.writeString(blocker, "not-a-directory")
+
+        val captures =
+            FailureArtifactCapture.captureWindows(
+                methodDirectory = methodDir,
+                windowCount = 1,
+                captureWindow = { fakeAtomicCapture(windowIndex = 0) },
+            )
+        assertTrue(captures.isEmpty())
+        // Best-effort: either the blocker file remains (mkdir never started) or a partial
+        // capture dir was removed. A half-written capture.json+png pair must not remain.
+        val json = methodDir.resolve("window-0").resolve("capture.json")
+        assertFalse(Files.isRegularFile(json))
+    }
+
     private fun fakeAtomicCapture(windowIndex: Int): AtomicCapture {
         val image = BufferedImage(4, 4, BufferedImage.TYPE_INT_ARGB)
         val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47) // minimal non-empty stub

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
@@ -85,26 +85,23 @@ class FailureArtifactCaptureTest {
     }
 
     @Test
-    fun `removes partial window directory when write fails after capture`(@TempDir temp: Path) {
-        val methodDir = temp.resolve("com.example.T").resolve("partial-write")
-        // Pre-create a stale half-written capture dir that a failed write would leave behind
-        // if cleanup did not run; the capture lambda succeeds but we force write failure by
-        // making the window path a *file* so createDirectories fails.
-        val blocker = methodDir.resolve("window-0")
-        Files.createDirectories(methodDir)
-        Files.writeString(blocker, "not-a-directory")
+    fun `clears stale window dir before capturing`(@TempDir temp: Path) {
+        val methodDir = temp.resolve("com.example.T").resolve("stale")
+        val windowDir = methodDir.resolve("window-0")
+        Files.createDirectories(windowDir)
+        val stale = windowDir.resolve("capture.json")
+        Files.writeString(stale, "stale-from-previous-failure")
 
+        // Capture fails before write — stale dir must still be gone so CI cannot publish it.
         val captures =
             FailureArtifactCapture.captureWindows(
                 methodDirectory = methodDir,
                 windowCount = 1,
-                captureWindow = { fakeAtomicCapture(windowIndex = 0) },
+                captureWindow = { error("capture boom") },
             )
         assertTrue(captures.isEmpty())
-        // Best-effort: either the blocker file remains (mkdir never started) or a partial
-        // capture dir was removed. A half-written capture.json+png pair must not remain.
-        val json = methodDir.resolve("window-0").resolve("capture.json")
-        assertFalse(Files.isRegularFile(json))
+        assertFalse(Files.exists(stale))
+        assertFalse(Files.exists(windowDir))
     }
 
     private fun fakeAtomicCapture(windowIndex: Int): AtomicCapture {

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactCaptureTest.kt
@@ -1,0 +1,106 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.capture.AtomicCapture
+import dev.sebastiano.spectre.core.capture.CaptureArtifactsWriter
+import dev.sebastiano.spectre.core.capture.CaptureDocument
+import dev.sebastiano.spectre.core.capture.CaptureRect
+import dev.sebastiano.spectre.core.capture.CaptureSummary
+import dev.sebastiano.spectre.core.capture.CaptureWindow
+import java.awt.image.BufferedImage
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class FailureArtifactCaptureTest {
+
+    @Test
+    fun `writes capture json and png for each window under window-N dirs`(@TempDir temp: Path) {
+        val methodDir = temp.resolve("com.example.T").resolve("fails")
+        val captures =
+            FailureArtifactCapture.captureWindows(
+                methodDirectory = methodDir,
+                windowCount = 2,
+                captureWindow = { index -> fakeAtomicCapture(windowIndex = index) },
+            )
+
+        assertEquals(2, captures.size)
+        for (index in 0..1) {
+            val windowDir = methodDir.resolve("window-$index")
+            val json = windowDir.resolve(CaptureArtifactsWriter.CAPTURE_JSON_NAME)
+            val png = windowDir.resolve(CaptureArtifactsWriter.SCREENSHOT_PNG_NAME)
+            assertTrue(Files.isRegularFile(json), "missing $json")
+            assertTrue(Files.isRegularFile(png), "missing $png")
+            assertTrue(Files.size(json) > 0)
+            assertTrue(Files.size(png) > 0)
+            assertEquals(windowDir, captures[index].directory)
+        }
+    }
+
+    @Test
+    fun `zero windows writes nothing`(@TempDir temp: Path) {
+        val methodDir = temp.resolve("com.example.T").resolve("empty")
+        val captures =
+            FailureArtifactCapture.captureWindows(
+                methodDirectory = methodDir,
+                windowCount = 0,
+                captureWindow = { error("should not capture") },
+            )
+        assertTrue(captures.isEmpty())
+        assertFalse(Files.exists(methodDir))
+    }
+
+    @Test
+    fun `continues remaining windows when one capture throws`(@TempDir temp: Path) {
+        val methodDir = temp.resolve("com.example.T").resolve("partial")
+        val captures =
+            FailureArtifactCapture.captureWindows(
+                methodDirectory = methodDir,
+                windowCount = 3,
+                captureWindow = { index ->
+                    if (index == 1) error("boom on window 1")
+                    fakeAtomicCapture(windowIndex = index)
+                },
+            )
+        assertEquals(2, captures.size)
+        assertTrue(Files.isRegularFile(methodDir.resolve("window-0").resolve("capture.json")))
+        assertFalse(Files.exists(methodDir.resolve("window-1")))
+        assertTrue(Files.isRegularFile(methodDir.resolve("window-2").resolve("capture.json")))
+    }
+
+    private fun fakeAtomicCapture(windowIndex: Int): AtomicCapture {
+        val image = BufferedImage(4, 4, BufferedImage.TYPE_INT_ARGB)
+        val pngBytes = byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47) // minimal non-empty stub
+        val document =
+            CaptureDocument(
+                schemaVersion = CaptureDocument.SCHEMA_VERSION,
+                capturedAt = "2026-01-01T00:00:00Z",
+                window =
+                    CaptureWindow(
+                        index = windowIndex,
+                        surfaceId = "surface-$windowIndex",
+                        title = "Window $windowIndex",
+                        isPopup = false,
+                        boundsScreen = CaptureRect(0, 0, 4, 4),
+                        densityScaleX = 1.0,
+                        densityScaleY = 1.0,
+                        imageWidth = 4,
+                        imageHeight = 4,
+                    ),
+                nodes = emptyList(),
+                summary =
+                    CaptureSummary(
+                        nodeCount = 0,
+                        taggedNodeCount = 0,
+                        textedNodeCount = 0,
+                        imageWidth = 4,
+                        imageHeight = 4,
+                        captureDurationMs = 1,
+                    ),
+            )
+        return AtomicCapture(image = image, pngBytes = pngBytes, document = document)
+    }
+}

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
@@ -193,6 +193,35 @@ class FailureArtifactPathsTest {
     }
 
     @Test
+    fun `trailing dots are stripped as a lossy Windows-safe transform`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "case.",
+                config = config,
+            )
+        assertFalse(dir.fileName.toString().endsWith("."))
+        assertTrue(dir.fileName.toString().startsWith("case"))
+    }
+
+    @Test
+    fun `multibyte truncation stays within byte budget`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val longName = "é".repeat(400)
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = longName,
+                config = config,
+            )
+        assertTrue(
+            dir.fileName.toString().toByteArray(Charsets.UTF_8).size <=
+                FailureArtifactPaths.MAX_SEGMENT_BYTES
+        )
+    }
+
+    @Test
     fun `config defaults to enabled`() {
         assertTrue(FailureArtifactsConfig().enabled)
     }

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.testing
 import java.nio.file.Path
 import kotlin.io.path.createTempDirectory
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Test
@@ -25,11 +26,13 @@ class FailureArtifactPathsTest {
                 testMethodName = "waitForNodeFails",
                 config = config,
             )
-        assertEquals(temp.resolve("com.example.MyTest").resolve("waitForNodeFails"), dir)
+        assertTrue(dir.startsWith(temp))
+        assertTrue(dir.parent.fileName.toString().startsWith("com.example.MyTest"))
+        assertTrue(dir.fileName.toString().startsWith("waitForNodeFails"))
     }
 
     @Test
-    fun `attempt index greater than 1 suffixes the method directory`(@TempDir temp: Path) {
+    fun `attempt index greater than 1 nests under attempt-N`(@TempDir temp: Path) {
         val config = FailureArtifactsConfig(reportsRoot = temp, attemptIndex = 2)
         val dir =
             FailureArtifactPaths.methodDirectory(
@@ -37,11 +40,55 @@ class FailureArtifactPathsTest {
                 testMethodName = "flaky",
                 config = config,
             )
-        assertEquals(temp.resolve("com.example.MyTest").resolve("flaky-attempt-2"), dir)
+        assertEquals("attempt-2", dir.fileName.toString())
+        assertTrue(dir.parent.fileName.toString().startsWith("flaky"))
     }
 
     @Test
-    fun `attempt index 1 does not suffix the method directory`(@TempDir temp: Path) {
+    fun `attempt nest does not collide with a literal attempt method name`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp, attemptIndex = 2)
+        val retryDir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "flaky",
+                config = config,
+            )
+        val literal =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "flaky-attempt-2",
+                config = FailureArtifactsConfig(reportsRoot = temp),
+            )
+        assertTrue(retryDir != literal)
+        assertEquals("attempt-2", retryDir.fileName.toString())
+    }
+
+    @Test
+    fun `non-positive attempt index is rejected`() {
+        assertFailsWith<IllegalArgumentException> { FailureArtifactsConfig(attemptIndex = 0) }
+        assertFailsWith<IllegalArgumentException> { FailureArtifactsConfig(attemptIndex = -1) }
+    }
+
+    @Test
+    fun `case-only differences get distinct directories`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val a =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "caseA",
+                config = config,
+            )
+        val b =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "CaseA",
+                config = config,
+            )
+        assertTrue(a.fileName != b.fileName)
+    }
+
+    @Test
+    fun `attempt index 1 does not nest attempt directory`(@TempDir temp: Path) {
         val config = FailureArtifactsConfig(reportsRoot = temp, attemptIndex = 1)
         val dir =
             FailureArtifactPaths.methodDirectory(
@@ -49,7 +96,8 @@ class FailureArtifactPathsTest {
                 testMethodName = "once",
                 config = config,
             )
-        assertEquals(temp.resolve("com.example.MyTest").resolve("once"), dir)
+        assertTrue(dir.fileName.toString().startsWith("once"))
+        assertFalse(dir.fileName.toString().startsWith("attempt-"))
     }
 
     @Test
@@ -119,7 +167,9 @@ class FailureArtifactPathsTest {
                 config = config,
             )
         assertTrue(dot.fileName.toString().startsWith("dot"))
-        assertTrue(dot.startsWith(temp.resolve("com.example.T")))
+        assertTrue(
+            dot.startsWith(temp.resolve(FailureArtifactPaths.sanitizePathSegment("com.example.T")))
+        )
 
         val dotdot =
             FailureArtifactPaths.methodDirectory(
@@ -186,10 +236,12 @@ class FailureArtifactPathsTest {
                 testMethodName = longName,
                 config = config,
             )
+        // Nested attempt-N is short; method segment itself must stay in bound.
         assertTrue(
-            dir.fileName.toString().toByteArray(Charsets.UTF_8).size <=
+            dir.parent.fileName.toString().toByteArray(Charsets.UTF_8).size <=
                 FailureArtifactPaths.MAX_SEGMENT_BYTES
         )
+        assertEquals("attempt-12", dir.fileName.toString())
     }
 
     @Test

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
@@ -45,6 +45,20 @@ class FailureArtifactPathsTest {
     }
 
     @Test
+    fun `invocationId nests under the method directory`(@TempDir temp: Path) {
+        val config =
+            FailureArtifactsConfig(reportsRoot = temp, invocationId = "invocation-unique-1")
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "parallel",
+                config = config,
+            )
+        assertTrue(dir.parent.fileName.toString().startsWith("parallel"))
+        assertTrue(dir.fileName.toString().startsWith("invocation-unique-1"))
+    }
+
+    @Test
     fun `attempt nest does not collide with a literal attempt method name`(@TempDir temp: Path) {
         val config = FailureArtifactsConfig(reportsRoot = temp, attemptIndex = 2)
         val retryDir =

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
@@ -78,7 +78,7 @@ class FailureArtifactPathsTest {
     }
 
     @Test
-    fun `reserved Windows device names are suffixed`(@TempDir temp: Path) {
+    fun `reserved Windows device names are escaped after the stem`(@TempDir temp: Path) {
         val config = FailureArtifactsConfig(reportsRoot = temp)
         val dir =
             FailureArtifactPaths.methodDirectory(
@@ -96,13 +96,15 @@ class FailureArtifactPathsTest {
             )
         assertEquals("com1_", com1.fileName.toString())
 
+        // Windows keys off the stem before the first '.'; so the underscore must land on the
+        // stem (`nul_.txt`), not as a trailing suffix on the whole segment (`nul.txt_`).
         val nulTxt =
             FailureArtifactPaths.methodDirectory(
                 testClassName = "com.example.T",
                 testMethodName = "nul.txt",
                 config = config,
             )
-        assertEquals("nul.txt_", nulTxt.fileName.toString())
+        assertEquals("nul_.txt", nulTxt.fileName.toString())
     }
 
     @Test

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
@@ -78,6 +78,34 @@ class FailureArtifactPathsTest {
     }
 
     @Test
+    fun `reserved Windows device names are suffixed`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "NUL",
+                config = config,
+            )
+        assertEquals("NUL_", dir.fileName.toString())
+
+        val com1 =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "com1",
+                config = config,
+            )
+        assertEquals("com1_", com1.fileName.toString())
+
+        val nulTxt =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "nul.txt",
+                config = config,
+            )
+        assertEquals("nul.txt_", nulTxt.fileName.toString())
+    }
+
+    @Test
     fun `config defaults to enabled`() {
         assertTrue(FailureArtifactsConfig().enabled)
     }

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
@@ -1,0 +1,99 @@
+package dev.sebastiano.spectre.testing
+
+import java.nio.file.Path
+import kotlin.io.path.createTempDirectory
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+class FailureArtifactPathsTest {
+
+    @Test
+    fun `default reports root is build reports spectre under user dir`() {
+        val root = FailureArtifactPaths.defaultReportsRoot()
+        assertEquals(Path.of("build", "reports", "spectre").toAbsolutePath().normalize(), root)
+    }
+
+    @Test
+    fun `method directory uses fully qualified class and method name`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.MyTest",
+                testMethodName = "waitForNodeFails",
+                config = config,
+            )
+        assertEquals(temp.resolve("com.example.MyTest").resolve("waitForNodeFails"), dir)
+    }
+
+    @Test
+    fun `attempt index greater than 1 suffixes the method directory`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp, attemptIndex = 2)
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.MyTest",
+                testMethodName = "flaky",
+                config = config,
+            )
+        assertEquals(temp.resolve("com.example.MyTest").resolve("flaky-attempt-2"), dir)
+    }
+
+    @Test
+    fun `attempt index 1 does not suffix the method directory`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp, attemptIndex = 1)
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.MyTest",
+                testMethodName = "once",
+                config = config,
+            )
+        assertEquals(temp.resolve("com.example.MyTest").resolve("once"), dir)
+    }
+
+    @Test
+    fun `sanitizes path-hostile characters in class and method names`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.Nested\$Inner",
+                testMethodName = "param[0] with spaces",
+                config = config,
+            )
+        val classSeg = dir.parent.fileName.toString()
+        val methodSeg = dir.fileName.toString()
+        assertFalse(classSeg.contains('$'))
+        assertFalse(methodSeg.contains('['))
+        assertFalse(methodSeg.contains(']'))
+        assertFalse(methodSeg.contains(' '))
+        assertTrue(methodSeg.isNotBlank())
+    }
+
+    @Test
+    fun `window directory is method dir plus window index`(@TempDir temp: Path) {
+        val methodDir = temp.resolve("cls").resolve("method")
+        val windowDir = FailureArtifactPaths.windowDirectory(methodDir, windowIndex = 3)
+        assertEquals(methodDir.resolve("window-3"), windowDir)
+    }
+
+    @Test
+    fun `config defaults to enabled`() {
+        assertTrue(FailureArtifactsConfig().enabled)
+    }
+
+    @Test
+    fun `disabled config is explicit opt-out`() {
+        assertFalse(FailureArtifactsConfig(enabled = false).enabled)
+    }
+
+    @Test
+    fun `defaultReportsRoot does not create directories`() {
+        // Ensure the helper is pure path computation — no mkdir side effects on a fresh path.
+        val before = createTempDirectory("spectre-fail-art-").toFile()
+        before.delete()
+        // Just exercise the pure function; existence is independent of call.
+        val root = FailureArtifactPaths.defaultReportsRoot()
+        assertEquals("spectre", root.fileName.toString())
+    }
+}

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
@@ -177,6 +177,22 @@ class FailureArtifactPathsTest {
     }
 
     @Test
+    fun `attempt suffix does not exceed segment byte limit`(@TempDir temp: Path) {
+        val longName = "m".repeat(400)
+        val config = FailureArtifactsConfig(reportsRoot = temp, attemptIndex = 12)
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = longName,
+                config = config,
+            )
+        assertTrue(
+            dir.fileName.toString().toByteArray(Charsets.UTF_8).size <=
+                FailureArtifactPaths.MAX_SEGMENT_BYTES
+        )
+    }
+
+    @Test
     fun `config defaults to enabled`() {
         assertTrue(FailureArtifactsConfig().enabled)
     }

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
@@ -86,7 +86,9 @@ class FailureArtifactPathsTest {
                 testMethodName = "NUL",
                 config = config,
             )
-        assertEquals("NUL_", dir.fileName.toString())
+        // Lossy escape also appends a stable hash of the original label.
+        assertTrue(dir.fileName.toString().startsWith("NUL_"))
+        assertTrue(dir.fileName.toString().length > "NUL_".length)
 
         val com1 =
             FailureArtifactPaths.methodDirectory(
@@ -94,17 +96,84 @@ class FailureArtifactPathsTest {
                 testMethodName = "com1",
                 config = config,
             )
-        assertEquals("com1_", com1.fileName.toString())
+        assertTrue(com1.fileName.toString().startsWith("com1_"))
 
         // Windows keys off the stem before the first '.'; so the underscore must land on the
-        // stem (`nul_.txt`), not as a trailing suffix on the whole segment (`nul.txt_`).
+        // stem (`nul_.txt…`), not as a trailing suffix on the whole segment (`nul.txt_`).
         val nulTxt =
             FailureArtifactPaths.methodDirectory(
                 testClassName = "com.example.T",
                 testMethodName = "nul.txt",
                 config = config,
             )
-        assertEquals("nul_.txt", nulTxt.fileName.toString())
+        assertTrue(nulTxt.fileName.toString().startsWith("nul_.txt"))
+    }
+
+    @Test
+    fun `dot-only names do not navigate the filesystem`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val dot =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = ".",
+                config = config,
+            )
+        assertTrue(dot.fileName.toString().startsWith("dot"))
+        assertTrue(dot.startsWith(temp.resolve("com.example.T")))
+
+        val dotdot =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "..",
+                testMethodName = "method",
+                config = config,
+            )
+        assertTrue(dotdot.parent.fileName.toString().startsWith("dotdot"))
+        assertTrue(dotdot.startsWith(temp))
+    }
+
+    @Test
+    fun `lossy sanitization keeps distinct punctuation variants unique`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val bracket =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "case[1]",
+                config = config,
+            )
+        val paren =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "case(1)",
+                config = config,
+            )
+        assertTrue(bracket.fileName != paren.fileName)
+        assertTrue(bracket.fileName.toString().startsWith("case_1_"))
+        assertTrue(paren.fileName.toString().startsWith("case_1_"))
+    }
+
+    @Test
+    fun `overlong segments are truncated under filesystem byte limit`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val longName = "a".repeat(400)
+        val dir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = longName,
+                config = config,
+            )
+        val segment = dir.fileName.toString()
+        assertTrue(
+            segment.toByteArray(Charsets.UTF_8).size <= FailureArtifactPaths.MAX_SEGMENT_BYTES
+        )
+        assertTrue(segment.contains('_'), "expected hash suffix for uniqueness: $segment")
+        // Distinct long names should not collapse to the same truncated path.
+        val other =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "b".repeat(400),
+                config = config,
+            )
+        assertTrue(dir.fileName != other.fileName)
     }
 
     @Test

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactPathsTest.kt
@@ -70,7 +70,7 @@ class FailureArtifactPathsTest {
     }
 
     @Test
-    fun `case-only differences get distinct directories`(@TempDir temp: Path) {
+    fun `case-only and unicode case-fold aliases get distinct directories`(@TempDir temp: Path) {
         val config = FailureArtifactsConfig(reportsRoot = temp)
         val a =
             FailureArtifactPaths.methodDirectory(
@@ -85,6 +85,20 @@ class FailureArtifactPathsTest {
                 config = config,
             )
         assertTrue(a.fileName != b.fileName)
+        // Greek final sigma / sigma fold on case-insensitive volumes
+        val sigma =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "σ",
+                config = config,
+            )
+        val finalSigma =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.T",
+                testMethodName = "ς",
+                config = config,
+            )
+        assertTrue(sigma.fileName != finalSigma.fileName)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds `FailureArtifactsConfig` (default-on, opt-out, reports root, attempt index)
- Adds `FailureArtifactPaths` for `build/reports/spectre/<class>/<method>[-attempt-N]/window-i/`
- Adds `FailureArtifactCapture` multi-window writer reusing `CaptureArtifactsWriter` / atomic capture layout
- Unit tests for path sanitize, attempt suffix, multi-window write, partial capture failure

Part of #205 (slice 1/3: foundation only — JUnit hooks, report entries, docs/e2e follow).

## Test plan
- [x] `./gradlew :testing:test --tests '*FailureArtifact*'`
- [x] `./gradlew check` (local; one unrelated agent attach flake retried green)
- [ ] CI green