### PR TITLE
feat(agent): attach waitForIdle (#362 P2)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -114,6 +114,8 @@ public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/Au
 	public static synthetic fun swipe$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;IIIIIJILjava/lang/Object;)V
 	public static synthetic fun swipe$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/String;Ljava/lang/String;IJILjava/lang/Object;)V
 	public final fun typeText (Ljava/lang/String;)V
+	public final fun waitForIdle (JJJ)V
+	public static synthetic fun waitForIdle$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;JJJILjava/lang/Object;)V
 	public final fun waitForNode (Ljava/lang/String;Ljava/lang/String;JJ)Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;
 	public static synthetic fun waitForNode$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/String;Ljava/lang/String;JJILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;
 	public final fun waitForVisualIdle (JIJ)V

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -329,6 +329,33 @@ internal constructor(
     }
 
     /**
+     * Wait until the semantics fingerprint is quiet (#362). Same as in-process
+     * `ComposeAutomator.waitForIdle` for timeout/quiet/poll and absolute deadline on the wire (like
+     * [waitForNode]). Idling-resource **registration** remains in-process-only — the target uses
+     * any resources it already registered; the attach client cannot add/remove them over IPC.
+     *
+     * Throws [SpectreAgentException] with category `timeout` when the wait expires.
+     */
+    @Throws(IOException::class)
+    public fun waitForIdle(
+        timeoutMs: Long = 5_000,
+        quietPeriodMs: Long = 64,
+        pollIntervalMs: Long = 16,
+    ) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        val resp =
+            exchange(
+                AgentRequest.WaitForIdle(
+                    timeoutMs = timeoutMs,
+                    quietPeriodMs = quietPeriodMs,
+                    pollIntervalMs = pollIntervalMs,
+                ),
+                deadlineEpochMs = deadline,
+            )
+        if (resp !is AgentResponse.Ok) throw wireMismatch("Ok", resp)
+    }
+
+    /**
      * Send [AgentRequest.Detach], wait for [AgentResponse.Detached], close the underlying client.
      * Idempotent — calling twice is a no-op.
      */

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -329,10 +329,13 @@ internal constructor(
     }
 
     /**
-     * Wait until the semantics fingerprint is quiet (#362). Same as in-process
-     * `ComposeAutomator.waitForIdle` for timeout/quiet/poll and absolute deadline on the wire (like
-     * [waitForNode]). Idling-resource **registration** remains in-process-only — the target uses
-     * any resources it already registered; the attach client cannot add/remove them over IPC.
+     * Wait until the agent-side semantics fingerprint is quiet (#362).
+     *
+     * Timeout / quiet / poll parameters and absolute deadline on the wire match [waitForNode]. The
+     * wait runs on the **agent's** in-target `ComposeAutomator` (a separate instance from any
+     * automator the app may hold). It is **fingerprint-only**: application-registered
+     * [dev.sebastiano.spectre.core.AutomatorIdlingResource]s on another automator instance are not
+     * observed. Idling-resource registration over attach is unsupported by design.
      *
      * Throws [SpectreAgentException] with category `timeout` when the wait expires.
      */

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -162,6 +162,7 @@ internal class ReflectiveAutomatorHandler(
             is AgentRequest.Cancel -> AgentResponse.Ok
             is AgentRequest.WaitForNode -> waitOps.handleWaitForNode(request)
             is AgentRequest.WaitForVisualIdle -> waitOps.handleWaitForVisualIdle(request)
+            is AgentRequest.WaitForIdle -> waitOps.handleWaitForIdle(request)
         }
 
     // Note on un-caught exceptions: any non-reflective `RuntimeException` thrown by the

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
@@ -17,9 +17,9 @@ import java.lang.reflect.Method
  * Lookups use parameter types, not the unmangled source name; invocations use
  * [durationStorageFromMs].
  *
