### PR TITLE
feat(core): window-scoped atomic capture stills (#355)

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -305,11 +305,13 @@ private constructor(
     /**
      * Atomic capture of one window: semantics tree snapshot + window PNG taken back-to-back.
      *
-     * The tree (including node geometry) is read first; an immediate Robot region screenshot
-     * follows without returning control to the caller between the two. This method is the
-     * best-effort same-tick pair agents should use instead of separate `allNodes()` +
-     * `screenshot()` calls that can straddle a recomposition. It intentionally does not use a
-     * one-shot native helper, whose startup time would invalidate this adjacency guarantee.
+     * The tree (including node geometry) is read first; the PNG is taken immediately afterward
+     * without returning control to the caller. Prefer settling with [waitForVisualIdle] /
+     * [waitForIdle] first so the pair stays decision-grade across any native still-helper latency.
+     * When `spectre-recording` is present the PNG uses the same **window-scoped** native still path
+     * as [screenshot] with a [windowIndex] (fails loudly rather than substituting a screen-region
+     * crop after a native failure). Without that backend (e.g. inject payload that omits
+     * recording), the still is a Robot region capture of the Compose surface.
      *
      * Node bounds in the returned document use **image-pixel space of the PNG as primary** and
      * screen space as secondary. Callers that want files on disk should pass the result through
@@ -327,6 +329,8 @@ private constructor(
         // *before* taking the PNG so JSON and pixels cannot describe different window layouts.
         data class PreCaptureSnapshot(
             val captureRegion: Rectangle,
+            val windowBounds: Rectangle,
+            val frameInsets: java.awt.Insets,
             val densityScaleX: Double,
             val densityScaleY: Double,
             val nodeSnapshots: List<CaptureNodeSnapshot>,
@@ -336,6 +340,8 @@ private constructor(
             val transform = trackedWindow.window.graphicsConfiguration.defaultTransform
             PreCaptureSnapshot(
                 captureRegion = region,
+                windowBounds = Rectangle(trackedWindow.window.bounds),
+                frameInsets = frameInsets(trackedWindow.window),
                 densityScaleX = transform.scaleX,
                 densityScaleY = transform.scaleY,
                 nodeSnapshots =
@@ -357,13 +363,33 @@ private constructor(
                     },
             )
         }
-        val image = screenCaptureBackend.captureRegion(pre.captureRegion)
+        // Window-scoped still when the recording native bridge is present (#355). Injected core
+        // excludes recording, so fall back to an explicit region capture only when the bridge is
+        // absent — never as a silent substitute after a failed native still.
+        val windowCapture =
+            if (
+                isNativeWindowCaptureAvailable(
+                    allowsPlatformCapture = robotDriver.allowsPlatformCapture
+                )
+            ) {
+                screenshotTrackedRegionCapture(
+                    trackedWindow,
+                    pre.captureRegion,
+                    pre.windowBounds,
+                    pre.frameInsets,
+                )
+            } else {
+                WindowCapture(
+                    image = screenCaptureBackend.captureRegion(pre.captureRegion),
+                    boundsOnScreen = pre.captureRegion,
+                )
+            }
         return AtomicCaptureBuilder.build(
             windowIndex = windowIndex,
             trackedWindow = trackedWindow,
             nodeSnapshots = pre.nodeSnapshots,
-            image = image,
-            captureRegion = pre.captureRegion,
+            image = windowCapture.image,
+            captureRegion = windowCapture.boundsOnScreen,
             densityScaleX = pre.densityScaleX,
             densityScaleY = pre.densityScaleY,
             startedAt = startedAt,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCapture.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCapture.kt
@@ -101,11 +101,18 @@ internal fun isNativeWindowCaptureAvailable(
     return nativeWindowCaptureFor(classLoader) != null
 }
 
-/** GitHub Actions hosted Windows is not an interactive console for WGC stills. */
+/**
+ * GitHub-**hosted** Windows Actions runners are not an interactive console for WGC stills.
+ *
+ * Uses `RUNNER_ENVIRONMENT=github-hosted` (not merely `GITHUB_ACTIONS=true`) so interactive
+ * self-hosted Windows runners keep native window capture.
+ */
 internal fun isNonInteractiveHostedWindows(
     osName: String = System.getProperty("os.name").orEmpty(),
     getenv: (String) -> String? = System::getenv,
-): Boolean = osName.startsWith("Windows", ignoreCase = true) && getenv("GITHUB_ACTIONS") == "true"
+): Boolean =
+    osName.startsWith("Windows", ignoreCase = true) &&
+        getenv("RUNNER_ENVIRONMENT") == "github-hosted"
 
 /** Marker for classloader defaults (avoids referencing ComposeAutomator from this helper). */
 private object VisualIdleSurfaceCapture

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCapture.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCapture.kt
@@ -82,11 +82,30 @@ internal fun hashTrackedSurfacesForVisualIdle(
     return hashes.contentHashCode()
 }
 
-/** True when the optional recording-owned native still bridge can be loaded. */
+/**
+ * True when window-scoped native stills can be used for visual-idle / atomic capture.
+ *
+ * Requires the recording-owned bridge on the classpath and a [RobotDriver] that allows platform
+ * capture. GitHub Actions Windows runners are treated as non-interactive: Windows Graphics Capture
+ * needs an interactive console there (same gate as Issue14 screenshot validation), so callers fall
+ * back to region sampling instead of hanging on a one-shot WGC helper.
+ */
 internal fun isNativeWindowCaptureAvailable(
     classLoader: ClassLoader = VisualIdleSurfaceCapture::class.java.classLoader,
     allowsPlatformCapture: Boolean = true,
-): Boolean = allowsPlatformCapture && nativeWindowCaptureFor(classLoader) != null
+    osName: String = System.getProperty("os.name").orEmpty(),
+    getenv: (String) -> String? = System::getenv,
+): Boolean {
+    if (!allowsPlatformCapture) return false
+    if (isNonInteractiveHostedWindows(osName, getenv)) return false
+    return nativeWindowCaptureFor(classLoader) != null
+}
+
+/** GitHub Actions hosted Windows is not an interactive console for WGC stills. */
+internal fun isNonInteractiveHostedWindows(
+    osName: String = System.getProperty("os.name").orEmpty(),
+    getenv: (String) -> String? = System::getenv,
+): Boolean = osName.startsWith("Windows", ignoreCase = true) && getenv("GITHUB_ACTIONS") == "true"
 
 /** Marker for classloader defaults (avoids referencing ComposeAutomator from this helper). */
 private object VisualIdleSurfaceCapture

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/AtomicCaptureWindowRoutingTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/AtomicCaptureWindowRoutingTest.kt
@@ -1,0 +1,150 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import java.awt.Frame
+import java.awt.Insets
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Routing contract for #355 atomic [ComposeAutomator.capture]: when the native window still path is
+ * used, region capture must not run. Production `capture()` calls the same crop-of-window path as
+ * [screenshotTrackedRegionCapture] tested here via the public backend seam.
+ */
+class AtomicCaptureWindowRoutingTest {
+
+    @Test
+    fun `atomic still prefers window capture and never calls region when native succeeds`() {
+        assumeLiveAwtAvailable()
+        val frame =
+            Frame("atomic-capture-window").apply {
+                setBounds(10, 20, 160, 120)
+                addNotify()
+            }
+        val windowBounds = Rectangle(frame.bounds)
+        val surface = Rectangle(10, 44, 160, 96)
+        val nativeImage = solidImage(160, 120, 0xFFAABBCC.toInt())
+        var regionCalls = 0
+        var windowCalls = 0
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = {
+                    regionCalls += 1
+                    error("atomic capture must not use screen-region when native works")
+                },
+                nativeCapture = {
+                    windowCalls += 1
+                    nativeImage
+                },
+                nativeCaptureBounds = { _, _, bounds, _ -> bounds },
+            )
+        try {
+            val capture =
+                backend.captureWindow(
+                    TrackedWindow("t", frame, composePanel = null, isPopup = false),
+                    windowBounds,
+                    Insets(24, 0, 0, 0),
+                )
+            // Production crops the native frame to the Compose surface (screenshotTrackedRegion).
+            val cropped =
+                dev.sebastiano.spectre.core.capture.cropImageToScreenRegion(
+                    dev.sebastiano.spectre.core.capture.normalizeImageToScreenBounds(
+                        capture.image,
+                        capture.boundsOnScreen,
+                    ),
+                    surface.intersection(capture.boundsOnScreen),
+                    capture.boundsOnScreen,
+                )
+            assertEquals(1, windowCalls)
+            assertEquals(0, regionCalls)
+            assertEquals(160, cropped.width)
+            assertEquals(96, cropped.height)
+        } finally {
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun `atomic still fails loudly when native window capture is disabled`() {
+        assumeLiveAwtAvailable()
+        val frame =
+            Frame("atomic-disabled").apply {
+                setBounds(0, 0, 80, 60)
+                addNotify()
+            }
+        var regionCalls = 0
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = {
+                    regionCalls += 1
+                    solidImage(1, 1, 0)
+                },
+                nativeCapture = { solidImage(80, 60, 0xFF00FF00.toInt()) },
+                nativeCaptureEnabled = { false },
+            )
+        try {
+            assertFailsWith<UnsupportedOperationException> {
+                backend.captureWindow(
+                    TrackedWindow("t", frame, composePanel = null, isPopup = false),
+                    Rectangle(frame.bounds),
+                    Insets(0, 0, 0, 0),
+                )
+            }
+            assertEquals(0, regionCalls)
+        } finally {
+            frame.dispose()
+        }
+    }
+
+    @Test
+    fun `atomic still fails loudly when native bridge is unavailable`() {
+        assumeLiveAwtAvailable()
+        val frame =
+            Frame("atomic-no-bridge").apply {
+                setBounds(0, 0, 40, 30)
+                addNotify()
+            }
+        var regionCalls = 0
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = {
+                    regionCalls += 1
+                    solidImage(1, 1, 0)
+                },
+                nativeCapture = {
+                    throw UnsupportedOperationException(
+                        "Native window capture bridge is unavailable"
+                    )
+                },
+            )
+        try {
+            val error =
+                assertFailsWith<UnsupportedOperationException> {
+                    backend.captureWindow(
+                        TrackedWindow("t", frame, composePanel = null, isPopup = false),
+                        Rectangle(frame.bounds),
+                        Insets(0, 0, 0, 0),
+                    )
+                }
+            assertTrue(error.message!!.contains("unavailable", ignoreCase = true))
+            assertEquals(0, regionCalls)
+        } finally {
+            frame.dispose()
+        }
+    }
+
+    private fun solidImage(width: Int, height: Int, rgb: Int): BufferedImage {
+        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                image.setRGB(x, y, rgb)
+            }
+        }
+        return image
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCaptureTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCaptureTest.kt
@@ -8,6 +8,7 @@ import java.awt.Rectangle
 import java.awt.image.BufferedImage
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -280,6 +281,38 @@ class VisualIdleSurfaceCaptureTest {
         } finally {
             window.dispose()
         }
