### PR TITLE
docs: record stock IntelliJ inject PASS evidence (#353 / #377)

### DIFF
--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -217,9 +217,11 @@ plugin) does **not** ship `spectre-core`, use [agent attach](agent.md) with the 
    fully restart the IDE. Without it, JDK 21+ warns (JEP 451) and a future JDK may reject
    attach. Config example on macOS:
    `~/Library/Application Support/JetBrains/IntelliJIdea2026.2/idea.vmoptions`
-2. Ensure a Compose surface is showing. Spectre's sample plugin tags tool-window nodes as
-   `ide.counter.*` and `ide.popup.*` (`SpectreSampleToolWindowContent`) — useful proving
-   tags when that plugin is installed.
+2. Ensure a Compose surface is showing. For a proving UI **without** `spectre-core`, install
+   Spectre's no-core sample plugin zip
+   (`./gradlew :sample-intellij-plugin:buildNoCorePlugin`) — same `ide.counter.*` /
+   `ide.popup.*` tags as `SpectreSampleToolWindowContent`. The default instrumented sample
+   plugin ships core and exercises the non-inject path.
 3. Find the IDE PID (`jps -l`), then from an attacher JVM with `spectre-agent` +
    `spectre-agent-runtime`:
 
@@ -239,7 +241,9 @@ If the sample plugin is on the classpath **with** `spectre-core`, attach uses th
 instrumented path instead of inject — same API either way. Prefer in-process
 `ComposeAutomator` (sections above) when your code already runs inside the IDE.
 
-Maintainer spike notes (recipe + evidence chain, not on the public site nav):
+Maintainers re-verify with
+`./gradlew :sample-intellij-plugin:stockInjectUiTest` (opt-in; not on every PR). Spike
+notes (recipe + evidence chain, not on the public site nav):
 [`docs/spikes/209-injection/stock-intellij-recipe.md`](https://github.com/rock3r/spectre/blob/main/docs/spikes/209-injection/stock-intellij-recipe.md).
 
 ## Validating from a separate test JVM

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -217,11 +217,13 @@ plugin) does **not** ship `spectre-core`, use [agent attach](agent.md) with the 
    fully restart the IDE. Without it, JDK 21+ warns (JEP 451) and a future JDK may reject
    attach. Config example on macOS:
    `~/Library/Application Support/JetBrains/IntelliJIdea2026.2/idea.vmoptions`
-2. Ensure a Compose surface is showing. For a proving UI **without** `spectre-core`, install
-   Spectre's no-core sample plugin zip
-   (`./gradlew :sample-intellij-plugin:buildNoCorePlugin`) — same `ide.counter.*` /
-   `ide.popup.*` tags as `SpectreSampleToolWindowContent`. The default instrumented sample
-   plugin ships core and exercises the non-inject path.
+2. Ensure a Compose surface is showing with known test tags (or product Compose semantics).
+   Any Jewel/Compose host in the IDE works; you do **not** need Spectre's sample plugin.
+   If you maintain Spectre itself and want the proving `ide.counter.*` / `ide.popup.*` tags
+   without shipping `spectre-core`, build the tags-only zip **from a Spectre source
+   checkout**: `./gradlew :sample-intellij-plugin:buildNoCorePlugin` →
+   `sample-intellij-plugin/build/distributions/sample-intellij-plugin-no-core-0.0.0-DEV.zip`.
+   The default instrumented sample plugin ships core and exercises the non-inject path.
 3. Find the IDE PID (`jps -l`), then from an attacher JVM with `spectre-agent` +
    `spectre-agent-runtime`:
 
