### PR TITLE
Make agent runtime jar discovery fail closed on multi-match (#165)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -12,6 +12,11 @@ public final class dev/sebastiano/spectre/agent/AgentJarNotFoundException : dev/
 	public fun <init> (Ljava/util/List;)V
 }
 
+public final class dev/sebastiano/spectre/agent/AmbiguousAgentRuntimeJarException : dev/sebastiano/spectre/agent/SpectreAttachException {
+	public fun <init> (Ljava/util/List;)V
+	public final fun getCandidates ()Ljava/util/List;
+}
+
 public final class dev/sebastiano/spectre/agent/AtomicCaptureResult {
 	public fun <init> (IILjava/lang/String;[BIIIIIJ)V
 	public final fun component1 ()I

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
@@ -40,24 +40,24 @@ internal object AgentJarResolution {
     private fun selectSingleRuntimeJar(matches: List<Path>): Path? {
         // Classpaths sometimes list the same physical jar twice (duplicate entries or
         // symlink + real path). Collapse by filesystem identity so only distinct files
-        // count as ambiguity.
+        // count as ambiguity. Preserve the original path string: lexical normalize() can
+        // break symlink + ".." classpath entries that still resolve on disk.
         val distinct = mutableListOf<Path>()
         for (candidate in matches) {
-            val normalized = candidate.toAbsolutePath().normalize()
             val alreadySeen = distinct.any { existing ->
                 try {
-                    Files.isSameFile(existing, normalized)
+                    Files.isSameFile(existing, candidate)
                 } catch (_: IOException) {
-                    existing == normalized
+                    existing.toAbsolutePath().normalize() == candidate.toAbsolutePath().normalize()
                 }
             }
-            if (!alreadySeen) distinct.add(normalized)
+            if (!alreadySeen) distinct.add(candidate)
         }
-        distinct.sortBy { it.toString() }
-        return when (distinct.size) {
+        val ordered = distinct.sortedBy { it.toString() }
+        return when (ordered.size) {
             0 -> null
-            1 -> distinct.single()
-            else -> throw AmbiguousAgentRuntimeJarException(distinct)
+            1 -> ordered.single()
+            else -> throw AmbiguousAgentRuntimeJarException(ordered)
         }
     }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
 package dev.sebastiano.spectre.agent
 
 import java.io.File
@@ -5,22 +7,46 @@ import java.nio.file.Files
 import java.nio.file.Path
 
 internal object AgentJarResolution {
-    fun findRuntimeJarOnClasspath(classPath: String): Path? =
-        classPath
-            .split(File.pathSeparator)
-            .asSequence()
-            .filter { it.isNotBlank() }
-            .map(Path::of)
-            .firstOrNull(::isRuntimeJar)
-
-    fun findRuntimeJarInDirectory(directory: Path): Path? =
-        Files.list(directory).use { stream ->
-            stream
+    /**
+     * Locate a single agent runtime jar on [classPath].
+     *
+     * Returns `null` when none match. Throws [AmbiguousAgentRuntimeJarException] when more than one
+     * candidate is present so callers never silently load a jar based on classpath order.
+     */
+    fun findRuntimeJarOnClasspath(classPath: String): Path? {
+        val matches =
+            classPath
+                .split(File.pathSeparator)
+                .asSequence()
+                .filter { it.isNotBlank() }
+                .map(Path::of)
                 .filter(::isRuntimeJar)
-                .sorted(compareBy { it.fileName.toString() })
-                .findFirst()
-                .orElse(null)
+                .toList()
+        return selectSingleRuntimeJar(matches)
+    }
+
+    /**
+     * Locate a single agent runtime jar under [directory].
+     *
+     * Returns `null` when none match. Throws [AmbiguousAgentRuntimeJarException] when more than one
+     * candidate is present so callers never silently load a jar based on directory order.
+     */
+    fun findRuntimeJarInDirectory(directory: Path): Path? {
+        val matches = Files.list(directory).use { stream -> stream.filter(::isRuntimeJar).toList() }
+        return selectSingleRuntimeJar(matches)
+    }
+
+    private fun selectSingleRuntimeJar(matches: List<Path>): Path? {
+        // Classpaths sometimes list the same physical jar twice. Collapse by absolute
+        // path so only distinct files count as ambiguity.
+        val distinct =
+            matches.map { it.toAbsolutePath().normalize() }.distinct().sortedBy { it.toString() }
+        return when (distinct.size) {
+            0 -> null
+            1 -> distinct.single()
+            else -> throw AmbiguousAgentRuntimeJarException(distinct)
         }
+    }
 
     private fun isRuntimeJar(path: Path): Boolean =
         Files.isRegularFile(path) && isRuntimeJarName(path.fileName?.toString().orEmpty())

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
@@ -3,6 +3,7 @@
 package dev.sebastiano.spectre.agent
 
 import java.io.File
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -37,10 +38,22 @@ internal object AgentJarResolution {
     }
 
     private fun selectSingleRuntimeJar(matches: List<Path>): Path? {
-        // Classpaths sometimes list the same physical jar twice. Collapse by absolute
-        // path so only distinct files count as ambiguity.
-        val distinct =
-            matches.map { it.toAbsolutePath().normalize() }.distinct().sortedBy { it.toString() }
+        // Classpaths sometimes list the same physical jar twice (duplicate entries or
+        // symlink + real path). Collapse by filesystem identity so only distinct files
+        // count as ambiguity.
+        val distinct = mutableListOf<Path>()
+        for (candidate in matches) {
+            val normalized = candidate.toAbsolutePath().normalize()
+            val alreadySeen = distinct.any { existing ->
+                try {
+                    Files.isSameFile(existing, normalized)
+                } catch (_: IOException) {
+                    existing == normalized
+                }
+            }
+            if (!alreadySeen) distinct.add(normalized)
+        }
+        distinct.sortBy { it.toString() }
         return when (distinct.size) {
             0 -> null
             1 -> distinct.single()

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
@@ -86,6 +86,22 @@ public class AgentJarNotFoundException(searched: List<java.nio.file.Path>) :
     )
 
 /**
+ * Thrown when more than one agent runtime JAR candidate is found during discovery.
+ *
+ * Attach refuses to guess which jar to load: classpath order and directory listing order are not
+ * stable selection keys. Pass [AttachOptions.agentJarPath] or set the
+ * `dev.sebastiano.spectre.agent.runtimeJar` system property to choose explicitly.
+ */
+@ExperimentalSpectreAgentApi
+public class AmbiguousAgentRuntimeJarException(public val candidates: List<java.nio.file.Path>) :
+    SpectreAttachException(
+        "Multiple Spectre agent runtime JARs found; refuse to guess which to load:\n" +
+            candidates.joinToString("\n") { "  - $it" } +
+            "\n\nPass AttachOptions(agentJarPath = ...) or set " +
+            "dev.sebastiano.spectre.agent.runtimeJar to select one explicitly."
+    )
+
+/**
  * Thrown when the attach process was interrupted (typically from cooperative cancellation: a test
  * runner cancelling a long-running fixture, or an interactive caller pressing Ctrl-C). Distinct
  * from [AgentBootstrapTimeoutException] (which means "the agent never came up") and from a generic

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
@@ -93,6 +93,24 @@ class AgentJarResolutionTest {
     }
 
     @Test
+    fun `treats symlink and real path of the same jar as a single candidate`() {
+        val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
+        val runtimeJar = Files.createFile(dir.resolve("spectre-agent-runtime-0.2.0.jar"))
+        val link = dir.resolve("spectre-agent-runtime-link.jar")
+        try {
+            Files.createSymbolicLink(link, runtimeJar.fileName)
+        } catch (_: UnsupportedOperationException) {
+            return // platform without symlink support
+        } catch (_: java.nio.file.FileSystemException) {
+            return // sandbox / privilege may refuse symlink creation
+        }
+
+        val classPath = listOf(runtimeJar, link).joinToString(File.pathSeparator)
+        val resolved = AgentJarResolution.findRuntimeJarOnClasspath(classPath)
+        assertTrue(Files.isSameFile(runtimeJar, resolved!!))
+    }
+
+    @Test
     fun `fails closed when multiple runtime jars are in a directory`() {
         val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
         val first = Files.createFile(dir.resolve("agent-runtime-0.1.0.jar"))

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
@@ -4,8 +4,10 @@ package dev.sebastiano.spectre.agent
 
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class AgentJarResolutionTest {
@@ -49,10 +51,75 @@ class AgentJarResolutionTest {
     }
 
     @Test
+    fun `fails closed when multiple runtime jars are on the classpath`() {
+        val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
+        val older = Files.createFile(dir.resolve("spectre-agent-runtime-0.1.0.jar"))
+        val newer = Files.createFile(dir.resolve("spectre-agent-runtime-0.2.0.jar"))
+
+        // Reverse order of the two candidates so a "first on classpath" policy would
+        // pick differently; fail-closed must name both regardless of order.
+        val classPathA = listOf(older, newer).joinToString(File.pathSeparator)
+        val classPathB = listOf(newer, older).joinToString(File.pathSeparator)
+
+        val errorA =
+            assertFailsWith<AmbiguousAgentRuntimeJarException> {
+                AgentJarResolution.findRuntimeJarOnClasspath(classPathA)
+            }
+        val errorB =
+            assertFailsWith<AmbiguousAgentRuntimeJarException> {
+                AgentJarResolution.findRuntimeJarOnClasspath(classPathB)
+            }
+
+        assertSameCandidateSet(setOf(older, newer), errorA.candidates)
+        assertSameCandidateSet(setOf(older, newer), errorB.candidates)
+        assertEquals(errorA.candidates, errorB.candidates)
+        assertTrue(errorA.message!!.contains(older.fileName.toString()))
+        assertTrue(errorA.message!!.contains(newer.fileName.toString()))
+        assertTrue(
+            errorA.message!!.contains("AttachOptions") || errorA.message!!.contains("runtimeJar")
+        )
+    }
+
+    @Test
+    fun `treats duplicate classpath entries of the same jar as a single candidate`() {
+        val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
+        val runtimeJar = Files.createFile(dir.resolve("spectre-agent-runtime-0.2.0.jar"))
+        val classPath = listOf(runtimeJar, runtimeJar).joinToString(File.pathSeparator)
+
+        assertEquals(
+            runtimeJar.toAbsolutePath().normalize(),
+            AgentJarResolution.findRuntimeJarOnClasspath(classPath),
+        )
+    }
+
+    @Test
+    fun `fails closed when multiple runtime jars are in a directory`() {
+        val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
+        val first = Files.createFile(dir.resolve("agent-runtime-0.1.0.jar"))
+        val second = Files.createFile(dir.resolve("agent-runtime-0.2.0.jar"))
+
+        val error =
+            assertFailsWith<AmbiguousAgentRuntimeJarException> {
+                AgentJarResolution.findRuntimeJarInDirectory(dir)
+            }
+
+        assertSameCandidateSet(setOf(first, second), error.candidates)
+        assertTrue(error.message!!.contains(first.fileName.toString()))
+        assertTrue(error.message!!.contains(second.fileName.toString()))
+    }
+
+    @Test
     fun `default UDS path uses a per-attach private directory`() {
         val path = AttachOptions.defaultUdsPath(targetPid = 1234)
 
         assertEquals("agent.sock", path.fileName.toString())
         assertTrue(path.parent.fileName.toString().startsWith("sp-a-1234-"))
+    }
+
+    private fun assertSameCandidateSet(expected: Set<Path>, actual: List<Path>) {
+        assertEquals(
+            expected.map { it.toAbsolutePath().normalize() }.toSet(),
+            actual.map { it.toAbsolutePath().normalize() }.toSet(),
+        )
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolutionTest.kt
@@ -111,6 +111,31 @@ class AgentJarResolutionTest {
     }
 
     @Test
+    fun `preserves original classpath path that uses symlink parent and dot-dot`() {
+        val root = Files.createTempDirectory("spectre-agent-jar-resolution")
+        val realDir = Files.createDirectory(root.resolve("real"))
+        val runtimeJar = Files.createFile(realDir.resolve("spectre-agent-runtime-0.2.0.jar"))
+        val linkDir = root.resolve("link")
+        try {
+            Files.createSymbolicLink(linkDir, realDir.fileName)
+        } catch (_: UnsupportedOperationException) {
+            return
+        } catch (_: java.nio.file.FileSystemException) {
+            return
+        }
+
+        // link/../real/jar is a valid on-disk path via the symlink parent, but lexical
+        // Path.normalize() would collapse it incorrectly on some layouts.
+        val symlinkSensitive =
+            linkDir.resolve("..").resolve("real").resolve(runtimeJar.fileName.toString())
+        assertTrue(Files.isRegularFile(symlinkSensitive))
+
+        val resolved = AgentJarResolution.findRuntimeJarOnClasspath(symlinkSensitive.toString())
+        assertEquals(symlinkSensitive, resolved)
+        assertTrue(Files.isSameFile(runtimeJar, resolved!!))
+    }
+
+    @Test
     fun `fails closed when multiple runtime jars are in a directory`() {
         val dir = Files.createTempDirectory("spectre-agent-jar-resolution")
         val first = Files.createFile(dir.resolve("agent-runtime-0.1.0.jar"))

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -111,6 +111,12 @@ listed in `java.class.path`; Spectre scans that classpath, takes the physical ja
 that path to `VirtualMachine.loadAgent(...)`. The attacher does not call classes from the runtime
 jar directly, and the target still does not need `spectre-agent-runtime` declared as a dependency.
 
+Classpath and directory discovery require exactly one runtime-jar candidate. If more than one
+`spectre-agent-runtime-*.jar` / `agent-runtime-*.jar` is present, attach fails with
+`AmbiguousAgentRuntimeJarException` naming every candidate rather than picking by classpath
+order. Use `AttachOptions.agentJarPath` or `-Ddev.sebastiano.spectre.agent.runtimeJar` to choose
+explicitly.
+
 ## How attach works
 
 `AgentAttach.attach(pid)` performs this sequence:


### PR DESCRIPTION
## Summary

- Fail closed when more than one `spectre-agent-runtime-*.jar` / `agent-runtime-*.jar` is present on the classpath or in a directory scan, instead of silently taking the first entry by order.
- New public `AmbiguousAgentRuntimeJarException` lists every distinct candidate and points callers at `AttachOptions.agentJarPath` / `dev.sebastiano.spectre.agent.runtimeJar`.
- Duplicate path entries of the same physical jar still resolve as a single candidate.
- Docs note the multi-match policy.

Closes #165.

## Test plan

- [x] `AgentJarResolutionTest` multi-order classpath + directory fail-closed + same-path dedupe
- [x] `./gradlew :agent:test`
- [x] `./gradlew check`