### PR TITLE
Document and e2e-prove JUnit failure artifacts (#205)

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -247,7 +247,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -164,7 +164,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -62,3 +62,10 @@ val result = automator.capture(windowIndex = 0)
 ```
 
 Library details live in `:core` under `dev.sebastiano.spectre.core.capture`.
+
+## Failure artifacts from JUnit
+
+On a **failed** Spectre JUnit test, `ComposeAutomatorExtension` / `ComposeAutomatorRule`
+write the same `capture.json` + `screenshot.png` layout under `build/reports/spectre/`
+(not `$TMPDIR`). See [JUnit integration — Failure artifacts](junit.md#failure-artifacts)
+and the CI upload snippet in [Running on CI](ci.md#failure-artifacts).

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -209,6 +209,13 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y xvfb
       - name: Run Spectre UI tests
         run: xvfb-run --auto-servernum ./gradlew spectreTest
+      - name: Upload Spectre failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: spectre-failure-artifacts
+          path: "**/build/reports/spectre/**"
+          if-no-files-found: ignore
 ```
 
 ```kotlin
@@ -222,3 +229,24 @@ val spectreTest by tasks.registering(Test::class) {
     }
 }
 ```
+
+## Failure artifacts
+
+When a Spectre JUnit test fails, the extension/rule writes atomic captures under
+`build/reports/spectre/` (see [JUnit integration](junit.md#failure-artifacts)). Upload that
+tree on CI failure so you can open `capture.json` + `screenshot.png` without re-running the
+suite:
+
+```yaml
+- name: Upload Spectre failure artifacts
+  if: failure()
+  uses: actions/upload-artifact@v4
+  with:
+    name: spectre-failure-artifacts
+    path: "**/build/reports/spectre/**"
+    if-no-files-found: ignore
+```
+
+`if-no-files-found: ignore` keeps the step green when every test passed or opt-out produced
+no files. Prefer a multi-module glob (`**/build/reports/spectre/**`) over a single module path
+when several projects run Spectre tests in one job.

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -88,8 +88,10 @@ When the UI under test is a **separate JVM** (prod-like `java -jar`, installDist
 `./gradlew :app:run` with warnings), use `LaunchAndAttachExtension` (JUnit 5) or
 `LaunchAndAttachRule` (JUnit 4) from `:testing`. They call the shared agent launch core
 before each test and tear the process tree down after — the same lifecycle window
-`ComposeAutomatorExtension` / `ComposeAutomatorRule` use, so future failure-artifact
-hooks can compose freely.
+`ComposeAutomatorExtension` / `ComposeAutomatorRule` use. Failure-artifact capture is
+wired into those automator wrappers (see [Failure artifacts](#failure-artifacts)); keep
+the automator rule/extension innermost if you also use launch-and-attach so capture still
+sees open windows.
 
 ```kotlin
 import dev.sebastiano.spectre.agent.launch.LaunchSpec
@@ -243,6 +245,78 @@ Compose's AWT key listener even when macOS never grants the window an AWT focus 
 Do not rely on UI-element mode for clipboard-backed `pasteText`; that path still goes
 through macOS clipboard services outside the synthetic key-event path. Run recording tests
 as a separate, foreground-capable task while establishing Screen Recording TCC grants.
+
+## Failure artifacts
+
+When a Spectre-driven test **fails**, `ComposeAutomatorExtension` and `ComposeAutomatorRule`
+capture an [atomic capture](capture.md) (PNG + `capture.json`) for every window the automator
+knows about. Capture runs **after** the failure and **before** the wrapper tears down the
+automator, so windows are still open.
+
+Default is **on**. Opt out when constructing the wrapper:
+
+```kotlin
+import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
+import dev.sebastiano.spectre.testing.FailureArtifactsConfig
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@JvmField
+@RegisterExtension
+val automatorExt =
+    ComposeAutomatorExtension(
+        failureArtifacts = FailureArtifactsConfig(enabled = false),
+    )
+```
+
+```kotlin
+import dev.sebastiano.spectre.testing.ComposeAutomatorRule
+import dev.sebastiano.spectre.testing.FailureArtifactsConfig
+import org.junit.Rule
+
+@get:Rule
+val automatorRule =
+    ComposeAutomatorRule(
+        failureArtifacts = FailureArtifactsConfig(enabled = false),
+    )
+```
+
+### Layout
+
+Artifacts land under Gradle’s reports tree (cleaned by `clean`), not under the CLI/agent
+`$TMPDIR` capture root:
+
+```text
+build/reports/spectre/<test-class>/<test-method>[/<invocation>][/attempt-N]/run-*/window-<i>/
+  capture.json
+  screenshot.png
+```
+
+- **`<test-class>` / `<test-method>`** — sanitized FQCN and method name.
+- **`<invocation>`** — distinguishes parallel or repeated runs of the same method (JUnit 5
+  unique id by default; JUnit 4 synthesizes one).
+- **`attempt-N`** — only when you set `FailureArtifactsConfig.attemptIndex` to a value greater
+  than 1 (1-based). Use this with retry runners so attempt 2 does not overwrite attempt 1.
+- **`run-*` / `window-<i>`** — one isolation tree per capture attempt; window index matches the
+  automator’s known windows. Same on-disk shape as a manual atomic capture, so the shipped
+  **`spectre-capture`** skill’s `jq` recipes work unchanged.
+
+Passing tests write nothing. Aborted tests (JUnit 5 assumptions / JUnit 4 `Assume`) also write
+nothing — they are skips, not failures.
+
+On JUnit 5, each written window directory is published as a report entry under the key
+`spectre.failureArtifact` (path string). JUnit 4 has no report-entry API; inspect disk under
+`build/reports/spectre/` (or your custom `reportsRoot`).
+
+### Caveats
+
+- Capture happens **after** the exception. Animations may advance a few frames past the failing
+  assertion; treat the PNG as “state at capture time,” not a perfect freeze of the assert line.
+- Capture is **best-effort**. A secondary capture error must never replace the original test
+  failure; if capture cannot run, you still see the real failure in the test report.
+- With multiple JUnit rules, keep `ComposeAutomatorRule` **innermost** (last `.around(...)` in
+  a `RuleChain`) so outer rules do not close UI or process state before capture runs.
+
+Point CI at the reports tree with a single upload glob — see [Running on CI](ci.md#failure-artifacts).
 
 ## Custom `AutomatorFactory`
 

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
 
     "validationImplementation"(libs.kotlin.testJunit5)
     "validationImplementation"(libs.junit5.api)
+    "validationImplementation"(libs.junit4)
+    "validationImplementation"(projects.testing)
     "validationRuntimeOnly"(libs.junit5.engine)
 }
 

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/FailureArtifactsValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/FailureArtifactsValidationTest.kt
@@ -1,0 +1,156 @@
+package dev.sebastiano.spectre.sample.validation
+
+import dev.sebastiano.spectre.core.capture.CaptureArtifactsWriter
+import dev.sebastiano.spectre.testing.ComposeAutomatorRule
+import dev.sebastiano.spectre.testing.FailureArtifactsConfig
+import java.awt.GraphicsEnvironment
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.isRegularFile
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.io.TempDir
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Live acceptance for failure artifacts: when a Spectre-driven JUnit test fails, the rule captures
+ * `capture.json` + `screenshot.png` for known windows **after** the failure and **before** the
+ * automator is cleared — while the sample UI is still open.
+ *
+ * This drives the public [ComposeAutomatorRule] statement path (not a private helper) so the
+ * artifact layout matches what consumers get on a real intentional fail.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FailureArtifactsValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre failure-artifacts validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `JUnit 4 rule writes capture json and png on failure while windows are open`(
+        @TempDir reportsRoot: Path
+    ): Unit = runBlocking {
+        // Settle the sample so capture has a non-empty tree.
+        with(fixture.automator) {
+            refreshWindows()
+            waitForIdle()
+        }
+        assertTrue(fixture.automator.surfaceIds().isNotEmpty(), "fixture must track a window")
+
+        val config = FailureArtifactsConfig(reportsRoot = reportsRoot)
+        // Reuse the live fixture automator so capture hits real windows (factory is per-test).
+        val rule = ComposeAutomatorRule(factory = { fixture.automator }, failureArtifacts = config)
+        val statement =
+            rule.apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        error("intentional failure for artifact capture")
+                    }
+                },
+                Description.createTestDescription(
+                    FailureArtifactsValidationTest::class.java.name,
+                    "intentionalFail",
+                ),
+            )
+
+        try {
+            statement.evaluate()
+            error("expected intentional failure")
+        } catch (expected: IllegalStateException) {
+            assertEquals("intentional failure for artifact capture", expected.message)
+        }
+
+        val jsonFiles =
+            Files.walk(reportsRoot).use { stream ->
+                stream
+                    .filter { path ->
+                        path.isRegularFile() &&
+                            path.fileName.toString() == CaptureArtifactsWriter.CAPTURE_JSON_NAME
+                    }
+                    .toList()
+            }
+        assertTrue(jsonFiles.isNotEmpty(), "expected capture.json under $reportsRoot")
+        for (json in jsonFiles) {
+            val windowDir = json.parent
+            assertTrue(windowDir.fileName.toString().startsWith("window-"), "got $windowDir")
+            assertTrue(
+                windowDir.parent.fileName.toString().startsWith("run-"),
+                "window dir must nest under run-*: $windowDir",
+            )
+            val png = windowDir.resolve(CaptureArtifactsWriter.SCREENSHOT_PNG_NAME)
+            assertTrue(png.isRegularFile(), "missing $png")
+            assertTrue(Files.size(json) > 0, "empty $json")
+            assertTrue(Files.size(png) > 0, "empty $png")
+        }
+        // Windows must still be trackable after capture (teardown clears the rule handle only).
+        assertTrue(
+            fixture.automator.surfaceIds().isNotEmpty(),
+            "fixture windows must remain open after rule after()",
+        )
+    }
+
+    @Test
+    fun `JUnit 4 rule writes nothing on pass`(@TempDir reportsRoot: Path) {
+        val config = FailureArtifactsConfig(reportsRoot = reportsRoot)
+        val rule = ComposeAutomatorRule(factory = { fixture.automator }, failureArtifacts = config)
+        val statement =
+            rule.apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        // pass
+                    }
+                },
+                Description.createTestDescription(
+                    FailureArtifactsValidationTest::class.java.name,
+                    "passing",
+                ),
+            )
+        statement.evaluate()
+        assertFalse(
+            Files.walk(reportsRoot).use { stream -> stream.anyMatch { Files.isRegularFile(it) } },
+            "passing tests must not write under $reportsRoot",
+        )
+    }
+
+    @Test
+    fun `JUnit 4 rule opt-out writes nothing on failure`(@TempDir reportsRoot: Path) {
+        val config = FailureArtifactsConfig(enabled = false, reportsRoot = reportsRoot)
+        val rule = ComposeAutomatorRule(factory = { fixture.automator }, failureArtifacts = config)
+        val statement =
+            rule.apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        error("fail with opt-out")
+                    }
+                },
+                Description.createTestDescription(
+                    FailureArtifactsValidationTest::class.java.name,
+                    "optOutFail",
+                ),
+            )
+        try {
+            statement.evaluate()
+        } catch (_: IllegalStateException) {
+            // expected
+        }
+        assertFalse(
+            Files.walk(reportsRoot).use { stream -> stream.anyMatch { Files.isRegularFile(it) } },
+            "opt-out must not write under $reportsRoot",
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Closes the last slice of #205: user-facing docs, CI upload guidance, and a live validation e2e for default-on failure artifacts.

- **Docs**: `junit.md` failure-artifacts section (layout, opt-out, assumptions skip, RuleChain, attempt-N); `ci.md` `upload-artifact` on failure; `capture.md` cross-link.
- **E2E**: `FailureArtifactsValidationTest` drives public `ComposeAutomatorRule` against `SampleAppFixture` — intentional fail writes `run-*/window-*/{capture.json,screenshot.png}` while windows remain open; pass and opt-out write nothing.
- **CI hygiene**: register the new validation class in Linux/Windows required-XML lists.

## Test plan

- [x] `./gradlew :testing:test --tests '*FailureArtifact*'`
- [x] `./gradlew :sample-desktop:validationTest --tests '*FailureArtifactsValidationTest*'` (live display)
- [x] `python3 -m mkdocs build --strict`
- [ ] CI validation-linux / validation-windows

Depends on #339 (hooks) already on main.