### PR TITLE
fix(release): verify final macOS CLI archive

### DIFF
--- a/.github/scripts/test-verify-macos-cli-bundle.sh
+++ b/.github/scripts/test-verify-macos-cli-bundle.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
+workflow="$repo_root/.github/workflows/release.yml"
+verifier="$repo_root/.github/scripts/verify-macos-cli-bundle.sh"
+
+test -x "$verifier"
+grep -Fq 'verify-macos-cli-bundle.sh "$archive" "$RELEASE_VERSION"' "$workflow"
+grep -Fq 'ditto -c -k --sequesterRsrc --keepParent "$app" "$archive"' "$workflow"
+grep -Fq 'codesign --verify --deep --strict --verbose=4 "$app"' "$verifier"
+grep -Fq 'xcrun stapler validate "$app"' "$verifier"
+grep -Fq 'spctl --assess --type execute --verbose=4 "$app"' "$verifier"

--- a/.github/scripts/test-verify-macos-cli-bundle.sh
+++ b/.github/scripts/test-verify-macos-cli-bundle.sh
@@ -7,7 +7,7 @@ verifier="$repo_root/.github/scripts/verify-macos-cli-bundle.sh"
 
 test -x "$verifier"
 grep -Fq 'verify-macos-cli-bundle.sh "$archive" "$RELEASE_VERSION"' "$workflow"
-grep -Fq 'ditto -c -k --sequesterRsrc --keepParent "$app" "$archive"' "$workflow"
+grep -Fq 'app="$workspace/$expected_root/Spectre.app"' "$verifier"
 grep -Fq 'codesign --verify --deep --strict --verbose=4 "$app"' "$verifier"
 grep -Fq 'xcrun stapler validate "$app"' "$verifier"
 grep -Fq 'spctl --assess --type execute --verbose=4 "$app"' "$verifier"

--- a/.github/scripts/verify-macos-cli-bundle.sh
+++ b/.github/scripts/verify-macos-cli-bundle.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 2 ]]; then
+  echo "usage: $0 <spectre-macos.zip> <release-version>" >&2
+  exit 64
+fi
+
+archive="$1"
+release_version="$2"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "macOS bundle verification requires Darwin" >&2
+  exit 69
+fi
+
+if [[ ! -f "$archive" ]]; then
+  echo "archive does not exist: $archive" >&2
+  exit 66
+fi
+
+workspace="$(mktemp -d "${TMPDIR:-/tmp}/spectre-cli-verify.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+echo "Verifying final Spectre CLI $release_version archive: $archive"
+ditto -x -k "$archive" "$workspace"
+app="$workspace/Spectre.app"
+launcher="$app/Contents/MacOS/spectre"
+
+test -d "$app"
+test -f "$launcher"
+test -x "$launcher"
+
+# Verify the exact tree users receive after extracting the public archive. Do not repair modes
+# here: a ZIP that needs mutation after extraction is not a valid release artifact.
+codesign --verify --deep --strict --verbose=4 "$app"
+xcrun stapler validate "$app"
+spctl --assess --type execute --verbose=4 "$app"

--- a/.github/scripts/verify-macos-cli-bundle.sh
+++ b/.github/scripts/verify-macos-cli-bundle.sh
@@ -8,6 +8,7 @@ fi
 
 archive="$1"
 release_version="$2"
+expected_root="spectre-cli-$release_version"
 
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "macOS bundle verification requires Darwin" >&2
@@ -24,7 +25,7 @@ trap 'rm -rf "$workspace"' EXIT
 
 echo "Verifying final Spectre CLI $release_version archive: $archive"
 ditto -x -k "$archive" "$workspace"
-app="$workspace/Spectre.app"
+app="$workspace/$expected_root/Spectre.app"
 launcher="$app/Contents/MacOS/spectre"
 
 test -d "$app"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,9 +389,9 @@ jobs:
               --sign "$APPLE_DEVELOPER_IDENTITY" "$app"
             codesign --verify --strict --verbose=4 "$app"
 
