### PR TITLE
Keep the automator factory as the last constructor parameter

### DIFF
--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -343,7 +343,7 @@ class HeadlessTest {
 
     @JvmField
     @RegisterExtension
-    val automatorExt = ComposeAutomatorExtension(headlessFactory)
+    val automatorExt = ComposeAutomatorExtension(factory = headlessFactory)
 }
 ```
 

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -1,8 +1,8 @@
 public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/AfterTestExecutionCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/LifecycleMethodExecutionExceptionHandler, org/junit/jupiter/api/extension/ParameterResolver {
 	public fun <init> ()V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
-	public fun <init> (Lkotlin/jvm/functions/Function0;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun afterTestExecution (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
@@ -16,8 +16,8 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : or
 public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/junit/rules/ExternalResource {
 	public fun <init> ()V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
-	public fun <init> (Lkotlin/jvm/functions/Function0;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function0;Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun after ()V
 	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
 	public fun before ()V

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -50,8 +50,13 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * parameter injection instead.
  */
 public class ComposeAutomatorExtension(
-    private val factory: AutomatorFactory,
+    // `factory` MUST stay last. It is function-typed, so Kotlin's trailing-lambda convention
+    // binds `ComposeAutomatorExtension { … }` to whichever parameter comes last; putting an
+    // optional non-function parameter after it silently breaks every trailing-lambda call site
+    // with "argument type mismatch: … but 'FailureArtifactsConfig' was expected".
+    // AutomatorFactoryTrailingLambdaTest stops compiling if this order is changed again.
     private val failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+    private val factory: AutomatorFactory,
 ) :
     BeforeEachCallback,
     AfterEachCallback,
@@ -62,11 +67,11 @@ public class ComposeAutomatorExtension(
     // Explicit no-arg secondary constructor so JUnit 5's @ExtendWith — which reflectively
     // calls the no-arg constructor — can instantiate the extension. Kotlin's default-parameter
     // primary constructor does not emit a true JVM no-arg overload without @JvmOverloads.
-    public constructor() : this({ ComposeAutomator.inProcess() })
+    public constructor() : this(factory = { ComposeAutomator.inProcess() })
 
     public constructor(
         failureArtifacts: FailureArtifactsConfig
-    ) : this({ ComposeAutomator.inProcess() }, failureArtifacts)
+    ) : this(failureArtifacts, { ComposeAutomator.inProcess() })
 
     @Volatile private var lastInstance: ComposeAutomator? = null
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -50,18 +50,21 @@ import org.junit.runners.model.Statement
  * better fit for parallel test execution.
  */
 public class ComposeAutomatorRule(
-    private val factory: AutomatorFactory,
+    // `factory` MUST stay last — see the matching note on ComposeAutomatorExtension. Kotlin's
+    // trailing-lambda convention binds `ComposeAutomatorRule { … }` to the last parameter, so an
+    // optional non-function parameter after it breaks every trailing-lambda call site.
     private val failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+    private val factory: AutomatorFactory,
 ) : ExternalResource() {
 
     // Explicit no-arg secondary constructor so JUnit 4 callers can write
     // `@get:Rule val r = ComposeAutomatorRule()` without relying on Kotlin's
     // default-parameter constructor synthesis (consistent with ComposeAutomatorExtension).
-    public constructor() : this({ ComposeAutomator.inProcess() })
+    public constructor() : this(factory = { ComposeAutomator.inProcess() })
 
     public constructor(
         failureArtifacts: FailureArtifactsConfig
-    ) : this({ ComposeAutomator.inProcess() }, failureArtifacts)
+    ) : this(failureArtifacts, { ComposeAutomator.inProcess() })
 
     private var instance: ComposeAutomator? = null
 

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/AutomatorFactoryTrailingLambdaTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/AutomatorFactoryTrailingLambdaTest.kt
@@ -1,0 +1,57 @@
+package dev.sebastiano.spectre.testing
+
+import kotlin.test.assertSame
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+/**
+ * Source-compatibility guard for the idiomatic trailing-lambda construction form.
+ *
+ * `ComposeAutomatorExtension { … }` and `ComposeAutomatorRule { … }` are the shapes every pre-0.3
+ * consumer wrote, and they are what Kotlin's trailing-lambda convention leads callers to write.
+ * When `failureArtifacts` was introduced it was appended *after* the `factory` parameter, which
+ * silently moved the trailing lambda onto a non-function parameter and broke every such call site
+ * with "argument type mismatch: … but 'FailureArtifactsConfig' was expected". Spectre's own tests
+ * all pass `factory = …` by name, so nothing caught it.
+ *
+ * This test does its real work at *compile* time: if the function-typed parameter ever stops being
+ * last, this file no longer compiles. Keep the trailing-lambda form here — rewriting it to a named
+ * argument would defeat the entire point of the guard.
+ */
+class AutomatorFactoryTrailingLambdaTest {
+
+    private val extensionInstances = mutableListOf<Any>()
+
+    @JvmField
+    @RegisterExtension
+    val automatorExt = ComposeAutomatorExtension {
+        val instance = newHeadlessAutomator()
+        extensionInstances += instance
+        instance
+    }
+
+    @Test
+    fun `extension accepts a trailing-lambda factory`() {
+        assertSame(extensionInstances.first(), automatorExt.automator)
+    }
+
+    @Test
+    fun `rule accepts a trailing-lambda factory`() {
+        // JUnit 4 rule constructed directly (not via @Rule) so this stays a JUnit 5 test class;
+        // constructing it is enough to pin the source shape.
+        val rule = ComposeAutomatorRule { newHeadlessAutomator() }
+        rule
+            .apply(
+                object : org.junit.runners.model.Statement() {
+                    override fun evaluate() {
+                        assertSame(rule.automator, rule.automator)
+                    }
+                },
+                org.junit.runner.Description.createTestDescription(
+                    AutomatorFactoryTrailingLambdaTest::class.java,
+                    "rule accepts a trailing-lambda factory",
+                ),
+            )
+            .evaluate()
+    }
+}


### PR DESCRIPTION
## What

`ComposeAutomatorExtension` and `ComposeAutomatorRule` take a function-typed `factory`. When
`failureArtifacts` was added it was appended **after** `factory`, so Kotlin's trailing-lambda
convention now binds the lambda to `failureArtifacts` instead:

```kotlin
// Idiomatic, and the only form that existed before `failureArtifacts` — broken since 0.3:
val ext = ComposeAutomatorExtension { ComposeAutomator.inProcess() }
// e: Argument type mismatch: actual type is '() -> ComposeAutomator',
//    but 'FailureArtifactsConfig' was expected.
```

This moves `factory` back to last in both classes.

## Why it wasn't caught

Every in-repo call site — tests, samples, docs — passes `factory = ...` **by name**, which is
immune to the ordering. So CI stayed green while the shape consumers actually write was broken.
It only surfaces downstream: Compose Pi hits it on **46 call sites** upgrading 0.2.1 → 0.4.0.

## Changes

- `factory` is last again in `ComposeAutomatorExtension` and `ComposeAutomatorRule`; secondary
  constructors delegate by name.
- New `AutomatorFactoryTrailingLambdaTest` constructs both types with a trailing lambda. It does
  its work at **compile** time — if the function-typed parameter ever stops being last, the file
  stops compiling. (Deliberately *not* written with named arguments; that would void the guard.)
- ABI dump regenerated — the diff is exactly the two reordered constructors, nothing else.
- One positional example in `docs/guide/junit.md` switched to a named argument.

## Compatibility

Named-argument call sites are unaffected. `ComposeAutomatorExtension(failureArtifacts = ...)`
still resolves to the existing single-argument secondary constructor. The no-arg constructors are
unchanged. This *is* an ABI change for anyone who adopted the 0.3/0.4 positional
`(factory, failureArtifacts)` order; given that order shipped broken for the idiomatic form and
the library is pre-1.0, restoring 0.2.x source compatibility looks like the right trade.

## Verification

`./gradlew check` green. The new test was confirmed **red before the fix** (same
`FailureArtifactsConfig` mismatch, for both `Extension` and `Rule`), then green after, with
`--rerun-tasks` and `tests="2" skipped="0" failures="0"` in the JUnit XML — not an up-to-date task.

## Not in this PR

Found while investigating #362 and worth separating out:

- `focusWindow` exists on in-process `ComposeAutomator` but is **absent from the attach wire**, so
  an attach client cannot raise/activate the target window at all.
- The #362 title-bar click symptom itself is still unexplained. Note for anyone picking it up:
  reproducing it on a live desktop is easy to get wrong — screenshot tooling that filters windows
  by app can hide whatever is actually stacked over the target, while `java.awt.Robot` posts to the
  real topmost window. Verify the true window stack (e.g. `CGWindowListCopyWindowInfo`) before
  drawing conclusions from a screenshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
