### PR TITLE
feat(agent): expose focusWindow over the attach wire (#364)

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -254,7 +254,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest NewInteractionsValidationTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -100,6 +100,7 @@ public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/Au
 	public final fun findByTestTag (Ljava/lang/String;)Ljava/util/List;
 	public final fun findByText (Ljava/lang/String;Z)Ljava/util/List;
 	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun focusWindow (Ljava/lang/String;)V
 	public final fun getPid ()J
 	public final fun longClick (Ljava/lang/String;J)V
 	public static synthetic fun longClick$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/String;JILjava/lang/Object;)V

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -17,8 +17,9 @@ import java.util.concurrent.atomic.AtomicBoolean
  * [AgentRequest.Detach] over the wire (Path A of the plan's D-7) before tearing down the underlying
  * socket. The target JVM's shutdown hook (Path B) covers crash cleanup.
  *
- * Current wire surface: windows, allNodes, findByTestTag, click, typeText, screenshot, capture,
- * windowIdentity, plus detach. Streaming/long-poll ops are deferred follow-ups (Q-3).
+ * Current wire surface: windows, allNodes, find*, click / input verbs, focusWindow, typeText,
+ * screenshot, capture, windowIdentity, waits, plus detach. Streaming/long-poll idling resources
+ * remain deferred follow-ups (Q-3).
  *
  * Not thread-safe. Callers needing concurrent automator access must serialise externally.
  *
@@ -177,6 +178,19 @@ internal constructor(
     @Throws(IOException::class)
     public fun pressKey(keyCode: Int, modifiers: Int = 0) {
         val resp = exchange(AgentRequest.PressKey(keyCode = keyCode, modifiers = modifiers))
+        if (resp !is AgentResponse.Ok) throw wireMismatch("Ok", resp)
+    }
+
+    /**
+     * Raise and request focus on the AWT window hosting [nodeKey] (#364).
+     *
+     * Mirrors in-process `ComposeAutomator.focusWindow`. Call this before [pressKey] / [typeText]
+     * when the target app may not own OS keyboard focus (common when the attach client is the
+     * foreground process).
+     */
+    @Throws(IOException::class)
+    public fun focusWindow(nodeKey: String) {
+        val resp = exchange(AgentRequest.FocusWindow(nodeKey))
         if (resp !is AgentResponse.Ok) throw wireMismatch("Ok", resp)
     }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/InputOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/InputOpsReflectiveMapper.kt
@@ -8,11 +8,15 @@ import dev.sebastiano.spectre.agent.transport.AgentResponse
 import java.lang.reflect.Method
 
 /**
- * Reflective bridge for richer input verbs (#203): doubleClick, longClick, swipe, scrollWheel,
- * pressKey. Kept out of [ReflectiveAutomatorHandler] for detekt size/complexity budgets.
+ * Reflective bridge for richer input verbs (#203 / #364): doubleClick, longClick, swipe,
+ * scrollWheel, pressKey, focusWindow. Kept out of [ReflectiveAutomatorHandler] for detekt
+ * size/complexity budgets.
  *
  * Kotlin mangles `Duration` parameters into primitive `long` carrying [Duration]'s packed
  * `rawValue` (not plain nanoseconds). Use [durationStorageFromMs] when invoking those methods.
+ *
+ * [handleFocusWindow] is non-suspend (core `focusWindow` is a plain method); other verbs use
+ * [BlockingSuspendInvoker].
  */
 internal class InputOpsReflectiveMapper(
     private val automator: Any,
@@ -80,6 +84,15 @@ internal class InputOpsReflectiveMapper(
                 it.parameterTypes[0] == intPrimitive &&
                 it.parameterTypes[1] == intPrimitive &&
                 it.parameterTypes[2].name == CONTINUATION_FQN
+        }
+
+    /**
+     * Non-suspend `focusWindow(node)`. JVM signature is a single node argument (no Continuation).
+     * Prefer exact arity so we never pick a future overload by accident.
+     */
+    private val focusWindowMethod: Method? =
+        automatorClass.methods.firstOrNull {
+            it.name == "focusWindow" && it.parameterTypes.size == 1
         }
 
     fun handleDoubleClick(nodeKey: String): AgentResponse =
@@ -230,6 +243,19 @@ internal class InputOpsReflectiveMapper(
         }
         refreshWindows()
         suspendInvoker.invoke(method, automator, request.keyCode, request.modifiers)
+        return AgentResponse.Ok
+    }
+
+    /**
+     * Raise/focus the AWT window that hosts [nodeKey] (#364). Non-suspend reflective invoke of
+     * `ComposeAutomator.focusWindow(node)`.
+     */
+    fun handleFocusWindow(nodeKey: String): AgentResponse {
+        val method = focusWindowMethod ?: return unsupported("focusWindow(node)")
+        val node = resolveNode(nodeKey) ?: return nodeNotFound(nodeKey)
+        // Core focusWindow dispatches toFront/requestFocus on the EDT itself; plain invoke is
+        // correct (no Continuation, no BlockingSuspendInvoker).
+        method.invoke(automator, node)
         return AgentResponse.Ok
     }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -146,6 +146,7 @@ internal class ReflectiveAutomatorHandler(
             is AgentRequest.Swipe -> inputOps.handleSwipe(request)
             is AgentRequest.ScrollWheel -> inputOps.handleScrollWheel(request)
             is AgentRequest.PressKey -> inputOps.handlePressKey(request)
+            is AgentRequest.FocusWindow -> inputOps.handleFocusWindow(request.nodeKey)
             is AgentRequest.TypeText -> handleTypeText(request.text)
             is AgentRequest.Screenshot -> handleScreenshot(request)
             is AgentRequest.Capture ->

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -115,6 +115,18 @@ internal sealed interface AgentRequest {
     data class PressKey(val keyCode: Int, val modifiers: Int = 0) : AgentRequest
 
     /**
+     * Raise and request focus on the AWT window hosting [nodeKey] (#364). Mirrors in-process
+     * `ComposeAutomator.focusWindow(node)`. Useful before real Robot keyboard input when the attach
+     * client JVM is foreground and the target app is not.
+     *
+     * Server replies with [AgentResponse.Ok] or [AgentResponse.Error] (`nodeNotFound` /
+     * `unsupportedOperation`).
+     */
+    @Serializable
+    @SerialName("focusWindow")
+    data class FocusWindow(val nodeKey: String) : AgentRequest
+
+    /**
      * Synthesize a sequence of key events that types [text] into whatever currently holds focus.
      * Server replies with [AgentResponse.Ok] or [AgentResponse.Error].
      */
@@ -231,6 +243,7 @@ internal val AgentRequest.logLabel: String
             is AgentRequest.Swipe -> "swipe"
             is AgentRequest.ScrollWheel -> "scrollWheel"
             is AgentRequest.PressKey -> "pressKey"
+            is AgentRequest.FocusWindow -> "focusWindow"
             is AgentRequest.TypeText -> "typeText"
             is AgentRequest.Screenshot -> "screenshot"
             is AgentRequest.Capture -> "capture"

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -178,6 +178,10 @@ class AgentAttachIntegrationTest {
             // mask identity regressions (identity does not need keyboard focus).
             assertWindowIdentityMatchesWindows(automator, windows, iteration = iteration)
 
+            // #364: raise/activate the fixture window via the attach wire before Robot input.
+            // Bare-throws on any wire/handler failure so a missing FocusWindow op fails loudly.
+            automator.focusWindow(buttonKey)
+
             // Click bare-throws on failure (no runCatching) so a broken suspend bridge or a
             // wire-level error fails the test loudly.
             automator.click(buttonKey)
@@ -383,8 +387,10 @@ class AgentAttachIntegrationTest {
         val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(FOCUS_TIMEOUT_MS)
         var lastMatches: List<NodeSnapshotDto> = emptyList()
         while (System.nanoTime() < deadline) {
-            // On macOS the first click may only activate the fixture app; retry until a refreshed
-            // semantics snapshot proves the field itself owns Compose focus.
+            // #364: raise/activate the fixture window first, then click the field. On macOS the
+            // first click may only activate the app; focusWindow makes that activation expressible
+            // over attach (the remediation pressKey/typeText error text already asks for).
+            focusWindow(textFieldKey)
             click(textFieldKey)
             lastMatches = findByTestTag(TAG_TEXT_FIELD)
             lastMatches

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
@@ -351,6 +351,10 @@ class AgentContractCorpusTest {
             automator.pressKey(keyCode, modifiers)
         }
 
+        override fun focusWindow(nodeKey: String) {
+            automator.focusWindow(nodeKey)
+        }
+
         override fun screenshotProbe(): ScreenshotProbe {
             val bytes = automator.screenshot()
             return ScreenshotProbe(byteCount = bytes.size, formatHint = "png")

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
@@ -651,6 +651,31 @@ class ReflectiveAutomatorHandlerMappingTest {
     }
 
     @Test
+    fun `FocusWindow dispatches to the matching node`() {
+        val fake =
+            FakeSuspendCapableAutomator(allNodesValue = listOf(FakeAutomatorNode(keyValue = "btn")))
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        assertEquals(AgentResponse.Ok, handler.handle(AgentRequest.FocusWindow("btn")))
+        assertEquals(listOf("btn"), fake.focusedWindowKeys)
+    }
+
+    @Test
+    fun `FocusWindow returns nodeNotFound for unknown key`() {
+        val fake = FakeSuspendCapableAutomator()
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response = handler.handle(AgentRequest.FocusWindow("missing"))
+        check(response is AgentResponse.Error)
+        assertEquals(
+            dev.sebastiano.spectre.agent.transport.AgentErrorCategory.NodeNotFound.wireName,
+            response.category,
+        )
+        assertTrue(response.message.contains("missing"))
+        assertEquals(emptyList(), fake.focusedWindowKeys)
+    }
+
+    @Test
     fun `PressKey refuses when target JVM lacks OS focus`() {
         val fake = FakeSuspendCapableAutomator()
         val handler = ReflectiveAutomatorHandler(fake, isTargetJvmFocused = { false })
@@ -913,6 +938,7 @@ private class FakeSuspendCapableAutomator(private val allNodesValue: List<Any> =
     val scrollWheels = mutableListOf<Pair<String, Int>>()
     val nodeSwipes = mutableListOf<Pair<String, String>>()
     val pressKeys = mutableListOf<Pair<Int, Int>>()
+    val focusedWindowKeys = mutableListOf<String>()
 
     @Suppress("unused") fun refreshWindows() = Unit
 
@@ -926,6 +952,12 @@ private class FakeSuspendCapableAutomator(private val allNodesValue: List<Any> =
     // `Object click(Object node, kotlin.coroutines.Continuation<? super Unit>)`.
     @Suppress("unused", "UNUSED_PARAMETER")
     fun click(node: Any, continuation: kotlin.coroutines.Continuation<Any?>): Any? = Unit
+
+    // Non-suspend, matching ComposeAutomator.focusWindow(node).
+    @Suppress("unused")
+    fun focusWindow(node: Any) {
+        focusedWindowKeys += nodeKey(node)
+    }
 
     @Suppress("unused", "UNUSED_PARAMETER")
     fun doubleClick(node: Any, continuation: kotlin.coroutines.Continuation<Any?>): Any? {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/InputParityTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/InputParityTest.kt
@@ -12,7 +12,10 @@ import kotlin.test.assertIs
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 
-/** #203: doubleClick / longClick / swipe / scrollWheel / pressKey over agent IPC. */
+/**
+ * #203 / #364: doubleClick / longClick / swipe / scrollWheel / pressKey / focusWindow over agent
+ * IPC.
+ */
 @EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
 class InputParityTest {
     private val udsPath: Path =
@@ -24,7 +27,7 @@ class InputParityTest {
     }
 
     @Test
-    fun `doubleClick longClick scrollWheel pressKey round-trip`() {
+    fun `doubleClick longClick scrollWheel pressKey focusWindow round-trip`() {
         val seen = mutableListOf<String>()
         IpcServer(
                 udsPath,
@@ -46,6 +49,10 @@ class InputParityTest {
                             seen += "pressKey:${req.keyCode}:${req.modifiers}"
                             AgentResponse.Ok
                         }
+                        is AgentRequest.FocusWindow -> {
+                            seen += "focusWindow:${req.nodeKey}"
+                            AgentResponse.Ok
+                        }
                         else -> AgentResponse.Error("unexpected $req")
                     }
                 },
@@ -63,10 +70,19 @@ class InputParityTest {
                     assertIs<AgentResponse.Ok>(
                         client.send(AgentRequest.PressKey(keyCode = 10, modifiers = 128))
                     )
+                    assertIs<AgentResponse.Ok>(
+                        client.send(AgentRequest.FocusWindow(nodeKey = "k1"))
+                    )
                 }
             }
         assertEquals(
-            listOf("doubleClick:k1", "longClick:k1:600", "scrollWheel:k1:3", "pressKey:10:128"),
+            listOf(
+                "doubleClick:k1",
+                "longClick:k1:600",
+                "scrollWheel:k1:3",
+                "pressKey:10:128",
+                "focusWindow:k1",
+            ),
             seen,
         )
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -480,6 +480,7 @@ class IpcRoundTripTest {
             is AgentRequest.Swipe,
             is AgentRequest.ScrollWheel,
             is AgentRequest.PressKey,
+            is AgentRequest.FocusWindow,
             is AgentRequest.TypeText,
             is AgentRequest.Cancel,
             is AgentRequest.WaitForVisualIdle -> AgentResponse.Ok

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
@@ -43,6 +43,14 @@ class WireCodecTest {
     }
 
     @Test
+    fun `FocusWindow round-trips and logLabel redacts nodeKey`() {
+        val req = AgentRequest.FocusWindow(nodeKey = "surface-0:1:42")
+        assertEquals(req, WireCodec.decodeRequest(WireCodec.encode(req)))
+        assertEquals("focusWindow", req.logLabel)
+        assertFalse(req.logLabel.contains(req.nodeKey))
+    }
+
+    @Test
     fun `TypeText round-trips with unicode payload`() {
         val req = AgentRequest.TypeText(text = "hello 🦀 world café")
         assertEquals(req, WireCodec.decodeRequest(WireCodec.encode(req)))

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -289,6 +289,7 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 | `swipe(...)`          | `AgentRequest.Swipe`             | `Unit` (node-to-node or screen coords) |
 | `scrollWheel(nodeKey, wheelClicks)` | `AgentRequest.ScrollWheel` | `Unit`       |
 | `pressKey(keyCode, modifiers?)` | `AgentRequest.PressKey`  | `Unit`            |
+| `focusWindow(nodeKey)` | `AgentRequest.FocusWindow` | `Unit` (raise/activate window hosting node) |
 | `typeText(text)`      | `AgentRequest.TypeText`          | `Unit`            |
 | `screenshot(windowIndex?, surfaceId?, fullscreen?)` | `AgentRequest.Screenshot` | `ByteArray` (PNG); default window index 0, not full desktop |
 | `capture(windowIndex)`| `AgentRequest.Capture`           | `AtomicCaptureResult` |
@@ -307,8 +308,10 @@ transport.
 
 `waitForNode` and `waitForVisualIdle` are available over the agent transport (#201).
 Richer input verbs (`doubleClick` / `longClick` / `swipe` / `scrollWheel` / `pressKey`)
-are available over agent, HTTP, and daemon/CLI/MCP (#203). Streaming / long-poll idling
-resources and `withTracing` remain deferred to a follow-up.
+are available over agent, HTTP, and daemon/CLI/MCP (#203). `focusWindow(nodeKey)` raises
+and focuses the AWT window hosting a node over attach (#364) — use it before `pressKey` /
+`typeText` when the attach client is the foreground process and the target app is not.
+Streaming / long-poll idling resources and `withTracing` remain deferred to a follow-up.
 
 ## Wire format
 

--- a/docs/guide/capability-matrix.md
+++ b/docs/guide/capability-matrix.md
@@ -77,8 +77,10 @@ verbs** (`doubleClick` / `swipe` / `scrollWheel` — #203) are **Supported** on 
 Xvfb and macOS desktop via `AgentContractCorpusTest` against `agent-test-fixture`. Agent
 `pressKey` is **Supported** on Linux Xvfb (fail-closed after focus retries) and
 **Experimental** on macOS desktop (hosted runners may soft-skip OS keyboard focus loss after
-retries — same class as `typeText`). HTTP selector entry points are covered by headless
-`HttpContractCorpusTest`. Some HTTP input/wait cells and agent `longClick` /
+retries — same class as `typeText`). Agent **`focusWindow`** (#364) is **Supported** on Linux
+Xvfb and macOS desktop (raises the window hosting a node before real keyboard input); HTTP
+`focusWindow` is **Unsupported by design** for this issue. HTTP selector entry points are covered
+by headless `HttpContractCorpusTest`. Some HTTP input/wait cells and agent `longClick` /
 `waitForVisualIdle` remain **Not yet CI-executed**.
 
 ## How to read a cell

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -183,7 +183,9 @@ All `suspend` on `ComposeAutomator`:
   no scrolling), so it can't fully replace OS input for most tests. For
   parallel-JVM focus contention, prefer `RobotDriver.synthetic(rootWindow)`
   — especially as soon as the test also types text.
-- `focusWindow(node)` — raises and focuses the window hosting `node`.
+- `focusWindow(node)` — raises and focuses the window hosting `node`. Over attach,
+  use `AttachedAutomator.focusWindow(nodeKey)` (#364) before `pressKey` / `typeText`
+  when the target app may not own OS keyboard focus.
 
 ## Synchronization — the part everyone gets wrong
 

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -131,6 +131,7 @@ public abstract interface class dev/sebastiano/spectre/testing/contract/Automato
 	public abstract fun findByTestTag (Ljava/lang/String;)Ljava/util/List;
 	public fun findByText (Ljava/lang/String;Z)Ljava/util/List;
 	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
+	public fun focusWindow (Ljava/lang/String;)V
 	public fun getExpectsFixtureSemantics ()Z
 	public fun getSupportsExtendedParity ()Z
 	public fun getSupportsFixtureParity ()Z
@@ -154,6 +155,7 @@ public final class dev/sebastiano/spectre/testing/contract/AutomatorContractDriv
 	public static fun findByRole (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;)Ljava/util/List;
 	public static fun findByText (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Z)Ljava/util/List;
 	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
+	public static fun focusWindow (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;)V
 	public static fun getExpectsFixtureSemantics (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
 	public static fun getSupportsExtendedParity (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
 	public static fun getSupportsFixtureParity (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
@@ -176,6 +178,7 @@ public final class dev/sebastiano/spectre/testing/contract/AutomatorOperation : 
 	public static final field FindByRole Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field FindByTestTag Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field FindByText Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
+	public static final field FocusWindow Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field LongClick Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field PressKey Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field RegisterIdlingResource Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
@@ -80,6 +80,11 @@ public interface AutomatorContractDriver : AutoCloseable {
         error("pressKey not implemented for $transport")
     }
 
+    /** Optional window activation (#364). Default: unsupported. */
+    public fun focusWindow(nodeKey: String) {
+        error("focusWindow not implemented for $transport")
+    }
+
     /**
      * Optional wait (#201). Should throw on timeout when waiting for a never-present selector.
      * Returns the matched node key on success.
@@ -371,6 +376,15 @@ public object AutomatorContractCorpus {
                     )
                 check(key.isNotBlank()) { "waitForNode returned blank key" }
                 "key=$key"
+            }
+        // #364: raise the window hosting a known node before further Robot input.
+        out +=
+            scenario("focus-window-fixture-button", driver.transport) {
+                val button =
+                    driver.findByTestTag(ContractFixtureTags.BUTTON).firstOrNull()
+                        ?: error("fixture button missing")
+                driver.focusWindow(button.key)
+                "focused-window-for=${button.key}"
             }
         // #203 input verbs (real Robot on fixture) — no soft-skip: failures fail the scenario.
         out +=

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
@@ -508,73 +508,12 @@ public object CapabilityMatrix {
                         "Not Supported until fail-closed without skip.",
             )
         )
-        // #364 focusWindow: attach clients can raise the target window before keyboard input.
-        // Evidence: AgentContractCorpus focus-window scenario + AgentAttachIntegrationTest.
-        add(
-            CapabilityCell(
-                operation = AutomatorOperation.FocusWindow,
-                transport = AutomatorTransport.Agent,
-                platform = PlatformPrerequisite.LinuxXvfb,
-                state = CellState.Supported,
-                evidence = listOf(agentLinuxXvfb, agentAttachLegacyLinux),
-            )
-        )
-        add(
-            CapabilityCell(
-                operation = AutomatorOperation.FocusWindow,
-                transport = AutomatorTransport.Agent,
-                platform = PlatformPrerequisite.MacOsDesktop,
-                state = CellState.Supported,
-                evidence = listOf(agentMacOs, agentAttachLegacyMacOs),
-            )
-        )
-        // In-process focusWindow needs a live AWT window (toFront/requestFocus) — not AnyJvm.
-        // Public-surface name checks are not executable evidence of display-backed raise/focus.
-        add(
-            CapabilityCell(
-                operation = AutomatorOperation.FocusWindow,
-                transport = AutomatorTransport.InProcess,
-                platform = PlatformPrerequisite.LinuxXvfb,
-                state = CellState.Supported,
-                evidence =
-                    listOf(
-                        CapabilityEvidence(
-                            id = "in-process-focus-window-validation-linux",
-                            description =
-                                "sample-desktop NewInteractionsValidationTest exercises " +
-                                    "ComposeAutomator.focusWindow under Xvfb (fail-closed class " +
-                                    "list in validation-linux.yml)",
-                            sourcePath =
-                                "sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/" +
-                                    "sample/validation/NewInteractionsValidationTest.kt",
-                            workflowPath = ".github/workflows/validation-linux.yml",
-                            gradleTaskHint =
-                                "./gradlew :sample-desktop:validationTest --tests " +
-                                    "\"*NewInteractionsValidationTest*\"",
-                        )
-                    ),
-            )
-        )
-        add(
-            CapabilityCell(
-                operation = AutomatorOperation.FocusWindow,
-                transport = AutomatorTransport.InProcess,
-                platform = PlatformPrerequisite.MacOsDesktop,
-                state = CellState.NotYetCiExecuted,
-                rationale =
-                    "In-process focusWindow is display-backed; no fail-closed macOS " +
-                        "sample-desktop validation workflow claims it yet (Linux Xvfb is Supported).",
-            )
-        )
-        add(
-            CapabilityCell(
-                operation = AutomatorOperation.FocusWindow,
-                transport = AutomatorTransport.Http,
-                platform = PlatformPrerequisite.AnyJvm,
-                state = CellState.UnsupportedByDesign,
-                rationale =
-                    "HTTP focusWindow is out of scope for #364 (AttachedAutomator wire only). " +
-                        "Callers needing remote activation over HTTP can file a follow-up.",
+        addAll(
+            focusWindowCapabilityCells(
+                agentLinuxXvfb = agentLinuxXvfb,
+                agentMacOs = agentMacOs,
+                agentAttachLegacyLinux = agentAttachLegacyLinux,
+                agentAttachLegacyMacOs = agentAttachLegacyMacOs,
             )
         )
         // HTTP selector routes exist; headless HttpContractCorpusTest only proves entry points

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
@@ -508,6 +508,54 @@ public object CapabilityMatrix {
                         "Not Supported until fail-closed without skip.",
             )
         )
+        // #364 focusWindow: attach clients can raise the target window before keyboard input.
+        // Evidence: AgentContractCorpus focus-window scenario + AgentAttachIntegrationTest.
+        add(
+            CapabilityCell(
+                operation = AutomatorOperation.FocusWindow,
+                transport = AutomatorTransport.Agent,
+                platform = PlatformPrerequisite.LinuxXvfb,
+                state = CellState.Supported,
+                evidence = listOf(agentLinuxXvfb, agentAttachLegacyLinux),
+            )
+        )
+        add(
+            CapabilityCell(
+                operation = AutomatorOperation.FocusWindow,
+                transport = AutomatorTransport.Agent,
+                platform = PlatformPrerequisite.MacOsDesktop,
+                state = CellState.Supported,
+                evidence = listOf(agentMacOs, agentAttachLegacyMacOs),
+            )
+        )
+        add(
+            CapabilityCell(
+                operation = AutomatorOperation.FocusWindow,
+                transport = AutomatorTransport.InProcess,
+                platform = PlatformPrerequisite.AnyJvm,
+                state = CellState.Supported,
+                evidence =
+                    listOf(
+                        coreEvidence(
+                            "core-focus-window-public-surface",
+                            "ComposeAutomatorPublicSurfaceTest.kt",
+                            "Public surface includes focusWindow; live smoke in " +
+                                "sample-desktop NewInteractionsValidationTest",
+                        )
+                    ),
+            )
+        )
+        add(
+            CapabilityCell(
+                operation = AutomatorOperation.FocusWindow,
+                transport = AutomatorTransport.Http,
+                platform = PlatformPrerequisite.AnyJvm,
+                state = CellState.UnsupportedByDesign,
+                rationale =
+                    "HTTP focusWindow is out of scope for #364 (AttachedAutomator wire only). " +
+                        "Callers needing remote activation over HTTP can file a follow-up.",
+            )
+        )
         // HTTP selector routes exist; headless HttpContractCorpusTest only proves entry points
         // with empty trees (expectsFixtureSemantics=false), not fixture-backed matches.
         for (op in

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
@@ -528,21 +528,42 @@ public object CapabilityMatrix {
                 evidence = listOf(agentMacOs, agentAttachLegacyMacOs),
             )
         )
+        // In-process focusWindow needs a live AWT window (toFront/requestFocus) — not AnyJvm.
+        // Public-surface name checks are not executable evidence of display-backed raise/focus.
         add(
             CapabilityCell(
                 operation = AutomatorOperation.FocusWindow,
                 transport = AutomatorTransport.InProcess,
-                platform = PlatformPrerequisite.AnyJvm,
+                platform = PlatformPrerequisite.LinuxXvfb,
                 state = CellState.Supported,
                 evidence =
                     listOf(
-                        coreEvidence(
-                            "core-focus-window-public-surface",
-                            "ComposeAutomatorPublicSurfaceTest.kt",
-                            "Public surface includes focusWindow; live smoke in " +
-                                "sample-desktop NewInteractionsValidationTest",
+                        CapabilityEvidence(
+                            id = "in-process-focus-window-validation-linux",
+                            description =
+                                "sample-desktop NewInteractionsValidationTest exercises " +
+                                    "ComposeAutomator.focusWindow under Xvfb (fail-closed class " +
+                                    "list in validation-linux.yml)",
+                            sourcePath =
+                                "sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/" +
+                                    "sample/validation/NewInteractionsValidationTest.kt",
+                            workflowPath = ".github/workflows/validation-linux.yml",
+                            gradleTaskHint =
+                                "./gradlew :sample-desktop:validationTest --tests " +
+                                    "\"*NewInteractionsValidationTest*\"",
                         )
                     ),
+            )
+        )
+        add(
+            CapabilityCell(
+                operation = AutomatorOperation.FocusWindow,
+                transport = AutomatorTransport.InProcess,
+                platform = PlatformPrerequisite.MacOsDesktop,
+                state = CellState.NotYetCiExecuted,
+                rationale =
+                    "In-process focusWindow is display-backed; no fail-closed macOS " +
+                        "sample-desktop validation workflow claims it yet (Linux Xvfb is Supported).",
             )
         )
         add(

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrixModels.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrixModels.kt
@@ -63,6 +63,8 @@ public enum class AutomatorOperation {
     Swipe,
     ScrollWheel,
     PressKey,
+    /** Raise/focus the AWT window hosting a node (#364). */
+    FocusWindow,
     FindByText,
     FindByContentDescription,
     FindByRole,

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/FocusWindowCapabilityCells.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/FocusWindowCapabilityCells.kt
@@ -1,0 +1,75 @@
+package dev.sebastiano.spectre.testing.contract
+
+/**
+ * Capability-matrix cells for [AutomatorOperation.FocusWindow] (#364).
+ *
+ * Kept out of [CapabilityMatrix]'s main object body so Detekt's LargeClass budget stays honest —
+ * focus-window rows are a self-contained op family (agent wire, in-process validation, HTTP
+ * exclusion).
+ */
+internal fun focusWindowCapabilityCells(
+    agentLinuxXvfb: CapabilityEvidence,
+    agentMacOs: CapabilityEvidence,
+    agentAttachLegacyLinux: CapabilityEvidence,
+    agentAttachLegacyMacOs: CapabilityEvidence,
+): List<CapabilityCell> {
+    val inProcessLinux =
+        CapabilityEvidence(
+            id = "in-process-focus-window-validation-linux",
+            description =
+                "sample-desktop NewInteractionsValidationTest exercises " +
+                    "ComposeAutomator.focusWindow under Xvfb (fail-closed class " +
+                    "list in validation-linux.yml)",
+            sourcePath =
+                "sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/" +
+                    "sample/validation/NewInteractionsValidationTest.kt",
+            workflowPath = ".github/workflows/validation-linux.yml",
+            gradleTaskHint =
+                "./gradlew :sample-desktop:validationTest --tests " +
+                    "\"*NewInteractionsValidationTest*\"",
+        )
+    return listOf(
+        // Attach clients can raise the target window before keyboard input.
+        // Evidence: AgentContractCorpus focus-window scenario + AgentAttachIntegrationTest.
+        CapabilityCell(
+            operation = AutomatorOperation.FocusWindow,
+            transport = AutomatorTransport.Agent,
+            platform = PlatformPrerequisite.LinuxXvfb,
+            state = CellState.Supported,
+            evidence = listOf(agentLinuxXvfb, agentAttachLegacyLinux),
+        ),
+        CapabilityCell(
+            operation = AutomatorOperation.FocusWindow,
+            transport = AutomatorTransport.Agent,
+            platform = PlatformPrerequisite.MacOsDesktop,
+            state = CellState.Supported,
+            evidence = listOf(agentMacOs, agentAttachLegacyMacOs),
+        ),
+        // In-process focusWindow needs a live AWT window (toFront/requestFocus) — not AnyJvm.
+        CapabilityCell(
+            operation = AutomatorOperation.FocusWindow,
+            transport = AutomatorTransport.InProcess,
+            platform = PlatformPrerequisite.LinuxXvfb,
+            state = CellState.Supported,
+            evidence = listOf(inProcessLinux),
+        ),
+        CapabilityCell(
+            operation = AutomatorOperation.FocusWindow,
+            transport = AutomatorTransport.InProcess,
+            platform = PlatformPrerequisite.MacOsDesktop,
+            state = CellState.NotYetCiExecuted,
+            rationale =
+                "In-process focusWindow is display-backed; no fail-closed macOS " +
+                    "sample-desktop validation workflow claims it yet (Linux Xvfb is Supported).",
+        ),
+        CapabilityCell(
+            operation = AutomatorOperation.FocusWindow,
+            transport = AutomatorTransport.Http,
+            platform = PlatformPrerequisite.AnyJvm,
+            state = CellState.UnsupportedByDesign,
+            rationale =
+                "HTTP focusWindow is out of scope for #364 (AttachedAutomator wire only). " +
+                    "Callers needing remote activation over HTTP can file a follow-up.",
+        ),
+    )
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/PressKeyAfterFocus.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/PressKeyAfterFocus.kt
@@ -1,13 +1,15 @@
 package dev.sebastiano.spectre.testing.contract
 
 /**
- * Click [fieldKey] then [AutomatorContractDriver.pressKey], retrying when the target JVM has not
- * yet acquired OS keyboard focus.
+ * Activate the window hosting [fieldKey] ([AutomatorContractDriver.focusWindow], #364), click the
+ * field, then [AutomatorContractDriver.pressKey], retrying when the target JVM has not yet acquired
+ * OS keyboard focus.
  *
  * On macOS under JBR, a single Robot click can leave Compose focus updated while OS keyboard focus
  * is still settling (or briefly lost to the attacher JVM). The agent refuses `pressKey` in that
- * window with an `inputRejected` / "OS keyboard focus" error. Re-click + short backoff makes the
- * matrix cell durable without soft-skipping the keyboard path.
+ * window with an `inputRejected` / "OS keyboard focus" error. Raising the window via focusWindow,
+ * re-click, and short backoff makes the matrix cell durable without soft-skipping the keyboard
+ * path.
  */
 public object PressKeyAfterFocus {
     /** Substring present in agent focus-rejection messages (typeText and pressKey). */
@@ -32,6 +34,8 @@ public object PressKeyAfterFocus {
         require(maxAttempts > 0) { "maxAttempts must be positive" }
         var lastError: Throwable? = null
         repeat(maxAttempts) { attempt ->
+            // #364: expressible remediation for the pressKey focus-rejection error text.
+            driver.focusWindow(fieldKey)
             driver.click(fieldKey)
             sleeper(sleepMs(attempt))
             try {

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/PressKeyAfterFocusTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/PressKeyAfterFocusTest.kt
@@ -21,6 +21,7 @@ class PressKeyAfterFocusTest {
                 sleeper = { sleeps.add(it) },
             )
         assertTrue(detail.contains("attempts=4"), detail)
+        assertEquals(4, driver.focusWindowCount)
         assertEquals(4, driver.clickCount)
         assertEquals(4, driver.pressKeyCount)
         assertEquals(listOf(50L, 100L, 150L, 200L), sleeps)
@@ -37,6 +38,7 @@ class PressKeyAfterFocusTest {
                 sleeper = {},
             )
         assertTrue(detail.contains("attempts=1"), detail)
+        assertEquals(1, driver.focusWindowCount)
         assertEquals(1, driver.clickCount)
         assertEquals(1, driver.pressKeyCount)
     }
@@ -65,6 +67,7 @@ class PressKeyAfterFocusTest {
                 ex.message,
             )
         }
+        assertEquals(3, driver.focusWindowCount)
         assertEquals(3, driver.clickCount)
         assertEquals(3, driver.pressKeyCount)
     }
@@ -87,6 +90,7 @@ class PressKeyAfterFocusTest {
                 )
             }
         assertEquals("boom-not-focus", ex.message)
+        assertEquals(1, driver.focusWindowCount)
         assertEquals(1, driver.clickCount)
     }
 
@@ -108,6 +112,7 @@ class PressKeyAfterFocusTest {
     private open class RecordingDriver(private val failFocusTimes: Int) : AutomatorContractDriver {
         var clickCount: Int = 0
         var pressKeyCount: Int = 0
+        var focusWindowCount: Int = 0
         private var focusFailuresRemaining: Int = failFocusTimes
 
         override val transport: AutomatorTransport = AutomatorTransport.Agent
@@ -120,6 +125,10 @@ class PressKeyAfterFocusTest {
 
         override fun click(nodeKey: String) {
             clickCount++
+        }
+
+        override fun focusWindow(nodeKey: String) {
+            focusWindowCount++
         }
 
         override fun typeText(text: String) = Unit


### PR DESCRIPTION
## Summary

- Exposes `ComposeAutomator.focusWindow` over the agent attach wire so cross-JVM clients can raise/activate the target window before real OS keyboard input.
- New `AgentRequest.FocusWindow(nodeKey)` → reflective non-suspend dispatch → `AttachedAutomator.focusWindow(nodeKey)`.
- Capability matrix + contract corpus scenario `focus-window-fixture-button`; `PressKeyAfterFocus` now calls `focusWindow` before click/pressKey retries (the remediation the pressKey error text already asked for).
- Attach e2e exercises `focusWindow` on the real fixture before input.

## Out of scope (follow-ups)

- CLI / daemon / MCP surface (planned as sub-issue 2)
- HTTP `/focusWindow`
- Window-index-only variant

## Test plan

- [x] `./gradlew check` (ktfmt, detekt, tests, ABI)
- [x] `:agent` unit/IPC: WireCodec, InputParity, ReflectiveAutomatorHandlerMapping
- [x] `AgentAttachIntegrationTest` + `AgentContractCorpusTest` (local macOS)
- [ ] CI green on PR
- [ ] Bugbot + Codex clean

Closes #364 (agent attach path; CLI may land in a follow-up PR)