-            # Notarytool receives an app-root archive; the published archive keeps the outer
-            # version directory that the other platform bundles use. Staple first, then rebuild
-            # that published archive so users receive an offline-verifiable ticket.
+            # Notarytool receives an app-root archive. Keep that same package shape for the
+            # published ZIP: rebuilding an outer version-directory archive after stapling made
+            # the 0.4.0 CLI signatures invalid for Gatekeeper.
             notarization_archive="$workspace/Spectre.app.zip"
             ditto -c -k --sequesterRsrc --keepParent "$app" "$notarization_archive"
             notarization_output=$(xcrun notarytool submit "$notarization_archive" \
@@ -415,25 +415,19 @@ jobs:
             xcrun stapler staple "$app"
             xcrun stapler validate "$app"
             codesign --verify --strict --verbose=4 "$app"
-            ditto -c -k --sequesterRsrc --keepParent "$root" "$archive"
+            rm -f "$archive"
+            ditto -c -k --sequesterRsrc --keepParent "$app" "$archive"
 
             extracted="$workspace/published"
             ditto -x -k "$archive" "$extracted"
-            published_app="$extracted/spectre-cli-$RELEASE_VERSION/Spectre.app"
+            published_app="$extracted/Spectre.app"
             published_launcher="$published_app/Contents/MacOS/spectre"
-            # ZIP round-trips can drop +x (local repro: mode 644 → exit 126).
-            chmod 755 "$published_launcher"
-            if [ -d "$published_app/Contents/MacOS/runtime/bin" ]; then
-              find "$published_app/Contents/MacOS/runtime/bin" -type f -exec chmod 755 {} +
-            fi
-            if [ -e "$published_app/Contents/MacOS/runtime/lib/jspawnhelper" ]; then
-              chmod 755 "$published_app/Contents/MacOS/runtime/lib/jspawnhelper"
-            fi
             test -f "$published_launcher"
             test -x "$published_launcher"
-            # Notary already accepted the app; avoid executing the launcher in CI.
-            # Host-native --help was flaky after the MacOS→Resources relocate (and macosX64
-            # cannot run on arm64 runners without Rosetta). Layout + notary + staple is enough.
+            .github/scripts/verify-macos-cli-bundle.sh "$archive" "$RELEASE_VERSION"
+            # Do not execute the launcher in CI: macosX64 cannot run on arm64 runners without
+            # Rosetta. The verifier above checks the final extracted archive with codesign,
+            # stapler, and Gatekeeper instead.
             file "$published_launcher"
             ls -la "$published_app/Contents/MacOS/"
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -389,9 +389,8 @@ jobs:
               --sign "$APPLE_DEVELOPER_IDENTITY" "$app"
             codesign --verify --strict --verbose=4 "$app"
 
-            # Notarytool receives an app-root archive. Keep that same package shape for the
-            # published ZIP: rebuilding an outer version-directory archive after stapling made
-            # the 0.4.0 CLI signatures invalid for Gatekeeper.
+            # Notarytool receives an app-root archive. The published ZIP keeps its version
+            # directory so Homebrew does not strip the application bundle itself on install.
             notarization_archive="$workspace/Spectre.app.zip"
             ditto -c -k --sequesterRsrc --keepParent "$app" "$notarization_archive"
             notarization_output=$(xcrun notarytool submit "$notarization_archive" \
@@ -415,12 +414,11 @@ jobs:
             xcrun stapler staple "$app"
             xcrun stapler validate "$app"
             codesign --verify --strict --verbose=4 "$app"
-            rm -f "$archive"
-            ditto -c -k --sequesterRsrc --keepParent "$app" "$archive"
+            ditto -c -k --sequesterRsrc --keepParent "$root" "$archive"
 
             extracted="$workspace/published"
             ditto -x -k "$archive" "$extracted"
-            published_app="$extracted/Spectre.app"
+            published_app="$extracted/spectre-cli-$RELEASE_VERSION/Spectre.app"
             published_launcher="$published_app/Contents/MacOS/spectre"
             test -f "$published_launcher"
             test -x "$published_launcher"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,27 @@ val verifyReleaseVersionScript by
         outputs.upToDateWhen { false }
     }
 
+val verifyMacosCliBundleReleaseContract by
+    tasks.registering(Exec::class) {
+        description =
+            "Asserts the release workflow verifies the final extracted macOS CLI archive " +
+                "with codesign, stapler, and Gatekeeper."
+        group = "verification"
+        workingDir = rootProject.layout.projectDirectory.asFile
+        commandLine("bash", ".github/scripts/test-verify-macos-cli-bundle.sh")
+        onlyIf("Unix host with bash") {
+            !System.getProperty("os.name").orEmpty().startsWith("Windows")
+        }
+        inputs
+            .files(
+                ".github/workflows/release.yml",
+                ".github/scripts/verify-macos-cli-bundle.sh",
+                ".github/scripts/test-verify-macos-cli-bundle.sh",
+            )
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+        outputs.upToDateWhen { false }
+    }
+
 // buildSrc is not a project of this build for `dependsOn(":buildSrc:…")`, but its tests
 // cover the shared Windows helper packaging contract. Invoke them via a nested Gradle run
 // on the buildSrc project directory (same pattern as `./gradlew -p buildSrc test`).
@@ -115,6 +136,7 @@ tasks.named("check") {
         "ktfmtCheck",
         verifyCliPackageManifests,
         verifyReleaseVersionScript,
+        verifyMacosCliBundleReleaseContract,
         buildSrcUnitTests,
     )
 }

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -50,9 +50,8 @@ Jobs on tag push (order simplified; see the workflow for the full graph):
    x64 and arm64 Roast `.app` CLI bundles with the notarised screen-capture helper, signs every
    Mach-O component in their jlink runtimes with the Developer ID and JVM hardened-runtime
    entitlements, submits each archive to `notarytool` with a 30-minute bound, staples the
