### PR TITLE
Harden Windows helper packaging verification (#163)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -311,6 +311,20 @@ val mavenLocalRepoRoot: String = "${System.getProperty("user.home")}/.m2/reposit
 // [WindowsGraphicsCaptureHelperPackagingContract] (shared with
 // `:recording-windows:verifyRecordingWindowsHelper`) so both verifiers enforce the same
 // multi-file helper runtime contract.
+// Windows arches expected when helpers are staged. Legacy -PprebuiltWindowsHelperPath is
+// x64-only; release/dir/host builds need both arches.
+val expectedWindowsHelperArches: List<String> = run {
+    val windowsHelpersDir = providers.gradleProperty("prebuiltWindowsHelpersDir").isPresent
+    val windowsHelperPathOnly =
+        providers.gradleProperty("prebuiltWindowsHelperPath").isPresent && !windowsHelpersDir
+    when {
+        windowsHelperPathOnly -> listOf("x64")
+        windowsHelpersDir || org.gradle.internal.os.OperatingSystem.current().isWindows ->
+            WindowsGraphicsCaptureHelperPackagingContract.ARCHES
+        else -> emptyList()
+    }
+}
+
 val expectedRecordingHelperEntriesByProject: Map<String, List<String>> =
     mutableMapOf<String, List<String>>().apply {
         val macOsExpected =
@@ -329,17 +343,15 @@ val expectedRecordingHelperEntriesByProject: Map<String, List<String>> =
                 ),
             )
         }