@@ -237,13 +239,13 @@ AgentAttach.attach(idePid).use { automator ->
 }
 ```
 
-If the sample plugin is on the classpath **with** `spectre-core`, attach uses the
-instrumented path instead of inject — same API either way. Prefer in-process
-`ComposeAutomator` (sections above) when your code already runs inside the IDE.
+If a plugin on the classpath **ships** `spectre-core`, attach uses the instrumented path
+instead of inject — same API either way. Prefer in-process `ComposeAutomator` (sections
+above) when your code already runs inside the IDE.
 
-Maintainers re-verify with
-`./gradlew :sample-intellij-plugin:stockInjectUiTest` (opt-in; not on every PR). Spike
-notes (recipe + evidence chain, not on the public site nav):
+Spectre maintainers re-verify inject against the no-core sample from a source checkout with
+`./gradlew :sample-intellij-plugin:stockInjectUiTest` (opt-in; not on every PR; requires a
+graphical host). Spike notes (recipe + evidence chain, not on the public site nav):
 [`docs/spikes/209-injection/stock-intellij-recipe.md`](https://github.com/rock3r/spectre/blob/main/docs/spikes/209-injection/stock-intellij-recipe.md).
 
 ## Validating from a separate test JVM

--- a/docs/spikes/209-injection/packaging-1.0-decision.md
+++ b/docs/spikes/209-injection/packaging-1.0-decision.md
@@ -44,7 +44,8 @@ Bootstrap order (see `AgentBootstrap.findSpectre`):
 ## Revisit triggers (post-1.0)
 
 - Metaspace / unload hardened enough for CI attach loops.
-- Stock-IDE inject green in release QA or CI with a no-core Jewel target.
+- Always-on PR CI for stock-IDE inject (currently opt-in `stockInjectUiTest` is green — #353).
 - Product need for CLI/MCP “attach without core” as a supported mode (not experimental).
 
 Until then, docs and STABILITY language must keep inject **experimental inspect**, not production attach.
+Stock no-core IDE inject is **proven** (opt-in e2e) but not promoted beyond experimental inspect.

--- a/docs/spikes/209-injection/practicalities.md
+++ b/docs/spikes/209-injection/practicalities.md
@@ -78,8 +78,10 @@ Full operator recipe, tag table, and evidence chain: **[stock-intellij-recipe.md
 | --- | --- |
 | Inject packaging + no-core fixture attach | Automated (`AgentInjectAttachIntegrationTest`, jar verify tasks; Windows opt-in e2e) |
 | Jewel `ide.counter.*` / `ide.popup.*` in IDEA 2026.2 | Automated via `:sample-intellij-plugin:uiTest` (**instrumented** sample — ships core) |
-| Stock IDE + inject (no preinstalled core) | **Not a 0.4.0 release gate** — recipe exists; full QA deferred to **0.4.1** ([#353](https://github.com/rock3r/spectre/issues/353)) |
-| Stock IDE + inject when no `spectre-core` | Documented manual / release-QA recipe (vmoptions + attach dump) |
+| No-core sample plugin packaging | Automated (`buildNoCorePlugin` / `verifyNoCorePluginZip` + buildSrc contract tests) (#375) |
+| Stock IDE + inject (no preinstalled core) | **PASS** via opt-in `:sample-intellij-plugin:stockInjectUiTest` (#353 / #376) — not always-on PR CI |
+| Manual operator path | [stock-intellij-recipe.md](stock-intellij-recipe.md) (vmoptions + attach dump) |
 
-Stock no-core inject remains **experimental inspect**, not a PR-blocking CI gate
-(see packaging-1.0-decision.md).
+Stock no-core inject remains **experimental inspect**, not a PR-blocking always-on CI gate
+(see packaging-1.0-decision.md). Re-verify with `stockInjectUiTest` before releases that
+touch inject bootstrap or IDE-hosted Compose discovery.

--- a/docs/spikes/209-injection/stock-intellij-recipe.md
+++ b/docs/spikes/209-injection/stock-intellij-recipe.md
@@ -1,19 +1,45 @@
-# #320: Stock IntelliJ inject attach recipe (post-#209)
+# #320 / #353: Stock IntelliJ inject attach recipe (post-#209)
 
-**Status:** documented + evidence chain recorded (closes #320).  
-**0.4.0 ship note:** fixture inject e2e is proven; **stock/no-core IDE inject + Jewel tags
-is not re-verified as a release gate** — tracked as a known incomplete for **0.4.1**
-([#353](https://github.com/rock3r/spectre/issues/353)).  
-**Date:** 2026-07-26 (recipe); 2026-07-27 (0.4.0 honesty note)  
-**Depends on:** inject packaging (#319), practicalities.md §1 (vmoptions)
+**Status:** **PASS** (0.4.1 / #353) — automated opt-in e2e + packaging contract.  
+**Date:** 2026-07-26 (recipe); 2026-07-27 (0.4.0 honesty note); 2026-08-03 (#353 close-out)  
+**Depends on:** inject packaging (#319), practicalities.md §1 (vmoptions), no-core sample
+plugin zip (#375), stock inject e2e (#376)
 
 ## Goal
 
-Attach from a sister JVM to **stock IntelliJ IDEA 2026.2+** that does **not** ship
+Attach from a sister JVM to **IntelliJ IDEA 2026.2+** that does **not** ship
 `spectre-core`, using nested inject-runtime, and dump Jewel-hosted tool-window tags
 (`ide.counter.*` / `ide.popup.*`) when a Compose surface with those tags is present.
 
-## Prerequisites
+## Automated path (opt-in — preferred re-verify)
+
+**Does not** run on every PR (always-on stock IDE inject CI remains a non-goal). Local /
+release QA:
+
+```bash
+# Builds no-core plugin zip + agent-runtime, boots IDEA 2026.2 via ide-starter,
+# AgentAttach.attach → inject + Jewel tags.
+./gradlew :sample-intellij-plugin:stockInjectUiTest
+```
+
+What it proves on a green run (real shipped APIs):
+
+1. `-XX:+EnableDynamicAgentLoading` on the IDE VM options patch.
+2. No-core plugin install (`buildNoCorePlugin` — Jewel tags only, no `spectre-core` jars).
+3. Tool window **Spectre Sample** opened via Driver.
+4. `AgentAttach.attach(idePid)` with nested inject-runtime.
+5. `waitForNode("ide.counter.text")` + other proving tags non-empty.
+6. `idea.log` contains `[spectre-agent] spectre-core not on target classpath; injecting`.
+
+Packaging-only (no IDE boot):
+
+```bash
+./gradlew :sample-intellij-plugin:verifyNoCorePluginZip
+# Contract unit tests (always on :check via buildSrcUnitTests):
+./gradlew -p buildSrc test --tests '*NoCorePluginPackagingContractTest*'
+```
+
+## Prerequisites (manual recipe)
 
 1. **IntelliJ IDEA 2026.2+** (platform 262 / JBR era matching Spectre’s sample plugin pin).
 2. **Custom VM options** include dynamic agent loading (see practicalities.md §1):
@@ -30,12 +56,13 @@ Attach from a sister JVM to **stock IntelliJ IDEA 2026.2+** that does **not** sh
 4. Built artifacts from this repo (or published snapshots):
 
    ```bash
