### PR TITLE
fix(core,agent): keep windows() in agreement with allNodes() (#362)

### DIFF
--- a/agent-test-fixture/src/main/kotlin/dev/sebastiano/spectre/agent/fixture/ComposeFixtureMain.kt
+++ b/agent-test-fixture/src/main/kotlin/dev/sebastiano/spectre/agent/fixture/ComposeFixtureMain.kt
@@ -66,6 +66,15 @@ fun main() {
     // agent attaches — matches the realistic case where the target app uses Spectre directly.
     val automatorClassName = dev.sebastiano.spectre.core.ComposeAutomator::class.java.name
 
+    // Optional chrome modes for attach parity regressions (#362):
+    // - SPECTRE_FIXTURE_UNDECORATED=true → undecorated JFrame (custom-chrome-like host)
+    // - SPECTRE_FIXTURE_DELAYED_SHOW=true → pack/displayable first, compose, then show (onboarding-
+    //   style delayed visibility). WindowTracker must still list the surface once semantics exist.
+    val undecorated = System.getenv("SPECTRE_FIXTURE_UNDECORATED").toBoolean()
+    val delayedShow = System.getenv("SPECTRE_FIXTURE_DELAYED_SHOW").toBoolean()
+    System.err.println("[fixture] chrome undecorated=$undecorated delayedShow=$delayedShow")
+    System.err.flush()
+
     val panelRef = java.util.concurrent.atomic.AtomicReference<ComposePanel>()
     SwingUtilities.invokeAndWait {
         val frame =
@@ -77,6 +86,9 @@ fun main() {
                 // clicks land on Compose pixels and can take OS keyboard focus on Windows. See the
                 // `isAlwaysOnTop` rationale in this file's KDoc.
                 isAlwaysOnTop = true
+                if (undecorated) {
+                    isUndecorated = true
+                }
             }
 
         val composePanel =
@@ -110,10 +122,41 @@ fun main() {
             }
 
         frame.contentPane.add(composePanel)
-        frame.isVisible = true
-        frame.toFront()
-        frame.requestFocus()
+        if (delayedShow) {
+            // Make the peer displayable without showing — mirrors Jewel onboarding's
+            // visible=false first composition, then flip to visible.
+            frame.pack()
+            frame.isVisible = false
+        } else {
+            frame.isVisible = true
+            frame.toFront()
+            frame.requestFocus()
+        }
         panelRef.set(composePanel)
+    }
+
+    if (delayedShow) {
+        // Wait for semantics while still not showing, then show — attach may probe either phase.
+        val panel = panelRef.get()
+        val deadline = System.currentTimeMillis() + READY_POLL_TIMEOUT_MS
+        while (semanticsOwnerCountOnEdt(panel) == 0) {
+            check(System.currentTimeMillis() < deadline) {
+                "Compose semantics tree did not populate within ${READY_POLL_TIMEOUT_MS}ms " +
+                    "(delayed-show phase)"
+            }
+            Thread.sleep(READY_POLL_INTERVAL_MS)
+        }
+        SwingUtilities.invokeAndWait {
+            val frames = java.awt.Frame.getFrames()
+            for (frame in frames) {
+                if (frame.title == SPECTRE_FIXTURE_WINDOW_TITLE) {
+                    frame.isVisible = true
+                    frame.toFront()
+                    frame.requestFocus()
+                    break
+                }
+            }
+        }
     }
 
     // Race-free readiness signal: poll `ComposePanel.semanticsOwners` until it's non-empty.

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -525,14 +525,16 @@ public final class dev/sebastiano/spectre/agent/transport/WindowIdentityDto$Comp
 
 public final class dev/sebastiano/spectre/agent/transport/WindowSummaryDto {
 	public static final field Companion Ldev/sebastiano/spectre/agent/transport/WindowSummaryDto$Companion;
-	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLdev/sebastiano/spectre/agent/transport/RectDto;)V
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;ZLdev/sebastiano/spectre/agent/transport/RectDto;Z)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;ZLdev/sebastiano/spectre/agent/transport/RectDto;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
 	public final fun component5 ()Ldev/sebastiano/spectre/agent/transport/RectDto;
-	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLdev/sebastiano/spectre/agent/transport/RectDto;)Ldev/sebastiano/spectre/agent/transport/WindowSummaryDto;
-	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/transport/WindowSummaryDto;ILjava/lang/String;Ljava/lang/String;ZLdev/sebastiano/spectre/agent/transport/RectDto;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/WindowSummaryDto;
+	public final fun component6 ()Z
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;ZLdev/sebastiano/spectre/agent/transport/RectDto;Z)Ldev/sebastiano/spectre/agent/transport/WindowSummaryDto;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/transport/WindowSummaryDto;ILjava/lang/String;Ljava/lang/String;ZLdev/sebastiano/spectre/agent/transport/RectDto;ZILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/WindowSummaryDto;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBounds ()Ldev/sebastiano/spectre/agent/transport/RectDto;
 	public final fun getIndex ()I
