### PR TITLE
fix(publish): align central portal check with SpectreCaptureHelper.app + pre-release smoke

### DIFF
--- a/scripts/central_portal_check.py
+++ b/scripts/central_portal_check.py
@@ -62,17 +62,45 @@ MIN_MAIN_JAR_SIZES = {
     "spectre-testing": 1_000,
 }
 
+# Aligns with :verifyMavenLocalPublication / WindowsGraphicsCaptureHelperPackagingContract
+# fixed basenames (deps.json asset closure remains Gradle-owned).
+WINDOWS_HELPER_ARCHES = ("x64", "arm64")
+WINDOWS_HELPER_REQUIRED_BASE_NAMES = (
+    "spectre-window-capture.exe",
+    "SpectreWindowCapture.dll",
+    "SpectreWindowCapture.deps.json",
+    "SpectreWindowCapture.runtimeconfig.json",
+    "Microsoft.WindowsAppRuntime.Bootstrap.dll",
+    "Microsoft.WindowsAppRuntime.Bootstrap.Net.dll",
+    "WinRT.Runtime.dll",
+    "Microsoft.Windows.SDK.NET.dll",
+    "Microsoft.Graphics.Canvas.dll",
+    "Microsoft.Graphics.Canvas.Interop.dll",
+)
+
+MACOS_HELPER_APP_ENTRIES = (
+    "native/macos/SpectreCaptureHelper.app/Contents/MacOS/spectre-screencapture",
+    "native/macos/SpectreCaptureHelper.app/Contents/Info.plist",
+    "native/macos/SpectreCaptureHelper.app/Contents/PkgInfo",
+    "native/macos/SpectreCaptureHelper.app/Contents/Resources/AppIcon.icns",
+)
+# Rejected bare layout superseded by SpectreCaptureHelper.app (#190).
+MACOS_HELPER_BARE_EXECUTABLE = "native/macos/spectre-screencapture"
+
 HELPER_ENTRIES = {
     "spectre-recording-linux": (
         "native/linux/x86_64/spectre-wayland-helper",
         "native/linux/aarch64/spectre-wayland-helper",
     ),
-    "spectre-recording-macos": ("native/macos/spectre-screencapture",),
-    "spectre-recording-windows": (
-        "native/windows/x64/spectre-window-capture.exe",
-        "native/windows/arm64/spectre-window-capture.exe",
+    "spectre-recording-macos": MACOS_HELPER_APP_ENTRIES,
+    "spectre-recording-windows": tuple(
+        f"native/windows/{arch}/{base}"
+        for arch in WINDOWS_HELPER_ARCHES
+        for base in WINDOWS_HELPER_REQUIRED_BASE_NAMES
     ),
 }
+
+AGENT_RUNTIME_INJECT_JAR = "META-INF/spectre/inject-runtime.jar"
 
 FORBIDDEN_AGENT_RUNTIME_PREFIXES = (
     "androidx/compose/",
@@ -324,6 +352,14 @@ def validate_jar(component: str, jar_path: Path) -> list[str]:
             elif entries[helper] <= 0:
                 errors.append(f"{component} helper entry {helper} is empty")
 
+        if component == "spectre-recording-macos":
+            if MACOS_HELPER_BARE_EXECUTABLE in entries:
+                errors.append(
+                    "spectre-recording-macos still contains bare "
+                    f"{MACOS_HELPER_BARE_EXECUTABLE}; helper must ship only as "
+                    "SpectreCaptureHelper.app (#190)"
+                )
+
         if component == "spectre-agent":
             spike_entries = sorted(
                 name for name in entries if name.startswith("dev/sebastiano/spectre/agent/spike/")
@@ -346,6 +382,17 @@ def validate_jar(component: str, jar_path: Path) -> list[str]:
             )
             if leaks:
                 errors.append("spectre-agent-runtime contains forbidden classes: " + ", ".join(leaks))
+            # Nested inject-runtime jar (#209). Full payload shape remains Gradle-owned
+            # (:agent-runtime:verifyAgentRuntimeJarContents / :agent-inject-runtime).
+            inject_size = entries.get(AGENT_RUNTIME_INJECT_JAR)
+            if inject_size is None:
+                errors.append(
+                    f"spectre-agent-runtime is missing nested {AGENT_RUNTIME_INJECT_JAR}"
+                )
+            elif inject_size <= 0:
+                errors.append(
+                    f"spectre-agent-runtime nested {AGENT_RUNTIME_INJECT_JAR} is empty"
+                )
 
     return errors
 

--- a/tests/test_central_portal_check.py
+++ b/tests/test_central_portal_check.py
@@ -93,6 +93,7 @@ class CentralPortalCheckTest(unittest.TestCase):
                     "\n"
                 ),
                 "dev/sebastiano/spectre/agent/runtime/SpectreAgent.class": b"class",
+                "META-INF/spectre/inject-runtime.jar": b"nested-inject",
             }
         )
 