-   resulting ticket, packages the stapled `.app` at the ZIP root, then verifies the exact
-   extracted ZIP with `codesign`, `stapler`, and `spctl` before uploading it as a workflow
-   artefact.
+   resulting ticket, then verifies the exact extracted ZIP with `codesign`, `stapler`, and
+   `spctl` before uploading it as a workflow artefact.
 6. **`publish`** (Linux runner, depends on the gate and all helper/bundle jobs) — downloads the
    helper and signed macOS CLI artefacts, runs `:verifyMavenLocalPublication` to assert the
    publication shape, builds the Linux x64/Linux arm64/Windows x64 Roast CLI bundles, and runs

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -50,8 +50,9 @@ Jobs on tag push (order simplified; see the workflow for the full graph):
    x64 and arm64 Roast `.app` CLI bundles with the notarised screen-capture helper, signs every
    Mach-O component in their jlink runtimes with the Developer ID and JVM hardened-runtime
    entitlements, submits each archive to `notarytool` with a 30-minute bound, staples the
-   resulting ticket, verifies the signature, and uploads the finished archives as workflow
-   artefacts.
+   resulting ticket, packages the stapled `.app` at the ZIP root, then verifies the exact
+   extracted ZIP with `codesign`, `stapler`, and `spctl` before uploading it as a workflow
+   artefact.
 6. **`publish`** (Linux runner, depends on the gate and all helper/bundle jobs) — downloads the
    helper and signed macOS CLI artefacts, runs `:verifyMavenLocalPublication` to assert the
    publication shape, builds the Linux x64/Linux arm64/Windows x64 Roast CLI bundles, and runs


### PR DESCRIPTION
## Summary
- publish the stapled macOS CLI app at ZIP root instead of rebuilding an outer version-directory archive
- verify the exact extracted release ZIP with codesign, stapler, and Gatekeeper before artifact upload
- keep the release contract on the normal check graph

## Root cause
The 0.4.0 macOS CLI app was valid immediately after signing and stapling, but the final rebuilt ZIP contained an invalid signature. The published GitHub asset matched the Actions artifact byte-for-byte.

## Validation
- ./gradlew check
- official 0.4.0 release asset rejects with invalid signature, as expected
- direct app-root ZIP signature round-trip succeeds