### PR TITLE
feat(sample-intellij-plugin): stock IDE inject attach e2e (#376)

### DIFF
--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -291,6 +291,7 @@ val uiTest by
 // #353 / #376: stock IntelliJ inject attach against the no-core sample plugin.
 // Boots IDEA, installs tags-only plugin (no spectre-core), AgentAttach from test JVM.
 // NOT wired into :check — always-on stock inject CI is an intentional non-goal.
+val noCorePluginZipProvider = buildNoCorePlugin.flatMap { it.outputZip }
 val stockInjectUiTest by
     tasks.registering(Test::class) {
         group = "verification"
@@ -301,14 +302,18 @@ val stockInjectUiTest by
         testClassesDirs = uiTestSourceSet.output.classesDirs
         classpath = uiTestSourceSet.runtimeClasspath
         dependsOn(buildNoCorePlugin, agentRuntimeJarProvider)
+        // Invalidate when inject packaging or agent-runtime content changes (same pattern as
+        // `:agent:test` wiring `runtimeJar` via inputs.file — Bugbot #381).
+        inputs.file(noCorePluginZipProvider)
+        inputs.file(agentRuntimeJarProvider)
         filter { includeTestsMatching("*StockIntellijInjectAttachUiTest*") }
         systemProperty(
             "path.to.no.core.plugin",
-            buildNoCorePlugin.flatMap { it.outputZip }.get().asFile.absolutePath,
+            noCorePluginZipProvider.map { it.asFile.absolutePath },
         )
         systemProperty(
             "dev.sebastiano.spectre.agent.runtimeJar",
-            agentRuntimeJarProvider.get().asFile.absolutePath,
+            agentRuntimeJarProvider.map { it.asFile.absolutePath },
         )
         javaLauncher.set(
             javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }

--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -322,4 +322,7 @@ val stockInjectUiTest by
             javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
         )
         jvmArgs("--add-opens=java.base/sun.nio.fs=ALL-UNNAMED")
+        // External e2e: a headless assumption-skip must not UP-TO-DATE-mask a later graphical
+        // run (DISPLAY / Xvfb state is not a Gradle input). Always re-enter (Codex #381).
+        outputs.upToDateWhen { false }
     }

--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -310,10 +310,7 @@ val stockInjectUiTest by
         // Resolve paths eagerly at configuration time (Test.systemProperty Object overload
         // does not reliably expand Provider values on all Gradle versions). inputs.file above
         // still owns up-to-date invalidation when those artifacts change.
