### PR TITLE
Add frame I/O timeouts to agent IPC transport (#168)

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/FrameIoDeadline.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/FrameIoDeadline.kt
@@ -1,0 +1,81 @@
+package dev.sebastiano.spectre.agent.transport
+
+import java.io.IOException
+import java.net.SocketTimeoutException
+import java.nio.channels.Channel
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Bounded I/O deadlines for agent UDS framing.
+ *
+ * Unix-domain [java.nio.channels.SocketChannel] has no portable `SO_TIMEOUT`. A scheduled closer
+ * cancels a stuck read/write by closing the channel; the blocked stream call then fails and we map
+ * that to [SocketTimeoutException].
+ */
+internal object FrameIoDeadline {
+    /** Default per-frame read/write budget for production attach sessions. */
+    const val DEFAULT_TIMEOUT_MS: Long = 30_000L
+
+    private val scheduler: ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor { r ->
+            Thread(r, "spectre-ipc-io-deadline").apply { isDaemon = true }
+        }
+
+    /**
+     * Runs [block] with a wall-clock deadline. If [timeoutMs] elapses before [block] returns,
+     * [channel] is closed and a [SocketTimeoutException] is thrown (wrapping the I/O failure if one
+     * surfaces).
+     *
+     * Pass [timeoutMs] `<= 0` to disable the deadline (tests only).
+     */
+    fun <T> withTimeout(channel: Channel, timeoutMs: Long, block: () -> T): T {
+        if (timeoutMs <= 0L) return block()
+        val timedOut = AtomicBoolean(false)
+        val future =
+            scheduler.schedule(
+                {
+                    if (timedOut.compareAndSet(false, true)) {
+                        runCatching { channel.close() }
+                    }
+                },
+                timeoutMs,
+                TimeUnit.MILLISECONDS,
+            )
+        // block may throw any I/O / framing failure; map only the deadline-closed path.
+        @Suppress("TooGenericExceptionCaught")
+        try {
+            return block()
+        } catch (ex: Exception) {
+            if (timedOut.get()) throw timeoutException(timeoutMs, ex)
+            throw ex
+        } finally {
+            future.cancel(false)
+        }
+    }
+
+    /** True when [error] (or its cause chain) is a frame-I/O deadline failure. */
+    fun isTimeout(error: Throwable?): Boolean {
+        var cur: Throwable? = error
+        while (cur != null) {
+            if (cur is SocketTimeoutException) return true
+            cur = cur.cause
+        }
+        return false
+    }
+
+    fun asTimeoutIoException(error: Throwable): IOException =
+        when (error) {
+            is SocketTimeoutException -> error
+            is IOException ->
+                if (isTimeout(error)) error else timeoutException(DEFAULT_TIMEOUT_MS, error)
+            else -> timeoutException(DEFAULT_TIMEOUT_MS, error)
+        }
+
+    private fun timeoutException(timeoutMs: Long, cause: Throwable?): SocketTimeoutException =
+        SocketTimeoutException("Spectre agent IPC frame I/O timed out after ${timeoutMs}ms").also {
+            if (cause != null) it.initCause(cause)
+        }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/FrameIoDeadline.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/FrameIoDeadline.kt
@@ -1,12 +1,18 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
 package dev.sebastiano.spectre.agent.transport
 
+import java.io.EOFException
 import java.io.IOException
+import java.io.InputStream
 import java.net.SocketTimeoutException
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
 import java.nio.channels.Channel
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
-import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Bounded I/O deadlines for agent UDS framing.
@@ -14,9 +20,13 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Unix-domain [java.nio.channels.SocketChannel] has no portable `SO_TIMEOUT`. A scheduled closer
  * cancels a stuck read/write by closing the channel; the blocked stream call then fails and we map
  * that to [SocketTimeoutException].
+ *
+ * **Idle vs mid-frame:** Waiting for the *next* frame's first header byte is unbounded (healthy
+ * sessions may be idle longer than the budget). Once any header byte arrives, the remainder of that
+ * frame must complete within [DEFAULT_TIMEOUT_MS] or the peer is treated as wedged.
  */
 internal object FrameIoDeadline {
-    /** Default per-frame read/write budget for production attach sessions. */
+    /** Default mid-frame / write budget for production attach sessions. */
     const val DEFAULT_TIMEOUT_MS: Long = 30_000L
 
     private val scheduler: ScheduledExecutorService =
@@ -24,35 +34,70 @@ internal object FrameIoDeadline {
             Thread(r, "spectre-ipc-io-deadline").apply { isDaemon = true }
         }
 
+    private enum class RunState {
+        RUNNING,
+        SUCCEEDED,
+        TIMED_OUT,
+    }
+
     /**
      * Runs [block] with a wall-clock deadline. If [timeoutMs] elapses before [block] returns,
-     * [channel] is closed and a [SocketTimeoutException] is thrown (wrapping the I/O failure if one
-     * surfaces).
+     * [channel] is closed and a [SocketTimeoutException] is thrown.
      *
      * Pass [timeoutMs] `<= 0` to disable the deadline (tests only).
      */
     fun <T> withTimeout(channel: Channel, timeoutMs: Long, block: () -> T): T {
         if (timeoutMs <= 0L) return block()
-        val timedOut = AtomicBoolean(false)
+        val state = AtomicReference(RunState.RUNNING)
         val future =
             scheduler.schedule(
                 {
-                    if (timedOut.compareAndSet(false, true)) {
+                    if (state.compareAndSet(RunState.RUNNING, RunState.TIMED_OUT)) {
                         runCatching { channel.close() }
                     }
                 },
                 timeoutMs,
                 TimeUnit.MILLISECONDS,
             )
-        // block may throw any I/O / framing failure; map only the deadline-closed path.
+        // block may throw any I/O / framing failure; map only when the closer fired.
         @Suppress("TooGenericExceptionCaught")
         try {
-            return block()
+            val result = block()
+            if (!state.compareAndSet(RunState.RUNNING, RunState.SUCCEEDED)) {
+                // Timer won after block returned but before we claimed success.
+                throw timeoutException(timeoutMs, null)
+            }
+            return result
         } catch (ex: Exception) {
-            if (timedOut.get()) throw timeoutException(timeoutMs, ex)
+            if (state.get() == RunState.TIMED_OUT) throw timeoutException(timeoutMs, ex)
+            state.compareAndSet(RunState.RUNNING, RunState.SUCCEEDED)
             throw ex
         } finally {
             future.cancel(false)
+            state.compareAndSet(RunState.RUNNING, RunState.SUCCEEDED)
+        }
+    }
+
+    /**
+     * Read one frame. Waiting for the first header byte is unbounded (idle sessions). Once any
+     * header byte is received, the rest of the frame must complete within [timeoutMs].
+     */
+    fun readFrameAllowingIdle(input: InputStream, channel: Channel, timeoutMs: Long): ByteArray? {
+        val first = input.read()
+        if (first == -1) return null
+        return withTimeout(channel, timeoutMs) {
+            val header = ByteArray(HEADER_BYTES)
+            header[0] = first.toByte()
+            readFully(input, header, offset = 1, length = HEADER_BYTES - 1)
+            val frameLength = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN).int
+            check(frameLength in 0..MAX_FRAME_BYTES) {
+                val headerDump = header.joinToString(",") { it.toInt().toString() }
+                "Invalid frame length $frameLength (header bytes: $headerDump)"
+            }
+            if (frameLength == 0) return@withTimeout ByteArray(0)
+            val payload = ByteArray(frameLength)
+            readFully(input, payload, offset = 0, length = frameLength)
+            payload
         }
     }
 
@@ -78,4 +123,17 @@ internal object FrameIoDeadline {
         SocketTimeoutException("Spectre agent IPC frame I/O timed out after ${timeoutMs}ms").also {
             if (cause != null) it.initCause(cause)
         }
+
+    private fun readFully(input: InputStream, buf: ByteArray, offset: Int, length: Int) {
+        var read = 0
+        while (read < length) {
+            val r = input.read(buf, offset + read, length - read)
+            if (r == -1) {
+                throw EOFException("Unexpected EOF after $read of $length frame bytes")
+            }
+            read += r
+        }
+    }
+
+    private const val HEADER_BYTES = 4
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/FrameIoDeadline.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/FrameIoDeadline.kt
@@ -9,8 +9,7 @@ import java.net.SocketTimeoutException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 import java.nio.channels.Channel
-import java.util.concurrent.Executors
-import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
 
@@ -29,10 +28,13 @@ internal object FrameIoDeadline {
     /** Default mid-frame / write budget for production attach sessions. */
     const val DEFAULT_TIMEOUT_MS: Long = 30_000L
 
-    private val scheduler: ScheduledExecutorService =
-        Executors.newSingleThreadScheduledExecutor { r ->
-            Thread(r, "spectre-ipc-io-deadline").apply { isDaemon = true }
-        }
+    // removeOnCancelPolicy avoids retaining every successful op's cancelled 30s deadline
+    // task in the delayed queue under sustained IPC throughput (Codex P2).
+    private val scheduler: ScheduledThreadPoolExecutor =
+        ScheduledThreadPoolExecutor(1) { r ->
+                Thread(r, "spectre-ipc-io-deadline").apply { isDaemon = true }
+            }
+            .also { it.removeOnCancelPolicy = true }
 
     private enum class RunState {
         RUNNING,

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -234,10 +234,9 @@ constructor(
         @Suppress("TooGenericExceptionCaught")
         try {
             while (!closed.get()) {
+                // Idle between responses is allowed; mid-frame stalls time out.
                 val bytes =
-                    FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
-                        Framing.readFrame(input)
-                    } ?: break
+                    FrameIoDeadline.readFrameAllowingIdle(input, channel, frameIoTimeoutMs) ?: break
                 dispatchOpResponse(bytes)
             }
         } catch (ex: Exception) {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -118,11 +118,7 @@ constructor(
         pending[opId] = future
         try {
             val frame = OpRequest(opId = opId, deadlineEpochMs = deadlineEpochMs, body = request)
-            synchronized(writeLock) {
-                FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
-                    Framing.writeFrame(output, WireCodec.encode(frame))
-                }
-            }
+            writeFrameInterruptSafe(WireCodec.encode(frame))
             // No client-side deadline: wait indefinitely for the server (matches pre-#200
             // blocking read). With a deadline: pad so server taxonomy timeout can still arrive.
             return if (deadlineEpochMs == null) {
@@ -191,11 +187,7 @@ constructor(
         pending[cancelId] = future
         try {
             val frame = OpRequest(opId = cancelId, body = AgentRequest.Cancel(opId = opId))
-            synchronized(writeLock) {
-                FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
-                    Framing.writeFrame(output, WireCodec.encode(frame))
-                }
-            }
+            writeFrameInterruptSafe(WireCodec.encode(frame))
             future.get(CANCEL_ACK_WAIT_MS, TimeUnit.MILLISECONDS)
         } catch (_: java.util.concurrent.TimeoutException) {
             // Best-effort: cancel ack lag is non-fatal.
@@ -272,12 +264,31 @@ constructor(
         pending.clear()
     }
 
+    /**
+     * SocketChannel is interruptible: a write from a thread with interrupt status set can close the
+     * shared client socket. Cancel/interrupt paths call [cancel] while interrupted, so clear
+     * interrupt only for the duration of the write and restore afterward (mirrors the server write
+     * path in MultiplexedIpcSession).
+     */
+    private fun writeFrameInterruptSafe(payload: ByteArray) {
+        val wasInterrupted = Thread.interrupted()
+        try {
+            synchronized(writeLock) {
+                FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                    Framing.writeFrame(output, payload)
+                }
+            }
+        } finally {
+            if (wasInterrupted) {
+                Thread.currentThread().interrupt()
+            }
+        }
+    }
+
     /** Bare (pre-envelope) exchange used only for Hello / best-effort Detach on failed Hello. */
     @Throws(IOException::class)
     private fun exchangeBare(request: AgentRequest): AgentResponse {
-        FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
-            Framing.writeFrame(output, WireCodec.encode(request))
-        }
+        writeFrameInterruptSafe(WireCodec.encode(request))
         val responseBytes =
             FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) { Framing.readFrame(input) }
                 ?: throw EOFException(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcClient.kt
@@ -29,7 +29,13 @@ import java.util.concurrent.atomic.AtomicLong
  * intentional agent teardown (see [dev.sebastiano.spectre.agent.AttachedAutomator.close]); a plain
  * client close must leave the server free to accept another connection (e.g. reconnect / tests).
  */
-internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) : AutoCloseable {
+internal class IpcClient
+@Throws(IOException::class)
+constructor(
+    udsPath: Path,
+    /** Per-frame read/write deadline; `<= 0` disables (tests only). */
+    private val frameIoTimeoutMs: Long = FrameIoDeadline.DEFAULT_TIMEOUT_MS,
+) : AutoCloseable {
     private val channel: SocketChannel =
         SocketChannel.open(StandardProtocolFamily.UNIX).also { channel ->
             var success = false
@@ -112,7 +118,11 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
         pending[opId] = future
         try {
             val frame = OpRequest(opId = opId, deadlineEpochMs = deadlineEpochMs, body = request)
-            synchronized(writeLock) { Framing.writeFrame(output, WireCodec.encode(frame)) }
+            synchronized(writeLock) {
+                FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                    Framing.writeFrame(output, WireCodec.encode(frame))
+                }
+            }
             // No client-side deadline: wait indefinitely for the server (matches pre-#200
             // blocking read). With a deadline: pad so server taxonomy timeout can still arrive.
             return if (deadlineEpochMs == null) {
@@ -181,7 +191,11 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
         pending[cancelId] = future
         try {
             val frame = OpRequest(opId = cancelId, body = AgentRequest.Cancel(opId = opId))
-            synchronized(writeLock) { Framing.writeFrame(output, WireCodec.encode(frame)) }
+            synchronized(writeLock) {
+                FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                    Framing.writeFrame(output, WireCodec.encode(frame))
+                }
+            }
             future.get(CANCEL_ACK_WAIT_MS, TimeUnit.MILLISECONDS)
         } catch (_: java.util.concurrent.TimeoutException) {
             // Best-effort: cancel ack lag is non-fatal.
@@ -214,15 +228,31 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
     internal fun lastOpId(): Long = nextOpId.get() - 1
 
     private fun readerLoop() {
+        var terminal: Exception =
+            EOFException("Agent closed the connection while waiting for a response")
+        // Framing/I/O failures are not a closed set of types (timeout, EOF, channel close, …).
+        @Suppress("TooGenericExceptionCaught")
         try {
             while (!closed.get()) {
-                val bytes = Framing.readFrame(input) ?: break
+                val bytes =
+                    FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                        Framing.readFrame(input)
+                    } ?: break
                 dispatchOpResponse(bytes)
             }
-        } catch (_: Exception) {
-            // Channel closed or transport error — complete outstanding futures below.
+        } catch (ex: Exception) {
+            // Channel closed, I/O timeout, or transport error — complete outstanding futures.
+            terminal =
+                if (FrameIoDeadline.isTimeout(ex)) {
+                    FrameIoDeadline.asTimeoutIoException(ex)
+                } else {
+                    EOFException(
+                            "Agent closed the connection while waiting for a response: ${ex.message}"
+                        )
+                        .apply { initCause(ex) }
+                }
         } finally {
-            failAllPending(EOFException("Agent closed the connection while waiting for a response"))
+            failAllPending(terminal)
         }
     }
 
@@ -246,9 +276,11 @@ internal class IpcClient @Throws(IOException::class) constructor(udsPath: Path) 
     /** Bare (pre-envelope) exchange used only for Hello / best-effort Detach on failed Hello. */
     @Throws(IOException::class)
     private fun exchangeBare(request: AgentRequest): AgentResponse {
-        Framing.writeFrame(output, WireCodec.encode(request))
+        FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+            Framing.writeFrame(output, WireCodec.encode(request))
+        }
         val responseBytes =
-            Framing.readFrame(input)
+            FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) { Framing.readFrame(input) }
                 ?: throw EOFException(
                     "Agent closed the connection before sending a response to ${request.logLabel}"
                 )

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -36,6 +36,8 @@ constructor(
     private val udsPath: Path,
     private val handler: AgentRequestHandler,
     private val onDetach: () -> Unit = {},
+    /** Per-frame read/write deadline; `<= 0` disables (not for production). */
+    private val frameIoTimeoutMs: Long = FrameIoDeadline.DEFAULT_TIMEOUT_MS,
 ) : AutoCloseable {
     private var createdParentDir: Path? = null
 
@@ -136,19 +138,32 @@ constructor(
             val input = Channels.newInputStream(socket)
             val output = Channels.newOutputStream(socket)
             // Phase 1: bare Hello (#199).
-            if (!performHandshake(input, output)) return
+            if (!performHandshake(socket, input, output)) return
             // Phase 2: multiplexed OpRequest frames on a worker pool (#200).
-            MultiplexedIpcSession(handler, running, onDetach).run(input, output)
+            MultiplexedIpcSession(
+                    handler = handler,
+                    running = running,
+                    onDetach = onDetach,
+                    channel = socket,
+                    frameIoTimeoutMs = frameIoTimeoutMs,
+                )
+                .run(input, output)
         }
     }
 
     /** Bare Hello handshake. Returns false if the connection should end. */
-    private fun performHandshake(input: InputStream, output: OutputStream): Boolean {
+    private fun performHandshake(
+        channel: SocketChannel,
+        input: InputStream,
+        output: OutputStream,
+    ): Boolean {
         var handshakeComplete = false
         while (running.get() && !handshakeComplete) {
             val requestBytes =
                 try {
-                    Framing.readFrame(input) ?: return false
+                    FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                        Framing.readFrame(input)
+                    } ?: return false
                 } catch (ex: IllegalStateException) {
                     running.set(false)
                     onDetach()
@@ -158,16 +173,16 @@ constructor(
                 try {
                     WireCodec.decodeRequest(requestBytes)
                 } catch (ex: kotlinx.serialization.SerializationException) {
-                    respondDecodeFailure(output, ex, handshakeComplete = false)
+                    respondDecodeFailure(channel, output, ex, handshakeComplete = false)
                     return false
                 }
             when (request) {
                 is AgentRequest.Hello -> {
-                    val ok = respondHello(output, request) { handshakeComplete = it }
+                    val ok = respondHello(channel, output, request) { handshakeComplete = it }
                     if (!ok) return false
                 }
                 else -> {
-                    rejectPreHandshake(output, request)
+                    rejectPreHandshake(channel, output, request)
                     return false
                 }
             }
@@ -177,6 +192,7 @@ constructor(
 
     /** Decode failure response; pre-handshake failures tear down agent state (#199). */
     private fun respondDecodeFailure(
+        channel: SocketChannel,
         output: OutputStream,
         ex: kotlinx.serialization.SerializationException,
         handshakeComplete: Boolean,
@@ -189,15 +205,17 @@ constructor(
             }
         val tearDown = !handshakeComplete
         try {
-            Framing.writeFrame(
-                output,
-                WireCodec.encode(
-                    AgentResponse.Error(
-                        message = "Malformed or unsupported request: ${ex.message}",
-                        category = category.wireName,
-                    )
-                ),
-            )
+            FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(
+                        AgentResponse.Error(
+                            message = "Malformed or unsupported request: ${ex.message}",
+                            category = category.wireName,
+                        )
+                    ),
+                )
+            }
         } finally {
             if (tearDown) {
                 running.set(false)
@@ -209,32 +227,39 @@ constructor(
 
     /** Hello handshake; mismatch tears down agent state so re-attach can re-bootstrap (#199). */
     private fun respondHello(
+        channel: SocketChannel,
         output: OutputStream,
         request: AgentRequest.Hello,
         setHandshakeComplete: (Boolean) -> Unit,
     ): Boolean {
         if (request.protocolVersion == ProtocolVersion.CURRENT) {
             setHandshakeComplete(true)
-            Framing.writeFrame(
-                output,
-                WireCodec.encode(AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)),
-            )
+            FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(
+                        AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
+                    ),
+                )
+            }
             return true
         }
         setHandshakeComplete(false)
         try {
-            Framing.writeFrame(
-                output,
-                WireCodec.encode(
-                    AgentResponse.Error(
-                        message =
-                            "Protocol version mismatch: client=${request.protocolVersion}, " +
-                                "runtime=${ProtocolVersion.CURRENT} (exact-match required " +
-                                "while agent API is experimental)",
-                        category = AgentErrorCategory.ProtocolMismatch.wireName,
-                    )
-                ),
-            )
+            FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(
+                        AgentResponse.Error(
+                            message =
+                                "Protocol version mismatch: client=${request.protocolVersion}, " +
+                                    "runtime=${ProtocolVersion.CURRENT} (exact-match required " +
+                                    "while agent API is experimental)",
+                            category = AgentErrorCategory.ProtocolMismatch.wireName,
+                        )
+                    ),
+                )
+            }
         } finally {
             running.set(false)
             onDetach()
@@ -243,18 +268,24 @@ constructor(
     }
 
     /** Non-Hello first frame (pre-#199 attacher); tear down and close the connection (#199). */
-    private fun rejectPreHandshake(output: OutputStream, request: AgentRequest): Boolean {
+    private fun rejectPreHandshake(
+        channel: SocketChannel,
+        output: OutputStream,
+        request: AgentRequest,
+    ): Boolean {
         try {
-            Framing.writeFrame(
-                output,
-                WireCodec.encode(
-                    AgentResponse.Error(
-                        message =
-                            "Protocol handshake required: send Hello before ${request.logLabel}",
-                        category = AgentErrorCategory.ProtocolMismatch.wireName,
-                    )
-                ),
-            )
+            FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(
+                        AgentResponse.Error(
+                            message =
+                                "Protocol handshake required: send Hello before ${request.logLabel}",
+                            category = AgentErrorCategory.ProtocolMismatch.wireName,
+                        )
+                    ),
+                )
+            }
         } finally {
             running.set(false)
             onDetach()

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -26,6 +26,8 @@ internal class MultiplexedIpcSession(
     private val handler: AgentRequestHandler,
     private val running: AtomicBoolean,
     private val onDetach: () -> Unit,
+    private val channel: java.nio.channels.Channel,
+    private val frameIoTimeoutMs: Long = FrameIoDeadline.DEFAULT_TIMEOUT_MS,
 ) {
     fun run(input: InputStream, output: OutputStream) {
         // Bound threads *and* queue so a buggy client cannot OOM the agent with enqueued ops.
@@ -65,7 +67,18 @@ internal class MultiplexedIpcSession(
         writeLock: Any,
     ) {
         while (running.get()) {
-            val requestBytes = Framing.readFrame(input) ?: return
+            val requestBytes =
+                try {
+                    FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                        Framing.readFrame(input)
+                    } ?: return
+                } catch (ex: java.net.SocketTimeoutException) {
+                    // Stalled peer mid-frame — drop this connection; accept loop continues.
+                    System.err.println(
+                        "[spectre-agent] frame I/O timed out (${ex.message}); closing connection"
+                    )
+                    return
+                }
             val op = decodeOpOrReport(requestBytes, output, writeLock) ?: continue
             when (val body = op.body) {
                 is AgentRequest.Cancel -> handleCancel(body, op.opId, output, writeLock, inFlight)
@@ -336,7 +349,11 @@ internal class MultiplexedIpcSession(
         // clear interrupt only for the duration of the write and restore afterward.
         val wasInterrupted = Thread.interrupted()
         try {
-            synchronized(writeLock) { Framing.writeFrame(output, toWrite) }
+            synchronized(writeLock) {
+                FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
+                    Framing.writeFrame(output, toWrite)
+                }
+            }
         } finally {
             if (wasInterrupted) {
                 Thread.currentThread().interrupt()

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -69,9 +69,9 @@ internal class MultiplexedIpcSession(
         while (running.get()) {
             val requestBytes =
                 try {
-                    FrameIoDeadline.withTimeout(channel, frameIoTimeoutMs) {
-                        Framing.readFrame(input)
-                    } ?: return
+                    // Idle between requests is allowed; mid-frame stalls time out.
+                    FrameIoDeadline.readFrameAllowingIdle(input, channel, frameIoTimeoutMs)
+                        ?: return
                 } catch (ex: java.net.SocketTimeoutException) {
                     // Stalled peer mid-frame — drop this connection; accept loop continues.
                     System.err.println(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -67,17 +67,23 @@ internal class MultiplexedIpcSession(
         writeLock: Any,
     ) {
         while (running.get()) {
+            // Channel-close deadlines may surface as SocketTimeoutException or as a
+            // ClosedChannelException / AsynchronousCloseException on some platforms.
+            @Suppress("TooGenericExceptionCaught")
             val requestBytes =
                 try {
                     // Idle between requests is allowed; mid-frame stalls time out.
                     FrameIoDeadline.readFrameAllowingIdle(input, channel, frameIoTimeoutMs)
                         ?: return
-                } catch (ex: java.net.SocketTimeoutException) {
-                    // Stalled peer mid-frame — drop this connection; accept loop continues.
-                    System.err.println(
-                        "[spectre-agent] frame I/O timed out (${ex.message}); closing connection"
-                    )
-                    return
+                } catch (ex: Exception) {
+                    if (FrameIoDeadline.isTimeout(ex) || !channel.isOpen) {
+                        System.err.println(
+                            "[spectre-agent] frame I/O timed out or peer closed " +
+                                "(${ex.javaClass.simpleName}: ${ex.message}); closing connection"
+                        )
+                        return
+                    }
+                    throw ex
                 }
             val op = decodeOpOrReport(requestBytes, output, writeLock) ?: continue
             when (val body = op.body) {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
@@ -51,13 +51,19 @@ class IpcIoTimeoutTest {
         IpcServer(udsPath, stubHandler(), frameIoTimeoutMs = frameTimeoutMs).use {
             awaitSocket(udsPath)
 
-            // Write a partial frame header and stop — server must not block the accept loop.
+            // Complete Hello, then write a partial next-frame header and stall so the deadline
+            // applies to mid-frame completion (idle between frames is intentionally unbounded).
             SocketChannel.open(StandardProtocolFamily.UNIX).use { raw ->
                 raw.connect(UnixDomainSocketAddress.of(udsPath))
                 val output = Channels.newOutputStream(raw)
-                output.write(byteArrayOf(0x00, 0x00)) // 2 of 4 length bytes
+                val input = Channels.newInputStream(raw)
+                Framing.writeFrame(
+                    output,
+                    WireCodec.encode(AgentRequest.Hello(protocolVersion = ProtocolVersion.CURRENT)),
+                )
+                Framing.readFrame(input) // HelloAck
+                output.write(byteArrayOf(0x00, 0x00)) // 2 of 4 length bytes of next frame
                 output.flush()
-                // Hold the socket open past the server's frame deadline.
                 Thread.sleep(frameTimeoutMs + 200)
             }
 
@@ -69,6 +75,24 @@ class IpcIoTimeoutTest {
                         "accept loop must survive a mid-frame stall",
                     )
                 }
+            }
+        }
+    }
+
+    @Test
+    fun `idle between frames does not time out a live session`() {
+        // Budget shorter than the intentional idle gap.
+        val frameTimeoutMs = 200L
+        IpcServer(udsPath, stubHandler(), frameIoTimeoutMs = frameTimeoutMs).use {
+            awaitSocket(udsPath)
+            IpcClient(udsPath, frameIoTimeoutMs = frameTimeoutMs).use { client ->
+                assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+                Thread.sleep(frameTimeoutMs * 3)
+                assertEquals(
+                    AgentResponse.Pong,
+                    client.send(AgentRequest.Ping),
+                    "session must survive idle longer than the mid-frame budget",
+                )
             }
         }
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
@@ -1,0 +1,149 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import java.net.SocketTimeoutException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * Regression tests for #168: bounded frame I/O so a same-UID wedged peer cannot hang the serial
+ * attach path forever.
+ */
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
+class IpcIoTimeoutTest {
+    private val udsPath: Path =
+        udsBase().resolve("sp-to-${UUID.randomUUID().toString().take(8)}.sock")
+
+    @AfterTest
+    fun cleanUp() {
+        runCatching { udsPath.deleteIfExists() }
+    }
+
+    @Test
+    fun `healthy Ping Pong still succeeds with frame I O deadlines enabled`() {
+        IpcServer(udsPath, stubHandler(), frameIoTimeoutMs = 5_000).use {
+            awaitSocket(udsPath)
+            IpcClient(udsPath, frameIoTimeoutMs = 5_000).use { client ->
+                assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+            }
+        }
+    }
+
+    @Test
+    fun `server times out when client stalls mid-frame and keeps accepting`() {
+        val frameTimeoutMs = 250L
+        IpcServer(udsPath, stubHandler(), frameIoTimeoutMs = frameTimeoutMs).use {
+            awaitSocket(udsPath)
+
+            // Write a partial frame header and stop — server must not block the accept loop.
+            SocketChannel.open(StandardProtocolFamily.UNIX).use { raw ->
+                raw.connect(UnixDomainSocketAddress.of(udsPath))
+                val output = Channels.newOutputStream(raw)
+                output.write(byteArrayOf(0x00, 0x00)) // 2 of 4 length bytes
+                output.flush()
+                // Hold the socket open past the server's frame deadline.
+                Thread.sleep(frameTimeoutMs + 200)
+            }
+
+            assertTimeoutPreemptively(java.time.Duration.ofSeconds(3)) {
+                IpcClient(udsPath, frameIoTimeoutMs = 5_000).use { client ->
+                    assertEquals(
+                        AgentResponse.Pong,
+                        client.send(AgentRequest.Ping),
+                        "accept loop must survive a mid-frame stall",
+                    )
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `client handshake times out when peer never responds`() {
+        val frameTimeoutMs = 250L
+        // Accept but never read/write — client Hello must time out, not hang.
+        val serverChannel =
+            java.nio.channels.ServerSocketChannel.open(StandardProtocolFamily.UNIX).also {
+                Files.deleteIfExists(udsPath)
+                it.bind(UnixDomainSocketAddress.of(udsPath))
+            }
+        val acceptThread =
+            Thread(
+                    {
+                        try {
+                            serverChannel.accept()?.use { /* hold open, no I/O */
+                                Thread.sleep(5_000)
+                            }
+                        } catch (_: Exception) {
+                            // closed
+                        }
+                    },
+                    "stall-accept",
+                )
+                .apply {
+                    isDaemon = true
+                    start()
+                }
+        try {
+            awaitSocket(udsPath)
+            val started = System.nanoTime()
+            val error =
+                assertFailsWith<Exception> {
+                    IpcClient(udsPath, frameIoTimeoutMs = frameTimeoutMs).use {}
+                }
+            val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started)
+            assertTrue(
+                FrameIoDeadline.isTimeout(error) ||
+                    error is SocketTimeoutException ||
+                    error.cause is SocketTimeoutException,
+                "expected SocketTimeoutException (or wrapped); got $error",
+            )
+            assertTrue(
+                elapsedMs < 2_000,
+                "handshake should fail near frame timeout, not hang; elapsed=${elapsedMs}ms",
+            )
+        } finally {
+            runCatching { serverChannel.close() }
+            acceptThread.join(1_000)
+        }
+    }
+
+    private fun stubHandler(): AgentRequestHandler = AgentRequestHandler { request ->
+        when (request) {
+            AgentRequest.Ping -> AgentResponse.Pong
+            AgentRequest.Detach -> AgentResponse.Detached
+            is AgentRequest.Hello ->
+                AgentResponse.HelloAck(protocolVersion = ProtocolVersion.CURRENT)
+            else -> AgentResponse.Error("unexpected $request")
+        }
+    }
+
+    private fun awaitSocket(path: Path, timeoutMs: Long = 2_000) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.exists(path)) return
+            Thread.sleep(10)
+        }
+        error("UDS file $path did not appear within ${timeoutMs} ms")
+    }
+
+    private fun udsBase(): Path =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true))
+            Path.of(System.getProperty("java.io.tmpdir"))
+        else Path.of("/tmp")
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
@@ -68,25 +68,32 @@ class IpcIoTimeoutTest {
                 output.write(byteArrayOf(0x00, 0x00)) // 2 of 4 length bytes of next frame
                 output.flush()
 
-                val deadline = System.currentTimeMillis() + frameTimeoutMs + 1_500
-                // Server deadline closes its end; reads eventually EOF or throw.
-                val sawPeerClose =
-                    generateSequence {
-                            if (System.currentTimeMillis() >= deadline) null
-                            else
+                // Server deadline closes its end; reads eventually EOF or throw. Watch from a
+                // helper thread so a non-firing timeout cannot hang the test on blocking read.
+                val sawPeerClose = java.util.concurrent.atomic.AtomicBoolean(false)
+                val watcher =
+                    Thread(
+                            {
                                 try {
-                                    if (input.read() == -1) true
-                                    else {
-                                        Thread.sleep(20)
-                                        false
+                                    while (!sawPeerClose.get()) {
+                                        if (input.read() == -1) {
+                                            sawPeerClose.set(true)
+                                            return@Thread
+                                        }
                                     }
                                 } catch (_: Exception) {
-                                    true
+                                    sawPeerClose.set(true)
                                 }
+                            },
+                            "stall-peer-close-watch",
+                        )
+                        .apply {
+                            isDaemon = true
+                            start()
                         }
-                        .any { it }
+                watcher.join(frameTimeoutMs + 1_500)
                 assertTrue(
-                    sawPeerClose,
+                    sawPeerClose.get(),
                     "server should close the stalled mid-frame peer within the I/O budget",
                 )
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
@@ -54,6 +54,8 @@ class IpcIoTimeoutTest {
 
             // Complete Hello, then write a partial next-frame header and stall so the deadline
             // applies to mid-frame completion (idle between frames is intentionally unbounded).
+            // Keep the stalled peer open past the deadline so recovery cannot be explained by
+            // client-side close alone — the server must have timed out and dropped the connection.
             SocketChannel.open(StandardProtocolFamily.UNIX).use { raw ->
                 raw.connect(UnixDomainSocketAddress.of(udsPath))
                 val output = Channels.newOutputStream(raw)
@@ -65,33 +67,38 @@ class IpcIoTimeoutTest {
                 Framing.readFrame(input) // HelloAck
                 output.write(byteArrayOf(0x00, 0x00)) // 2 of 4 length bytes of next frame
                 output.flush()
-                Thread.sleep(frameTimeoutMs + 400)
-            }
 
-            // Give accept loop a beat after the dead peer is closed (Windows AF_UNIX).
-            Thread.sleep(100)
-
-            assertTimeoutPreemptively(java.time.Duration.ofSeconds(8)) {
-                var lastError: Exception? = null
-                repeat(5) { attempt ->
+                val deadline = System.currentTimeMillis() + frameTimeoutMs + 1_500
+                var sawPeerClose = false
+                while (System.currentTimeMillis() < deadline) {
                     try {
-                        IpcClient(udsPath, frameIoTimeoutMs = 5_000).use { client ->
-                            assertEquals(
-                                AgentResponse.Pong,
-                                client.send(AgentRequest.Ping),
-                                "accept loop must survive a mid-frame stall",
-                            )
+                        // Server deadline closes its end; reads eventually EOF.
+                        if (input.read() == -1) {
+                            sawPeerClose = true
+                            break
                         }
-                        return@assertTimeoutPreemptively
-                    } catch (ex: Exception) {
-                        lastError = ex
-                        Thread.sleep(100L * (attempt + 1))
+                    } catch (_: Exception) {
+                        sawPeerClose = true
+                        break
+                    }
+                    Thread.sleep(20)
+                }
+                assertTrue(
+                    sawPeerClose,
+                    "server should close the stalled mid-frame peer within the I/O budget",
+                )
+
+                // Re-attach while the old peer socket is still open to prove accept loop recovery
+                // is not just "client left".
+                assertTimeoutPreemptively(java.time.Duration.ofSeconds(8)) {
+                    IpcClient(udsPath, frameIoTimeoutMs = 5_000).use { client ->
+                        assertEquals(
+                            AgentResponse.Pong,
+                            client.send(AgentRequest.Ping),
+                            "accept loop must survive a mid-frame stall",
+                        )
                     }
                 }
-                throw AssertionError(
-                    "could not re-attach after mid-frame stall: ${lastError?.message}",
-                    lastError,
-                )
             }
         }
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
@@ -69,20 +69,22 @@ class IpcIoTimeoutTest {
                 output.flush()
 
                 val deadline = System.currentTimeMillis() + frameTimeoutMs + 1_500
-                var sawPeerClose = false
-                while (System.currentTimeMillis() < deadline) {
-                    try {
-                        // Server deadline closes its end; reads eventually EOF.
-                        if (input.read() == -1) {
-                            sawPeerClose = true
-                            break
+                // Server deadline closes its end; reads eventually EOF or throw.
+                val sawPeerClose =
+                    generateSequence {
+                            if (System.currentTimeMillis() >= deadline) null
+                            else
+                                try {
+                                    if (input.read() == -1) true
+                                    else {
+                                        Thread.sleep(20)
+                                        false
+                                    }
+                                } catch (_: Exception) {
+                                    true
+                                }
                         }
-                    } catch (_: Exception) {
-                        sawPeerClose = true
-                        break
-                    }
-                    Thread.sleep(20)
-                }
+                        .any { it }
                 assertTrue(
                     sawPeerClose,
                     "server should close the stalled mid-frame peer within the I/O budget",

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcIoTimeoutTest.kt
@@ -47,7 +47,8 @@ class IpcIoTimeoutTest {
 
     @Test
     fun `server times out when client stalls mid-frame and keeps accepting`() {
-        val frameTimeoutMs = 250L
+        // Slightly looser than unit-test minimum so Windows AF_UNIX scheduling still fires.
+        val frameTimeoutMs = 400L
         IpcServer(udsPath, stubHandler(), frameIoTimeoutMs = frameTimeoutMs).use {
             awaitSocket(udsPath)
 
@@ -64,17 +65,33 @@ class IpcIoTimeoutTest {
                 Framing.readFrame(input) // HelloAck
                 output.write(byteArrayOf(0x00, 0x00)) // 2 of 4 length bytes of next frame
                 output.flush()
-                Thread.sleep(frameTimeoutMs + 200)
+                Thread.sleep(frameTimeoutMs + 400)
             }
 
-            assertTimeoutPreemptively(java.time.Duration.ofSeconds(3)) {
-                IpcClient(udsPath, frameIoTimeoutMs = 5_000).use { client ->
-                    assertEquals(
-                        AgentResponse.Pong,
-                        client.send(AgentRequest.Ping),
-                        "accept loop must survive a mid-frame stall",
-                    )
+            // Give accept loop a beat after the dead peer is closed (Windows AF_UNIX).
+            Thread.sleep(100)
+
+            assertTimeoutPreemptively(java.time.Duration.ofSeconds(8)) {
+                var lastError: Exception? = null
+                repeat(5) { attempt ->
+                    try {
+                        IpcClient(udsPath, frameIoTimeoutMs = 5_000).use { client ->
+                            assertEquals(
+                                AgentResponse.Pong,
+                                client.send(AgentRequest.Ping),
+                                "accept loop must survive a mid-frame stall",
+                            )
+                        }
+                        return@assertTimeoutPreemptively
+                    } catch (ex: Exception) {
+                        lastError = ex
+                        Thread.sleep(100L * (attempt + 1))
+                    }
                 }
+                throw AssertionError(
+                    "could not re-attach after mid-frame stall: ${lastError?.message}",
+                    lastError,
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `FrameIoDeadline` for per-frame read/write budgets on UDS (channel-close deadline; no portable `SO_TIMEOUT`).
- Wire deadlines into `IpcClient` (handshake, op writes, reader loop) and `IpcServer` / `MultiplexedIpcSession` (handshake + frame read/write).
- Default budget 30s; constructor override for tests.
- Regression tests: mid-frame stall does not kill accept loop; client handshake times out if peer never responds; healthy Ping/Pong still works.

Closes #168.

## Test plan

- [x] `IpcIoTimeoutTest` (macOS)
- [x] `IpcRoundTripTest`
- [x] `./gradlew check`
- [ ] Windows remote SSH unavailable (publickey); CI Windows AF_UNIX runs the same tests