### PR TITLE
Docs/skills: recommend runSpectreTest for Spectre UI tests (#110 M3)

### DIFF
--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/DocsGuidanceContractTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/DocsGuidanceContractTest.kt
@@ -23,7 +23,7 @@ class DocsGuidanceContractTest {
         assertContains(docs, "apple.awt.UIElement=true")
         assertContains(docs, "pasteText")
         assertContains(docs, "java.awt.headless")
-        assertContains(docs, "fun mySpec(): Unit = runBlocking")
+        assertContains(docs, "fun mySpec(): Unit = runSpectreTest")
         assertContains(docs, "printTree()` returns an empty string")
         assertContains(docs, "No Component provided")
         assertContains(docs, "RobotDriver.synthetic(rootWindow =")

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -76,7 +76,11 @@ for a change, note it explicitly in the final report.
 
 ## Coroutine Testing
 
-- Prefer `runTest` for coroutine-based logic.
+- Prefer `runTest` for coroutine-based logic **that is not Spectre UI automation**.
+- Prefer `runSpectreTest` (from `:testing`) for Spectre UI tests: real wall-clock `delay`
+  for longClick/swipe/paste settle, plus unfinished-child leak detection. Do **not** use
+  `runTest` for Spectre interaction tests (virtual time collapses internal delays).
+  Plain `runBlocking` remains a valid fallback.
 - Avoid real sleeps when a deterministic scheduler or fake clock will do.
 - Cancel/close long-lived scopes created in tests.
 - If asynchronous behaviour cannot be made deterministic, isolate the nondeterminism behind a small

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -116,7 +116,7 @@ quietly skip the bounded worker that enforces their timeout, so they raise
 `IllegalStateException` up front. The wait name in the message tells you which call
 to wrap.
 
-JUnit test methods don't run on the EDT, so a plain `runBlocking { … }` body is all you
+JUnit test methods don't run on the EDT, so a a `runSpectreTest { … }` body is all you
 need — no extra `withContext` required. Only add `withContext(Dispatchers.Default)` if
 your test body runs inside a coroutine already dispatched on `Dispatchers.Main` or any
 other Swing-backed dispatcher.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -46,7 +46,7 @@ description, or role — see [Finding nodes](selectors.md).
 
     ```kotlin
     import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
-    import kotlinx.coroutines.runBlocking
+    import dev.sebastiano.spectre.testing.runSpectreTest
     import org.junit.jupiter.api.Test
     import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -57,7 +57,7 @@ description, or role — see [Finding nodes](selectors.md).
         val automatorExt = ComposeAutomatorExtension()
 
         @Test
-        fun `clicking increment bumps the counter`(): Unit = runBlocking {
+        fun `clicking increment bumps the counter`(): Unit = runSpectreTest {
             launchCounterApp() // your harness — opens the Compose window
 
             val automator = automatorExt.automator
@@ -84,7 +84,7 @@ description, or role — see [Finding nodes](selectors.md).
 
     ```kotlin
     import dev.sebastiano.spectre.testing.ComposeAutomatorRule
-    import kotlinx.coroutines.runBlocking
+    import dev.sebastiano.spectre.testing.runSpectreTest
     import org.junit.Rule
     import org.junit.Test
 
@@ -94,7 +94,7 @@ description, or role — see [Finding nodes](selectors.md).
         val automatorRule = ComposeAutomatorRule()
 
         @Test
-        fun clickingIncrementBumpsTheCounter(): Unit = runBlocking {
+        fun clickingIncrementBumpsTheCounter(): Unit = runSpectreTest {
             launchCounterApp()
 
             val automator = automatorRule.automator
@@ -134,20 +134,20 @@ description, or role — see [Finding nodes](selectors.md).
 
 All interaction methods (`click`, `doubleClick`, `swipe`, `typeText`, `pasteText`, …) and all wait
 helpers (`waitForNode`, `waitForIdle`, `waitForVisualIdle`) are `suspend`, so the test
-body runs inside `runBlocking { … }`. JUnit test methods don't run on the AWT event
-dispatch thread, so no extra `withContext` is needed here. If you ever call wait helpers
-from a coroutine on `Dispatchers.Main` (Swing EDT), wrap them in
+body runs inside `runSpectreTest { … }` from the testing module. JUnit test methods don't
+run on the AWT event dispatch thread, so no extra `withContext` is needed here. If you
+ever call wait helpers from a coroutine on `Dispatchers.Main` (Swing EDT), wrap them in
 `withContext(Dispatchers.Default)` — they reject EDT callers at runtime. See
 [Synchronization](synchronization.md).
 
 !!! warning "Force JUnit expression-body tests to return `Unit`"
     In JUnit 5.14 and newer, `@Test` methods whose JVM return type is not `void` are
     rejected during discovery. Kotlin expression-body tests infer their return type from
-    the last expression inside `runBlocking { ... }`; assertions such as `assertNotNull`
-    return the asserted value, not `Unit`. Write `fun mySpec(): Unit = runBlocking { ... }`
+    the last expression inside `runSpectreTest { ... }`; assertions such as `assertNotNull`
+    return the asserted value, not `Unit`. Write `fun mySpec(): Unit = runSpectreTest { ... }`
     so the JVM signature stays `void` regardless of the last assertion.
 
-!!! warning "Use `runBlocking`, not `runTest`"
+!!! warning "Use `runSpectreTest`, not `runTest`"
     `runTest` from `kotlinx-coroutines-test` controls time via a virtual scheduler and
     skips `delay()` calls, advancing the clock instantly. Spectre uses `delay` internally
     for timing-sensitive operations — `longClick` hold durations, `swipe` step pacing, and
@@ -155,7 +155,9 @@ from a coroutine on `Dispatchers.Main` (Swing EDT), wrap them in
     those pauses to zero. The result is that `longClick` doesn't actually hold, `swipe`
     jumps to the end position instantly, and clipboard operations may race.
 
-    Stick with `runBlocking` for Spectre tests.
+    Prefer `runSpectreTest` from `dev.sebastiano.spectre.testing`: real wall-clock delays,
+    structured concurrency, and unfinished-child leak detection. Plain `runBlocking` remains
+    a valid fallback when you do not need leak reporting.
 
 ## Where to go next
 

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -41,7 +41,7 @@ class RunSpectreAction : AnAction() {
 ```
 
 `printTree()` is synchronous. Interaction and wait methods (`waitForNode`, `click`, `typeText`,
-etc.) are `suspend` — wrap them in `runBlocking { … }` inside the pooled thread:
+etc.) are `suspend` — wrap them in `runBlocking { … }` inside the pooled thread (for JUnit tests prefer `runSpectreTest` instead):
 
 ```kotlin
 ApplicationManager.getApplication().executeOnPooledThread {

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -15,7 +15,7 @@ than parking the worker thread until the hold completes.
 behind a coroutine boundary.
 
 The snippets below are written as if they sit inside a suspend block (e.g. a JUnit
-test wrapped in `runBlocking { … }`).
+test wrapped in `runSpectreTest { … }`).
 
 ## Mouse: clicks and drags
 

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -55,8 +55,8 @@ class MyTest {
 !!! warning "Expression-body tests should declare `: Unit`"
     JUnit 5.14 and newer reject `@Test` methods whose JVM return type is not `void`.
     Kotlin expression-body tests infer the return type from the last expression in the
-    `runBlocking { ... }` body; some assertions, including `assertNotNull`, return the
-    asserted value. Prefer `fun mySpec(): Unit = runBlocking { ... }` for Spectre tests.
+    `runSpectreTest { ... }` body; some assertions, including `assertNotNull`, return the
+    asserted value. Prefer `fun mySpec(): Unit = runSpectreTest { ... }` for Spectre tests.
 
 ## JUnit 4: `ComposeAutomatorRule`
 

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -31,7 +31,7 @@ needed:
 
 ```kotlin
 @Test
-fun mySpec(): Unit = runBlocking {
+fun mySpec(): Unit = runSpectreTest {
     launchApp()
     automator.waitForNode(tag = "Root")
     // ...your test body
@@ -45,7 +45,7 @@ around the offending call — see
 
 ## JUnit expression-body return types
 
-When you write Spectre tests as `fun mySpec(): Unit = runBlocking { ... }`, the explicit
+When you write Spectre tests as `fun mySpec(): Unit = runSpectreTest { ... }`, the explicit
 `: Unit` matters. JUnit 5.14 and newer reject `@Test` methods whose JVM return type is
 not `void`, and Kotlin expression-body functions infer their return type from the last
 expression in the body. Some assertion helpers return the asserted value, not `Unit`, so

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -54,7 +54,7 @@ bounded worker that enforces the timeout, so the helpers raise
 `IllegalStateException` instead. The exact wait name in the message tells you which
 call to wrap.
 
-JUnit test methods don't run on the EDT, so a plain `runBlocking { … }` body is fine
+JUnit test methods don't run on the EDT, so a a `runSpectreTest { … }` body is fine (or plain `runBlocking` as a fallback)
 there — no `withContext` needed. The error appears when the call originates from a
 coroutine on `Dispatchers.Main` or any Swing-backed dispatcher, e.g.:
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -24,7 +24,7 @@ If you're testing an individual composable in isolation → use `ComposeTestRule
 
 ## Gotchas
 
-- **Use `runBlocking`, not `runTest`.** `runTest` collapses `delay()` to zero, which silently breaks `longClick` hold durations, `swipe` step pacing, and clipboard-settle polling inside `typeText`. This breaks Spectre's internal delays.
+- **Use `runSpectreTest`, not `runTest`.** `runTest` collapses `delay()` to zero, which silently breaks `longClick` hold durations, `swipe` step pacing, and clipboard-settle polling. Prefer `runSpectreTest` from the testing module (real wall time + leak detection); plain `runBlocking` is a fallback.
 - **Selectors are non-waiting.** Every `findBy...` / `findOneBy...` call reads the semantics tree once. Call `waitForNode` before querying any node that might not exist yet.
 - **EDT rule.** `waitForIdle` and `waitForVisualIdle` throw `IllegalStateException` when called from the AWT event dispatch thread. Standard JUnit test methods run off the EDT so this isn't normally an issue; if you call them from the EDT, wrap with `withContext(Dispatchers.Default)`.
 
@@ -50,7 +50,7 @@ Sequential tests — own the extension on the class:
 
 ```kotlin
 import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
-import kotlinx.coroutines.runBlocking
+import dev.sebastiano.spectre.testing.runSpectreTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -59,7 +59,7 @@ class MyTest {
     val automatorExt = ComposeAutomatorExtension()
 
     @Test
-    fun myTest() = runBlocking {
+    fun myTest() = runSpectreTest {
         launchMyApp()  // your responsibility — Spectre manages the automator, not the window
         val automator = automatorExt.automator
         automator.waitForNode(tag = "root-content")
@@ -75,14 +75,14 @@ class MyTest {
 ```kotlin
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
-import kotlinx.coroutines.runBlocking
+import dev.sebastiano.spectre.testing.runSpectreTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 
 @ExtendWith(ComposeAutomatorExtension::class)
 class MyTest {
     @Test
-    fun myTest(automator: ComposeAutomator) = runBlocking {
+    fun myTest(automator: ComposeAutomator) = runSpectreTest {
         launchMyApp()
         automator.waitForNode(tag = "root-content")
         // interact and assert
@@ -109,7 +109,7 @@ Key `AutomatorNode` properties: `testTag`, `text`, `texts`, `contentDescription`
 
 ## Interactions
 
-All interaction methods are `suspend` — they must be called from inside `runBlocking { ... }`.
+All interaction methods are `suspend` — they must be called from inside `runSpectreTest { ... }` (or `runBlocking` as a fallback).
 
 ```kotlin
 automator.click(node)

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -47,7 +47,7 @@ A test owns three things, in this order:
    it discovers Compose surfaces and reads their semantics.
 3. **Suspending input + synchronization calls** against that automator. All
    input methods (`click`, `typeText`, etc.) and waits are `suspend` functions
-   — wrap the test body in `runBlocking { ... }`.
+   — wrap the test body in `runSpectreTest { ... }` (from `dev.sebastiano.spectre.testing`).
 
 There is no `compose-test` style auto-wait. Every `findBy…` call is a single
 read against current state. **You wait explicitly**, then you query.
@@ -56,7 +56,7 @@ read against current state. **You wait explicitly**, then you query.
 
 ```kotlin
 import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
-import kotlinx.coroutines.runBlocking
+import dev.sebastiano.spectre.testing.runSpectreTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -66,7 +66,7 @@ class CounterTest {
     val automatorExt = ComposeAutomatorExtension()
 
     @Test
-    fun `clicking increment bumps the counter`(): Unit = runBlocking {
+    fun `clicking increment bumps the counter`(): Unit = runSpectreTest {
         launchCounterApp() // your harness — opens the Compose window
 
         val automator = automatorExt.automator
@@ -223,18 +223,18 @@ custom `Swing` dispatcher, etc.), wrap the wait in
 wait suspends off-thread. The user docs you may have read elsewhere have an
 older carve-out for `waitForNode` — that exception is gone in current code.
 
-### Rule 4: use `runBlocking`, not `runTest`
+### Rule 4: use `runSpectreTest`, not `runTest`
 
 `kotlinx-coroutines-test`'s `runTest` skips `delay()`. That collapses
 `longClick` hold durations, `swipe` pacing, and the macOS clipboard-settle
-poll inside `pasteText` to zero, breaking them all. Use `runBlocking { ... }`
+poll inside `pasteText` to zero, breaking them all. Use `runSpectreTest { ... }`
 in the test body.
 
 ### Rule 4b: force expression-body tests to return `Unit`
 
-Write `@Test fun mySpec(): Unit = runBlocking { ... }`. JUnit 5.14+ rejects
+Write `@Test fun mySpec(): Unit = runSpectreTest { ... }`. JUnit 5.14+ rejects
 non-void test methods during discovery, and Kotlin infers an expression-body
-function's return type from the last expression in the `runBlocking` body. Some
+function's return type from the last expression in the `runSpectreTest` body. Some
 assertions return the asserted value, not `Unit`.
 
 ### Custom idling resources
@@ -314,7 +314,7 @@ touches that area*; they are not needed for the common case.
 |---|---|---|
 | `findOneBy…` returns `null` right after an interaction | Selectors don't wait | Add `waitForNode(...)` or `waitForVisualIdle()` first |
 | Test deadlocks or throws inside any `waitFor…` | Called from the AWT EDT | Wrap in `withContext(Dispatchers.Default) { … }` — applies to all three waits, including `waitForNode` |
-| `longClick`/`swipe`/`typeText` complete instantly and miss | Test body uses `runTest` | Switch to `runBlocking` |
+| `longClick`/`swipe`/`typeText` complete instantly and miss | Test body uses `runTest` | Switch to `runSpectreTest` |
 | Two parallel test JVMs steal focus from each other | Both use real `RobotDriver()` | Use `RobotDriver.synthetic(rootWindow)` |
 | Cmd+Tab or OS shortcuts don't work under synthetic driver | Synthetic events bypass HID | Use real `RobotDriver()` for those tests |
 | Screenshot is blurry / mid-animation | Captured before frame stabilised | `waitForVisualIdle()` first |

--- a/skills/spectre/references/junit.md
+++ b/skills/spectre/references/junit.md
@@ -12,7 +12,7 @@ field at runtime):
 
 ```kotlin
 import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
-import kotlinx.coroutines.runBlocking
+import dev.sebastiano.spectre.testing.runSpectreTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -22,7 +22,7 @@ class DialogTest {
     val automatorExt = ComposeAutomatorExtension()
 
     @Test
-    fun `opens settings dialog`() = runBlocking {
+    fun `opens settings dialog`() = runSpectreTest {
         launchHarness()
         val automator = automatorExt.automator
         // ...
@@ -35,7 +35,7 @@ automator can be injected as a test parameter:
 
 ```kotlin
 @Test
-fun example(automator: ComposeAutomator) = runBlocking {
+fun example(automator: ComposeAutomator) = runSpectreTest {
     // ...
 }
 ```
@@ -47,7 +47,7 @@ helpers.
 
 ```kotlin
 import dev.sebastiano.spectre.testing.ComposeAutomatorRule
-import kotlinx.coroutines.runBlocking
+import dev.sebastiano.spectre.testing.runSpectreTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -56,7 +56,7 @@ class DialogTest {
     val automatorRule = ComposeAutomatorRule()
 
     @Test
-    fun `opens settings dialog`() = runBlocking {
+    fun `opens settings dialog`() = runSpectreTest {
         launchHarness()
         val automator = automatorRule.automator
         // ...
@@ -101,6 +101,6 @@ The JUnit 4 rule is identical: `ComposeAutomatorRule { ComposeAutomator.inProces
 - The extension/rule does **not** open a Compose window for you. Launch your
   app or harness in `@BeforeEach`/`@Before`, or at the top of each test.
 - Each test gets a fresh `ComposeAutomator`. Don't cache one across tests.
-- The test body must still be wrapped in `runBlocking { ... }` because input
-  and wait calls are `suspend`. `runTest` will break timing — see the main
+- The test body must still be wrapped in `runSpectreTest { ... }` because input
+  and wait calls are `suspend`. `runTest` will break timing — use `runSpectreTest` instead; see the main
   SKILL.md.


### PR DESCRIPTION
## Summary

- Recommend `runSpectreTest` in getting-started, junit, synchronization, TESTING, and Spectre skills.
- Restate the `runTest` virtual-time warning against the new runner; keep `runBlocking` as fallback.
- Sample shapes use `fun mySpec(): Unit = runSpectreTest { … }`.

M3 of #110 (M1 #346, M2 #347).

## Test plan

- [x] Static read/grep of updated guides and skills
- [ ] CI docs/check green