-        val currentOs = org.gradle.internal.os.OperatingSystem.current()
-        val windowsExpected =
-            providers.gradleProperty("prebuiltWindowsHelperPath").isPresent ||
-                providers.gradleProperty("prebuiltWindowsHelpersDir").isPresent ||
-                currentOs.isWindows
-        if (windowsExpected) {
+        if (expectedWindowsHelperArches.isNotEmpty()) {
             put(
                 ":recording-windows",
-                WindowsGraphicsCaptureHelperPackagingContract.requiredJarEntryPaths(),
+                WindowsGraphicsCaptureHelperPackagingContract.requiredJarEntryPaths(
+                    expectedWindowsHelperArches
+                ),
             )
         }
+        val currentOs = org.gradle.internal.os.OperatingSystem.current()
         val crossArchLinux =
             providers.gradleProperty("prebuiltLinuxHelpersDir").isPresent ||
                 (currentOs.isLinux && providers.gradleProperty("allLinuxArches").isPresent)
@@ -389,6 +401,7 @@ val verifyMavenLocalPublication by tasks.registering {
     val artifactIds = publishArtifactIds
     val repoRoot = file(mavenLocalRepoRoot)
     val expectedHelpersByProject = expectedRecordingHelperEntriesByProject
+    val windowsArches = expectedWindowsHelperArches
 
     doLast {
         val errors = mutableListOf<String>()
@@ -512,7 +525,10 @@ val verifyMavenLocalPublication by tasks.registering {
                         // shared with `:recording-windows:verifyRecordingWindowsHelper`.
                         ZipFile(jar).use { zip ->
                             for (gap in
-                                WindowsGraphicsCaptureHelperPackagingContract.validateZip(zip)) {
+                                WindowsGraphicsCaptureHelperPackagingContract.validateZip(
+                                    zip,
+                                    windowsArches,
+                                )) {
                                 errors += "$moduleName: published jar (${jar.name}): $gap"
                             }
                         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,12 +100,11 @@ val buildSrcUnitTests by
         group = "verification"
         description = "Runs buildSrc unit tests (Windows helper packaging contract and related)."
         workingDir = rootProject.layout.projectDirectory.asFile
-        commandLine(
-            rootProject.layout.projectDirectory.file("gradlew").asFile.absolutePath,
-            "-p",
-            "buildSrc",
-            "test",
-        )
+        val isWindows = System.getProperty("os.name").orEmpty().startsWith("Windows")
+        val wrapperName = if (isWindows) "gradlew.bat" else "gradlew"
+        val wrapper = rootProject.layout.projectDirectory.file(wrapperName).asFile.absolutePath
+        // On Windows, Exec launches the .bat directly. On Unix, the shell script is executable.
+        commandLine(wrapper, "-p", "buildSrc", "test")
         // Nested Gradle manages its own up-to-date checks; always re-enter so check is honest.
         outputs.upToDateWhen { false }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,6 +5,7 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import com.vanniktech.maven.publish.SourcesJar
 import dev.detekt.gradle.Detekt
 import dev.detekt.gradle.extensions.DetektExtension
+import dev.sebastiano.spectre.build.WindowsGraphicsCaptureHelperPackagingContract
 import java.util.jar.JarFile
 import java.util.zip.ZipFile
 import javax.xml.parsers.DocumentBuilderFactory
@@ -91,8 +92,32 @@ val verifyReleaseVersionScript by
         outputs.upToDateWhen { false }
     }
 
+// buildSrc is not a project of this build for `dependsOn(":buildSrc:…")`, but its tests
+// cover the shared Windows helper packaging contract. Invoke them via a nested Gradle run
+// on the buildSrc project directory (same pattern as `./gradlew -p buildSrc test`).
+val buildSrcUnitTests by
+    tasks.registering(Exec::class) {
+        group = "verification"
+        description = "Runs buildSrc unit tests (Windows helper packaging contract and related)."
+        workingDir = rootProject.layout.projectDirectory.asFile
+        commandLine(
+            rootProject.layout.projectDirectory.file("gradlew").asFile.absolutePath,
+            "-p",
+            "buildSrc",
+            "test",
+        )
+        // Nested Gradle manages its own up-to-date checks; always re-enter so check is honest.
+        outputs.upToDateWhen { false }
+    }
+
 tasks.named("check") {
-    dependsOn("detekt", "ktfmtCheck", verifyCliPackageManifests, verifyReleaseVersionScript)
+    dependsOn(
+        "detekt",
+        "ktfmtCheck",
+        verifyCliPackageManifests,
+        verifyReleaseVersionScript,
+        buildSrcUnitTests,
+    )
 }
 
 tasks.withType<Detekt>().configureEach {
@@ -283,9 +308,10 @@ val publishArtifactIds: Map<String, String> = publishedLibraryProjects.associate
 }
 val mavenLocalRepoRoot: String = "${System.getProperty("user.home")}/.m2/repository"
 
-// Recording jar entries we expect to find — keep in sync with
-// `VerifyBundledRecordingHelpers`'s expectations so a contradiction between the two surfaces
-// as a duplicate failure rather than one silently passing.
+// Recording jar entries we expect to find. Windows uses
+// [WindowsGraphicsCaptureHelperPackagingContract] (shared with
+// `:recording-windows:verifyRecordingWindowsHelper`) so both verifiers enforce the same
+// multi-file helper runtime contract.
 val expectedRecordingHelperEntriesByProject: Map<String, List<String>> =
     mutableMapOf<String, List<String>>().apply {
         val macOsExpected =
@@ -293,7 +319,16 @@ val expectedRecordingHelperEntriesByProject: Map<String, List<String>> =
                 providers.gradleProperty("stubMacHelperForTesting").isPresent ||
                 org.gradle.internal.os.OperatingSystem.current().isMacOsX
         if (macOsExpected) {
-            put(":recording-macos", listOf("native/macos/spectre-screencapture"))
+            // App-bundle layout (#190); bare native/macos/spectre-screencapture is rejected.
+            put(
+                ":recording-macos",
+                listOf(
+                    "native/macos/SpectreCaptureHelper.app/Contents/MacOS/spectre-screencapture",
+                    "native/macos/SpectreCaptureHelper.app/Contents/Info.plist",
+                    "native/macos/SpectreCaptureHelper.app/Contents/PkgInfo",
+                    "native/macos/SpectreCaptureHelper.app/Contents/Resources/AppIcon.icns",
+                ),
+            )
         }
         val currentOs = org.gradle.internal.os.OperatingSystem.current()
         val windowsExpected =
@@ -303,10 +338,7 @@ val expectedRecordingHelperEntriesByProject: Map<String, List<String>> =
         if (windowsExpected) {
             put(
                 ":recording-windows",
-                listOf(
-                    "native/windows/x64/spectre-window-capture.exe",
-                    "native/windows/arm64/spectre-window-capture.exe",
-                ),
+                WindowsGraphicsCaptureHelperPackagingContract.requiredJarEntryPaths(),
             )
         }
         val crossArchLinux =
@@ -473,15 +505,29 @@ val verifyMavenLocalPublication by tasks.registering {
                     }
                 }
                 if (jarSuffix == ".jar") {
-                    for (path in expectedHelpersByProject[moduleName].orEmpty()) {
-                        if (path !in entriesInJar) {
-                            errors +=
-                                "$moduleName: published jar (${jar.name}) is missing " +
-                                    "expected helper entry `$path`"
-                        } else if ((entrySizesInJar[path] ?: 0L) <= 0L) {
-                            errors +=
-                                "$moduleName: published jar (${jar.name}) has empty " +
-                                    "helper entry `$path`"
+                    if (
+                        moduleName == ":recording-windows" &&
+                            expectedHelpersByProject.containsKey(":recording-windows")
+                    ) {
+                        // Full multi-file contract (fixed required set + deps.json closure),
+                        // shared with `:recording-windows:verifyRecordingWindowsHelper`.
+                        ZipFile(jar).use { zip ->
+                            for (gap in
+                                WindowsGraphicsCaptureHelperPackagingContract.validateZip(zip)) {
+                                errors += "$moduleName: published jar (${jar.name}): $gap"
+                            }
+                        }
+                    } else {
+                        for (path in expectedHelpersByProject[moduleName].orEmpty()) {
+                            if (path !in entriesInJar) {
+                                errors +=
+                                    "$moduleName: published jar (${jar.name}) is missing " +
+                                        "expected helper entry `$path`"
+                            } else if ((entrySizesInJar[path] ?: 0L) <= 0L) {
+                                errors +=
+                                    "$moduleName: published jar (${jar.name}) has empty " +
+                                        "helper entry `$path`"
+                            }
                         }
                     }
                 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,3 +1,10 @@
 plugins { `kotlin-dsl` }
 
 repositories { gradlePluginPortal() }
+
+dependencies {
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test { useJUnitPlatform() }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -196,10 +196,21 @@ object WindowsGraphicsCaptureHelperPackagingContract {
         if (targets.isEmpty()) {
             throw IllegalArgumentException("deps.json 'targets' map is empty")
         }
-        val assetNames = linkedSetOf<String>()
-        val targetKeys = targets.keys.toList()
         val ridToken = ridTokenForArch(arch)
         val ridName = ridNameForArch(arch)
+        // When runtimeTarget.name declares a Windows RID, it must match the directory arch.
+        val runtimeTarget = root["runtimeTarget"] as? Map<*, *>
+        val runtimeTargetName = runtimeTarget?.get("name") as? String
+        if (runtimeTargetName != null &&
+            runtimeTargetName.contains("/win-", ignoreCase = true) &&
+            !runtimeTargetName.contains(ridToken, ignoreCase = true)
+        ) {
+            throw WrongArchDepsException(
+                "runtimeTarget.name='$runtimeTargetName' does not match arch RID '$ridName'"
+            )
+        }
+        val assetNames = linkedSetOf<String>()
+        val targetKeys = targets.keys.toList()
         val preferred = targetKeys.filter { it.contains(ridToken, ignoreCase = true) }
         if (preferred.isEmpty()) {
             val otherWin =
@@ -263,14 +274,22 @@ object WindowsGraphicsCaptureHelperPackagingContract {
                         "deps.json package '$packageKey' must be an object, was " +
                             (metaAny?.let { it::class.java.simpleName } ?: "null")
                     )
-            collectAssetBasenames(meta["runtime"] as? Map<String, Any?>, into)
-            collectAssetBasenames(meta["native"] as? Map<String, Any?>, into)
-            collectRuntimeTargetBasenames(
-                meta["runtimeTargets"] as? Map<String, Any?>,
-                ridName,
-                into,
-            )
+            collectAssetBasenames(requireAssetTable(meta, "runtime"), into)
+            collectAssetBasenames(requireAssetTable(meta, "native"), into)
+            collectRuntimeTargetBasenames(requireAssetTable(meta, "runtimeTargets"), ridName, into)
         }
+    }
+
+    private fun requireAssetTable(meta: Map<String, Any?>, key: String): Map<String, Any?>? {
+        if (!meta.containsKey(key)) return null
+        val value = meta[key]
+        if (value == null) return null
+        @Suppress("UNCHECKED_CAST")
+        return value as? Map<String, Any?>
+            ?: throw IllegalArgumentException(
+                "deps.json package asset table '$key' must be an object, was " +
+                    value::class.java.simpleName
+            )
     }
 
     private fun collectAssetBasenames(assets: Map<String, Any?>?, into: MutableSet<String>) {

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -211,7 +211,14 @@ object WindowsGraphicsCaptureHelperPackagingContract {
         }
         val assetNames = linkedSetOf<String>()
         val targetKeys = targets.keys.toList()
-        val preferred = targetKeys.filter { it.contains(ridToken, ignoreCase = true) }
+        // Prefer the exact runtimeTarget.name when present; otherwise any target whose key
+        // contains the arch RID token.
+        val preferred =
+            if (runtimeTargetName != null && targets.containsKey(runtimeTargetName)) {
+                listOf(runtimeTargetName)
+            } else {
+                targetKeys.filter { it.contains(ridToken, ignoreCase = true) }
+            }
         if (preferred.isEmpty()) {
             val otherWin =
                 targetKeys.filter {

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -198,9 +198,26 @@ object WindowsGraphicsCaptureHelperPackagingContract {
         }
         val ridToken = ridTokenForArch(arch)
         val ridName = ridNameForArch(arch)
-        // When runtimeTarget.name declares a Windows RID, it must match the directory arch.
-        val runtimeTarget = root["runtimeTarget"] as? Map<*, *>
-        val runtimeTargetName = runtimeTarget?.get("name") as? String
+        // When runtimeTarget is present, it must be an object with a string name.
+        // Omitted runtimeTarget is allowed (framework-only / incomplete host metadata).
+        val runtimeTargetName: String? =
+            if (root.containsKey("runtimeTarget")) {
+                val runtimeTarget =
+                    root["runtimeTarget"] as? Map<*, *>
+                        ?: throw IllegalArgumentException(
+                            "deps.json runtimeTarget must be an object, was " +
+                                (root["runtimeTarget"]?.let { it::class.java.simpleName }
+                                    ?: "null")
+                        )
+                val name = runtimeTarget["name"]
+                name as? String
+                    ?: throw IllegalArgumentException(
+                        "deps.json runtimeTarget.name must be a string, was " +
+                            (name?.let { it::class.java.simpleName } ?: "null")
+                    )
+            } else {
+                null
+            }
         if (runtimeTargetName != null &&
             runtimeTargetName.contains("/win-", ignoreCase = true) &&
             !runtimeTargetName.contains(ridToken, ignoreCase = true)

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -182,58 +182,102 @@ object WindowsGraphicsCaptureHelperPackagingContract {
      */
     @Suppress("UNCHECKED_CAST")
     fun runtimeAssetBaseNames(depsJson: String, arch: String = "x64"): Set<String> {
-        val root = JsonSlurper().parseText(depsJson) as Map<String, Any?>
-        val targets = root["targets"] as? Map<String, Any?> ?: return emptySet()
+        val root = JsonSlurper().parseText(depsJson) as? Map<*, *>
+            ?: throw IllegalArgumentException("deps.json root must be a JSON object")
+        val targets =
+            root["targets"] as? Map<String, Any?>
+                ?: throw IllegalArgumentException("deps.json is missing a non-null 'targets' map")
+        if (targets.isEmpty()) {
+            throw IllegalArgumentException("deps.json 'targets' map is empty")
+        }
         val assetNames = linkedSetOf<String>()
         val targetKeys = targets.keys.toList()
         val ridToken = ridTokenForArch(arch)
+        val ridName = ridNameForArch(arch)
         val preferred = targetKeys.filter { it.contains(ridToken, ignoreCase = true) }
         if (preferred.isEmpty()) {
             val otherWin =
-                targetKeys.filter { it.contains("/win-", ignoreCase = true) &&
-                    !it.contains(ridToken, ignoreCase = true) }
+                targetKeys.filter {
+                    it.contains("/win-", ignoreCase = true) &&
+                        !it.contains(ridToken, ignoreCase = true)
+                }
             if (otherWin.isNotEmpty()) {
                 throw WrongArchDepsException(
                     "expected target containing '$ridToken' but found only " +
                         otherWin.joinToString()
                 )
             }
-            // Framework-only deps (no RID target): use all targets.
+            // Framework-only deps (no RID target): use all targets, still filter
+            // runtimeTargets entries by RID when present.
             for (targetKey in targetKeys) {
-                collectFromTarget(targets[targetKey], assetNames)
+                collectFromTarget(targets[targetKey], ridName, assetNames)
             }
             return assetNames
         }
         for (targetKey in preferred) {
-            collectFromTarget(targets[targetKey], assetNames)
+            collectFromTarget(targets[targetKey], ridName, assetNames)
         }
         return assetNames
     }
 
-    fun ridTokenForArch(arch: String): String =
+    fun ridTokenForArch(arch: String): String = "/${ridNameForArch(arch)}"
+
+    fun ridNameForArch(arch: String): String =
         when (arch.lowercase()) {
             "x64",
             "amd64",
-            "x86_64" -> "/win-x64"
+            "x86_64" -> "win-x64"
             "arm64",
-            "aarch64" -> "/win-arm64"
-            else -> "/win-"
+            "aarch64" -> "win-arm64"
+            else -> "win-"
         }
 
     @Suppress("UNCHECKED_CAST")
-    private fun collectFromTarget(targetAny: Any?, into: MutableSet<String>) {
+    private fun collectFromTarget(targetAny: Any?, ridName: String, into: MutableSet<String>) {
         val packages = targetAny as? Map<String, Any?> ?: return
         for ((_, metaAny) in packages) {
             val meta = metaAny as? Map<String, Any?> ?: continue
             collectAssetBasenames(meta["runtime"] as? Map<String, Any?>, into)
             collectAssetBasenames(meta["native"] as? Map<String, Any?>, into)
-            collectAssetBasenames(meta["runtimeTargets"] as? Map<String, Any?>, into)
+            collectRuntimeTargetBasenames(meta["runtimeTargets"] as? Map<String, Any?>, ridName, into)
         }
     }
 
     private fun collectAssetBasenames(assets: Map<String, Any?>?, into: MutableSet<String>) {
         if (assets == null) return
         for (path in assets.keys) {
+            val base = path.substringAfterLast('/').substringAfterLast('\\')
+            if (base.isNotEmpty() && !base.endsWith(".pdb", ignoreCase = true)) {
+                into += base
+            }
+        }
+    }
+
+    /**
+     * runtimeTargets entries may carry a `rid` field. When present, only entries for
+     * [ridName] are required; path-based RID heuristics apply when metadata is absent.
+     */
+    @Suppress("UNCHECKED_CAST")
+    private fun collectRuntimeTargetBasenames(
+        assets: Map<String, Any?>?,
+        ridName: String,
+        into: MutableSet<String>,
+    ) {
+        if (assets == null) return
+        for ((path, metaAny) in assets) {
+            val meta = metaAny as? Map<String, Any?>
+            val entryRid = meta?.get("rid") as? String
+            val matches =
+                when {
+                    entryRid != null -> entryRid.equals(ridName, ignoreCase = true)
+                    path.contains("/$ridName/", ignoreCase = true) ||
+                        path.contains("\\$ridName\\", ignoreCase = true) -> true
+                    // No rid metadata and path doesn't name a Windows RID → keep (portable).
+                    !path.contains("/win-", ignoreCase = true) &&
+                        !path.contains("\\win-", ignoreCase = true) -> true
+                    else -> false
+                }
+            if (!matches) continue
             val base = path.substringAfterLast('/').substringAfterLast('\\')
             if (base.isNotEmpty() && !base.endsWith(".pdb", ignoreCase = true)) {
                 into += base

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -144,7 +144,7 @@ object WindowsGraphicsCaptureHelperPackagingContract {
         if (depsJson != null) {
             val requiredFromDeps =
                 try {
-                    runtimeAssetBaseNames(depsJson)
+                    runtimeAssetBaseNames(depsJson, arch)
                 } catch (e: Exception) {
                     errors +=
                         "invalid $pathPrefix$DEPS_JSON for arch $arch: " +
@@ -170,16 +170,28 @@ object WindowsGraphicsCaptureHelperPackagingContract {
 
     /**
      * Collects basenames of runtime and native assets from a .NET deps.json document
-     * for the Windows RID target present in the file.
+     * for the Windows RID target matching [arch] (`x64` → `win-x64`, `arm64` → `win-arm64`).
      */
     @Suppress("UNCHECKED_CAST")
-    fun runtimeAssetBaseNames(depsJson: String): Set<String> {
+    fun runtimeAssetBaseNames(depsJson: String, arch: String = "x64"): Set<String> {
         val root = JsonSlurper().parseText(depsJson) as Map<String, Any?>
         val targets = root["targets"] as? Map<String, Any?> ?: return emptySet()
         val assetNames = linkedSetOf<String>()
         val targetKeys = targets.keys.toList()
+        val ridToken =
+            when (arch.lowercase()) {
+                "x64",
+                "amd64",
+                "x86_64" -> "/win-x64"
+                "arm64",
+                "aarch64" -> "/win-arm64"
+                else -> "/win-"
+            }
         val preferred =
-            targetKeys.filter { it.contains("/win-", ignoreCase = true) }.ifEmpty { targetKeys }
+            targetKeys.filter { it.contains(ridToken, ignoreCase = true) }.ifEmpty {
+                // Fall back to any win RID, then to all targets (framework-only deps).
+                targetKeys.filter { it.contains("/win-", ignoreCase = true) }.ifEmpty { targetKeys }
+            }
         for (targetKey in preferred) {
             val packages = targets[targetKey] as? Map<String, Any?> ?: continue
             for ((_, metaAny) in packages) {

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -216,24 +216,27 @@ object WindowsGraphicsCaptureHelperPackagingContract {
             // Framework-only deps (no RID target): use all targets, still filter
             // runtimeTargets entries by RID when present.
             for (targetKey in targetKeys) {
-                collectFromTarget(targets[targetKey], ridName, assetNames)
+                collectFromTarget(requireTargetBody(targetKey, targets[targetKey]), ridName, assetNames)
             }
             return assetNames
         }
         for (targetKey in preferred) {
-            val body = targets[targetKey]
-            if (body !is Map<*, *>) {
-                throw IllegalArgumentException(
-                    "deps.json target '$targetKey' must be a non-empty object, was " +
-                        (body?.let { it::class.java.simpleName } ?: "null")
-                )
-            }
-            if (body.isEmpty()) {
-                throw IllegalArgumentException("deps.json target '$targetKey' is an empty object")
-            }
-            collectFromTarget(body, ridName, assetNames)
+            collectFromTarget(requireTargetBody(targetKey, targets[targetKey]), ridName, assetNames)
         }
         return assetNames
+    }
+
+    private fun requireTargetBody(targetKey: String, body: Any?): Map<*, *> {
+        if (body !is Map<*, *>) {
+            throw IllegalArgumentException(
+                "deps.json target '$targetKey' must be a non-empty object, was " +
+                    (body?.let { it::class.java.simpleName } ?: "null")
+            )
+        }
+        if (body.isEmpty()) {
+            throw IllegalArgumentException("deps.json target '$targetKey' is an empty object")
+        }
+        return body
     }
 
     fun ridTokenForArch(arch: String): String = "/${ridNameForArch(arch)}"

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -211,10 +211,15 @@ object WindowsGraphicsCaptureHelperPackagingContract {
         }
         val assetNames = linkedSetOf<String>()
         val targetKeys = targets.keys.toList()
-        // Prefer the exact runtimeTarget.name when present; otherwise any target whose key
-        // contains the arch RID token.
+        // Prefer the exact runtimeTarget.name when present. If declared but missing from
+        // targets, reject — do not silently fall back to another RID-matching key.
         val preferred =
-            if (runtimeTargetName != null && targets.containsKey(runtimeTargetName)) {
+            if (runtimeTargetName != null) {
+                if (!targets.containsKey(runtimeTargetName)) {
+                    throw IllegalArgumentException(
+                        "deps.json runtimeTarget.name='$runtimeTargetName' is not present in targets"
+                    )
+                }
                 listOf(runtimeTargetName)
             } else {
                 targetKeys.filter { it.contains(ridToken, ignoreCase = true) }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -253,12 +253,23 @@ object WindowsGraphicsCaptureHelperPackagingContract {
 
     @Suppress("UNCHECKED_CAST")
     private fun collectFromTarget(targetAny: Any?, ridName: String, into: MutableSet<String>) {
-        val packages = targetAny as? Map<String, Any?> ?: return
-        for ((_, metaAny) in packages) {
-            val meta = metaAny as? Map<String, Any?> ?: continue
+        val packages =
+            targetAny as? Map<String, Any?>
+                ?: throw IllegalArgumentException("deps.json target body must be an object")
+        for ((packageKey, metaAny) in packages) {
+            val meta =
+                metaAny as? Map<String, Any?>
+                    ?: throw IllegalArgumentException(
+                        "deps.json package '$packageKey' must be an object, was " +
+                            (metaAny?.let { it::class.java.simpleName } ?: "null")
+                    )
             collectAssetBasenames(meta["runtime"] as? Map<String, Any?>, into)
             collectAssetBasenames(meta["native"] as? Map<String, Any?>, into)
-            collectRuntimeTargetBasenames(meta["runtimeTargets"] as? Map<String, Any?>, ridName, into)
+            collectRuntimeTargetBasenames(
+                meta["runtimeTargets"] as? Map<String, Any?>,
+                ridName,
+                into,
+            )
         }
     }
 

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -283,7 +283,11 @@ object WindowsGraphicsCaptureHelperPackagingContract {
     private fun requireAssetTable(meta: Map<String, Any?>, key: String): Map<String, Any?>? {
         if (!meta.containsKey(key)) return null
         val value = meta[key]
-        if (value == null) return null
+        if (value == null) {
+            throw IllegalArgumentException(
+                "deps.json package asset table '$key' must be an object, was null"
+            )
+        }
         @Suppress("UNCHECKED_CAST")
         return value as? Map<String, Any?>
             ?: throw IllegalArgumentException(

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -145,6 +145,10 @@ object WindowsGraphicsCaptureHelperPackagingContract {
             val requiredFromDeps =
                 try {
                     runtimeAssetBaseNames(depsJson, arch)
+                } catch (e: WrongArchDepsException) {
+                    errors +=
+                        "arch-mismatched $pathPrefix$DEPS_JSON for arch $arch: " + e.message
+                    emptySet()
                 } catch (e: Exception) {
                     errors +=
                         "invalid $pathPrefix$DEPS_JSON for arch $arch: " +
@@ -169,8 +173,12 @@ object WindowsGraphicsCaptureHelperPackagingContract {
     }
 
     /**
-     * Collects basenames of runtime and native assets from a .NET deps.json document
-     * for the Windows RID target matching [arch] (`x64` → `win-x64`, `arm64` → `win-arm64`).
+     * Collects basenames of runtime, native, and runtimeTargets assets from a .NET
+     * deps.json document for the Windows RID target matching [arch]
+     * (`x64` → `win-x64`, `arm64` → `win-arm64`).
+     *
+     * Throws [WrongArchDepsException] when the file only declares other Windows RIDs
+     * (e.g. win-x64 deps under an arm64 directory).
      */
     @Suppress("UNCHECKED_CAST")
     fun runtimeAssetBaseNames(depsJson: String, arch: String = "x64"): Set<String> {
@@ -178,29 +186,49 @@ object WindowsGraphicsCaptureHelperPackagingContract {
         val targets = root["targets"] as? Map<String, Any?> ?: return emptySet()
         val assetNames = linkedSetOf<String>()
         val targetKeys = targets.keys.toList()
-        val ridToken =
-            when (arch.lowercase()) {
-                "x64",
-                "amd64",
-                "x86_64" -> "/win-x64"
-                "arm64",
-                "aarch64" -> "/win-arm64"
-                else -> "/win-"
+        val ridToken = ridTokenForArch(arch)
+        val preferred = targetKeys.filter { it.contains(ridToken, ignoreCase = true) }
+        if (preferred.isEmpty()) {
+            val otherWin =
+                targetKeys.filter { it.contains("/win-", ignoreCase = true) &&
+                    !it.contains(ridToken, ignoreCase = true) }
+            if (otherWin.isNotEmpty()) {
+                throw WrongArchDepsException(
+                    "expected target containing '$ridToken' but found only " +
+                        otherWin.joinToString()
+                )
             }
-        val preferred =
-            targetKeys.filter { it.contains(ridToken, ignoreCase = true) }.ifEmpty {
-                // Fall back to any win RID, then to all targets (framework-only deps).
-                targetKeys.filter { it.contains("/win-", ignoreCase = true) }.ifEmpty { targetKeys }
+            // Framework-only deps (no RID target): use all targets.
+            for (targetKey in targetKeys) {
+                collectFromTarget(targets[targetKey], assetNames)
             }
+            return assetNames
+        }
         for (targetKey in preferred) {
-            val packages = targets[targetKey] as? Map<String, Any?> ?: continue
-            for ((_, metaAny) in packages) {
-                val meta = metaAny as? Map<String, Any?> ?: continue
-                collectAssetBasenames(meta["runtime"] as? Map<String, Any?>, assetNames)
-                collectAssetBasenames(meta["native"] as? Map<String, Any?>, assetNames)
-            }
+            collectFromTarget(targets[targetKey], assetNames)
         }
         return assetNames
+    }
+
+    fun ridTokenForArch(arch: String): String =
+        when (arch.lowercase()) {
+            "x64",
+            "amd64",
+            "x86_64" -> "/win-x64"
+            "arm64",
+            "aarch64" -> "/win-arm64"
+            else -> "/win-"
+        }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun collectFromTarget(targetAny: Any?, into: MutableSet<String>) {
+        val packages = targetAny as? Map<String, Any?> ?: return
+        for ((_, metaAny) in packages) {
+            val meta = metaAny as? Map<String, Any?> ?: continue
+            collectAssetBasenames(meta["runtime"] as? Map<String, Any?>, into)
+            collectAssetBasenames(meta["native"] as? Map<String, Any?>, into)
+            collectAssetBasenames(meta["runtimeTargets"] as? Map<String, Any?>, into)
+        }
     }
 
     private fun collectAssetBasenames(assets: Map<String, Any?>?, into: MutableSet<String>) {
@@ -212,4 +240,7 @@ object WindowsGraphicsCaptureHelperPackagingContract {
             }
         }
     }
+
+    /** deps.json only contains Windows RID targets for a different architecture. */
+    class WrongArchDepsException(message: String) : IllegalArgumentException(message)
 }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -43,9 +43,9 @@ object WindowsGraphicsCaptureHelperPackagingContract {
             "Microsoft.Graphics.Canvas.Interop.dll",
         )
 
-    /** Flat jar entry paths for every fixed required basename on both arches. */
-    fun requiredJarEntryPaths(): List<String> =
-        ARCHES.flatMap { arch -> REQUIRED_BASE_NAMES.map { base -> jarEntryPath(arch, base) } }
+    /** Flat jar entry paths for every fixed required basename on [arches]. */
+    fun requiredJarEntryPaths(arches: List<String> = ARCHES): List<String> =
+        arches.flatMap { arch -> REQUIRED_BASE_NAMES.map { base -> jarEntryPath(arch, base) } }
 
     fun jarEntryPath(arch: String, baseName: String): String = "$RESOURCE_ROOT/$arch/$baseName"
 
@@ -55,21 +55,27 @@ object WindowsGraphicsCaptureHelperPackagingContract {
      * @param entrySizes map of full jar entry path → uncompressed size
      * @param depsJsonByArch raw deps.json text per arch when available; when provided,
      *   the deps.json runtime/native asset closure is enforced for that arch
+     * @param arches which arch directories to validate (default: both x64 and arm64)
      * @return human-readable error messages (empty when the contract is satisfied)
      */
     fun validateJarEntries(
         entrySizes: Map<String, Long>,
         depsJsonByArch: Map<String, String> = emptyMap(),
+        arches: List<String> = ARCHES,
     ): List<String> {
         val errors = mutableListOf<String>()
-        for (arch in ARCHES) {
+        for (arch in arches) {
             errors += validateArch(arch, entrySizes, depsJsonByArch[arch])
         }
         return errors
     }
 
-    /** Validates an open [ZipFile] against the full contract, including deps.json closure. */
-    fun validateZip(zip: ZipFile): List<String> {
+    /**
+     * Validates an open [ZipFile] against the full contract, including deps.json closure.
+     *
+     * @param arches which arch directories to validate (default: both)
+     */
+    fun validateZip(zip: ZipFile, arches: List<String> = ARCHES): List<String> {
         val entrySizes = linkedMapOf<String, Long>()
         val depsJsonByArch = linkedMapOf<String, String>()
         zip.entries().asSequence().forEach { entry ->
@@ -77,7 +83,7 @@ object WindowsGraphicsCaptureHelperPackagingContract {
                 entrySizes[entry.name] = entry.size
             }
         }
-        for (arch in ARCHES) {
+        for (arch in arches) {
             val depsPath = jarEntryPath(arch, DEPS_JSON)
             val entry: ZipEntry? = zip.getEntry(depsPath)
             if (entry != null && !entry.isDirectory) {
@@ -85,19 +91,19 @@ object WindowsGraphicsCaptureHelperPackagingContract {
                     zip.getInputStream(entry).bufferedReader(Charsets.UTF_8).use { it.readText() }
             }
         }
-        return validateJarEntries(entrySizes, depsJsonByArch)
+        return validateJarEntries(entrySizes, depsJsonByArch, arches)
     }
 
     /**
      * Validates a staged prebuilt helpers directory shaped as
      * `<root>/<arch>/<files>` (the `prebuiltWindowsHelpersDir` layout).
      */
-    fun validatePrebuiltHelpersDir(root: File): List<String> {
+    fun validatePrebuiltHelpersDir(root: File, arches: List<String> = ARCHES): List<String> {
         if (!root.isDirectory) {
             return listOf("prebuilt Windows helpers root is not a directory: $root")
         }
         val errors = mutableListOf<String>()
-        for (arch in ARCHES) {
+        for (arch in arches) {
             val archDir = root.resolve(arch)
             if (!archDir.isDirectory) {
                 errors += "missing prebuilt Windows helper arch directory: $arch"
@@ -215,7 +221,17 @@ object WindowsGraphicsCaptureHelperPackagingContract {
             return assetNames
         }
         for (targetKey in preferred) {
-            collectFromTarget(targets[targetKey], ridName, assetNames)
+            val body = targets[targetKey]
+            if (body !is Map<*, *>) {
+                throw IllegalArgumentException(
+                    "deps.json target '$targetKey' must be a non-empty object, was " +
+                        (body?.let { it::class.java.simpleName } ?: "null")
+                )
+            }
+            if (body.isEmpty()) {
+                throw IllegalArgumentException("deps.json target '$targetKey' is an empty object")
+            }
+            collectFromTarget(body, ridName, assetNames)
         }
         return assetNames
     }

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContract.kt
@@ -1,0 +1,203 @@
+package dev.sebastiano.spectre.build
+
+import groovy.json.JsonSlurper
+import java.io.File
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+
+/**
+ * Packaging contract for the Windows Graphics Capture helper bundled in
+ * `spectre-recording-windows`.
+ *
+ * The helper is a **framework-dependent multi-file** directory per arch: the runtime
+ * extractor copies every regular file under `native/windows/<arch>/` before launch.
+ * Verifiers must therefore reject an orphan top-level exe.
+ *
+ * Contract (each of [ARCHES]):
+ * 1. Fixed identity/bootstrap basenames (non-empty).
+ * 2. Every runtime/native asset basename named by that arch's
+ *    `SpectreWindowCapture.deps.json` must exist as a non-empty sibling.
+ * 3. `.pdb` files are not runtime-required.
+ */
+object WindowsGraphicsCaptureHelperPackagingContract {
+    val ARCHES: List<String> = listOf("x64", "arm64")
+
+    const val RESOURCE_ROOT: String = "native/windows"
+    const val EXE_NAME: String = "spectre-window-capture.exe"
+    const val MANAGED_ASSEMBLY: String = "SpectreWindowCapture.dll"
+    const val DEPS_JSON: String = "SpectreWindowCapture.deps.json"
+    const val RUNTIME_CONFIG: String = "SpectreWindowCapture.runtimeconfig.json"
+
+    /** Always-required basenames; catches orphan-exe without relying on deps.json alone. */
+    val REQUIRED_BASE_NAMES: List<String> =
+        listOf(
+            EXE_NAME,
+            MANAGED_ASSEMBLY,
+            DEPS_JSON,
+            RUNTIME_CONFIG,
+            "Microsoft.WindowsAppRuntime.Bootstrap.dll",
+            "Microsoft.WindowsAppRuntime.Bootstrap.Net.dll",
+            "WinRT.Runtime.dll",
+            "Microsoft.Windows.SDK.NET.dll",
+            "Microsoft.Graphics.Canvas.dll",
+            "Microsoft.Graphics.Canvas.Interop.dll",
+        )
+
+    /** Flat jar entry paths for every fixed required basename on both arches. */
+    fun requiredJarEntryPaths(): List<String> =
+        ARCHES.flatMap { arch -> REQUIRED_BASE_NAMES.map { base -> jarEntryPath(arch, base) } }
+
+    fun jarEntryPath(arch: String, baseName: String): String = "$RESOURCE_ROOT/$arch/$baseName"
+
+    /**
+     * Validates zip/jar packaging of the Windows helper.
+     *
+     * @param entrySizes map of full jar entry path → uncompressed size
+     * @param depsJsonByArch raw deps.json text per arch when available; when provided,
+     *   the deps.json runtime/native asset closure is enforced for that arch
+     * @return human-readable error messages (empty when the contract is satisfied)
+     */
+    fun validateJarEntries(
+        entrySizes: Map<String, Long>,
+        depsJsonByArch: Map<String, String> = emptyMap(),
+    ): List<String> {
+        val errors = mutableListOf<String>()
+        for (arch in ARCHES) {
+            errors += validateArch(arch, entrySizes, depsJsonByArch[arch])
+        }
+        return errors
+    }
+
+    /** Validates an open [ZipFile] against the full contract, including deps.json closure. */
+    fun validateZip(zip: ZipFile): List<String> {
+        val entrySizes = linkedMapOf<String, Long>()
+        val depsJsonByArch = linkedMapOf<String, String>()
+        zip.entries().asSequence().forEach { entry ->
+            if (!entry.isDirectory) {
+                entrySizes[entry.name] = entry.size
+            }
+        }
+        for (arch in ARCHES) {
+            val depsPath = jarEntryPath(arch, DEPS_JSON)
+            val entry: ZipEntry? = zip.getEntry(depsPath)
+            if (entry != null && !entry.isDirectory) {
+                depsJsonByArch[arch] =
+                    zip.getInputStream(entry).bufferedReader(Charsets.UTF_8).use { it.readText() }
+            }
+        }
+        return validateJarEntries(entrySizes, depsJsonByArch)
+    }
+
+    /**
+     * Validates a staged prebuilt helpers directory shaped as
+     * `<root>/<arch>/<files>` (the `prebuiltWindowsHelpersDir` layout).
+     */
+    fun validatePrebuiltHelpersDir(root: File): List<String> {
+        if (!root.isDirectory) {
+            return listOf("prebuilt Windows helpers root is not a directory: $root")
+        }
+        val errors = mutableListOf<String>()
+        for (arch in ARCHES) {
+            val archDir = root.resolve(arch)
+            if (!archDir.isDirectory) {
+                errors += "missing prebuilt Windows helper arch directory: $arch"
+                continue
+            }
+            val files =
+                archDir.listFiles()?.filter { it.isFile }?.associate { it.name to it.length() }
+                    .orEmpty()
+            val depsText = archDir.resolve(DEPS_JSON).takeIf { it.isFile }?.readText()
+            errors += validateArchFiles(arch, files, depsText, pathPrefix = "$arch/")
+        }
+        return errors
+    }
+
+    private fun validateArch(
+        arch: String,
+        entrySizes: Map<String, Long>,
+        depsJson: String?,
+    ): List<String> {
+        val prefix = "$RESOURCE_ROOT/$arch/"
+        val files =
+            entrySizes
+                .filterKeys { it.startsWith(prefix) && !it.removePrefix(prefix).contains('/') }
+                .mapKeys { it.key.removePrefix(prefix) }
+        return validateArchFiles(arch, files, depsJson, pathPrefix = prefix)
+    }
+
+    private fun validateArchFiles(
+        arch: String,
+        files: Map<String, Long>,
+        depsJson: String?,
+        pathPrefix: String,
+    ): List<String> {
+        val errors = mutableListOf<String>()
+        for (base in REQUIRED_BASE_NAMES) {
+            val size = files[base]
+            when {
+                size == null ->
+                    errors += "missing Windows helper entry `$pathPrefix$base` (arch $arch)"
+                size <= 0L ->
+                    errors += "empty Windows helper entry `$pathPrefix$base` (arch $arch)"
+            }
+        }
+        if (depsJson != null) {
+            val requiredFromDeps =
+                try {
+                    runtimeAssetBaseNames(depsJson)
+                } catch (e: Exception) {
+                    errors +=
+                        "invalid $pathPrefix$DEPS_JSON for arch $arch: " +
+                            (e.message ?: e::class.java.simpleName)
+                    emptySet()
+                }
+            for (base in requiredFromDeps) {
+                val size = files[base]
+                when {
+                    size == null ->
+                        errors +=
+                            "missing Windows helper companion `$pathPrefix$base` " +
+                                "required by $DEPS_JSON (arch $arch)"
+                    size <= 0L ->
+                        errors +=
+                            "empty Windows helper companion `$pathPrefix$base` " +
+                                "required by $DEPS_JSON (arch $arch)"
+                }
+            }
+        }
+        return errors
+    }
+
+    /**
+     * Collects basenames of runtime and native assets from a .NET deps.json document
+     * for the Windows RID target present in the file.
+     */
+    @Suppress("UNCHECKED_CAST")
+    fun runtimeAssetBaseNames(depsJson: String): Set<String> {
+        val root = JsonSlurper().parseText(depsJson) as Map<String, Any?>
+        val targets = root["targets"] as? Map<String, Any?> ?: return emptySet()
+        val assetNames = linkedSetOf<String>()
+        val targetKeys = targets.keys.toList()
+        val preferred =
+            targetKeys.filter { it.contains("/win-", ignoreCase = true) }.ifEmpty { targetKeys }
+        for (targetKey in preferred) {
+            val packages = targets[targetKey] as? Map<String, Any?> ?: continue
+            for ((_, metaAny) in packages) {
+                val meta = metaAny as? Map<String, Any?> ?: continue
+                collectAssetBasenames(meta["runtime"] as? Map<String, Any?>, assetNames)
+                collectAssetBasenames(meta["native"] as? Map<String, Any?>, assetNames)
+            }
+        }
+        return assetNames
+    }
+
+    private fun collectAssetBasenames(assets: Map<String, Any?>?, into: MutableSet<String>) {
+        if (assets == null) return
+        for (path in assets.keys) {
+            val base = path.substringAfterLast('/').substringAfterLast('\\')
+            if (base.isNotEmpty() && !base.endsWith(".pdb", ignoreCase = true)) {
+                into += base
+            }
+        }
+    }
+}

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
@@ -86,6 +86,11 @@ class WindowsGraphicsCaptureHelperPackagingContractTest {
                   "SpectreWindowCapture/1.0.0": {
                     "runtime": { "SpectreWindowCapture.dll": {} }
                   }
+                },
+                ".NETCoreApp,Version=v8.0/win-arm64": {
+                  "SpectreWindowCapture/1.0.0": {
+                    "runtime": { "SpectreWindowCapture.dll": {} }
+                  }
                 }
               }
             }
@@ -138,9 +143,14 @@ class WindowsGraphicsCaptureHelperPackagingContractTest {
                 .toMap()
         val depsBody =
             """
-            {"targets":{".NETCoreApp,Version=v8.0/win-x64":{
-              "SpectreWindowCapture/1.0.0":{"runtime":{"SpectreWindowCapture.dll":{}}}
-            }}}
+            {"targets":{
+              ".NETCoreApp,Version=v8.0/win-x64":{
+                "SpectreWindowCapture/1.0.0":{"runtime":{"SpectreWindowCapture.dll":{}}}
+              },
+              ".NETCoreApp,Version=v8.0/win-arm64":{
+                "SpectreWindowCapture/1.0.0":{"runtime":{"SpectreWindowCapture.dll":{}}}
+              }
+            }}
             """
                 .trimIndent()
         val withDeps =
@@ -236,6 +246,81 @@ class WindowsGraphicsCaptureHelperPackagingContractTest {
         assertTrue(
             arm64.contains("OnlyArm64.dll") && !arm64.contains("OnlyX64.dll"),
             arm64.toString(),
+        )
+    }
+
+    @Test
+    fun `wrong-arch-only deps json is rejected for the directory arch`() {
+        val x64OnlyDeps =
+            """
+            {
+              "targets": {
+                ".NETCoreApp,Version=v8.0/win-x64": {
+                  "pkg/1": {
+                    "native": { "runtimes/win-x64/native/OnlyX64.dll": {} }
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val files = completeFixedRequiredFiles()
+        val entrySizes =
+            files.mapKeys { "native/windows/arm64/${it.key}" } +
+                files.mapKeys { "native/windows/x64/${it.key}" }
+        val errors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                // arm64 directory claims a win-x64-only deps.json
+                depsJsonByArch = mapOf("arm64" to x64OnlyDeps, "x64" to x64OnlyDeps),
+            )
+        assertTrue(
+            errors.any { it.contains("arch-mismatched") && it.contains("arm64") },
+            "expected arch mismatch for arm64; errors=$errors",
+        )
+    }
+
+    @Test
+    fun `runtimeTargets assets are required by the deps closure`() {
+        val deps =
+            """
+            {
+              "targets": {
+                ".NETCoreApp,Version=v8.0/win-x64": {
+                  "pkg/1": {
+                    "runtimeTargets": {
+                      "runtimes/win-x64/native/FromRuntimeTargets.dll": {}
+                    }
+                  }
+                },
+                ".NETCoreApp,Version=v8.0/win-arm64": {
+                  "pkg/1": {
+                    "runtimeTargets": {
+                      "runtimes/win-arm64/native/FromRuntimeTargets.dll": {}
+                    }
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val files = completeFixedRequiredFiles()
+        // No FromRuntimeTargets.dll in the tree.
+        val entrySizes =
+            WindowsGraphicsCaptureHelperPackagingContract.ARCHES.flatMap { arch ->
+                    files.map { (base, size) -> "native/windows/$arch/$base" to size }
+                }
+                .toMap()
+        val errors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                depsJsonByArch = mapOf("x64" to deps, "arm64" to deps),
+            )
+        assertTrue(
+            errors.any {
+                it.contains("FromRuntimeTargets.dll") && it.contains("required by")
+            },
+            "expected runtimeTargets companion to be required; errors=$errors",
         )
     }
 

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
@@ -325,6 +325,64 @@ class WindowsGraphicsCaptureHelperPackagingContractTest {
     }
 
     @Test
+    fun `empty targets map in deps json is rejected`() {
+        val files = completeFixedRequiredFiles()
+        val entrySizes =
+            WindowsGraphicsCaptureHelperPackagingContract.ARCHES.flatMap { arch ->
+                    files.map { (base, size) -> "native/windows/$arch/$base" to size }
+                }
+                .toMap()
+        val errors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                depsJsonByArch = mapOf("x64" to "{}", "arm64" to """{"targets":{}}"""),
+            )
+        assertTrue(
+            errors.any { it.contains("invalid") && it.contains("x64") },
+            "expected empty/missing targets to fail; errors=$errors",
+        )
+        assertTrue(
+            errors.any { it.contains("invalid") && it.contains("arm64") },
+            "expected empty targets to fail for arm64; errors=$errors",
+        )
+    }
+
+    @Test
+    fun `runtimeTargets are filtered by rid metadata`() {
+        val deps =
+            """
+            {
+              "targets": {
+                ".NETCoreApp,Version=v8.0": {
+                  "pkg/1": {
+                    "runtimeTargets": {
+                      "runtimes/win-x64/native/OnlyX64Rt.dll": {
+                        "rid": "win-x64",
+                        "assetType": "native"
+                      },
+                      "runtimes/win-arm64/native/OnlyArm64Rt.dll": {
+                        "rid": "win-arm64",
+                        "assetType": "native"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val x64 =
+            WindowsGraphicsCaptureHelperPackagingContract.runtimeAssetBaseNames(deps, "x64")
+        val arm64 =
+            WindowsGraphicsCaptureHelperPackagingContract.runtimeAssetBaseNames(deps, "arm64")
+        assertTrue(x64.contains("OnlyX64Rt.dll") && !x64.contains("OnlyArm64Rt.dll"), x64.toString())
+        assertTrue(
+            arm64.contains("OnlyArm64Rt.dll") && !arm64.contains("OnlyX64Rt.dll"),
+            arm64.toString(),
+        )
+    }
+
+    @Test
     fun `requiredJarEntryPaths covers both arches and core basenames`() {
         val paths = WindowsGraphicsCaptureHelperPackagingContract.requiredJarEntryPaths()
         assertTrue(paths.contains("native/windows/x64/spectre-window-capture.exe"))

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
@@ -201,10 +201,42 @@ class WindowsGraphicsCaptureHelperPackagingContractTest {
             }
             """
                 .trimIndent()
-        val names = WindowsGraphicsCaptureHelperPackagingContract.runtimeAssetBaseNames(deps)
+        val names =
+            WindowsGraphicsCaptureHelperPackagingContract.runtimeAssetBaseNames(deps, "x64")
         assertTrue(names.contains("Foo.dll"), names.toString())
         assertTrue(names.contains("Bar.dll"), names.toString())
         assertTrue(!names.contains("Foo.pdb"), names.toString())
+    }
+
+    @Test
+    fun `runtimeAssetBaseNames prefers RID matching the requested arch`() {
+        val deps =
+            """
+            {
+              "targets": {
+                ".NETCoreApp,Version=v8.0/win-x64": {
+                  "pkg/1": {
+                    "native": { "runtimes/win-x64/native/OnlyX64.dll": {} }
+                  }
+                },
+                ".NETCoreApp,Version=v8.0/win-arm64": {
+                  "pkg/1": {
+                    "native": { "runtimes/win-arm64/native/OnlyArm64.dll": {} }
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val x64 =
+            WindowsGraphicsCaptureHelperPackagingContract.runtimeAssetBaseNames(deps, "x64")
+        val arm64 =
+            WindowsGraphicsCaptureHelperPackagingContract.runtimeAssetBaseNames(deps, "arm64")
+        assertTrue(x64.contains("OnlyX64.dll") && !x64.contains("OnlyArm64.dll"), x64.toString())
+        assertTrue(
+            arm64.contains("OnlyArm64.dll") && !arm64.contains("OnlyX64.dll"),
+            arm64.toString(),
+        )
     }
 
     @Test

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
@@ -250,6 +250,85 @@ class WindowsGraphicsCaptureHelperPackagingContractTest {
     }
 
     @Test
+    fun `null package body under selected target is rejected`() {
+        val deps =
+            """
+            {
+              "targets": {
+                ".NETCoreApp,Version=v8.0/win-x64": {
+                  "SpectreWindowCapture/1.0.0": null
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val files = completeFixedRequiredFiles()
+        val entrySizes = files.mapKeys { "native/windows/x64/${it.key}" }
+        val errors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                depsJsonByArch = mapOf("x64" to deps),
+                arches = listOf("x64"),
+            )
+        assertTrue(
+            errors.any { it.contains("invalid") && it.contains("package") },
+            "expected null package body rejection; errors=$errors",
+        )
+    }
+
+    @Test
+    fun `null runtime asset table is rejected`() {
+        val deps =
+            """
+            {
+              "targets": {
+                ".NETCoreApp,Version=v8.0/win-x64": {
+                  "SpectreWindowCapture/1.0.0": {
+                    "runtime": null
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val files = completeFixedRequiredFiles()
+        val entrySizes = files.mapKeys { "native/windows/x64/${it.key}" }
+        val errors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                depsJsonByArch = mapOf("x64" to deps),
+                arches = listOf("x64"),
+            )
+        assertTrue(
+            errors.any { it.contains("invalid") && it.contains("runtime") },
+            "expected null runtime table rejection; errors=$errors",
+        )
+    }
+
+    @Test
+    fun `runtimeTarget name selects the exact target key`() {
+        val deps =
+            """
+            {
+              "runtimeTarget": { "name": ".NETCoreApp,Version=v8.0/win-x64" },
+              "targets": {
+                ".NETCoreApp,Version=v7.0/win-x64": {
+                  "pkg/1": { "runtime": { "WrongGeneration.dll": {} } }
+                },
+                ".NETCoreApp,Version=v8.0/win-x64": {
+                  "pkg/1": { "runtime": { "RightGeneration.dll": {} } }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val names =
+            WindowsGraphicsCaptureHelperPackagingContract.runtimeAssetBaseNames(deps, "x64")
+        assertTrue(names.contains("RightGeneration.dll"), names.toString())
+        assertTrue(!names.contains("WrongGeneration.dll"), names.toString())
+    }
+
+    @Test
     fun `runtimeTarget name RID must match the directory arch`() {
         val mismatched =
             """

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
@@ -306,6 +306,36 @@ class WindowsGraphicsCaptureHelperPackagingContractTest {
     }
 
     @Test
+    fun `missing runtimeTarget name in targets is rejected`() {
+        val deps =
+            """
+            {
+              "runtimeTarget": { "name": ".NETCoreApp,Version=v8.0/win-x64" },
+              "targets": {
+                ".NETCoreApp,Version=v7.0/win-x64": {
+                  "pkg/1": { "runtime": { "OnlyV7.dll": {} } }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val files = completeFixedRequiredFiles()
+        val entrySizes = files.mapKeys { "native/windows/x64/${it.key}" }
+        val errors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                depsJsonByArch = mapOf("x64" to deps),
+                arches = listOf("x64"),
+            )
+        assertTrue(
+            errors.any {
+                it.contains("invalid") && it.contains("runtimeTarget.name")
+            },
+            "expected missing declared runtimeTarget rejection; errors=$errors",
+        )
+    }
+
+    @Test
     fun `runtimeTarget name selects the exact target key`() {
         val deps =
             """

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
@@ -250,6 +250,38 @@ class WindowsGraphicsCaptureHelperPackagingContractTest {
     }
 
     @Test
+    fun `runtimeTarget name RID must match the directory arch`() {
+        val mismatched =
+            """
+            {
+              "runtimeTarget": { "name": ".NETCoreApp,Version=v8.0/win-x64" },
+              "targets": {
+                ".NETCoreApp,Version=v8.0/win-arm64": {
+                  "pkg/1": {
+                    "runtime": { "SpectreWindowCapture.dll": {} }
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val files = completeFixedRequiredFiles()
+        val entrySizes = files.mapKeys { "native/windows/arm64/${it.key}" }
+        val errors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                depsJsonByArch = mapOf("arm64" to mismatched),
+                arches = listOf("arm64"),
+            )
+        assertTrue(
+            errors.any {
+                it.contains("arch-mismatched") && it.contains("runtimeTarget.name")
+            },
+            "expected runtimeTarget RID mismatch rejection; errors=$errors",
+        )
+    }
+
+    @Test
     fun `wrong-arch-only deps json is rejected for the directory arch`() {
         val x64OnlyDeps =
             """

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
@@ -325,6 +325,42 @@ class WindowsGraphicsCaptureHelperPackagingContractTest {
     }
 
     @Test
+    fun `null or empty selected target body is rejected`() {
+        val nullBody =
+            """
+            {"targets":{".NETCoreApp,Version=v8.0/win-x64":null}}
+            """
+                .trimIndent()
+        val emptyBody =
+            """
+            {"targets":{".NETCoreApp,Version=v8.0/win-x64":{}}}
+            """
+                .trimIndent()
+        val files = completeFixedRequiredFiles()
+        val entrySizes = files.mapKeys { "native/windows/x64/${it.key}" }
+        val nullErrors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                depsJsonByArch = mapOf("x64" to nullBody),
+                arches = listOf("x64"),
+            )
+        val emptyErrors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                depsJsonByArch = mapOf("x64" to emptyBody),
+                arches = listOf("x64"),
+            )
+        assertTrue(
+            nullErrors.any { it.contains("invalid") },
+            "expected null target body to fail; errors=$nullErrors",
+        )
+        assertTrue(
+            emptyErrors.any { it.contains("invalid") },
+            "expected empty target body to fail; errors=$emptyErrors",
+        )
+    }
+
+    @Test
     fun `empty targets map in deps json is rejected`() {
         val files = completeFixedRequiredFiles()
         val entrySizes =

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/WindowsGraphicsCaptureHelperPackagingContractTest.kt
@@ -1,0 +1,238 @@
+package dev.sebastiano.spectre.build
+
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.createTempFile
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.outputStream
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Proves the shared Windows helper packaging contract rejects incomplete payloads
+ * (orphan exe, missing deps.json companions, empty entries) and accepts a complete
+ * multi-file tree. Uses the same [WindowsGraphicsCaptureHelperPackagingContract] object
+ * as `:recording-windows:verifyRecordingWindowsHelper` and `:verifyMavenLocalPublication`.
+ */
+class WindowsGraphicsCaptureHelperPackagingContractTest {
+
+    @Test
+    fun `orphan exe only payload is rejected for both arches`() {
+        val entries =
+            mapOf(
+                "native/windows/x64/spectre-window-capture.exe" to 1024L,
+                "native/windows/arm64/spectre-window-capture.exe" to 1024L,
+            )
+        val errors = WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(entries)
+        assertTrue(errors.isNotEmpty(), "expected orphan-exe payload to fail")
+        assertTrue(
+            errors.any { it.contains("SpectreWindowCapture.dll") && it.contains("x64") },
+            "expected missing managed assembly for x64; errors=$errors",
+        )
+        assertTrue(
+            errors.any { it.contains("SpectreWindowCapture.dll") && it.contains("arm64") },
+            "expected missing managed assembly for arm64; errors=$errors",
+        )
+    }
+
+    @Test
+    fun `missing companion required by deps json is rejected`() {
+        val deps =
+            """
+            {
+              "runtimeTarget": { "name": ".NETCoreApp,Version=v8.0/win-x64" },
+              "targets": {
+                ".NETCoreApp,Version=v8.0/win-x64": {
+                  "SpectreWindowCapture/1.0.0": {
+                    "runtime": { "SpectreWindowCapture.dll": {} }
+                  },
+                  "Microsoft.Graphics.Win2D/1.4.0": {
+                    "native": { "runtimes/win-x64/native/Microsoft.Graphics.Canvas.dll": {} }
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val baseFiles = completeFixedRequiredFiles()
+        val x64Files = baseFiles - "Microsoft.Graphics.Canvas.dll"
+        val entrySizes =
+            x64Files.mapKeys { "native/windows/x64/${it.key}" } +
+                baseFiles.mapKeys { "native/windows/arm64/${it.key}" }
+        val errors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(
+                entrySizes,
+                depsJsonByArch = mapOf("x64" to deps, "arm64" to deps),
+            )
+        assertTrue(
+            errors.any {
+                it.contains("Microsoft.Graphics.Canvas.dll") &&
+                    it.contains("required by") &&
+                    it.contains("x64")
+            },
+            "expected deps-closure failure for missing Canvas.dll; errors=$errors",
+        )
+    }
+
+    @Test
+    fun `complete fixed required set with deps closure passes`() {
+        val deps =
+            """
+            {
+              "targets": {
+                ".NETCoreApp,Version=v8.0/win-x64": {
+                  "SpectreWindowCapture/1.0.0": {
+                    "runtime": { "SpectreWindowCapture.dll": {} }
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val files = completeFixedRequiredFiles()
+        val entrySizes =
+            WindowsGraphicsCaptureHelperPackagingContract.ARCHES.flatMap { arch ->
+                    files.map { (base, size) -> "native/windows/$arch/$base" to size }
+                }
+                .toMap()
+        val depsByArch =
+            WindowsGraphicsCaptureHelperPackagingContract.ARCHES.associateWith { deps }
+        val errors =
+            WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(entrySizes, depsByArch)
+        assertTrue(errors.isEmpty(), "expected complete payload to pass; errors=$errors")
+    }
+
+    @Test
+    fun `empty required entry is rejected`() {
+        val files = completeFixedRequiredFiles().toMutableMap()
+        files["SpectreWindowCapture.dll"] = 0L
+        val entrySizes =
+            WindowsGraphicsCaptureHelperPackagingContract.ARCHES.flatMap { arch ->
+                    files.map { (base, size) -> "native/windows/$arch/$base" to size }
+                }
+                .toMap()
+        val errors = WindowsGraphicsCaptureHelperPackagingContract.validateJarEntries(entrySizes)
+        assertTrue(
+            errors.any { it.contains("empty") && it.contains("SpectreWindowCapture.dll") },
+            "expected empty-entry failure; errors=$errors",
+        )
+    }
+
+    @Test
+    fun `validateZip rejects incomplete jar and accepts complete jar`() {
+        val incomplete =
+            zipWithEntries(mapOf("native/windows/x64/spectre-window-capture.exe" to "exe"))
+        ZipFile(incomplete.toFile()).use { zip ->
+            val errors = WindowsGraphicsCaptureHelperPackagingContract.validateZip(zip)
+            assertTrue(errors.isNotEmpty(), "incomplete zip must fail")
+        }
+        incomplete.deleteIfExists()
+
+        val files = completeFixedRequiredFiles()
+        val completeEntries =
+            WindowsGraphicsCaptureHelperPackagingContract.ARCHES.flatMap { arch ->
+                    files.keys.map { base -> "native/windows/$arch/$base" to "payload-$base" }
+                }
+                .toMap()
+        val depsBody =
+            """
+            {"targets":{".NETCoreApp,Version=v8.0/win-x64":{
+              "SpectreWindowCapture/1.0.0":{"runtime":{"SpectreWindowCapture.dll":{}}}
+            }}}
+            """
+                .trimIndent()
+        val withDeps =
+            completeEntries +
+                mapOf(
+                    "native/windows/x64/SpectreWindowCapture.deps.json" to depsBody,
+                    "native/windows/arm64/SpectreWindowCapture.deps.json" to depsBody,
+                )
+        val complete = zipWithEntries(withDeps)
+        ZipFile(complete.toFile()).use { zip ->
+            val errors = WindowsGraphicsCaptureHelperPackagingContract.validateZip(zip)
+            assertTrue(errors.isEmpty(), "complete zip must pass; errors=$errors")
+        }
+        complete.deleteIfExists()
+    }
+
+    @Test
+    fun `validatePrebuiltHelpersDir rejects orphan exe tree`() {
+        val root = createTempDirectory("windows-helpers-prebuilt")
+        try {
+            for (arch in WindowsGraphicsCaptureHelperPackagingContract.ARCHES) {
+                val archDir = root.resolve(arch).toFile()
+                archDir.mkdirs()
+                archDir.resolve("spectre-window-capture.exe").writeBytes(ByteArray(64) { 1 })
+            }
+            val errors =
+                WindowsGraphicsCaptureHelperPackagingContract.validatePrebuiltHelpersDir(
+                    root.toFile()
+                )
+            assertTrue(errors.isNotEmpty(), "orphan exe prebuilt dir must fail")
+            assertTrue(
+                errors.any { it.contains("SpectreWindowCapture.dll") },
+                "expected missing companion in prebuilt dir; errors=$errors",
+            )
+        } finally {
+            root.toFile().deleteRecursively()
+        }
+    }
+
+    @Test
+    fun `runtimeAssetBaseNames extracts basenames and skips pdb`() {
+        val deps =
+            """
+            {
+              "targets": {
+                ".NETCoreApp,Version=v8.0/win-x64": {
+                  "pkg/1": {
+                    "runtime": {
+                      "lib/net8.0/Foo.dll": {},
+                      "lib/net8.0/Foo.pdb": {}
+                    },
+                    "native": {
+                      "runtimes/win-x64/native/Bar.dll": {}
+                    }
+                  }
+                }
+              }
+            }
+            """
+                .trimIndent()
+        val names = WindowsGraphicsCaptureHelperPackagingContract.runtimeAssetBaseNames(deps)
+        assertTrue(names.contains("Foo.dll"), names.toString())
+        assertTrue(names.contains("Bar.dll"), names.toString())
+        assertTrue(!names.contains("Foo.pdb"), names.toString())
+    }
+
+    @Test
+    fun `requiredJarEntryPaths covers both arches and core basenames`() {
+        val paths = WindowsGraphicsCaptureHelperPackagingContract.requiredJarEntryPaths()
+        assertTrue(paths.contains("native/windows/x64/spectre-window-capture.exe"))
+        assertTrue(paths.contains("native/windows/arm64/spectre-window-capture.exe"))
+        assertTrue(paths.contains("native/windows/x64/SpectreWindowCapture.dll"))
+        assertTrue(paths.contains("native/windows/arm64/Microsoft.WindowsAppRuntime.Bootstrap.dll"))
+        assertTrue(
+            paths.size ==
+                WindowsGraphicsCaptureHelperPackagingContract.ARCHES.size *
+                    WindowsGraphicsCaptureHelperPackagingContract.REQUIRED_BASE_NAMES.size
+        )
+    }
+
+    private fun completeFixedRequiredFiles(): Map<String, Long> =
+        WindowsGraphicsCaptureHelperPackagingContract.REQUIRED_BASE_NAMES.associateWith { 64L }
+
+    private fun zipWithEntries(entries: Map<String, String>): java.nio.file.Path {
+        val path = createTempFile("windows-helper-contract-", ".jar")
+        ZipOutputStream(path.outputStream()).use { zip ->
+            for ((name, content) in entries) {
+                zip.putNextEntry(ZipEntry(name))
+                zip.write(content.toByteArray(Charsets.UTF_8))
+                zip.closeEntry()
+            }
+        }
+        return path
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -116,7 +116,8 @@ Expected long-term responsibilities:
 - mirror the runtime resource paths the extractors probe:
   `native/macos/SpectreCaptureHelper.app`,
   `native/linux/<arch>/spectre-wayland-helper`, and
-  `native/windows/<arch>/spectre-window-capture.exe`
+  `native/windows/<arch>/` multi-file Windows Graphics Capture helper tree
+  (exe + companions; framework-dependent)
 
 Current backends:
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -113,9 +113,13 @@ Manual promotion checklist:
 - Confirm `spectre-recording-linux-<version>.jar` contains
   `native/linux/x86_64/spectre-wayland-helper` and
   `native/linux/aarch64/spectre-wayland-helper`.
-- Confirm `spectre-recording-windows-<version>.jar` contains
-  `native/windows/x64/spectre-window-capture.exe` and
-  `native/windows/arm64/spectre-window-capture.exe`.
+- Confirm `spectre-recording-windows-<version>.jar` contains a complete multi-file
+  Windows Graphics Capture helper for **both** `x64` and `arm64` under
+  `native/windows/<arch>/` — not only `spectre-window-capture.exe`. Each arch must
+  include the renamed apphost, `SpectreWindowCapture.dll`,
+  `SpectreWindowCapture.deps.json`, `SpectreWindowCapture.runtimeconfig.json`, WASDK
+  bootstrap/WinRT/Win2D core DLLs, and every runtime/native asset named by that arch's
+  deps.json (see `WindowsGraphicsCaptureHelperPackagingContract` in `buildSrc`).
 - Confirm `spectre-agent-runtime-<version>.jar` exists and its manifest declares
   `Agent-Class: dev.sebastiano.spectre.agent.runtime.SpectreAgent`.
 - Run the Central Portal deployment checker:
@@ -186,8 +190,9 @@ It additionally asserts:
   (executable, Info.plist, PkgInfo, AppIcon.icns)
 - `:recording-linux` contains `native/linux/x86_64/spectre-wayland-helper` and
   `native/linux/aarch64/spectre-wayland-helper` when built with release helper inputs
-- `:recording-windows` contains `native/windows/x64/spectre-window-capture.exe` and
-  `native/windows/arm64/spectre-window-capture.exe` when built with release helper inputs
+- `:recording-windows` contains the full multi-file Windows Graphics Capture helper
+  contract for `x64` and `arm64` under `native/windows/<arch>/` when built with release
+  helper inputs (fixed required basenames + deps.json asset closure — not exe-only)
 - `:agent-runtime` publishes the Java Agent runtime jar; it must carry the Java Agent
   manifest and must not bundle Compose, Skiko, Spectre core, or Kotlin stdlib classes
 
@@ -203,8 +208,26 @@ previous release-CI run), point at it instead of the stub:
 
 The `prebuiltLinuxHelpersDir` directory must contain
 `x86_64/spectre-wayland-helper` and `aarch64/spectre-wayland-helper`.
-The `prebuiltWindowsHelpersDir` directory must contain
-`x64/spectre-window-capture.exe` and `arm64/spectre-window-capture.exe`.
+The `prebuiltWindowsHelpersDir` directory must contain the **complete** framework-dependent
+publish output for each arch (as produced by
+`:recording:assembleWindowsScreenshotHelper` / the release `windows-helper` job), shaped as:
+
+```text
+windows-helpers/
+  x64/
+    spectre-window-capture.exe
+    SpectreWindowCapture.dll
+    SpectreWindowCapture.deps.json
+    SpectreWindowCapture.runtimeconfig.json
+    Microsoft.WindowsAppRuntime.Bootstrap.dll
+    … remaining companions from the .NET publish …
+  arm64/
+    … same multi-file tree …
+```
+
+Providing only the two renamed executables is **not** sufficient: the runtime extractor
+copies the whole arch directory, and packaging verification enforces the multi-file
+contract (fixed required set + deps.json closure) for both arches.
 
 ## Coordinates
 

--- a/recording-windows/build.gradle.kts
+++ b/recording-windows/build.gradle.kts
@@ -1,3 +1,4 @@
+import dev.sebastiano.spectre.build.WindowsGraphicsCaptureHelperPackagingContract
 import java.util.zip.ZipFile
 import org.gradle.api.GradleException
 import org.gradle.internal.os.OperatingSystem
@@ -54,23 +55,23 @@ tasks.named<ProcessResources>("processResources") {
 tasks.register("verifyRecordingWindowsHelper") {
     group = "verification"
     description =
-        "Verifies the Windows Graphics Capture helper resource is packaged in spectre-recording-windows."
+        "Verifies the Windows Graphics Capture helper multi-file runtime contract is packaged " +
+            "in spectre-recording-windows for x64 and arm64."
     enabled = shouldVerifyWindowsHelper
     dependsOn(tasks.named("jar"))
 
     val jarFile = tasks.named<Jar>("jar").flatMap { it.archiveFile }
     doLast {
         val jar = jarFile.get().asFile
-        val containsHelpers =
+        val errors =
             ZipFile(jar).use { zip ->
-                val x64 = zip.getEntry("native/windows/x64/spectre-window-capture.exe")
-                val arm64 = zip.getEntry("native/windows/arm64/spectre-window-capture.exe")
-                x64 != null && x64.size > 0 && arm64 != null && arm64.size > 0
+                WindowsGraphicsCaptureHelperPackagingContract.validateZip(zip)
             }
-        if (!containsHelpers) {
+        if (errors.isNotEmpty()) {
             throw GradleException(
-                "spectre-recording-windows jar is missing non-empty x64 and/or arm64 " +
-                    "Windows Graphics Capture helpers"
+                "spectre-recording-windows jar fails the Windows Graphics Capture helper " +
+                    "packaging contract:\n" +
+                    errors.joinToString("\n") { "  - $it" }
             )
         }
     }

--- a/recording-windows/build.gradle.kts
+++ b/recording-windows/build.gradle.kts
@@ -42,6 +42,17 @@ val shouldVerifyWindowsHelper =
     OperatingSystem.current().isWindows ||
         prebuiltWindowsHelperPath.isPresent ||
         prebuiltWindowsHelpersDir.isPresent
+// Legacy -PprebuiltWindowsHelperPath stages x64 only; full dual-arch contract requires
+// -PprebuiltWindowsHelpersDir or a Windows host build.
+val windowsHelperArchesToVerify: List<String> =
+    if (
+        prebuiltWindowsHelpersDir.isPresent ||
+            (!prebuiltWindowsHelperPath.isPresent && OperatingSystem.current().isWindows)
+    ) {
+        WindowsGraphicsCaptureHelperPackagingContract.ARCHES
+    } else {
+        listOf("x64")
+    }
 
 tasks.named<ProcessResources>("processResources") {
     from(recordingProject.layout.buildDirectory.dir("generated/windowsScreenshotHelper"))
@@ -56,16 +67,17 @@ tasks.register("verifyRecordingWindowsHelper") {
     group = "verification"
     description =
         "Verifies the Windows Graphics Capture helper multi-file runtime contract is packaged " +
-            "in spectre-recording-windows for x64 and arm64."
+            "in spectre-recording-windows (x64+arm64, or x64-only for legacy prebuilt path)."
     enabled = shouldVerifyWindowsHelper
     dependsOn(tasks.named("jar"))
 
     val jarFile = tasks.named<Jar>("jar").flatMap { it.archiveFile }
+    val arches = windowsHelperArchesToVerify
     doLast {
         val jar = jarFile.get().asFile
         val errors =
             ZipFile(jar).use { zip ->
-                WindowsGraphicsCaptureHelperPackagingContract.validateZip(zip)
+                WindowsGraphicsCaptureHelperPackagingContract.validateZip(zip, arches)
             }
         if (errors.isNotEmpty()) {
             throw GradleException(

--- a/recording/README.md
+++ b/recording/README.md
@@ -329,8 +329,10 @@ generated resources staged by `:recording`'s native build tasks:
 - `:recording-macos` expects `native/macos/SpectreCaptureHelper.app` when a mac helper can
   be produced or provided.
 - `:recording-linux` expects `native/linux/<arch>/spectre-wayland-helper` on Linux.
-- `:recording-windows` expects both `native/windows/x64/spectre-window-capture.exe` and
-  `native/windows/arm64/spectre-window-capture.exe` on Windows.
+- `:recording-windows` expects a complete multi-file Windows Graphics Capture helper for
+  both `x64` and `arm64` under `native/windows/<arch>/` (exe + managed assembly + deps/
+  runtimeconfig + WASDK/Win2D companions; see
+  `WindowsGraphicsCaptureHelperPackagingContract`) when helpers are expected.
 
 When `-PallLinuxArches` is set the task expects both `x86_64` and `aarch64` Linux
 helpers. CI invokes it as

--- a/recording/native/windows/README.md
+++ b/recording/native/windows/README.md
@@ -1,11 +1,21 @@
 # Spectre Windows Graphics Capture helper
 
 This .NET 8 Windows helper owns Spectre's native Windows window capture. It is packaged by
-`:recording-windows` as a runtime resource for both x64 and arm64:
+`:recording-windows` as a **multi-file** runtime resource directory for both x64 and arm64:
 
 ```text
 native/windows/<arch>/spectre-window-capture.exe
+native/windows/<arch>/SpectreWindowCapture.dll
+native/windows/<arch>/SpectreWindowCapture.deps.json
+native/windows/<arch>/SpectreWindowCapture.runtimeconfig.json
+native/windows/<arch>/… WASDK / Win2D / WinRT companions …
 ```
+
+The runtime extractor copies every regular file under each arch directory before launch.
+Packaging verification (`:recording-windows:verifyRecordingWindowsHelper` and
+`:verifyMavenLocalPublication`) enforces the multi-file contract — an orphan
+`spectre-window-capture.exe` without companions fails the gate. See
+`WindowsGraphicsCaptureHelperPackagingContract` in `buildSrc`.
 
 The helper is framework-dependent. Runtime machines need:
 


### PR DESCRIPTION
## Summary

- Record and enforce a **multi-file framework-dependent** Windows Graphics Capture helper contract for x64 and arm64 (not exe-only / not single-file).
- Share `WindowsGraphicsCaptureHelperPackagingContract` (buildSrc) between `:recording-windows:verifyRecordingWindowsHelper` and `:verifyMavenLocalPublication`: fixed required basenames + deps.json runtime/native asset closure; `.pdb` not required.
- Unit tests prove orphan-exe and missing deps companions are rejected; live packaging tasks fail with named gaps when only the renamed exes are staged.
- Update `docs/PUBLISHING.md` checklist + `prebuiltWindowsHelpersDir` layout, plus recording/Windows README and architecture notes.
- Small fix: maven-local mac expected entries now match the `SpectreCaptureHelper.app` bundle (was still checking the bare legacy path).

Closes #163.

## Test plan

- [x] `buildSrc` packaging contract unit tests (orphan exe, deps closure, empty entry, validateZip, prebuilt dir)
- [x] `:recording-windows:verifyRecordingWindowsHelper -PprebuiltWindowsHelpersDir=<complete>` green
- [x] Same with orphan-exe-only tree fails naming missing companions
- [x] `verifyMavenLocalPublication -PstubMacHelperForTesting -PprebuiltWindowsHelpersDir=<complete>` green
- [x] Incomplete Windows helpers fail maven-local with the same contract gaps
- [x] `./gradlew check` green
- [ ] CI green on PR
- [ ] Windows consumer smoke skipped: `ssh rock3r@192.168.1.8` timed out (packaging bar per plan)