- * Attach `waitForIdle` runs the target-side fingerprint wait (one RT). Idling-resource registration
- * remains in-process-only — the target uses whatever resources it already registered; the attach
- * client cannot add/remove them over IPC.
+ * Attach `waitForIdle` runs a fingerprint wait on the **agent's** in-target automator instance (one
+ * RT). That instance is separate from any automator the app may hold, so application-registered
+ * idling resources are not observed. Registration over attach remains unsupported by design.
  */
 internal class WaitOpsReflectiveMapper(
     private val automator: Any,

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
@@ -9,13 +9,17 @@ import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import java.lang.reflect.Method
 
 /**
- * Reflective bridge for [AgentRequest.WaitForNode] / [AgentRequest.WaitForVisualIdle] (#201). Lives
+ * Reflective bridge for wait ops (#201 waitForNode/waitForVisualIdle, #362 waitForIdle). Lives
  * outside [ReflectiveAutomatorHandler] to keep that class under detekt complexity limits.
  *
  * Kotlin mangles `Duration` parameters into primitive `long` carrying [kotlin.time.Duration]'s
  * packed `rawValue` (not plain nanoseconds) and renames methods (e.g. `waitForNode-ck1zr5g`).
  * Lookups use parameter types, not the unmangled source name; invocations use
  * [durationStorageFromMs].
+ *
+ * Attach `waitForIdle` runs the target-side fingerprint wait (one RT). Idling-resource registration
+ * remains in-process-only — the target uses whatever resources it already registered; the attach
+ * client cannot add/remove them over IPC.
  */
 internal class WaitOpsReflectiveMapper(
     private val automator: Any,
@@ -45,6 +49,18 @@ internal class WaitOpsReflectiveMapper(
                 it.parameterTypes.size == 4 &&
                 it.parameterTypes[0] == longPrimitive &&
                 it.parameterTypes[1] == intPrimitive &&
+                it.parameterTypes[2] == longPrimitive &&
+                it.parameterTypes[3].name == CONTINUATION_FQN
+        }
+
+    /** `waitForIdle(timeout, quietPeriod, pollInterval)` — three Durations + Continuation. */
+    private val waitForIdleSuspendMethod: Method? =
+        automatorClass.methods.firstOrNull {
+            it.name.startsWith("waitForIdle") &&
+                !it.name.startsWith("waitForIdleInternal") &&
+                it.parameterTypes.size == 4 &&
+                it.parameterTypes[0] == longPrimitive &&
+                it.parameterTypes[1] == longPrimitive &&
                 it.parameterTypes[2] == longPrimitive &&
                 it.parameterTypes[3].name == CONTINUATION_FQN
         }
@@ -110,6 +126,29 @@ internal class WaitOpsReflectiveMapper(
         }
     }
 
+    fun handleWaitForIdle(request: AgentRequest.WaitForIdle): AgentResponse {
+        val method =
+            waitForIdleSuspendMethod
+                ?: return AgentResponse.Error(
+                    message = "ComposeAutomator does not expose waitForIdle",
+                    category = AgentErrorCategory.UnsupportedOperation.wireName,
+                )
+        val timeoutMs = request.timeoutMs ?: DEFAULT_WAIT_TIMEOUT_MS
+        val quietMs = request.quietPeriodMs ?: DEFAULT_QUIET_PERIOD_MS
+        val pollMs = request.pollIntervalMs ?: DEFAULT_IDLE_POLL_MS
+        return runWait {
+            suspendInvoker.invoke(
+                method,
+                automator,
+                durationStorageFromMs(timeoutMs),
+                durationStorageFromMs(quietMs),
+                durationStorageFromMs(pollMs),
+                timeoutMsOverride = timeoutMs + SUSPEND_BRIDGE_SLACK_MS,
+            )
+            AgentResponse.Ok
+        }
+    }
+
     /**
      * Maps wait-loop timeouts (stdlib [TimeoutException], IdleTimeoutException,
      * TimeoutCancellationException) to taxonomy `timeout`; rethrows everything else.
@@ -144,6 +183,10 @@ internal class WaitOpsReflectiveMapper(
         const val DEFAULT_WAIT_TIMEOUT_MS: Long = 5_000
         const val DEFAULT_WAIT_POLL_MS: Long = 100
         const val DEFAULT_VISUAL_POLL_MS: Long = 16
+        /** Matches core `DEFAULT_POLL_INTERVAL` for waitForIdle (~60 FPS). */
+        const val DEFAULT_IDLE_POLL_MS: Long = 16
+        /** Matches core `DEFAULT_QUIET_PERIOD` (64 ms). */
+        const val DEFAULT_QUIET_PERIOD_MS: Long = 64
         const val DEFAULT_STABLE_FRAMES: Int = 3
         const val SUSPEND_BRIDGE_SLACK_MS: Long = 2_000
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -224,6 +224,20 @@ internal sealed interface AgentRequest {
         val stableFrames: Int? = null,
         val pollIntervalMs: Long? = null,
     ) : AgentRequest
+
+    /**
+     * Wait until the semantics fingerprint is quiet (#362). Same as in-process
+     * `ComposeAutomator.waitForIdle` **without** live idling-resource registration (callbacks stay
+     * in-process-only by design). Null durations use automator defaults. Replies with
+     * [AgentResponse.Ok] or [AgentResponse.Error] category `timeout`.
+     */
+    @Serializable
+    @SerialName("waitForIdle")
+    data class WaitForIdle(
+        val timeoutMs: Long? = null,
+        val quietPeriodMs: Long? = null,
+        val pollIntervalMs: Long? = null,
+    ) : AgentRequest
 }
 
 /** Payload-free operation label for diagnostics. Never include caller-controlled request data. */
