### PR TITLE
fix(agent): harden attach node screenshots for Windows (#362)

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -408,11 +408,11 @@ internal class ReflectiveAutomatorHandler(
     /**
      * Capture a node's on-screen bounds (#362).
      *
-     * Prefers in-process `screenshot(AutomatorNode)` (native window-scoped, matches local Spectre
-     * when the recording bridge is on the target classpath). When that path is missing or rejects
-     * with "Native window capture bridge is unavailable" — the common inject-attach case, which
-     * deliberately omits recording — falls back to region capture of `boundsOnScreen`, the same
-     * framebuffer policy as attach window screenshots (#289).
+     * Prefers in-process `screenshot(AutomatorNode)` (native window-scoped) when the recording
+     * bridge is present and returns a non-degenerate image. Otherwise uses region capture of live
+     * `boundsOnScreen` — the same framebuffer policy as attach window screenshots (#289).
+     * Degenerate native crops (empty intersection / DPI mishap) also fall back to region so Windows
+     * desktops do not return 1×1 / ~90-byte PNGs for real nodes.
      */
     private fun handleNodeScreenshot(request: AgentRequest.Screenshot): AgentResponse {
         val nodeKey =
@@ -443,8 +443,26 @@ internal class ReflectiveAutomatorHandler(
                         dev.sebastiano.spectre.agent.transport.AgentErrorCategory.NodeNotFound
                             .wireName,
                 )
+        val bounds =
+            extractBoundsOnScreen(node)
+                ?: return AgentResponse.Error(
+                    message = "Node has no boundsOnScreen for key=$nodeKey",
+                    category =
+                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InternalError
+                            .wireName,
+                )
+        if (bounds.width < 1 || bounds.height < 1) {
+            return AgentResponse.Error(
+                message =
+                    "Node boundsOnScreen are empty for key=$nodeKey " +
+                        "(${bounds.width}x${bounds.height}); cannot capture screenshot",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InvalidSelector
+                        .wireName,
+            )
+        }
         val image =
-            captureNodeScreenshotPreferNative(node)
+            captureNodeScreenshotPreferNative(node, bounds)
                 ?: return AgentResponse.Error(
                     message =
                         "ComposeAutomator does not expose screenshot(AutomatorNode) or " +
@@ -458,25 +476,54 @@ internal class ReflectiveAutomatorHandler(
     }
 
     /**
-     * Prefer native window-scoped node capture; fall back to region of [boundsOnScreen] when the
-     * recording bridge is absent (inject attach) or the node overload is missing.
+     * Prefer native window-scoped node capture; fall back to region of [bounds] when the recording
+     * bridge is absent, the node overload is missing, or native returns a degenerate crop.
+     *
+     * Region capture uses a **defensive copy** of the AWT rectangle: live `boundsOnScreen` getters
+     * return snapshots that must not be mutated by `Robot.createScreenCapture` / AWT.
      */
-    private fun captureNodeScreenshotPreferNative(node: Any): BufferedImage? {
+    private fun captureNodeScreenshotPreferNative(
+        node: Any,
+        bounds: java.awt.Rectangle,
+    ): BufferedImage? {
+        val captureBounds = java.awt.Rectangle(bounds)
         val nodeScreenshotMethod = nodeScreenshotMethodOrError()
         if (nodeScreenshotMethod != null) {
             try {
-                return nodeScreenshotMethod.invoke(automator, node) as BufferedImage
+                val image = nodeScreenshotMethod.invoke(automator, node) as BufferedImage
+                if (isPlausibleNodeCapture(image, captureBounds)) return image
+                // Native crop can be empty after DPI / coordinate mismatch — use region.
             } catch (ex: ReflectiveOperationException) {
                 if (!isNativeWindowCaptureUnavailable(ex)) throw ex
-                // Fall through to region capture — attach windows already use this path.
             }
         }
         val regionScreenshotMethod = regionScreenshotMethodOrError() ?: return null
-        val bounds =
+        val image = regionScreenshotMethod.invoke(automator, captureBounds) as BufferedImage
+        check(isPlausibleNodeCapture(image, captureBounds)) {
+            "Region node screenshot ${image.width}x${image.height} is implausible for " +
+                "boundsOnScreen ${captureBounds.width}x${captureBounds.height} at " +
+                "(${captureBounds.x},${captureBounds.y})"
+        }
+        return image
+    }
+
+    private fun extractBoundsOnScreen(node: Any): java.awt.Rectangle? {
+        val raw =
             node.javaClass.methods
                 .firstOrNull { it.name == "getBoundsOnScreen" && it.parameterCount == 0 }
                 ?.invoke(node) ?: return null
-        return regionScreenshotMethod.invoke(automator, bounds) as BufferedImage
+        return raw as? java.awt.Rectangle
+    }
+
+    /**
+     * Reject empty / 1×1 native crops that are clearly not the requested node. Allow DPI scale down
+     * to roughly 1/4 of logical bounds (HiDPI edge cases).
+     */
+    private fun isPlausibleNodeCapture(image: BufferedImage, bounds: java.awt.Rectangle): Boolean {
+        if (image.width < 1 || image.height < 1) return false
+        val minW = (bounds.width / 4).coerceAtLeast(1).coerceAtMost(bounds.width.coerceAtLeast(1))
+        val minH = (bounds.height / 4).coerceAtLeast(1).coerceAtMost(bounds.height.coerceAtLeast(1))
+        return image.width >= minW && image.height >= minH
     }
 
     /**
@@ -553,8 +600,25 @@ internal class ReflectiveAutomatorHandler(
     }
 
     private fun imageToPng(image: BufferedImage): ByteArray {
+        // Normalize to a PNG-friendly sRGB type; some platform Robot captures use types that
+        // ImageIO encodes poorly or not at all on Windows.
+        val normalized =
+            if (
+                image.type == BufferedImage.TYPE_INT_RGB ||
+                    image.type == BufferedImage.TYPE_INT_ARGB
+            ) {
+                image
+            } else {
+                BufferedImage(image.width, image.height, BufferedImage.TYPE_INT_ARGB).also { dst ->
+                    val g = dst.createGraphics()
+                    g.drawImage(image, 0, 0, null)
+                    g.dispose()
+                }
+            }
         val baos = ByteArrayOutputStream()
-        ImageIO.write(image, "png", baos)
+        check(ImageIO.write(normalized, "png", baos)) {
+            "ImageIO failed to encode ${normalized.width}x${normalized.height} screenshot as PNG"
+        }
         return baos.toByteArray()
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -155,6 +155,11 @@ class AgentAttachIntegrationTest {
                     "'$SPECTRE_FIXTURE_WINDOW_TITLE' window. Either WindowTracker didn't see the " +
                     "fixture or the fixture didn't bring up its UI before READY.",
             )
+            println(
+                "[362-user-like] iter=$iteration windows.size=${windows.size} " +
+                    "windows=${windows.map { "idx=${it.index} surface=${it.surfaceId} " +
+                        "title=${it.title} showing=${it.isShowing}" }}"
+            )
 
             // #362: surfaces that contribute nodes must appear in windows() — never empty windows
             // while allNodes() returns window:* (or embedded:*) keys for a live surface.
@@ -184,6 +189,7 @@ class AgentAttachIntegrationTest {
 
             // #362 P2/P3 attach parity: fingerprint wait + human-readable dump before input.
             automator.waitForIdle()
+            println("[362-user-like] iter=$iteration waitForIdle=ok")
             val treeDump = automator.printTree()
             assertTrue(
                 treeDump.isNotBlank(),
@@ -193,6 +199,10 @@ class AgentAttachIntegrationTest {
                 treeDump.contains(TAG_BUTTON) || treeDump.contains(buttonKey),
                 "iteration $iteration: printTree() should mention button tag or key; dump=$treeDump",
             )
+            println(
+                "[362-user-like] iter=$iteration printTree.chars=${treeDump.length} " +
+                    "printTree.head=${treeDump.lineSequence().take(12).joinToString(" | ")}"
+            )
 
             // #364: raise/activate the fixture window via the attach wire before Robot input.
             // Bare-throws on any wire/handler failure so a missing FocusWindow op fails loudly.
@@ -201,6 +211,58 @@ class AgentAttachIntegrationTest {
             // #362: DTO click convenience uses the same wire path as key-based click.
             val buttonNode = buttonMatches.first()
             automator.click(buttonNode)
+            println(
+                "[362-user-like] iter=$iteration dtoClick=ok key=${buttonNode.key} " +
+                    "tag=${buttonNode.testTag} bounds=${buttonNode.bounds}"
+            )
+
+            // Capture screenshots before keyboard-focus work so #362 attach ops stay proven even
+            // when OS focus handoff flakes on a busy local desktop (typeText path is below).
+            val screenshotBytes = automator.screenshot()
+            assertTrue(
+                screenshotBytes.size >= MIN_PNG_BYTES,
+                "iteration $iteration: screenshot too small (${screenshotBytes.size}b) — not a real PNG?",
+            )
+            assertTrue(
+                screenshotBytes.startsWith(PNG_MAGIC),
+                "iteration $iteration: screenshot bytes do not start with PNG magic header",
+            )
+
+            // #362: node-bounds PNG (native when bridge present; region fallback for inject).
+            // Assert **decoded pixel dimensions**, not compressed byte size: solid-color node
+            // crops can compress under MIN_PNG_BYTES while still being a valid capture (Windows
+            // Mattone regression was 92b for a real button — byte-size alone is the wrong signal).
+            val nodePng = automator.screenshot(buttonNode)
+            assertTrue(
+                nodePng.startsWith(PNG_MAGIC),
+                "iteration $iteration: node screenshot missing PNG magic (${nodePng.size}b)",
+            )
+            val nodeImage =
+                javax.imageio.ImageIO.read(java.io.ByteArrayInputStream(nodePng))
+                    ?: error(
+                        "iteration $iteration: ImageIO could not decode node PNG (${nodePng.size}b)"
+                    )
+            val expectedW = buttonNode.bounds.width.coerceAtLeast(1)
+            val expectedH = buttonNode.bounds.height.coerceAtLeast(1)
+            // Allow HiDPI scale-down to ~1/4 of logical bounds; reject empty / 1×1 crops.
+            val minW = (expectedW / 4).coerceAtLeast(1)
+            val minH = (expectedH / 4).coerceAtLeast(1)
+            assertTrue(
+                nodeImage.width >= minW && nodeImage.height >= minH,
+                "iteration $iteration: node screenshot ${nodeImage.width}x${nodeImage.height} " +
+                    "implausible for bounds ${expectedW}x${expectedH} (pngBytes=${nodePng.size})",
+            )
+            println(
+                "[362-user-like] iter=$iteration nodeScreenshot.bytes=${nodePng.size} " +
+                    "decoded=${nodeImage.width}x${nodeImage.height} " +
+                    "nodeBounds=${expectedW}x${expectedH} " +
+                    "windowScreenshot.bytes=${screenshotBytes.size}"
+            )
+            println(
+                "[362-user-like] iter=$iteration RESULT=SUCCESS " +
+                    "primary_observables_non_empty=true " +
+                    "(windows,waitForIdle,printTree,dtoClick,nodeScreenshot)"
+            )
 
             val textFieldMatches = automator.findByTestTag(TAG_TEXT_FIELD)
             assertTrue(
@@ -228,27 +290,6 @@ class AgentAttachIntegrationTest {
                     )
                 }
             }
-
-            val screenshotBytes = automator.screenshot()
-            assertTrue(
-                screenshotBytes.size >= MIN_PNG_BYTES,
-                "iteration $iteration: screenshot too small (${screenshotBytes.size}b) — not a real PNG?",
-            )
-            assertTrue(
-                screenshotBytes.startsWith(PNG_MAGIC),
-                "iteration $iteration: screenshot bytes do not start with PNG magic header",
-            )
-
-            // #362: node-bounds PNG via window-scoped screenshot(AutomatorNode) on the agent.
-            val nodePng = automator.screenshot(buttonNode)
-            assertTrue(
-                nodePng.size >= MIN_PNG_BYTES,
-                "iteration $iteration: node screenshot too small (${nodePng.size}b)",
-            )
-            assertTrue(
-                nodePng.startsWith(PNG_MAGIC),
-                "iteration $iteration: node screenshot missing PNG magic",
-            )
         }
 
         assertFalse(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -187,81 +187,13 @@ class AgentAttachIntegrationTest {
             // mask identity regressions (identity does not need keyboard focus).
             assertWindowIdentityMatchesWindows(automator, windows, iteration = iteration)
 
-            // #362 P2/P3 attach parity: fingerprint wait + human-readable dump before input.
-            automator.waitForIdle()
-            println("[362-user-like] iter=$iteration waitForIdle=ok")
-            val treeDump = automator.printTree()
-            assertTrue(
-                treeDump.isNotBlank(),
-                "iteration $iteration: printTree() empty after waitForIdle; expected fixture tags",
-            )
-            assertTrue(
-                treeDump.contains(TAG_BUTTON) || treeDump.contains(buttonKey),
-                "iteration $iteration: printTree() should mention button tag or key; dump=$treeDump",
-            )
-            println(
-                "[362-user-like] iter=$iteration printTree.chars=${treeDump.length} " +
-                    "printTree.head=${treeDump.lineSequence().take(12).joinToString(" | ")}"
-            )
-
-            // #364: raise/activate the fixture window via the attach wire before Robot input.
-            // Bare-throws on any wire/handler failure so a missing FocusWindow op fails loudly.
-            automator.focusWindow(buttonKey)
-
-            // #362: DTO click convenience uses the same wire path as key-based click.
-            val buttonNode = buttonMatches.first()
-            automator.click(buttonNode)
-            println(
-                "[362-user-like] iter=$iteration dtoClick=ok key=${buttonNode.key} " +
-                    "tag=${buttonNode.testTag} bounds=${buttonNode.bounds}"
-            )
-
-            // Capture screenshots before keyboard-focus work so #362 attach ops stay proven even
-            // when OS focus handoff flakes on a busy local desktop (typeText path is below).
-            val screenshotBytes = automator.screenshot()
-            assertTrue(
-                screenshotBytes.size >= MIN_PNG_BYTES,
-                "iteration $iteration: screenshot too small (${screenshotBytes.size}b) — not a real PNG?",
-            )
-            assertTrue(
-                screenshotBytes.startsWith(PNG_MAGIC),
-                "iteration $iteration: screenshot bytes do not start with PNG magic header",
-            )
-
-            // #362: node-bounds PNG (native when bridge present; region fallback for inject).
-            // Assert **decoded pixel dimensions**, not compressed byte size: solid-color node
-            // crops can compress under MIN_PNG_BYTES while still being a valid capture (Windows
-            // Mattone regression was 92b for a real button — byte-size alone is the wrong signal).
-            val nodePng = automator.screenshot(buttonNode)
-            assertTrue(
-                nodePng.startsWith(PNG_MAGIC),
-                "iteration $iteration: node screenshot missing PNG magic (${nodePng.size}b)",
-            )
-            val nodeImage =
-                javax.imageio.ImageIO.read(java.io.ByteArrayInputStream(nodePng))
-                    ?: error(
-                        "iteration $iteration: ImageIO could not decode node PNG (${nodePng.size}b)"
-                    )
-            val expectedW = buttonNode.bounds.width.coerceAtLeast(1)
-            val expectedH = buttonNode.bounds.height.coerceAtLeast(1)
-            // Allow HiDPI scale-down to ~1/4 of logical bounds; reject empty / 1×1 crops.
-            val minW = (expectedW / 4).coerceAtLeast(1)
-            val minH = (expectedH / 4).coerceAtLeast(1)
-            assertTrue(
-                nodeImage.width >= minW && nodeImage.height >= minH,
-                "iteration $iteration: node screenshot ${nodeImage.width}x${nodeImage.height} " +
-                    "implausible for bounds ${expectedW}x${expectedH} (pngBytes=${nodePng.size})",
-            )
-            println(
-                "[362-user-like] iter=$iteration nodeScreenshot.bytes=${nodePng.size} " +
-                    "decoded=${nodeImage.width}x${nodeImage.height} " +
-                    "nodeBounds=${expectedW}x${expectedH} " +
-                    "windowScreenshot.bytes=${screenshotBytes.size}"
-            )
-            println(
-                "[362-user-like] iter=$iteration RESULT=SUCCESS " +
-                    "primary_observables_non_empty=true " +
-                    "(windows,waitForIdle,printTree,dtoClick,nodeScreenshot)"
+            // #362 / #364: wait, dump, focus, DTO click, window + node screenshots (before
+            // typeText).
+            exerciseIssue362AttachParity(
+                automator = automator,
+                buttonNode = buttonMatches.first(),
+                buttonKey = buttonKey,
+                iteration = iteration,
             )
 
             val textFieldMatches = automator.findByTestTag(TAG_TEXT_FIELD)
@@ -295,6 +227,93 @@ class AgentAttachIntegrationTest {
         assertFalse(
             Files.exists(udsPath),
             "iteration $iteration: UDS path $udsPath should not exist after detach",
+        )
+    }
+
+    /**
+     * #362 attach parity: waitForIdle, printTree, DTO click, window + node screenshots.
+     *
+     * Screenshots run **before** typeText focus work so OS focus flakes do not mask capture
+     * regressions. Node PNG is validated by **decoded dimensions** (not compressed size): solid
+     * Windows button crops can compress to ~90 bytes while remaining a valid 100×40 capture.
+     */
+    private fun exerciseIssue362AttachParity(
+        automator: AttachedAutomator,
+        buttonNode: NodeSnapshotDto,
+        buttonKey: String,
+        iteration: Int,
+    ) {
+        automator.waitForIdle()
+        println("[362-user-like] iter=$iteration waitForIdle=ok")
+        val treeDump = automator.printTree()
+        assertTrue(
+            treeDump.isNotBlank(),
+            "iteration $iteration: printTree() empty after waitForIdle; expected fixture tags",
+        )
+        assertTrue(
+            treeDump.contains(TAG_BUTTON) || treeDump.contains(buttonKey),
+            "iteration $iteration: printTree() should mention button tag or key; dump=$treeDump",
+        )
+        println(
+            "[362-user-like] iter=$iteration printTree.chars=${treeDump.length} " +
+                "printTree.head=${treeDump.lineSequence().take(12).joinToString(" | ")}"
+        )
+
+        // #364: raise/activate the fixture window before Robot input.
+        automator.focusWindow(buttonKey)
+        automator.click(buttonNode)
+        println(
+            "[362-user-like] iter=$iteration dtoClick=ok key=${buttonNode.key} " +
+                "tag=${buttonNode.testTag} bounds=${buttonNode.bounds}"
+        )
+
+        val screenshotBytes = automator.screenshot()
+        assertTrue(
+            screenshotBytes.size >= MIN_PNG_BYTES,
+            "iteration $iteration: screenshot too small (${screenshotBytes.size}b) — not a real PNG?",
+        )
+        assertTrue(
+            screenshotBytes.startsWith(PNG_MAGIC),
+            "iteration $iteration: screenshot bytes do not start with PNG magic header",
+        )
+        assertNodeScreenshotDimensions(automator, buttonNode, screenshotBytes, iteration)
+        println(
+            "[362-user-like] iter=$iteration RESULT=SUCCESS " +
+                "primary_observables_non_empty=true " +
+                "(windows,waitForIdle,printTree,dtoClick,nodeScreenshot)"
+        )
+    }
+
+    private fun assertNodeScreenshotDimensions(
+        automator: AttachedAutomator,
+        buttonNode: NodeSnapshotDto,
+        windowScreenshotBytes: ByteArray,
+        iteration: Int,
+    ) {
+        val nodePng = automator.screenshot(buttonNode)
+        assertTrue(
+            nodePng.startsWith(PNG_MAGIC),
+            "iteration $iteration: node screenshot missing PNG magic (${nodePng.size}b)",
+        )
+        val nodeImage =
+            javax.imageio.ImageIO.read(java.io.ByteArrayInputStream(nodePng))
+                ?: error(
+                    "iteration $iteration: ImageIO could not decode node PNG (${nodePng.size}b)"
+                )
+        val expectedW = buttonNode.bounds.width.coerceAtLeast(1)
+        val expectedH = buttonNode.bounds.height.coerceAtLeast(1)
+        val minW = (expectedW / 4).coerceAtLeast(1)
+        val minH = (expectedH / 4).coerceAtLeast(1)
+        assertTrue(
+            nodeImage.width >= minW && nodeImage.height >= minH,
+            "iteration $iteration: node screenshot ${nodeImage.width}x${nodeImage.height} " +
+                "implausible for bounds ${expectedW}x${expectedH} (pngBytes=${nodePng.size})",
+        )
+        println(
+            "[362-user-like] iter=$iteration nodeScreenshot.bytes=${nodePng.size} " +
+                "decoded=${nodeImage.width}x${nodeImage.height} " +
+                "nodeBounds=${expectedW}x${expectedH} " +
+                "windowScreenshot.bytes=${windowScreenshotBytes.size}"
         )
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/PrintTreeAndNodeScreenshotHandlerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/PrintTreeAndNodeScreenshotHandlerTest.kt
@@ -71,6 +71,39 @@ class PrintTreeAndNodeScreenshotHandlerTest {
     }
 
     @Test
+    fun `Screenshot nodeKey falls back to region when native returns degenerate crop`() {
+        val node =
+            DebugFakeNode(
+                keyValue = "window:0:0:5",
+                boundsOnScreenValue = Rectangle(10, 20, 40, 30),
+            )
+        val fake =
+            DebugFakeAutomator(
+                allNodesValue = listOf(node),
+                // 1×1 native crop is implausible for 40×30 bounds → region fallback.
+                nodeScreenshotImage = BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB),
+            )
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response = handler.handle(AgentRequest.Screenshot(nodeKey = "window:0:0:5"))
+        check(response is AgentResponse.Screenshot) { "expected Screenshot, got $response" }
+        assertTrue(response.pngBytes.isNotEmpty())
+        assertEquals(1, fake.nodeScreenshotCalls)
+        assertEquals(1, fake.regionScreenshotCalls)
+        assertEquals(Rectangle(10, 20, 40, 30), fake.lastRegion)
+    }
+
+    @Test
+    fun `Screenshot nodeKey rejects empty boundsOnScreen`() {
+        val node =
+            DebugFakeNode(keyValue = "window:0:0:5", boundsOnScreenValue = Rectangle(10, 20, 0, 0))
+        val handler = ReflectiveAutomatorHandler(DebugFakeAutomator(allNodesValue = listOf(node)))
+        val response = handler.handle(AgentRequest.Screenshot(nodeKey = "window:0:0:5"))
+        check(response is AgentResponse.Error)
+        assertEquals(AgentErrorCategory.InvalidSelector.wireName, response.category)
+    }
+
+    @Test
     fun `Screenshot nodeKey unknown returns nodeNotFound`() {
         val handler = ReflectiveAutomatorHandler(DebugFakeAutomator())
         val response = handler.handle(AgentRequest.Screenshot(nodeKey = "missing"))
@@ -92,6 +125,7 @@ internal class DebugFakeAutomator(
     private val allNodesValue: List<Any> = emptyList(),
     private val printTreeValue: String = "",
     private val nodeScreenshotThrows: RuntimeException? = null,
+    private val nodeScreenshotImage: BufferedImage? = null,
 ) {
     var printTreeCalls = 0
     var regionScreenshotCalls = 0
@@ -128,6 +162,9 @@ internal class DebugFakeAutomator(
         nodeScreenshotCalls++
         lastNodeScreenshotTarget = node
         nodeScreenshotThrows?.let { throw it }
+        nodeScreenshotImage?.let {
+            return it
+        }
         val bounds = node.getBoundsOnScreen()
         return BufferedImage(
             bounds.width.coerceAtLeast(1),


### PR DESCRIPTION
## Summary

Windows attach e2e on Mattone failed with node screenshot **92b < MIN_PNG_BYTES(100)** while window screenshots passed. Compressed byte size is the wrong signal for solid-color node crops; this PR:

- Validates non-empty live `boundsOnScreen` before capture
- Falls back to region capture when native returns a degenerate crop (DPI / empty intersection)
- Defensive-copies the AWT rectangle and normalizes PNG encoding
- E2e asserts **decoded image dimensions** vs node bounds (¼ scale tolerance), not byte length
- Captures screenshots before typeText focus thrashing

## Test plan

- [x] `./gradlew :agent:test --tests '*PrintTreeAndNodeScreenshot*'`
- [x] `./gradlew :agent:test --tests '*AgentAttachIntegrationTest.attach exercise*'` (macOS)
- [ ] Windows Mattone: `AgentAttachIntegrationTest` with `-Pspectre.agent.attachE2e.allowWindows=true`

Refs #362