@@ -540,6 +542,7 @@ public final class dev/sebastiano/spectre/agent/transport/WindowSummaryDto {
 	public final fun getTitle ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun isPopup ()Z
+	public final fun isShowing ()Z
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -90,8 +90,8 @@ public final class dev/sebastiano/spectre/agent/AttachUnsupportedException : dev
 
 public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/AutoCloseable {
 	public final fun allNodes ()Ljava/util/List;
-	public final fun capture (I)Ldev/sebastiano/spectre/agent/AtomicCaptureResult;
-	public static synthetic fun capture$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;IILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AtomicCaptureResult;
+	public final fun capture (Ljava/lang/Integer;)Ldev/sebastiano/spectre/agent/AtomicCaptureResult;
+	public static synthetic fun capture$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AtomicCaptureResult;
 	public final fun click (Ljava/lang/String;)V
 	public fun close ()V
 	public final fun doubleClick (Ljava/lang/String;)V

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -220,8 +220,19 @@ internal constructor(
      * artifacts to disk and keeping only the summary in agent context.
      */
     @Throws(IOException::class)
-    public fun capture(windowIndex: Int = 0): AtomicCaptureResult {
-        val resp = exchange(AgentRequest.Capture(windowIndex))
+    /**
+     * Atomic capture of one tracked window.
+     *
+     * When [windowIndex] is null (default), uses the first **showing** window from [windows] so
+     * delayed-show hosts listed for #362 agreement are not captured by accident. An explicit index
+     * is never remapped.
+     */
+    public fun capture(windowIndex: Int? = null): AtomicCaptureResult {
+        val resolvedIndex =
+            windowIndex
+                ?: windows().firstOrNull { it.isShowing }?.index
+                ?: error("No showing tracked window to capture")
+        val resp = exchange(AgentRequest.Capture(resolvedIndex))
         val capture = resp as? AgentResponse.Capture ?: throw wireMismatch("Capture", resp)
         return AtomicCaptureResult(
             windowIndex = capture.windowIndex,

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -257,7 +257,10 @@ internal object LaunchReadiness {
                 )
             }
             try {
-                if (automator.windows().isNotEmpty()) return
+                // #362: windows() may list displayable-but-not-yet-showing surfaces so it agrees
+                // with allNodes(). FIRST_WINDOW promises a visible window for Robot/screenshot —
+                // require isShowing (wire field; defaults true on older agents).
+                if (automator.windows().any { it.isShowing }) return
             } catch (ex: IOException) {
                 lastError = ex
             }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
@@ -29,23 +29,15 @@ internal object AtomicCaptureReflectiveMapper {
         val result =
             captureMethod.invoke(automator, windowIndex)
                 ?: return AgentResponse.Error("capture returned null")
-        return map(result, requestedWindowIndex = windowIndex)
+        return map(result, windowIndex)
     }
 
-    private fun map(result: Any, requestedWindowIndex: Int): AgentResponse {
+    private fun map(result: Any, windowIndex: Int): AgentResponse {
         val resultClass = result.javaClass
         val document =
             resultClass.getMethod("getDocument").invoke(result)
                 ?: return AgentResponse.Error("AtomicCapture.document was null")
         val documentClass = document.javaClass
-        // Prefer the index stored in the capture document — core may resolve default index 0 to
-        // the first showing surface when slot 0 is a delayed-show host (#362).
-        val resolvedWindowIndex =
-            runCatching {
-                    val window = documentClass.getMethod("getWindow").invoke(document)
-                    window?.javaClass?.getMethod("getIndex")?.invoke(window) as? Int
-                }
-                .getOrNull() ?: requestedWindowIndex
         val summary =
             documentClass.getMethod("getSummary").invoke(document)
                 ?: return AgentResponse.Error("CaptureDocument.summary was null")
@@ -65,7 +57,7 @@ internal object AtomicCaptureReflectiveMapper {
             )
         }
         return AgentResponse.Capture(
-            windowIndex = resolvedWindowIndex,
+            windowIndex = windowIndex,
             schemaVersion = documentClass.getMethod("getSchemaVersion").invoke(document) as Int,
             captureJsonUtf8 = captureJsonUtf8,
             pngBytes = pngBytes,

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
@@ -29,15 +29,23 @@ internal object AtomicCaptureReflectiveMapper {
         val result =
             captureMethod.invoke(automator, windowIndex)
                 ?: return AgentResponse.Error("capture returned null")
-        return map(result, windowIndex)
+        return map(result, requestedWindowIndex = windowIndex)
     }
 
-    private fun map(result: Any, windowIndex: Int): AgentResponse {
+    private fun map(result: Any, requestedWindowIndex: Int): AgentResponse {
         val resultClass = result.javaClass
         val document =
             resultClass.getMethod("getDocument").invoke(result)
                 ?: return AgentResponse.Error("AtomicCapture.document was null")
         val documentClass = document.javaClass
+        // Prefer the index stored in the capture document — core may resolve default index 0 to
+        // the first showing surface when slot 0 is a delayed-show host (#362).
+        val resolvedWindowIndex =
+            runCatching {
+                    val window = documentClass.getMethod("getWindow").invoke(document)
+                    window?.javaClass?.getMethod("getIndex")?.invoke(window) as? Int
+                }
+                .getOrNull() ?: requestedWindowIndex
         val summary =
             documentClass.getMethod("getSummary").invoke(document)
                 ?: return AgentResponse.Error("CaptureDocument.summary was null")
@@ -57,7 +65,7 @@ internal object AtomicCaptureReflectiveMapper {
             )
         }
         return AgentResponse.Capture(
-            windowIndex = windowIndex,
+            windowIndex = resolvedWindowIndex,
             schemaVersion = documentClass.getMethod("getSchemaVersion").invoke(document) as Int,
             captureJsonUtf8 = captureJsonUtf8,
             pngBytes = pngBytes,

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -172,7 +172,9 @@ internal class ReflectiveAutomatorHandler(
     private fun handleWindows(): AgentResponse {
         refreshWindowsMethod.invoke(automator)
         val windows = getWindowsMethod.invoke(automator) as List<*>
-        return AgentResponse.Windows(windows.mapIndexedNotNull(::mapTrackedWindow))
+        // Per-window resilience: a single bounds/title mapping failure must not drop the whole
+        // list or turn a successful discovery into an empty/error response (#362).
+        return AgentResponse.Windows(windows.mapIndexedNotNull(::mapTrackedWindowResilient))
     }
 
     private fun handleAllNodes(): AgentResponse {
@@ -406,18 +408,37 @@ internal class ReflectiveAutomatorHandler(
      * - `getSurfaceId()` for `val surfaceId: String`
      * - `isPopup()` for `val isPopup: Boolean` (Kotlin "is" prefix convention)
      * - `getComposeSurfaceBoundsOnScreen()` for `val composeSurfaceBoundsOnScreen: Rectangle`
-     * - `getWindow()` for `val window: java.awt.Window` — used to extract `title` (only meaningful
-     *   when the underlying window is a `java.awt.Frame`).
+     * - `getWindow()` / `getWindowTitle()` for title (Frame and Dialog; bare Window → null)
+     *
+     * Bounds and title failures fall back rather than nulling the entry — dropping a tracked
+     * surface from `windows()` while `allNodes()` still exposes `window:*` keys is the #362 bug.
      */
-    private fun mapTrackedWindow(index: Int, trackedWindow: Any?): WindowSummaryDto? {
+    private fun mapTrackedWindowResilient(index: Int, trackedWindow: Any?): WindowSummaryDto? {
         if (trackedWindow == null) return null
+        // Catch broad failures so one bad surface cannot empty the whole windows() list while
+        // allNodes() still exposes its keys (#362). Reflective invoke wraps target exceptions in
+        // InvocationTargetException; ClassCastException / IllegalStateException can surface too.
+        @Suppress("TooGenericExceptionCaught")
+        return try {
+            mapTrackedWindow(index, trackedWindow)
+        } catch (ex: Exception) {
+            System.err.println(
+                "[spectre-agent] mapTrackedWindow failed for index=$index: " +
+                    "${ex.javaClass.simpleName}: " +
+                    ((ex as? ReflectiveOperationException)?.targetMessage() ?: ex.message)
+            )
+            fallbackWindowSummary(index, trackedWindow)
+        }
+    }
+
+    private fun mapTrackedWindow(index: Int, trackedWindow: Any): WindowSummaryDto {
         val klass = trackedWindow.javaClass
         val surfaceId = klass.getMethod("getSurfaceId").invoke(trackedWindow) as String
         val isPopup = klass.getMethod("isPopup").invoke(trackedWindow) as Boolean
-        val bounds = klass.getMethod("getComposeSurfaceBoundsOnScreen").invoke(trackedWindow)
-        val window = klass.getMethod("getWindow").invoke(trackedWindow)
-        // Only Frame has getTitle(); Window does not. JFrame extends Frame.
-        val title = (window as? java.awt.Frame)?.title
+        val bounds =
+            runCatching { klass.getMethod("getComposeSurfaceBoundsOnScreen").invoke(trackedWindow) }
+                .getOrNull()
+        val title = extractWindowTitle(trackedWindow, klass)
         return WindowSummaryDto(
             index = index,
             surfaceId = surfaceId,
@@ -425,6 +446,50 @@ internal class ReflectiveAutomatorHandler(
             isPopup = isPopup,
             bounds = boundsToRect(bounds),
         )
+    }
+
+    private fun fallbackWindowSummary(index: Int, trackedWindow: Any): WindowSummaryDto? {
+        return try {
+            val klass = trackedWindow.javaClass
+            val surfaceId =
+                klass.getMethod("getSurfaceId").invoke(trackedWindow) as? String ?: return null
+            val isPopup =
+                runCatching { klass.getMethod("isPopup").invoke(trackedWindow) as Boolean }
+                    .getOrDefault(false)
+            WindowSummaryDto(
+                index = index,
+                surfaceId = surfaceId,
+                title = extractWindowTitle(trackedWindow, klass),
+                isPopup = isPopup,
+                bounds = RectDto(0, 0, 0, 0),
+            )
+        } catch (_: ReflectiveOperationException) {
+            null
+        }
+    }
+
+    /**
+     * Prefer `TrackedWindow.windowTitle` (Frame + Dialog). Fall back to Frame/Dialog casts on
+     * `getWindow()` for older core builds that lack the property.
+     */
+    private fun extractWindowTitle(trackedWindow: Any, klass: Class<*>): String? {
+        runCatching {
+                klass.methods
+                    .firstOrNull { it.name == "getWindowTitle" && it.parameterCount == 0 }
+                    ?.invoke(trackedWindow) as? String
+            }
+            .getOrNull()
+            ?.let {
+                return it
+            }
+        val window =
+            runCatching { klass.getMethod("getWindow").invoke(trackedWindow) }.getOrNull()
+                ?: return null
+        return when (window) {
+            is java.awt.Frame -> window.title
+            is java.awt.Dialog -> window.title
+            else -> null
+        }
     }
 
     private fun mapAutomatorNode(node: Any): NodeSnapshotDto {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -341,7 +341,7 @@ internal class ReflectiveAutomatorHandler(
         val target =
             resolveScreenshotTarget(
                     fullscreen = request.fullscreen,
-                    windowIndex = request.windowIndex,
+                    windowIndex = defaultScreenshotWindowIndex(request, windows),
                     surfaceId = request.surfaceId,
                     windows = windowSummaries,
                 )
@@ -372,27 +372,59 @@ internal class ReflectiveAutomatorHandler(
 
         val image =
             when (target) {
-                is ScreenshotTarget.Fullscreen -> {
+                is ScreenshotTarget.Fullscreen ->
                     // null region = full virtual desktop. Explicit opt-in only (#289).
                     regionScreenshotMethod.invoke(automator, null) as BufferedImage
-                }
-                is ScreenshotTarget.Window -> {
-                    // Capture bounds from the window list we just resolved against. Do not call
-                    // screenshot(windowIndex): that path refreshes windows again and can bind a
-                    // different surface at the same index after a popup open/close (#289 P2).
-                    val tracked =
-                        windows.getOrNull(target.windowIndex)
-                            ?: return AgentResponse.Error(
-                                "No tracked window at index ${target.windowIndex} (have ${windows.size})"
-                            )
-                    val bounds =
-                        tracked.javaClass
-                            .getMethod("getComposeSurfaceBoundsOnScreen")
-                            .invoke(tracked)
-                    regionScreenshotMethod.invoke(automator, bounds) as BufferedImage
-                }
+                is ScreenshotTarget.Window ->
+                    captureWindowScreenshot(windows, target, regionScreenshotMethod)
+                        ?: return AgentResponse.Error(
+                            message =
+                                "Tracked window at index ${target.windowIndex} is missing or " +
+                                    "not showing; wait until it is visible before screenshot",
+                            category =
+                                dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                                    .InvalidSelector
+                                    .wireName,
+                        )
             }
         return AgentResponse.Screenshot(imageToPng(image))
+    }
+
+    /**
+     * Default (no windowIndex/surfaceId): first showing surface so delayed-show hosts listed
+     * for #362 agreement are not the visual capture target.
+     */
+    private fun defaultScreenshotWindowIndex(
+        request: AgentRequest.Screenshot,
+        windows: List<*>,
+    ): Int? =
+        when {
+            request.fullscreen || request.surfaceId != null -> request.windowIndex
+            request.windowIndex != null -> request.windowIndex
+            else -> firstShowingWindowIndex(windows) ?: 0
+        }
+
+    private fun firstShowingWindowIndex(windows: List<*>): Int? =
+        windows
+            .mapIndexedNotNull { index, tracked ->
+                if (tracked != null && extractIsShowing(tracked, tracked.javaClass)) index else null
+            }
+            .firstOrNull()
+
+    /**
+     * Capture bounds from the window list we just resolved against. Do not call
+     * `screenshot(windowIndex)`: that path refreshes windows again and can bind a different surface
+     * at the same index after a popup open/close (#289 P2).
+     */
+    private fun captureWindowScreenshot(
+        windows: List<*>,
+        target: ScreenshotTarget.Window,
+        regionScreenshotMethod: Method,
+    ): BufferedImage? {
+        val tracked = windows.getOrNull(target.windowIndex) ?: return null
+        if (!extractIsShowing(tracked, tracked.javaClass)) return null
+        val bounds = tracked.javaClass.getMethod("getComposeSurfaceBoundsOnScreen").invoke(tracked)
+        return regionScreenshotMethod.invoke(automator, bounds) as BufferedImage
     }
 
     private fun imageToPng(image: BufferedImage): ByteArray {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -445,6 +445,7 @@ internal class ReflectiveAutomatorHandler(
             title = title,
             isPopup = isPopup,
             bounds = boundsToRect(bounds),
+            isShowing = extractIsShowing(trackedWindow, klass),
         )
     }
 
@@ -462,10 +463,24 @@ internal class ReflectiveAutomatorHandler(
                 title = extractWindowTitle(trackedWindow, klass),
                 isPopup = isPopup,
                 bounds = RectDto(0, 0, 0, 0),
+                isShowing = extractIsShowing(trackedWindow, klass),
             )
         } catch (_: ReflectiveOperationException) {
             null
         }
+    }
+
+    /** Reads AWT `Window.isShowing` via `TrackedWindow.getWindow()`. Defaults true if unknown. */
+    private fun extractIsShowing(trackedWindow: Any, klass: Class<*>): Boolean {
+        val window =
+            runCatching { klass.getMethod("getWindow").invoke(trackedWindow) }.getOrNull()
+                ?: return true
+        return runCatching {
+                window.javaClass.methods
+                    .firstOrNull { it.name == "isShowing" && it.parameterCount == 0 }
+                    ?.invoke(window) as? Boolean
+            }
+            .getOrNull() ?: true
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -373,6 +373,15 @@ public data class WindowSummaryDto(
     public val title: String?,
     public val isPopup: Boolean,
     public val bounds: RectDto,
+    /**
+     * Whether the AWT window is currently showing ([java.awt.Window.isShowing]).
+     *
+     * Tracked surfaces may be listed before show (displayable + semantics, delayed-show hosts
+     * from #362) so `windows()` stays in agreement with `allNodes()`. Launch readiness and
+     * Robot/screenshot callers should prefer [isShowing] == true. Defaults to `true` so older wire
+     * peers without the field still decode.
+     */
+    public val isShowing: Boolean = true,
 )
 
 /**

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -156,6 +156,10 @@ class AgentAttachIntegrationTest {
                     "fixture or the fixture didn't bring up its UI before READY.",
             )
 
+            // #362: surfaces that contribute nodes must appear in windows() — never empty windows
+            // while allNodes() returns window:* (or embedded:*) keys for a live surface.
+            assertWindowsAgreeWithAllNodes(automator, windows, iteration = iteration)
+
             val labelMatches = automator.findByTestTag(TAG_LABEL)
             assertTrue(
                 labelMatches.isNotEmpty(),
@@ -224,6 +228,45 @@ class AgentAttachIntegrationTest {
             Files.exists(udsPath),
             "iteration $iteration: UDS path $udsPath should not exist after detach",
         )
+    }
+
+    /**
+     * #362 acceptance: every surface id that appears in `allNodes()` keys must appear in
+     * `windows()`. Disagreement is the original attach bug (empty windows while nodes use
+     * `window:0:0:*` keys).
+     */
+    private fun assertWindowsAgreeWithAllNodes(
+        automator: AttachedAutomator,
+        windows: List<WindowSummaryDto>,
+        iteration: Int,
+    ) {
+        val nodes = automator.allNodes()
+        assertTrue(
+            nodes.isNotEmpty(),
+            "iteration $iteration: allNodes() empty; cannot check windows/allNodes agreement",
+        )
+        val windowSurfaceIds = windows.map { it.surfaceId }.toSet()
+        val nodeSurfaceIds =
+            nodes.map { node -> surfaceIdFromNodeKey(node.key) }.filter { it.isNotEmpty() }.toSet()
+        val missing = nodeSurfaceIds - windowSurfaceIds
+        assertTrue(
+            missing.isEmpty(),
+            "iteration $iteration: windows() missing surfaces that allNodes() reports: $missing " +
+                "(windows=$windowSurfaceIds nodeSurfaces=$nodeSurfaceIds). " +
+                "See #362 windows()/allNodes() agreement.",
+        )
+    }
+
+    /** Node keys are `surfaceId:ownerIndex:nodeId`; surfaceId itself may contain `:`. */
+    private fun surfaceIdFromNodeKey(key: String): String {
+        val parts = key.split(':')
+        // Need at least surfacePrefix:index:owner:node — surfaceId is everything but the last two
+        // colon-separated segments when those are integers (ownerIndex, nodeId).
+        if (parts.size < 3) return key
+        val owner = parts[parts.lastIndex - 1]
+        val nodeId = parts.last()
+        if (owner.toIntOrNull() == null || nodeId.toIntOrNull() == null) return key
+        return parts.dropLast(2).joinToString(":")
     }
 
     /**

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
@@ -836,7 +836,7 @@ private class FakeTrackedWindow(
     private val surfaceIdValue: String,
     private val isPopupValue: Boolean,
     private val composeSurfaceBoundsOnScreenValue: Rectangle,
-    private val windowValue: Frame?,
+    private val windowValue: java.awt.Window?,
 ) {
     @Suppress("unused") fun getSurfaceId(): String = surfaceIdValue
 
@@ -845,10 +845,8 @@ private class FakeTrackedWindow(
     @Suppress("unused")
     fun getComposeSurfaceBoundsOnScreen(): Rectangle = composeSurfaceBoundsOnScreenValue
 
-    // Returns `java.awt.Window?` typed in the real `TrackedWindow.getWindow()` — but Kotlin's
-    // reflection sees the declared static return type, so declaring `Frame?` here matches the
-    // handler's `(window as? Frame)?.title` shape (and lets the null branch resolve correctly).
-    @Suppress("unused") fun getWindow(): Frame? = windowValue
+    // Real TrackedWindow.getWindow() returns java.awt.Window; title is Frame or Dialog.
+    @Suppress("unused") fun getWindow(): java.awt.Window? = windowValue
 }
 
 @Suppress("LongParameterList")

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerWindowsAgreementTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerWindowsAgreementTest.kt
@@ -1,0 +1,147 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.transport.AgentRequest
+import dev.sebastiano.spectre.agent.transport.AgentResponse
+import java.awt.Dialog
+import java.awt.Frame
+import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
+
+/**
+ * #362 windows()/allNodes() agreement at the reflective mapping seam: Dialog titles, windowTitle
+ * property, and bounds failures must not drop tracked surfaces from the Windows wire response.
+ */
+class ReflectiveAutomatorHandlerWindowsAgreementTest {
+
+    @Test
+    fun `Windows op extracts title from Dialog and windowTitle property`() {
+        assumeFalse(
+            GraphicsEnvironment.isHeadless(),
+            "Dialog() requires a non-headless JVM; skipped on Linux CI.",
+        )
+        val dialog = Dialog(null as Frame?, "Dialog Title")
+        try {
+            val viaGetWindow =
+                AgreementFakeTrackedWindow(
+                    surfaceIdValue = "dialog-surface",
+                    isPopupValue = true,
+                    composeSurfaceBoundsOnScreenValue = Rectangle(1, 2, 3, 4),
+                    windowValue = dialog,
+                )
+            val viaWindowTitle =
+                AgreementFakeTrackedWindowWithTitle(
+                    surfaceIdValue = "titled-surface",
+                    isPopupValue = false,
+                    composeSurfaceBoundsOnScreenValue = Rectangle(5, 6, 7, 8),
+                    windowTitleValue = "From windowTitle",
+                )
+            val automator =
+                AgreementFakeAutomator(windowsValue = listOf(viaGetWindow, viaWindowTitle))
+            val handler = ReflectiveAutomatorHandler(automator)
+
+            val response = handler.handle(AgentRequest.Windows)
+            check(response is AgentResponse.Windows)
+            assertEquals(2, response.windows.size)
+            assertEquals("Dialog Title", response.windows[0].title)
+            assertEquals("dialog-surface", response.windows[0].surfaceId)
+            assertEquals("From windowTitle", response.windows[1].title)
+            assertEquals("titled-surface", response.windows[1].surfaceId)
+        } finally {
+            dialog.dispose()
+        }
+    }
+
+    @Test
+    fun `Windows op keeps surface when composeSurfaceBoundsOnScreen throws`() {
+        val trackedWindow =
+            AgreementFakeTrackedWindowThrowingBounds(
+                surfaceIdValue = "window:0",
+                isPopupValue = false,
+                windowTitleValue = "Still listed",
+            )
+        val automator = AgreementFakeAutomator(windowsValue = listOf(trackedWindow))
+        val handler = ReflectiveAutomatorHandler(automator)
+
+        val response = handler.handle(AgentRequest.Windows)
+        check(response is AgentResponse.Windows) {
+            "expected AgentResponse.Windows, got ${response::class.simpleName}: $response"
+        }
+        assertEquals(1, response.windows.size)
+        val dto = response.windows.single()
+        assertEquals("window:0", dto.surfaceId)
+        assertEquals("Still listed", dto.title)
+        assertEquals(false, dto.isPopup)
+        assertEquals(0, dto.bounds.width)
+        assertEquals(0, dto.bounds.height)
+        assertTrue(dto.surfaceId.startsWith("window:"))
+    }
+}
+
+private class AgreementFakeTrackedWindow(
+    private val surfaceIdValue: String,
+    private val isPopupValue: Boolean,
+    private val composeSurfaceBoundsOnScreenValue: Rectangle,
+    private val windowValue: java.awt.Window?,
+) {
+    @Suppress("unused") fun getSurfaceId(): String = surfaceIdValue
+
+    @Suppress("unused") fun isPopup(): Boolean = isPopupValue
+
+    @Suppress("unused")
+    fun getComposeSurfaceBoundsOnScreen(): Rectangle = composeSurfaceBoundsOnScreenValue
+
+    @Suppress("unused") fun getWindow(): java.awt.Window? = windowValue
+}
+
+private class AgreementFakeTrackedWindowWithTitle(
+    private val surfaceIdValue: String,
+    private val isPopupValue: Boolean,
+    private val composeSurfaceBoundsOnScreenValue: Rectangle,
+    private val windowTitleValue: String?,
+) {
+    @Suppress("unused") fun getSurfaceId(): String = surfaceIdValue
+
+    @Suppress("unused") fun isPopup(): Boolean = isPopupValue
+
+    @Suppress("unused")
+    fun getComposeSurfaceBoundsOnScreen(): Rectangle = composeSurfaceBoundsOnScreenValue
+
+    @Suppress("unused") fun getWindowTitle(): String? = windowTitleValue
+
+    @Suppress("unused", "FunctionOnlyReturningConstant") fun getWindow(): java.awt.Window? = null
+}
+
+private class AgreementFakeTrackedWindowThrowingBounds(
+    private val surfaceIdValue: String,
+    private val isPopupValue: Boolean,
+    private val windowTitleValue: String?,
+) {
+    @Suppress("unused") fun getSurfaceId(): String = surfaceIdValue
+
+    @Suppress("unused") fun isPopup(): Boolean = isPopupValue
+
+    @Suppress("unused")
+    fun getComposeSurfaceBoundsOnScreen(): Rectangle {
+        error("simulated locationOnScreen failure")
+    }
+
+    @Suppress("unused") fun getWindowTitle(): String? = windowTitleValue
+
+    @Suppress("unused", "FunctionOnlyReturningConstant") fun getWindow(): java.awt.Window? = null
+}
+
+private class AgreementFakeAutomator(private val windowsValue: List<Any>) {
+    @Suppress("unused") fun refreshWindows() = Unit
+
+    @Suppress("unused") fun getWindows(): List<Any> = windowsValue
+
+    @Suppress("unused") fun allNodes(): List<Any> = emptyList()
+
+    @Suppress("unused") fun findByTestTag(tag: String): List<Any> = emptyList()
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerWindowsAgreementTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerWindowsAgreementTest.kt
@@ -81,6 +81,48 @@ class ReflectiveAutomatorHandlerWindowsAgreementTest {
         assertEquals(0, dto.bounds.height)
         assertTrue(dto.surfaceId.startsWith("window:"))
     }
+
+    @Test
+    fun `Windows op reports isShowing from the AWT window`() {
+        assumeFalse(
+            GraphicsEnvironment.isHeadless(),
+            "Frame() requires a non-headless JVM; skipped on Linux CI.",
+        )
+        val frame = Frame("showing-probe")
+        try {
+            // Not shown yet — isShowing should be false after peer creation via pack().
+            frame.pack()
+            assertEquals(false, frame.isShowing)
+            val tracked =
+                AgreementFakeTrackedWindow(
+                    surfaceIdValue = "window:0",
+                    isPopupValue = false,
+                    composeSurfaceBoundsOnScreenValue = Rectangle(0, 0, 100, 80),
+                    windowValue = frame,
+                )
+            val handler =
+                ReflectiveAutomatorHandler(AgreementFakeAutomator(windowsValue = listOf(tracked)))
+            val response = handler.handle(AgentRequest.Windows)
+            check(response is AgentResponse.Windows)
+            assertEquals(false, response.windows.single().isShowing)
+
+            frame.isVisible = true
+            val shown =
+                AgreementFakeTrackedWindow(
+                    surfaceIdValue = "window:0",
+                    isPopupValue = false,
+                    composeSurfaceBoundsOnScreenValue = Rectangle(0, 0, 100, 80),
+                    windowValue = frame,
+                )
+            val shownResponse =
+                ReflectiveAutomatorHandler(AgreementFakeAutomator(windowsValue = listOf(shown)))
+                    .handle(AgentRequest.Windows)
+            check(shownResponse is AgentResponse.Windows)
+            assertEquals(true, shownResponse.windows.single().isShowing)
+        } finally {
+            frame.dispose()
+        }
+    }
 }
 
 private class AgreementFakeTrackedWindow(

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -73,8 +73,8 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public static final field Companion Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;
 	public synthetic fun <init> (Ldev/sebastiano/spectre/core/WindowTracker;Ldev/sebastiano/spectre/core/SemanticsReader;Ldev/sebastiano/spectre/core/RobotDriver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun allNodes ()Ljava/util/List;
-	public final fun capture (Ljava/lang/Integer;)Ldev/sebastiano/spectre/core/capture/AtomicCapture;
-	public static synthetic fun capture$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/core/capture/AtomicCapture;
+	public final fun capture (I)Ldev/sebastiano/spectre/core/capture/AtomicCapture;
+	public static synthetic fun capture$default (Ldev/sebastiano/spectre/core/ComposeAutomator;IILjava/lang/Object;)Ldev/sebastiano/spectre/core/capture/AtomicCapture;
 	public final fun clearAndTypeText (Ldev/sebastiano/spectre/core/AutomatorNode;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun click (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun doubleClick (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -261,6 +261,7 @@ public final class dev/sebastiano/spectre/core/TrackedWindow {
 	public final fun getComposeSurfaceBoundsOnScreen ()Ljava/awt/Rectangle;
 	public final fun getSurfaceId ()Ljava/lang/String;
 	public final fun getWindow ()Ljava/awt/Window;
+	public final fun getWindowTitle ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun isPopup ()Z
 	public fun toString ()Ljava/lang/String;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -73,8 +73,8 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public static final field Companion Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;
 	public synthetic fun <init> (Ldev/sebastiano/spectre/core/WindowTracker;Ldev/sebastiano/spectre/core/SemanticsReader;Ldev/sebastiano/spectre/core/RobotDriver;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun allNodes ()Ljava/util/List;
-	public final fun capture (I)Ldev/sebastiano/spectre/core/capture/AtomicCapture;
-	public static synthetic fun capture$default (Ldev/sebastiano/spectre/core/ComposeAutomator;IILjava/lang/Object;)Ldev/sebastiano/spectre/core/capture/AtomicCapture;
+	public final fun capture (Ljava/lang/Integer;)Ldev/sebastiano/spectre/core/capture/AtomicCapture;
+	public static synthetic fun capture$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/core/capture/AtomicCapture;
 	public final fun clearAndTypeText (Ldev/sebastiano/spectre/core/AutomatorNode;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun click (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun doubleClick (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -286,7 +286,8 @@ private constructor(
      */
     public fun screenshot(windowIndex: Int): BufferedImage {
         refreshWindows()
-        val trackedWindow = requireShowingTrackedWindow(windowIndex)
+        val resolvedIndex = resolveVisualWindowIndex(windowIndex)
+        val trackedWindow = requireShowingTrackedWindow(resolvedIndex)
         val geometry = readOnEdt {
             ScreenshotGeometry(
                 trackedWindow.composeSurfaceBoundsOnScreen,
@@ -318,17 +319,13 @@ private constructor(
      * Does **not** auto-call [waitForVisualIdle] or [waitForIdle] — settle the UI first when that
      * matters, matching [screenshot].
      */
-    /**
-     * @param windowIndex tracked window index, or null to capture the first **showing** window
-     *   (preferred default so delayed-show hosts listed for #362 are not captured by accident).
-     */
-    public fun capture(windowIndex: Int? = null): AtomicCapture {
+    public fun capture(windowIndex: Int = 0): AtomicCapture {
         val startedAt = TimeSource.Monotonic.markNow()
         refreshWindows()
-        val resolvedIndex =
-            windowIndex
-                ?: firstShowingWindowIndex()
-                ?: error("No showing tracked window to capture (have ${windows.size})")
+        // Index 0 is the long-standing default: if that slot is a delayed-show/hidden host listed
+        // for #362 agreement, prefer the first showing surface and record **that** index in the
+        // capture document (never claim index 0 while capturing another surface).
+        val resolvedIndex = resolveVisualWindowIndex(windowIndex)
         val trackedWindow = requireShowingTrackedWindow(resolvedIndex)
         // Freeze capture region, density, node properties, and screen geometry in one EDT pass
         // *before* taking the PNG so JSON and pixels cannot describe different window layouts.
@@ -471,10 +468,29 @@ private constructor(
     }
 
     /**
-     * Resolves a tracked window for visual ops at an **exact** index. Does not remap indices —
-     * callers that want "first showing" must pass [firstShowingWindowIndex] themselves (see
-     * [capture]). Silent remap would corrupt capture metadata.
+     * For visual ops: keep exact indices except the default slot 0, which falls back to the first
+     * showing surface when 0 is hidden (delayed-show hosts from #362). Callers must still record
+     * the **resolved** index in capture metadata — never claim index 0 while capturing another
+     * surface.
      */
+    private fun resolveVisualWindowIndex(windowIndex: Int): Int {
+        val preferred = windows.getOrNull(windowIndex)
+        if (preferred != null && preferred.window.isShowing) return windowIndex
+        if (windowIndex == 0) {
+            firstShowingWindowIndex()?.let {
+                return it
+            }
+        }
+        if (preferred != null && !preferred.window.isShowing) {
+            error(
+                "Tracked window at index $windowIndex is not showing " +
+                    "(surfaceId=${preferred.surfaceId}); wait until it is visible before " +
+                    "screenshot/capture"
+            )
+        }
+        error("No tracked window at index $windowIndex (have ${windows.size})")
+    }
+
     private fun requireShowingTrackedWindow(windowIndex: Int): TrackedWindow {
         val preferred =
             windows.getOrNull(windowIndex)
@@ -482,8 +498,7 @@ private constructor(
         if (!preferred.window.isShowing) {
             error(
                 "Tracked window at index $windowIndex is not showing " +
-                    "(surfaceId=${preferred.surfaceId}); wait until it is visible before " +
-                    "screenshot/capture, or omit windowIndex to capture the first showing surface"
+                    "(surfaceId=${preferred.surfaceId})"
             )
         }
         return preferred

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -318,10 +318,18 @@ private constructor(
      * Does **not** auto-call [waitForVisualIdle] or [waitForIdle] — settle the UI first when that
      * matters, matching [screenshot].
      */
-    public fun capture(windowIndex: Int = 0): AtomicCapture {
+    /**
+     * @param windowIndex tracked window index, or null to capture the first **showing** window
+     *   (preferred default so delayed-show hosts listed for #362 are not captured by accident).
+     */
+    public fun capture(windowIndex: Int? = null): AtomicCapture {
         val startedAt = TimeSource.Monotonic.markNow()
         refreshWindows()
-        val trackedWindow = requireShowingTrackedWindow(windowIndex)
+        val resolvedIndex =
+            windowIndex
+                ?: firstShowingWindowIndex()
+                ?: error("No showing tracked window to capture (have ${windows.size})")
+        val trackedWindow = requireShowingTrackedWindow(resolvedIndex)
         // Freeze capture region, density, node properties, and screen geometry in one EDT pass
         // *before* taking the PNG so JSON and pixels cannot describe different window layouts.
         data class PreCaptureSnapshot(
@@ -358,7 +366,7 @@ private constructor(
         }
         val image = screenCaptureBackend.captureRegion(pre.captureRegion)
         return AtomicCaptureBuilder.build(
-            windowIndex = windowIndex,
+            windowIndex = resolvedIndex,
             trackedWindow = trackedWindow,
             nodeSnapshots = pre.nodeSnapshots,
             image = image,
@@ -463,32 +471,26 @@ private constructor(
     }
 
     /**
-     * Resolves a tracked window for visual ops (screenshot / capture).
-     *
-     * #362 may list displayable-but-not-yet-showing surfaces so `windows()` agrees with
-     * `allNodes()`. Visual capture must not target those: for the default index 0, prefer the first
-     * showing surface; for an explicit non-showing index, fail with a clear error.
+     * Resolves a tracked window for visual ops at an **exact** index. Does not remap indices —
+     * callers that want "first showing" must pass [firstShowingWindowIndex] themselves (see
+     * [capture]). Silent remap would corrupt capture metadata.
      */
     private fun requireShowingTrackedWindow(windowIndex: Int): TrackedWindow {
-        val list = windows
-        val preferred = list.getOrNull(windowIndex)
-        if (preferred != null && preferred.window.isShowing) return preferred
-        if (windowIndex == 0) {
-            list
-                .firstOrNull { it.window.isShowing }
-                ?.let {
-                    return it
-                }
-        }
-        if (preferred != null && !preferred.window.isShowing) {
+        val preferred =
+            windows.getOrNull(windowIndex)
+                ?: error("No tracked window at index $windowIndex (have ${windows.size})")
+        if (!preferred.window.isShowing) {
             error(
                 "Tracked window at index $windowIndex is not showing " +
                     "(surfaceId=${preferred.surfaceId}); wait until it is visible before " +
-                    "screenshot/capture, or pass a showing windowIndex"
+                    "screenshot/capture, or omit windowIndex to capture the first showing surface"
             )
         }
-        error("No tracked window at index $windowIndex (have ${list.size})")
+        return preferred
     }
+
+    private fun firstShowingWindowIndex(): Int? =
+        windows.indexOfFirst { it.window.isShowing }.takeIf { it >= 0 }
 
     private fun rejectEdtCaller(name: String) {
         // The wait loops drain the EDT, snapshot semantics via invokeAndWait, and capture

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -286,9 +286,7 @@ private constructor(
      */
     public fun screenshot(windowIndex: Int): BufferedImage {
         refreshWindows()
-        val trackedWindow =
-            windows.getOrNull(windowIndex)
-                ?: error("No tracked window at index $windowIndex (have ${windows.size})")
+        val trackedWindow = requireShowingTrackedWindow(windowIndex)
         val geometry = readOnEdt {
             ScreenshotGeometry(
                 trackedWindow.composeSurfaceBoundsOnScreen,
@@ -323,9 +321,7 @@ private constructor(
     public fun capture(windowIndex: Int = 0): AtomicCapture {
         val startedAt = TimeSource.Monotonic.markNow()
         refreshWindows()
-        val trackedWindow =
-            windows.getOrNull(windowIndex)
-                ?: error("No tracked window at index $windowIndex (have ${windows.size})")
+        val trackedWindow = requireShowingTrackedWindow(windowIndex)
         // Freeze capture region, density, node properties, and screen geometry in one EDT pass
         // *before* taking the PNG so JSON and pixels cannot describe different window layouts.
         data class PreCaptureSnapshot(
@@ -464,6 +460,34 @@ private constructor(
             pollInterval = pollInterval,
             frameHash = frameHasher::hash,
         )
+    }
+
+    /**
+     * Resolves a tracked window for visual ops (screenshot / capture).
+     *
+     * #362 may list displayable-but-not-yet-showing surfaces so `windows()` agrees with
+     * `allNodes()`. Visual capture must not target those: for the default index 0, prefer the first
+     * showing surface; for an explicit non-showing index, fail with a clear error.
+     */
+    private fun requireShowingTrackedWindow(windowIndex: Int): TrackedWindow {
+        val list = windows
+        val preferred = list.getOrNull(windowIndex)
+        if (preferred != null && preferred.window.isShowing) return preferred
+        if (windowIndex == 0) {
+            list
+                .firstOrNull { it.window.isShowing }
+                ?.let {
+                    return it
+                }
+        }
+        if (preferred != null && !preferred.window.isShowing) {
+            error(
+                "Tracked window at index $windowIndex is not showing " +
+                    "(surfaceId=${preferred.surfaceId}); wait until it is visible before " +
+                    "screenshot/capture, or pass a showing windowIndex"
+            )
+        }
+        error("No tracked window at index $windowIndex (have ${list.size})")
     }
 
     private fun rejectEdtCaller(name: String) {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -286,8 +286,7 @@ private constructor(
      */
     public fun screenshot(windowIndex: Int): BufferedImage {
         refreshWindows()
-        val resolvedIndex = resolveVisualWindowIndex(windowIndex)
-        val trackedWindow = requireShowingTrackedWindow(resolvedIndex)
+        val trackedWindow = requireShowingTrackedWindow(windowIndex)
         val geometry = readOnEdt {
             ScreenshotGeometry(
                 trackedWindow.composeSurfaceBoundsOnScreen,
@@ -317,16 +316,13 @@ private constructor(
      * [dev.sebastiano.spectre.core.capture.CaptureArtifactsWriter].
      *
      * Does **not** auto-call [waitForVisualIdle] or [waitForIdle] — settle the UI first when that
-     * matters, matching [screenshot].
+     * matters, matching [screenshot]. Exact [windowIndex] only (must be showing); attach clients
+     * that want "first showing" resolve via [windows] + `isShowing` before calling.
      */
     public fun capture(windowIndex: Int = 0): AtomicCapture {
         val startedAt = TimeSource.Monotonic.markNow()
         refreshWindows()
-        // Index 0 is the long-standing default: if that slot is a delayed-show/hidden host listed
-        // for #362 agreement, prefer the first showing surface and record **that** index in the
-        // capture document (never claim index 0 while capturing another surface).
-        val resolvedIndex = resolveVisualWindowIndex(windowIndex)
-        val trackedWindow = requireShowingTrackedWindow(resolvedIndex)
+        val trackedWindow = requireShowingTrackedWindow(windowIndex)
         // Freeze capture region, density, node properties, and screen geometry in one EDT pass
         // *before* taking the PNG so JSON and pixels cannot describe different window layouts.
         data class PreCaptureSnapshot(
@@ -363,7 +359,7 @@ private constructor(
         }
         val image = screenCaptureBackend.captureRegion(pre.captureRegion)
         return AtomicCaptureBuilder.build(
-            windowIndex = resolvedIndex,
+            windowIndex = windowIndex,
             trackedWindow = trackedWindow,
             nodeSnapshots = pre.nodeSnapshots,
             image = image,
@@ -467,30 +463,7 @@ private constructor(
         )
     }
 
-    /**
-     * For visual ops: keep exact indices except the default slot 0, which falls back to the first
-     * showing surface when 0 is hidden (delayed-show hosts from #362). Callers must still record
-     * the **resolved** index in capture metadata — never claim index 0 while capturing another
-     * surface.
-     */
-    private fun resolveVisualWindowIndex(windowIndex: Int): Int {
-        val preferred = windows.getOrNull(windowIndex)
-        if (preferred != null && preferred.window.isShowing) return windowIndex
-        if (windowIndex == 0) {
-            firstShowingWindowIndex()?.let {
-                return it
-            }
-        }
-        if (preferred != null && !preferred.window.isShowing) {
-            error(
-                "Tracked window at index $windowIndex is not showing " +
-                    "(surfaceId=${preferred.surfaceId}); wait until it is visible before " +
-                    "screenshot/capture"
-            )
-        }
-        error("No tracked window at index $windowIndex (have ${windows.size})")
-    }
-
+    /** Exact index; fails if missing or not showing (no silent remap). */
     private fun requireShowingTrackedWindow(windowIndex: Int): TrackedWindow {
         val preferred =
             windows.getOrNull(windowIndex)
@@ -498,14 +471,12 @@ private constructor(
         if (!preferred.window.isShowing) {
             error(
                 "Tracked window at index $windowIndex is not showing " +
-                    "(surfaceId=${preferred.surfaceId})"
+                    "(surfaceId=${preferred.surfaceId}); wait until it is visible before " +
+                    "screenshot/capture"
             )
         }
         return preferred
     }
-
-    private fun firstShowingWindowIndex(): Int? =
-        windows.indexOfFirst { it.window.isShowing }.takeIf { it >= 0 }
 
     private fun rejectEdtCaller(name: String) {
         // The wait loops drain the EDT, snapshot semantics via invokeAndWait, and capture

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
@@ -54,14 +54,18 @@ public data class TrackedWindow(
                 ?: locationOnScreenOrNull((window as? JFrame)?.contentPane)
                 ?: locationOnScreenOrNull((window as? JDialog)?.contentPane)
                 ?: locationOnScreenOrNull(window)
+                ?: layoutScreenOrigin(composePanel, window)
+                ?: layoutScreenOrigin((window as? JFrame)?.contentPane, window)
+                ?: layoutScreenOrigin((window as? JDialog)?.contentPane, window)
                 ?: Point(window.x, window.y)
 
     /**
      * Compose surface bounds in screen coordinates.
      *
-     * Tries the panel, then Swing content panes (Frame / Dialog), then the window itself. Each
-     * candidate is skipped when `locationOnScreen` is unavailable so a single not-yet-showing
-     * intermediate does not fail the whole read (#362 attach `windows()` mapping).
+     * Tries live `locationOnScreen` first (panel → content pane → window). When the host is
+     * displayable but not yet showing, falls back to **window-relative layout** (child offsets
+     * summed to the top-level window, then offset by the window's layout x/y) so decorated frames
+     * and non-full-size panels keep correct surface geometry during delayed-show (#362).
      */
     val composeSurfaceBoundsOnScreen: Rectangle
         get() = readOnEdt {
@@ -69,6 +73,9 @@ public data class TrackedWindow(
                 ?: screenBoundsOrNull((window as? JFrame)?.contentPane)
                 ?: screenBoundsOrNull((window as? JDialog)?.contentPane)
                 ?: screenBoundsOrNull(window)
+                ?: layoutScreenBounds(composePanel, window)
+                ?: layoutScreenBounds((window as? JFrame)?.contentPane, window)
+                ?: layoutScreenBounds((window as? JDialog)?.contentPane, window)
                 ?: Rectangle(
                     window.x,
                     window.y,
@@ -103,4 +110,35 @@ private fun screenBoundsOrNull(component: Component?): Rectangle? {
     } catch (_: IllegalComponentStateException) {
         null
     }
+}
+
+/**
+ * Screen-space origin for [component] when `locationOnScreen` is unavailable: sum parent offsets up
+ * to [window], then add the window's layout position.
+ */
+private fun layoutScreenOrigin(component: Component?, window: Window): Point? {
+    val inWindow = boundsInWindow(component, window) ?: return null
+    return Point(window.x + inWindow.x, window.y + inWindow.y)
+}
+
+private fun layoutScreenBounds(component: Component?, window: Window): Rectangle? {
+    val inWindow = boundsInWindow(component, window) ?: return null
+    return Rectangle(window.x + inWindow.x, window.y + inWindow.y, inWindow.width, inWindow.height)
+}
+
+private fun boundsInWindow(component: Component?, window: Window): Rectangle? {
+    if (component == null) return null
+    val width = component.width
+    val height = component.height
+    if (width <= 0 || height <= 0) return null
+    var x = 0
+    var y = 0
+    var current: Component? = component
+    while (current != null && current !== window) {
+        x += current.x
+        y += current.y
+        current = current.parent
+    }
+    if (current !== window) return null
+    return Rectangle(x, y, width, height)
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/TrackedWindow.kt
@@ -3,9 +3,13 @@ package dev.sebastiano.spectre.core
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.semantics.SemanticsOwner
+import java.awt.Component
+import java.awt.Dialog
+import java.awt.IllegalComponentStateException
 import java.awt.Point
 import java.awt.Rectangle
 import java.awt.Window
+import javax.swing.JDialog
 import javax.swing.JFrame
 
 @InternalSpectreApi
@@ -39,17 +43,64 @@ public data class TrackedWindow(
      * below the title bar. For embedded ComposePanels, the panel's own location is used. This is
      * critical for correct coordinate mapping: boundsInWindow is relative to the content area, not
      * the window frame.
+     *
+     * Falls through candidates when a component is not yet on-screen
+     * (`IllegalComponentStateException`) so attach probes against delayed-show / custom-chrome
+     * windows still get a usable origin (#362).
      */
     val composeContentOrigin: Point
         get() =
-            composePanel?.locationOnScreen
-                ?: (window as? JFrame)?.contentPane?.locationOnScreen
-                ?: window.locationOnScreen
+            locationOnScreenOrNull(composePanel)
+                ?: locationOnScreenOrNull((window as? JFrame)?.contentPane)
+                ?: locationOnScreenOrNull((window as? JDialog)?.contentPane)
+                ?: locationOnScreenOrNull(window)
+                ?: Point(window.x, window.y)
 
+    /**
+     * Compose surface bounds in screen coordinates.
+     *
+     * Tries the panel, then Swing content panes (Frame / Dialog), then the window itself. Each
+     * candidate is skipped when `locationOnScreen` is unavailable so a single not-yet-showing
+     * intermediate does not fail the whole read (#362 attach `windows()` mapping).
+     */
     val composeSurfaceBoundsOnScreen: Rectangle
         get() = readOnEdt {
-            composePanel?.let { Rectangle(it.locationOnScreen, it.size) }
-                ?: (window as? JFrame)?.contentPane?.let { Rectangle(it.locationOnScreen, it.size) }
-                ?: Rectangle(window.locationOnScreen, window.size)
+            screenBoundsOrNull(composePanel)
+                ?: screenBoundsOrNull((window as? JFrame)?.contentPane)
+                ?: screenBoundsOrNull((window as? JDialog)?.contentPane)
+                ?: screenBoundsOrNull(window)
+                ?: Rectangle(
+                    window.x,
+                    window.y,
+                    window.width.coerceAtLeast(0),
+                    window.height.coerceAtLeast(0),
+                )
         }
+
+    /** Title from [java.awt.Frame] or [Dialog]; null for bare [Window]. */
+    val windowTitle: String?
+        get() =
+            when (val w = window) {
+                is java.awt.Frame -> w.title
+                is Dialog -> w.title
+                else -> null
+            }
+}
+
+private fun locationOnScreenOrNull(component: Component?): Point? {
+    if (component == null) return null
+    return try {
+        component.locationOnScreen
+    } catch (_: IllegalComponentStateException) {
+        null
+    }
+}
+
+private fun screenBoundsOrNull(component: Component?): Rectangle? {
+    if (component == null) return null
+    return try {
+        Rectangle(component.locationOnScreen, component.size)
+    } catch (_: IllegalComponentStateException) {
+        null
+    }
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
@@ -46,10 +46,26 @@ public object WindowIdentityResolver {
         )
     }
 
+    /**
+     * Top-level window bounds in screen coordinates.
+     *
+     * When the window is displayable but not yet showing (delayed-show hosts admitted by
+     * [WindowTracker] for #362), `locationOnScreen` throws. Fall back to the window's layout
+     * position/size so identity resolution does not fail the whole list.
+     */
     private fun windowBoundsOnScreen(window: Window): Rectangle {
-        val location = window.locationOnScreen
-        val size = window.size
-        return Rectangle(location.x, location.y, size.width, size.height)
+        return try {
+            val location = window.locationOnScreen
+            val size = window.size
+            Rectangle(location.x, location.y, size.width, size.height)
+        } catch (_: java.awt.IllegalComponentStateException) {
+            Rectangle(
+                window.x,
+                window.y,
+                window.width.coerceAtLeast(0),
+                window.height.coerceAtLeast(0),
+            )
+        }
     }
 
     private fun rectsEqualWithin(a: Rectangle, b: Rectangle, tolerancePx: Int): Boolean =

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowIdentityResolver.kt
@@ -2,8 +2,6 @@
 
 package dev.sebastiano.spectre.core
 
-import java.awt.Dialog
-import java.awt.Frame
 import java.awt.Rectangle
 import java.awt.Window
 import kotlin.math.abs
@@ -34,7 +32,7 @@ public object WindowIdentityResolver {
         WindowIdentitySnapshot(
             index = index,
             surfaceId = tracked.surfaceId,
-            title = windowTitle(window),
+            title = tracked.windowTitle,
             isPopup = tracked.isPopup,
             nativeHandle = nativeHandle,
             cropRequired = cropRequired,
@@ -53,14 +51,6 @@ public object WindowIdentityResolver {
         val size = window.size
         return Rectangle(location.x, location.y, size.width, size.height)
     }
-
-    /** Title from [Frame] or [Dialog] (ComposeDialog / JDialog); null for bare [Window]. */
-    private fun windowTitle(window: Window): String? =
-        when (window) {
-            is Frame -> window.title
-            is Dialog -> window.title
-            else -> null
-        }
 
     private fun rectsEqualWithin(a: Rectangle, b: Rectangle, tolerancePx: Int): Boolean =
         abs(a.x - b.x) <= tolerancePx &&

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -50,10 +50,25 @@ internal constructor(
         val topLevelWindows = allWindows().filter { it.owner == null }
         for (window in topLevelWindows) {
             when {
-                window is ComposeWindow && window.isShowing -> trackComposeWindow(pending, window)
-                window.isShowing -> trackEmbeddedPanels(pending, window)
-                // Hidden parent (e.g. SharedOwnerFrame) — skip its own panels but still walk its
-                // owned dialogs in case any of them are showing.
+                // Use isDisplayable (not isShowing) so delayed-show / custom-chrome hosts stay
+                // discoverable once they have a peer and a semantics tree (#362).
+                //
+                // Jewel/Compose Desktop onboarding often creates the window with `visible =
+                // false`, runs a first composition (transparent title-bar client properties,
+                // minimum size), then flips visible. During that window `isShowing` is false
+                // while `semanticsOwners` / panel owners can already be non-empty. Requiring
+                // isShowing made `windows()` empty while a later `allNodes()` refresh could
+                // still report `window:*` keys after show.
+                //
+                // Track helpers still require non-empty semantics owners / panels, so bare
+                // not-yet-composed displayable frames are not listed. Hidden parents without
+                // panels (e.g. SharedOwnerFrame) still fall through to owned-popup walks.
+                window is ComposeWindow && window.isDisplayable ->
+                    trackComposeWindow(pending, window)
+                // Includes owned-popup walk (see trackEmbeddedPanels).
+                window.isDisplayable -> trackEmbeddedPanels(pending, window)
+                // Not displayable (e.g. SharedOwnerFrame before peer): skip own panels but still
+                // walk owned dialogs in case any of them are showing.
                 else -> trackOwnedPopups(pending, window)
             }
         }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.awt.ComposeWindow
 import java.awt.Container
 import java.awt.Window
+import java.lang.ref.WeakReference
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -23,6 +24,15 @@ internal constructor(
     private val surfaceIdAssigner = SurfaceIdAssigner()
 
     private val _trackedWindows = MutableStateFlow<List<TrackedWindow>>(emptyList())
+
+    /**
+     * Windows observed as [Window.isShowing] at least once during this tracker's lifetime.
+     *
+     * Used so #362 delayed-show hosts (displayable + semantics, never yet shown) remain
+     * discoverable, while HIDE_ON_CLOSE / setVisible(false) frames that **have** shown before are
+     * not re-listed after dismiss (they stay displayable with stale semantics).
+     */
+    private val everShownWindows = mutableListOf<WeakReference<Window>>()
 
     /**
      * Live view of the currently tracked surfaces. Backed by a [StateFlow] so that subscribers
@@ -49,30 +59,44 @@ internal constructor(
         // descendants).
         val topLevelWindows = allWindows().filter { it.owner == null }
         for (window in topLevelWindows) {
+            if (window.isShowing) markEverShown(window)
             when {
-                // Use isDisplayable (not isShowing) so delayed-show / custom-chrome hosts stay
-                // discoverable once they have a peer and a semantics tree (#362).
-                //
-                // Jewel/Compose Desktop onboarding often creates the window with `visible =
-                // false`, runs a first composition (transparent title-bar client properties,
-                // minimum size), then flips visible. During that window `isShowing` is false
-                // while `semanticsOwners` / panel owners can already be non-empty. Requiring
-                // isShowing made `windows()` empty while a later `allNodes()` refresh could
-                // still report `window:*` keys after show.
-                //
-                // Track helpers still require non-empty semantics owners / panels, so bare
-                // not-yet-composed displayable frames are not listed. Hidden parents without
-                // panels (e.g. SharedOwnerFrame) still fall through to owned-popup walks.
-                window is ComposeWindow && window.isDisplayable ->
+                // #362 delayed-show: admit never-yet-shown displayable Compose hosts with
+                // semantics. Once a window has been showing, only re-list while isShowing so
+                // HIDE_ON_CLOSE dismissals are not re-admitted with stale trees.
+                window is ComposeWindow && shouldTrackTopLevel(window) ->
                     trackComposeWindow(pending, window)
-                // Includes owned-popup walk (see trackEmbeddedPanels).
-                window.isDisplayable -> trackEmbeddedPanels(pending, window)
-                // Not displayable (e.g. SharedOwnerFrame before peer): skip own panels but still
-                // walk owned dialogs in case any of them are showing.
+                shouldTrackTopLevel(window) -> trackEmbeddedPanels(pending, window)
+                // Not displayable / not trackable: still walk owned dialogs in case any show.
                 else -> trackOwnedPopups(pending, window)
             }
         }
+        pruneEverShown()
         _trackedWindows.value = pending.toList()
+    }
+
+    /**
+     * True when [window] is currently showing, or is a delayed-show candidate (displayable, never
+     * observed showing, will be filtered further by semantics/panel presence in track helpers).
+     */
+    private fun shouldTrackTopLevel(window: Window): Boolean {
+        if (window.isShowing) return true
+        if (!window.isDisplayable) return false
+        return !hasEverShown(window)
+    }
+
+    private fun markEverShown(window: Window) {
+        if (hasEverShown(window)) return
+        everShownWindows += WeakReference(window)
+    }
+
+    private fun hasEverShown(window: Window): Boolean {
+        pruneEverShown()
+        return everShownWindows.any { it.get() === window }
+    }
+
+    private fun pruneEverShown() {
+        everShownWindows.removeAll { it.get() == null }
     }
 
     @OptIn(ExperimentalComposeUiApi::class)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -101,8 +101,10 @@ internal constructor(
         owner: Window,
         skip: Set<Window> = emptySet(),
     ) {
-        val visibleOwned = owner.ownedWindows.filter { it.isShowing && it !in skip }
-        for (owned in visibleOwned) {
+        // #362: admit displayable owned dialogs (packed but not yet showing) the same way as
+        // top-level hosts, so delayed-show ComposeDialog / JDialog surfaces are discoverable.
+        val candidateOwned = owner.ownedWindows.filter { it.isDisplayable && it !in skip }
+        for (owned in candidateOwned) {
             when (owned) {
                 is ComposeWindow -> {
                     if (owned.semanticsOwners.isNotEmpty()) {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WindowTracker.kt
@@ -101,9 +101,11 @@ internal constructor(
         owner: Window,
         skip: Set<Window> = emptySet(),
     ) {
-        // #362: admit displayable owned dialogs (packed but not yet showing) the same way as
-        // top-level hosts, so delayed-show ComposeDialog / JDialog surfaces are discoverable.
-        val candidateOwned = owner.ownedWindows.filter { it.isDisplayable && it !in skip }
+        // Owned popups: keep isShowing (not mere isDisplayable). HIDE_ON_CLOSE dialogs remain
+        // displayable with stale semantics after dismiss; re-listing them would pollute
+        // windows()/allNodes() with closed surfaces. Delayed-show for owned dialogs is rare
+        // compared to top-level onboarding hosts (handled above via isDisplayable).
+        val candidateOwned = owner.ownedWindows.filter { it.isShowing && it !in skip }
         for (owned in candidateOwned) {
             when (owned) {
                 is ComposeWindow -> {

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -280,7 +280,7 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 
 | Method                | Wire op                          | Returns           |
 |-----------------------|----------------------------------|-------------------|
-| `windows()`           | `AgentRequest.Windows`           | `List<WindowSummaryDto>` |
+| `windows()`           | `AgentRequest.Windows`           | `List<WindowSummaryDto>` (includes `isShowing`; delayed-show hosts may appear before they are visible so keys agree with `allNodes()` — #362) |
 | `allNodes()`          | `AgentRequest.AllNodes`          | `List<NodeSnapshotDto>`  |
 | `findByTestTag(tag)`  | `AgentRequest.FindByTestTag`     | `List<NodeSnapshotDto>`  |
 | `click(nodeKey)`      | `AgentRequest.Click`             | `Unit`            |


### PR DESCRIPTION
## Summary

- **WindowTracker** discovers Compose and embedded hosts when they are **displayable** (not only `isShowing`), so delayed-show / custom-chrome windows (onboarding-style `visible=false` first composition) appear in `windows()` as soon as they have semantics.
- **TrackedWindow** bounds/origin fall through panel → content pane (Frame/Dialog) → window without throwing; adds `windowTitle` for Frame **and** Dialog.
- **ReflectiveAutomatorHandler** maps Windows DTOs resiliently (Dialog titles; bounds failure keeps the surface with zero bounds instead of emptying the list).
- Attach e2e asserts every `allNodes()` surface id appears in `windows()`; fixture supports `SPECTRE_FIXTURE_UNDECORATED` / `SPECTRE_FIXTURE_DELAYED_SHOW` for regression.

Fixes the remaining #362 windows listing bug (empty `windows()` while nodes use `window:*` keys on undecorated/onboarding-like hosts). Does **not** implement waitForIdle / printTree / node screenshot / DTO click (later #362 phases) or #364 focusWindow.

## Test plan

- [x] `./gradlew check` green
- [x] `ReflectiveAutomatorHandlerWindowsAgreementTest` (Dialog title + bounds throw keeps surface)
- [x] `AgentAttachIntegrationTest` agreement assert (repeat cycles)
- [x] User-like: undecorated + delayed-show fixture + `attachSpike` → `getWindows().size = 1`
- [ ] CI green on PR
- [ ] Windows desktop attach e2e optional (path-sensitive; host `rock3r@192.168.1.8` if needed)