### PR TITLE
Decide OverlayLayerInspector multi-version adapter policy (#322)

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/OverlayLayerInspector.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/OverlayLayerInspector.kt
@@ -19,10 +19,12 @@ import java.awt.Window
  *   `attachLayer` / `detachLayer`) Each `WindowComposeSceneLayer` then exposes a private `mediator:
  *   ComposeSceneMediator?` whose `semanticsOwners` collection is what we want.
  *
- * Tracked as #39. The reflection is purposely concentrated here so a future change in Compose's
- * internals can be adapted in one place — `findOverlayLayerWindows` returns an empty list rather
- * than throwing if any field is missing or renamed, so the rest of the automator keeps working
- * against newer Compose versions while a contributor updates this file.
+ * Tracked as #39. Policy for multi-version support is **degrade-to-empty on a single chain**
+ * matching Spectre's pinned Compose Desktop line — no multi-version adapter matrix for 1.0 (see
+ * `docs/spikes/209-injection/overlay-adapter-policy.md`, #322). Reflection stays concentrated here
+ * so a future Compose rename is adapted in one place: [findOverlayLayerWindows] returns an empty
+ * list rather than throwing if any field is missing or renamed, so main-scene automation keeps
+ * working while a contributor updates this file (or adds a post-1.0 chain try-order).
  */
 internal object OverlayLayerInspector {
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspector.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/perf/RecomposerInspector.kt
@@ -13,7 +13,9 @@ import java.awt.Window
  *
  * The traversal mirrors `OverlayLayerInspector`: walk the private CMP host chain by field name, so
  * a renamed internal field degrades gracefully (returns `null`) instead of crashing the rest of the
- * automator. The chain is:
+ * automator. Same multi-version policy as overlays (#322): single pinned-Compose chain,
+ * degrade-to-empty/null — no adapter matrix for 1.0
+ * (`docs/spikes/209-injection/overlay-adapter-policy.md`). The chain is:
  * ```
  * ComposeWindow.composePanel  (ComposeWindowPanel)
  *   ._composeContainer         (ComposeContainer)

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/OverlayAdapterPolicyContractTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/OverlayAdapterPolicyContractTest.kt
@@ -1,0 +1,42 @@
+package dev.sebastiano.spectre.core
+
+import java.nio.file.Path
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Structural contract for the #322 overlay multi-version adapter policy.
+ *
+ * Pins the spike decision so CI fails if the policy doc is removed or loses the 1.0 choice
+ * (degrade-to-empty, no multi-version matrix).
+ */
+class OverlayAdapterPolicyContractTest {
+
+    @Test
+    fun `overlay adapter policy documents degrade-to-empty for 1_0`() {
+        assertTrue(policyPath.exists(), "Missing #322 policy at $policyPath")
+        val text = policyPath.readText()
+
+        assertContains(text, "Degrade to empty")
+        assertContains(text, "**No** for 1.0")
+        assertContains(text, "OverlayLayerInspector")
+        assertContains(text, "findOverlayLayerWindows")
+        assertContains(text, "RecomposerInspector")
+        assertContains(text, "**pinned** Compose Desktop")
+        assertContains(text, "degrade-to-empty")
+    }
+
+    private fun assertContains(haystack: String, needle: String) {
+        assertTrue(
+            haystack.contains(needle),
+            "Expected docs/spikes/209-injection/overlay-adapter-policy.md to contain: $needle",
+        )
+    }
+
+    private companion object {
+        val root: Path = Path.of("..").toAbsolutePath().normalize()
+        val policyPath: Path = root.resolve("docs/spikes/209-injection/overlay-adapter-policy.md")
+    }
+}

--- a/docs/spikes/209-injection/decision.md
+++ b/docs/spikes/209-injection/decision.md
@@ -44,10 +44,10 @@ Filed after decision (not before):
    [stock-intellij-recipe.md](stock-intellij-recipe.md).
 2. **#321** — Nested inject-runtime 1.0 fate — **closed** via
    [packaging-1.0-decision.md](packaging-1.0-decision.md) (**keep**, experimental).
-3. **#322** — OverlayLayerInspector multi-version adapter policy (still open).
+3. **#322** — OverlayLayerInspector multi-version adapter policy — **closed** via
+   [overlay-adapter-policy.md](overlay-adapter-policy.md) (**degrade-to-empty**, no matrix for 1.0).
 
 ## Closes
 
-This decision, the API audit, practicalities, packaging prototype, and fixture e2e evidence
-together **close spike #209** even without a stock-IDE screenshot: negative stock-IDE automation
-is environmental and documented.
+This decision, the API audit, practicalities, packaging prototype, fixture e2e evidence, and
+follow-ups #320–#322 together **close the #209 epic**.

--- a/docs/spikes/209-injection/overlay-adapter-policy.md
+++ b/docs/spikes/209-injection/overlay-adapter-policy.md
@@ -1,0 +1,102 @@
+# #322: OverlayLayerInspector multi-version adapter policy
+
+**Status:** decided (closes #322)  
+**Date:** 2026-07-26  
+**Depends on:** [api-audit.md](api-audit.md) §1.1, [practicalities.md](practicalities.md) §2, [decision.md](decision.md)
+
+## Decision
+
+| Question | 1.0 outcome |
+| --- | --- |
+| Runtime behaviour when the reflective OnWindow chain does not match | **Degrade to empty** — `findOverlayLayerWindows` returns `emptyList()`, never throws |
+| Ship a multi-version reflective adapter matrix (per Compose Desktop / IDE major) | **No** for 1.0 |
+| Number of supported internal field layouts in-tree | **One** — the chain that matches Spectre’s **pinned** Compose Desktop line |
+| Where adapters would live if added later | Still concentrated in `OverlayLayerInspector` (and `RecomposerInspector` for recomposer only) |
+| Main-scene semantics when overlays fail | **Unaffected** — public `ComposeWindow` / `ComposePanel.semanticsOwners` path stays primary |
+| Product implication for inject / experimental attach | Overlay popups may be **invisible to selectors** on unsupported Compose internals; main-scene inspect still works |
+
+## What the code does today
+
+`OverlayLayerInspector` (internal) walks Compose Desktop private fields:
+
+```text
+ComposeWindow.composePanel
+  → ComposeWindowPanel._composeContainer
+    → ComposeContainer.layers
+      → WindowComposeSceneLayer.layerWindow / mediator.getSemanticsOwners()
+```
+
+- Field/method missing or access failure → **null / empty**, uniform degrade via `readField` / `invokeGetter`.
+- OnSameCanvas / OnComponent layers (no `layerWindow`) are skipped, not errors.
+- `WindowTracker` still tracks AWT-owned popups separately; only the OnWindow **layer** path is adapter-risk.
+
+`RecomposerInspector` follows the same **degrade-to-null** rule for idle/recomposition monitoring (not required for tree dump).
+
+## Options considered
+
+### A. Degrade-to-empty (chosen)
+
+**Pros**
+
+- Automator never dies because an IDE minor renamed a private field.
+- Matches inject/read-only goals: main scene is public Compose API and remains the contract.
+- Zero maintenance of a version matrix across IDE majors for 1.0.
+- Already implemented and documented in source KDoc (#39 lineage).
+
+**Cons**
+
+- OnWindow popup tags disappear silently if the chain breaks until someone updates the single adapter.
+- Full popup parity on every Compose Desktop line used by every IDE major is **not** guaranteed.
+
+### B. Multi-version reflective adapters in 1.0 (rejected)
+
+**Pros**
+
+- Higher chance of popup discovery across 2024.3–2026.2 IDE lines.
+
+**Cons**
+
+- practicalities estimate: **1–3 variants** for overlays (+ recomposer) — ongoing cost in experimental territory.
+- Needs a matrix of CI / host pins Spectre does not ship for inject 1.0 (decision.md: version adapter matrix **not shipped**).
+- Silent wrong-adapter selection is worse than empty: partial field matches could return incomplete layers.
+- Overkill while inject remains experimental inspect and instrumented sample-plugin CI already covers Jewel popups on the **pinned** line.
+
+### C. Fail-hard / throw on missing fields (rejected)
+
+Breaks main-scene attach and tree dump when only the overlay chain is wrong — violates “rest of automator keeps working”.
+
+## Policy for 1.0 (normative)
+
+1. **Degrade-to-empty is the contract** for `OverlayLayerInspector.findOverlayLayerWindows` and sibling internal reflection (`RecomposerInspector`).
+2. **Single chain** for the Compose Desktop version Spectre pins in Gradle; no `if (composeVersion)` adapter table in 1.0.
+3. **Do not** block attach, inject bootstrap, or main-scene selectors on overlay discovery failure.
+4. **Document** for operators: if OnWindow popup nodes are missing under a non-pinned Compose line, update `OverlayLayerInspector` (or file an issue) — do not expect a built-in multi-version matrix.
+5. **Validation** stays on the pinned line: sample-desktop popup validation tasks, sample-intellij Jewel popup tags, existing overlay-related tests — not a combinatorial IDE×Compose matrix.
+
+## When to add adapters later (post-1.0)
+
+Add a second (or third) reflective chain **only if**:
+
+- A **supported** platform tier (see `docs/STABILITY.md`) ships a Compose Desktop line that renames the host chain **and**
+- Product requires OnWindow popup parity on that tier (not just main scene) **and**
+- The new chain is proven on a CI-hosted fixture (not only local).
+
+Shape then:
+
+- Keep degrade-to-empty as the outer contract.
+- Try chains in order (newest pin first, then legacy).
+- Still concentrate all reflection in `OverlayLayerInspector` / `RecomposerInspector`.
+- Never throw from discovery; optional debug logging only.
+
+## Mapping to #209 / 1.0 inject
+
+| Surface | 1.0 stance |
+| --- | --- |
+| Main-scene read (public) | Supported experimental attach / inject inspect |
+| OnWindow overlay read | Best-effort on pinned Compose; degrade empty otherwise |
+| Multi-IDE adapter matrix | Out of 1.0 (this decision) |
+| Full injection Robot + every popup mode | Deferred (decision.md) |
+
+## Closes
+
+This policy closes **#322** and finishes the #209 follow-up list with #320 and #321.

--- a/docs/spikes/209-injection/practicalities.md
+++ b/docs/spikes/209-injection/practicalities.md
@@ -31,14 +31,19 @@ edited by the user/operator.
 
 - **Read-only main scene:** expect **0–1 adapter** if experimental public API stays stable; otherwise
   a thin shims package per Compose Desktop line used by an IDE major.
-- **Overlay popups + recomposer:** **1–3 reflective adapter variants** over that window if full
-  parity is required — concentrate in `OverlayLayerInspector` / `RecomposerInspector` only.
+- **Overlay popups + recomposer:** **1–3 reflective adapter variants** *if* full parity across that
+  window were a 1.0 goal — concentrate in `OverlayLayerInspector` / `RecomposerInspector` only.
 - **Jewel version:** Jewel is theming/UI; Spectre reads semantics, not Jewel widgets. Jewel skew
   does not require Spectre adapters unless Jewel embeds Compose through a non-standard host
   (none known for stock tool windows).
 
-Spike prototype does **not** ship a multi-version adapter matrix; it validates the inject packaging
-and bootstrap against the project's pinned Compose Desktop line.
+### Decided policy (#322)
+
+**Degrade-to-empty on a single pinned Compose Desktop chain — no multi-version adapter matrix
+for 1.0.** Full write-up: [overlay-adapter-policy.md](overlay-adapter-policy.md).
+
+Spike / 1.0 ship shape validates inject packaging and bootstrap (and overlay discovery) against
+the project's **pinned** Compose Desktop line only.
 
 ## 3. Detach / classloader-leak acceptability (inspect mode)
 


### PR DESCRIPTION
## Summary

Closes **#322** — last open #209 follow-up:

**Decision:** degrade-to-empty on a **single** reflective chain for Spectre’s pinned Compose Desktop line. **No** multi-version adapter matrix for 1.0.

- New spike: `docs/spikes/209-injection/overlay-adapter-policy.md`
- Cross-links in `decision.md` / `practicalities.md`
- KDoc on `OverlayLayerInspector` + `RecomposerInspector`
- `OverlayAdapterPolicyContractTest` pins the policy doc

This matches existing runtime behaviour (`findOverlayLayerWindows` → empty list, never throw) and keeps main-scene inspect working when overlay internals drift.

## Test plan

- [x] `:core:test` OverlayAdapterPolicyContractTest + InjectionApiAuditContractTest
- [x] ktfmt check main/test
- [ ] CI

Closes #322