### PR TITLE
fix(agent): node screenshot fallback + #362 attach e2e close-out

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -239,9 +239,10 @@ internal constructor(
     /**
      * Capture a PNG of a resolved node's on-screen bounds (#362).
      *
-     * Wire-equivalent of in-process `ComposeAutomator.screenshot(node)`: the agent invokes the
-     * native window-scoped node overload (not screen-region capture), so occluding apps are
-     * excluded on platforms that support window capture.
+     * Preferentially uses in-process `screenshot(AutomatorNode)` (native window-scoped) when the
+     * target has the recording capture bridge. When that bridge is absent — typical inject attach
+     * without a preinstalled recording module — falls back to region capture of the node's
+     * on-screen bounds, matching attach window screenshot policy.
      */
     @Throws(IOException::class)
     public fun screenshot(node: NodeSnapshotDto): ByteArray {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -479,11 +479,18 @@ internal class ReflectiveAutomatorHandler(
         return regionScreenshotMethod.invoke(automator, bounds) as BufferedImage
     }
 
+    /**
+     * Only the missing recording bridge (inject attach) may fall back to region capture. Other
+     * [UnsupportedOperationException]s from native capture (e.g. non-Frame hosts) must surface —
+     * silent framebuffer fallback would reintroduce occluded-pixel captures.
+     */
     private fun isNativeWindowCaptureUnavailable(ex: ReflectiveOperationException): Boolean {
-        val cause = ex.cause ?: ex
-        val message = cause.message.orEmpty()
-        return cause is UnsupportedOperationException ||
-            message.contains("Native window capture bridge is unavailable")
+        var current: Throwable? = ex
+        while (current != null) {
+            if (current.message.orEmpty().contains(NATIVE_BRIDGE_UNAVAILABLE_SNIPPET)) return true
+            current = current.cause
+        }
+        return false
     }
 
     private fun regionScreenshotMethodOrError(): Method? =
@@ -807,6 +814,9 @@ internal class ReflectiveAutomatorHandler(
         const val CONTINUATION_FQN: String = "kotlin.coroutines.Continuation"
         const val AWT_RECTANGLE_FQN: String = "java.awt.Rectangle"
         const val NO_MESSAGE_PLACEHOLDER: String = "<no message>"
+        /** Matches core ScreenCaptureBackend when NativeWindowCaptureBridge is not loadable. */
+        const val NATIVE_BRIDGE_UNAVAILABLE_SNIPPET: String =
+            "Native window capture bridge is unavailable"
         /** Sentinel when a fake/partial AutomatorNode lacks an optional boolean getter. */
         val MISSING_BOOLEAN_METHOD: Method = Object::class.java.getMethod("hashCode")
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -406,11 +406,13 @@ internal class ReflectiveAutomatorHandler(
     }
 
     /**
-     * Capture a node's on-screen bounds (#362) via in-process `screenshot(AutomatorNode)`.
+     * Capture a node's on-screen bounds (#362).
      *
-     * Must not use the screen-framebuffer `screenshot(Rectangle?)` path: that can include pixels
-     * from occluding apps on macOS/Windows. The node overload is native window-scoped and matches
-     * attach documentation parity with in-process Spectre.
+     * Prefers in-process `screenshot(AutomatorNode)` (native window-scoped, matches local Spectre
+     * when the recording bridge is on the target classpath). When that path is missing or rejects
+     * with "Native window capture bridge is unavailable" — the common inject-attach case, which
+     * deliberately omits recording — falls back to region capture of `boundsOnScreen`, the same
+     * framebuffer policy as attach window screenshots (#289).
      */
     private fun handleNodeScreenshot(request: AgentRequest.Screenshot): AgentResponse {
         val nodeKey =
@@ -430,16 +432,6 @@ internal class ReflectiveAutomatorHandler(
                         .wireName,
             )
         }
-        val nodeScreenshotMethod =
-            nodeScreenshotMethodOrError()
-                ?: return AgentResponse.Error(
-                    message =
-                        "ComposeAutomator does not expose screenshot(AutomatorNode) on this build",
-                    category =
-                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
-                            .UnsupportedOperation
-                            .wireName,
-                )
         refreshWindowsMethod.invoke(automator)
         val node =
             (allNodesMethod.invoke(automator) as List<*>).firstOrNull {
@@ -451,8 +443,47 @@ internal class ReflectiveAutomatorHandler(
                         dev.sebastiano.spectre.agent.transport.AgentErrorCategory.NodeNotFound
                             .wireName,
                 )
-        val image = nodeScreenshotMethod.invoke(automator, node) as BufferedImage
+        val image =
+            captureNodeScreenshotPreferNative(node)
+                ?: return AgentResponse.Error(
+                    message =
+                        "ComposeAutomator does not expose screenshot(AutomatorNode) or " +
+                            "screenshot(Rectangle?) for nodeKey capture on this build",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+                            .UnsupportedOperation
+                            .wireName,
+                )
         return AgentResponse.Screenshot(imageToPng(image))
+    }
+
+    /**
+     * Prefer native window-scoped node capture; fall back to region of [boundsOnScreen] when the
+     * recording bridge is absent (inject attach) or the node overload is missing.
+     */
+    private fun captureNodeScreenshotPreferNative(node: Any): BufferedImage? {
+        val nodeScreenshotMethod = nodeScreenshotMethodOrError()
+        if (nodeScreenshotMethod != null) {
+            try {
+                return nodeScreenshotMethod.invoke(automator, node) as BufferedImage
+            } catch (ex: ReflectiveOperationException) {
+                if (!isNativeWindowCaptureUnavailable(ex)) throw ex
+                // Fall through to region capture — attach windows already use this path.
+            }
+        }
+        val regionScreenshotMethod = regionScreenshotMethodOrError() ?: return null
+        val bounds =
+            node.javaClass.methods
+                .firstOrNull { it.name == "getBoundsOnScreen" && it.parameterCount == 0 }
+                ?.invoke(node) ?: return null
+        return regionScreenshotMethod.invoke(automator, bounds) as BufferedImage
+    }
+
+    private fun isNativeWindowCaptureUnavailable(ex: ReflectiveOperationException): Boolean {
+        val cause = ex.cause ?: ex
+        val message = cause.message.orEmpty()
+        return cause is UnsupportedOperationException ||
+            message.contains("Native window capture bridge is unavailable")
     }
 
     private fun regionScreenshotMethodOrError(): Method? =

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -182,13 +182,25 @@ class AgentAttachIntegrationTest {
             // mask identity regressions (identity does not need keyboard focus).
             assertWindowIdentityMatchesWindows(automator, windows, iteration = iteration)
 
+            // #362 P2/P3 attach parity: fingerprint wait + human-readable dump before input.
+            automator.waitForIdle()
+            val treeDump = automator.printTree()
+            assertTrue(
+                treeDump.isNotBlank(),
+                "iteration $iteration: printTree() empty after waitForIdle; expected fixture tags",
+            )
+            assertTrue(
+                treeDump.contains(TAG_BUTTON) || treeDump.contains(buttonKey),
+                "iteration $iteration: printTree() should mention button tag or key; dump=$treeDump",
+            )
+
             // #364: raise/activate the fixture window via the attach wire before Robot input.
             // Bare-throws on any wire/handler failure so a missing FocusWindow op fails loudly.
             automator.focusWindow(buttonKey)
 
-            // Click bare-throws on failure (no runCatching) so a broken suspend bridge or a
-            // wire-level error fails the test loudly.
-            automator.click(buttonKey)
+            // #362: DTO click convenience uses the same wire path as key-based click.
+            val buttonNode = buttonMatches.first()
+            automator.click(buttonNode)
 
             val textFieldMatches = automator.findByTestTag(TAG_TEXT_FIELD)
             assertTrue(
@@ -225,6 +237,17 @@ class AgentAttachIntegrationTest {
             assertTrue(
                 screenshotBytes.startsWith(PNG_MAGIC),
                 "iteration $iteration: screenshot bytes do not start with PNG magic header",
+            )
+
+            // #362: node-bounds PNG via window-scoped screenshot(AutomatorNode) on the agent.
+            val nodePng = automator.screenshot(buttonNode)
+            assertTrue(
+                nodePng.size >= MIN_PNG_BYTES,
+                "iteration $iteration: node screenshot too small (${nodePng.size}b)",
+            )
+            assertTrue(
+                nodePng.startsWith(PNG_MAGIC),
+                "iteration $iteration: node screenshot missing PNG magic",
             )
         }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/PrintTreeAndNodeScreenshotHandlerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/PrintTreeAndNodeScreenshotHandlerTest.kt
@@ -30,7 +30,7 @@ class PrintTreeAndNodeScreenshotHandlerTest {
     }
 
     @Test
-    fun `Screenshot with nodeKey invokes window-scoped node overload`() {
+    fun `Screenshot with nodeKey prefers window-scoped node overload`() {
         val node =
             DebugFakeNode(
                 keyValue = "window:0:0:5",
@@ -45,6 +45,29 @@ class PrintTreeAndNodeScreenshotHandlerTest {
         assertEquals(1, fake.nodeScreenshotCalls)
         assertEquals(0, fake.regionScreenshotCalls)
         assertEquals(node, fake.lastNodeScreenshotTarget)
+    }
+
+    @Test
+    fun `Screenshot nodeKey falls back to region when native bridge unavailable`() {
+        val node =
+            DebugFakeNode(
+                keyValue = "window:0:0:5",
+                boundsOnScreenValue = Rectangle(10, 20, 40, 30),
+            )
+        val fake =
+            DebugFakeAutomator(
+                allNodesValue = listOf(node),
+                nodeScreenshotThrows =
+                    UnsupportedOperationException("Native window capture bridge is unavailable"),
+            )
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response = handler.handle(AgentRequest.Screenshot(nodeKey = "window:0:0:5"))
+        check(response is AgentResponse.Screenshot) { "expected Screenshot, got $response" }
+        assertTrue(response.pngBytes.isNotEmpty())
+        assertEquals(1, fake.nodeScreenshotCalls)
+        assertEquals(1, fake.regionScreenshotCalls)
+        assertEquals(Rectangle(10, 20, 40, 30), fake.lastRegion)
     }
 
     @Test
@@ -68,6 +91,7 @@ class PrintTreeAndNodeScreenshotHandlerTest {
 internal class DebugFakeAutomator(
     private val allNodesValue: List<Any> = emptyList(),
     private val printTreeValue: String = "",
+    private val nodeScreenshotThrows: RuntimeException? = null,
 ) {
     var printTreeCalls = 0
     var regionScreenshotCalls = 0
@@ -103,6 +127,7 @@ internal class DebugFakeAutomator(
     fun screenshot(node: DebugFakeNode): BufferedImage {
         nodeScreenshotCalls++
         lastNodeScreenshotTarget = node
+        nodeScreenshotThrows?.let { throw it }
         val bounds = node.getBoundsOnScreen()
         return BufferedImage(
             bounds.width.coerceAtLeast(1),

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -298,7 +298,7 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 | `waitForVisualIdle(...)` | `AgentRequest.WaitForVisualIdle` | `Unit`         |
 | `waitForIdle(...)`    | `AgentRequest.WaitForIdle`       | `Unit` (fingerprint wait; no idling-resource registration over attach — #362) |
 | `printTree()`         | `AgentRequest.PrintTree`         | `String` (human-readable dump — #362) |
-| `screenshot(node)`    | `AgentRequest.Screenshot(nodeKey)` | `ByteArray` (PNG of node bounds — #362) |
+| `screenshot(node)`    | `AgentRequest.Screenshot(nodeKey)` | `ByteArray` (PNG of node bounds — #362; native when recording bridge present, else region of bounds like attach window screenshots) |
 | `click(node)`         | `AgentRequest.Click`             | `Unit` (DTO overload uses [NodeSnapshotDto.key] — #362) |
 | `close()` (auto)      | `AgentRequest.Detach`            | tear-down         |
 


### PR DESCRIPTION
## Summary

- Prefer `screenshot(AutomatorNode)` for attach node screenshots; fall back to region of `boundsOnScreen` when the native capture bridge is unavailable (inject attach excludes recording).
- Attach e2e now exercises `waitForIdle`, `printTree`, DTO `click`, and node screenshot (closes the last #362 parity gaps).
- Docs note the native-vs-region policy.

## Test plan

- [x] `./gradlew check`
- [x] `AgentAttachIntegrationTest` attach exercise detach ×2 (user-like)
- [x] `PrintTreeAndNodeScreenshotHandlerTest` (prefer native + fallback unit)

Closes #362