### PR TITLE
fix(core): let cold visual capture warm up

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -247,7 +247,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -164,7 +164,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -277,6 +277,7 @@ class DaemonFixtureIntegrationTest {
                     )
                 assertEquals(0, start.exitCode, start.output + start.errorOutput)
                 assertTrue(Files.exists(output) || start.output.contains("mp4"), start.output)
+                waitForNonEmptyRecording(output)
 
                 // Kill the target mid-record; daemon + SCK helper must keep running.
                 fixture.close()
@@ -323,6 +324,17 @@ private fun deleteTemporaryDaemonFixtureSocketPath(socketPath: Path) {
 private fun deleteDaemonSocketAndParent(socketPath: Path) {
     Files.deleteIfExists(socketPath)
     Files.deleteIfExists(socketPath.parent)
+}
+
+private fun waitForNonEmptyRecording(output: Path) {
+    val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(RECORD_START_TIMEOUT_SECONDS)
+    while (System.nanoTime() < deadline) {
+        if (Files.isRegularFile(output) && Files.size(output) > 0) return
+        Thread.sleep(RECORD_START_POLL_MILLIS)
+    }
+    error(
+        "recording did not write its first frame within $RECORD_START_TIMEOUT_SECONDS seconds: $output"
+    )
 }
 
 private fun spawnComposeFixture(): FixtureProcess {
@@ -565,6 +577,8 @@ private const val FIXTURE_STOP_TIMEOUT_SECONDS: Long = 2
 private const val DRAINER_JOIN_TIMEOUT_MILLIS: Long = 500
 private const val CLI_PROCESS_TIMEOUT_SECONDS: Long = 30
 private const val MCP_CONNECTION_TIMEOUT_MILLIS: Long = 10_000
+private const val RECORD_START_TIMEOUT_SECONDS: Long = 10
+private const val RECORD_START_POLL_MILLIS: Long = 100
 private const val RECORD_AFTER_KILL_SETTLE_MILLIS: Long = 1_500
 private const val MIN_PNG_BYTES: Int = 100
 private val PNG_MAGIC: ByteArray =

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -24,6 +24,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.TimeSource
+import kotlinx.coroutines.runInterruptible
 
 /**
  * Single user-facing entry point for driving live Compose Desktop UIs: tracked-window discovery,
@@ -343,13 +344,6 @@ private constructor(
     // that fits their test.
     private val idlingResources = CopyOnWriteArrayList<AutomatorIdlingResource>()
 
-    private val visualFrameHasher =
-        BoundedFrameHasher(
-            steadyStateBudgetMs = FRAME_HASH_BUDGET_MS,
-            sample = ::sampleFrameHash,
-            unsampledHash = { System.nanoTime().toInt() },
-        )
-
     public fun registerIdlingResource(resource: AutomatorIdlingResource) {
         idlingResources.addIfAbsent(resource)
     }
@@ -423,11 +417,17 @@ private constructor(
         pollInterval: Duration = DEFAULT_POLL_INTERVAL,
     ) {
         rejectEdtCaller("waitForVisualIdle")
+        val frameHasher =
+            BoundedFrameHasher(
+                steadyStateBudgetMs = FRAME_HASH_BUDGET_MS,
+                sample = ::sampleFrameHash,
+                unsampledHash = { System.nanoTime().toInt() },
+            )
         waitForVisualIdleInternal(
             timeout = timeout,
             stableFrames = stableFrames,
             pollInterval = pollInterval,
-            frameHash = ::computeFrameHash,
+            frameHash = frameHasher::hash,
         )
     }
 
@@ -508,34 +508,26 @@ private constructor(
         }
     }
 
-    private fun computeFrameHash(remainingMs: Long): Int {
-        // Hash each tracked Compose surface independently, then combine the per-surface hashes.
-        // - Sampling the full virtual desktop would let unrelated pixel churn (notifications,
-        //   other apps, the cursor outside the app) break the stable-frame streak.
-        // - A single union rectangle would include the gap between disjoint surfaces (main
-        //   window + a popup floating elsewhere), and gap-pixel churn would still break the
-        //   streak. Per-surface hashes ignore the gap entirely.
-        // - When no surfaces are tracked, or the bounded sampling budget elapses, we
-        //   deliberately return a value that differs every call so the streak never completes
-        //   — waitForVisualIdle keeps waiting (or times out) rather than declaring success
-        //   against an unsampleable UI.
-        return visualFrameHasher.hash(remainingMs.coerceAtLeast(0))
-    }
-
-    private fun sampleFrameHash(budgetMs: Long): Int? {
+    private suspend fun sampleFrameHash(budgetMs: Long): Int? {
+        // Hash tracked Compose surfaces independently: a virtual-desktop capture would let
+        // unrelated windows, notifications, or the cursor outside the app reset the streak.
+        // Returning null for no surfaces or a budget expiry makes the per-wait hasher produce a
+        // changing value, so an unsampleable UI cannot be reported as visually idle.
         // Native capture can take seconds on its first use, so BoundedFrameHasher gives the cold
         // sample the wait's remaining budget. After the first completed sample, this worker is
         // capped at FRAME_HASH_BUDGET_MS: an unexpectedly hung EDT or capture API still cannot
         // out-block waitForVisualIdle's overall deadline.
-        return runBoundedOnWorker(budgetMs) {
-            refreshWindows()
-            val rects = composeSurfaceRects()
-            if (rects.isEmpty()) {
-                null
-            } else {
-                val hashes = IntArray(rects.size)
-                for (i in rects.indices) hashes[i] = hashScreenRegion(rects[i])
-                hashes.contentHashCode()
+        return runInterruptible {
+            runBoundedOnWorker(budgetMs) {
+                refreshWindows()
+                val rects = composeSurfaceRects()
+                if (rects.isEmpty()) {
+                    null
+                } else {
+                    val hashes = IntArray(rects.size)
+                    for (i in rects.indices) hashes[i] = hashScreenRegion(rects[i])
+                    hashes.contentHashCode()
+                }
             }
         }
     }
@@ -579,23 +571,28 @@ private constructor(
                 )
                 .apply { isDaemon = true }
         thread.start()
-        return if (latch.await(budgetMs, TimeUnit.MILLISECONDS)) {
-            requireNotNull(resultRef.get()) {
-                    "spectre-bounded-worker counted down the latch without publishing a Result"
+        try {
+            return if (latch.await(budgetMs, TimeUnit.MILLISECONDS)) {
+                requireNotNull(resultRef.get()) {
+                        "spectre-bounded-worker counted down the latch without publishing a Result"
+                    }
+                    .getOrThrow()
+            } else {
+                thread.interrupt()
+                // Brief grace window to let cooperative blockers (invokeAndWait) honour the
+                // interrupt and exit cleanly before we abandon the thread. Skipped when the
+                // caller's remaining budget was already exhausted (budgetMs == 0): in that case
+                // even a 50ms grace would push the public wait API past the caller's timeout.
+                // Native non-interruptible calls still leak, but the daemon flag keeps a stuck
+                // thread from holding the JVM open.
+                if (budgetMs > 0) {
+                    latch.await(WORKER_INTERRUPT_GRACE_MS, TimeUnit.MILLISECONDS)
                 }
-                .getOrThrow()
-        } else {
-            thread.interrupt()
-            // Brief grace window to let cooperative blockers (invokeAndWait) honour the
-            // interrupt and exit cleanly before we abandon the thread. Skipped when the
-            // caller's remaining budget was already exhausted (budgetMs == 0): in that case
-            // even a 50ms grace would push the public wait API past the caller's timeout.
-            // Native non-interruptible calls still leak, but the daemon flag keeps a stuck
-            // thread from holding the JVM open.
-            if (budgetMs > 0) {
-                latch.await(WORKER_INTERRUPT_GRACE_MS, TimeUnit.MILLISECONDS)
+                null
             }
-            null
+        } catch (e: InterruptedException) {
+            thread.interrupt()
+            throw e
         }
     }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -343,6 +343,13 @@ private constructor(
     // that fits their test.
     private val idlingResources = CopyOnWriteArrayList<AutomatorIdlingResource>()
 
+    private val visualFrameHasher =
+        BoundedFrameHasher(
+            steadyStateBudgetMs = FRAME_HASH_BUDGET_MS,
+            sample = ::sampleFrameHash,
+            unsampledHash = { System.nanoTime().toInt() },
+        )
+
     public fun registerIdlingResource(resource: AutomatorIdlingResource) {
         idlingResources.addIfAbsent(resource)
     }
@@ -512,21 +519,25 @@ private constructor(
         //   deliberately return a value that differs every call so the streak never completes
         //   — waitForVisualIdle keeps waiting (or times out) rather than declaring success
         //   against an unsampleable UI.
-        // The sampling itself runs on a worker thread bounded by FRAME_HASH_BUDGET_MS so a
-        // hung EDT or stuck Robot.createScreenCapture cannot out-block the wait loop's
-        // overall timeout enforcement.
-        val budget = remainingMs.coerceAtMost(FRAME_HASH_BUDGET_MS).coerceAtLeast(0)
-        return runBoundedOnWorker(budget) {
+        return visualFrameHasher.hash(remainingMs.coerceAtLeast(0))
+    }
+
+    private fun sampleFrameHash(budgetMs: Long): Int? {
+        // Native capture can take seconds on its first use, so BoundedFrameHasher gives the cold
+        // sample the wait's remaining budget. After the first completed sample, this worker is
+        // capped at FRAME_HASH_BUDGET_MS: an unexpectedly hung EDT or capture API still cannot
+        // out-block waitForVisualIdle's overall deadline.
+        return runBoundedOnWorker(budgetMs) {
             refreshWindows()
             val rects = composeSurfaceRects()
             if (rects.isEmpty()) {
-                System.nanoTime().toInt()
+                null
             } else {
                 val hashes = IntArray(rects.size)
                 for (i in rects.indices) hashes[i] = hashScreenRegion(rects[i])
                 hashes.contentHashCode()
             }
-        } ?: System.nanoTime().toInt()
+        }
     }
 
     private fun <T> runBoundedOnWorker(budgetMs: Long, block: () -> T): T? {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -421,7 +421,6 @@ private constructor(
             BoundedFrameHasher(
                 steadyStateBudgetMs = FRAME_HASH_BUDGET_MS,
                 sample = ::sampleFrameHash,
-                unsampledHash = { System.nanoTime().toInt() },
             )
         waitForVisualIdleInternal(
             timeout = timeout,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
@@ -105,7 +105,7 @@ internal suspend fun waitForVisualIdleInternal(
     timeout: Duration,
     stableFrames: Int,
     pollInterval: Duration,
-    frameHash: (remainingMs: Long) -> Int,
+    frameHash: suspend (remainingMs: Long) -> Int,
     clock: MonotonicClock = SystemClock(),
     sleep: suspend (Duration) -> Unit = { delay(it) },
 ) {
@@ -143,12 +143,12 @@ internal suspend fun waitForVisualIdleInternal(
  */
 internal class BoundedFrameHasher(
     private val steadyStateBudgetMs: Long,
-    private val sample: (budgetMs: Long) -> Int?,
+    private val sample: suspend (budgetMs: Long) -> Int?,
     private val unsampledHash: () -> Int,
 ) {
     private val hasSuccessfulSample = AtomicBoolean(false)
 
-    fun hash(remainingMs: Long): Int {
+    suspend fun hash(remainingMs: Long): Int {
         val budgetMs =
             if (hasSuccessfulSample.get()) {
                 remainingMs.coerceAtMost(steadyStateBudgetMs)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
@@ -105,7 +105,7 @@ internal suspend fun waitForVisualIdleInternal(
     timeout: Duration,
     stableFrames: Int,
     pollInterval: Duration,
-    frameHash: suspend (remainingMs: Long) -> Int,
+    frameHash: suspend (remainingMs: Long) -> Int?,
     clock: MonotonicClock = SystemClock(),
     sleep: suspend (Duration) -> Unit = { delay(it) },
 ) {
@@ -115,12 +115,18 @@ internal suspend fun waitForVisualIdleInternal(
 
     while (true) {
         val hash = frameHash((deadline - clock.now()).coerceAtLeast(0))
-        if (window.isNotEmpty() && window.last() != hash) {
-            window.clear()
-        }
-        window.addLast(hash)
-        if (window.size > stableFrames) window.removeFirst()
-        val streakComplete = window.size == stableFrames && window.all { it == window.first() }
+        val streakComplete =
+            if (hash == null) {
+                window.clear()
+                false
+            } else {
+                if (window.isNotEmpty() && window.last() != hash) {
+                    window.clear()
+                }
+                window.addLast(hash)
+                if (window.size > stableFrames) window.removeFirst()
+                window.size == stableFrames && window.all { it == window.first() }
+            }
 
         val nowAfterSample = clock.now()
         if (streakComplete && nowAfterSample <= deadline) return
@@ -144,18 +150,17 @@ internal suspend fun waitForVisualIdleInternal(
 internal class BoundedFrameHasher(
     private val steadyStateBudgetMs: Long,
     private val sample: suspend (budgetMs: Long) -> Int?,
-    private val unsampledHash: () -> Int,
 ) {
     private val hasSuccessfulSample = AtomicBoolean(false)
 
-    suspend fun hash(remainingMs: Long): Int {
+    suspend fun hash(remainingMs: Long): Int? {
         val budgetMs =
             if (hasSuccessfulSample.get()) {
                 remainingMs.coerceAtMost(steadyStateBudgetMs)
             } else {
                 remainingMs
             }
-        return sample(budgetMs)?.also { hasSuccessfulSample.set(true) } ?: unsampledHash()
+        return sample(budgetMs)?.also { hasSuccessfulSample.set(true) }
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.core
 
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.time.Duration
 import kotlinx.coroutines.delay
 
@@ -130,6 +131,31 @@ internal suspend fun waitForVisualIdleInternal(
             )
         }
         sleep(pollInterval)
+    }
+}
+
+/**
+ * Applies the visual-idle capture budget without treating a cold native capture like a changed
+ * frame. The first successful capture is allowed to use the caller's remaining timeout, because
+ * platform capture paths can have a one-off startup cost. Once one sample has completed, every
+ * later sample is capped at [steadyStateBudgetMs] so a stuck capture still cannot overrun the
+ * public wait timeout.
+ */
+internal class BoundedFrameHasher(
+    private val steadyStateBudgetMs: Long,
+    private val sample: (budgetMs: Long) -> Int?,
+    private val unsampledHash: () -> Int,
+) {
+    private val hasSuccessfulSample = AtomicBoolean(false)
+
+    fun hash(remainingMs: Long): Int {
+        val budgetMs =
+            if (hasSuccessfulSample.get()) {
+                remainingMs.coerceAtMost(steadyStateBudgetMs)
+            } else {
+                remainingMs
+            }
+        return sample(budgetMs)?.also { hasSuccessfulSample.set(true) } ?: unsampledHash()
     }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
@@ -46,7 +46,6 @@ class WaitForVisualIdleTest {
                             7
                         }
                     },
-                    unsampledHash = { Int.MIN_VALUE },
                 )
 
             waitForVisualIdleInternal(
@@ -72,7 +71,6 @@ class WaitForVisualIdleTest {
                     firstBudgets += budgetMs
                     1
                 },
-                unsampledHash = { Int.MIN_VALUE },
             )
         val secondWait =
             BoundedFrameHasher(
@@ -81,7 +79,6 @@ class WaitForVisualIdleTest {
                     secondBudgets += budgetMs
                     1
                 },
-                unsampledHash = { Int.MIN_VALUE },
             )
 
         firstWait.hash(5_000)

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
@@ -11,6 +11,40 @@ import kotlinx.coroutines.test.runTest
 class WaitForVisualIdleTest {
 
     @Test
+    fun `cold frame capture receives the remaining wait budget before steady state cap`() =
+        runTest {
+            val clock = FakeClock()
+            val budgets = mutableListOf<Long>()
+            var captures = 0
+            val hasher =
+                BoundedFrameHasher(
+                    steadyStateBudgetMs = 500,
+                    sample = { budgetMs ->
+                        budgets += budgetMs
+                        val captureDurationMs = if (captures++ == 0) 3_600L else 100L
+                        if (budgetMs < captureDurationMs) {
+                            null
+                        } else {
+                            clock.advance(captureDurationMs.milliseconds)
+                            7
+                        }
+                    },
+                    unsampledHash = { Int.MIN_VALUE },
+                )
+
+            waitForVisualIdleInternal(
+                timeout = 5.seconds,
+                stableFrames = 3,
+                pollInterval = 100.milliseconds,
+                frameHash = hasher::hash,
+                clock = clock,
+                sleep = clock::advance,
+            )
+
+            assertEquals(listOf(5_000L, 500L, 500L), budgets)
+        }
+
+    @Test
     fun `waitForVisualIdle returns when stableFrames consecutive hashes match`() = runTest {
         val clock = FakeClock()
         val frames = ArrayDeque(listOf(1, 2, 3, 3, 3))

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
@@ -6,9 +6,26 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 
 class WaitForVisualIdleTest {
+
+    @Test
+    fun `visual idle cancellation interrupts a cold capture wait`() = runTest {
+        assertFailsWith<TimeoutCancellationException> {
+            withTimeout(100.milliseconds) {
+                waitForVisualIdleInternal(
+                    timeout = 5.seconds,
+                    stableFrames = 1,
+                    pollInterval = 1.milliseconds,
+                    frameHash = { awaitCancellation() },
+                )
+            }
+        }
+    }
 
     @Test
     fun `cold frame capture receives the remaining wait budget before steady state cap`() =
@@ -43,6 +60,37 @@ class WaitForVisualIdleTest {
 
             assertEquals(listOf(5_000L, 500L, 500L), budgets)
         }
+
+    @Test
+    fun `each visual-idle wait gets an independent cold capture budget`() = runTest {
+        val firstBudgets = mutableListOf<Long>()
+        val secondBudgets = mutableListOf<Long>()
+        val firstWait =
+            BoundedFrameHasher(
+                steadyStateBudgetMs = 500,
+                sample = { budgetMs ->
+                    firstBudgets += budgetMs
+                    1
+                },
+                unsampledHash = { Int.MIN_VALUE },
+            )
+        val secondWait =
+            BoundedFrameHasher(
+                steadyStateBudgetMs = 500,
+                sample = { budgetMs ->
+                    secondBudgets += budgetMs
+                    1
+                },
+                unsampledHash = { Int.MIN_VALUE },
+            )
+
+        firstWait.hash(5_000)
+        firstWait.hash(4_000)
+        secondWait.hash(5_000)
+
+        assertEquals(listOf(5_000L, 500L), firstBudgets)
+        assertEquals(listOf(5_000L), secondBudgets)
+    }
 
     @Test
     fun `waitForVisualIdle returns when stableFrames consecutive hashes match`() = runTest {

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -159,10 +159,11 @@ A few details worth knowing:
   `pollInterval` only kicking in when the capture is faster than that floor. The
   default `16.milliseconds` is a 60Hz *target*, not a guarantee of 60 polls per
   second.
-- **Bounded sampling budget.** Each frame hash runs on a worker thread capped at 500ms.
-  If the capture or hash exceeds that, `waitForVisualIdle` returns a value that differs
-  every call, so the streak never completes and the wait times out rather than silently
-  succeeding against an unsampleable UI.
+- **Bounded sampling budget.** The first completed frame hash may use the wait's remaining
+  timeout: native capture paths can have a one-off cold-start cost. Later frame hashes run on
+  a worker thread capped at 500ms. If a steady-state capture or hash exceeds that cap,
+  `waitForVisualIdle` returns a value that differs every call, so the streak never completes
+  and the wait times out rather than silently succeeding against an unsampleable UI.
 - **Pixel hashing isn't free.** Multiple large surfaces, full-screen windows on a 4K /
   Retina monitor, or running under a software-rendered virtual GPU all push the
   per-poll cost up. If `waitForVisualIdle` is timing out or burning more CPU than you

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
@@ -436,6 +436,7 @@ final class Recorder {
     private var pipelineError: Error?
     private var framesSeen: Int = 0
     private var framesAppended: Int = 0
+    private let firstFrameAppended = DispatchSemaphore(value: 0)
     private var framesDropped: Int = 0
     private var streamDelegate: StreamLogger?
     private var frameOutput: FrameOutput?
@@ -746,6 +747,10 @@ final class Recorder {
         try await stream.startCapture()
         self.stream = stream
 
+        if args.mode == .recording {
+            try await waitForFirstRecordingFrame()
+        }
+
         // Signal the JVM-side recorder that capture is fully running. The JVM blocks on
         // reading this line from stdout in `start()` so it can return a recording handle
         // synchronously rather than racing against the helper's window-discovery + SCK init.
@@ -819,6 +824,9 @@ final class Recorder {
         }
         if adaptor.append(imageBuffer, withPresentationTime: presentationTime) {
             framesAppended += 1
+            if framesAppended == 1 {
+                firstFrameAppended.signal()
+            }
         } else {
             framesDropped += 1
             if pipelineError == nil { pipelineError = writer.error }
@@ -947,6 +955,19 @@ final class Recorder {
         let didAppendFrame = framesAppended > 0
         lock.unlock()
         return didAppendFrame
+    }
+
+    private func waitForFirstRecordingFrame() async throws {
+        let completed = await withCheckedContinuation {
+            (continuation: CheckedContinuation<Bool, Never>) in
+            DispatchQueue.global(qos: .utility).async { [firstFrameAppended] in
+                continuation.resume(
+                    returning: firstFrameAppended.wait(timeout: .now() + 10) == .success)
+            }
+        }
+        if !completed {
+            throw CLIError(code: 5, message: "timed out waiting for first recording frame")
+        }
     }
 
     private func finalize() async throws {

--- a/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
+++ b/recording/native/macos/Sources/SpectreScreenCaptureCore/SpectreScreenCapture.swift
@@ -436,7 +436,9 @@ final class Recorder {
     private var pipelineError: Error?
     private var framesSeen: Int = 0
     private var framesAppended: Int = 0
-    private let firstFrameAppended = DispatchSemaphore(value: 0)
+    // Wakes startup after either its first successfully appended frame or a terminal pipeline
+    // error. The waiter inspects the protected state to distinguish the two outcomes.
+    private let firstRecordingFrameResult = DispatchSemaphore(value: 0)
     private var framesDropped: Int = 0
     private var streamDelegate: StreamLogger?
     private var frameOutput: FrameOutput?
@@ -825,11 +827,12 @@ final class Recorder {
         if adaptor.append(imageBuffer, withPresentationTime: presentationTime) {
             framesAppended += 1
             if framesAppended == 1 {
-                firstFrameAppended.signal()
+                firstRecordingFrameResult.signal()
             }
         } else {
             framesDropped += 1
             if pipelineError == nil { pipelineError = writer.error }
+            firstRecordingFrameResult.signal()
         }
     }
 
@@ -882,6 +885,7 @@ final class Recorder {
         if pipelineError == nil { pipelineError = error }
         lock.unlock()
         stopRequested.signal()
+        firstRecordingFrameResult.signal()
     }
 
     /// Installs a SIGTERM handler that wakes [waitForStop] via [stopRequested]. Called from
@@ -960,14 +964,29 @@ final class Recorder {
     private func waitForFirstRecordingFrame() async throws {
         let completed = await withCheckedContinuation {
             (continuation: CheckedContinuation<Bool, Never>) in
-            DispatchQueue.global(qos: .utility).async { [firstFrameAppended] in
+            DispatchQueue.global(qos: .utility).async { [firstRecordingFrameResult] in
                 continuation.resume(
-                    returning: firstFrameAppended.wait(timeout: .now() + 10) == .success)
+                    returning: firstRecordingFrameResult.wait(timeout: .now() + 10) == .success)
             }
         }
         if !completed {
             throw CLIError(code: 5, message: "timed out waiting for first recording frame")
         }
+        if let pipelineError = currentPipelineError() {
+            throw CLIError(
+                code: 5,
+                message: "capture pipeline failed before first recording frame: \(pipelineError.localizedDescription)")
+        }
+        if !didAppendFrame() {
+            throw CLIError(code: 5, message: "capture stopped before appending the first recording frame")
+        }
+    }
+
+    private func currentPipelineError() -> Error? {
+        lock.lock()
+        let current = pipelineError
+        lock.unlock()
+        return current
     }
 
     private func finalize() async throws {

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -545,11 +545,12 @@ private const val HELPER_EXIT_PIPELINE: Int = 5
 private const val DEFAULT_DISCOVERY_TIMEOUT_MS: Int = 2000
 
 // Upper bound on how long start() will wait for the helper to either signal READY on stdout
-// or exit with one of the documented fast-fail codes. Must be greater than the helper's own
-// [DEFAULT_DISCOVERY_TIMEOUT_MS] plus enough allowance for SCK initialization under runner
-// load. Discovery still reports a missing window promptly; this only prevents start() from
+// or exit with one of the documented fast-fail codes. It must cover the helper's complete
+// startup path: up to [DEFAULT_DISCOVERY_TIMEOUT_MS] for window discovery, up to ten seconds
+// for the first frame to be appended, and a small allowance for process/SCK startup overhead.
+// Discovery still reports a missing window promptly; this only prevents start() from
 // force-killing a healthy helper while its stream comes online.
-private const val READY_WAIT_MILLIS: Long = 10_000
+private const val READY_WAIT_MILLIS: Long = 13_000
 
 // Single-line marker the helper writes to stdout once SCK + AVAssetWriter are running.
 // start() blocks until either this line appears (success) or the helper exits (failure

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -550,7 +550,7 @@ private const val DEFAULT_DISCOVERY_TIMEOUT_MS: Int = 2000
 // for the first frame to be appended, and a small allowance for process/SCK startup overhead.
 // Discovery still reports a missing window promptly; this only prevents start() from
 // force-killing a healthy helper while its stream comes online.
-private const val READY_WAIT_MILLIS: Long = 13_000
+private const val READY_WAIT_MILLIS: Long = 15_000
 
 // Single-line marker the helper writes to stdout once SCK + AVAssetWriter are running.
 // start() blocks until either this line appears (success) or the helper exits (failure

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/screencapturekit/ScreenCaptureKitRecorder.kt
@@ -546,10 +546,10 @@ private const val DEFAULT_DISCOVERY_TIMEOUT_MS: Int = 2000
 
 // Upper bound on how long start() will wait for the helper to either signal READY on stdout
 // or exit with one of the documented fast-fail codes. Must be greater than the helper's own
-// [DEFAULT_DISCOVERY_TIMEOUT_MS] plus a margin for SCK init, otherwise start() can return
-// before the helper has finished window discovery and the user would only learn of a
-// window-not-found failure when stop() throws.
-private const val READY_WAIT_MILLIS: Long = (DEFAULT_DISCOVERY_TIMEOUT_MS + 1500).toLong()
+// [DEFAULT_DISCOVERY_TIMEOUT_MS] plus enough allowance for SCK initialization under runner
+// load. Discovery still reports a missing window promptly; this only prevents start() from
+// force-killing a healthy helper while its stream comes online.
+private const val READY_WAIT_MILLIS: Long = 10_000
 
 // Single-line marker the helper writes to stdout once SCK + AVAssetWriter are running.
 // start() blocks until either this line appears (success) or the helper exits (failure

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitForVisualIdleValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitForVisualIdleValidationTest.kt
@@ -1,0 +1,47 @@
+package dev.sebastiano.spectre.sample.validation
+
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Live acceptance for the cold-capture path in
+ * [dev.sebastiano.spectre.core.ComposeAutomator.waitForVisualIdle].
+ *
+ * The fixture starts in a fresh worker JVM. Navigation and `waitForIdle()` are semantics-only, so
+ * `waitForVisualIdle()` below is the first pixel capture a user performs against a static Compose
+ * surface. This is the ordering that previously made an otherwise idle UI time out when native
+ * screen capture had a one-off startup cost. One stable frame intentionally isolates that cold
+ * public-capture path from the separate window-scoped capture fidelity work in #355, which can make
+ * repeated synthetic-screen samples differ even when the Compose content is static.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class WaitForVisualIdleValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre waitForVisualIdle validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `first visual-idle capture completes against a static live Compose surface`() =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.hidpi")
+                waitForTestTag("hidpi.target.40x0")
+                waitForIdle()
+
+                waitForVisualIdle(timeout = 5.seconds, stableFrames = 1)
+            }
+        }
+}


### PR DESCRIPTION
## Summary

Fixes the cold-capture timeout in `waitForVisualIdle`: the first successful frame sample may use the caller's remaining timeout, while all later samples retain the 500 ms cap.

The previous behavior converted a one-off slow native capture into a changing nonce, making a stable-frame streak unreachable even on a static UI.

## Validation

- `./gradlew :core:test --tests '*WaitForVisualIdleTest'`
- `./gradlew :sample-desktop:validationTest --tests '*WaitForVisualIdleValidationTest'`
- `./gradlew check`
- `python3 -m mkdocs build --strict`

## Scope

The live acceptance exercises the public first-capture path in a fresh Compose worker JVM. Repeated synthetic-frame instability remains intentionally out of scope as issue #355.
