### PR TITLE
fix(agent,cli): fail closed on attach window screenshots (#359)

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -211,10 +211,13 @@ internal constructor(
     }
 
     /**
-     * Capture a PNG of a tracked window (default) or the full desktop when [fullscreen] is true.
+     * Capture a PNG of the full desktop when [fullscreen] is true.
      *
-     * Without [windowIndex], [surfaceId], or [fullscreen], targets window index 0. Window capture
-     * failures surface as [IOException] rather than silently returning a full-desktop grab (#289).
+     * Window/surface targets (default, [windowIndex], or [surfaceId]) fail closed on the attach
+     * path (#359): they would crop occlusion-prone desktop pixels rather than a native window
+     * surface. Only [fullscreen] is supported as an explicit screen-pixel capture mode. Prefer
+     * in-process `ComposeAutomator.screenshot(windowIndex)` with the recording native backend for
+     * occlusion-safe window stills.
      *
      * @return raw PNG bytes
      */

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/ScreenshotTarget.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/ScreenshotTarget.kt
@@ -4,8 +4,9 @@ package dev.sebastiano.spectre.agent
  * Resolved screenshot capture target for the agent/daemon/CLI path.
  *
  * Default is a tracked window (index 0 when the caller does not name one). Full-desktop capture is
- * never implied: callers must request [Fullscreen] explicitly. Window capture failure must surface
- * as an error rather than silently falling back to the full desktop.
+ * never implied: callers must request [Fullscreen] explicitly. Window/surface targets are resolved
+ * for validation, then rejected at capture time on the attach path (#359) rather than silently
+ * cropping occlusion-prone desktop pixels.
  */
 @ExperimentalSpectreAgentApi
 public sealed interface ScreenshotTarget {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -374,6 +374,18 @@ internal class ReflectiveAutomatorHandler(
                     )
                 }
 
+        // Window/surface targets: fail closed rather than cropping desktop pixels (#359).
+        // The attach path has no native window-surface capture; Robot region crops are
+        // occlusion-prone and can capture unrelated on-screen content (privacy risk).
+        if (target is ScreenshotTarget.Window) {
+            return AgentResponse.Error(
+                message = WINDOW_SCREENSHOT_UNSUPPORTED_MESSAGE,
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.UnsupportedOperation
+                        .wireName,
+            )
+        }
+
         val regionScreenshotMethod =
             regionScreenshotMethodOrError()
                 ?: return AgentResponse.Error(
@@ -385,23 +397,9 @@ internal class ReflectiveAutomatorHandler(
                             .wireName,
                 )
 
-        val image =
-            when (target) {
-                is ScreenshotTarget.Fullscreen ->
-                    // null region = full virtual desktop. Explicit opt-in only (#289).
-                    regionScreenshotMethod.invoke(automator, null) as BufferedImage
-                is ScreenshotTarget.Window ->
-                    captureWindowScreenshot(windows, target, regionScreenshotMethod)
-                        ?: return AgentResponse.Error(
-                            message =
-                                "Tracked window at index ${target.windowIndex} is missing or " +
-                                    "not showing; wait until it is visible before screenshot",
-                            category =
-                                dev.sebastiano.spectre.agent.transport.AgentErrorCategory
-                                    .InvalidSelector
-                                    .wireName,
-                        )
-            }
+        // Only Fullscreen remains (explicit opt-in). null region = full virtual desktop (#289).
+        check(target is ScreenshotTarget.Fullscreen)
+        val image = regionScreenshotMethod.invoke(automator, null) as BufferedImage
         return AgentResponse.Screenshot(imageToPng(image))
     }
 
@@ -410,7 +408,7 @@ internal class ReflectiveAutomatorHandler(
      *
      * Prefers in-process `screenshot(AutomatorNode)` (native window-scoped) when the recording
      * bridge is present and returns a non-degenerate image. Otherwise uses region capture of live
-     * `boundsOnScreen` — the same framebuffer policy as attach window screenshots (#289).
+     * `boundsOnScreen` (node-key path only; window/surface attach screenshots fail closed — #359).
      * Degenerate native crops (empty intersection / DPI mishap) also fall back to region so Windows
      * desktops do not return 1×1 / ~90-byte PNGs for real nodes.
      */
@@ -582,22 +580,6 @@ internal class ReflectiveAutomatorHandler(
                 if (tracked != null && extractIsShowing(tracked, tracked.javaClass)) index else null
             }
             .firstOrNull()
-
-    /**
-     * Capture bounds from the window list we just resolved against. Do not call
-     * `screenshot(windowIndex)`: that path refreshes windows again and can bind a different surface
-     * at the same index after a popup open/close (#289 P2).
-     */
-    private fun captureWindowScreenshot(
-        windows: List<*>,
-        target: ScreenshotTarget.Window,
-        regionScreenshotMethod: Method,
-    ): BufferedImage? {
-        val tracked = windows.getOrNull(target.windowIndex) ?: return null
-        if (!extractIsShowing(tracked, tracked.javaClass)) return null
-        val bounds = tracked.javaClass.getMethod("getComposeSurfaceBoundsOnScreen").invoke(tracked)
-        return regionScreenshotMethod.invoke(automator, bounds) as BufferedImage
-    }
 
     private fun imageToPng(image: BufferedImage): ByteArray {
         // Normalize to a PNG-friendly sRGB type; some platform Robot captures use types that
@@ -881,6 +863,15 @@ internal class ReflectiveAutomatorHandler(
         /** Matches core ScreenCaptureBackend when NativeWindowCaptureBridge is not loadable. */
         const val NATIVE_BRIDGE_UNAVAILABLE_SNIPPET: String =
             "Native window capture bridge is unavailable"
+        /**
+         * Fail-closed message for attach/CLI window or surface screenshots (#359). Must mention
+         * occlusion/privacy risk and point callers at explicit fullscreen opt-in.
+         */
+        const val WINDOW_SCREENSHOT_UNSUPPORTED_MESSAGE: String =
+            "Window/surface screenshots are not supported on the attach path: they would crop " +
+                "occlusion-prone desktop pixels (privacy risk if another window covers the " +
+                "target). Use --fullscreen (or fullscreen=true) for an explicit full-desktop " +
+                "capture."
         /** Sentinel when a fake/partial AutomatorNode lacks an optional boolean getter. */
         val MISSING_BOOLEAN_METHOD: Method = Object::class.java.getMethod("hashCode")
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -267,7 +267,9 @@ class AgentAttachIntegrationTest {
                 "tag=${buttonNode.testTag} bounds=${buttonNode.bounds}"
         )
 
-        val screenshotBytes = automator.screenshot()
+        // Window-scoped attach screenshots fail closed (#359); fullscreen is the only
+        // screen-pixel capture mode on this path.
+        val screenshotBytes = automator.screenshot(fullscreen = true)
         assertTrue(
             screenshotBytes.size >= MIN_PNG_BYTES,
             "iteration $iteration: screenshot too small (${screenshotBytes.size}b) — not a real PNG?",

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
@@ -356,7 +356,8 @@ class AgentContractCorpusTest {
         }
 
         override fun screenshotProbe(): ScreenshotProbe {
-            val bytes = automator.screenshot()
+            // Attach window screenshots fail closed (#359); probe the supported fullscreen path.
+            val bytes = automator.screenshot(fullscreen = true)
             return ScreenshotProbe(byteCount = bytes.size, formatHint = "png")
         }
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
@@ -10,10 +10,10 @@ import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import java.awt.Frame
 import java.awt.GraphicsEnvironment
 import java.awt.Rectangle
-import javax.imageio.ImageIO
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.Assumptions.assumeFalse
@@ -286,9 +286,8 @@ class ReflectiveAutomatorHandlerMappingTest {
     }
 
     @Test
-    fun `Screenshot op defaults to window surface bounds not full desktop`() {
-        var receivedRegion: Any? = "<not invoked>"
-        val image = java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    fun `Screenshot op defaults to fail closed not occlusion prone region crop`() {
+        var regionInvoked = false
         val surfaceBounds = Rectangle(10, 20, 800, 600)
         val automator =
             FakeAutomator(
@@ -302,26 +301,19 @@ class ReflectiveAutomatorHandlerMappingTest {
                         )
                     ),
                 screenshotWindowImpl = { error("must not call screenshot(windowIndex)") },
-                screenshotImpl = { region ->
-                    receivedRegion = region
-                    image
+                screenshotImpl = { _ ->
+                    regionInvoked = true
+                    error("must not crop desktop pixels for window-scoped screenshot (#359)")
                 },
             )
         val handler = ReflectiveAutomatorHandler(automator)
 
         val response = handler.handle(AgentRequest.Screenshot())
-        check(response is AgentResponse.Screenshot) {
-            "expected Screenshot, got ${response::class.simpleName}: $response"
+        check(response is AgentResponse.Error) {
+            "expected Error, got ${response::class.simpleName}: $response"
         }
-        assertEquals(
-            surfaceBounds,
-            receivedRegion,
-            "default screenshot must crop to window surface bounds, not full desktop",
-        )
-
-        val decoded = ImageIO.read(response.pngBytes.inputStream())
-        assertEquals(2, decoded.width)
-        assertEquals(2, decoded.height)
+        assertFalse(regionInvoked, "default screenshot must not invoke region capture")
+        assertWindowScreenshotUnsupported(response)
     }
 
     @Test
@@ -349,9 +341,8 @@ class ReflectiveAutomatorHandlerMappingTest {
     }
 
     @Test
-    fun `Screenshot op with explicit window index captures that surface bounds`() {
-        var receivedRegion: Any? = null
-        val image = java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    fun `Screenshot op with explicit window index fails closed without region crop`() {
+        var regionInvoked = false
         val targetBounds = Rectangle(5, 6, 200, 200)
         val automator =
             FakeAutomator(
@@ -370,22 +361,24 @@ class ReflectiveAutomatorHandlerMappingTest {
                             windowValue = null,
                         ),
                     ),
-                screenshotImpl = { region ->
-                    receivedRegion = region
-                    image
+                screenshotImpl = { _ ->
+                    regionInvoked = true
+                    error("must not crop desktop for --window (#359)")
                 },
             )
         val handler = ReflectiveAutomatorHandler(automator)
 
         val response = handler.handle(AgentRequest.Screenshot(windowIndex = 1))
-        check(response is AgentResponse.Screenshot)
-        assertEquals(targetBounds, receivedRegion)
+        check(response is AgentResponse.Error) {
+            "expected Error, got ${response::class.simpleName}: $response"
+        }
+        assertFalse(regionInvoked)
+        assertWindowScreenshotUnsupported(response)
     }
 
     @Test
-    fun `Screenshot op with surface id captures matching surface bounds without reindex race`() {
-        var receivedRegion: Any? = null
-        val image = java.awt.image.BufferedImage(3, 3, java.awt.image.BufferedImage.TYPE_INT_ARGB)
+    fun `Screenshot op with surface id fails closed without region crop`() {
+        var regionInvoked = false
         val targetBounds = Rectangle(9, 10, 200, 200)
         val automator =
             FakeAutomator(
@@ -405,16 +398,19 @@ class ReflectiveAutomatorHandlerMappingTest {
                         ),
                     ),
                 screenshotWindowImpl = { error("must not re-resolve via screenshot(windowIndex)") },
-                screenshotImpl = { region ->
-                    receivedRegion = region
-                    image
+                screenshotImpl = { _ ->
+                    regionInvoked = true
+                    error("must not crop desktop for --surface (#359)")
                 },
             )
         val handler = ReflectiveAutomatorHandler(automator)
 
         val response = handler.handle(AgentRequest.Screenshot(surfaceId = "window:1"))
-        check(response is AgentResponse.Screenshot)
-        assertEquals(targetBounds, receivedRegion)
+        check(response is AgentResponse.Error) {
+            "expected Error, got ${response::class.simpleName}: $response"
+        }
+        assertFalse(regionInvoked)
+        assertWindowScreenshotUnsupported(response)
     }
 
     @Test
@@ -435,6 +431,24 @@ class ReflectiveAutomatorHandlerMappingTest {
             response.message.contains("window", ignoreCase = true) ||
                 response.message.contains("full-desktop", ignoreCase = true),
             response.message,
+        )
+    }
+
+    private fun assertWindowScreenshotUnsupported(response: AgentResponse.Error) {
+        assertEquals(
+            dev.sebastiano.spectre.agent.transport.AgentErrorCategory.UnsupportedOperation.wireName,
+            response.category,
+            response.message,
+        )
+        val message = response.message
+        assertTrue(
+            message.contains("occlusion", ignoreCase = true) ||
+                message.contains("privacy", ignoreCase = true),
+            "error must name occlusion/privacy risk: $message",
+        )
+        assertTrue(
+            message.contains("fullscreen", ignoreCase = true),
+            "error must point users to explicit fullscreen: $message",
         )
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.parse
 import com.github.ajalt.clikt.core.subcommands
@@ -196,15 +197,35 @@ private class ScreenshotCommand(
 ) : CliktCommand(name = "screenshot") {
     private val sessionId: String by argument()
     private val outputPath: Path? by option("--output").path()
-    private val windowIndex: Int? by option("--window").int()
-    private val surfaceId: String? by option("--surface")
+    private val windowIndex: Int? by
+        option(
+                "--window",
+                help =
+                    "Tracked window index. Currently unsupported on attach (fails closed; " +
+                        "occlusion/privacy risk) — use --fullscreen instead.",
+            )
+            .int()
+    private val surfaceId: String? by
+        option(
+            "--surface",
+            help =
+                "Tracked surface id from `spectre windows --json`. Currently unsupported on " +
+                    "attach (fails closed) — use --fullscreen instead.",
+        )
     private val fullscreen: Boolean by
         option(
                 "--fullscreen",
-                help = "Capture the full virtual desktop instead of a tracked window",
+                help =
+                    "Capture the full virtual desktop (explicit opt-in; the only screen-pixel " +
+                        "mode on this CLI path).",
             )
             .flag(default = false)
     private val json: Boolean by option("--json").flag(default = false)
+
+    override fun help(context: Context): String =
+        "Capture a PNG of the attached session. Window/surface targets (default) fail closed " +
+            "because attach cannot produce an occlusion-safe native window still (#359). " +
+            "Pass --fullscreen for an explicit full-desktop capture."
 
     override fun run() {
         if (fullscreen && (windowIndex != null || surfaceId != null)) {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -630,10 +630,12 @@ private fun registerScreenshotTool(server: Server, request: (DaemonRequest) -> D
     server.addTool(
         name = "screenshot",
         description =
-            "Capture a tracked window of the attached UI (default: window index 0) and return " +
-                "a PNG inline as MCP image content, never as a file path. Pass fullscreen=true " +
-                "only when a full virtual-desktop grab is intentional; do not combine fullscreen " +
-                "with window_index or surface_id.",
+            "Capture a PNG of the attached UI and return it inline as MCP image content " +
+                "(never a file path). Window/surface targets (default, window_index, " +
+                "surface_id) fail closed on the attach path because capture would crop " +
+                "occlusion-prone desktop pixels (privacy risk). Pass fullscreen=true for an " +
+                "explicit full virtual-desktop grab; do not combine fullscreen with " +
+                "window_index or surface_id.",
         inputSchema = ToolSchema(properties = properties, required = listOf("session_id")),
     ) { call ->
         handleScreenshotTool(call, request)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -85,9 +85,24 @@ class DaemonFixtureIntegrationTest {
                             .jsonPrimitive
                             .content
                     mcpText(client, "click", mapOf("session_id" to attached, "node_key" to button))
+                    // Window-scoped attach screenshots fail closed (#359).
+                    val windowShot = client.callTool("screenshot", mapOf("session_id" to attached))
+                    assertTrue(
+                        windowShot.isError == true ||
+                            windowShot.content.any {
+                                it is TextContent &&
+                                    (it.text.contains("occlusion", ignoreCase = true) ||
+                                        it.text.contains("fullscreen", ignoreCase = true) ||
+                                        it.text.contains("privacy", ignoreCase = true))
+                            },
+                        "default MCP screenshot must fail closed: ${windowShot.content}",
+                    )
                     val image =
                         client
-                            .callTool("screenshot", mapOf("session_id" to attached))
+                            .callTool(
+                                "screenshot",
+                                mapOf("session_id" to attached, "fullscreen" to true),
+                            )
                             .content
                             .single() as ImageContent
                     assertEquals("image/png", image.mimeType)
@@ -150,12 +165,39 @@ class DaemonFixtureIntegrationTest {
                         .content
 
                 assertEquals(0, runCliBinary(daemonUser, "click", sessionId, buttonKey).exitCode)
+                // #359: default / window-scoped CLI screenshot must fail closed (no PNG).
+                val windowShot =
+                    runCliBinary(
+                        daemonUser,
+                        "screenshot",
+                        sessionId,
+                        "--window",
+                        "0",
+                        "--output",
+                        screenshot.toString(),
+                    )
+                assertTrue(
+                    windowShot.exitCode != 0,
+                    "window screenshot must fail: ${windowShot.output}\n${windowShot.errorOutput}",
+                )
+                assertTrue(
+                    windowShot.errorOutput.contains("occlusion", ignoreCase = true) ||
+                        windowShot.errorOutput.contains("privacy", ignoreCase = true) ||
+                        windowShot.errorOutput.contains("fullscreen", ignoreCase = true),
+                    windowShot.errorOutput,
+                )
+                assertTrue(
+                    !Files.exists(screenshot) || Files.size(screenshot) == 0L,
+                    "must not write an occlusion-prone window crop PNG",
+                )
+
                 assertEquals(
                     0,
                     runCliBinary(
                             daemonUser,
                             "screenshot",
                             sessionId,
+                            "--fullscreen",
                             "--output",
                             screenshot.toString(),
                         )
@@ -215,9 +257,21 @@ class DaemonFixtureIntegrationTest {
                         client.request(DaemonRequest.Click(attached.sessionId, button.key)),
                     )
 
+                    // #359: non-fullscreen window screenshot fails; fullscreen still works.
+                    val windowError = client.request(DaemonRequest.Screenshot(attached.sessionId))
+                    check(windowError is DaemonResponse.Error) {
+                        "expected Error for default window screenshot, got $windowError"
+                    }
+                    assertTrue(
+                        windowError.message.contains("occlusion", ignoreCase = true) ||
+                            windowError.message.contains("privacy", ignoreCase = true) ||
+                            windowError.message.contains("fullscreen", ignoreCase = true),
+                        windowError.message,
+                    )
                     val screenshot =
-                        client.request(DaemonRequest.Screenshot(attached.sessionId))
-                            as DaemonResponse.Screenshot
+                        client.request(
+                            DaemonRequest.Screenshot(attached.sessionId, fullscreen = true)
+                        ) as DaemonResponse.Screenshot
                     assertTrue(screenshot.pngBytes.size >= MIN_PNG_BYTES)
                     assertTrue(screenshot.pngBytes.startsWith(PNG_MAGIC))
                     assertEquals(

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -242,7 +242,9 @@ AgentAttach.attach(target.pid).use { automator ->
     if (submitNodes.isNotEmpty()) {
         automator.click(submitNodes.first().key)
     }
-    val pngBytes = automator.screenshot()
+    // Window/surface attach screenshots fail closed (#359); fullscreen is the only
+    // screen-pixel capture mode on this path.
+    val pngBytes = automator.screenshot(fullscreen = true)
 } // detach + cleanup on close()
 ```
 
@@ -291,14 +293,14 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 | `pressKey(keyCode, modifiers?)` | `AgentRequest.PressKey`  | `Unit`            |
 | `focusWindow(nodeKey)` | `AgentRequest.FocusWindow` | `Unit` (raise/activate window hosting node) |
 | `typeText(text)`      | `AgentRequest.TypeText`          | `Unit`            |
-| `screenshot(windowIndex?, surfaceId?, fullscreen?)` | `AgentRequest.Screenshot` | `ByteArray` (PNG); default window index 0, not full desktop |
+| `screenshot(windowIndex?, surfaceId?, fullscreen?)` | `AgentRequest.Screenshot` | `ByteArray` (PNG); **only `fullscreen=true` succeeds** on attach — window/surface fail closed (#359) |
 | `capture(windowIndex)`| `AgentRequest.Capture`           | `AtomicCaptureResult` |
 | `windowIdentities(windowIndex?)` | `AgentRequest.WindowIdentity` | `List<WindowIdentityDto>` |
 | `waitForNode(...)`    | `AgentRequest.WaitForNode`       | `NodeSnapshotDto` |
 | `waitForVisualIdle(...)` | `AgentRequest.WaitForVisualIdle` | `Unit`         |
 | `waitForIdle(...)`    | `AgentRequest.WaitForIdle`       | `Unit` (fingerprint wait; no idling-resource registration over attach — #362) |
 | `printTree()`         | `AgentRequest.PrintTree`         | `String` (human-readable dump — #362) |
-| `screenshot(node)`    | `AgentRequest.Screenshot(nodeKey)` | `ByteArray` (PNG of node bounds — #362; native when recording bridge present, else region of bounds like attach window screenshots) |
+| `screenshot(node)`    | `AgentRequest.Screenshot(nodeKey)` | `ByteArray` (PNG of node bounds — #362; native when recording bridge present, else region of `boundsOnScreen`) |
 | `click(node)`         | `AgentRequest.Click`             | `Unit` (DTO overload uses [NodeSnapshotDto.key] — #362) |
 | `close()` (auto)      | `AgentRequest.Detach`            | tear-down         |
 
@@ -495,9 +497,9 @@ spectre attach <pid> --json
 ```
 
 The attach response contains an `id`. Pass it to commands such as `tree`, `find`, `click`, and
-`screenshot`. `screenshot` writes a PNG of the attached session's tracked window (default index
-`0`) to `--output`; without that option it creates a temporary file and prints its path. Use
-`--window`, `--surface`, or opt-in `--fullscreen` as described in [CLI](cli.md).
+`screenshot`. On the attach path, `screenshot` **requires** `--fullscreen` for screen-pixel
+capture; default / `--window` / `--surface` fail closed (occlusion/privacy risk — #359). Without
+`--output`, a successful capture creates a temporary file and prints its path. See [CLI](cli.md).
 
 ### Claude Code recipe
 
@@ -521,8 +523,8 @@ Restart Claude Code after changing the configuration. It can then use these tool
 1. `list_processes` to find the target PID.
 2. `attach` with that PID and retain the returned `sessionId`.
 3. `tree` or `find` to retrieve current node keys, then `click` or `type_text` to interact.
-4. `screenshot` to receive a window-scoped PNG as MCP image content (optional `window_index` /
-   `surface_id` / `fullscreen`), rather than a file path.
+4. `screenshot` with `fullscreen=true` to receive a full-desktop PNG as MCP image content
+   (window/surface targets fail closed on attach — #359), rather than a file path.
 5. When the target runs under Compose Hot Reload: call `wait_for_reload_settled` **before**
    triggering a code reload (it must observe the settle chain), then re-run `tree` / `find`
    before further input.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -85,11 +85,9 @@ spectre find <session-id> save-button --json
 spectre click <session-id> <node-key>
 spectre type <session-id> "A short note"
 
-# Keep visual evidence (default: tracked window index 0, not the whole desktop).
-spectre screenshot <session-id> --output ./after-save.png
-# Target a specific window from `spectre windows --json`, or opt into full desktop.
-spectre screenshot <session-id> --window 0 --output ./window.png
-spectre screenshot <session-id> --surface window:0 --output ./surface.png
+# Full-desktop capture is the only screen-pixel mode on the CLI attach path (#359).
+# Window/surface targets fail closed (occlusion/privacy risk) until native window
+# capture is wired into attach.
 spectre screenshot <session-id> --fullscreen --output ./desktop.png
 # Atomic capture: window PNG + full semantics tree on disk (summary only on stdout).
 spectre capture <session-id> --json
@@ -108,21 +106,24 @@ spectre record stop <session-id>
 ```
 
 `tree` lists the current semantics nodes. `find` performs an exact match on a Compose test tag.
-`windows` includes top-level windows and popup roots. `screenshot` captures a tracked window of the
-attached session (default index `0`) and writes a PNG to `--output`, or creates a temporary PNG and
-prints its path. Pass `--window <index>` or `--surface <surfaceId>` (as returned by
-`spectre windows --json`) to target a specific surface. Full virtual-desktop capture is opt-in only
-via `--fullscreen`; if window capture cannot be performed, the command fails rather than silently
-writing a full-screen image. `capture` takes a window screenshot and the semantics
-tree under the same tick, writes `capture.json` + `screenshot.png` under a sequenced capture
-directory (`NNNN-<timestamp>/` under `$TMPDIR/spectre/captures` by default, mode `0700`, or under
-`--out-dir`), appends a crash-proof ledger entry, and returns only a decision-grade summary
-(paths, node counts, image size). Default-root captures are lazily capped (keep last 50 closed
-sessions' captures); client `--out-dir` captures are never auto-deleted. Summaries and detach
-reports point agents at the **`spectre-capture`** skill for `jq` recipes — see
-[Atomic capture](capture.md). `record start` records a tracked window by default (index `0`;
-`--window` / `--window-index`). Full-display recording is opt-in via `--fullscreen` (primary
-display only; multi-monitor desktops are rejected until multi-display capture is supported).
+`windows` includes top-level windows and popup roots. `screenshot` writes a PNG to `--output`, or
+creates a temporary PNG and prints its path. On the attach/CLI path, **only `--fullscreen` is
+supported** as a screen-pixel capture mode: it grabs the full virtual desktop after an explicit
+opt-in. Default, `--window`, and `--surface` requests **fail closed** rather than silently
+cropping the desktop framebuffer — that crop is occlusion-prone and can capture unrelated
+on-screen content (privacy risk) until a true native window-surface backend is wired into attach
+(#359). For occlusion-safe window stills from in-process library code, use
+`ComposeAutomator.screenshot(windowIndex)` with the `:recording` native backends. `capture` takes a
+window screenshot and the semantics tree under the same tick, writes `capture.json` +
+`screenshot.png` under a sequenced capture directory (`NNNN-<timestamp>/` under
+`$TMPDIR/spectre/captures` by default, mode `0700`, or under `--out-dir`), appends a crash-proof
+ledger entry, and returns only a decision-grade summary (paths, node counts, image size).
+Default-root captures are lazily capped (keep last 50 closed sessions' captures); client
+`--out-dir` captures are never auto-deleted. Summaries and detach reports point agents at the
+**`spectre-capture`** skill for `jq` recipes — see [Atomic capture](capture.md). `record start`
+records a tracked window by default (index `0`; `--window` / `--window-index`). Full-display
+recording is opt-in via `--fullscreen` (primary display only; multi-monitor desktops are rejected
+until multi-display capture is supported).
 
 `spectre captures list [--all] [--json]` lists ledger-backed capture directories with size and
 live/closed status. `spectre captures prune` supports `--keep N`, `--older-than 7d`, `--all`,


### PR DESCRIPTION
## Summary

- Attach/CLI/MCP window and surface screenshots no longer crop the desktop framebuffer (occlusion/privacy risk).
- Those targets fail closed with an actionable error that points users to explicit `--fullscreen` / `fullscreen=true`.
- `--fullscreen` remains the only screen-pixel capture mode on this path; e2e and unit tests lock both behaviours.
- CLI help and user guide (`docs/guide/cli.md`, `docs/guide/agent.md`) updated so they no longer claim window screenshots are occlusion-safe on attach.

Closes #359.

## Test plan

- [x] Unit: `ReflectiveAutomatorHandlerMappingTest` — default / window / surface fail; fullscreen succeeds; no region crop.
- [x] E2E: `DaemonFixtureIntegrationTest` — CLI/MCP window path fails; fullscreen writes PNG.
- [x] Integration/corpus probes use `screenshot(fullscreen = true)`.
- [x] `./gradlew check` green locally.
- [x] `spectre screenshot --help` documents fail-closed window/surface and `--fullscreen` opt-in.