@@ -253,6 +267,7 @@ internal val AgentRequest.logLabel: String
             is AgentRequest.Cancel -> "cancel"
             is AgentRequest.WaitForNode -> "waitForNode"
             is AgentRequest.WaitForVisualIdle -> "waitForVisualIdle"
+            is AgentRequest.WaitForIdle -> "waitForIdle"
         }
 
 /** Server-to-client response envelope. */

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveHandlerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveHandlerTest.kt
@@ -64,6 +64,39 @@ class WaitOpsReflectiveHandlerTest {
         check(response is AgentResponse.Error)
         assertEquals(AgentErrorCategory.InvalidSelector.wireName, response.category)
     }
+
+    @Test
+    fun `WaitForIdle success invokes target-side wait with packed Duration rawValues`() {
+        val fake = WaitFakeAutomator()
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response =
+            handler.handle(
+                AgentRequest.WaitForIdle(timeoutMs = 2_000, quietPeriodMs = 64, pollIntervalMs = 16)
+            )
+        check(response is AgentResponse.Ok) { "expected Ok, got $response" }
+        val expectedTimeoutRaw = 2_000L * 1_000_000L shl 1
+        val expectedQuietRaw = 64L * 1_000_000L shl 1
+        val expectedPollRaw = 16L * 1_000_000L shl 1
+        assertEquals(listOf(expectedTimeoutRaw), fake.waitForIdleTimeoutRaw.toList())
+        assertEquals(listOf(expectedQuietRaw), fake.waitForIdleQuietRaw.toList())
+        assertEquals(listOf(expectedPollRaw), fake.waitForIdlePollRaw.toList())
+    }
+
+    @Test
+    fun `WaitForIdle timeout maps to taxonomy timeout`() {
+        val fake =
+            WaitFakeAutomator(
+                waitForIdleImpl = { _: Long, _: Long, _: Long ->
+                    throw FakeIdleTimeoutException("waitForIdle timed out after 300ms")
+                }
+            )
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response = handler.handle(AgentRequest.WaitForIdle(timeoutMs = 300, quietPeriodMs = 50))
+        check(response is AgentResponse.Error) { "expected Error, got $response" }
+        assertEquals(AgentErrorCategory.Timeout.wireName, response.category)
+    }
 }
 
 /** Name-shape matches core IdleTimeoutException for WaitOps taxonomy matching. */
