### PR TITLE
Gate in-repo agent runtime jar fallback to Spectre checkouts (#167)

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -75,37 +75,16 @@ public object AgentAttach {
      * 2. The system property `dev.sebastiano.spectre.agent.runtimeJar`.
      * 3. A `spectre-agent-runtime-<version>.jar` or `agent-runtime-<version>.jar` entry on the
      *    attacher's `java.class.path`.
-     * 4. `<cwd>/agent-runtime/build/libs/agent-runtime-*.jar` (any match).
+     * 4. In-repo fallback at `<spectre-checkout>/agent-runtime/build/libs/agent-runtime-*.jar`,
+     *    only when the current working directory is inside a Spectre source checkout.
      */
-    @Suppress("ReturnCount")
-    private fun resolveAgentJar(options: AttachOptions): Path {
-        val tried = mutableListOf<Path>()
-
-        options.agentJarPath?.let { path ->
-            tried.add(path)
-            if (Files.isRegularFile(path)) return path
-        }
-
-        val sysProp = System.getProperty(AGENT_JAR_PROPERTY)?.takeIf { it.isNotBlank() }
-        if (sysProp != null) {
-            val path = Paths.get(sysProp)
-            tried.add(path)
-            if (Files.isRegularFile(path)) return path
-        }
-
-        val classpathRuntime =
-            AgentJarResolution.findRuntimeJarOnClasspath(System.getProperty("java.class.path"))
-        if (classpathRuntime != null) return classpathRuntime
-
-        val cwdGuess = Paths.get(System.getProperty("user.dir")).resolve("agent-runtime/build/libs")
-        if (Files.isDirectory(cwdGuess)) {
-            val match = AgentJarResolution.findRuntimeJarInDirectory(cwdGuess)
-            if (match != null) return match
-            tried.add(cwdGuess.resolve("agent-runtime-*.jar"))
-        }
-
-        throw AgentJarNotFoundException(tried)
-    }
+    private fun resolveAgentJar(options: AttachOptions): Path =
+        AgentJarResolution.resolveRuntimeJar(
+            agentJarPath = options.agentJarPath,
+            runtimeJarSystemProperty = System.getProperty(AGENT_JAR_PROPERTY),
+            classPath = System.getProperty("java.class.path").orEmpty(),
+            cwd = Paths.get(System.getProperty("user.dir")),
+        )
 
     /**
      * Resolves the public `com.sun.tools.attach.VirtualMachine` class and calls its static

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
@@ -38,15 +38,31 @@ internal object AgentJarResolution {
     }
 
     /**
-     * True when [directory] is the root of a Spectre monorepo checkout (settings + agent modules).
+     * True when [directory] is the root of a Spectre monorepo checkout.
      *
-     * Used to gate the in-repo `agent-runtime/build/libs` fallback so published consumers never
-     * silently load jars from a coincidental path under their application cwd.
+     * Requires the agent module layout **and** a Spectre-specific marker (`rootProject.name =
+     * "Spectre"` in settings, or `GROUP=dev.sebastiano.spectre` in `gradle.properties`) so
+     * unrelated projects that happen to have `agent` / `agent-runtime` subprojects are not treated
+     * as Spectre checkouts.
      */
-    fun isSpectreSourceCheckout(directory: Path): Boolean =
-        Files.isRegularFile(directory.resolve("settings.gradle.kts")) &&
-            Files.isRegularFile(directory.resolve("agent/build.gradle.kts")) &&
-            Files.isRegularFile(directory.resolve("agent-runtime/build.gradle.kts"))
+    fun isSpectreSourceCheckout(directory: Path): Boolean {
+        if (!Files.isRegularFile(directory.resolve("settings.gradle.kts"))) return false
+        if (!Files.isRegularFile(directory.resolve("agent/build.gradle.kts"))) return false
+        if (!Files.isRegularFile(directory.resolve("agent-runtime/build.gradle.kts"))) return false
+        return hasSpectreIdentityMarker(directory)
+    }
+
+    private fun hasSpectreIdentityMarker(directory: Path): Boolean {
+        val settings =
+            runCatching { Files.readString(directory.resolve("settings.gradle.kts")) }.getOrNull()
+        if (settings != null && settings.contains("""rootProject.name = "Spectre"""")) {
+            return true
+        }
+        val propsPath = directory.resolve("gradle.properties")
+        if (!Files.isRegularFile(propsPath)) return false
+        val props = runCatching { Files.readString(propsPath) }.getOrNull() ?: return false
+        return props.lineSequence().any { it.trim() == "GROUP=dev.sebastiano.spectre" }
+    }
 
     /** Walk parents from [start] and return the nearest Spectre source checkout root, if any. */
     fun findSpectreSourceCheckoutRoot(start: Path): Path? {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
@@ -55,14 +55,21 @@ internal object AgentJarResolution {
     private fun hasSpectreIdentityMarker(directory: Path): Boolean {
         val settings =
             runCatching { Files.readString(directory.resolve("settings.gradle.kts")) }.getOrNull()
-        if (settings != null && settings.contains("""rootProject.name = "Spectre"""")) {
+        if (settings != null && ACTIVE_SPECTRE_ROOT_NAME.containsMatchIn(settings)) {
             return true
         }
         val propsPath = directory.resolve("gradle.properties")
         if (!Files.isRegularFile(propsPath)) return false
         val props = runCatching { Files.readString(propsPath) }.getOrNull() ?: return false
-        return props.lineSequence().any { it.trim() == "GROUP=dev.sebastiano.spectre" }
+        return props.lineSequence().any { line ->
+            val trimmed = line.trim()
+            !trimmed.startsWith("#") && trimmed == "GROUP=dev.sebastiano.spectre"
+        }
     }
+
+    /** Active (non-commented) assignment only — comments must not enable the fallback. */
+    private val ACTIVE_SPECTRE_ROOT_NAME =
+        Regex("""(?m)^\s*rootProject\.name\s*=\s*"Spectre"\s*(//.*)?$""")
 
     /** Walk parents from [start] and return the nearest Spectre source checkout root, if any. */
     fun findSpectreSourceCheckoutRoot(start: Path): Path? {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
@@ -37,6 +37,80 @@ internal object AgentJarResolution {
         return selectSingleRuntimeJar(matches)
     }
 
+    /**
+     * True when [directory] is the root of a Spectre monorepo checkout (settings + agent modules).
+     *
+     * Used to gate the in-repo `agent-runtime/build/libs` fallback so published consumers never
+     * silently load jars from a coincidental path under their application cwd.
+     */
+    fun isSpectreSourceCheckout(directory: Path): Boolean =
+        Files.isRegularFile(directory.resolve("settings.gradle.kts")) &&
+            Files.isRegularFile(directory.resolve("agent/build.gradle.kts")) &&
+            Files.isRegularFile(directory.resolve("agent-runtime/build.gradle.kts"))
+
+    /** Walk parents from [start] and return the nearest Spectre source checkout root, if any. */
+    fun findSpectreSourceCheckoutRoot(start: Path): Path? {
+        var dir: Path? = start.toAbsolutePath().normalize()
+        while (dir != null) {
+            if (isSpectreSourceCheckout(dir)) return dir
+            dir = dir.parent
+        }
+        return null
+    }
+
+    /**
+     * In-repo fallback: only when [cwd] is inside a Spectre source checkout, look under
+     * `<checkout>/agent-runtime/build/libs` for a single runtime jar.
+     */
+    fun findRuntimeJarInRepoFallback(cwd: Path): Path? {
+        val root = findSpectreSourceCheckoutRoot(cwd) ?: return null
+        val libs = root.resolve("agent-runtime/build/libs")
+        if (!Files.isDirectory(libs)) return null
+        return findRuntimeJarInDirectory(libs)
+    }
+
+    /**
+     * Resolve the agent runtime jar using the public attach lookup order.
+     *
+     * 1. [agentJarPath] if present and a regular file
+     * 2. [runtimeJarSystemProperty] path if present and a regular file
+     * 3. Classpath auto-discovery
+     * 4. In-repo fallback gated on Spectre source-checkout detection from [cwd]
+     */
+    fun resolveRuntimeJar(
+        agentJarPath: Path?,
+        runtimeJarSystemProperty: String?,
+        classPath: String,
+        cwd: Path,
+    ): Path {
+        val tried = mutableListOf<Path>()
+
+        agentJarPath?.let { path ->
+            tried.add(path)
+            if (Files.isRegularFile(path)) return path
+        }
+
+        val sysProp = runtimeJarSystemProperty?.takeIf { it.isNotBlank() }
+        if (sysProp != null) {
+            val path = Path.of(sysProp)
+            tried.add(path)
+            if (Files.isRegularFile(path)) return path
+        }
+
+        val classpathRuntime = findRuntimeJarOnClasspath(classPath)
+        if (classpathRuntime != null) return classpathRuntime
+
+        val repoFallback = findRuntimeJarInRepoFallback(cwd)
+        if (repoFallback != null) return repoFallback
+
+        val checkoutRoot = findSpectreSourceCheckoutRoot(cwd)
+        if (checkoutRoot != null) {
+            tried.add(checkoutRoot.resolve("agent-runtime/build/libs/agent-runtime-*.jar"))
+        }
+
+        throw AgentJarNotFoundException(tried)
+    }
+
     private fun selectSingleRuntimeJar(matches: List<Path>): Path? {
         // Classpaths sometimes list the same physical jar twice (duplicate entries or
         // symlink + real path). Collapse by filesystem identity so only distinct files

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentJarResolution.kt
@@ -55,7 +55,10 @@ internal object AgentJarResolution {
     private fun hasSpectreIdentityMarker(directory: Path): Boolean {
         val settings =
             runCatching { Files.readString(directory.resolve("settings.gradle.kts")) }.getOrNull()
-        if (settings != null && ACTIVE_SPECTRE_ROOT_NAME.containsMatchIn(settings)) {
+        if (
+            settings != null &&
+                ACTIVE_SPECTRE_ROOT_NAME.containsMatchIn(stripKotlinLikeNonCode(settings))
+        ) {
             return true
         }
         val propsPath = directory.resolve("gradle.properties")
@@ -63,13 +66,28 @@ internal object AgentJarResolution {
         val props = runCatching { Files.readString(propsPath) }.getOrNull() ?: return false
         return props.lineSequence().any { line ->
             val trimmed = line.trim()
-            !trimmed.startsWith("#") && trimmed == "GROUP=dev.sebastiano.spectre"
+            !trimmed.startsWith("#") &&
+                !trimmed.startsWith("!") &&
+                trimmed == "GROUP=dev.sebastiano.spectre"
         }
     }
 
-    /** Active (non-commented) assignment only — comments must not enable the fallback. */
+    /**
+     * Best-effort removal of non-executable regions from settings.gradle.kts so identity markers
+     * inside block comments or triple-quoted strings cannot enable the fallback.
+     */
+    private fun stripKotlinLikeNonCode(source: String): String {
+        var text = BLOCK_COMMENT.replace(source, " ")
+        text = TRIPLE_QUOTE_STRING.replace(text, " ")
+        return text.lineSequence().joinToString("\n") { line -> line.substringBefore("//") }
+    }
+
+    /** Active assignment only — comments/strings must not enable the fallback. */
     private val ACTIVE_SPECTRE_ROOT_NAME =
-        Regex("""(?m)^\s*rootProject\.name\s*=\s*"Spectre"\s*(//.*)?$""")
+        Regex("""(?m)^\s*rootProject\.name\s*=\s*"Spectre"\s*$""")
+
+    private val BLOCK_COMMENT = Regex("""/\*.*?\*/""", setOf(RegexOption.DOT_MATCHES_ALL))
+    private val TRIPLE_QUOTE_STRING = Regex("\"\"\".*?\"\"\"", setOf(RegexOption.DOT_MATCHES_ALL))
 
     /** Walk parents from [start] and return the nearest Spectre source checkout root, if any. */
     fun findSpectreSourceCheckoutRoot(start: Path): Path? {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -12,7 +12,8 @@ import java.util.UUID
  *    integration tests so they don't have to know the absolute build path).
  * 2. A `spectre-agent-runtime-<version>.jar` or `agent-runtime-<version>.jar` entry on the
  *    attacher's `java.class.path`.
- * 3. `<cwd>/agent-runtime/build/libs/agent-runtime-<version>.jar` if the worktree layout matches.
+ * 3. `<spectre-checkout>/agent-runtime/build/libs/agent-runtime-<version>.jar` only when the
+ *    current working directory is inside a Spectre source checkout (not for published consumers).
  *
  * The fallback throws when none of the candidates exist, with a message pointing the user at
  * `./gradlew :agent-runtime:jar` to produce the JAR.

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolveTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolveTest.kt
@@ -134,6 +134,36 @@ class AgentJarResolveTest {
         assertNull(AgentJarResolution.findRuntimeJarInRepoFallback(root))
     }
 
+    @Test
+    fun `commented spectre identity markers do not enable checkout fallback`() {
+        val root = Files.createTempDirectory("commented-identity")
+        Files.writeString(
+            root.resolve("settings.gradle.kts"),
+            """
+            // rootProject.name = "Spectre"
+            rootProject.name = "Other"
+            """
+                .trimIndent(),
+        )
+        Files.writeString(
+            root.resolve("gradle.properties"),
+            """
+            # GROUP=dev.sebastiano.spectre
+            GROUP=com.example.other
+            """
+                .trimIndent(),
+        )
+        Files.createDirectories(root.resolve("agent"))
+        Files.createFile(root.resolve("agent/build.gradle.kts"))
+        Files.createDirectories(root.resolve("agent-runtime"))
+        Files.createFile(root.resolve("agent-runtime/build.gradle.kts"))
+        val libs = Files.createDirectories(root.resolve("agent-runtime/build/libs"))
+        Files.createFile(libs.resolve("agent-runtime-0.2.0.jar"))
+
+        assertFalse(AgentJarResolution.isSpectreSourceCheckout(root))
+        assertNull(AgentJarResolution.findRuntimeJarInRepoFallback(root))
+    }
+
     private fun touchCheckoutMarkers(root: Path) {
         Files.writeString(root.resolve("settings.gradle.kts"), """rootProject.name = "Spectre"""")
         Files.createDirectories(root.resolve("agent"))

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolveTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolveTest.kt
@@ -1,0 +1,129 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AgentJarResolveTest {
+    @Test
+    fun `detects spectre source checkout by monorepo markers`() {
+        val root = Files.createTempDirectory("spectre-checkout")
+        touchCheckoutMarkers(root)
+
+        assertTrue(AgentJarResolution.isSpectreSourceCheckout(root))
+        assertEquals(root, AgentJarResolution.findSpectreSourceCheckoutRoot(root))
+        assertEquals(root, AgentJarResolution.findSpectreSourceCheckoutRoot(root.resolve("agent")))
+    }
+
+    @Test
+    fun `generic directory is not a spectre source checkout`() {
+        val generic = Files.createTempDirectory("not-spectre")
+        Files.createDirectories(generic.resolve("agent-runtime/build/libs"))
+        Files.createFile(generic.resolve("agent-runtime/build/libs/agent-runtime-0.2.0.jar"))
+
+        assertFalse(AgentJarResolution.isSpectreSourceCheckout(generic))
+        assertNull(AgentJarResolution.findSpectreSourceCheckoutRoot(generic))
+    }
+
+    @Test
+    fun `repo fallback finds jar only under a spectre checkout`() {
+        val root = Files.createTempDirectory("spectre-checkout")
+        touchCheckoutMarkers(root)
+        val libs = Files.createDirectories(root.resolve("agent-runtime/build/libs"))
+        val jar = Files.createFile(libs.resolve("agent-runtime-0.2.0.jar"))
+
+        assertEquals(jar, AgentJarResolution.findRuntimeJarInRepoFallback(root))
+        assertEquals(jar, AgentJarResolution.findRuntimeJarInRepoFallback(root.resolve("cli")))
+    }
+
+    @Test
+    fun `repo fallback is disabled for a generic cwd even with matching layout path`() {
+        val generic = Files.createTempDirectory("consumer-app")
+        val libs = Files.createDirectories(generic.resolve("agent-runtime/build/libs"))
+        Files.createFile(libs.resolve("agent-runtime-0.2.0.jar"))
+
+        assertNull(AgentJarResolution.findRuntimeJarInRepoFallback(generic))
+    }
+
+    @Test
+    fun `resolve prefers explicit path then sysprop then classpath before repo fallback`() {
+        val root = Files.createTempDirectory("spectre-checkout")
+        touchCheckoutMarkers(root)
+        val libs = Files.createDirectories(root.resolve("agent-runtime/build/libs"))
+        val fallbackJar = Files.createFile(libs.resolve("agent-runtime-0.2.0.jar"))
+
+        val explicit = Files.createTempFile("explicit-runtime", ".jar")
+        val viaProp = Files.createTempFile("prop-runtime", ".jar")
+        val viaClasspath =
+            Files.createTempDirectory("cp").resolve("spectre-agent-runtime-0.2.0.jar")
+        Files.createFile(viaClasspath)
+
+        assertEquals(
+            explicit,
+            AgentJarResolution.resolveRuntimeJar(
+                agentJarPath = explicit,
+                runtimeJarSystemProperty = viaProp.toString(),
+                classPath = viaClasspath.toString(),
+                cwd = root,
+            ),
+        )
+        assertEquals(
+            viaProp,
+            AgentJarResolution.resolveRuntimeJar(
+                agentJarPath = null,
+                runtimeJarSystemProperty = viaProp.toString(),
+                classPath = viaClasspath.toString(),
+                cwd = root,
+            ),
+        )
+        assertEquals(
+            viaClasspath,
+            AgentJarResolution.resolveRuntimeJar(
+                agentJarPath = null,
+                runtimeJarSystemProperty = null,
+                classPath = viaClasspath.toString(),
+                cwd = root,
+            ),
+        )
+        assertEquals(
+            fallbackJar,
+            AgentJarResolution.resolveRuntimeJar(
+                agentJarPath = null,
+                runtimeJarSystemProperty = null,
+                classPath = "",
+                cwd = root,
+            ),
+        )
+    }
+
+    @Test
+    fun `resolve does not use generic cwd fallback when higher sources miss`() {
+        val generic = Files.createTempDirectory("consumer-app")
+        val libs = Files.createDirectories(generic.resolve("agent-runtime/build/libs"))
+        Files.createFile(libs.resolve("agent-runtime-0.2.0.jar"))
+
+        assertFailsWith<AgentJarNotFoundException> {
+            AgentJarResolution.resolveRuntimeJar(
+                agentJarPath = null,
+                runtimeJarSystemProperty = null,
+                classPath = "",
+                cwd = generic,
+            )
+        }
+    }
+
+    private fun touchCheckoutMarkers(root: Path) {
+        Files.createFile(root.resolve("settings.gradle.kts"))
+        Files.createDirectories(root.resolve("agent"))
+        Files.createFile(root.resolve("agent/build.gradle.kts"))
+        Files.createDirectories(root.resolve("agent-runtime"))
+        Files.createFile(root.resolve("agent-runtime/build.gradle.kts"))
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolveTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolveTest.kt
@@ -141,6 +141,10 @@ class AgentJarResolveTest {
             root.resolve("settings.gradle.kts"),
             """
             // rootProject.name = "Spectre"
+            /* rootProject.name = "Spectre" */
+            val docs = ${"\"\"\""}
+                rootProject.name = "Spectre"
+            ${"\"\"\""}
             rootProject.name = "Other"
             """
                 .trimIndent(),

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolveTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentJarResolveTest.kt
@@ -119,8 +119,23 @@ class AgentJarResolveTest {
         }
     }
 
+    @Test
+    fun `layout alone without spectre identity is not a checkout`() {
+        val root = Files.createTempDirectory("lookalike")
+        Files.writeString(root.resolve("settings.gradle.kts"), """rootProject.name = "Other"""")
+        Files.createDirectories(root.resolve("agent"))
+        Files.createFile(root.resolve("agent/build.gradle.kts"))
+        Files.createDirectories(root.resolve("agent-runtime"))
+        Files.createFile(root.resolve("agent-runtime/build.gradle.kts"))
+        val libs = Files.createDirectories(root.resolve("agent-runtime/build/libs"))
+        Files.createFile(libs.resolve("agent-runtime-0.2.0.jar"))
+
+        assertFalse(AgentJarResolution.isSpectreSourceCheckout(root))
+        assertNull(AgentJarResolution.findRuntimeJarInRepoFallback(root))
+    }
+
     private fun touchCheckoutMarkers(root: Path) {
-        Files.createFile(root.resolve("settings.gradle.kts"))
+        Files.writeString(root.resolve("settings.gradle.kts"), """rootProject.name = "Spectre"""")
         Files.createDirectories(root.resolve("agent"))
         Files.createFile(root.resolve("agent/build.gradle.kts"))
         Files.createDirectories(root.resolve("agent-runtime"))

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -104,7 +104,9 @@ dependencies {
 1. `AttachOptions.agentJarPath`
 2. `-Ddev.sebastiano.spectre.agent.runtimeJar=<path>`
 3. Classpath auto-discovery of a physical `spectre-agent-runtime-<version>.jar`
-4. The in-repo fallback at `<cwd>/agent-runtime/build/libs/agent-runtime-*.jar`
+4. In-repo fallback at `<spectre-checkout>/agent-runtime/build/libs/agent-runtime-*.jar`,
+   **only when the attacher cwd is inside a Spectre source checkout** (detected via monorepo
+   markers). Published consumers should use options 1–3; the fallback is a Spectre-dev convenience.
 
 In normal Gradle usage, `runtimeOnly(...)` makes Gradle launch the attacher with the runtime jar
 listed in `java.class.path`; Spectre scans that classpath, takes the physical jar path, and passes
@@ -176,9 +178,12 @@ AgentAttach.attach(
 
 Equivalent: set `-Ddev.sebastiano.spectre.agent.runtimeJar=<path>` on the attacher's JVM.
 
-When working inside the Spectre repo, `AgentAttach` also falls back to
-`<cwd>/agent-runtime/build/libs/agent-runtime-*.jar` so local manual recipes keep working after
-`./gradlew :agent-runtime:jar`.
+When the attacher process is running from inside a Spectre source checkout (or a subdirectory of
+one), `AgentAttach` also falls back to
+`<checkout>/agent-runtime/build/libs/agent-runtime-*.jar` so local manual recipes keep working after
+`./gradlew :agent-runtime:jar`. That path is **not** enabled for arbitrary application working
+directories — published consumers should put `spectre-agent-runtime` on the attacher classpath or
+pass an explicit path/system property.
 
 Consumers that cannot use the published Maven coordinate still have two supported paths:
 


### PR DESCRIPTION
## Summary

- Gate the `<cwd>/agent-runtime/build/libs` runtime-jar fallback so it only runs when the attacher is inside a Spectre source checkout (walk-up detection via monorepo markers).
- Extract testable `AgentJarResolution.resolveRuntimeJar` / checkout helpers used by `AgentAttach`.
- Update `AttachOptions` KDoc and `docs/guide/agent.md` to document the policy.
- Published consumers should use classpath auto-discovery, `AttachOptions.agentJarPath`, or `-Ddev.sebastiano.spectre.agent.runtimeJar`.

Closes #167.

## Test plan

- [x] `AgentJarResolveTest` (checkout detect, generic cwd disabled, priority order)
- [x] Existing `AgentJarResolutionTest`
- [x] `./gradlew check`