-   ./gradlew :agent-runtime:jar :agent:jar
+   ./gradlew :agent-runtime:jar :agent:jar :sample-intellij-plugin:buildNoCorePlugin
    ```
 
 5. A **Jewel/Compose surface with known test tags** in the IDE process:
-   - **Recommended proving UI:** install Spectre’s `:sample-intellij-plugin` (dev zip /
-     `runIde` sandbox). Tags are defined in `SpectreSampleToolWindowContent`:
+   - **Recommended proving UI:** install the **no-core** sample plugin zip from
+     `sample-intellij-plugin/build/distributions/sample-intellij-plugin-no-core-0.0.0-DEV.zip`
+     (or run the automated path above). Tags are defined in `SpectreSampleToolWindowContent`:
 
      | Tag | Role |
      | --- | --- |
@@ -44,20 +71,21 @@ Attach from a sister JVM to **stock IntelliJ IDEA 2026.2+** that does **not** sh
      | `ide.popup.toggleButton` | opens popup |
      | `ide.popup.body` / `ide.popup.text` / `ide.popup.dismissButton` | popup tree |
 
+   - **Instrumented sample plugin** (`buildPlugin` / `uiTest`) still ships `spectre-core` for
+     in-process validation — that path does **not** exercise inject.
    - **True stock IDE (no sample plugin):** only Compose surfaces that already expose
      semantics (and any tags the product sets) are visible. There is no guarantee of
      `ide.counter.*` tags without a plugin or product code that sets them.
 
 ### Note on sample plugin vs pure inject
 
-The sample plugin **ships `spectre-core`** so its in-process `RunSpectreAction` and
+The default sample plugin **ships `spectre-core`** so its in-process `RunSpectreAction` and
 `:sample-intellij-plugin:uiTest` exercise the **instrumented** path (bootstrap prefers
 preinstalled core). That is intentional for CI IDE validation.
 
 To exercise **inject** against the same Jewel tags:
 
-1. Build a throwaway plugin zip that includes only the tool-window UI (Jewel + tags)
-   **without** `spectre-core` on the plugin classpath, **or**
+1. Use `:sample-intellij-plugin:buildNoCorePlugin` / `stockInjectUiTest` (preferred), **or**
 2. Attach to any third-party / stock Compose surface that has no Spectre dependency.
 
 If `spectre-core` is present, attach still works — inject is simply not used.
@@ -66,9 +94,9 @@ If `spectre-core` is present, attach still works — inject is simply not used.
 
 ### 1. Start the IDE
 
-With `-XX:+EnableDynamicAgentLoading` already in custom VM options. Open the sample
-tool window (**View → Tool Windows → Spectre Sample**, or the plugin’s registered id)
-so Compose has painted and tags exist.
+With `-XX:+EnableDynamicAgentLoading` already in custom VM options. Install the **no-core**
+plugin zip (not the instrumented `buildPlugin` zip). Open the sample tool window
+(**View → Tool Windows → Spectre Sample**) so Compose has painted and tags exist.
 
 ### 2. Find the IDE PID
 
@@ -125,6 +153,7 @@ Or rely on classpath discovery of `spectre-agent-runtime` and call
 | Non-empty `windows()` / `allNodes()` | Agent + IPC + Compose host discovery OK |
 | `findByTestTag("ide.counter.text")` non-empty | Jewel tool window semantics visible |
 | `ide.popup.*` after opening popup | Popup roots tracked (open via UI or later Robot) |
+| Agent log: `spectre-core not on target classpath; injecting` | Inject path used (not instrumented) |
 | JEP 451 stderr / attach reject | Missing `EnableDynamicAgentLoading` |
 | `ComposeNotOnClasspathException` | No Compose host in that process |
 | `SpectreNotOnClasspathException` | Inject resource missing from agent-runtime jar |
@@ -135,17 +164,18 @@ Or rely on classpath discovery of `spectre-agent-runtime` and call
 | Layer | How proven | What it proves |
 | --- | --- | --- |
 | Nested inject packaging | `:agent-inject-runtime` / `:agent-runtime` verify tasks + #329 strip tests | Jar shape + Windows CP strip |
-| Inject attach without core | `AgentInjectAttachIntegrationTest` (Linux/macOS; physical Windows validated) | Real attach/UDS/tree via inject |
-| Jewel tags in IDE process | `:sample-intellij-plugin:uiTest` + `ide-uitest.yml` | `ide.counter.*` / `ide.popup.*` discoverable in IDEA 2026.2 sandbox (instrumented) |
-| Stock IDE + inject + Jewel tags | **This recipe** (manual / release QA) | Operator checklist when IDE has no core |
+| Inject attach without core (fixture) | `AgentInjectAttachIntegrationTest` (Linux/macOS; physical Windows validated) | Real attach/UDS/tree via inject |
+| Jewel tags in IDE (instrumented) | `:sample-intellij-plugin:uiTest` + `ide-uitest.yml` | `ide.counter.*` / `ide.popup.*` in IDEA 2026.2 sandbox with core |
+| No-core plugin packaging | `NoCorePluginPackagingContract` + `verifyNoCorePluginZip` (#375) | Tags-only zip; zero core jars |
+| Stock IDE + inject + Jewel tags | **`stockInjectUiTest`** (#376) — opt-in; local macOS PASS 2026-08-03 | Full no-core IDE attach via inject |
 
-Combined: packaging and inject transport are CI-proven; Jewel tag names and IDE hosting
-are CI-proven on the sample plugin; full stock no-core + inject is the documented QA
-path above (environment-dependent, same gap noted in practicalities.md before #320).
+Combined: packaging, fixture inject, instrumented IDE tags, and **stock no-core IDE inject**
+are all automated. Inject remains **experimental inspect** (see STABILITY.md / packaging-1.0-decision.md).
 
 ## CI stance
 
 Do **not** add always-on hosted CI that boots stock IntelliJ and attaches inject for every
-PR — `ide-uitest.yml` already owns IDE boot cost for the instrumented sample. Revisit only
-if product requires no-core inject as a release gate (see packaging-1.0-decision.md
-revisit triggers).
+PR — `ide-uitest.yml` already owns IDE boot cost for the instrumented sample.
+`stockInjectUiTest` is the durable re-verify entry point for release QA / when inject or
+IDE-hosting code changes. Revisit always-on only if product requires no-core inject as a
+release gate (see packaging-1.0-decision.md revisit triggers).

--- a/docs/spikes/209-injection/stock-intellij-recipe.md
+++ b/docs/spikes/209-injection/stock-intellij-recipe.md
@@ -14,7 +14,8 @@ Attach from a sister JVM to **IntelliJ IDEA 2026.2+** that does **not** ship
 ## Automated path (opt-in — preferred re-verify)
 
 **Does not** run on every PR (always-on stock IDE inject CI remains a non-goal). Local /
-release QA:
+release QA on a **graphical** host (non-headless JVM; Linux needs `DISPLAY` or
+`xvfb-run -a`):
 
 ```bash
 # Builds no-core plugin zip + agent-runtime, boots IDEA 2026.2 via ide-starter,
