### PR TITLE
fix(core): honest waitForVisualIdle timeout for unsampleable frames

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
@@ -121,8 +121,25 @@ internal suspend fun waitForVisualIdleInternal(
     var lastSuccessfulHash: Int? = null
     var sawHashChange = false
 
+    fun timeoutException(): IdleTimeoutException =
+        IdleTimeoutException(
+            "waitForVisualIdle timed out after ${timeout.inWholeMilliseconds}ms: " +
+                visualIdleTimeoutDiagnostic(
+                    stableFrames = stableFrames,
+                    sampleCount = sampleCount,
+                    unsampleableCount = unsampleableCount,
+                    sawHashChange = sawHashChange,
+                )
+        )
+
     while (true) {
-        val hash = frameHash((deadline - clock.now()).coerceAtLeast(0))
+        // If a prior sleep already exhausted the wait, stop without taking another sample.
+        // A zero remaining budget makes BoundedFrameHasher return null, which would spuriously
+        // inflate unsampleable counts on pure pixel-churn timeouts.
+        val remainingMs = (deadline - clock.now()).coerceAtLeast(0)
+        if (remainingMs == 0L) throw timeoutException()
+
+        val hash = frameHash(remainingMs)
         sampleCount++
         val streakComplete =
             if (hash == null) {
@@ -143,17 +160,7 @@ internal suspend fun waitForVisualIdleInternal(
 
         val nowAfterSample = clock.now()
         if (streakComplete && nowAfterSample <= deadline) return
-        if (nowAfterSample >= deadline) {
-            throw IdleTimeoutException(
-                "waitForVisualIdle timed out after ${timeout.inWholeMilliseconds}ms: " +
-                    visualIdleTimeoutDiagnostic(
-                        stableFrames = stableFrames,
-                        sampleCount = sampleCount,
-                        unsampleableCount = unsampleableCount,
-                        sawHashChange = sawHashChange,
-                    )
-            )
-        }
+        if (nowAfterSample >= deadline) throw timeoutException()
         sleep(pollInterval)
     }
 }
@@ -172,6 +179,7 @@ internal fun visualIdleTimeoutDiagnostic(
     sawHashChange: Boolean,
 ): String {
     val unstable = "frames did not stabilise across $stableFrames samples"
+    val incompleteStreak = "stable-frame streak did not complete across $stableFrames samples"
     val unsampleable =
         if (unsampleableCount > 0 && sampleCount > 0) {
             "$unsampleableCount/$sampleCount samples were unsampleable " +
@@ -181,15 +189,17 @@ internal fun visualIdleTimeoutDiagnostic(
         }
 
     return when {
-        unsampleable == null -> unstable
-        unsampleableCount == sampleCount ->
+        unsampleableCount == sampleCount && unsampleable != null ->
             // Every attempt failed to produce a hash — do not send the caller hunting for
             // animations.
             unsampleable
-        sawHashChange -> "$unsampleable; $unstable"
-        else ->
-            // Successful hashes were identical; nulls alone prevented the streak.
-            "$unsampleable; stable-frame streak did not complete across $stableFrames samples"
+        // Only blame pixel churn when non-null hashes actually differed.
+        sawHashChange && unsampleable != null -> "$unsampleable; $unstable"
+        sawHashChange -> unstable
+        // Hashes that did land were identical (or never landed a second time); incomplete streak
+        // from timeout and/or unsampleable polls — not an animation.
+        unsampleable != null -> "$unsampleable; $incompleteStreak"
+        else -> incompleteStreak
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
@@ -100,6 +100,10 @@ internal suspend fun waitForIdleInternal(
  * Stricter than [waitForIdleInternal]: the UI must not just be structurally stable, it must also
  * paint the same pixels for several frames in a row. Useful before screenshots and recordings to
  * avoid capturing in the middle of an animation.
+ *
+ * A `null` frame hash means the sample was unsampleable (capture budget exceeded or no Compose
+ * surface available). Those samples clear the streak and are counted so a timeout can name the real
+ * cause instead of only blaming unstable pixels.
  */
 internal suspend fun waitForVisualIdleInternal(
     timeout: Duration,
@@ -112,11 +116,15 @@ internal suspend fun waitForVisualIdleInternal(
     require(stableFrames > 0) { "stableFrames must be positive, was $stableFrames" }
     val deadline = clock.now() + timeout.inWholeMilliseconds
     val window = ArrayDeque<Int>(stableFrames)
+    var sampleCount = 0
+    var unsampleableCount = 0
 
     while (true) {
         val hash = frameHash((deadline - clock.now()).coerceAtLeast(0))
+        sampleCount++
         val streakComplete =
             if (hash == null) {
+                unsampleableCount++
                 window.clear()
                 false
             } else {
@@ -133,10 +141,37 @@ internal suspend fun waitForVisualIdleInternal(
         if (nowAfterSample >= deadline) {
             throw IdleTimeoutException(
                 "waitForVisualIdle timed out after ${timeout.inWholeMilliseconds}ms: " +
-                    "frames did not stabilise across $stableFrames samples"
+                    visualIdleTimeoutDiagnostic(
+                        stableFrames = stableFrames,
+                        sampleCount = sampleCount,
+                        unsampleableCount = unsampleableCount,
+                    )
             )
         }
         sleep(pollInterval)
+    }
+}
+
+/**
+ * Builds the diagnostic tail for a [waitForVisualIdleInternal] timeout.
+ *
+ * Pure so unit tests can pin the wording without driving the full wait loop.
+ */
+internal fun visualIdleTimeoutDiagnostic(
+    stableFrames: Int,
+    sampleCount: Int,
+    unsampleableCount: Int,
+): String {
+    val unstable = "frames did not stabilise across $stableFrames samples"
+    if (unsampleableCount <= 0 || sampleCount <= 0) return unstable
+    val unsampleable =
+        "$unsampleableCount/$sampleCount samples were unsampleable " +
+            "(capture budget exceeded or no Compose surface available)"
+    return if (unsampleableCount == sampleCount) {
+        // Every attempt failed to produce a hash — do not send the caller hunting for animations.
+        unsampleable
+    } else {
+        "$unsampleable; $unstable"
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitForIdle.kt
@@ -118,6 +118,8 @@ internal suspend fun waitForVisualIdleInternal(
     val window = ArrayDeque<Int>(stableFrames)
     var sampleCount = 0
     var unsampleableCount = 0
+    var lastSuccessfulHash: Int? = null
+    var sawHashChange = false
 
     while (true) {
         val hash = frameHash((deadline - clock.now()).coerceAtLeast(0))
@@ -128,6 +130,9 @@ internal suspend fun waitForVisualIdleInternal(
                 window.clear()
                 false
             } else {
+                val previous = lastSuccessfulHash
+                if (previous != null && previous != hash) sawHashChange = true
+                lastSuccessfulHash = hash
                 if (window.isNotEmpty() && window.last() != hash) {
                     window.clear()
                 }
@@ -145,6 +150,7 @@ internal suspend fun waitForVisualIdleInternal(
                         stableFrames = stableFrames,
                         sampleCount = sampleCount,
                         unsampleableCount = unsampleableCount,
+                        sawHashChange = sawHashChange,
                     )
             )
         }
@@ -155,23 +161,35 @@ internal suspend fun waitForVisualIdleInternal(
 /**
  * Builds the diagnostic tail for a [waitForVisualIdleInternal] timeout.
  *
- * Pure so unit tests can pin the wording without driving the full wait loop.
+ * Pure so unit tests can pin the wording without driving the full wait loop. Only blames unstable
+ * frames when non-null hashes actually differed; intermittent unsampleable polls that merely
+ * interrupt identical hashes are not reported as pixel churn.
  */
 internal fun visualIdleTimeoutDiagnostic(
     stableFrames: Int,
     sampleCount: Int,
     unsampleableCount: Int,
+    sawHashChange: Boolean,
 ): String {
     val unstable = "frames did not stabilise across $stableFrames samples"
-    if (unsampleableCount <= 0 || sampleCount <= 0) return unstable
     val unsampleable =
-        "$unsampleableCount/$sampleCount samples were unsampleable " +
-            "(capture budget exceeded or no Compose surface available)"
-    return if (unsampleableCount == sampleCount) {
-        // Every attempt failed to produce a hash — do not send the caller hunting for animations.
-        unsampleable
-    } else {
-        "$unsampleable; $unstable"
+        if (unsampleableCount > 0 && sampleCount > 0) {
+            "$unsampleableCount/$sampleCount samples were unsampleable " +
+                "(capture budget exceeded or no Compose surface available)"
+        } else {
+            null
+        }
+
+    return when {
+        unsampleable == null -> unstable
+        unsampleableCount == sampleCount ->
+            // Every attempt failed to produce a hash — do not send the caller hunting for
+            // animations.
+            unsampleable
+        sawHashChange -> "$unsampleable; $unstable"
+        else ->
+            // Successful hashes were identical; nulls alone prevented the streak.
+            "$unsampleable; stable-frame streak did not complete across $stableFrames samples"
     }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
@@ -221,7 +221,40 @@ class WaitForVisualIdleTest {
         )
         assertTrue(
             message.contains("frames did not stabilise"),
-            "Should still mention unstable frames when some hashes were returned: $message",
+            "Should still mention unstable frames when hashes actually changed: $message",
+        )
+    }
+
+    @Test
+    fun `timeout does not blame unstable frames when nulls interrupt identical hashes`() = runTest {
+        val clock = FakeClock()
+        var calls = 0
+        val error =
+            assertFailsWith<IdleTimeoutException> {
+                waitForVisualIdleInternal(
+                    timeout = 80.milliseconds,
+                    stableFrames = 3,
+                    pollInterval = 10.milliseconds,
+                    // Identical successful hashes interrupted by nulls: streak never
+                    // completes, but pixels that did hash never changed.
+                    frameHash = { _ -> if (calls++ % 2 == 0) null else 7 },
+                    clock = clock,
+                    sleep = clock::advance,
+                )
+            }
+
+        val message = error.message.orEmpty()
+        assertTrue(
+            Regex("""\d+/\d+ samples were unsampleable""").containsMatchIn(message),
+            "Should report unsampleable sample counts: $message",
+        )
+        assertTrue(
+            !message.contains("frames did not stabilise"),
+            "Must not blame pixel churn when non-null hashes were identical: $message",
+        )
+        assertTrue(
+            message.contains("stable-frame streak did not complete"),
+            "Should explain incomplete streak without implying animation: $message",
         )
     }
 
@@ -276,14 +309,24 @@ class WaitForVisualIdleTest {
     fun `visualIdleTimeoutDiagnostic only blames unstable frames when every sample hashed`() {
         assertEquals(
             "frames did not stabilise across 3 samples",
-            visualIdleTimeoutDiagnostic(stableFrames = 3, sampleCount = 5, unsampleableCount = 0),
+            visualIdleTimeoutDiagnostic(
+                stableFrames = 3,
+                sampleCount = 5,
+                unsampleableCount = 0,
+                sawHashChange = true,
+            ),
         )
     }
 
     @Test
     fun `visualIdleTimeoutDiagnostic prioritises fully unsampleable waits`() {
         val message =
-            visualIdleTimeoutDiagnostic(stableFrames = 3, sampleCount = 4, unsampleableCount = 4)
+            visualIdleTimeoutDiagnostic(
+                stableFrames = 3,
+                sampleCount = 4,
+                unsampleableCount = 4,
+                sawHashChange = false,
+            )
         assertTrue(
             message.startsWith("4/4 samples were unsampleable"),
             "Should lead with unsampleable counts: $message",
@@ -295,6 +338,29 @@ class WaitForVisualIdleTest {
         assertTrue(
             !message.contains("frames did not stabilise"),
             "All-null waits should not claim pixel churn: $message",
+        )
+    }
+
+    @Test
+    fun `visualIdleTimeoutDiagnostic omits unstable-frame blame when hashes never changed`() {
+        val message =
+            visualIdleTimeoutDiagnostic(
+                stableFrames = 3,
+                sampleCount = 6,
+                unsampleableCount = 3,
+                sawHashChange = false,
+            )
+        assertTrue(
+            message.contains("3/6 samples were unsampleable"),
+            "Should report unsampleable counts: $message",
+        )
+        assertTrue(
+            !message.contains("frames did not stabilise"),
+            "No observed pixel change → no unstable-frame blame: $message",
+        )
+        assertTrue(
+            message.contains("stable-frame streak did not complete"),
+            "Should explain incomplete streak: $message",
         )
     }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
@@ -165,6 +165,41 @@ class WaitForVisualIdleTest {
     }
 
     @Test
+    fun `timeout does not count a post-deadline zero-budget sample as unsampleable`() = runTest {
+        val clock = FakeClock()
+        val hasher =
+            BoundedFrameHasher(
+                steadyStateBudgetMs = 500,
+                sample = { budgetMs ->
+                    // Mirror production: zero budget cannot sample.
+                    if (budgetMs <= 0L) null else clock.now().toInt()
+                },
+            )
+
+        val error =
+            assertFailsWith<IdleTimeoutException> {
+                waitForVisualIdleInternal(
+                    timeout = 50.milliseconds,
+                    stableFrames = 3,
+                    pollInterval = 30.milliseconds,
+                    frameHash = hasher::hash,
+                    clock = clock,
+                    sleep = clock::advance,
+                )
+            }
+
+        val message = error.message.orEmpty()
+        assertTrue(
+            message.contains("frames did not stabilise"),
+            "Pure changing hashes should still report unstable frames: $message",
+        )
+        assertTrue(
+            !message.contains("unsampleable"),
+            "Must not count a zero-budget post-deadline sample as unsampleable: $message",
+        )
+    }
+
+    @Test
     fun `timeout names unsampleable samples when every frame hash is null`() = runTest {
         val clock = FakeClock()
         val error =
@@ -306,7 +341,7 @@ class WaitForVisualIdleTest {
     }
 
     @Test
-    fun `visualIdleTimeoutDiagnostic only blames unstable frames when every sample hashed`() {
+    fun `visualIdleTimeoutDiagnostic only blames unstable frames when hashes changed`() {
         assertEquals(
             "frames did not stabilise across 3 samples",
             visualIdleTimeoutDiagnostic(
@@ -315,6 +350,44 @@ class WaitForVisualIdleTest {
                 unsampleableCount = 0,
                 sawHashChange = true,
             ),
+        )
+    }
+
+    @Test
+    fun `visualIdleTimeoutDiagnostic uses incomplete streak when hashes never changed`() {
+        assertEquals(
+            "stable-frame streak did not complete across 3 samples",
+            visualIdleTimeoutDiagnostic(
+                stableFrames = 3,
+                sampleCount = 2,
+                unsampleableCount = 0,
+                sawHashChange = false,
+            ),
+        )
+    }
+
+    @Test
+    fun `identical hashes timing out report incomplete streak not pixel churn`() = runTest {
+        val clock = FakeClock()
+        val error =
+            assertFailsWith<IdleTimeoutException> {
+                waitForVisualIdleInternal(
+                    timeout = 50.milliseconds,
+                    stableFrames = 3,
+                    pollInterval = 30.milliseconds,
+                    frameHash = { _ -> 7 },
+                    clock = clock,
+                    sleep = clock::advance,
+                )
+            }
+        val message = error.message.orEmpty()
+        assertTrue(
+            message.contains("stable-frame streak did not complete"),
+            "Identical hashes that ran out of time are not pixel churn: $message",
+        )
+        assertTrue(
+            !message.contains("frames did not stabilise"),
+            "Must not blame unstable frames when every hash matched: $message",
         )
     }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitForVisualIdleTest.kt
@@ -154,6 +154,75 @@ class WaitForVisualIdleTest {
             error.message?.contains("waitForVisualIdle") == true,
             "Should mention waitForVisualIdle: ${error.message}",
         )
+        assertTrue(
+            error.message?.contains("frames did not stabilise") == true,
+            "Should attribute pure pixel churn to unstable frames: ${error.message}",
+        )
+        assertTrue(
+            error.message?.contains("unsampleable") != true,
+            "Must not claim unsampleable/budget failure when every sample returned a hash: ${error.message}",
+        )
+    }
+
+    @Test
+    fun `timeout names unsampleable samples when every frame hash is null`() = runTest {
+        val clock = FakeClock()
+        val error =
+            assertFailsWith<IdleTimeoutException> {
+                waitForVisualIdleInternal(
+                    timeout = 50.milliseconds,
+                    stableFrames = 3,
+                    pollInterval = 10.milliseconds,
+                    frameHash = { _ -> null },
+                    clock = clock,
+                    sleep = clock::advance,
+                )
+            }
+
+        val message = error.message.orEmpty()
+        assertTrue(
+            message.contains("waitForVisualIdle timed out after 50ms"),
+            "Should include wait name and timeout: $message",
+        )
+        assertTrue(
+            Regex("""\d+/\d+ samples were unsampleable""").containsMatchIn(message),
+            "Should report unsampleable sample counts: $message",
+        )
+        assertTrue(
+            message.contains("capture budget") || message.contains("no Compose surface"),
+            "Should hint at capture budget or missing surfaces: $message",
+        )
+    }
+
+    @Test
+    fun `timeout reports mixed unsampleable and unstable samples`() = runTest {
+        val clock = FakeClock()
+        var calls = 0
+        val error =
+            assertFailsWith<IdleTimeoutException> {
+                waitForVisualIdleInternal(
+                    timeout = 80.milliseconds,
+                    stableFrames = 3,
+                    pollInterval = 10.milliseconds,
+                    frameHash = { _ ->
+                        // Alternate null (budget/surface miss) with changing hashes so neither
+                        // cause alone explains the timeout.
+                        if (calls++ % 2 == 0) null else calls
+                    },
+                    clock = clock,
+                    sleep = clock::advance,
+                )
+            }
+
+        val message = error.message.orEmpty()
+        assertTrue(
+            Regex("""\d+/\d+ samples were unsampleable""").containsMatchIn(message),
+            "Should report partial unsampleable counts: $message",
+        )
+        assertTrue(
+            message.contains("frames did not stabilise"),
+            "Should still mention unstable frames when some hashes were returned: $message",
+        )
     }
 
     @Test
@@ -200,6 +269,32 @@ class WaitForVisualIdleTest {
         assertTrue(
             budgets.zipWithNext().all { (prev, next) -> next <= prev },
             "Budget should monotonically decrease across polls: $budgets",
+        )
+    }
+
+    @Test
+    fun `visualIdleTimeoutDiagnostic only blames unstable frames when every sample hashed`() {
+        assertEquals(
+            "frames did not stabilise across 3 samples",
+            visualIdleTimeoutDiagnostic(stableFrames = 3, sampleCount = 5, unsampleableCount = 0),
+        )
+    }
+
+    @Test
+    fun `visualIdleTimeoutDiagnostic prioritises fully unsampleable waits`() {
+        val message =
+            visualIdleTimeoutDiagnostic(stableFrames = 3, sampleCount = 4, unsampleableCount = 4)
+        assertTrue(
+            message.startsWith("4/4 samples were unsampleable"),
+            "Should lead with unsampleable counts: $message",
+        )
+        assertTrue(
+            message.contains("capture budget exceeded"),
+            "Should name capture budget: $message",
+        )
+        assertTrue(
+            !message.contains("frames did not stabilise"),
+            "All-null waits should not claim pixel churn: $message",
         )
     }
 

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -161,9 +161,11 @@ A few details worth knowing:
   second.
 - **Bounded sampling budget.** The first completed frame hash may use the wait's remaining
   timeout: native capture paths can have a one-off cold-start cost. Later frame hashes run on
-  a worker thread capped at 500ms. If a steady-state capture or hash exceeds that cap,
-  `waitForVisualIdle` returns a value that differs every call, so the streak never completes
-  and the wait times out rather than silently succeeding against an unsampleable UI.
+  a worker thread capped at 500ms. If a steady-state capture or hash exceeds that cap — or no
+  Compose surface is available — that poll is treated as unsampleable: the stable-frame streak
+  resets and the wait times out rather than silently succeeding. When that happens,
+  `IdleTimeoutException` reports how many samples were unsampleable (capture budget or missing
+  surface) instead of only saying the frames did not stabilise.
 - **Pixel hashing isn't free.** Multiple large surfaces, full-screen windows on a 4K /
   Retina monitor, or running under a software-rendered virtual GPU all push the
   per-poll cost up. If `waitForVisualIdle` is timing out or burning more CPU than you


### PR DESCRIPTION
## Summary

Closes the remaining #356 residual after PR #357's cold-budget fix:

- Count null frame samples (capture budget exceeded or no Compose surface) in `waitForVisualIdleInternal`
- Surface `N/M samples were unsampleable (capture budget exceeded or no Compose surface available)` in `IdleTimeoutException` instead of only blaming unstable pixels
- Pure pixel churn still reports `frames did not stabilise` only
- Docs: `docs/guide/synchronization.md` describes the honest timeout wording

Cold first-sample remaining-budget behaviour remains as landed in #357; this PR does not change the 500ms steady-state cap or public API.

## Validation

- `./gradlew :core:test --tests '*WaitForVisualIdleTest*'`
- `./gradlew :core:check` (ktfmt + detekt + tests)
- `./gradlew :sample-desktop:validationTest --tests '*WaitForVisualIdleValidationTest*'` (fresh worker JVM first-capture path)
- User-like re-run of the same validation path on local macOS: PASS
- Local `./gradlew check` excluding unrelated agent/cli focus flakes green; agent attach focus flakes are pre-existing and pass when run in isolation

## Scope

- Out of scope: #355 window-backend routing
- Out of scope: re-implementing cold capture budget (already on main)

Closes #356