### PR TITLE
feat(agent): printTree, node screenshot, DTO click (#362 P3)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -92,6 +92,7 @@ public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/Au
 	public final fun allNodes ()Ljava/util/List;
 	public final fun capture (Ljava/lang/Integer;)Ldev/sebastiano/spectre/agent/AtomicCaptureResult;
 	public static synthetic fun capture$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AtomicCaptureResult;
+	public final fun click (Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;)V
 	public final fun click (Ljava/lang/String;)V
 	public fun close ()V
 	public final fun doubleClick (Ljava/lang/String;)V
@@ -106,6 +107,8 @@ public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/Au
 	public static synthetic fun longClick$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/String;JILjava/lang/Object;)V
 	public final fun pressKey (II)V
 	public static synthetic fun pressKey$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;IIILjava/lang/Object;)V
+	public final fun printTree ()Ljava/lang/String;
+	public final fun screenshot (Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;)[B
 	public final fun screenshot (Ljava/lang/Integer;Ljava/lang/String;Z)[B
 	public static synthetic fun screenshot$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/Integer;Ljava/lang/String;ZILjava/lang/Object;)[B
 	public final fun scrollWheel (Ljava/lang/String;I)V

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -91,6 +91,15 @@ internal constructor(
         if (resp !is AgentResponse.Ok) throw wireMismatch("Ok", resp)
     }
 
+    /**
+     * Click a previously resolved node DTO (#362). Equivalent to [click] with [NodeSnapshotDto.key]
+     * so callers need not extract the key (avoids confusing key vs testTag).
+     */
+    @Throws(IOException::class)
+    public fun click(node: NodeSnapshotDto) {
+        click(node.key)
+    }
+
     /** Double-click the node identified by [nodeKey] (#203). */
     @Throws(IOException::class)
     public fun doubleClick(nodeKey: String) {
@@ -225,6 +234,27 @@ internal constructor(
             )
         return (resp as? AgentResponse.Screenshot)?.pngBytes
             ?: throw wireMismatch("Screenshot", resp)
+    }
+
+    /**
+     * Capture a PNG of a resolved node's on-screen bounds (#362). Same wire path as window
+     * screenshots; dimensions follow node bounds (± scale policy used for window screenshots).
+     */
+    @Throws(IOException::class)
+    public fun screenshot(node: NodeSnapshotDto): ByteArray {
+        val resp = exchange(AgentRequest.Screenshot(nodeKey = node.key))
+        return (resp as? AgentResponse.Screenshot)?.pngBytes
+            ?: throw wireMismatch("Screenshot", resp)
+    }
+
+    /**
+     * Human-readable semantics tree dump (#362), equivalent to in-process
+     * `ComposeAutomator.printTree()`.
+     */
+    @Throws(IOException::class)
+    public fun printTree(): String {
+        val resp = exchange(AgentRequest.PrintTree)
+        return (resp as? AgentResponse.TreeDump)?.text ?: throw wireMismatch("TreeDump", resp)
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -237,8 +237,11 @@ internal constructor(
     }
 
     /**
-     * Capture a PNG of a resolved node's on-screen bounds (#362). Same wire path as window
-     * screenshots; dimensions follow node bounds (± scale policy used for window screenshots).
+     * Capture a PNG of a resolved node's on-screen bounds (#362).
+     *
+     * Wire-equivalent of in-process `ComposeAutomator.screenshot(node)`: the agent invokes the
+     * native window-scoped node overload (not screen-region capture), so occluding apps are
+     * excluded on platforms that support window capture.
      */
     @Throws(IOException::class)
     public fun screenshot(node: NodeSnapshotDto): ByteArray {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -36,9 +36,8 @@ import javax.imageio.ImageIO
  * developers expect them; we deliberately don't ship them across the wire because that would mean
  * smuggling `Throwable` types we can't safely reconstruct on the client side.
  */
-// Snapshot/input/wait ops each live in helpers where possible; remaining private methods stay
-// under detekt's function-count budget.
-@Suppress("TooManyFunctions")
+// Snapshot/input/wait/debug ops: helpers hold most of the surface; this class is the dispatch hub.
+@Suppress("TooManyFunctions", "LargeClass")
 internal class ReflectiveAutomatorHandler(
     private val automator: Any,
     private val isTargetJvmFocused: () -> Boolean = ::targetJvmHasKeyboardFocus,
@@ -163,6 +162,7 @@ internal class ReflectiveAutomatorHandler(
             is AgentRequest.WaitForNode -> waitOps.handleWaitForNode(request)
             is AgentRequest.WaitForVisualIdle -> waitOps.handleWaitForVisualIdle(request)
             is AgentRequest.WaitForIdle -> waitOps.handleWaitForIdle(request)
+            AgentRequest.PrintTree -> handlePrintTree()
         }
 
     // Note on un-caught exceptions: any non-reflective `RuntimeException` thrown by the
@@ -331,7 +331,24 @@ internal class ReflectiveAutomatorHandler(
         return AgentResponse.Ok
     }
 
+    private fun handlePrintTree(): AgentResponse {
+        val method =
+            automatorClass.methods.firstOrNull { it.name == "printTree" && it.parameterCount == 0 }
+                ?: return AgentResponse.Error(
+                    message = "ComposeAutomator does not expose printTree()",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
+                )
+        val text = (method.invoke(automator) as? String).orEmpty()
+        return AgentResponse.TreeDump(text = text)
+    }
+
     private fun handleScreenshot(request: AgentRequest.Screenshot): AgentResponse {
+        if (request.nodeKey != null) {
+            return handleNodeScreenshot(request)
+        }
         refreshWindowsMethod.invoke(automator)
         val windows = getWindowsMethod.invoke(automator) as List<*>
         val windowSummaries = windows.mapIndexedNotNull { index, tracked ->
@@ -358,11 +375,7 @@ internal class ReflectiveAutomatorHandler(
                 }
 
         val regionScreenshotMethod =
-            automatorClass.methods.firstOrNull {
-                it.name == "screenshot" &&
-                    it.parameterTypes.size == 1 &&
-                    it.parameterTypes[0].name == AWT_RECTANGLE_FQN
-            }
+            regionScreenshotMethodOrError()
                 ?: return AgentResponse.Error(
                     message =
                         "ComposeAutomator does not expose screenshot(Rectangle?) on this build",
@@ -393,15 +406,80 @@ internal class ReflectiveAutomatorHandler(
     }
 
     /**
-     * Default (no windowIndex/surfaceId): first showing surface so delayed-show hosts listed
-     * for #362 agreement are not the visual capture target.
+     * Capture a node's on-screen bounds (#362). Uses region screenshot of [AutomatorNode] bounds so
+     * attach matches in-process `screenshot(node)` scale policy for the PNG size.
+     */
+    private fun handleNodeScreenshot(request: AgentRequest.Screenshot): AgentResponse {
+        val nodeKey =
+            request.nodeKey
+                ?: return AgentResponse.Error(
+                    message = "nodeKey required for node screenshot",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InvalidSelector
+                            .wireName,
+                )
+        if (request.fullscreen || request.windowIndex != null || request.surfaceId != null) {
+            return AgentResponse.Error(
+                message =
+                    "nodeKey screenshot cannot be combined with fullscreen, windowIndex, or surfaceId",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InvalidSelector
+                        .wireName,
+            )
+        }
+        refreshWindowsMethod.invoke(automator)
+        val node =
+            (allNodesMethod.invoke(automator) as List<*>).firstOrNull {
+                it != null && extractKey(it) == nodeKey
+            }
+                ?: return AgentResponse.Error(
+                    message = "No node found with key=$nodeKey",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory.NodeNotFound
+                            .wireName,
+                )
+        val regionScreenshotMethod =
+            regionScreenshotMethodOrError()
+                ?: return AgentResponse.Error(
+                    message =
+                        "ComposeAutomator does not expose screenshot(Rectangle?) on this build",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
+                )
+        val bounds =
+            node.javaClass.methods
+                .firstOrNull { it.name == "getBoundsOnScreen" && it.parameterCount == 0 }
+                ?.invoke(node)
+                ?: return AgentResponse.Error(
+                    message = "Node has no boundsOnScreen for key=$nodeKey",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InternalError
+                            .wireName,
+                )
+        val image = regionScreenshotMethod.invoke(automator, bounds) as BufferedImage
+        return AgentResponse.Screenshot(imageToPng(image))
+    }
+
+    private fun regionScreenshotMethodOrError(): Method? =
+        automatorClass.methods.firstOrNull {
+            it.name == "screenshot" &&
+                it.parameterTypes.size == 1 &&
+                it.parameterTypes[0].name == AWT_RECTANGLE_FQN
+        }
+
+    /**
+     * Default (no windowIndex/surfaceId/nodeKey): first showing surface so delayed-show hosts
+     * listed for #362 agreement are not the visual capture target.
      */
     private fun defaultScreenshotWindowIndex(
         request: AgentRequest.Screenshot,
         windows: List<*>,
     ): Int? =
         when {
-            request.fullscreen || request.surfaceId != null -> request.windowIndex
+            request.fullscreen || request.surfaceId != null || request.nodeKey != null ->
+                request.windowIndex
             request.windowIndex != null -> request.windowIndex
             else -> firstShowingWindowIndex(windows) ?: 0
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -406,8 +406,11 @@ internal class ReflectiveAutomatorHandler(
     }
 
     /**
-     * Capture a node's on-screen bounds (#362). Uses region screenshot of [AutomatorNode] bounds so
-     * attach matches in-process `screenshot(node)` scale policy for the PNG size.
+     * Capture a node's on-screen bounds (#362) via in-process `screenshot(AutomatorNode)`.
+     *
+     * Must not use the screen-framebuffer `screenshot(Rectangle?)` path: that can include pixels
+     * from occluding apps on macOS/Windows. The node overload is native window-scoped and matches
+     * attach documentation parity with in-process Spectre.
      */
     private fun handleNodeScreenshot(request: AgentRequest.Screenshot): AgentResponse {
         val nodeKey =
@@ -427,6 +430,16 @@ internal class ReflectiveAutomatorHandler(
                         .wireName,
             )
         }
+        val nodeScreenshotMethod =
+            nodeScreenshotMethodOrError()
+                ?: return AgentResponse.Error(
+                    message =
+                        "ComposeAutomator does not expose screenshot(AutomatorNode) on this build",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
+                )
         refreshWindowsMethod.invoke(automator)
         val node =
             (allNodesMethod.invoke(automator) as List<*>).firstOrNull {
@@ -438,27 +451,7 @@ internal class ReflectiveAutomatorHandler(
                         dev.sebastiano.spectre.agent.transport.AgentErrorCategory.NodeNotFound
                             .wireName,
                 )
-        val regionScreenshotMethod =
-            regionScreenshotMethodOrError()
-                ?: return AgentResponse.Error(
-                    message =
-                        "ComposeAutomator does not expose screenshot(Rectangle?) on this build",
-                    category =
-                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
-                            .UnsupportedOperation
-                            .wireName,
-                )
-        val bounds =
-            node.javaClass.methods
-                .firstOrNull { it.name == "getBoundsOnScreen" && it.parameterCount == 0 }
-                ?.invoke(node)
-                ?: return AgentResponse.Error(
-                    message = "Node has no boundsOnScreen for key=$nodeKey",
-                    category =
-                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InternalError
-                            .wireName,
-                )
-        val image = regionScreenshotMethod.invoke(automator, bounds) as BufferedImage
+        val image = nodeScreenshotMethod.invoke(automator, node) as BufferedImage
         return AgentResponse.Screenshot(imageToPng(image))
     }
 
@@ -467,6 +460,20 @@ internal class ReflectiveAutomatorHandler(
             it.name == "screenshot" &&
                 it.parameterTypes.size == 1 &&
                 it.parameterTypes[0].name == AWT_RECTANGLE_FQN
+        }
+
+    /**
+     * `screenshot(node: AutomatorNode)` — single non-primitive param that is not [Rectangle] /
+     * [Int] (windowIndex overload). Agent has no compile-time `core` dependency, so match by
+     * exclusion rather than FQN.
+     */
+    private fun nodeScreenshotMethodOrError(): Method? =
+        automatorClass.methods.firstOrNull {
+            it.name == "screenshot" &&
+                it.parameterTypes.size == 1 &&
+                it.parameterTypes[0].name != AWT_RECTANGLE_FQN &&
+                it.parameterTypes[0] != Int::class.javaPrimitiveType &&
+                it.parameterTypes[0] != Int::class.javaObjectType
         }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -140,12 +140,13 @@ internal sealed interface AgentRequest {
      * [fullscreen]; the server must not silently fall back to the full desktop when window capture
      * fails (#289).
      *
-     * Serial name is `screenshot_v2` (not the pre-#289 payload-free `screenshot`) so an older
-     * agent-runtime JAR that still maps `screenshot` → full-desktop `screenshot(null)` rejects this
-     * request instead of ignoring new fields and silently grabbing the whole desktop.
+     * Serial name is `screenshot_v3` so mixed-version attach fails closed when a client sends
+     * [nodeKey] (or other v3 fields) to an older agent that only knows `screenshot_v2` / payload-free
+     * `screenshot`. Unknown discriminators become `unsupportedOperation` rather than dropping
+     * `nodeKey` under `ignoreUnknownKeys` and returning a window capture (#362 / #289).
      */
     @Serializable
-    @SerialName("screenshot_v2")
+    @SerialName("screenshot_v3")
     data class Screenshot(
         val windowIndex: Int? = null,
         val surfaceId: String? = null,

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -150,6 +150,11 @@ internal sealed interface AgentRequest {
         val windowIndex: Int? = null,
         val surfaceId: String? = null,
         val fullscreen: Boolean = false,
+        /**
+         * When set, capture the node's on-screen bounds (#362); mutually exclusive with window
+         * targets.
+         */
+        val nodeKey: String? = null,
     ) : AgentRequest
 
     /**
@@ -238,6 +243,12 @@ internal sealed interface AgentRequest {
         val quietPeriodMs: Long? = null,
         val pollIntervalMs: Long? = null,
     ) : AgentRequest
+
+    /**
+     * Human-readable semantics tree dump (#362), same shape as in-process
+     * `ComposeAutomator.printTree()`. Replies with [AgentResponse.TreeDump].
+     */
+    @Serializable @SerialName("printTree") data object PrintTree : AgentRequest
 }
 
 /** Payload-free operation label for diagnostics. Never include caller-controlled request data. */
@@ -268,6 +279,7 @@ internal val AgentRequest.logLabel: String
             is AgentRequest.WaitForNode -> "waitForNode"
             is AgentRequest.WaitForVisualIdle -> "waitForVisualIdle"
             is AgentRequest.WaitForIdle -> "waitForIdle"
+            AgentRequest.PrintTree -> "printTree"
         }
 
 /** Server-to-client response envelope. */
@@ -278,6 +290,9 @@ internal sealed interface AgentResponse {
 
     /** Generic OK signal for void operations (click, typeText). */
     @Serializable @SerialName("ok") data object Ok : AgentResponse
+
+    /** Reply to [AgentRequest.PrintTree] — human-readable tree dump (#362). */
+    @Serializable @SerialName("treeDump") data class TreeDump(val text: String) : AgentResponse
 
     /** Reply to [AgentRequest.Windows]. */
     @Serializable

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -141,9 +141,9 @@ internal sealed interface AgentRequest {
      * fails (#289).
      *
      * Serial name is `screenshot_v3` so mixed-version attach fails closed when a client sends
-     * [nodeKey] (or other v3 fields) to an older agent that only knows `screenshot_v2` / payload-free
-     * `screenshot`. Unknown discriminators become `unsupportedOperation` rather than dropping
-     * `nodeKey` under `ignoreUnknownKeys` and returning a window capture (#362 / #289).
+     * [nodeKey] (or other v3 fields) to an older agent that only knows `screenshot_v2` /
+     * payload-free `screenshot`. Unknown discriminators become `unsupportedOperation` rather than
+     * dropping `nodeKey` under `ignoreUnknownKeys` and returning a window capture (#362 / #289).
      */
     @Serializable
     @SerialName("screenshot_v3")

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/PrintTreeAndNodeScreenshotHandlerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/PrintTreeAndNodeScreenshotHandlerTest.kt
@@ -30,7 +30,7 @@ class PrintTreeAndNodeScreenshotHandlerTest {
     }
 
     @Test
-    fun `Screenshot with nodeKey captures node boundsOnScreen region`() {
+    fun `Screenshot with nodeKey invokes window-scoped node overload`() {
         val node =
             DebugFakeNode(
                 keyValue = "window:0:0:5",
@@ -42,8 +42,9 @@ class PrintTreeAndNodeScreenshotHandlerTest {
         val response = handler.handle(AgentRequest.Screenshot(nodeKey = "window:0:0:5"))
         check(response is AgentResponse.Screenshot) { "expected Screenshot, got $response" }
         assertTrue(response.pngBytes.isNotEmpty())
-        assertEquals(1, fake.regionScreenshotCalls)
-        assertEquals(Rectangle(10, 20, 40, 30), fake.lastRegion)
+        assertEquals(1, fake.nodeScreenshotCalls)
+        assertEquals(0, fake.regionScreenshotCalls)
+        assertEquals(node, fake.lastNodeScreenshotTarget)
     }
 
     @Test
@@ -70,7 +71,9 @@ internal class DebugFakeAutomator(
 ) {
     var printTreeCalls = 0
     var regionScreenshotCalls = 0
+    var nodeScreenshotCalls = 0
     var lastRegion: Rectangle? = null
+    var lastNodeScreenshotTarget: Any? = null
 
     @Suppress("unused") fun refreshWindows() = Unit
 
@@ -93,6 +96,19 @@ internal class DebugFakeAutomator(
         val w = region?.width?.coerceAtLeast(1) ?: 1
         val h = region?.height?.coerceAtLeast(1) ?: 1
         return BufferedImage(w, h, BufferedImage.TYPE_INT_RGB)
+    }
+
+    /** Mirrors in-process `ComposeAutomator.screenshot(AutomatorNode)` window-scoped path. */
+    @Suppress("unused")
+    fun screenshot(node: DebugFakeNode): BufferedImage {
+        nodeScreenshotCalls++
+        lastNodeScreenshotTarget = node
+        val bounds = node.getBoundsOnScreen()
+        return BufferedImage(
+            bounds.width.coerceAtLeast(1),
+            bounds.height.coerceAtLeast(1),
+            BufferedImage.TYPE_INT_RGB,
+        )
     }
 }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/PrintTreeAndNodeScreenshotHandlerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/PrintTreeAndNodeScreenshotHandlerTest.kt
@@ -1,0 +1,139 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+import dev.sebastiano.spectre.agent.transport.AgentRequest
+import dev.sebastiano.spectre.agent.transport.AgentResponse
+import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
+import dev.sebastiano.spectre.agent.transport.RectDto
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * #362 printTree + node-key screenshot through [ReflectiveAutomatorHandler] (real reflective path).
+ * DTO click is a client convenience covered by [AttachedAutomator.click] overload.
+ */
+class PrintTreeAndNodeScreenshotHandlerTest {
+
+    @Test
+    fun `PrintTree returns dump from ComposeAutomator printTree`() {
+        val fake = DebugFakeAutomator(printTreeValue = "Window 0 (main): window:0\n  Button")
+        val handler = ReflectiveAutomatorHandler(fake)
+        val response = handler.handle(AgentRequest.PrintTree)
+        check(response is AgentResponse.TreeDump) { "expected TreeDump, got $response" }
+        assertEquals("Window 0 (main): window:0\n  Button", response.text)
+        assertEquals(1, fake.printTreeCalls)
+    }
+
+    @Test
+    fun `Screenshot with nodeKey captures node boundsOnScreen region`() {
+        val node =
+            DebugFakeNode(
+                keyValue = "window:0:0:5",
+                boundsOnScreenValue = Rectangle(10, 20, 40, 30),
+            )
+        val fake = DebugFakeAutomator(allNodesValue = listOf(node))
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response = handler.handle(AgentRequest.Screenshot(nodeKey = "window:0:0:5"))
+        check(response is AgentResponse.Screenshot) { "expected Screenshot, got $response" }
+        assertTrue(response.pngBytes.isNotEmpty())
+        assertEquals(1, fake.regionScreenshotCalls)
+        assertEquals(Rectangle(10, 20, 40, 30), fake.lastRegion)
+    }
+
+    @Test
+    fun `Screenshot nodeKey unknown returns nodeNotFound`() {
+        val handler = ReflectiveAutomatorHandler(DebugFakeAutomator())
+        val response = handler.handle(AgentRequest.Screenshot(nodeKey = "missing"))
+        check(response is AgentResponse.Error)
+        assertEquals(AgentErrorCategory.NodeNotFound.wireName, response.category)
+    }
+
+    @Test
+    fun `Screenshot nodeKey rejects combination with fullscreen`() {
+        val handler = ReflectiveAutomatorHandler(DebugFakeAutomator())
+        val response =
+            handler.handle(AgentRequest.Screenshot(nodeKey = "window:0:0:1", fullscreen = true))
+        check(response is AgentResponse.Error)
+        assertEquals(AgentErrorCategory.InvalidSelector.wireName, response.category)
+    }
+}
+
+internal class DebugFakeAutomator(
+    private val allNodesValue: List<Any> = emptyList(),
+    private val printTreeValue: String = "",
+) {
+    var printTreeCalls = 0
+    var regionScreenshotCalls = 0
+    var lastRegion: Rectangle? = null
+
+    @Suppress("unused") fun refreshWindows() = Unit
+
+    @Suppress("unused") fun getWindows(): List<Any> = emptyList()
+
+    @Suppress("unused") fun allNodes(): List<Any> = allNodesValue
+
+    @Suppress("unused") fun findByTestTag(tag: String): List<Any> = emptyList()
+
+    @Suppress("unused")
+    fun printTree(): String {
+        printTreeCalls++
+        return printTreeValue
+    }
+
+    @Suppress("unused")
+    fun screenshot(region: Rectangle?): BufferedImage {
+        regionScreenshotCalls++
+        lastRegion = region
+        val w = region?.width?.coerceAtLeast(1) ?: 1
+        val h = region?.height?.coerceAtLeast(1) ?: 1
+        return BufferedImage(w, h, BufferedImage.TYPE_INT_RGB)
+    }
+}
+
+@Suppress("FunctionOnlyReturningConstant")
+internal class DebugFakeNode(
+    private val keyValue: String,
+    private val boundsOnScreenValue: Rectangle,
+) {
+    @Suppress("unused") fun getKey(): String = keyValue
+
+    @Suppress("unused") fun getTestTag(): String? = null
+
+    @Suppress("unused") fun getTexts(): List<String> = emptyList()
+
+    @Suppress("unused") fun getEditableText(): String? = null
+
+    @Suppress("unused") fun getRole(): String? = null
+
+    @Suppress("unused") fun getContentDescription(): String? = null
+
+    @Suppress("unused") fun isFocused(): Boolean = false
+
+    @Suppress("unused") fun isVisible(): Boolean = true
+
+    @Suppress("unused") fun getBoundsOnScreen(): Rectangle = boundsOnScreenValue
+}
+
+/** Ensures DTO click convenience compiles against the public API shape. */
+class NodeDtoClickConvenienceTest {
+    @Test
+    fun `NodeSnapshotDto key is used for click overload identity`() {
+        val dto =
+            NodeSnapshotDto(
+                key = "window:0:0:9",
+                testTag = "Submit",
+                texts = listOf("Go"),
+                role = null,
+                contentDescription = null,
+                isVisible = true,
+                bounds = RectDto(0, 0, 1, 1),
+            )
+        assertEquals("window:0:0:9", dto.key)
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -485,6 +485,7 @@ class IpcRoundTripTest {
             is AgentRequest.Cancel,
             is AgentRequest.WaitForVisualIdle,
             is AgentRequest.WaitForIdle -> AgentResponse.Ok
+            AgentRequest.PrintTree -> AgentResponse.TreeDump("")
             is AgentRequest.Screenshot -> AgentResponse.Screenshot(ByteArray(0))
             is AgentRequest.Capture ->
                 AgentResponse.Capture(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WireCodecTest.kt
@@ -72,14 +72,14 @@ class WireCodecTest {
     }
 
     @Test
-    fun `Screenshot request uses screenshot_v2 discriminator so pre-289 agents cannot silently fullscreen`() {
-        // Old agent runtimes mapped SerialName("screenshot") to a payload-free object that always
-        // called screenshot(null). The new request must not share that discriminator.
-        val encoded = WireCodec.encode(AgentRequest.Screenshot())
+    fun `Screenshot request uses screenshot_v3 discriminator for fail-closed nodeKey`() {
+        // Old agents that only know screenshot_v2 would ignore unknown nodeKey and return a
+        // window capture. v3 discriminator forces unsupportedOperation on older runtimes.
+        val encoded = WireCodec.encode(AgentRequest.Screenshot(nodeKey = "window:0:0:1"))
         val asText = encoded.toString(Charsets.ISO_8859_1)
         assertTrue(
-            asText.contains("screenshot_v2"),
-            "encoded request must use screenshot_v2 discriminator",
+            asText.contains("screenshot_v3"),
+            "encoded request must use screenshot_v3 discriminator",
         )
     }
 

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -297,6 +297,9 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 | `waitForNode(...)`    | `AgentRequest.WaitForNode`       | `NodeSnapshotDto` |
 | `waitForVisualIdle(...)` | `AgentRequest.WaitForVisualIdle` | `Unit`         |
 | `waitForIdle(...)`    | `AgentRequest.WaitForIdle`       | `Unit` (fingerprint wait; no idling-resource registration over attach — #362) |
+| `printTree()`         | `AgentRequest.PrintTree`         | `String` (human-readable dump — #362) |
+| `screenshot(node)`    | `AgentRequest.Screenshot(nodeKey)` | `ByteArray` (PNG of node bounds — #362) |
+| `click(node)`         | `AgentRequest.Click`             | `Unit` (DTO overload uses [NodeSnapshotDto.key] — #362) |
 | `close()` (auto)      | `AgentRequest.Detach`            | tear-down         |
 
 `windowIdentities` returns native handle/id (when resolvable), window and Compose-surface


### PR DESCRIPTION
## Summary

- **printTree** over attach (human-readable dump like in-process)
- **screenshot(node)** via `nodeKey` on the screenshot wire verb (PNG of node on-screen bounds)
- **click(NodeSnapshotDto)** convenience overload (uses `key`; no wire change)

## Test plan

- [x] `PrintTreeAndNodeScreenshotHandlerTest`
- [x] `./gradlew check`
- [ ] CI green