### PR TITLE
fix(core): green ScreenCaptureBackendTest on Windows (#365)

### DIFF
--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackendTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackendTest.kt
@@ -42,7 +42,11 @@ class ScreenCaptureBackendTest {
     @Test
     fun `native client images crop in their client-window coordinate space`() {
         assumeLiveAwtAvailable()
-        val frame = Frame().apply { setBounds(20, 30, 300, 200) }
+        val frame =
+            Frame().apply {
+                setBounds(20, 30, 300, 200)
+                addNotify()
+            }
         val clientBounds = Rectangle(20, 54, 300, 176)
         val image = BufferedImage(300, 176, BufferedImage.TYPE_INT_ARGB)
         image.setRGB(10, 10, 0xFF112233.toInt())
@@ -123,7 +127,11 @@ class ScreenCaptureBackendTest {
     @Test
     fun `tracked Frame capture prefers the native window backend`() {
         assumeLiveAwtAvailable()
-        val frame = Frame().apply { setBounds(40, 50, 300, 200) }
+        val frame =
+            Frame().apply {
+                setBounds(40, 50, 300, 200)
+                addNotify()
+            }
         val expected = BufferedImage(300, 200, BufferedImage.TYPE_INT_ARGB)
         var fallbackCalls = 0
         val backend =
@@ -156,7 +164,11 @@ class ScreenCaptureBackendTest {
     @Test
     fun `native unavailability fails without capturing a screen region`() {
         assumeLiveAwtAvailable()
-        val frame = Frame().apply { setBounds(40, 50, 300, 200) }
+        val frame =
+            Frame().apply {
+                setBounds(40, 50, 300, 200)
+                addNotify()
+            }
         var regionCaptureCalls = 0
         val backend =
             PlatformScreenCaptureBackend(
@@ -181,7 +193,11 @@ class ScreenCaptureBackendTest {
     @Test
     fun `disabled native capture preserves the driver's loud failure`() {
         assumeLiveAwtAvailable()
-        val frame = Frame().apply { setBounds(40, 50, 300, 200) }
+        val frame =
+            Frame().apply {
+                setBounds(40, 50, 300, 200)
+                addNotify()
+            }
         val backend =
             PlatformScreenCaptureBackend(
                 regionCapture = { error("screen-region capture must not be used") },


### PR DESCRIPTION
## Summary

- Restores green `check-windows` for the three standing `ScreenCaptureBackendTest` failures (#365).
- Root cause: after #361, `PlatformScreenCaptureBackend.captureWindow` requires `frame.isDisplayable`, but three live-AWT tests only called `setBounds` (never `addNotify()`).
- Fix is **test-only**: call `addNotify()` so frames under test match the production contract (same pattern already used by the disposed-frame and duplicate-title tests). Also aligned `disabled native capture…` so it does not depend on check order.

## Loud-failure contract preserved

- No production changes.
- Native unavailability still fails without region capture.
- Disposed / non-displayable targets still fail with the displayable identity error.
- Duplicate-title behaviour unchanged.

## Test plan

- [x] `./gradlew :core:test --tests '*ScreenCaptureBackendTest*'` with live AWT on macOS — 15/15 pass
- [x] `./gradlew check` green locally
- [ ] GHA `check-windows` green on this PR (primary Windows proof; local Windows PC unreachable this session)
- [ ] Confirm the three named methods no longer appear in Windows failure output

Fixes #365