@@ -22,7 +23,12 @@ release QA:
 ./gradlew :sample-intellij-plugin:stockInjectUiTest
 ```
 
-What it proves on a green run (real shipped APIs):
+**Pass criteria:** the task must **execute** `StockIntellijInjectAttachUiTest` (not
+assumption-skip). A headless run skips with a successful Gradle exit — that is **not**
+stock-inject proof. Check the HTML/XML test report for `tests=1` / `skipped=0`, or look
+for the inject log line below in the sandbox `idea.log`.
+
+What a non-skipped green run proves (real shipped APIs):
 
 1. `-XX:+EnableDynamicAgentLoading` on the IDE VM options patch.
 2. No-core plugin install (`buildNoCorePlugin` — Jewel tags only, no `spectre-core` jars).


### PR DESCRIPTION
## Summary

Closes the #353 documentation / evidence close-out after #375 (no-core packaging) and #376 (stock inject e2e):

- `docs/spikes/209-injection/stock-intellij-recipe.md` — **PASS** + `stockInjectUiTest` / `buildNoCorePlugin` how-to
- `practicalities.md` — status table updated
- `packaging-1.0-decision.md` — revisit triggers (opt-in e2e green; always-on CI still optional)
- `docs/guide/intellij.md` — no-core plugin + re-verify task for operators

Inject remains **experimental inspect**.

Closes #377  
Closes #353