+    }
+
+    @Test
+    fun `native window capture is unavailable on GitHub Actions Windows`() {
+        assertTrue(
+            isNonInteractiveHostedWindows(
+                osName = "Windows 11",
+                getenv = { if (it == "GITHUB_ACTIONS") "true" else null },
+            )
+        )
+        assertFalse(
+            isNativeWindowCaptureAvailable(
+                allowsPlatformCapture = true,
+                osName = "Windows 11",
+                getenv = { if (it == "GITHUB_ACTIONS") "true" else null },
+            )
+        )
+    }
+
+    @Test
+    fun `native window capture remains available on interactive Windows`() {
+        assertFalse(isNonInteractiveHostedWindows(osName = "Windows 11", getenv = { null }))
+    }
+
+    @Test
+    fun `native window capture remains available on GitHub Actions non-Windows`() {
+        assertFalse(
+            isNonInteractiveHostedWindows(
+                osName = "Linux",
+                getenv = { if (it == "GITHUB_ACTIONS") "true" else null },
+            )
+        )
     }
 
     private fun tracked(frame: Frame): TrackedWindow =

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCaptureTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/VisualIdleSurfaceCaptureTest.kt
@@ -284,18 +284,34 @@ class VisualIdleSurfaceCaptureTest {
     }
 
     @Test
