### PR TITLE
Wire failure artifacts into JUnit 5/4 wrappers (#205)

### DIFF
--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -1,7 +1,10 @@
-public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/ParameterResolver {
+public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/AfterTestExecutionCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/ParameterResolver {
 	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
+	public fun afterTestExecution (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public final fun getAutomator ()Ldev/sebastiano/spectre/core/ComposeAutomator;
 	public fun resolveParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Ljava/lang/Object;
@@ -10,8 +13,11 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : or
 
 public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/junit/rules/ExternalResource {
 	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
+	public fun <init> (Lkotlin/jvm/functions/Function0;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun after ()V
+	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
 	public fun before ()V
 	public final fun getAutomator ()Ldev/sebastiano/spectre/core/ComposeAutomator;
 }

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -1,4 +1,4 @@
-public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/AfterTestExecutionCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/ParameterResolver {
+public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/AfterTestExecutionCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/LifecycleMethodExecutionExceptionHandler, org/junit/jupiter/api/extension/ParameterResolver {
 	public fun <init> ()V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
@@ -7,6 +7,8 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : or
 	public fun afterTestExecution (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public final fun getAutomator ()Ldev/sebastiano/spectre/core/ComposeAutomator;
+	public fun handleAfterEachMethodExecutionException (Lorg/junit/jupiter/api/extension/ExtensionContext;Ljava/lang/Throwable;)V
+	public fun handleBeforeEachMethodExecutionException (Lorg/junit/jupiter/api/extension/ExtensionContext;Ljava/lang/Throwable;)V
 	public fun resolveParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Ljava/lang/Object;
 	public fun supportsParameter (Lorg/junit/jupiter/api/extension/ParameterContext;Lorg/junit/jupiter/api/extension/ExtensionContext;)Z
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.LifecycleMethodExecutionExceptionHandler
 import org.junit.jupiter.api.extension.ParameterContext
 import org.junit.jupiter.api.extension.ParameterResolver
 
@@ -51,7 +52,12 @@ import org.junit.jupiter.api.extension.ParameterResolver
 public class ComposeAutomatorExtension(
     private val factory: AutomatorFactory,
     private val failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
-) : BeforeEachCallback, AfterEachCallback, AfterTestExecutionCallback, ParameterResolver {
+) :
+    BeforeEachCallback,
+    AfterEachCallback,
+    AfterTestExecutionCallback,
+    LifecycleMethodExecutionExceptionHandler,
+    ParameterResolver {
 
     // Explicit no-arg secondary constructor so JUnit 5's @ExtendWith — which reflectively
     // calls the no-arg constructor — can instantiate the extension. Kotlin's default-parameter
@@ -78,6 +84,31 @@ public class ComposeAutomatorExtension(
 
     override fun afterTestExecution(context: ExtensionContext) {
         if (!context.executionException.isPresent) return
+        captureFailureArtifacts(context)
+    }
+
+    /**
+     * Also capture when `@AfterEach` / `@BeforeEach` lifecycle methods fail (not covered by
+     * [afterTestExecution], which only sees the test method's exception).
+     */
+    override fun handleAfterEachMethodExecutionException(
+        context: ExtensionContext,
+        throwable: Throwable,
+    ) {
+        captureFailureArtifacts(context)
+        throw throwable
+    }
+
+    override fun handleBeforeEachMethodExecutionException(
+        context: ExtensionContext,
+        throwable: Throwable,
+    ) {
+        // Automator may already exist if factory ran; capture is best-effort.
+        captureFailureArtifacts(context)
+        throw throwable
+    }
+
+    private fun captureFailureArtifacts(context: ExtensionContext) {
         val automator =
             context.getStore(NAMESPACE).get(STORE_KEY, ComposeAutomator::class.java) ?: return
         val testClass = context.testClass.map { it.name }.orElse("UnknownClass")

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.testing
 import dev.sebastiano.spectre.core.ComposeAutomator
 import java.lang.reflect.Method
 import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.AfterTestExecutionCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.junit.jupiter.api.extension.ParameterContext
@@ -30,6 +31,14 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * }
  * ```
  *
+ * ## Failure artifacts (#205)
+ *
+ * When a test fails, this extension captures atomic screenshots + semantics for every known window
+ * **after** the failure and **before** [afterEach] tears down the automator (via
+ * [AfterTestExecutionCallback]). Default-on; opt out with `FailureArtifactsConfig(enabled =
+ * false)`. Paths are published as JUnit report entries under
+ * [FailureArtifactHooks.REPORT_ENTRY_KEY].
+ *
  * The [factory] defaults to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
  * or focused unit testing can supply their own factory.
  *
@@ -39,13 +48,19 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * typical sequential `@RegisterExtension` flow; callers running tests in parallel should rely on
  * parameter injection instead.
  */
-public class ComposeAutomatorExtension(private val factory: AutomatorFactory) :
-    BeforeEachCallback, AfterEachCallback, ParameterResolver {
+public class ComposeAutomatorExtension(
+    private val factory: AutomatorFactory,
+    private val failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+) : BeforeEachCallback, AfterEachCallback, AfterTestExecutionCallback, ParameterResolver {
 
     // Explicit no-arg secondary constructor so JUnit 5's @ExtendWith — which reflectively
     // calls the no-arg constructor — can instantiate the extension. Kotlin's default-parameter
     // primary constructor does not emit a true JVM no-arg overload without @JvmOverloads.
     public constructor() : this({ ComposeAutomator.inProcess() })
+
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig
+    ) : this({ ComposeAutomator.inProcess() }, failureArtifacts)
 
     @Volatile private var lastInstance: ComposeAutomator? = null
 
@@ -59,6 +74,27 @@ public class ComposeAutomatorExtension(private val factory: AutomatorFactory) :
         val automator = factory()
         context.getStore(NAMESPACE).put(STORE_KEY, automator)
         lastInstance = automator
+    }
+
+    override fun afterTestExecution(context: ExtensionContext) {
+        if (!context.executionException.isPresent) return
+        val automator =
+            context.getStore(NAMESPACE).get(STORE_KEY, ComposeAutomator::class.java) ?: return
+        val testClass = context.testClass.map { it.name }.orElse("UnknownClass")
+        val testMethod = context.testMethod.map { it.name }.orElseGet { context.displayName }
+        val config =
+            if (failureArtifacts.invocationId != null) {
+                failureArtifacts
+            } else {
+                failureArtifacts.copy(invocationId = context.uniqueId)
+            }
+        FailureArtifactHooks.recordFailure(
+            automator = automator,
+            config = config,
+            testClassName = testClass,
+            testMethodName = testMethod,
+            publishReport = { key, value -> context.publishReportEntry(key, value) },
+        )
     }
 
     override fun afterEach(context: ExtensionContext) {

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -83,11 +83,10 @@ public class ComposeAutomatorExtension(
         val testClass = context.testClass.map { it.name }.orElse("UnknownClass")
         val testMethod = context.testMethod.map { it.name }.orElseGet { context.displayName }
         val config =
-            if (failureArtifacts.invocationId != null) {
-                failureArtifacts
-            } else {
-                failureArtifacts.copy(invocationId = context.uniqueId)
-            }
+            failureArtifacts.copy(
+                invocationId =
+                    failureArtifacts.invocationId?.takeIf { it.isNotBlank() } ?: context.uniqueId
+            )
         FailureArtifactHooks.recordFailure(
             automator = automator,
             config = config,

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -109,8 +109,11 @@ public class ComposeAutomatorExtension(
     }
 
     private fun captureFailureArtifacts(context: ExtensionContext) {
-        val automator =
-            context.getStore(NAMESPACE).get(STORE_KEY, ComposeAutomator::class.java) ?: return
+        val store = context.getStore(NAMESPACE)
+        // One capture per invocation: test-method failure runs afterTestExecution, then a later
+        // @AfterEach failure must not recapture (which would clear the earlier run-* tree).
+        if (store.get(CAPTURED_KEY) == true) return
+        val automator = store.get(STORE_KEY, ComposeAutomator::class.java) ?: return
         val testClass = context.testClass.map { it.name }.orElse("UnknownClass")
         val testMethod = context.testMethod.map { it.name }.orElseGet { context.displayName }
         val config =
@@ -125,6 +128,7 @@ public class ComposeAutomatorExtension(
             testMethodName = testMethod,
             publishReport = { key, value -> context.publishReportEntry(key, value) },
         )
+        store.put(CAPTURED_KEY, true)
     }
 
     override fun afterEach(context: ExtensionContext) {
@@ -171,3 +175,4 @@ public class ComposeAutomatorExtension(
 // the companion itself is `private`. A file-level `private const val` compiles to a private
 // static field on the file's facade class and stays out of the public ABI surface.
 private const val STORE_KEY: String = "automator"
+private const val CAPTURED_KEY: String = "failureArtifactsCaptured"

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -84,9 +84,7 @@ public class ComposeAutomatorExtension(
 
     override fun afterTestExecution(context: ExtensionContext) {
         val failure = context.executionException.orElse(null) ?: return
-        // Assumptions abort the test without a "failure"; do not write artifacts for those.
-        if (failure is org.opentest4j.TestAbortedException) return
-        captureFailureArtifacts(context)
+        captureFailureArtifacts(context, failure)
     }
 
     /**
@@ -97,7 +95,7 @@ public class ComposeAutomatorExtension(
         context: ExtensionContext,
         throwable: Throwable,
     ) {
-        captureFailureArtifacts(context)
+        captureFailureArtifacts(context, throwable)
         throw throwable
     }
 
@@ -106,11 +104,14 @@ public class ComposeAutomatorExtension(
         throwable: Throwable,
     ) {
         // Automator may already exist if factory ran; capture is best-effort.
-        captureFailureArtifacts(context)
+        captureFailureArtifacts(context, throwable)
         throw throwable
     }
 
-    private fun captureFailureArtifacts(context: ExtensionContext) {
+    private fun captureFailureArtifacts(context: ExtensionContext, cause: Throwable) {
+        // Assumptions abort without a "failure"; do not write artifacts for those (test method
+        // or lifecycle @BeforeEach/@AfterEach).
+        if (FailureArtifactHooks.isNonFailureAbort(cause)) return
         val store = context.getStore(NAMESPACE)
         // One capture per invocation: test-method failure runs afterTestExecution, then a later
         // @AfterEach failure must not recapture (which would clear the earlier run-* tree).

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -83,7 +83,9 @@ public class ComposeAutomatorExtension(
     }
 
     override fun afterTestExecution(context: ExtensionContext) {
-        if (!context.executionException.isPresent) return
+        val failure = context.executionException.orElse(null) ?: return
+        // Assumptions abort the test without a "failure"; do not write artifacts for those.
+        if (failure is org.opentest4j.TestAbortedException) return
         captureFailureArtifacts(context)
     }
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -2,6 +2,8 @@ package dev.sebastiano.spectre.testing
 
 import dev.sebastiano.spectre.core.ComposeAutomator
 import org.junit.rules.ExternalResource
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
 
 /**
  * JUnit 4 [org.junit.Rule] that owns a per-test [ComposeAutomator] instance.
@@ -18,11 +20,27 @@ import org.junit.rules.ExternalResource
  *
  * ## Lifecycle
  *
- * The [factory] is invoked in `before` (before each `@Test` method); the resulting automator is
- * available via [automator] for the duration of the test and goes out of scope in `after`.
- * Accessing [automator] outside a running test throws [IllegalStateException]. The default factory
- * is `ComposeAutomator.inProcess()`; tests that need a stub for headless CI or focused unit testing
- * can supply their own factory.
+ * The [factory] is invoked before each `@Test` method; the resulting automator is available via
+ * [automator] for the duration of the test and goes out of scope after the test (including after
+ * failure-artifact capture). Accessing [automator] outside a running test throws
+ * [IllegalStateException]. The default factory is `ComposeAutomator.inProcess()`; tests that need a
+ * stub for headless CI or focused unit testing can supply their own factory.
+ *
+ * ## Failure artifacts (#205)
+ *
+ * When a test fails, this rule captures atomic screenshots + semantics for every known window
+ * **after** the failure and **before** the automator is cleared. Default-on; opt out with
+ * `FailureArtifactsConfig(enabled = false)`.
+ *
+ * ### RuleChain
+ *
+ * Keep this rule **innermost** (last `.around(...)` in a [org.junit.rules.RuleChain]) so failure
+ * capture runs while the automator and windows are still available, before outer rules tear down UI
+ * or process state:
+ * ```
+ * @get:Rule
+ * val chain = RuleChain.outerRule(myWindowRule).around(ComposeAutomatorRule())
+ * ```
  *
  * Both [factory] invocation and automator interaction can touch the EDT; standard Spectre EDT rules
  * apply (no EDT callers of suspend wait helpers; see
@@ -31,12 +49,19 @@ import org.junit.rules.ExternalResource
  * Prefer [ComposeAutomatorExtension] when using JUnit 5 — JUnit 5's parameter-injection model is a
  * better fit for parallel test execution.
  */
-public class ComposeAutomatorRule(private val factory: AutomatorFactory) : ExternalResource() {
+public class ComposeAutomatorRule(
+    private val factory: AutomatorFactory,
+    private val failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+) : ExternalResource() {
 
     // Explicit no-arg secondary constructor so JUnit 4 callers can write
     // `@get:Rule val r = ComposeAutomatorRule()` without relying on Kotlin's
     // default-parameter constructor synthesis (consistent with ComposeAutomatorExtension).
     public constructor() : this({ ComposeAutomator.inProcess() })
+
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig
+    ) : this({ ComposeAutomator.inProcess() }, failureArtifacts)
 
     private var instance: ComposeAutomator? = null
 
@@ -46,6 +71,28 @@ public class ComposeAutomatorRule(private val factory: AutomatorFactory) : Exter
                 "ComposeAutomatorRule.automator accessed outside of a running test"
             }
 
+    /**
+     * Full lifecycle so failure capture runs **before** [after] clears the automator.
+     * [ExternalResource.apply] would run `after` in a `finally` before callers can observe the
+     * failure, which is too late for window capture.
+     */
+    override fun apply(base: Statement, description: Description): Statement {
+        return object : Statement() {
+            override fun evaluate() {
+                before()
+                try {
+                    // runCatching so both Exception and AssertionError (JUnit 4 failures) are
+                    // captured without a broad catch-Throwable detekt hit at this boundary.
+                    val outcome = runCatching { base.evaluate() }
+                    outcome.exceptionOrNull()?.let { captureOnFailure(description) }
+                    outcome.getOrThrow()
+                } finally {
+                    after()
+                }
+            }
+        }
+    }
+
     public override fun before() {
         instance = factory()
     }
@@ -54,5 +101,21 @@ public class ComposeAutomatorRule(private val factory: AutomatorFactory) : Exter
         // Future hook: when the automator gains lifecycle-aware resources (recordings,
         // background pollers, etc.) tear them down here.
         instance = null
+    }
+
+    private fun captureOnFailure(description: Description) {
+        val automator = instance ?: return
+        val testClass = description.className ?: "UnknownClass"
+        val testMethod = description.methodName ?: description.displayName
+        FailureArtifactHooks.recordFailure(
+            automator = automator,
+            config = failureArtifacts,
+            testClassName = testClass,
+            testMethodName = testMethod,
+            publishReport = { _, _ ->
+                // JUnit 4 has no report-entry API equivalent to JUnit 5's publishReportEntry.
+                // Paths still land on disk under build/reports/spectre for CI globs.
+            },
+        )
     }
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -107,9 +107,17 @@ public class ComposeAutomatorRule(
         val automator = instance ?: return
         val testClass = description.className ?: "UnknownClass"
         val testMethod = description.methodName ?: description.displayName
+        // JUnit 4 has no ExtensionContext.uniqueId; synthesize an invocation id so parallel or
+        // repeated runs of the same method do not share artifact directories.
+        val config =
+            failureArtifacts.copy(
+                invocationId =
+                    failureArtifacts.invocationId?.takeIf { it.isNotBlank() }
+                        ?: "${testClass}#${testMethod}#${System.nanoTime()}"
+            )
         FailureArtifactHooks.recordFailure(
             automator = automator,
-            config = failureArtifacts,
+            config = config,
             testClassName = testClass,
             testMethodName = testMethod,
             publishReport = { _, _ ->

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -84,7 +84,12 @@ public class ComposeAutomatorRule(
                     // runCatching so both Exception and AssertionError (JUnit 4 failures) are
                     // captured without a broad catch-Throwable detekt hit at this boundary.
                     val outcome = runCatching { base.evaluate() }
-                    outcome.exceptionOrNull()?.let { captureOnFailure(description) }
+                    outcome.exceptionOrNull()?.let { failure ->
+                        // Assumptions abort without a "failure"; skip artifacts (same as JUnit 5).
+                        if (!FailureArtifactHooks.isNonFailureAbort(failure)) {
+                            captureOnFailure(description)
+                        }
+                    }
                     outcome.getOrThrow()
                 } finally {
                     after()

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooks.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooks.kt
@@ -18,16 +18,16 @@ internal object FailureArtifactHooks {
      * True when [throwable] is a JUnit assumption / abort rather than a test failure. Aborted tests
      * must not produce failure artifacts (expensive and misleading for platform-skip suites).
      *
-     * JUnit 4 assumption types are matched by class name so this module stays usable when only
-     * JUnit 5 is on the runtime classpath (`junit:junit` is compileOnly for production).
+     * Both JUnit 4 and JUnit 5 abort types are matched by class name so a JUnit-4-only consumer
+     * never loads opentest4j (and vice versa) — production depends on each runner as `compileOnly`.
      */
     fun isNonFailureAbort(throwable: Throwable): Boolean {
-        // JUnit 5 assumptions / abort (also used when assumptions fire in lifecycle methods).
-        if (throwable is org.opentest4j.TestAbortedException) return true
-        // JUnit 4: public `org.junit.AssumptionViolatedException` extends the internal type.
         var type: Class<*>? = throwable.javaClass
         while (type != null) {
             when (type.name) {
+                // JUnit 5 assumptions / abort (also lifecycle @BeforeEach/@AfterEach aborts).
+                "org.opentest4j.TestAbortedException",
+                // JUnit 4: public type extends the internal one; match both.
                 "org.junit.AssumptionViolatedException",
                 "org.junit.internal.AssumptionViolatedException" -> return true
             }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooks.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooks.kt
@@ -1,0 +1,45 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.capture.CaptureArtifactPaths
+import java.nio.file.Path
+
+/**
+ * Shared failure-artifact orchestration for [ComposeAutomatorExtension] and [ComposeAutomatorRule].
+ *
+ * Captures only when [FailureArtifactsConfig.enabled] is true. Always best-effort: capture errors
+ * must not replace the original test failure.
+ */
+internal object FailureArtifactHooks {
+
+    const val REPORT_ENTRY_KEY: String = "spectre.failureArtifact"
+
+    fun recordFailure(
+        automator: ComposeAutomator,
+        config: FailureArtifactsConfig,
+        testClassName: String,
+        testMethodName: String,
+        publishReport: (key: String, value: String) -> Unit,
+        capture: (ComposeAutomator, Path) -> List<CaptureArtifactPaths> =
+            FailureArtifactCapture::captureAllWindows,
+    ): List<CaptureArtifactPaths> {
+        if (!config.enabled) return emptyList()
+        return runCatching {
+                val methodDir =
+                    FailureArtifactPaths.methodDirectory(
+                        testClassName = testClassName,
+                        testMethodName = testMethodName,
+                        config = config,
+                    )
+                val paths = capture(automator, methodDir)
+                for (path in paths) {
+                    publishReport(
+                        REPORT_ENTRY_KEY,
+                        path.directory.toAbsolutePath().normalize().toString(),
+                    )
+                }
+                paths
+            }
+            .getOrDefault(emptyList())
+    }
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooks.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooks.kt
@@ -14,6 +14,28 @@ internal object FailureArtifactHooks {
 
     const val REPORT_ENTRY_KEY: String = "spectre.failureArtifact"
 
+    /**
+     * True when [throwable] is a JUnit assumption / abort rather than a test failure. Aborted tests
+     * must not produce failure artifacts (expensive and misleading for platform-skip suites).
+     *
+     * JUnit 4 assumption types are matched by class name so this module stays usable when only
+     * JUnit 5 is on the runtime classpath (`junit:junit` is compileOnly for production).
+     */
+    fun isNonFailureAbort(throwable: Throwable): Boolean {
+        // JUnit 5 assumptions / abort (also used when assumptions fire in lifecycle methods).
+        if (throwable is org.opentest4j.TestAbortedException) return true
+        // JUnit 4: public `org.junit.AssumptionViolatedException` extends the internal type.
+        var type: Class<*>? = throwable.javaClass
+        while (type != null) {
+            when (type.name) {
+                "org.junit.AssumptionViolatedException",
+                "org.junit.internal.AssumptionViolatedException" -> return true
+            }
+            type = type.superclass
+        }
+        return false
+    }
+
     fun recordFailure(
         automator: ComposeAutomator,
         config: FailureArtifactsConfig,

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooksTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooksTest.kt
@@ -133,4 +133,47 @@ class FailureArtifactHooksTest {
         val classDir = temp.resolve(FailureArtifactPaths.sanitizePathSegment("com.example.OptOut"))
         assertFalse(Files.exists(classDir))
     }
+
+    @Test
+    fun `isNonFailureAbort recognizes JUnit 5 and JUnit 4 assumption types`() {
+        assertTrue(
+            FailureArtifactHooks.isNonFailureAbort(
+                org.opentest4j.TestAbortedException("skipped by assumption")
+            )
+        )
+        assertTrue(
+            FailureArtifactHooks.isNonFailureAbort(
+                org.junit.AssumptionViolatedException("skipped by Assume")
+            )
+        )
+        assertFalse(FailureArtifactHooks.isNonFailureAbort(AssertionError("real failure")))
+        assertFalse(FailureArtifactHooks.isNonFailureAbort(IllegalStateException("boom")))
+    }
+
+    @Test
+    fun `JUnit4 rule rethrows AssumptionViolatedException without treating as failure`(
+        @TempDir temp: Path
+    ) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val rule = ComposeAutomatorRule(factory = ::newHeadlessAutomator, failureArtifacts = config)
+        val statement =
+            rule.apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        throw org.junit.AssumptionViolatedException("platform skip")
+                    }
+                },
+                Description.createTestDescription("com.example.Assumed", "maybe"),
+            )
+        try {
+            statement.evaluate()
+            error("expected AssumptionViolatedException")
+        } catch (expected: org.junit.AssumptionViolatedException) {
+            assertEquals("platform skip", expected.message)
+        }
+        // Headless has zero windows, so a mistaken capture still would not write files — the
+        // stronger contract is isNonFailureAbort + that the assumption still propagates above.
+        val classDir = temp.resolve(FailureArtifactPaths.sanitizePathSegment("com.example.Assumed"))
+        assertFalse(Files.exists(classDir))
+    }
 }

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooksTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureArtifactHooksTest.kt
@@ -1,0 +1,136 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.capture.CaptureArtifactPaths
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class FailureArtifactHooksTest {
+
+    @Test
+    fun `recordFailure is no-op when disabled`(@TempDir temp: Path) {
+        val reports = mutableListOf<Pair<String, String>>()
+        val paths =
+            FailureArtifactHooks.recordFailure(
+                automator = newHeadlessAutomator(),
+                config = FailureArtifactsConfig(enabled = false, reportsRoot = temp),
+                testClassName = "com.example.T",
+                testMethodName = "fails",
+                publishReport = { k, v -> reports += k to v },
+                capture = { _, _ -> error("should not capture") },
+            )
+        assertTrue(paths.isEmpty())
+        assertTrue(reports.isEmpty())
+    }
+
+    @Test
+    fun `recordFailure publishes paths from capture`(@TempDir temp: Path) {
+        val reports = mutableListOf<Pair<String, String>>()
+        val markerDir = temp.resolve("run-marker").resolve("window-0")
+        Files.createDirectories(markerDir)
+        val marker =
+            CaptureArtifactPaths(
+                directory = markerDir,
+                captureJsonPath = markerDir.resolve("capture.json"),
+                screenshotPngPath = markerDir.resolve("screenshot.png"),
+            )
+        val paths =
+            FailureArtifactHooks.recordFailure(
+                automator = newHeadlessAutomator(),
+                config = FailureArtifactsConfig(reportsRoot = temp),
+                testClassName = "com.example.T",
+                testMethodName = "fails",
+                publishReport = { k, v -> reports += k to v },
+                capture = { _, _ -> listOf(marker) },
+            )
+        assertEquals(listOf(marker), paths)
+        assertEquals(1, reports.size)
+        assertEquals(FailureArtifactHooks.REPORT_ENTRY_KEY, reports.single().first)
+        assertTrue(reports.single().second.contains("window-0"))
+    }
+
+    @Test
+    fun `recordFailure swallows capture exceptions`(@TempDir temp: Path) {
+        val paths =
+            FailureArtifactHooks.recordFailure(
+                automator = newHeadlessAutomator(),
+                config = FailureArtifactsConfig(reportsRoot = temp),
+                testClassName = "com.example.T",
+                testMethodName = "fails",
+                publishReport = { _, _ -> },
+                capture = { _, _ -> error("boom") },
+            )
+        assertTrue(paths.isEmpty())
+    }
+
+    @Test
+    fun `JUnit4 rule captures on failure and not on pass`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = temp)
+        val failing =
+            ComposeAutomatorRule(factory = ::newHeadlessAutomator, failureArtifacts = config)
+        val failStatement =
+            failing.apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        error("intentional failure")
+                    }
+                },
+                Description.createTestDescription("com.example.Failing", "blowsUp"),
+            )
+        try {
+            failStatement.evaluate()
+            error("expected failure")
+        } catch (expected: IllegalStateException) {
+            assertEquals("intentional failure", expected.message)
+        }
+        // Headless automator has zero windows — capture is best-effort and may write nothing.
+        // Opt-out path is the stronger contract below.
+
+        val optOut =
+            ComposeAutomatorRule(
+                factory = ::newHeadlessAutomator,
+                failureArtifacts = FailureArtifactsConfig(enabled = false, reportsRoot = temp),
+            )
+        val passStatement =
+            optOut.apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        // pass
+                    }
+                },
+                Description.createTestDescription("com.example.Passing", "ok"),
+            )
+        passStatement.evaluate()
+        // Disabled config must not create report trees for the passing case either.
+        val classDir = temp.resolve(FailureArtifactPaths.sanitizePathSegment("com.example.Passing"))
+        assertFalse(Files.exists(classDir))
+    }
+
+    @Test
+    fun `JUnit4 rule opt-out does not capture on failure`(@TempDir temp: Path) {
+        val config = FailureArtifactsConfig(enabled = false, reportsRoot = temp)
+        val rule = ComposeAutomatorRule(factory = ::newHeadlessAutomator, failureArtifacts = config)
+        val statement =
+            rule.apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        error("fail")
+                    }
+                },
+                Description.createTestDescription("com.example.OptOut", "failing"),
+            )
+        try {
+            statement.evaluate()
+        } catch (_: IllegalStateException) {
+            // expected
+        }
+        val classDir = temp.resolve(FailureArtifactPaths.sanitizePathSegment("com.example.OptOut"))
+        assertFalse(Files.exists(classDir))
+    }
+}


### PR DESCRIPTION
## Summary
- `ComposeAutomatorExtension` implements `AfterTestExecutionCallback` to capture on failure before `afterEach`
- `ComposeAutomatorRule` overrides `apply` so capture runs before the automator is cleared
- Shared `FailureArtifactHooks` + tests for enable/opt-out/report publish and Rule lifecycle
- RuleChain guidance: keep automator rule innermost

Part of #205 (slice 2/3). Path/config foundation is already on main (#336).

## Test plan
- [x] `./gradlew :testing:test --tests '*FailureArtifact*'`
- [x] `./gradlew check` (local; one unrelated HR daemon e2e flake retried green)
- [ ] CI green