### PR TITLE
test(agent): opt-in Windows attach UI e2e on physical desktops (#194)

### DIFF
--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -90,10 +90,14 @@ tasks.withType<Test>().configureEach {
     // Physical Windows desktop attach UI e2e opt-in (#194). Hosted windows-latest stays
     // skip-safe; Mattone-style desktops pass -Pspectre.agent.attachE2e.allowWindows=true.
     // Gradle CLI `-D` alone does not reach Test workers — forward via this provider.
+    // Declared as a task input so toggling the flag invalidates `:agent:test` (otherwise a
+    // prior assumption-skipped run can stay UP-TO-DATE and never re-launch workers).
     val allowWindowsAttachE2e =
         providers
             .gradleProperty("spectre.agent.attachE2e.allowWindows")
             .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.attachE2e.allowWindows"))
+            .orElse("")
+    inputs.property("spectre.agent.attachE2e.allowWindows", allowWindowsAttachE2e)
 
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
@@ -106,7 +110,7 @@ tasks.withType<Test>().configureEach {
                 if (home != null) {
                     add("-Ddev.sebastiano.spectre.agent.fixtureJavaHome=$home")
                 }
-                val allowWin = allowWindowsAttachE2e.orNull?.takeIf { it.isNotBlank() }
+                val allowWin = allowWindowsAttachE2e.orNull.takeIf { it.isNotBlank() }
                 if (allowWin != null) {
                     add("-Ddev.sebastiano.spectre.agent.attachE2e.allowWindows=$allowWin")
                 }

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -110,7 +110,7 @@ tasks.withType<Test>().configureEach {
                 if (home != null) {
                     add("-Ddev.sebastiano.spectre.agent.fixtureJavaHome=$home")
                 }
-                val allowWin = allowWindowsAttachE2e.orNull.takeIf { it.isNotBlank() }
+                val allowWin = allowWindowsAttachE2e.get().takeIf { it.isNotBlank() }
                 if (allowWin != null) {
                     add("-Ddev.sebastiano.spectre.agent.attachE2e.allowWindows=$allowWin")
                 }

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -87,6 +87,14 @@ tasks.withType<Test>().configureEach {
             .orElse(providers.environmentVariable("SPECTRE_FIXTURE_JAVA_HOME"))
             .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.fixtureJavaHome"))
 
+    // Physical Windows desktop attach UI e2e opt-in (#194). Hosted windows-latest stays
+    // skip-safe; Mattone-style desktops pass -Pspectre.agent.attachE2e.allowWindows=true.
+    // Gradle CLI `-D` alone does not reach Test workers — forward via this provider.
+    val allowWindowsAttachE2e =
+        providers
+            .gradleProperty("spectre.agent.attachE2e.allowWindows")
+            .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.attachE2e.allowWindows"))
+
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
             buildList {
@@ -97,6 +105,10 @@ tasks.withType<Test>().configureEach {
                 val home = fixtureJavaHome.orNull?.takeIf { it.isNotBlank() }
                 if (home != null) {
                     add("-Ddev.sebastiano.spectre.agent.fixtureJavaHome=$home")
+                }
+                val allowWin = allowWindowsAttachE2e.orNull?.takeIf { it.isNotBlank() }
+                if (allowWin != null) {
+                    add("-Ddev.sebastiano.spectre.agent.attachE2e.allowWindows=$allowWin")
                 }
             }
         }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 
@@ -62,10 +63,12 @@ import org.junit.jupiter.api.condition.OS
  * developers can diagnose real keyboard regressions.
  *
  * Gating:
- * - **Runs on Linux and macOS** via `@EnabledOnOs(OS.LINUX, OS.MAC)`. The hosted Windows runner
- *   does not provide a reliable interactive desktop for this Robot-backed fixture; its Windows
- *   transport and ACL contracts are covered by dedicated non-UI tests instead. Linux's Xvfb
- *   validation workflow is the authoritative full attach-to-UI end-to-end gate.
+ * - **Runs on Linux, macOS, and Windows** via `@EnabledOnOs`. Hosted GitHub `windows-latest` lacks
+ *   a reliable interactive desktop for this Robot-backed fixture, so Windows additionally requires
+ *   the opt-in [WindowsAttachE2eGate] property (physical desktops / Mattone). Without it, Windows
+ *   methods are assumption-skipped and stay green under `:check`. Non-UI Windows transport and ACL
+ *   contracts always run. Linux Xvfb validation remains the hosted full attach-to-UI gate; physical
+ *   Windows is the authorized Windows UI proof path (#194).
  * - Skipped on headless JVMs (`java.awt.GraphicsEnvironment.isHeadless()`). Compose Desktop refuses
  *   to create a `JFrame + ComposePanel` without a display.
  * - Skipped when `dev.sebastiano.spectre.agent.runtimeJar` isn't set. Gradle's `:agent:test` task
@@ -73,7 +76,7 @@ import org.junit.jupiter.api.condition.OS
  * - Real-keyboard `typeText` tolerates a CI-only loss of OS keyboard focus on any platform (see
  *   `typeTextOrSkipCiFocusLoss`); the attach/click/focus contract is still asserted.
  */
-@EnabledOnOs(OS.LINUX, OS.MAC)
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
 class AgentAttachIntegrationTest {
     private val orphanUdsFiles = mutableListOf<Path>()
 
@@ -84,6 +87,7 @@ class AgentAttachIntegrationTest {
 
     @Test
     fun `attach exercise detach cycle works against a real Compose fixture`() {
+        assumeWindowsAttachE2eAllowed()
         assumeFalse(
             GraphicsEnvironment.isHeadless(),
             "Requires non-headless JVM for Compose Desktop + java.awt.Robot",
@@ -99,6 +103,7 @@ class AgentAttachIntegrationTest {
 
     @Test
     fun `attach explains when the target JVM disables dynamic agent loading`() {
+        assumeWindowsAttachE2eAllowed()
         assumeFalse(
             GraphicsEnvironment.isHeadless(),
             "Requires non-headless JVM for the Compose Desktop fixture",
@@ -343,6 +348,16 @@ class AgentAttachIntegrationTest {
         }
 
         return FixtureProcess(process, process.pid(), reader, drainerThread)
+    }
+
+    private fun assumeWindowsAttachE2eAllowed() {
+        assumeTrue(
+            WindowsAttachE2eGate.isAllowed(),
+            "Windows attach UI e2e is opt-in (hosted CI has no reliable interactive desktop). " +
+                "On a physical Windows desktop pass " +
+                "-Pspectre.agent.attachE2e.allowWindows=true (or " +
+                "-D${WindowsAttachE2eGate.ALLOW_PROP}=true on the test JVM).",
+        )
     }
 
     private fun locateAgentJarOrSkip(): Path {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/WindowsAttachE2eGate.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/WindowsAttachE2eGate.kt
@@ -1,0 +1,34 @@
+package dev.sebastiano.spectre.agent
+
+/**
+ * Opt-in gate for Robot-backed agent attach UI e2e on Windows.
+ *
+ * Hosted GitHub `windows-latest` runners do not provide a reliable interactive desktop for the
+ * Compose fixture + `java.awt.Robot` path (see #194 close-out / historical re-disable in PR #244).
+ * Non-UI Windows transport and ACL tests still run under `:agent:test` on every Windows CI job.
+ * Physical desktops (e.g. Mattone) opt in with:
+ * ```
+ * ./gradlew :agent:test --tests '*AgentAttachIntegrationTest*' \
+ *   -Pspectre.agent.attachE2e.allowWindows=true
+ * ```
+ *
+ * or `-Ddev.sebastiano.spectre.agent.attachE2e.allowWindows=true` on the test JVM (Gradle forwards
+ * the `-P` form via [agent/build.gradle.kts]).
+ */
+internal object WindowsAttachE2eGate {
+    const val ALLOW_PROP: String = "dev.sebastiano.spectre.agent.attachE2e.allowWindows"
+
+    /**
+     * Returns true when attach UI e2e may run on this host.
+     *
+     * Non-Windows is always allowed (Linux/macOS use `@EnabledOnOs` + headless skip as usual).
+     * Windows requires [ALLOW_PROP] to be exactly `"true"`.
+     */
+    fun isAllowed(
+        osName: String = System.getProperty("os.name").orEmpty(),
+        allowWindows: String? = System.getProperty(ALLOW_PROP),
+    ): Boolean {
+        if (!osName.startsWith("Windows", ignoreCase = true)) return true
+        return allowWindows == "true"
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/WindowsAttachE2eGateTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/WindowsAttachE2eGateTest.kt
@@ -1,0 +1,26 @@
+package dev.sebastiano.spectre.agent
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for the physical-desktop opt-in that keeps hosted `windows-latest` skip-safe while
+ * allowing Mattone-style desktops to run [AgentAttachIntegrationTest].
+ */
+class WindowsAttachE2eGateTest {
+    @Test
+    fun `non-Windows platforms are always allowed`() {
+        assertTrue(WindowsAttachE2eGate.isAllowed(osName = "Mac OS X", allowWindows = null))
+        assertTrue(WindowsAttachE2eGate.isAllowed(osName = "Linux", allowWindows = "false"))
+    }
+
+    @Test
+    fun `Windows requires the allow property to be exactly true`() {
+        assertFalse(WindowsAttachE2eGate.isAllowed(osName = "Windows 11", allowWindows = null))
+        assertFalse(WindowsAttachE2eGate.isAllowed(osName = "Windows 11", allowWindows = "false"))
+        assertFalse(WindowsAttachE2eGate.isAllowed(osName = "Windows 11", allowWindows = "TRUE"))
+        assertTrue(WindowsAttachE2eGate.isAllowed(osName = "Windows 11", allowWindows = "true"))
+        assertTrue(WindowsAttachE2eGate.isAllowed(osName = "windows 10", allowWindows = "true"))
+    }
+}

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -425,7 +425,11 @@ Not additive-safe without a version bump:
 ## Current limitations
 
 - **Windows needs 10 version 1803 / Server 2019 or newer.** That's when native `AF_UNIX` landed;
-  older Windows fails the attach preflight with `AttachPlatformUnsupportedException`.
+  older Windows fails the attach preflight with `AttachPlatformUnsupportedException`. Hosted
+  GitHub `windows-latest` is not a reliable interactive desktop for the Robot-backed attach
+  fixture; the full attach → exercise → detach UI e2e is opt-in on physical Windows desktops
+  via `-Pspectre.agent.attachE2e.allowWindows=true` (non-UI transport/ACL tests still run on
+  every Windows CI job).
 - **Wait ops.** `waitForNode` / `waitForVisualIdle` are supported over agent IPC (#201) with
   shared deadline budgets and cancel. Idling-resource `waitForIdle` stays in-process only.
 - **IntelliJ-hosted Compose**: the classloader-disambiguation rule (D-14 in the plan) was

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -143,7 +143,7 @@ workflow (epic #215 / issue #216):
 | --- | --- |
 | Runtime | JBR 21, JBR 25, Temurin LTS |
 | OS | macOS, Linux (`xvfb`), Windows |
-| Suites | Contract corpus (all OSes); agent attach same-runtime on Linux/macOS + mixed vanilla↔JBR on Linux; Linux X11 recording smoke. Agent suites are `@EnabledOnOs(LINUX, MAC)` only — Windows cells still run the non-agent corpus. |
+| Suites | Contract corpus (all OSes); agent attach same-runtime on Linux/macOS + mixed vanilla↔JBR on Linux; Linux X11 recording smoke. Full attach UI e2e is hosted on Linux/macOS; Windows cells run non-UI transport/ACL agent tests (UI attach e2e is opt-in on physical desktops via `-Pspectre.agent.attachE2e.allowWindows=true`). |
 
 Pins live in [`.github/jbr-pins.env`](https://github.com/rock3r/spectre/blob/main/.github/jbr-pins.env)
 (JBRSDK / `jdk` package, not `jbr_jcef`). Bump procedure is in that file’s header comments.


### PR DESCRIPTION
## Summary

- Re-enable `OS.WINDOWS` on `AgentAttachIntegrationTest` behind an explicit opt-in (`-Pspectre.agent.attachE2e.allowWindows=true` / `WindowsAttachE2eGate`).
- Hosted GitHub `windows-latest` remains skip-safe (assumption skip when the property is unset); non-UI Windows transport/ACL tests still run under `:check`.
- Document the physical-desktop proof path in `docs/guide/agent.md` and the runtime-matrix note in `docs/guide/ci.md`.
- Unit-test the gate; Gradle forwards the property into test workers.

Part of residual #194 close-out after #195/#196 product work landed. Physical Windows e2e on Mattone (`rock3r@192.168.1.8`) is the authorized UI proof path.

## Test plan

- [x] `WindowsAttachE2eGateTest` unit coverage
- [x] macOS `AgentAttachIntegrationTest` green (standalone)
- [x] `CI=true ./gradlew check` green locally
- [ ] Physical Windows: `./gradlew.bat :agent:test --tests \"*AgentAttachIntegrationTest*\" -Pspectre.agent.attachE2e.allowWindows=true` on Mattone
- [ ] Non-UI Windows agent tests still green without the property (default skip)