-    fun `native window capture is unavailable on GitHub Actions Windows`() {
+    fun `native window capture is unavailable on GitHub-hosted Windows`() {
         assertTrue(
             isNonInteractiveHostedWindows(
                 osName = "Windows 11",
-                getenv = { if (it == "GITHUB_ACTIONS") "true" else null },
+                getenv = { if (it == "RUNNER_ENVIRONMENT") "github-hosted" else null },
             )
         )
         assertFalse(
             isNativeWindowCaptureAvailable(
                 allowsPlatformCapture = true,
                 osName = "Windows 11",
-                getenv = { if (it == "GITHUB_ACTIONS") "true" else null },
+                getenv = { if (it == "RUNNER_ENVIRONMENT") "github-hosted" else null },
+            )
+        )
+    }
+
+    @Test
+    fun `native window capture remains available on self-hosted Actions Windows`() {
+        assertFalse(
+            isNonInteractiveHostedWindows(
+                osName = "Windows 11",
+                getenv = {
+                    when (it) {
+                        "GITHUB_ACTIONS" -> "true"
+                        "RUNNER_ENVIRONMENT" -> "self-hosted"
+                        else -> null
+                    }
+                },
             )
         )
     }
@@ -306,11 +322,11 @@ class VisualIdleSurfaceCaptureTest {
     }
 
     @Test
-    fun `native window capture remains available on GitHub Actions non-Windows`() {
+    fun `native window capture remains available on GitHub-hosted non-Windows`() {
         assertFalse(
             isNonInteractiveHostedWindows(
                 osName = "Linux",
-                getenv = { if (it == "GITHUB_ACTIONS") "true" else null },
+                getenv = { if (it == "RUNNER_ENVIRONMENT") "github-hosted" else null },
             )
         )
     }

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -57,9 +57,16 @@ For reload settle and generation-stamped keys, see
 ## In-process API
 
 ```kotlin
+automator.waitForVisualIdle() // settle first when pixels matter
 val result = automator.capture(windowIndex = 0)
 // result.captureJson + result.pngBytes; write via your own paths or the agent/CLI surfaces
 ```
+
+With `spectre-recording` present, the PNG is a **window-scoped** native still (same path as
+`screenshot(windowIndex)`), not a silent desktop crop after a failed native still. Without
+recording on the classpath, the still is a Robot region capture of the Compose surface (agent
+inject payloads often omit recording). Settle the UI before calling so the semantics tree and
+pixels stay decision-grade across native still-helper latency.
 
 Library details live in `:core` under `dev.sebastiano.spectre.core.capture`.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -222,10 +222,12 @@ wrapper when your UI reads Jewel locals such as `LocalComponent`.
 
 `screenshot(windowIndex)` and `screenshot(node)` use the platform window-capture backend when
 `spectre-recording` is on the runtime classpath. They fail if that backend is unavailable or cannot
-identify the requested window; they never substitute a screen-region crop. On Linux X11/Xvfb the
-native backend itself reads visible framebuffer pixels, so keep the target frontmost and unobscured.
-`capture()` intentionally uses an immediate Robot region capture to keep its semantics snapshot
-adjacent to its pixels, so its image can include occlusion.
+identify the requested window; they never substitute a screen-region crop. `capture()` uses the same
+window-scoped still when recording is present; without recording (for example an inject payload that
+omits it) it uses a Robot region capture of the Compose surface so attach/agent stills still work.
+On Linux X11/Xvfb native stills read visible framebuffer pixels — keep the target frontmost. Settle
+the UI (`waitForIdle` / `waitForVisualIdle`) before `capture()` so the semantics snapshot and PNG
+stay a usable pair across one-shot native still latency.
 
 `waitForVisualIdle()` samples **window-scoped** pixels for tracked Compose surfaces when
 `spectre-recording` is present (same native still path as `screenshot(windowIndex)`). Without that

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -222,12 +222,14 @@ wrapper when your UI reads Jewel locals such as `LocalComponent`.
 
 `screenshot(windowIndex)` and `screenshot(node)` use the platform window-capture backend when
 `spectre-recording` is on the runtime classpath. They fail if that backend is unavailable or cannot
-identify the requested window; they never substitute a screen-region crop. `capture()` uses the same
-window-scoped still when recording is present; without recording (for example an inject payload that
-omits it) it uses a Robot region capture of the Compose surface so attach/agent stills still work.
-On Linux X11/Xvfb native stills read visible framebuffer pixels — keep the target frontmost. Settle
-the UI (`waitForIdle` / `waitForVisualIdle`) before `capture()` so the semantics snapshot and PNG
-stay a usable pair across one-shot native still latency.
+identify the requested window; they never substitute a screen-region crop. `capture()` and
+`waitForVisualIdle()` use the same window-scoped still when recording is present **and** the
+environment can actually run it (GitHub Actions hosted Windows is treated as non-interactive for
+WGC, so those paths fall back to Robot region capture of the Compose surface). Without recording
+(for example an inject payload that omits it) they likewise use region capture. On Linux X11/Xvfb
+native stills read visible framebuffer pixels — keep the target frontmost. Settle the UI
+(`waitForIdle` / `waitForVisualIdle`) before `capture()` so the semantics snapshot and PNG stay a
+usable pair across one-shot native still latency.
 
 `waitForVisualIdle()` samples **window-scoped** pixels for tracked Compose surfaces when
 `spectre-recording` is present (same native still path as `screenshot(windowIndex)`). Without that


### PR DESCRIPTION
## Summary

Completes residual #355 work for **`capture(...)`**:

- When `spectre-recording` is present, the atomic PNG uses the same **window-scoped** native still path as `screenshot(windowIndex)` (cropped to the pre-frozen Compose surface).
- Does **not** silently substitute region capture after a native failure.
- When the native bridge is **absent** (inject payload intentionally omits recording), falls back to Robot region of the Compose surface so agent/attach capture still works.
- Freeze window bounds + insets with the semantics pre-snapshot; docs tell callers to settle UI first for adjacency across one-shot helper latency.

Depends on #380 (visual-idle) already on main.

## Test plan

- [x] `AtomicCaptureWindowRoutingTest` — window vs region routing / loud fail
- [x] `:sample-desktop:validationTest --tests '*AtomicCapture*'` (native helper observed)
- [x] `:agent:test --tests '*AgentContractCorpusTest*'` (inject without recording still captures)
- [x] `:core:check`

Partial #355 (atomic capture residual). After merge: multi-OS smoke + issue close-out.