### PR TITLE
feat(sample-intellij-plugin): no-core plugin zip for stock inject QA (#375)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,7 +119,8 @@ val verifyMacosCliBundleReleaseContract by
 val buildSrcUnitTests by
     tasks.registering(Exec::class) {
         group = "verification"
-        description = "Runs buildSrc unit tests (Windows helper packaging contract and related)."
+        description =
+            "Runs buildSrc unit tests (Windows helper packaging, no-core plugin packaging, and related)."
         workingDir = rootProject.layout.projectDirectory.asFile
         val isWindows = System.getProperty("os.name").orEmpty().startsWith("Windows")
         val wrapperName = if (isWindows) "gradlew.bat" else "gradlew"

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/BuildNoCorePluginZip.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/BuildNoCorePluginZip.kt
@@ -1,0 +1,27 @@
+package dev.sebastiano.spectre.build
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Transforms the instrumented sample-plugin zip into the #353 no-core inject-QA distribution.
+ */
+abstract class BuildNoCorePluginZip : DefaultTask() {
+    @get:InputFile abstract val instrumentedPluginZip: RegularFileProperty
+
+    @get:InputFile abstract val noCorePluginXml: RegularFileProperty
+
+    @get:OutputFile abstract val outputZip: RegularFileProperty
+
+    @TaskAction
+    fun build() {
+        NoCorePluginPackagingContract.transformInstrumentedZipToNoCore(
+            instrumentedZip = instrumentedPluginZip.get().asFile,
+            outputZip = outputZip.get().asFile,
+            noCorePluginXml = noCorePluginXml.get().asFile.readText(),
+        )
+    }
+}

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/NoCorePluginPackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/NoCorePluginPackagingContract.kt
@@ -1,0 +1,265 @@
+package dev.sebastiano.spectre.build
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.jar.JarEntry
+import java.util.jar.JarInputStream
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createTempDirectory
+import kotlin.io.path.writeBytes
+
+/**
+ * Packaging contract for the **no-core** Spectre sample IntelliJ plugin zip (#353 / #375).
+ *
+ * The default sample plugin ships `spectre-core` so in-process / instrumented attach works.
+ * Stock inject QA needs a Jewel-tagged tool window **without** core on the plugin classpath so
+ * attach bootstrap takes the nested inject-runtime path.
+ *
+ * Rules:
+ * - No `core-*.jar` / `spectre-core*.jar` under `lib/`
+ * - Plugin jar must not retain `RunSpectreAction` / `SpectreAutoRunStartupActivity` (core deps)
+ * - Must retain tool-window factory + content classes and a tool-window-only `plugin.xml`
+ * - Content class bytes must embed the proving `ide.counter.*` / `ide.popup.*` tag strings
+ */
+object NoCorePluginPackagingContract {
+    const val PLUGIN_ROOT_DIR: String = "sample-intellij-plugin"
+    const val TOOL_WINDOW_ID: String = "Spectre Sample"
+    const val TOOL_WINDOW_FACTORY_FQN: String =
+        "dev.sebastiano.spectre.intellij.SpectreSampleToolWindowFactory"
+
+    val REQUIRED_PROVING_TAGS: List<String> =
+        listOf(
+            "ide.counter.button",
+            "ide.counter.text",
+            "ide.popup.toggleButton",
+            "ide.popup.body",
+            "ide.popup.text",
+            "ide.popup.dismissButton",
+        )
+
+    private val STRIP_CLASS_PREFIXES: List<String> =
+        listOf(
+            "dev/sebastiano/spectre/intellij/RunSpectreAction",
+            "dev/sebastiano/spectre/intellij/SpectreAutoRunStartupActivity",
+        )
+
+    private val REQUIRED_PLUGIN_CLASS_SUFFIXES: List<String> =
+        listOf(
+            "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowFactory.class",
+            "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowContentKt.class",
+        )
+
+    fun isForbiddenLibJar(fileName: String): Boolean {
+        val base = fileName.substringAfterLast('/').substringAfterLast('\\')
+        if (base == "core.jar") return true
+        if (base.startsWith("core-") && base.endsWith(".jar")) return true
+        if (base == "spectre-core.jar") return true
+        if (base.startsWith("spectre-core-") && base.endsWith(".jar")) return true
+        return false
+    }
+
+    fun shouldStripPluginClass(entryName: String): Boolean {
+        val n = entryName.replace('\\', '/')
+        return STRIP_CLASS_PREFIXES.any { prefix -> n == "$prefix.class" || n.startsWith("$prefix$") }
+    }
+
+    /**
+     * Validates an open no-core plugin distribution zip.
+     *
+     * @return human-readable errors (empty when the contract is satisfied)
+     */
+    fun validateNoCorePluginZip(zip: ZipFile): List<String> {
+        val errors = mutableListOf<String>()
+        val entries = zip.entries().asSequence().map { it.name.replace('\\', '/') }.toList()
+        val libJars =
+            entries.filter { it.matches(Regex(".*/lib/[^/]+\\.jar$")) }.map { it.substringAfterLast('/') }
+
+        if (libJars.none { it.startsWith("sample-intellij-plugin-") && !it.contains("searchableOptions") }) {
+            errors += "missing sample-intellij-plugin-*.jar under lib/"
+        }
+
+        for (jar in libJars) {
+            if (isForbiddenLibJar(jar)) {
+                errors += "forbidden spectre-core jar present: $jar"
+            }
+        }
+
+        val pluginJarEntry =
+            entries.firstOrNull {
+                it.matches(Regex(".*/lib/sample-intellij-plugin-[^/]+\\.jar$")) &&
+                    !it.contains("searchableOptions")
+            }
+        if (pluginJarEntry == null) {
+            errors += "could not locate primary sample-intellij-plugin jar entry"
+            return errors
+        }
+
+        val pluginJarBytes = zip.getInputStream(zip.getEntry(pluginJarEntry)).use { it.readBytes() }
+        errors += validatePluginJarBytes(pluginJarBytes)
+        return errors
+    }
+
+    fun validatePluginJarBytes(pluginJarBytes: ByteArray): List<String> {
+        val errors = mutableListOf<String>()
+        val entryNames = linkedSetOf<String>()
+        var pluginXml: String? = null
+        var contentClassBytes: ByteArray? = null
+
+        JarInputStream(ByteArrayInputStream(pluginJarBytes)).use { jis ->
+            while (true) {
+                val entry = jis.nextJarEntry ?: break
+                val name = entry.name.replace('\\', '/')
+                entryNames += name
+                if (name == "META-INF/plugin.xml") {
+                    pluginXml = jis.readBytes().toString(Charsets.UTF_8)
+                } else if (name.endsWith("SpectreSampleToolWindowContentKt.class")) {
+                    contentClassBytes = jis.readBytes()
+                } else {
+                    jis.skip(Long.MAX_VALUE)
+                }
+                jis.closeEntry()
+            }
+        }
+
+        for (name in entryNames) {
+            if (shouldStripPluginClass(name)) {
+                errors += "core-dependent class retained: $name"
+            }
+        }
+
+        for (required in REQUIRED_PLUGIN_CLASS_SUFFIXES) {
+            if (entryNames.none { it.endsWith(required) || it == required }) {
+                errors += "missing required class entry: $required"
+            }
+        }
+
+        val xml = pluginXml
+        if (xml == null) {
+            errors += "missing META-INF/plugin.xml"
+        } else {
+            if (!xml.contains(TOOL_WINDOW_ID)) {
+                errors += "plugin.xml missing tool window id '$TOOL_WINDOW_ID'"
+            }
+            if (!xml.contains(TOOL_WINDOW_FACTORY_FQN)) {
+                errors += "plugin.xml missing factory $TOOL_WINDOW_FACTORY_FQN"
+            }
+            // Match class references only (not prose in XML comments).
+            if (Regex("""class\s*=\s*"[^"]*RunSpectreAction"""").containsMatchIn(xml) ||
+                Regex("""implementation\s*=\s*"[^"]*SpectreAutoRunStartupActivity"""").containsMatchIn(xml)
+            ) {
+                errors += "plugin.xml still references core-dependent extensions/actions"
+            }
+            if (!xml.contains("com.intellij.modules.compose")) {
+                errors += "plugin.xml must depend on com.intellij.modules.compose"
+            }
+        }
+
+        val content = contentClassBytes
+        if (content == null) {
+            errors += "missing SpectreSampleToolWindowContentKt.class bytes for tag scan"
+        } else {
+            val haystack = content.toString(Charsets.ISO_8859_1)
+            for (tag in REQUIRED_PROVING_TAGS) {
+                if (tag !in haystack) {
+                    errors += "proving tag '$tag' not found in tool window content class bytes"
+                }
+            }
+        }
+
+        return errors
+    }
+
+    /**
+     * Transforms a full instrumented sample-plugin zip into a no-core inject-QA zip:
+     * strips forbidden core jars, rewrites the plugin jar (drop core-dependent classes,
+     * install [noCorePluginXml]), and drops unrelated transitive lib jars so the classpath
+     * is tags-only against the IDE's bundled Compose/Jewel modules.
+     */
+    fun transformInstrumentedZipToNoCore(
+        instrumentedZip: java.io.File,
+        outputZip: java.io.File,
+        noCorePluginXml: String,
+    ) {
+        val staging = createTempDirectory(prefix = "spectre-no-core-plugin-")
+        try {
+            ZipFile(instrumentedZip).use { zip ->
+                zip.entries().asSequence().forEach { entry ->
+                    if (entry.isDirectory) return@forEach
+                    val name = entry.name.replace('\\', '/')
+                    val relative = name.removePrefix("$PLUGIN_ROOT_DIR/").removePrefix("/")
+                    if (!relative.startsWith("lib/")) return@forEach
+                    val fileName = relative.substringAfterLast('/')
+                    if (isForbiddenLibJar(fileName)) return@forEach
+                    // Keep only the primary plugin jar — no searchableOptions, no core transitives.
+                    if (!fileName.startsWith("sample-intellij-plugin-") ||
+                        fileName.contains("searchableOptions")
+                    ) {
+                        return@forEach
+                    }
+                    val target = staging.resolve(relative)
+                    target.parent.toFile().mkdirs()
+                    zip.getInputStream(entry).use { input -> target.writeBytes(input.readBytes()) }
+                }
+            }
+
+            val pluginJars =
+                staging
+                    .toFile()
+                    .resolve("lib")
+                    .listFiles()
+                    ?.filter { it.isFile && it.name.endsWith(".jar") }
+                    .orEmpty()
+            check(pluginJars.size == 1) {
+                "expected exactly one plugin jar after strip, found: ${pluginJars.map { it.name }}"
+            }
+            val pluginJar = pluginJars.single()
+            val rewritten = rewritePluginJar(pluginJar.readBytes(), noCorePluginXml)
+            pluginJar.writeBytes(rewritten)
+
+            outputZip.parentFile?.mkdirs()
+            if (outputZip.exists()) {
+                check(outputZip.delete()) { "could not delete existing ${outputZip.absolutePath}" }
+            }
+            ZipOutputStream(outputZip.outputStream()).use { zos ->
+                staging.toFile().walkTopDown().filter { it.isFile }.forEach { file ->
+                    val relative =
+                        staging.relativize(file.toPath()).toString().replace('\\', '/')
+                    val entryName = "$PLUGIN_ROOT_DIR/$relative"
+                    zos.putNextEntry(ZipEntry(entryName))
+                    file.inputStream().use { it.copyTo(zos) }
+                    zos.closeEntry()
+                }
+            }
+        } finally {
+            staging.toFile().deleteRecursively()
+        }
+    }
+
+    fun rewritePluginJar(originalJarBytes: ByteArray, noCorePluginXml: String): ByteArray {
+        val baos = ByteArrayOutputStream()
+        JarOutputStream(baos).use { jos ->
+            JarInputStream(ByteArrayInputStream(originalJarBytes)).use { jis ->
+                while (true) {
+                    val entry = jis.nextJarEntry ?: break
+                    val name = entry.name.replace('\\', '/')
+                    val bytes = jis.readBytes()
+                    jis.closeEntry()
+                    if (shouldStripPluginClass(name)) continue
+                    if (name == "META-INF/plugin.xml") {
+                        jos.putNextEntry(JarEntry("META-INF/plugin.xml"))
+                        jos.write(noCorePluginXml.toByteArray(Charsets.UTF_8))
+                        jos.closeEntry()
+                        continue
+                    }
+                    jos.putNextEntry(JarEntry(name))
+                    jos.write(bytes)
+                    jos.closeEntry()
+                }
+            }
+        }
+        return baos.toByteArray()
+    }
+}

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyNoCorePluginZip.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyNoCorePluginZip.kt
@@ -1,0 +1,27 @@
+package dev.sebastiano.spectre.build
+
+import java.util.zip.ZipFile
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+/** Asserts the no-core sample plugin zip satisfies [NoCorePluginPackagingContract]. */
+abstract class VerifyNoCorePluginZip : DefaultTask() {
+    @get:InputFile abstract val noCorePluginZip: RegularFileProperty
+
+    @TaskAction
+    fun verify() {
+        val zipFile = noCorePluginZip.get().asFile
+        check(zipFile.isFile && zipFile.length() > 0L) {
+            "no-core plugin zip missing or empty: ${zipFile.absolutePath}"
+        }
+        ZipFile(zipFile).use { zip ->
+            val errors = NoCorePluginPackagingContract.validateNoCorePluginZip(zip)
+            check(errors.isEmpty()) {
+                "no-core plugin zip failed packaging contract:\n" +
+                    errors.joinToString("\n") { "  - $it" }
+            }
+        }
+    }
+}

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/NoCorePluginPackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/NoCorePluginPackagingContractTest.kt
@@ -1,0 +1,246 @@
+package dev.sebastiano.spectre.build
+
+import java.io.ByteArrayOutputStream
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import java.util.zip.ZipFile
+import java.util.zip.ZipOutputStream
+import kotlin.io.path.createTempFile
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.outputStream
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit coverage for the #353 / #375 no-core sample plugin packaging contract used by
+ * `:sample-intellij-plugin:buildNoCorePlugin` and `verifyNoCorePluginZip`.
+ *
+ * Proves the real [NoCorePluginPackagingContract] predicates and zip validator — not a
+ * re-implementation — reject core jars / core-dependent classes and accept a minimal
+ * tags-only plugin zip shape.
+ */
+class NoCorePluginPackagingContractTest {
+
+    @Test
+    fun `core project jars are classified as forbidden`() {
+        assertTrue(NoCorePluginPackagingContract.isForbiddenLibJar("core-0.1.0-SNAPSHOT.jar"))
+        assertTrue(NoCorePluginPackagingContract.isForbiddenLibJar("spectre-core-0.1.0-SNAPSHOT.jar"))
+        assertTrue(NoCorePluginPackagingContract.isForbiddenLibJar("spectre-core.jar"))
+        assertTrue(NoCorePluginPackagingContract.isForbiddenLibJar("core.jar"))
+    }
+
+    @Test
+    fun `plugin jar itself is not a forbidden lib jar`() {
+        assertFalse(
+            NoCorePluginPackagingContract.isForbiddenLibJar(
+                "sample-intellij-plugin-0.0.0-DEV.jar"
+            )
+        )
+        assertFalse(
+            NoCorePluginPackagingContract.isForbiddenLibJar(
+                "sample-intellij-plugin-0.1.0-SNAPSHOT-searchableOptions.jar"
+            )
+        )
+    }
+
+    @Test
+    fun `core-dependent class entries are stripped`() {
+        assertTrue(
+            NoCorePluginPackagingContract.shouldStripPluginClass(
+                "dev/sebastiano/spectre/intellij/RunSpectreAction.class"
+            )
+        )
+        assertTrue(
+            NoCorePluginPackagingContract.shouldStripPluginClass(
+                "dev/sebastiano/spectre/intellij/RunSpectreAction\$Companion.class"
+            )
+        )
+        assertTrue(
+            NoCorePluginPackagingContract.shouldStripPluginClass(
+                "dev/sebastiano/spectre/intellij/SpectreAutoRunStartupActivity.class"
+            )
+        )
+        assertTrue(
+            NoCorePluginPackagingContract.shouldStripPluginClass(
+                "dev/sebastiano/spectre/intellij/SpectreAutoRunStartupActivity\$execute\$1.class"
+            )
+        )
+    }
+
+    @Test
+    fun `tool window class entries are kept`() {
+        assertFalse(
+            NoCorePluginPackagingContract.shouldStripPluginClass(
+                "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowFactory.class"
+            )
+        )
+        assertFalse(
+            NoCorePluginPackagingContract.shouldStripPluginClass(
+                "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowContentKt.class"
+            )
+        )
+        assertFalse(
+            NoCorePluginPackagingContract.shouldStripPluginClass("META-INF/plugin.xml")
+        )
+    }
+
+    @Test
+    fun `zip with core jar fails validation`() {
+        val zip =
+            writeSyntheticPluginZip(
+                libJars =
+                    mapOf(
+                        "core-0.1.0-SNAPSHOT.jar" to byteArrayOf(1),
+                        "sample-intellij-plugin-0.0.0-DEV.jar" to
+                            pluginJarBytes(
+                                classes =
+                                    listOf(
+                                        "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowFactory.class",
+                                        "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowContentKt.class",
+                                    ),
+                                pluginXml = VALID_NO_CORE_PLUGIN_XML,
+                                classPayloadWithTags = true,
+                            ),
+                    )
+            )
+        try {
+            ZipFile(zip.toFile()).use { zf ->
+                val errors = NoCorePluginPackagingContract.validateNoCorePluginZip(zf)
+                assertTrue(errors.isNotEmpty(), "expected core jar to fail")
+                assertTrue(
+                    errors.any { it.contains("core-0.1.0-SNAPSHOT.jar") },
+                    "errors=$errors",
+                )
+            }
+        } finally {
+            zip.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `zip retaining RunSpectreAction fails validation`() {
+        val zip =
+            writeSyntheticPluginZip(
+                libJars =
+                    mapOf(
+                        "sample-intellij-plugin-0.0.0-DEV.jar" to
+                            pluginJarBytes(
+                                classes =
+                                    listOf(
+                                        "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowFactory.class",
+                                        "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowContentKt.class",
+                                        "dev/sebastiano/spectre/intellij/RunSpectreAction.class",
+                                    ),
+                                pluginXml = VALID_NO_CORE_PLUGIN_XML,
+                                classPayloadWithTags = true,
+                            ),
+                    )
+            )
+        try {
+            ZipFile(zip.toFile()).use { zf ->
+                val errors = NoCorePluginPackagingContract.validateNoCorePluginZip(zf)
+                assertTrue(errors.isNotEmpty(), "expected RunSpectreAction retention to fail")
+                assertTrue(
+                    errors.any { it.contains("RunSpectreAction") },
+                    "errors=$errors",
+                )
+            }
+        } finally {
+            zip.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `minimal tags-only zip passes validation`() {
+        val zip =
+            writeSyntheticPluginZip(
+                libJars =
+                    mapOf(
+                        "sample-intellij-plugin-0.0.0-DEV.jar" to
+                            pluginJarBytes(
+                                classes =
+                                    listOf(
+                                        "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowFactory.class",
+                                        "dev/sebastiano/spectre/intellij/SpectreSampleToolWindowContentKt.class",
+                                    ),
+                                pluginXml = VALID_NO_CORE_PLUGIN_XML,
+                                classPayloadWithTags = true,
+                            ),
+                    )
+            )
+        try {
+            ZipFile(zip.toFile()).use { zf ->
+                val errors = NoCorePluginPackagingContract.validateNoCorePluginZip(zf)
+                assertTrue(errors.isEmpty(), "expected valid no-core zip; errors=$errors")
+            }
+        } finally {
+            zip.deleteIfExists()
+        }
+    }
+
+    private fun writeSyntheticPluginZip(libJars: Map<String, ByteArray>): java.nio.file.Path {
+        val path = createTempFile(prefix = "no-core-plugin-", suffix = ".zip")
+        ZipOutputStream(path.outputStream()).use { zos ->
+            for ((name, bytes) in libJars) {
+                val entryName = "sample-intellij-plugin/lib/$name"
+                zos.putNextEntry(ZipEntry(entryName))
+                zos.write(bytes)
+                zos.closeEntry()
+            }
+        }
+        return path
+    }
+
+    private fun pluginJarBytes(
+        classes: List<String>,
+        pluginXml: String,
+        classPayloadWithTags: Boolean,
+    ): ByteArray {
+        val baos = ByteArrayOutputStream()
+        JarOutputStream(baos).use { jos ->
+            jos.putNextEntry(JarEntry("META-INF/plugin.xml"))
+            jos.write(pluginXml.toByteArray(Charsets.UTF_8))
+            jos.closeEntry()
+            for (className in classes) {
+                jos.putNextEntry(JarEntry(className))
+                // Embed proving tag UTF-8 constants so the contract can scan for them.
+                val payload =
+                    if (classPayloadWithTags && className.contains("ToolWindowContent")) {
+                        buildString {
+                                append("synthetic-class-bytes ")
+                                for (tag in NoCorePluginPackagingContract.REQUIRED_PROVING_TAGS) {
+                                    append(tag)
+                                    append(' ')
+                                }
+                            }
+                            .toByteArray(Charsets.UTF_8)
+                    } else {
+                        byteArrayOf(0xCA.toByte(), 0xFE.toByte(), 0xBA.toByte(), 0xBE.toByte())
+                    }
+                jos.write(payload)
+                jos.closeEntry()
+            }
+        }
+        return baos.toByteArray()
+    }
+
+    private companion object {
+        val VALID_NO_CORE_PLUGIN_XML =
+            """
+            <idea-plugin>
+              <id>dev.sebastiano.spectre.sample</id>
+              <name>Spectre IDE Sample</name>
+              <depends>com.intellij.modules.platform</depends>
+              <depends>com.intellij.modules.compose</depends>
+              <extensions defaultExtensionNs="com.intellij">
+                <toolWindow id="Spectre Sample"
+                            anchor="right"
+                            factoryClass="dev.sebastiano.spectre.intellij.SpectreSampleToolWindowFactory"/>
+              </extensions>
+            </idea-plugin>
+            """
+                .trimIndent()
+    }
+}

--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -1,3 +1,6 @@
+import dev.sebastiano.spectre.build.BuildNoCorePluginZip
+import dev.sebastiano.spectre.build.VerifyNoCorePluginZip
+
 plugins {
     alias(libs.plugins.detekt)
     alias(libs.plugins.ktfmt)
@@ -142,6 +145,12 @@ tasks.named<JavaExec>("runIde") {
 // `detektUiTest` is hooked into `:check` so the uiTest source set is statically validated on every
 // PR even though `:uiTest` itself (which boots a real IDE) is opt-in — keeps the linter from going
 // stale on a source set that only runs in the dedicated `ide-uitest.yml` CI job.
+//
+// No-core packaging (#353 / #375): pure contract unit tests live in buildSrc
+// (`NoCorePluginPackagingContractTest`) and run on every root `:check` via `buildSrcUnitTests`.
+// The real zip (`buildNoCorePlugin` + `verifyNoCorePluginZip`) stays off default `:check` so
+// unrelated PRs don't pay `buildPlugin`; run those when packaging / inject QA changes and from
+// the stock inject e2e (#376).
 tasks.named("check") { dependsOn("verifyPluginStructure", "detektUiTest") }
 
 // Disable the IntelliJ Platform Gradle plugin's `buildSearchableOptions` task. That task boots a
@@ -206,6 +215,35 @@ dependencies {
 
 val buildPluginTask = tasks.named<Zip>("buildPlugin")
 val pluginZipProvider = buildPluginTask.flatMap { it.archiveFile }
+
+// --- No-core plugin zip for stock IntelliJ inject QA (#353 / #375) -------------------------
+//
+// Transforms the instrumented `buildPlugin` zip into a tags-only distribution: Jewel tool
+// window with `ide.counter.*` / `ide.popup.*` tags, zero spectre-core jars, no RunSpectreAction.
+// Used by the stock inject attach e2e (#376) and manual recipe; not the default `uiTest` plugin.
+val noCorePluginXmlFile = layout.projectDirectory.file("packaging/plugin-no-core.xml")
+val noCorePluginZipFile =
+    layout.buildDirectory.file("distributions/sample-intellij-plugin-no-core-0.0.0-DEV.zip")
+
+val buildNoCorePlugin by
+    tasks.registering(BuildNoCorePluginZip::class) {
+        group = "build"
+        description =
+            "Build a no-core sample plugin zip (Jewel tags only) for stock IntelliJ inject QA (#353)."
+        dependsOn(buildPluginTask)
+        instrumentedPluginZip.set(pluginZipProvider)
+        noCorePluginXml.set(noCorePluginXmlFile)
+        outputZip.set(noCorePluginZipFile)
+    }
+
+val verifyNoCorePluginZip by
+    tasks.registering(VerifyNoCorePluginZip::class) {
+        group = "verification"
+        description =
+            "Assert the no-core sample plugin zip has no spectre-core and retains Jewel proving tags (#353)."
+        dependsOn(buildNoCorePlugin)
+        noCorePluginZip.set(buildNoCorePlugin.flatMap { it.outputZip })
+    }
 
 val uiTest by
     tasks.registering(Test::class) {

--- a/sample-intellij-plugin/packaging/plugin-no-core.xml
+++ b/sample-intellij-plugin/packaging/plugin-no-core.xml
@@ -1,0 +1,30 @@
+<!--
+  No-core Spectre sample plugin for #353 stock IntelliJ inject QA.
+
+  Hosts the same Jewel-tagged tool window as the instrumented sample
+  (SpectreSampleToolWindowContent) without in-process Spectre classes, and is
+  packaged without the core library on the plugin classpath so AgentAttach must
+  take the nested inject-runtime path.
+
+  Built by :sample-intellij-plugin:buildNoCorePlugin. Not for marketplace use.
+-->
+<idea-plugin>
+    <id>dev.sebastiano.spectre.sample</id>
+    <name>Spectre IDE Sample (no-core inject QA)</name>
+    <version>0.0.0-DEV</version>
+    <vendor>Spectre</vendor>
+    <idea-version since-build="262.8665"/>
+    <description><![CDATA[
+        Tags-only Jewel tool window for stock IntelliJ inject attach validation (#353).
+        Does not ship the Spectre core library on the plugin classpath.
+    ]]></description>
+
+    <depends>com.intellij.modules.platform</depends>
+    <depends>com.intellij.modules.compose</depends>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <toolWindow id="Spectre Sample"
+                    anchor="right"
+                    factoryClass="dev.sebastiano.spectre.intellij.SpectreSampleToolWindowFactory"/>
+    </extensions>
+</idea-plugin>


### PR DESCRIPTION
## Summary

- Adds a **tags-only** sample IntelliJ plugin distribution for stock inject attach QA ([#353](https://github.com/rock3r/spectre/issues/353) / [#375](https://github.com/rock3r/spectre/issues/375)): Jewel tool window with `ide.counter.*` / `ide.popup.*` and **no** `spectre-core` on the plugin classpath.
- Shared packaging contract + unit tests in `buildSrc` (covered by root `buildSrcUnitTests` on `:check`).
- Gradle tasks: `:sample-intellij-plugin:buildNoCorePlugin` and `:verifyNoCorePluginZip` (off default `:check` so unrelated PRs do not pay `buildPlugin`; run when packaging / inject QA changes).

Instrumented sample plugin and existing `uiTest` are **unchanged**.

## Test plan

- [x] `./gradlew :buildSrc:test --tests '*NoCorePluginPackagingContractTest*'`
- [x] `./gradlew :sample-intellij-plugin:verifyNoCorePluginZip`
- [x] Inspected zip: only plugin jar; no `core-*.jar`; tool-window classes + no-core `plugin.xml`
- [ ] CI green

## Follow-up

- #376 — stock IDE inject attach e2e (ide-starter + `AgentAttach`)
- #377 — recipe evidence + close #353

Closes #375