-        systemProperty(
-            "path.to.no.core.plugin",
-            noCorePluginZipProvider.get().asFile.absolutePath,
-        )
+        systemProperty("path.to.no.core.plugin", noCorePluginZipProvider.get().asFile.absolutePath)
         systemProperty(
             "dev.sebastiano.spectre.agent.runtimeJar",
             agentRuntimeJarProvider.get().asFile.absolutePath,

--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -307,13 +307,16 @@ val stockInjectUiTest by
         inputs.file(noCorePluginZipProvider)
         inputs.file(agentRuntimeJarProvider)
         filter { includeTestsMatching("*StockIntellijInjectAttachUiTest*") }
+        // Resolve paths eagerly at configuration time (Test.systemProperty Object overload
+        // does not reliably expand Provider values on all Gradle versions). inputs.file above
+        // still owns up-to-date invalidation when those artifacts change.
         systemProperty(
             "path.to.no.core.plugin",
-            noCorePluginZipProvider.map { it.asFile.absolutePath },
+            noCorePluginZipProvider.get().asFile.absolutePath,
         )
         systemProperty(
             "dev.sebastiano.spectre.agent.runtimeJar",
-            agentRuntimeJarProvider.map { it.asFile.absolutePath },
+            agentRuntimeJarProvider.get().asFile.absolutePath,
         )
         javaLauncher.set(
             javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }

--- a/sample-intellij-plugin/build.gradle.kts
+++ b/sample-intellij-plugin/build.gradle.kts
@@ -1,5 +1,6 @@
 import dev.sebastiano.spectre.build.BuildNoCorePluginZip
 import dev.sebastiano.spectre.build.VerifyNoCorePluginZip
+import org.gradle.jvm.tasks.Jar
 
 plugins {
     alias(libs.plugins.detekt)
@@ -204,6 +205,8 @@ dependencies {
     "uiTestImplementation"(libs.ideStarter.driverSdk)
     "uiTestImplementation"(libs.ideStarter.driverModel)
     "uiTestImplementation"(libs.kotlinx.coroutines.core)
+    // Stock inject e2e (#353 / #376): attach from the test JVM into the IDE process.
+    "uiTestImplementation"(projects.agent)
     "uiTestRuntimeOnly"(libs.junit5.engine)
     // Gradle 8+ test execution needs junit-platform-launcher on the test runtime classpath
     // OR `useJUnitPlatform()` on a task that pulls it via convention. The Test task we
@@ -245,6 +248,9 @@ val verifyNoCorePluginZip by
         noCorePluginZip.set(buildNoCorePlugin.flatMap { it.outputZip })
     }
 
+val agentRuntimeJarProvider =
+    project(":agent-runtime").tasks.named<Jar>("jar").flatMap { it.archiveFile }
+
 val uiTest by
     tasks.registering(Test::class) {
         group = "verification"
@@ -262,6 +268,9 @@ val uiTest by
         // upstream task; depending on `prepareSandbox` instead would skip the
         // pluginConfiguration validation that surfaces e.g. malformed plugin.xml early.
         dependsOn(buildPluginTask)
+        // Only the instrumented-path test (RunSpectreAction / idea.log). Stock inject e2e is
+        // `stockInjectUiTest` so this task stays focused and path-filter CI cost is predictable.
+        filter { includeTestsMatching("*RunSpectreUiTest*") }
         // `path.to.build.plugin` is the system property the ide-starter sample tests use to
         // point at a locally-built plugin zip — we follow the same convention so the test
         // code reads naturally for anyone familiar with the JetBrains examples.
@@ -276,5 +285,33 @@ val uiTest by
             javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
         )
         // Required by ide-starter 2026.2 changelog for recent IDE runs.
+        jvmArgs("--add-opens=java.base/sun.nio.fs=ALL-UNNAMED")
+    }
+
+// #353 / #376: stock IntelliJ inject attach against the no-core sample plugin.
+// Boots IDEA, installs tags-only plugin (no spectre-core), AgentAttach from test JVM.
+// NOT wired into :check — always-on stock inject CI is an intentional non-goal.
+val stockInjectUiTest by
+    tasks.registering(Test::class) {
+        group = "verification"
+        description =
+            "Stock IntelliJ inject attach e2e (#353): no-core Jewel plugin + AgentAttach inject " +
+                "path. NOT wired into :check — opt-in."
+        useJUnitPlatform()
+        testClassesDirs = uiTestSourceSet.output.classesDirs
+        classpath = uiTestSourceSet.runtimeClasspath
+        dependsOn(buildNoCorePlugin, agentRuntimeJarProvider)
+        filter { includeTestsMatching("*StockIntellijInjectAttachUiTest*") }
+        systemProperty(
+            "path.to.no.core.plugin",
+            buildNoCorePlugin.flatMap { it.outputZip }.get().asFile.absolutePath,
+        )
+        systemProperty(
+            "dev.sebastiano.spectre.agent.runtimeJar",
+            agentRuntimeJarProvider.get().asFile.absolutePath,
+        )
+        javaLauncher.set(
+            javaToolchains.launcherFor { languageVersion.set(JavaLanguageVersion.of(25)) }
+        )
         jvmArgs("--add-opens=java.base/sun.nio.fs=ALL-UNNAMED")
     }

--- a/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/StockIntellijInjectAttachUiTest.kt
+++ b/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/StockIntellijInjectAttachUiTest.kt
@@ -155,21 +155,41 @@ class StockIntellijInjectAttachUiTest {
 
     /**
      * Prefer [candidatePid] when it is a live JVM visible to Attach. On Linux, ide-starter may
-     * expose an xvfb-run wrapper — fall back to [SpectreProcesses] matching idea/intellij.
+     * expose an xvfb-run wrapper — walk that process tree and pick an attachable descendant that
+     * looks like IDEA (never a machine-wide "newest IntelliJ" guess — Codex #381).
      */
     private fun resolveIdeJvmPid(candidatePid: Long): Long {
         val listed = runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList())
-        if (listed.any { it.pid == candidatePid }) return candidatePid
-        val matches = listed.filter { info ->
-            val name = info.displayName.lowercase()
-            ("idea" in name || "intellij" in name) && "jps" !in name
+        val attachableByPid = listed.associateBy { it.pid }
+        if (attachableByPid.containsKey(candidatePid)) return candidatePid
+
+        val root =
+            ProcessHandle.of(candidatePid).orElse(null)
+                ?: error(
+                    "Candidate pid $candidatePid is not a live process and is not attach-visible. " +
+                        "Attach-visible JVMs: ${listed.map { "${it.pid}:${it.displayName}" }}"
+                )
+        val treePids = buildList {
+            add(root.pid())
+            root.descendants().forEach { add(it.pid()) }
         }
-        require(matches.isNotEmpty()) {
-            "Could not resolve IDE JVM pid (candidate=$candidatePid). " +
-                "Attach-visible JVMs: ${listed.map { "${it.pid}:${it.displayName}" }}"
+        val inTree =
+            treePids
+                .mapNotNull { attachableByPid[it] }
+                .filter { info ->
+                    val name = info.displayName.lowercase()
+                    ("idea" in name || "intellij" in name) && "jps" !in name
+                }
+        if (inTree.isNotEmpty()) {
+            // Prefer the oldest suitable descendant in this tree (main IDE JVM, not helpers).
+            return inTree.minBy { it.pid }.pid
         }
-        // Prefer the newest match when multiple (sandbox may leave helpers).
-        return matches.maxBy { it.pid }.pid
+        val anyInTree = treePids.mapNotNull { attachableByPid[it] }
+        require(anyInTree.isNotEmpty()) {
+            "Could not resolve IDE JVM pid under process tree of $candidatePid. " +
+                "Tree pids=$treePids; attach-visible=${listed.map { "${it.pid}:${it.displayName}" }}"
+        }
+        return anyInTree.minBy { it.pid }.pid
     }
 
     private fun waitForInjectLog(logPath: Path, deadlineMs: Long): Boolean {

--- a/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/StockIntellijInjectAttachUiTest.kt
+++ b/sample-intellij-plugin/src/uiTest/kotlin/dev/sebastiano/spectre/intellij/uitest/StockIntellijInjectAttachUiTest.kt
@@ -1,0 +1,200 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.intellij.uitest
+
+import com.intellij.driver.sdk.openToolWindow
+import com.intellij.driver.sdk.waitForIndicators
+import com.intellij.driver.sdk.waitForProjectOpen
+import com.intellij.ide.starter.driver.engine.runIdeWithDriver
+import com.intellij.ide.starter.junit5.hyphenateWithClass
+import com.intellij.ide.starter.models.TestCase
+import com.intellij.ide.starter.plugins.PluginConfigurator
+import com.intellij.ide.starter.project.LocalProjectInfo
+import com.intellij.ide.starter.runner.CurrentTestMethod
+import com.intellij.ide.starter.runner.IDERunContext
+import com.intellij.ide.starter.runner.Starter
+import com.intellij.tools.ide.starter.product.idea.ultimate.IdeaUltimateProductInit
+import dev.sebastiano.spectre.agent.AgentAttach
+import dev.sebastiano.spectre.agent.AttachOptions
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.SpectreProcesses
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.io.path.createDirectories
+import kotlin.io.path.exists
+import kotlin.io.path.readText
+import kotlin.time.Duration.Companion.minutes
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+/**
+ * #353 / #376: stock IntelliJ inject attach e2e.
+ *
+ * Boots IDEA via ide-starter with the **no-core** sample plugin (Jewel tags only, no spectre-core),
+ * enables dynamic agent loading, opens the Spectre Sample tool window, then attaches from this test
+ * JVM with [AgentAttach] so bootstrap must inject nested `META-INF/spectre/inject-runtime.jar`.
+ * Asserts proving tags and the inject agent log line.
+ *
+ * Opt-in: `./gradlew :sample-intellij-plugin:stockInjectUiTest` — not part of default `:check`
+ * (always-on stock IDE inject CI remains a non-goal per #353).
+ */
+class StockIntellijInjectAttachUiTest {
+
+    @Test
+    @DisplayName("inject attach discovers Jewel tags on no-core sample plugin")
+    fun injectAttachDiscoversJewelTagsOnNoCoreSamplePlugin() {
+        assumeFalse(
+            java.awt.GraphicsEnvironment.isHeadless(),
+            "Requires non-headless JVM for IDE-hosted Compose / attach e2e",
+        )
+        val pluginPath = noCorePluginZipPath()
+        val agentJar = agentRuntimeJarPath()
+        val tempProject = createEmptyProject()
+
+        val testContext =
+            Starter.newContext(
+                    CurrentTestMethod.hyphenateWithClass(),
+                    TestCase(
+                        IdeaUltimateProductInit()
+                            .ideInfo
+                            .copy(buildType = "release", buildNumber = IDE_BUILD_NUMBER),
+                        LocalProjectInfo(tempProject),
+                    ),
+                )
+                .apply { PluginConfigurator(this).installPluginFromPath(pluginPath) }
+                .applyVMOptionsPatch {
+                    addSystemProperty("jetbrainsd.discovery.enabled", false)
+                    addSystemProperty("jetbrainsd.uri.handling.enabled", false)
+                    addSystemProperty("idea.trust.all.projects", true)
+                    setIdeStartupDialogEnabled(false)
+                    disableStartupDialogs()
+                    disableNewUsersOnboardingDialogue()
+                    // JEP 451 — required for dynamic agent attach on JDK 21+.
+                    addLine("-XX:+EnableDynamicAgentLoading")
+                }
+                .skipIndicesInitialization()
+
+        val capturedRunContext = AtomicReference<IDERunContext>()
+        val backgroundRun =
+            testContext.runIdeWithDriver(configure = { capturedRunContext.set(this) })
+
+        backgroundRun.useDriverAndCloseIde {
+            val runContext =
+                requireNotNull(capturedRunContext.get()) {
+                    "IDERunContext was never captured — runIdeWithDriver configure block did not fire."
+                }
+            val ideLog = runContext.logsDir.resolve("idea.log")
+
+            waitForProjectOpen(timeout = PROJECT_OPEN_TIMEOUT)
+            waitForIndicators(timeout = INDICATOR_QUIESCENCE_TIMEOUT)
+
+            openToolWindow(TOOL_WINDOW_ID)
+
+            val idePid = resolveIdeJvmPid(backgroundRun.process.id.toLong())
+            AgentAttach.attach(pid = idePid, options = AttachOptions(agentJarPath = agentJar))
+                .use { automator ->
+                    // Composition is async after tool-window show; wait on the wire.
+                    automator.waitForNode(tag = "ide.counter.text", timeoutMs = TAG_WAIT_TIMEOUT_MS)
+                    assertTrue(automator.findByTestTag("ide.counter.button").isNotEmpty()) {
+                        "expected ide.counter.button after inject; tags=" +
+                            automator.allNodes().mapNotNull { it.testTag }
+                    }
+                    assertTrue(automator.findByTestTag("ide.popup.toggleButton").isNotEmpty()) {
+                        "expected ide.popup.toggleButton after inject; tags=" +
+                            automator.allNodes().mapNotNull { it.testTag }
+                    }
+                }
+
+            // Prove inject path (not preinstalled core): agent logs to target System.err →
+            // idea.log.
+            val injectLogSeen = waitForInjectLog(ideLog, deadlineMs = INJECT_LOG_POLL_MS)
+            assertTrue(injectLogSeen) {
+                "expected inject bootstrap log in $ideLog (" +
+                    "\"spectre-core not on target classpath; injecting\"). " +
+                    (if (ideLog.exists()) "log tail:\n" + ideLog.readText().takeLast(LOG_TAIL_CHARS)
+                    else "log missing")
+            }
+        }
+    }
+
+    private fun noCorePluginZipPath(): Path {
+        val raw =
+            requireNotNull(System.getProperty(NO_CORE_PLUGIN_PROP)) {
+                "System property `$NO_CORE_PLUGIN_PROP` is not set — run via " +
+                    "`./gradlew :sample-intellij-plugin:stockInjectUiTest`."
+            }
+        val path = Path.of(raw)
+        require(path.exists()) {
+            "No-core plugin zip $path does not exist. Run " +
+                "`:sample-intellij-plugin:buildNoCorePlugin` first."
+        }
+        return path
+    }
+
+    private fun agentRuntimeJarPath(): Path {
+        val raw =
+            requireNotNull(System.getProperty(AGENT_RUNTIME_JAR_PROP)) {
+                "System property `$AGENT_RUNTIME_JAR_PROP` is not set — stockInjectUiTest must " +
+                    "wire the :agent-runtime jar path."
+            }
+        val path = Path.of(raw)
+        require(Files.isRegularFile(path)) { "Agent runtime jar not found at $path" }
+        return path
+    }
+
+    private fun createEmptyProject(): Path {
+        val base = Path.of(System.getProperty("java.io.tmpdir"), "spectre-stock-inject-uitest")
+        base.createDirectories()
+        return Files.createTempDirectory(base, "project-").toRealPath().also { dir ->
+            dir.toFile().deleteOnExit()
+        }
+    }
+
+    /**
+     * Prefer [candidatePid] when it is a live JVM visible to Attach. On Linux, ide-starter may
+     * expose an xvfb-run wrapper — fall back to [SpectreProcesses] matching idea/intellij.
+     */
+    private fun resolveIdeJvmPid(candidatePid: Long): Long {
+        val listed = runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList())
+        if (listed.any { it.pid == candidatePid }) return candidatePid
+        val matches = listed.filter { info ->
+            val name = info.displayName.lowercase()
+            ("idea" in name || "intellij" in name) && "jps" !in name
+        }
+        require(matches.isNotEmpty()) {
+            "Could not resolve IDE JVM pid (candidate=$candidatePid). " +
+                "Attach-visible JVMs: ${listed.map { "${it.pid}:${it.displayName}" }}"
+        }
+        // Prefer the newest match when multiple (sandbox may leave helpers).
+        return matches.maxBy { it.pid }.pid
+    }
+
+    private fun waitForInjectLog(logPath: Path, deadlineMs: Long): Boolean {
+        val deadline = System.currentTimeMillis() + deadlineMs
+        while (System.currentTimeMillis() < deadline) {
+            if (logPath.exists()) {
+                val text = logPath.readText()
+                if (INJECT_LOG_MARKER in text) return true
+            }
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        return logPath.exists() && INJECT_LOG_MARKER in logPath.readText()
+    }
+
+    private companion object {
+        const val IDE_BUILD_NUMBER = "262.8665.337"
+        const val TOOL_WINDOW_ID = "Spectre Sample"
+        const val NO_CORE_PLUGIN_PROP = "path.to.no.core.plugin"
+        const val AGENT_RUNTIME_JAR_PROP = "dev.sebastiano.spectre.agent.runtimeJar"
+        const val INJECT_LOG_MARKER = "spectre-core not on target classpath; injecting"
+        const val TAG_WAIT_TIMEOUT_MS: Long = 60_000
+        const val INJECT_LOG_POLL_MS: Long = 15_000
+        const val POLL_INTERVAL_MS: Long = 250
+        const val LOG_TAIL_CHARS: Int = 4_000
+        val INDICATOR_QUIESCENCE_TIMEOUT = 3.minutes
+        val PROJECT_OPEN_TIMEOUT = 5.minutes
+    }
+}


### PR DESCRIPTION
## Summary

- Opt-in `:sample-intellij-plugin:stockInjectUiTest` for [#353](https://github.com/rock3r/spectre/issues/353) / [#376](https://github.com/rock3r/spectre/issues/376): boots IDEA 2026.2 via ide-starter with the **no-core** Jewel tags plugin (#375), sets `-XX:+EnableDynamicAgentLoading`, opens the Spectre Sample tool window, and calls real `AgentAttach.attach(idePid)`.
- Asserts inject bootstrap log (`spectre-core not on target classpath; injecting`) in `idea.log` and non-empty `ide.counter.*` / `ide.popup.toggleButton` tags.
- Default `:uiTest` remains instrumented-path only (`RunSpectreUiTest`); stock inject stays off default `:check` (always-on stock inject CI remains a non-goal).

Depends on #378 (merged).

## Local proof

```text
./gradlew :sample-intellij-plugin:stockInjectUiTest
# BUILD SUCCESSFUL
# idea.log: [spectre-agent] spectre-core not on target classpath; injecting from …
# idea.log: [spectre-agent] ComposeAutomator ready: …
```

## Test plan

- [x] Local `stockInjectUiTest` PASS on macOS (this machine)
- [x] detektUiTest + ktfmtCheckUiTest
- [ ] CI green

Closes #376