### PR TITLE
feat(core): window-scoped waitForVisualIdle sampling (#355)

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -564,6 +564,10 @@ private constructor(
         // sample the wait's remaining budget. After the first completed sample, this worker is
         // capped at FRAME_HASH_BUDGET_MS: an unexpectedly hung EDT or capture API still cannot
         // out-block waitForVisualIdle's overall deadline.
+        //
+        // Prefer window-scoped pixels when the recording native still bridge is present (#355):
+        // one-shot helper startup is paid on the cold sample; steady-state budget is sized for a
+        // warm one-shot still (see FRAME_HASH_BUDGET_MS), not a continuous frame stream.
         return runInterruptible {
             runBoundedOnWorker(budgetMs) {
                 refreshWindows()
@@ -571,16 +575,22 @@ private constructor(
                 if (surfaces.isEmpty()) {
                     null
                 } else {
-                    val hashes = IntArray(surfaces.size)
-                    for (i in surfaces.indices) {
-                        val (_, region) = surfaces[i]
-                        // AutoScreenshotter starts a native helper for each still image. Repeating
-                        // that startup on every visual-idle poll makes a stable-frame streak
-                        // unreachable on a cold helper, so use Robot's long-lived region path
-                        // until the native API exposes a persistent frame stream.
-                        hashes[i] = imageHash(screenCaptureBackend.captureRegion(region))
+                    val geometry = readOnEdt {
+                        surfaces.associate { (window, _) ->
+                            window to
+                                (Rectangle(window.window.bounds) to frameInsets(window.window))
+                        }
                     }
-                    hashes.contentHashCode()
+                    hashTrackedSurfacesForVisualIdle(
+                        surfaces = surfaces,
+                        windowBoundsFor = { geometry.getValue(it).first },
+                        frameInsetsFor = { geometry.getValue(it).second },
+                        backend = screenCaptureBackend,
+                        nativeWindowCaptureAvailable =
+                            isNativeWindowCaptureAvailable(
+                                allowsPlatformCapture = robotDriver.allowsPlatformCapture
+                            ),
+                    )
                 }
             }
         }
@@ -752,7 +762,10 @@ private val DEFAULT_QUIET_PERIOD: Duration = 64.milliseconds
 private val DEFAULT_POLL_INTERVAL: Duration = 16.milliseconds
 private const val DEFAULT_STABLE_FRAMES: Int = 3
 private const val EDT_DRAIN_BUDGET_MS: Long = 250
-private const val FRAME_HASH_BUDGET_MS: Long = 500
+// Steady-state sample budget after the cold sample. Warm one-shot native stills are typically
+// a few hundred ms (Issue14: ~400ms hot on macOS); keep headroom for multi-surface waits and
+// slower Windows/Linux helper startup without treating a static UI as permanently unstable.
+private const val FRAME_HASH_BUDGET_MS: Long = 2_000
 private const val FINGERPRINT_BUDGET_MS: Long = 500
 private const val WORKER_INTERRUPT_GRACE_MS: Long = 50
 private const val EMPTY_FINGERPRINT_PREFIX: String = "spectre-fingerprint-budget-elapsed:"

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCapture.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCapture.kt
@@ -1,0 +1,92 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import dev.sebastiano.spectre.core.capture.cropImageToScreenRegion
+import dev.sebastiano.spectre.core.capture.normalizeImageToScreenBounds
+import java.awt.Insets
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+
+/**
+ * Captures one tracked Compose surface for visual-idle frame hashing.
+ *
+ * When [nativeWindowCaptureAvailable] is true, uses window-scoped pixels via
+ * [ScreenCaptureBackend.captureWindow] and crops to [surfaceRegion]. Failures do **not** fall back
+ * to screen-region capture (that would reintroduce occlusion sensitivity #355 exists to remove).
+ * Returning `null` makes the visual-idle streak reset so the wait times out rather than reporting
+ * fake stability.
+ *
+ * When the native bridge is absent or disabled, falls back to [ScreenCaptureBackend.captureRegion]
+ * so visual-idle still works in environments without `spectre-recording` on the classpath.
+ */
+internal fun captureSurfaceForVisualIdle(
+    backend: ScreenCaptureBackend,
+    window: TrackedWindow,
+    surfaceRegion: Rectangle,
+    windowBounds: Rectangle,
+    frameInsets: Insets,
+    nativeWindowCaptureAvailable: Boolean,
+): BufferedImage? {
+    if (!nativeWindowCaptureAvailable) {
+        return backend.captureRegion(surfaceRegion)
+    }
+    return try {
+        val capture = backend.captureWindow(window, windowBounds, frameInsets)
+        val normalized = normalizeImageToScreenBounds(capture.image, capture.boundsOnScreen)
+        if (capture.boundsOnScreen == surfaceRegion) {
+            normalized
+        } else {
+            val visibleRegion = surfaceRegion.intersection(capture.boundsOnScreen)
+            if (visibleRegion.isEmpty) {
+                null
+            } else {
+                cropImageToScreenRegion(normalized, visibleRegion, capture.boundsOnScreen)
+            }
+        }
+    } catch (_: UnsupportedOperationException) {
+        null
+    } catch (_: IllegalStateException) {
+        null
+    } catch (_: IllegalArgumentException) {
+        null
+    }
+}
+
+/**
+ * Hashes every tracked surface in order. Returns `null` if any surface cannot be sampled (empty
+ * surface list is the caller's concern — they should also return null).
+ */
+internal fun hashTrackedSurfacesForVisualIdle(
+    surfaces: List<Pair<TrackedWindow, Rectangle>>,
+    windowBoundsFor: (TrackedWindow) -> Rectangle,
+    frameInsetsFor: (TrackedWindow) -> Insets,
+    backend: ScreenCaptureBackend,
+    nativeWindowCaptureAvailable: Boolean,
+): Int? {
+    if (surfaces.isEmpty()) return null
+    val hashes = IntArray(surfaces.size)
+    for (i in surfaces.indices) {
+        val (window, region) = surfaces[i]
+        val image =
+            captureSurfaceForVisualIdle(
+                backend = backend,
+                window = window,
+                surfaceRegion = region,
+                windowBounds = windowBoundsFor(window),
+                frameInsets = frameInsetsFor(window),
+                nativeWindowCaptureAvailable = nativeWindowCaptureAvailable,
+            ) ?: return null
+        hashes[i] = imageHash(image)
+    }
+    return hashes.contentHashCode()
+}
+
+/** True when the optional recording-owned native still bridge can be loaded. */
+internal fun isNativeWindowCaptureAvailable(
+    classLoader: ClassLoader = VisualIdleSurfaceCapture::class.java.classLoader,
+    allowsPlatformCapture: Boolean = true,
+): Boolean = allowsPlatformCapture && nativeWindowCaptureFor(classLoader) != null
+
+/** Marker for classloader defaults (avoids referencing ComposeAutomator from this helper). */
+private object VisualIdleSurfaceCapture

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCaptureTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCaptureTest.kt
@@ -1,0 +1,282 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import java.awt.Frame
+import java.awt.Insets
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Routing contract for #355 visual-idle sampling: when a native window backend is available,
+ * surfaces are hashed from window-scoped pixels (not `captureRegion` / Robot screen rects).
+ */
+class VisualIdleSurfaceCaptureTest {
+
+    @Test
+    fun `prefers window-scoped capture and never calls region when native path succeeds`() {
+        assumeLiveAwtAvailable()
+        val frame =
+            Frame("visual-idle-window").apply {
+                setBounds(40, 50, 200, 100)
+                addNotify()
+            }
+        val windowBounds = Rectangle(frame.bounds)
+        val surface = Rectangle(40, 74, 200, 76)
+        val nativeImage = solidImage(200, 100, 0xFF112233.toInt())
+        var regionCalls = 0
+        var windowCalls = 0
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = {
+                    regionCalls += 1
+                    error(
+                        "screen-region capture must not be used for visual-idle when native works"
+                    )
+                },
+                nativeCapture = {
+                    windowCalls += 1
+                    nativeImage
+                },
+                nativeCaptureBounds = { _, _, bounds, _ -> bounds },
+            )
+        try {
+            val image =
+                captureSurfaceForVisualIdle(
+                    backend = backend,
+                    window = tracked(frame),
+                    surfaceRegion = surface,
+                    windowBounds = windowBounds,
+                    frameInsets = Insets(24, 0, 0, 0),
+                    nativeWindowCaptureAvailable = true,
+                )
+            assertEquals(1, windowCalls)
+            assertEquals(0, regionCalls)
+            assertEquals(200, image!!.width)
+            // Cropped to surface height (100 - 24 chrome).
+            assertEquals(76, image.height)
+        } finally {
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun `uses region capture only when native window backend is unavailable`() {
+        var regionCalls = 0
+        var windowCalls = 0
+        val regionImage = solidImage(10, 10, 0xFF00FF00.toInt())
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = {
+                    regionCalls += 1
+                    regionImage
+                },
+                nativeCapture = {
+                    windowCalls += 1
+                    error("native must not be invoked when marked unavailable")
+                },
+            )
+        val image =
+            captureSurfaceForVisualIdle(
+                backend = backend,
+                window = tracked(Frame()),
+                surfaceRegion = Rectangle(1, 2, 10, 10),
+                windowBounds = Rectangle(0, 0, 100, 100),
+                frameInsets = Insets(0, 0, 0, 0),
+                nativeWindowCaptureAvailable = false,
+            )
+        assertSame(regionImage, image)
+        assertEquals(1, regionCalls)
+        assertEquals(0, windowCalls)
+    }
+
+    @Test
+    fun `does not silently fall back to region when native is available but fails`() {
+        assumeLiveAwtAvailable()
+        val frame =
+            Frame("ambiguous-a").apply {
+                setBounds(0, 0, 80, 60)
+                addNotify()
+            }
+        val twin =
+            Frame("ambiguous-a").apply {
+                setBounds(100, 0, 80, 60)
+                addNotify()
+            }
+        var regionCalls = 0
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = {
+                    regionCalls += 1
+                    solidImage(1, 1, 0)
+                },
+                nativeCapture = { solidImage(80, 60, 0xFFAABBCC.toInt()) },
+                nativeCaptureEnabled = { true },
+                nativeCaptureDisambiguatesTitles = { false },
+            )
+        try {
+            val image =
+                captureSurfaceForVisualIdle(
+                    backend = backend,
+                    window = tracked(frame),
+                    surfaceRegion = Rectangle(frame.bounds),
+                    windowBounds = Rectangle(frame.bounds),
+                    frameInsets = Insets(0, 0, 0, 0),
+                    nativeWindowCaptureAvailable = true,
+                )
+            assertNull(image, "ambiguous native identity must not yield region pixels")
+            assertEquals(0, regionCalls)
+        } finally {
+            twin.dispose()
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun `hashes combined surfaces from window captures in order`() {
+        assumeLiveAwtAvailable()
+        val frame =
+            Frame("hash-order").apply {
+                setBounds(0, 0, 40, 20)
+                addNotify()
+            }
+        val imgA = solidImage(40, 20, 0xFF010101.toInt())
+        val imgB = solidImage(40, 20, 0xFF020202.toInt())
+        var n = 0
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = { error("no region") },
+                nativeCapture = {
+                    n += 1
+                    if (n == 1) imgA else imgB
+                },
+                nativeCaptureBounds = { _, _, bounds, _ -> bounds },
+            )
+        try {
+            val surfaces =
+                listOf(
+                    Triple(tracked(frame), Rectangle(0, 0, 40, 20), Rectangle(0, 0, 40, 20)),
+                    Triple(tracked(frame), Rectangle(0, 0, 40, 20), Rectangle(0, 0, 40, 20)),
+                )
+            val hash =
+                hashTrackedSurfacesForVisualIdle(
+                    surfaces = surfaces.map { it.first to it.second },
+                    windowBoundsFor = { surfaces.first().third },
+                    frameInsetsFor = { Insets(0, 0, 0, 0) },
+                    backend = backend,
+                    nativeWindowCaptureAvailable = true,
+                )
+            val expected = intArrayOf(imageHash(imgA), imageHash(imgB)).contentHashCode()
+            assertEquals(expected, hash)
+            assertTrue(n >= 2)
+        } finally {
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun `hash returns null when any surface cannot be sampled under native routing`() {
+        assumeLiveAwtAvailable()
+        val frame =
+            Frame("fail-one").apply {
+                setBounds(0, 0, 40, 20)
+                addNotify()
+            }
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = { error("no region") },
+                nativeCapture = { error("native boom") },
+            )
+        try {
+            val hash =
+                hashTrackedSurfacesForVisualIdle(
+                    surfaces = listOf(tracked(frame) to Rectangle(0, 0, 40, 20)),
+                    windowBoundsFor = { Rectangle(0, 0, 40, 20) },
+                    frameInsetsFor = { Insets(0, 0, 0, 0) },
+                    backend = backend,
+                    nativeWindowCaptureAvailable = true,
+                )
+            assertNull(hash)
+        } finally {
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun `unsupported native absence uses region without throwing`() {
+        val regionImage = solidImage(8, 8, 0xFF334455.toInt())
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = { regionImage },
+                nativeCapture = {
+                    throw UnsupportedOperationException(
+                        "Native window capture bridge is unavailable"
+                    )
+                },
+            )
+        val image =
+            captureSurfaceForVisualIdle(
+                backend = backend,
+                window = tracked(Frame()),
+                surfaceRegion = Rectangle(0, 0, 8, 8),
+                windowBounds = Rectangle(0, 0, 8, 8),
+                frameInsets = Insets(0, 0, 0, 0),
+                nativeWindowCaptureAvailable = false,
+            )
+        assertSame(regionImage, image)
+    }
+
+    @Test
+    fun `native path does not region-fallback when host is not a Frame`() {
+        // A bare Window (not Frame) cannot use native capture; when native is "available" we must
+        // not silently substitute region — callers see null (unsampleable) instead.
+        var regionCalls = 0
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = {
+                    regionCalls += 1
+                    solidImage(1, 1, 0)
+                },
+                nativeCapture = { solidImage(10, 10, 0xFF0000FF.toInt()) },
+            )
+        val window =
+            object : java.awt.Window(null as java.awt.Frame?) {
+                init {
+                    setBounds(0, 0, 10, 10)
+                }
+            }
+        try {
+            val image =
+                captureSurfaceForVisualIdle(
+                    backend = backend,
+                    window = TrackedWindow("w", window, composePanel = null, isPopup = false),
+                    surfaceRegion = Rectangle(0, 0, 10, 10),
+                    windowBounds = Rectangle(0, 0, 10, 10),
+                    frameInsets = Insets(0, 0, 0, 0),
+                    nativeWindowCaptureAvailable = true,
+                )
+            assertNull(image)
+            assertEquals(0, regionCalls)
+        } finally {
+            window.dispose()
+        }
+    }
+
+    private fun tracked(frame: Frame): TrackedWindow =
+        TrackedWindow("test", frame, composePanel = null, isPopup = false)
+
+    private fun solidImage(width: Int, height: Int, rgb: Int): BufferedImage {
+        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                image.setRGB(x, y, rgb)
+            }
+        }
+        return image
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCaptureTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCaptureTest.kt
@@ -67,6 +67,9 @@ class VisualIdleSurfaceCaptureTest {
 
     @Test
     fun `uses region capture only when native window backend is unavailable`() {
+        // Frame is only a TrackedWindow carrier; region path never calls native. Still needs a
+        // non-headless AWT toolkit to construct the Frame on CI Ubuntu without xvfb.
+        assumeLiveAwtAvailable()
         var regionCalls = 0
         var windowCalls = 0
         val regionImage = solidImage(10, 10, 0xFF00FF00.toInt())
@@ -81,18 +84,23 @@ class VisualIdleSurfaceCaptureTest {
                     error("native must not be invoked when marked unavailable")
                 },
             )
-        val image =
-            captureSurfaceForVisualIdle(
-                backend = backend,
-                window = tracked(Frame()),
-                surfaceRegion = Rectangle(1, 2, 10, 10),
-                windowBounds = Rectangle(0, 0, 100, 100),
-                frameInsets = Insets(0, 0, 0, 0),
-                nativeWindowCaptureAvailable = false,
-            )
-        assertSame(regionImage, image)
-        assertEquals(1, regionCalls)
-        assertEquals(0, windowCalls)
+        val frame = Frame()
+        try {
+            val image =
+                captureSurfaceForVisualIdle(
+                    backend = backend,
+                    window = tracked(frame),
+                    surfaceRegion = Rectangle(1, 2, 10, 10),
+                    windowBounds = Rectangle(0, 0, 100, 100),
+                    frameInsets = Insets(0, 0, 0, 0),
+                    nativeWindowCaptureAvailable = false,
+                )
+            assertSame(regionImage, image)
+            assertEquals(1, regionCalls)
+            assertEquals(0, windowCalls)
+        } finally {
+            frame.dispose()
+        }
     }
 
     @Test
@@ -209,6 +217,7 @@ class VisualIdleSurfaceCaptureTest {
 
     @Test
     fun `unsupported native absence uses region without throwing`() {
+        assumeLiveAwtAvailable()
         val regionImage = solidImage(8, 8, 0xFF334455.toInt())
         val backend =
             PlatformScreenCaptureBackend(
@@ -219,20 +228,26 @@ class VisualIdleSurfaceCaptureTest {
                     )
                 },
             )
-        val image =
-            captureSurfaceForVisualIdle(
-                backend = backend,
-                window = tracked(Frame()),
-                surfaceRegion = Rectangle(0, 0, 8, 8),
-                windowBounds = Rectangle(0, 0, 8, 8),
-                frameInsets = Insets(0, 0, 0, 0),
-                nativeWindowCaptureAvailable = false,
-            )
-        assertSame(regionImage, image)
+        val frame = Frame()
+        try {
+            val image =
+                captureSurfaceForVisualIdle(
+                    backend = backend,
+                    window = tracked(frame),
+                    surfaceRegion = Rectangle(0, 0, 8, 8),
+                    windowBounds = Rectangle(0, 0, 8, 8),
+                    frameInsets = Insets(0, 0, 0, 0),
+                    nativeWindowCaptureAvailable = false,
+                )
+            assertSame(regionImage, image)
+        } finally {
+            frame.dispose()
+        }
     }
 
     @Test
     fun `native path does not region-fallback when host is not a Frame`() {
+        assumeLiveAwtAvailable()
         // A bare Window (not Frame) cannot use native capture; when native is "available" we must
         // not silently substitute region — callers see null (unsampleable) instead.
         var regionCalls = 0

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -151,17 +151,21 @@ A few details worth knowing:
 - **No surfaces tracked → never idle.** If no Compose surfaces are tracked, or all of
   them have empty bounds, `waitForVisualIdle` returns a different value every poll and
   times out rather than reporting fake stability.
-- **`pollInterval` is a floor, not the real cadence.** Each poll captures the pixel
-  buffer of every tracked surface (`java.awt.Robot.createScreenCapture`) and hashes
-  it. The native capture call is the dominant cost — typically tens of milliseconds
-  per surface on a desktop, more on Wayland, large displays, or software-rendered VMs.
-  In practice the gap between completed polls is whatever the capture takes, with
-  `pollInterval` only kicking in when the capture is faster than that floor. The
-  default `16.milliseconds` is a 60Hz *target*, not a guarantee of 60 polls per
-  second.
+- **`pollInterval` is a floor, not the real cadence.** Each poll captures every tracked
+  Compose surface and hashes the pixels. When `spectre-recording` is on the runtime
+  classpath, surfaces are sampled with the same **window-scoped** native still path as
+  `screenshot(windowIndex)` (occlusion-immune on platforms with true window capture).
+  Without that backend, Spectre falls back to `java.awt.Robot` region capture of the
+  surface rectangle. Capture cost dominates the poll cadence — typically tens to a few
+  hundred milliseconds per surface (one-shot native helper startup is larger on the first
+  sample), more on Wayland, large displays, or software-rendered VMs. In practice the gap
+  between completed polls is whatever the capture takes, with `pollInterval` only kicking
+  in when the capture is faster than that floor. The default `16.milliseconds` is a 60Hz
+  *target*, not a guarantee of 60 polls per second.
 - **Bounded sampling budget.** The first completed frame hash may use the wait's remaining
   timeout: native capture paths can have a one-off cold-start cost. Later frame hashes run on
-  a worker thread capped at 500ms. If a steady-state capture or hash exceeds that cap — or no
+  a worker thread capped at 2s so a warm one-shot window still can complete without treating a
+  static UI as permanently unstable. If a steady-state capture or hash exceeds that cap — or no
   Compose surface is available — that poll is treated as unsampleable: the stable-frame streak
   resets and the wait times out rather than silently succeeding. When that happens,
   `IdleTimeoutException` reports how many samples were unsampleable (capture budget or missing

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -227,9 +227,11 @@ native backend itself reads visible framebuffer pixels, so keep the target front
 `capture()` intentionally uses an immediate Robot region capture to keep its semantics snapshot
 adjacent to its pixels, so its image can include occlusion.
 
-`waitForVisualIdle()` samples screen regions until the native capture API can keep one frame
-stream alive across polls. Bring the target to the front before using it when another window may
-overlap the Compose surface.
+`waitForVisualIdle()` samples **window-scoped** pixels for tracked Compose surfaces when
+`spectre-recording` is present (same native still path as `screenshot(windowIndex)`). Without that
+backend it falls back to Robot region capture of each surface rectangle — keep the target frontmost
+and unobscured in that fallback mode (Linux X11 region and some embedded cases still need
+visibility).
 
 **Rule of thumb: when you're validating colours from a `screenshot()`, always think
 about the node's interaction state first.** If the node is currently focused,

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitForVisualIdleValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitForVisualIdleValidationTest.kt
@@ -10,15 +10,16 @@ import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.TestInstance
 
 /**
- * Live acceptance for the cold-capture path in
- * [dev.sebastiano.spectre.core.ComposeAutomator.waitForVisualIdle].
+ * Live acceptance for [dev.sebastiano.spectre.core.ComposeAutomator.waitForVisualIdle].
  *
- * The fixture starts in a fresh worker JVM. Navigation and `waitForIdle()` are semantics-only, so
- * `waitForVisualIdle()` below is the first pixel capture a user performs against a static Compose
- * surface. This is the ordering that previously made an otherwise idle UI time out when native
- * screen capture had a one-off startup cost. One stable frame intentionally isolates that cold
- * public-capture path from the separate window-scoped capture fidelity work in #355, which can make
- * repeated synthetic-screen samples differ even when the Compose content is static.
+ * Covers:
+ * - **Cold capture (#356):** the fixture starts in a fresh worker JVM. Navigation and
+ *   `waitForIdle()` are semantics-only, so the first `waitForVisualIdle` poll is the first pixel
+ *   capture against a static Compose surface.
+ * - **Window-scoped sampling (#355):** with `spectre-recording` on the classpath (this module),
+ *   frame hashes come from native window capture, not `Robot.createScreenCapture` of a screen
+ *   rectangle. A full default `stableFrames = 3` streak must complete against a static UI so
+ *   one-shot helper cost cannot make visual idle unreachable by construction.
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WaitForVisualIdleValidationTest {
@@ -42,6 +43,19 @@ class WaitForVisualIdleValidationTest {
                 waitForIdle()
 
                 waitForVisualIdle(timeout = 5.seconds, stableFrames = 1)
+            }
+        }
+
+    @Test
+    fun `window-scoped visual idle reaches a three-frame streak on a static live Compose surface`() =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.hidpi")
+                waitForTestTag("hidpi.target.40x0")
+                waitForIdle()
+
+                // Default stableFrames; longer timeout absorbs cold helper + three warm stills.
+                waitForVisualIdle(timeout = 15.seconds, stableFrames = 3)
             }
         }
 }

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitForVisualIdleValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitForVisualIdleValidationTest.kt
@@ -20,6 +20,9 @@ import org.junit.jupiter.api.TestInstance
  *   frame hashes come from native window capture, not `Robot.createScreenCapture` of a screen
  *   rectangle. A full default `stableFrames = 3` streak must complete against a static UI so
  *   one-shot helper cost cannot make visual idle unreachable by construction.
+ *
+ * Skips GitHub-hosted Windows: WGC still capture needs an interactive console (same gate as Issue14
+ * screenshot warmup).
  */
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class WaitForVisualIdleValidationTest {
@@ -29,6 +32,10 @@ class WaitForVisualIdleValidationTest {
     @BeforeAll
     fun start() {
         assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        assumeFalse(
+            isHostedWindows(),
+            "Live Windows Graphics Capture requires an interactive console",
+        )
         fixture.start()
     }
 
@@ -58,4 +65,10 @@ class WaitForVisualIdleValidationTest {
                 waitForVisualIdle(timeout = 15.seconds, stableFrames = 3)
             }
         }
+
+    private companion object {
+        fun isHostedWindows(): Boolean =
+            System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true) &&
+                System.getenv("GITHUB_ACTIONS") == "true"
+    }
 }

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -205,10 +205,12 @@ querying state that depends on a prior action.
 - **`waitForIdle()`** — wait until the semantics fingerprint stabilizes and
   all registered `AutomatorIdlingResource`s are idle. Use this when you've
   triggered work that updates semantics but no specific node appears.
-- **`waitForVisualIdle(stableFrames = 3)`** — wait until the on-screen pixels
-  are stable for N consecutive frames. Heavier than `waitForIdle`. Use it
-  before screenshotting, or when work is animation-bound rather than
-  semantics-bound.
+- **`waitForVisualIdle(stableFrames = 3)`** — wait until tracked Compose
+  surface pixels are stable for N consecutive frames. With `spectre-recording`
+  present, samples use the same window-scoped native still path as
+  `screenshot(windowIndex)` (not a screen-region crop). Heavier than
+  `waitForIdle`. Use it before screenshotting, or when work is animation-bound
+  rather than semantics-bound.
 
 A typical pattern after an interaction is `waitForVisualIdle()`. After
 triggering a screen *change* (e.g. opening a dialog), `waitForNode(tag = …)`


### PR DESCRIPTION
## Summary

Completes residual #355 work for **visual-idle** sampling:

- Route `waitForVisualIdle` frame hashes through the same **window-scoped** native still path as `screenshot(windowIndex)` when `spectre-recording` is present (no silent `Robot.createScreenCapture` of the surface rect).
- Fall back to region capture **only** when the native bridge is absent/disabled — not when native is available but fails (ambiguous title, non-Frame host, etc.).
- Raise steady-state sample budget from 500ms → 2s so warm one-shot helper latency can complete a `stableFrames` streak on a static UI (cold sample still uses remaining wait budget from #356/`BoundedFrameHasher`).
- Docs/skills no longer claim visual-idle is pure screen-region when recording is present.

Does **not** change `capture(...)` (Sub-B next) or reimplement #358/#361 screenshot routing.

## Test plan

- [x] Unit: `VisualIdleSurfaceCaptureTest` — window vs region routing, no silent fallback
- [x] Unit: existing `WaitForVisualIdleTest` still green
- [x] Live: `:sample-desktop:validationTest --tests '*WaitForVisualIdle*'` (cold + 3-frame streak; helper process observed)
- [x] `./gradlew check`

Partial #355 (visual-idle residual). Follow-up: atomic `capture(...)` window path.