### PR TITLE
fix(sample-desktop): harden SampleAppFixture cold-start on Windows CI

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -254,7 +254,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest NewInteractionsValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest NewInteractionsValidationTest SampleAppFixtureStartupDiagnosticsTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -164,7 +164,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest SampleAppFixtureStartupDiagnosticsTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -128,10 +128,11 @@ val applyValidationJvmArgs: Test.() -> Unit = {
     // Xvfb / headless-CI hosts often lack a working GL stack; Skiko then logs
     // "Cannot create Linux GL context" and can hang or abandon a forked validation JVM
     // without writing per-class JUnit XML (AtomicCaptureValidationTest envelope-only skip).
-    // Default SOFTWARE_COMPAT matches the Linux Robot smoke path, but honor a caller
-    // override (e.g. -Dskiko.renderApi=OPENGL) so local GPU/fidelity work is not forced
-    // through the software renderer.
-    if (OperatingSystem.current().isLinux) {
+    // Windows GHA runners hit a related cold-start flake: first GPU/ANGLE init can delay
+    // Compose Desktop application{} past the fixture budget. Default SOFTWARE_COMPAT on
+    // Linux *and* Windows; honor a caller override (e.g. -Dskiko.renderApi=OPENGL) so local
+    // GPU/fidelity work is not forced through the software renderer.
+    if (OperatingSystem.current().isLinux || OperatingSystem.current().isWindows) {
         val renderApi = providers.systemProperty("skiko.renderApi").orElse("SOFTWARE_COMPAT").get()
         systemProperty("skiko.renderApi", renderApi)
     }
@@ -151,7 +152,8 @@ val validationTest by
         // a previous shutdown finalises the AWT runtime).
         forkEvery = 1
         // Re-render the picker / spawn the window inside each test method via the fixture's poll
-        // loop. The 10-second startupTimeout is enough headroom for cold JVM warmup on CI hardware.
+        // loop. SampleAppFixture.DEFAULT_STARTUP_TIMEOUT (30s) leaves headroom for cold AWT +
+        // Compose Desktop init on Windows GHA workers (see AtomicCaptureValidationTest flake).
         applyValidationJvmArgs()
     }
 

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
@@ -96,27 +96,21 @@ class SampleAppFixture(
         thread.start()
         val entered =
             applicationStarted.await(startupTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
-        val error = startupError.get()
-        if (!entered || error != null) {
-            throw IllegalStateException(
-                describeApplicationStartupFailure(
-                    timeout = startupTimeout,
-                    enteredApplication = entered,
-                    threadAlive = thread.isAlive,
-                    startupError = error,
-                ),
-                error,
-            )
-        }
+        throwIfStartupFailed(enteredApplication = entered)
         // The Window enters the AWT hierarchy a few frames after application{} starts. Poll a
         // bootstrap WindowTracker until it surfaces our window so we can construct the
         // automator with a synthetic driver bound to it. Match by title — `Window.getWindows()`
         // can return multiple top-level windows in unspecified order (other JVM windows, the
         // sample app's previous instance, etc.), so taking `.first()` would risk attaching the
         // synthetic driver to an unrelated surface.
+        //
+        // Re-check [startupError] each poll: Window/composition can still throw *after*
+        // applicationStarted counted down; without this, that failure only surfaces 30s later
+        // as a generic "window did not appear" with no cause (Codex review on #373).
         val bootstrapTracker = WindowTracker()
         val deadline = System.nanoTime() + startupTimeout.inWholeNanoseconds
         while (System.nanoTime() < deadline) {
+            throwIfStartupFailed(enteredApplication = true)
             bootstrapTracker.refresh()
             val tracked =
                 bootstrapTracker.trackedWindows.value.firstOrNull {
@@ -130,7 +124,22 @@ class SampleAppFixture(
             }
             Thread.sleep(WINDOW_POLL.inWholeMilliseconds)
         }
+        throwIfStartupFailed(enteredApplication = true)
         error("Main window with title '$title' did not appear within $startupTimeout")
+    }
+
+    private fun throwIfStartupFailed(enteredApplication: Boolean) {
+        val error = startupError.get()
+        if (enteredApplication && error == null) return
+        throw IllegalStateException(
+            describeApplicationStartupFailure(
+                timeout = startupTimeout,
+                enteredApplication = enteredApplication,
+                threadAlive = ::thread.isInitialized && thread.isAlive,
+                startupError = error,
+            ),
+            error,
+        )
     }
 
     fun stop() {

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixture.kt
@@ -9,8 +9,10 @@ import dev.sebastiano.spectre.core.InternalSpectreApi
 import dev.sebastiano.spectre.core.RobotDriver
 import dev.sebastiano.spectre.core.WindowTracker
 import java.awt.GraphicsEnvironment
+import java.awt.Toolkit
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
@@ -34,10 +36,11 @@ import kotlin.time.Duration.Companion.seconds
  */
 class SampleAppFixture(
     private val title: String = "Spectre validation",
-    private val startupTimeout: Duration = 10.seconds,
+    private val startupTimeout: Duration = DEFAULT_STARTUP_TIMEOUT,
 ) {
 
     private val applicationStarted = CountDownLatch(1)
+    private val startupError = AtomicReference<Throwable?>(null)
     @Volatile private var exitFn: (() -> Unit)? = null
     private lateinit var thread: Thread
     private lateinit var _automator: ComposeAutomator
@@ -58,23 +61,52 @@ class SampleAppFixture(
 
     fun start() {
         requireDisplay()
+        // Cold Windows CI workers spend a noticeable chunk of the startup budget on first-time
+        // AWT Toolkit / peer init. Warm the toolkit on the test thread *before* arming the latch
+        // clock so that budget is spent waiting for Compose Desktop's application{} entry, not
+        // for AWT itself.
+        Toolkit.getDefaultToolkit()
         thread =
             Thread(
                     {
-                        application {
-                            exitFn = ::exitApplication
-                            applicationStarted.countDown()
-                            Window(onCloseRequest = ::exitApplication, title = title) {
-                                dev.sebastiano.spectre.sample.App()
+                        try {
+                            application {
+                                exitFn = ::exitApplication
+                                applicationStarted.countDown()
+                                Window(onCloseRequest = ::exitApplication, title = title) {
+                                    dev.sebastiano.spectre.sample.App()
+                                }
                             }
+                        } catch (t: Throwable) {
+                            startupError.compareAndSet(null, t)
+                            // Unblock the waiter even when application{} never entered so the
+                            // failure path can report the real exception instead of only a timeout.
+                            applicationStarted.countDown()
+                            throw t
                         }
                     },
                     "spectre-sample-fixture",
                 )
-                .apply { isDaemon = true }
+                .apply {
+                    isDaemon = true
+                    uncaughtExceptionHandler = Thread.UncaughtExceptionHandler { _, error ->
+                        startupError.compareAndSet(null, error)
+                    }
+                }
         thread.start()
-        check(applicationStarted.await(startupTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)) {
-            "Sample app did not enter application{} within $startupTimeout"
+        val entered =
+            applicationStarted.await(startupTimeout.inWholeMilliseconds, TimeUnit.MILLISECONDS)
+        val error = startupError.get()
+        if (!entered || error != null) {
+            throw IllegalStateException(
+                describeApplicationStartupFailure(
+                    timeout = startupTimeout,
+                    enteredApplication = entered,
+                    threadAlive = thread.isAlive,
+                    startupError = error,
+                ),
+                error,
+            )
         }
         // The Window enters the AWT hierarchy a few frames after application{} starts. Poll a
         // bootstrap WindowTracker until it surfaces our window so we can construct the
@@ -113,10 +145,48 @@ class SampleAppFixture(
         }
     }
 
-    private companion object {
-        val WINDOW_POLL: Duration = 100.milliseconds
-        val SHUTDOWN_TIMEOUT: Duration = 5.seconds
+    companion object {
+        /**
+         * Default wait for Compose Desktop `application {}` entry and subsequent window discovery.
+         *
+         * 10s proved tight on cold Windows GHA workers (`AtomicCaptureValidationTest` — "Sample app
+         * did not enter application{} within 10s"). Each validation class forks a fresh JVM
+         * (`forkEvery = 1`), so first AWT + Compose Desktop init regularly burns several seconds
+         * before the application lambda runs.
+         */
+        val DEFAULT_STARTUP_TIMEOUT: Duration = 30.seconds
+
+        private val WINDOW_POLL: Duration = 100.milliseconds
+        private val SHUTDOWN_TIMEOUT: Duration = 5.seconds
     }
+}
+
+/**
+ * Human-readable startup failure text for [SampleAppFixture.start]. Pure so diagnostics can be
+ * unit-tested without spawning AWT / Compose Desktop.
+ */
+internal fun describeApplicationStartupFailure(
+    timeout: Duration,
+    enteredApplication: Boolean,
+    threadAlive: Boolean,
+    startupError: Throwable?,
+): String {
+    val parts = mutableListOf<String>()
+    if (!enteredApplication) {
+        parts += "Sample app did not enter application{} within $timeout"
+    } else {
+        parts += "Sample app application{} failed during startup"
+    }
+    parts +=
+        if (threadAlive) {
+            "fixture thread still alive"
+        } else {
+            "fixture thread already exited"
+        }
+    if (startupError != null) {
+        parts += "cause=${startupError::class.java.name}: ${startupError.message ?: "(no message)"}"
+    }
+    return parts.joinToString("; ")
 }
 
 /**

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixtureStartupDiagnosticsTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/SampleAppFixtureStartupDiagnosticsTest.kt
@@ -1,0 +1,55 @@
+package dev.sebastiano.spectre.sample.validation
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Pure diagnostics for [SampleAppFixture] startup failures — no AWT display required.
+ *
+ * Keeps the Windows cold-start failure message contract locked so CI flakes stay diagnosable when
+ * `application {}` is slow or dies before the latch trips.
+ */
+class SampleAppFixtureStartupDiagnosticsTest {
+
+    @Test
+    fun `default startup timeout leaves headroom for cold Windows CI JVMs`() {
+        // Regression lock for the AtomicCaptureValidationTest flake that timed out at 10s on
+        // validation-windows (GHA) before application{} entered.
+        assertTrue(
+            SampleAppFixture.DEFAULT_STARTUP_TIMEOUT >= 30.seconds,
+            "DEFAULT_STARTUP_TIMEOUT must be at least 30s; was ${SampleAppFixture.DEFAULT_STARTUP_TIMEOUT}",
+        )
+    }
+
+    @Test
+    fun `timeout failure mentions budget and thread liveness`() {
+        val message =
+            describeApplicationStartupFailure(
+                timeout = 30.seconds,
+                enteredApplication = false,
+                threadAlive = true,
+                startupError = null,
+            )
+        assertTrue(message.contains("did not enter application{}"))
+        assertTrue(message.contains("30s") || message.contains("30.0s"))
+        assertTrue(message.contains("fixture thread still alive"))
+        assertFalse(message.contains("cause="))
+    }
+
+    @Test
+    fun `startup exception is folded into the failure message`() {
+        val message =
+            describeApplicationStartupFailure(
+                timeout = 30.seconds,
+                enteredApplication = true,
+                threadAlive = false,
+                startupError = IllegalStateException("compose exploded"),
+            )
+        assertTrue(message.contains("failed during startup"))
+        assertTrue(message.contains("fixture thread already exited"))
+        assertTrue(message.contains("IllegalStateException"))
+        assertTrue(message.contains("compose exploded"))
+    }
+}


### PR DESCRIPTION
## Summary

Hardens the sample validation fixture against the Windows `validation-windows` flake seen on #366:

`AtomicCaptureValidationTest` → `Sample app did not enter application{} within 10s`

That failure is a cold-start race on forked validation JVMs (`forkEvery = 1`): first AWT + Compose Desktop init can exceed a 10s budget before `application {}` enters.

### Changes
- Raise `SampleAppFixture.DEFAULT_STARTUP_TIMEOUT` from **10s → 30s**
- Pre-warm `Toolkit.getDefaultToolkit()` before arming the latch clock
- Capture fixture-thread exceptions and fold them into the startup failure (with cause)
- Default Skiko `SOFTWARE_COMPAT` on **Windows** validation workers (same as Linux)
- Pure diagnostics tests lock the timeout/message contract; required in validation workflows

## Test plan
- [x] `:sample-desktop:validationTest --tests '*SampleAppFixtureStartupDiagnosticsTest*'`
- [x] `:sample-desktop:validationTest --tests '*AtomicCaptureValidationTest*'` (local macOS)
- [x] `./gradlew check`
- [ ] GHA `validation-windows` green on this PR