@@ -109,6 +110,7 @@ class CentralPortalCheckTest(unittest.TestCase):
                     "Premain-Class: dev.sebastiano.spectre.agent.runtime.SpectreAgent\n"
                     "\n"
                 ),
+                "META-INF/spectre/inject-runtime.jar": b"nested-inject",
                 "kotlinx/coroutines/Job.class": b"class",
             }
         )
@@ -117,7 +119,24 @@ class CentralPortalCheckTest(unittest.TestCase):
 
         self.assertIn("forbidden classes", "\n".join(errors))
 
-    def test_recording_helper_validation(self):
+    def test_agent_runtime_requires_nested_inject_runtime_jar(self):
+        jar = self._jar(
+            {
+                "META-INF/MANIFEST.MF": (
+                    "Manifest-Version: 1.0\n"
+                    "Agent-Class: dev.sebastiano.spectre.agent.runtime.SpectreAgent\n"
+                    "Premain-Class: dev.sebastiano.spectre.agent.runtime.SpectreAgent\n"
+                    "\n"
+                ),
+                "dev/sebastiano/spectre/agent/runtime/SpectreAgent.class": b"class",
+            }
+        )
+
+        errors = central.validate_jar("spectre-agent-runtime", jar)
+
+        self.assertIn("inject-runtime.jar", "\n".join(errors))
+
+    def test_recording_helper_validation_linux(self):
         jar = self._jar(
             {
                 "native/linux/x86_64/spectre-wayland-helper": b"x64",
@@ -128,6 +147,77 @@ class CentralPortalCheckTest(unittest.TestCase):
         errors = central.validate_jar("spectre-recording-linux", jar)
 
         self.assertEqual(errors, [])
+
+    def test_recording_helper_validation_macos_app_bundle(self):
+        entries = {path: b"helper" for path in central.MACOS_HELPER_APP_ENTRIES}
+        jar = self._jar(entries)
+
+        errors = central.validate_jar("spectre-recording-macos", jar)
+
+        self.assertEqual(errors, [])
+
+    def test_recording_helper_rejects_bare_macos_executable(self):
+        entries = {path: b"helper" for path in central.MACOS_HELPER_APP_ENTRIES}
+        entries[central.MACOS_HELPER_BARE_EXECUTABLE] = b"legacy"
+        jar = self._jar(entries)
+
+        errors = central.validate_jar("spectre-recording-macos", jar)
+
+        self.assertIn("bare", "\n".join(errors))
+        self.assertIn("SpectreCaptureHelper.app", "\n".join(errors))
+
+    def test_recording_helper_validation_windows_multi_file(self):
+        entries = {
+            path: b"helper" for path in central.HELPER_ENTRIES["spectre-recording-windows"]
+        }
+        jar = self._jar(entries)
+
+        errors = central.validate_jar("spectre-recording-windows", jar)
+
+        self.assertEqual(errors, [])
+
+    def test_recording_helper_rejects_windows_exe_only(self):
+        jar = self._jar(
+            {
+                "native/windows/x64/spectre-window-capture.exe": b"x64",
+                "native/windows/arm64/spectre-window-capture.exe": b"arm64",
+            }
+        )
+
+        errors = central.validate_jar("spectre-recording-windows", jar)
+        joined = "\n".join(errors)
+
+        self.assertIn("SpectreWindowCapture.deps.json", joined)
+        self.assertIn("SpectreWindowCapture.dll", joined)
+        self.assertGreater(len(errors), 2)
+
+    def test_helper_entries_match_app_bundle_and_wgc_contract(self):
+        self.assertEqual(
+            central.HELPER_ENTRIES["spectre-recording-macos"],
+            central.MACOS_HELPER_APP_ENTRIES,
+        )
+        self.assertIn(
+            "native/macos/SpectreCaptureHelper.app/Contents/MacOS/spectre-screencapture",
+            central.HELPER_ENTRIES["spectre-recording-macos"],
+        )
+        self.assertNotIn(
+            "native/macos/spectre-screencapture",
+            central.HELPER_ENTRIES["spectre-recording-macos"],
+        )
+        windows = central.HELPER_ENTRIES["spectre-recording-windows"]
+        self.assertEqual(
+            len(windows),
+            len(central.WINDOWS_HELPER_ARCHES)
+            * len(central.WINDOWS_HELPER_REQUIRED_BASE_NAMES),
+        )
+        self.assertIn(
+            "native/windows/x64/SpectreWindowCapture.deps.json",
+            windows,
+        )
+        self.assertIn(
+            "native/windows/arm64/Microsoft.WindowsAppRuntime.Bootstrap.dll",
+            windows,
+        )
 
     def test_agent_rejects_spike_class(self):
         jar = self._jar({"dev/sebastiano/spectre/agent/spike/AttachSpike.class": b"class"})


### PR DESCRIPTION
## Summary

- Update `scripts/central_portal_check.py` `HELPER_ENTRIES` to the 0.4 macOS **SpectreCaptureHelper.app** layout (executable + Info.plist + PkgInfo + AppIcon.icns), reject the bare `native/macos/spectre-screencapture` path, and tighten Windows expectations to the multi-file WGC fixed basename contract (`deps.json` closure remains Gradle-owned).
- Assert nested `META-INF/spectre/inject-runtime.jar` in `spectre-agent-runtime` (payload shape still owned by Gradle verifiers).
- Align `tests/test_central_portal_check.py` coverage for app-bundle, bare-path rejection, Windows multi-file, and inject-runtime.

## Part B — Pre-release smoke (`-PVERSION_NAME=0.4.0-rc.smoke`)

Artifacts built with `verifyMavenLocalPublication` (release-shaped, non-SNAPSHOT). **Notarization gap (macOS):** local smoke used host-built/unsigned helper packaging path; Apple notarize/staple remains CI-only (`release.yml` / `mac-helper` job).

### Results matrix

| OS | check / publish | capture | record / screenshot | attach | Notes |
|---|---|---|---|---|---|
| **macOS** (this machine) | ✅ `./gradlew check` green; `verifyMavenLocalPublication` OK; `central_portal_check.validate_jar` OK against local jars | ✅ `AtomicCaptureValidationTest` + `FailureArtifactsValidationTest` (schemaVersion 1 capture.json + PNG); sample `jq` saw `schemaVersion: 1` | ✅ `spectre permissions check` granted for `SpectreCaptureHelper.app`; `:recording:runWindowScreenshotSmoke` → 720×360 PNG | ✅ `:agent:test --tests '*AgentAttachIntegrationTest.attach*'` green | Full `:agent:test` suite can flake on focus races under load; isolated attach smoke green |
| **Windows** (`ssh mattone`) | ✅ `verifyMavenLocalPublication` OK; multi-file helper in jar + extracted under `%LOCALAPPDATA%\spectre\helpers\…\x64\` (exe + deps.json + Bootstrap.dll + …) | ⚠️ `AtomicCaptureValidationTest` ran but **failed** pixel check (all-black samples) + Skiko render exception under SSH non-interactive session | ❌ WGC screenshot smoke: `GraphicsCaptureSession.IsSupported` → `COMException 0x80070424` (“service does not exist”) from SSH session (`UserInteractive=false`); layout extract still multi-file | ✅ Agent attach integration green | Console session 1 is Active; SSH jobs are not in that interactive desktop. Re-run WGC/capture from an interactive console session with .NET 8 Desktop + Windows App Runtime 1.8 installed |
| **Linux** (Hyper-V VM via mattone → `seb@172.23.14.104`) | ✅ `verifyMavenLocalPublication -PstubMacHelperForTesting` (host x86_64 helper; `-PallLinuxArches` N/A — aarch64 cross-cargo not set up on VM) | ✅ `xvfb-run` validation: RunSpectreTest + FailureArtifacts + AtomicCapture green | ✅ `:recording:runWindowScreenshotSmoke` under Xvfb → 360×180 PNG (ximagesrc path). **Wayland portal N/A** on pure Xvfb (`WAYLAND_DISPLAY` unset) | ✅ Agent attach under `xvfb-run` green | |

### Operator re-run commands

**macOS**
```bash
./gradlew check
./gradlew verifyMavenLocalPublication -PVERSION_NAME=0.4.0-rc.smoke
python3 -m unittest tests.test_central_portal_check -v
./gradlew :sample-desktop:validationTest \
  --tests '*RunSpectreTestValidationTest*' \
  --tests '*FailureArtifactsValidationTest*' \
  --tests '*AtomicCaptureValidationTest*' \
  -PVERSION_NAME=0.4.0-rc.smoke
./gradlew :cli:installShadowDist -PVERSION_NAME=0.4.0-rc.smoke
cli/build/install/spectre-shadow/bin/spectre permissions check
./gradlew :recording:runWindowScreenshotSmoke -PVERSION_NAME=0.4.0-rc.smoke
./gradlew :agent:test --tests '*AgentAttachIntegrationTest.attach*' -PVERSION_NAME=0.4.0-rc.smoke
```

**Windows (`ssh mattone`)**
```bat
set JAVA_HOME=C:\Users\rock3r\.jdks\jbr-21.0.10
set PATH=%JAVA_HOME%\bin;C:\Program Files\Git\cmd;%PATH%
cd /d C:\Users\rock3r\src\spectre
git fetch origin main & git checkout -B smoke-0.4 origin/main
gradlew.bat verifyMavenLocalPublication -PVERSION_NAME=0.4.0-rc.smoke --no-daemon
gradlew.bat :agent:test --tests *AgentAttachIntegrationTest.attach* -PVERSION_NAME=0.4.0-rc.smoke --no-daemon
rem Prefer interactive console session for UI/WGC:
gradlew.bat :sample-desktop:validationTest --tests *AtomicCaptureValidationTest* -PVERSION_NAME=0.4.0-rc.smoke --no-daemon
gradlew.bat :recording:runWindowScreenshotSmoke -PVERSION_NAME=0.4.0-rc.smoke --no-daemon
```

**Linux VM (from mattone)**
```bash
# IP may change after Hyper-V Default Switch re-subnet; current: 172.23.14.104
ssh -i ~/.ssh/spectre_vm_ed25519 -o IdentitiesOnly=yes seb@172.23.14.104
cd ~/src/spectre && git fetch origin main && git checkout -B smoke-0.4 origin/main
export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
./gradlew verifyMavenLocalPublication -PVERSION_NAME=0.4.0-rc.smoke -PstubMacHelperForTesting --no-daemon
xvfb-run -a ./gradlew :sample-desktop:validationTest \
  --tests '*RunSpectreTestValidationTest*' \
  --tests '*FailureArtifactsValidationTest*' \
  --tests '*AtomicCaptureValidationTest*' \
  -PVERSION_NAME=0.4.0-rc.smoke --no-daemon
xvfb-run -a ./gradlew :recording:runWindowScreenshotSmoke -PVERSION_NAME=0.4.0-rc.smoke --no-daemon
xvfb-run -a ./gradlew :agent:test --tests '*AgentAttachIntegrationTest.attach*' \
  -PVERSION_NAME=0.4.0-rc.smoke --no-daemon
```

### Supported-path judgment

- **macOS Supported paths all green** (check/publish, capture, record screenshot, attach).
- **Windows:** publish shape + multi-file extract + agent attach green; WGC/UI pixel capture **blocked by non-interactive SSH session / missing WGC service path**, not by packaging. Not treated as a product regression for this PR; re-run from interactive console before tagging.
- **Linux:** core/testing/agent + X11 screenshot green under Xvfb; Wayland recording correctly N/A without a compositor portal session.

No Central publish/tag in this PR.

## Test plan

- [x] `python3 -m unittest tests.test_central_portal_check -v`
- [x] Local jar validation via `validate_jar` against `0.4.0-rc.smoke` Maven Local artifacts
- [x] `./gradlew check` green on the worktree
- [x] Cross-OS smoke matrix documented above