@@ -76,9 +109,13 @@ private class FakeIdleTimeoutException(message: String) : RuntimeException(messa
 internal class WaitFakeAutomator(
     private val allNodesValue: List<Any> = emptyList(),
     private val waitForNodeImpl: ((String?, String?, Long, Long) -> Any?)? = null,
+    private val waitForIdleImpl: ((Long, Long, Long) -> Any?)? = null,
 ) {
     val waitForNodeTags = mutableListOf<String?>()
     val waitForNodeTimeoutRaw = mutableListOf<Long>()
+    val waitForIdleTimeoutRaw = mutableListOf<Long>()
+    val waitForIdleQuietRaw = mutableListOf<Long>()
+    val waitForIdlePollRaw = mutableListOf<Long>()
 
     @Suppress("unused") fun refreshWindows() = Unit
 
@@ -117,6 +154,22 @@ internal class WaitFakeAutomator(
         pollRaw: Long,
         continuation: kotlin.coroutines.Continuation<Any?>,
     ): Any? = Unit
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun waitForIdle(
+        timeoutRaw: Long,
+        quietRaw: Long,
+        pollRaw: Long,
+        continuation: kotlin.coroutines.Continuation<Any?>,
+    ): Any? {
+        waitForIdleTimeoutRaw += timeoutRaw
+        waitForIdleQuietRaw += quietRaw
+        waitForIdlePollRaw += pollRaw
+        waitForIdleImpl?.let {
+            return it(timeoutRaw, quietRaw, pollRaw)
+        }
+        return Unit
+    }
 }
 
 internal class WaitFakeNode(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -483,7 +483,8 @@ class IpcRoundTripTest {
             is AgentRequest.FocusWindow,
             is AgentRequest.TypeText,
             is AgentRequest.Cancel,
-            is AgentRequest.WaitForVisualIdle -> AgentResponse.Ok
+            is AgentRequest.WaitForVisualIdle,
+            is AgentRequest.WaitForIdle -> AgentResponse.Ok
             is AgentRequest.Screenshot -> AgentResponse.Screenshot(ByteArray(0))
             is AgentRequest.Capture ->
                 AgentResponse.Capture(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WaitOpsInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WaitOpsInfrastructureTest.kt
@@ -101,6 +101,49 @@ class WaitOpsInfrastructureTest {
     }
 
     @Test
+    fun `waitForIdle Ok and timeout taxonomy over IPC`() {
+        val calls = AtomicInteger(0)
+        IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    when (request) {
+                        is AgentRequest.WaitForIdle -> {
+                            if (calls.getAndIncrement() == 0) {
+                                AgentResponse.Ok
+                            } else {
+                                AgentResponse.Error(
+                                    message = "waitForIdle timed out",
+                                    category = AgentErrorCategory.Timeout.wireName,
+                                )
+                            }
+                        }
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+            .use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { client ->
+                    assertEquals(
+                        AgentResponse.Ok,
+                        client.send(
+                            AgentRequest.WaitForIdle(
+                                timeoutMs = 500,
+                                quietPeriodMs = 64,
+                                pollIntervalMs = 16,
+                            )
+                        ),
+                    )
+                    val err =
+                        assertIs<AgentResponse.Error>(
+                            client.send(AgentRequest.WaitForIdle(timeoutMs = 100))
+                        )
+                    assertEquals(AgentErrorCategory.Timeout.wireName, err.category)
+                }
+            }
+    }
+
+    @Test
     fun `slow waitForNode can be cancelled`() {
         val started = CountDownLatch(1)
         IpcServer(

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -310,10 +310,10 @@ recording (#183) uses this so capture stays on the daemon host rather than over 
 transport.
 
 `waitForNode`, `waitForVisualIdle` (#201), and `waitForIdle` (#362) are available over the
-agent transport. `waitForIdle` runs the target-side semantics-fingerprint wait (timeout /
-quiet / poll; absolute deadline on the wire like `waitForNode`). **Idling-resource
-registration** (`registerIdlingResource` / `unregisterIdlingResource`) and `withTracing`
-remain in-process-only — live JVM callbacks cannot cross attach.
+agent transport. `waitForIdle` runs a **fingerprint-only** wait on the agent's in-target
+automator (timeout / quiet / poll; absolute deadline on the wire like `waitForNode`). It does
+**not** observe idling resources registered on a different automator instance in the app.
+**Idling-resource registration** and `withTracing` remain in-process-only.
 
 Richer input verbs (`doubleClick` / `longClick` / `swipe` / `scrollWheel` / `pressKey`)
 are available over agent, HTTP, and daemon/CLI/MCP (#203). `focusWindow(nodeKey)` raises

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -294,6 +294,9 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 | `screenshot(windowIndex?, surfaceId?, fullscreen?)` | `AgentRequest.Screenshot` | `ByteArray` (PNG); default window index 0, not full desktop |
 | `capture(windowIndex)`| `AgentRequest.Capture`           | `AtomicCaptureResult` |
 | `windowIdentities(windowIndex?)` | `AgentRequest.WindowIdentity` | `List<WindowIdentityDto>` |
+| `waitForNode(...)`    | `AgentRequest.WaitForNode`       | `NodeSnapshotDto` |
+| `waitForVisualIdle(...)` | `AgentRequest.WaitForVisualIdle` | `Unit`         |
+| `waitForIdle(...)`    | `AgentRequest.WaitForIdle`       | `Unit` (fingerprint wait; no idling-resource registration over attach — #362) |
 | `close()` (auto)      | `AgentRequest.Detach`            | tear-down         |
 
 `windowIdentities` returns native handle/id (when resolvable), window and Compose-surface
@@ -306,12 +309,16 @@ translateY)`; scale widths/heights by `scaleX`/`scaleY` only (no translation). D
 recording (#183) uses this so capture stays on the daemon host rather than over the
 transport.
 
-`waitForNode` and `waitForVisualIdle` are available over the agent transport (#201).
+`waitForNode`, `waitForVisualIdle` (#201), and `waitForIdle` (#362) are available over the
+agent transport. `waitForIdle` runs the target-side semantics-fingerprint wait (timeout /
+quiet / poll; absolute deadline on the wire like `waitForNode`). **Idling-resource
+registration** (`registerIdlingResource` / `unregisterIdlingResource`) and `withTracing`
+remain in-process-only — live JVM callbacks cannot cross attach.
+
 Richer input verbs (`doubleClick` / `longClick` / `swipe` / `scrollWheel` / `pressKey`)
 are available over agent, HTTP, and daemon/CLI/MCP (#203). `focusWindow(nodeKey)` raises
 and focuses the AWT window hosting a node over attach (#364) — use it before `pressKey` /
 `typeText` when the attach client is the foreground process and the target app is not.
-Streaming / long-poll idling resources and `withTracing` remain deferred to a follow-up.
 
 ## Wire format
 

--- a/docs/guide/capability-matrix.md
+++ b/docs/guide/capability-matrix.md
@@ -69,19 +69,21 @@ boundary without a different design:
 | --- | --- |
 | `registerIdlingResource` / idling resources | Live callbacks in the UI JVM |
 | `withTracing` | Live tracer hooks |
-| `waitForIdle` (idling-resource variant) | Same as idling resources |
+| `waitForIdle` (idling-resource registration) | Live callbacks — use fingerprint wait over attach instead (#362) |
 
 Remote **waits** (`waitForNode` over agent — #201, also CLI `wait-for-node` / MCP
-`wait_for_node`), **selectors** (`findByText` / role / content-description — #202), and **input
-verbs** (`doubleClick` / `swipe` / `scrollWheel` — #203) are **Supported** on agent under Linux
-Xvfb and macOS desktop via `AgentContractCorpusTest` against `agent-test-fixture`. Agent
+`wait_for_node`; **`waitForIdle` fingerprint wait** over agent — #362), **selectors**
+(`findByText` / role / content-description — #202), and **input verbs** (`doubleClick` /
+`swipe` / `scrollWheel` — #203) are **Supported** on agent under Linux Xvfb and macOS desktop
+via `AgentContractCorpusTest` / reflective wait suites against `agent-test-fixture`. Agent
 `pressKey` is **Supported** on Linux Xvfb (fail-closed after focus retries) and
 **Experimental** on macOS desktop (hosted runners may soft-skip OS keyboard focus loss after
 retries — same class as `typeText`). Agent **`focusWindow`** (#364) is **Supported** on Linux
 Xvfb and macOS desktop (raises the window hosting a node before real keyboard input); HTTP
 `focusWindow` is **Unsupported by design** for this issue. HTTP selector entry points are covered
 by headless `HttpContractCorpusTest`. Some HTTP input/wait cells and agent `longClick` /
-`waitForVisualIdle` remain **Not yet CI-executed**.
+`waitForVisualIdle` remain **Not yet CI-executed**. Idling-resource **registration** over attach
+stays **Unsupported by design**.
 
 ## How to read a cell
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
@@ -377,9 +377,10 @@ public object CapabilityMatrix {
                 platform = PlatformPrerequisite.AnyJvm,
                 state = CellState.Supported,
                 rationale =
-                    "Fingerprint/EDT waitForIdle over attach (#362). Absolute deadline on the " +
-                        "wire like waitForNode. Idling-resource registration remains " +
-                        "in-process-only (live callbacks).",
+                    "Fingerprint-only waitForIdle over attach (#362) on the agent-owned " +
+                        "ComposeAutomator. Absolute deadline on the wire like waitForNode. Does " +
+                        "not observe app-registered idling resources on another automator " +
+                        "instance; registration remains in-process-only.",
                 evidence =
                     listOf(
                         CapabilityEvidence(
@@ -392,7 +393,18 @@ public object CapabilityMatrix {
                             workflowPath = ".github/workflows/ci.yml",
                             gradleTaskHint =
                                 "./gradlew :agent:test --tests \"*WaitOpsReflectiveHandlerTest*\"",
-                        )
+                        ),
+                        CapabilityEvidence(
+                            id = "agent-wait-for-idle-ipc",
+                            description =
+                                "WaitOpsInfrastructureTest WaitForIdle Ok + timeout over multiplexed IPC",
+                            sourcePath =
+                                "agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/" +
+                                    "WaitOpsInfrastructureTest.kt",
+                            workflowPath = ".github/workflows/ci.yml",
+                            gradleTaskHint =
+                                "./gradlew :agent:test --tests \"*WaitOpsInfrastructureTest*\"",
+                        ),
                     ),
             )
         )

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
@@ -341,13 +341,11 @@ public object CapabilityMatrix {
         )
 
         // --- Deliberate exclusions (remote + live-JVM-object ops) ---
-        for (transport in listOf(AutomatorTransport.Http, AutomatorTransport.Agent)) {
-            for (op in
-                listOf(
-                    AutomatorOperation.WaitForIdle,
-                    AutomatorOperation.RegisterIdlingResource,
-                    AutomatorOperation.WithTracing,
-                )) {
+        // RegisterIdlingResource / withTracing stay in-process-only (live callbacks).
+        // waitForIdle fingerprint wait is available over Agent (#362); HTTP still deferred.
+        for (op in
+            listOf(AutomatorOperation.RegisterIdlingResource, AutomatorOperation.WithTracing)) {
+            for (transport in listOf(AutomatorTransport.Http, AutomatorTransport.Agent)) {
                 add(
                     CapabilityCell(
                         operation = op,
@@ -361,6 +359,43 @@ public object CapabilityMatrix {
                 )
             }
         }
+        add(
+            CapabilityCell(
+                operation = AutomatorOperation.WaitForIdle,
+                transport = AutomatorTransport.Http,
+                platform = PlatformPrerequisite.AnyJvm,
+                state = CellState.UnsupportedByDesign,
+                rationale =
+                    "HTTP waitForIdle not in #362 scope; use in-process or agent attach. " +
+                        "Idling-resource registration remains in-process-only.",
+            )
+        )
+        add(
+            CapabilityCell(
+                operation = AutomatorOperation.WaitForIdle,
+                transport = AutomatorTransport.Agent,
+                platform = PlatformPrerequisite.AnyJvm,
+                state = CellState.Supported,
+                rationale =
+                    "Fingerprint/EDT waitForIdle over attach (#362). Absolute deadline on the " +
+                        "wire like waitForNode. Idling-resource registration remains " +
+                        "in-process-only (live callbacks).",
+                evidence =
+                    listOf(
+                        CapabilityEvidence(
+                            id = "agent-wait-for-idle-reflective",
+                            description =
+                                "WaitOpsReflectiveHandlerTest WaitForIdle success + timeout taxonomy",
+                            sourcePath =
+                                "agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/" +
+                                    "WaitOpsReflectiveHandlerTest.kt",
+                            workflowPath = ".github/workflows/ci.yml",
+                            gradleTaskHint =
+                                "./gradlew :agent:test --tests \"*WaitOpsReflectiveHandlerTest*\"",
+                        )
+                    ),
+            )
+        )
 
         // In-process owns the full wait/idling surface
         fun coreEvidence(id: String, file: String, description: String) =

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrixEvidenceTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrixEvidenceTest.kt
@@ -119,13 +119,11 @@ class CapabilityMatrixEvidenceTest {
 
     @Test
     fun `deliberate remote exclusions for idling and tracing are recorded`() {
+        // Idling-resource registration / withTracing stay remote-unsupported. waitForIdle
+        // fingerprint wait is Supported on Agent (#362); HTTP waitForIdle remains excluded.
         for (transport in listOf(AutomatorTransport.Http, AutomatorTransport.Agent)) {
             for (op in
-                listOf(
-                    AutomatorOperation.RegisterIdlingResource,
-                    AutomatorOperation.WithTracing,
-                    AutomatorOperation.WaitForIdle,
-                )) {
+                listOf(AutomatorOperation.RegisterIdlingResource, AutomatorOperation.WithTracing)) {
                 val cell =
                     CapabilityMatrix.cell(op, transport, PlatformPrerequisite.AnyJvm)
                         ?: error("Missing exclusion cell for $op on $transport")
@@ -135,6 +133,26 @@ class CapabilityMatrixEvidenceTest {
                 )
             }
         }
+        val httpIdle =
+            CapabilityMatrix.cell(
+                AutomatorOperation.WaitForIdle,
+                AutomatorTransport.Http,
+                PlatformPrerequisite.AnyJvm,
+            ) ?: error("Missing HTTP WaitForIdle exclusion")
+        assertTrue(
+            httpIdle.state == CellState.UnsupportedByDesign,
+            "Expected HTTP WaitForIdle UnsupportedByDesign, got ${httpIdle.state}",
+        )
+        val agentIdle =
+            CapabilityMatrix.cell(
+                AutomatorOperation.WaitForIdle,
+                AutomatorTransport.Agent,
+                PlatformPrerequisite.AnyJvm,
+            ) ?: error("Missing Agent WaitForIdle cell")
+        assertTrue(
+            agentIdle.state == CellState.Supported,
+            "Expected Agent WaitForIdle Supported (#362), got ${agentIdle.state}",
+        )
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Wire `AgentRequest.WaitForIdle` (timeoutMs / quietPeriodMs / pollIntervalMs)
- Reflective target-side `waitForIdle` via `WaitOpsReflectiveMapper` (packed Duration rawValues)
- `AttachedAutomator.waitForIdle` with absolute deadline on the wire
- Capability matrix: Agent WaitForIdle **Supported** (fingerprint); HTTP still excluded; idling-resource registration remains in-process-only
- Docs: `docs/guide/agent.md`, `capability-matrix.md`

## Test plan

- [x] `WaitOpsReflectiveHandlerTest` success + timeout taxonomy
- [x] `./gradlew check` green
- [ ] CI green on PR