### PR TITLE
fix(agent): POSIX UID same-user attach preflight (#166)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -74,7 +74,8 @@ public final class dev/sebastiano/spectre/agent/AttachOptions$Companion {
 }
 
 public final class dev/sebastiano/spectre/agent/AttachPermissionDeniedException : dev/sebastiano/spectre/agent/SpectreAttachException {
-	public fun <init> (JLjava/lang/String;)V
+	public fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;)V
+	public synthetic fun <init> (JLjava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class dev/sebastiano/spectre/agent/AttachPlatformUnsupportedException : dev/sebastiano/spectre/agent/SpectreAttachException {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
@@ -70,8 +70,8 @@ public class AttachPermissionDeniedException(
     targetPid: Long,
     targetUser: String?,
     currentUser: String? = System.getProperty("user.name"),
-    targetUid: Int? = null,
-    currentUid: Int? = null,
+    targetUid: Long? = null,
+    currentUid: Long? = null,
 ) :
     SpectreAttachException(
         buildAttachPermissionDeniedMessage(
@@ -87,8 +87,8 @@ private fun buildAttachPermissionDeniedMessage(
     targetPid: Long,
     targetUser: String?,
     currentUser: String?,
-    targetUid: Int?,
-    currentUid: Int?,
+    targetUid: Long?,
+    currentUid: Long?,
 ): String {
     val targetDesc = formatOwner(targetUser, targetUid)
     val currentDesc = formatOwner(currentUser, currentUid)
@@ -97,7 +97,7 @@ private fun buildAttachPermissionDeniedMessage(
         "the same OS user identity (numeric UID on POSIX when available)."
 }
 
-private fun formatOwner(userName: String?, uid: Int?): String =
+private fun formatOwner(userName: String?, uid: Long?): String =
     when {
         uid != null && userName != null -> "uid=$uid (user '$userName')"
         uid != null -> "uid=$uid"

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
@@ -57,18 +57,53 @@ public class AgentBootstrapTimeoutException(udsPath: java.nio.file.Path, timeout
 /**
  * Thrown when the target JVM is owned by a different OS user than the attacher.
  *
- * The JDK Attach API requires compatible same-user ownership on POSIX. We pre-check this with
- * `ProcessHandle.of(pid).info().user()`, which reports user names rather than numeric UIDs, because
- * the underlying error from `VirtualMachine.attach` is generic and hard to diagnose.
+ * The JDK Attach API requires compatible same-user ownership on POSIX. On POSIX hosts we prefer
+ * numeric UID comparison when both sides resolve, and fall back to `ProcessHandle` usernames
+ * otherwise (#166). The underlying error from `VirtualMachine.attach` is generic and hard to
+ * diagnose, so this preflight surfaces a structured ownership message first.
+ *
+ * Optional [currentUser], [targetUid], and [currentUid] improve diagnostics; the two-argument form
+ * remains source-compatible for existing call sites.
  */
 @ExperimentalSpectreAgentApi
-public class AttachPermissionDeniedException(targetPid: Long, targetUser: String?) :
+public class AttachPermissionDeniedException(
+    targetPid: Long,
+    targetUser: String?,
+    currentUser: String? = System.getProperty("user.name"),
+    targetUid: Int? = null,
+    currentUid: Int? = null,
+) :
     SpectreAttachException(
-        "Target JVM (pid=$targetPid) is owned by " +
-            "${targetUser?.let { "user '$it'" } ?: "a different user"} but this process is " +
-            "running as '${System.getProperty("user.name")}'. The JDK Attach API only works " +
-            "across processes owned by the same OS user on POSIX systems."
+        buildAttachPermissionDeniedMessage(
+            targetPid = targetPid,
+            targetUser = targetUser,
+            currentUser = currentUser,
+            targetUid = targetUid,
+            currentUid = currentUid,
+        )
     )
+
+private fun buildAttachPermissionDeniedMessage(
+    targetPid: Long,
+    targetUser: String?,
+    currentUser: String?,
+    targetUid: Int?,
+    currentUid: Int?,
+): String {
+    val targetDesc = formatOwner(targetUser, targetUid)
+    val currentDesc = formatOwner(currentUser, currentUid)
+    return "Target JVM (pid=$targetPid) is owned by $targetDesc but this process is " +
+        "running as $currentDesc. The JDK Attach API only works across processes owned by " +
+        "the same OS user identity (numeric UID on POSIX when available)."
+}
+
+private fun formatOwner(userName: String?, uid: Int?): String =
+    when {
+        uid != null && userName != null -> "uid=$uid (user '$userName')"
+        uid != null -> "uid=$uid"
+        userName != null -> "user '$userName'"
+        else -> "a different user"
+    }
 
 /**
  * Thrown when the agent JAR could not be located by [AgentAttach.attach]. Caller can fix by passing

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflight.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflight.kt
@@ -52,8 +52,8 @@ internal interface AttachUserPreflight {
 internal class PosixUserPreflight(
     private val currentUser: () -> String? = defaultCurrentUser,
     private val targetUser: (Long) -> String? = defaultTargetUser,
-    private val currentUid: () -> Int? = defaultCurrentUid,
-    private val targetUid: (Long) -> Int? = defaultTargetUid,
+    private val currentUid: () -> Long? = defaultCurrentUid,
+    private val targetUid: (Long) -> Long? = defaultTargetUid,
 ) : AttachUserPreflight {
     override fun requireSameUser(targetPid: Long) {
         val curUid = currentUid()
@@ -111,8 +111,8 @@ private inline fun requireSameUserOwnership(
     targetPid: Long,
     current: String?,
     target: String?,
-    currentUid: Int?,
-    targetUid: Int?,
+    currentUid: Long?,
+    targetUid: Long?,
     normalize: (String) -> String,
 ) {
     // Undeterminable ownership must not block the attach — the OS remains the real boundary.
@@ -139,8 +139,8 @@ private val defaultTargetUser: (Long) -> String? = { pid ->
 
 private val defaultUidLookup: ProcessUidLookup = ProcessUidLookup.forOs()
 
-private val defaultCurrentUid: () -> Int? = {
+private val defaultCurrentUid: () -> Long? = {
     defaultUidLookup.uidOf(ProcessHandle.current().pid())
 }
 
-private val defaultTargetUid: (Long) -> Int? = { pid -> defaultUidLookup.uidOf(pid) }
+private val defaultTargetUid: (Long) -> Long? = { pid -> defaultUidLookup.uidOf(pid) }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflight.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflight.kt
@@ -11,8 +11,8 @@ package dev.sebastiano.spectre.agent
  * a clear message before opening the VM connection.
  *
  * **Advisory, not authoritative.** The real boundary is the OS. When ownership cannot be determined
- * (sandboxes return an empty `ProcessHandle.user()`), the preflight proceeds and lets the attach
- * surface whatever the OS reports.
+ * (sandboxes return an empty `ProcessHandle.user()`, or UID lookup fails), the preflight proceeds
+ * and lets the attach surface whatever the OS reports.
  *
  * Both implementations resolve the current *and* target owner through the same
  * `ProcessHandle.info().user()` API so the two strings are directly comparable. The previous
@@ -20,8 +20,9 @@ package dev.sebastiano.spectre.agent
  * `System.getProperty("user.name")` (bare) — a mismatch that wrongly rejected the same user
  * attaching to their own JVM on Windows.
  *
- * The per-platform split leaves room for #166 (numeric POSIX UID comparison) and a future Windows
- * SID/elevation refinement to drop in without reshaping call sites.
+ * On POSIX, numeric UID equality is preferred when both sides can be resolved (#166); username
+ * equality is the fallback when UID lookup is unavailable. Windows keeps name-based comparison (SID
+ * refinement is a future follow-up).
  */
 @ExperimentalSpectreAgentApi
 internal interface AttachUserPreflight {
@@ -40,19 +41,44 @@ internal interface AttachUserPreflight {
 }
 
 /**
- * POSIX same-user preflight: case-sensitive username equality via `ProcessHandle.info().user()`.
+ * POSIX same-user preflight.
  *
- * #166 will refine this to a numeric UID comparison (name equality can false-negative under
- * directory services, domain prefixes, or localized name formatting) and keep the name path as a
- * fallback when a numeric UID is unavailable.
+ * Prefer numeric UID equality when both the attacher and target UIDs can be resolved. Name equality
+ * alone false-negatives under directory services, domain prefixes, case differences, or localized
+ * formatting even when both processes share one OS identity. When either UID is unavailable, fall
+ * back to case-sensitive username equality via `ProcessHandle.info().user()`.
  */
 @ExperimentalSpectreAgentApi
 internal class PosixUserPreflight(
     private val currentUser: () -> String? = defaultCurrentUser,
     private val targetUser: (Long) -> String? = defaultTargetUser,
+    private val currentUid: () -> Int? = defaultCurrentUid,
+    private val targetUid: (Long) -> Int? = defaultTargetUid,
 ) : AttachUserPreflight {
     override fun requireSameUser(targetPid: Long) {
-        requireSameUserOwnership(targetPid, currentUser(), targetUser(targetPid)) { it }
+        val curUid = currentUid()
+        val tgtUid = targetUid(targetPid)
+        if (curUid != null && tgtUid != null) {
+            if (curUid != tgtUid) {
+                throw AttachPermissionDeniedException(
+                    targetPid = targetPid,
+                    targetUser = targetUser(targetPid),
+                    currentUser = currentUser(),
+                    targetUid = tgtUid,
+                    currentUid = curUid,
+                )
+            }
+            // Same UID: accept even when ProcessHandle name strings differ.
+            return
+        }
+        requireSameUserOwnership(
+            targetPid = targetPid,
+            current = currentUser(),
+            target = targetUser(targetPid),
+            currentUid = curUid,
+            targetUid = tgtUid,
+            normalize = { it },
+        )
     }
 }
 
@@ -70,7 +96,14 @@ internal class WindowsUserPreflight(
     private val targetUser: (Long) -> String? = defaultTargetUser,
 ) : AttachUserPreflight {
     override fun requireSameUser(targetPid: Long) {
-        requireSameUserOwnership(targetPid, currentUser(), targetUser(targetPid)) { it.lowercase() }
+        requireSameUserOwnership(
+            targetPid = targetPid,
+            current = currentUser(),
+            target = targetUser(targetPid),
+            currentUid = null,
+            targetUid = null,
+            normalize = { it.lowercase() },
+        )
     }
 }
 
@@ -78,13 +111,21 @@ private inline fun requireSameUserOwnership(
     targetPid: Long,
     current: String?,
     target: String?,
+    currentUid: Int?,
+    targetUid: Int?,
     normalize: (String) -> String,
 ) {
     // Undeterminable ownership must not block the attach — the OS remains the real boundary.
     if (current == null || target == null) return
     if (normalize(current) != normalize(target)) {
         @OptIn(ExperimentalSpectreAgentApi::class)
-        throw AttachPermissionDeniedException(targetPid, target)
+        throw AttachPermissionDeniedException(
+            targetPid = targetPid,
+            targetUser = target,
+            currentUser = current,
+            targetUid = targetUid,
+            currentUid = currentUid,
+        )
     }
 }
 
@@ -95,3 +136,11 @@ private val defaultCurrentUser: () -> String? = {
 private val defaultTargetUser: (Long) -> String? = { pid ->
     ProcessHandle.of(pid).flatMap { it.info().user() }.orElse(null)
 }
+
+private val defaultUidLookup: ProcessUidLookup = ProcessUidLookup.forOs()
+
+private val defaultCurrentUid: () -> Int? = {
+    defaultUidLookup.uidOf(ProcessHandle.current().pid())
+}
+
+private val defaultTargetUid: (Long) -> Int? = { pid -> defaultUidLookup.uidOf(pid) }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/ProcessUidLookup.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/ProcessUidLookup.kt
@@ -6,13 +6,19 @@ import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 
 /**
- * Resolves the real numeric UID of a process for POSIX same-user preflight (#166).
+ * Resolves the effective numeric UID of a process for POSIX same-user preflight (#166).
+ *
+ * Effective UID (not real UID) matches attach-relevant identity: HotSpot attach rendezvous and
+ * filesystem credentials follow euid, and macOS `ps -o uid=` reports euid. Linux
+ * `/proc/<pid>/status` exposes both; we deliberately read the effective field.
  *
  * Returns `null` when the UID cannot be determined so callers can fall back to username equality.
  * Lookup is advisory — the OS remains the real attach boundary.
+ *
+ * UIDs are [Long] so the full unsigned 32-bit `uid_t` range (0..2^32-1) is representable.
  */
 internal fun interface ProcessUidLookup {
-    fun uidOf(pid: Long): Int?
+    fun uidOf(pid: Long): Long?
 
     companion object {
         fun forOs(osName: String = System.getProperty("os.name").orEmpty()): ProcessUidLookup {
@@ -22,13 +28,13 @@ internal fun interface ProcessUidLookup {
     }
 }
 
-/** Linux: parse the real UID from `/proc/<pid>/status` (shell-free). */
+/** Linux: parse the effective UID from `/proc/<pid>/status` (shell-free). */
 internal object LinuxProcUidLookup : ProcessUidLookup {
-    override fun uidOf(pid: Long): Int? {
+    override fun uidOf(pid: Long): Long? {
         if (pid <= 0L) return null
         return try {
             val status = Files.readString(Path.of("/proc", pid.toString(), "status"))
-            parseProcStatusRealUid(status)
+            parseProcStatusEffectiveUid(status)
         } catch (_: IOException) {
             null
         } catch (_: SecurityException) {
@@ -39,12 +45,12 @@ internal object LinuxProcUidLookup : ProcessUidLookup {
 
 /**
  * macOS / other Unix: `ps -o uid= -p <pid>` (argv list, no shell). Used when `/proc` is
- * unavailable.
+ * unavailable. On macOS this reports the effective UID.
  */
 internal object PsProcessUidLookup : ProcessUidLookup {
     private const val WAIT_SECONDS = 2L
 
-    override fun uidOf(pid: Long): Int? {
+    override fun uidOf(pid: Long): Long? {
         if (pid <= 0L) return null
         return try {
             val process =
@@ -57,7 +63,7 @@ internal object PsProcessUidLookup : ProcessUidLookup {
                 return null
             }
             if (process.exitValue() != 0) return null
-            process.inputStream.bufferedReader().use { it.readText() }.trim().toIntOrNull()
+            process.inputStream.bufferedReader().use { it.readText() }.trim().toUidOrNull()
         } catch (_: IOException) {
             null
         } catch (_: InterruptedException) {
@@ -70,17 +76,31 @@ internal object PsProcessUidLookup : ProcessUidLookup {
 }
 
 /**
- * Parses the real UID from a Linux `/proc/<pid>/status` body.
+ * Parses the **effective** UID from a Linux `/proc/<pid>/status` body.
  *
- * Format: `Uid:\t<real>\t<effective>\t<saved>\t<fs>` (tabs or spaces).
+ * Format: `Uid:\t<real>\t<effective>\t<saved>\t<fs>` (tabs or spaces). Index 1 is effective. When
+ * only one field is present, treat it as the sole reported identity.
  */
-internal fun parseProcStatusRealUid(statusText: String): Int? {
+internal fun parseProcStatusEffectiveUid(statusText: String): Long? {
     for (line in statusText.lineSequence()) {
         if (!line.startsWith("Uid:")) continue
         val fields = line.removePrefix("Uid:").trim().split(WHITESPACE)
-        return fields.firstOrNull()?.toIntOrNull()
+        // Prefer effective (field 1); fall back to a single-field line if the kernel omits the
+        // rest.
+        val raw = fields.getOrNull(1) ?: fields.firstOrNull() ?: return null
+        return raw.toUidOrNull()
     }
     return null
 }
+
+/** Parse a decimal UID covering the full unsigned 32-bit `uid_t` range. */
+internal fun String.toUidOrNull(): Long? {
+    val value = toLongOrNull() ?: return null
+    if (value < 0L || value > MAX_UID_T) return null
+    return value
+}
+
+/** Max value of POSIX `uid_t` when it is an unsigned 32-bit integer. */
+internal const val MAX_UID_T: Long = 0xFFFF_FFFFL
 
 private val WHITESPACE = Regex("\\s+")

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/ProcessUidLookup.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/ProcessUidLookup.kt
@@ -1,0 +1,86 @@
+package dev.sebastiano.spectre.agent
+
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+
+/**
+ * Resolves the real numeric UID of a process for POSIX same-user preflight (#166).
+ *
+ * Returns `null` when the UID cannot be determined so callers can fall back to username equality.
+ * Lookup is advisory — the OS remains the real attach boundary.
+ */
+internal fun interface ProcessUidLookup {
+    fun uidOf(pid: Long): Int?
+
+    companion object {
+        fun forOs(osName: String = System.getProperty("os.name").orEmpty()): ProcessUidLookup {
+            val os = osName.lowercase()
+            return if (os.startsWith("linux")) LinuxProcUidLookup else PsProcessUidLookup
+        }
+    }
+}
+
+/** Linux: parse the real UID from `/proc/<pid>/status` (shell-free). */
+internal object LinuxProcUidLookup : ProcessUidLookup {
+    override fun uidOf(pid: Long): Int? {
+        if (pid <= 0L) return null
+        return try {
+            val status = Files.readString(Path.of("/proc", pid.toString(), "status"))
+            parseProcStatusRealUid(status)
+        } catch (_: IOException) {
+            null
+        } catch (_: SecurityException) {
+            null
+        }
+    }
+}
+
+/**
+ * macOS / other Unix: `ps -o uid= -p <pid>` (argv list, no shell). Used when `/proc` is
+ * unavailable.
+ */
+internal object PsProcessUidLookup : ProcessUidLookup {
+    private const val WAIT_SECONDS = 2L
+
+    override fun uidOf(pid: Long): Int? {
+        if (pid <= 0L) return null
+        return try {
+            val process =
+                ProcessBuilder("ps", "-o", "uid=", "-p", pid.toString())
+                    .redirectError(ProcessBuilder.Redirect.DISCARD)
+                    .start()
+            val finished = process.waitFor(WAIT_SECONDS, TimeUnit.SECONDS)
+            if (!finished) {
+                process.destroyForcibly()
+                return null
+            }
+            if (process.exitValue() != 0) return null
+            process.inputStream.bufferedReader().use { it.readText() }.trim().toIntOrNull()
+        } catch (_: IOException) {
+            null
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+            null
+        } catch (_: SecurityException) {
+            null
+        }
+    }
+}
+
+/**
+ * Parses the real UID from a Linux `/proc/<pid>/status` body.
+ *
+ * Format: `Uid:\t<real>\t<effective>\t<saved>\t<fs>` (tabs or spaces).
+ */
+internal fun parseProcStatusRealUid(statusText: String): Int? {
+    for (line in statusText.lineSequence()) {
+        if (!line.startsWith("Uid:")) continue
+        val fields = line.removePrefix("Uid:").trim().split(WHITESPACE)
+        return fields.firstOrNull()?.toIntOrNull()
+    }
+    return null
+}
+
+private val WHITESPACE = Regex("\\s+")

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachSameUserPreflightE2eTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachSameUserPreflightE2eTest.kt
@@ -1,0 +1,170 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * End-to-end same-user preflight through the real [AgentAttach.attach] entry point (#166).
+ *
+ * These tests intentionally do **not** mock UID resolvers: they use the production
+ * [ProcessUidLookup] + [PosixUserPreflight] path that attach calls before `VirtualMachine.attach`.
+ *
+ * - **Same UID:** attach to a short-lived child JVM owned by this user must not fail preflight.
+ * - **Different UID:** attach to a known foreign-UID process (typically pid 1 / root) must fail
+ *   with [AttachPermissionDeniedException] before the JDK attach handshake.
+ *
+ * Windows is out of scope for this class (name-based preflight unchanged; no SID work in #166).
+ *
+ * Full Compose attach happy-path remains covered by [AgentAttachIntegrationTest]; this class
+ * isolates ownership preflight on the shipped attach path.
+ */
+@DisabledOnOs(OS.WINDOWS)
+class AgentAttachSameUserPreflightE2eTest {
+
+    @Test
+    fun `attach to a same-UID child JVM passes the ownership preflight`() {
+        val agentJar = locateAgentJarOrSkip()
+        val lookup = ProcessUidLookup.forOs()
+        val myUid = lookup.uidOf(ProcessHandle.current().pid())
+        assumeTrue(myUid != null, "host UID lookup must work for this e2e")
+
+        spawnBareJvm().use { child ->
+            val childUid = lookup.uidOf(child.pid)
+            assumeTrue(childUid != null, "child UID must be resolvable")
+            assertTrue(
+                childUid == myUid,
+                "expected same-UID child (myUid=$myUid childUid=$childUid pid=${child.pid})",
+            )
+
+            // Exercise the shipped preflight path. A bare JVM without a Compose UI may fail later
+            // in agent bootstrap or attach timeout; ownership must not be the failure mode.
+            val thrown =
+                runCatching {
+                        AgentAttach.attach(
+                                child.pid,
+                                AttachOptions(agentJarPath = agentJar, attachTimeoutMs = 3_000),
+                            )
+                            .close()
+                    }
+                    .exceptionOrNull()
+
+            assertTrue(
+                thrown !is AttachPermissionDeniedException,
+                "same-UID child must not be rejected by same-user preflight; got: $thrown",
+            )
+        }
+    }
+
+    @Test
+    fun `attach to a different-UID process fails preflight with uid diagnostics`() {
+        val agentJar = locateAgentJarOrSkip()
+        val lookup = ProcessUidLookup.forOs()
+        val myUid = lookup.uidOf(ProcessHandle.current().pid())
+        assumeTrue(myUid != null, "host UID lookup must work for this e2e")
+
+        val foreign = findDifferentUidProcess(lookup, myUid!!)
+        assumeTrue(foreign != null, "no different-UID process available on this host")
+
+        val (foreignPid, foreignUid) = foreign!!
+        val ex =
+            assertFailsWith<AttachPermissionDeniedException> {
+                AgentAttach.attach(
+                    foreignPid,
+                    AttachOptions(agentJarPath = agentJar, attachTimeoutMs = 2_000),
+                )
+            }
+
+        val message = ex.message.orEmpty()
+        assertTrue(
+            message.contains("uid=$foreignUid") && message.contains("uid=$myUid"),
+            "expected both UIDs in message, got: $message",
+        )
+        assertTrue(message.contains("pid=$foreignPid"), "expected target pid in message: $message")
+    }
+
+    /**
+     * Prefer pid 1 (init/launchd, almost always root). Fall back to a short scan of live processes
+     * when pid 1 is unreadable or same-UID (unusual containers).
+     */
+    private fun findDifferentUidProcess(lookup: ProcessUidLookup, myUid: Int): Pair<Long, Int>? {
+        val pid1Uid = lookup.uidOf(1L)
+        if (pid1Uid != null && pid1Uid != myUid) return 1L to pid1Uid
+
+        return ProcessHandle.allProcesses()
+            .limit(64)
+            .map { handle ->
+                val uid = lookup.uidOf(handle.pid())
+                if (uid != null && uid != myUid) handle.pid() to uid else null
+            }
+            .filter { it != null }
+            .findFirst()
+            .orElse(null)
+    }
+
+    /**
+     * Minimal child JVM — enough for ProcessHandle ownership + attach preflight. Does not open a
+     * UI; only used to prove same-UID preflight on the real attach path.
+     */
+    private fun spawnBareJvm(): BareJvm {
+        val javaHome = System.getProperty("java.home")
+        val javaBin = Paths.get(javaHome, "bin", "java").toString()
+        val process =
+            ProcessBuilder(
+                    javaBin,
+                    "-cp",
+                    System.getProperty("java.class.path"),
+                    AgentAttachIdleJvmMain::class.java.name,
+                )
+                .redirectErrorStream(true)
+                .start()
+
+        var attempts = 0
+        while (!process.isAlive && attempts < 40) {
+            Thread.sleep(25)
+            attempts++
+        }
+        check(process.isAlive) { "bare JVM child exited immediately" }
+        return BareJvm(process)
+    }
+
+    private fun locateAgentJarOrSkip(): Path {
+        val prop = System.getProperty("dev.sebastiano.spectre.agent.runtimeJar")
+        assumeFalse(
+            prop.isNullOrBlank(),
+            "Requires -Ddev.sebastiano.spectre.agent.runtimeJar; :agent:test sets it.",
+        )
+        return Paths.get(prop!!)
+    }
+
+    private class BareJvm(private val process: Process) : AutoCloseable {
+        val pid: Long = process.pid()
+
+        override fun close() {
+            process.destroyForcibly()
+            process.waitFor(2, TimeUnit.SECONDS)
+        }
+    }
+}
+
+/**
+ * Keeps a JVM process alive until destroyed — test-only attach target for same-UID preflight e2e.
+ * Lives as a top-level type so [ProcessBuilder] can resolve a stable main class name.
+ */
+object AgentAttachIdleJvmMain {
+    @JvmStatic
+    fun main(args: Array<String>) {
+        // Park forever; parent destroyForcibly() ends the process.
+        CountDownLatch(1).await()
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachSameUserPreflightE2eTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachSameUserPreflightE2eTest.kt
@@ -97,7 +97,7 @@ class AgentAttachSameUserPreflightE2eTest {
      * Prefer pid 1 (init/launchd, almost always root). Fall back to a short scan of live processes
      * when pid 1 is unreadable or same-UID (unusual containers).
      */
-    private fun findDifferentUidProcess(lookup: ProcessUidLookup, myUid: Int): Pair<Long, Int>? {
+    private fun findDifferentUidProcess(lookup: ProcessUidLookup, myUid: Long): Pair<Long, Long>? {
         val pid1Uid = lookup.uidOf(1L)
         if (pid1Uid != null && pid1Uid != myUid) return 1L to pid1Uid
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflightTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflightTest.kt
@@ -3,7 +3,12 @@
 package dev.sebastiano.spectre.agent
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.OS
 
 class AttachUserPreflightTest {
 
@@ -33,6 +38,98 @@ class AttachUserPreflightTest {
             preflight(posix = true, current = "Rock3r", target = "rock3r")
                 .requireSameUser(targetPid)
         }
+    }
+
+    // ---- POSIX preflight: numeric UID preferred over name equality (#166) ----
+
+    @Test
+    fun `posix preflight passes when UIDs match even if usernames differ`() {
+        // Enterprise / directory-service false-negative shape: same identity, different name
+        // strings from ProcessHandle.info().user().
+        preflight(
+                posix = true,
+                current = "DOMAIN\\rock3r",
+                target = "rock3r",
+                currentUid = 501,
+                targetUid = 501,
+            )
+            .requireSameUser(targetPid)
+    }
+
+    @Test
+    fun `posix preflight throws when UIDs differ even if usernames match`() {
+        val ex =
+            assertFailsWith<AttachPermissionDeniedException> {
+                preflight(
+                        posix = true,
+                        current = "rock3r",
+                        target = "rock3r",
+                        currentUid = 501,
+                        targetUid = 0,
+                    )
+                    .requireSameUser(targetPid)
+            }
+        assertTrue(ex.message!!.contains("uid=0") || ex.message!!.contains("uid 0"))
+        assertTrue(ex.message!!.contains("501"))
+    }
+
+    @Test
+    fun `posix preflight throws when UIDs differ and reports both names and uids`() {
+        val ex =
+            assertFailsWith<AttachPermissionDeniedException> {
+                preflight(
+                        posix = true,
+                        current = "rock3r",
+                        target = "root",
+                        currentUid = 501,
+                        targetUid = 0,
+                    )
+                    .requireSameUser(targetPid)
+            }
+        assertTrue(ex.message!!.contains("root"))
+        assertTrue(ex.message!!.contains("501"))
+        assertTrue(ex.message!!.contains("0"))
+    }
+
+    @Test
+    fun `posix preflight falls back to name equality when UIDs unavailable`() {
+        assertFailsWith<AttachPermissionDeniedException> {
+            preflight(
+                    posix = true,
+                    current = "rock3r",
+                    target = "root",
+                    currentUid = null,
+                    targetUid = null,
+                )
+                .requireSameUser(targetPid)
+        }
+    }
+
+    @Test
+    fun `posix preflight falls back to names when only one UID is available`() {
+        // Partial UID resolution must not invent a same-user pass from one side alone.
+        assertFailsWith<AttachPermissionDeniedException> {
+            preflight(
+                    posix = true,
+                    current = "rock3r",
+                    target = "root",
+                    currentUid = 501,
+                    targetUid = null,
+                )
+                .requireSameUser(targetPid)
+        }
+    }
+
+    @Test
+    fun `posix preflight proceeds when both UIDs and target name are unavailable`() {
+        preflight(
+                posix = true,
+                current = "rock3r",
+                target = null,
+                currentUid = null,
+                targetUid = null,
+            )
+            .requireSameUser(targetPid)
     }
 
     // ---- Windows preflight: case-insensitive, DOMAIN\name on BOTH sides (the bug fix) ----
@@ -79,10 +176,86 @@ class AttachUserPreflightTest {
         assert(AttachUserPreflight.forOs("Linux") is PosixUserPreflight)
     }
 
-    private fun preflight(posix: Boolean, current: String?, target: String?): AttachUserPreflight {
+    // ---- Live POSIX UID lookup (integration; skips when lookup cannot resolve) ----
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    fun `posix uid lookup resolves the current process uid`() {
+        val lookup = ProcessUidLookup.forOs()
+        val uid = lookup.uidOf(ProcessHandle.current().pid())
+        assertNotNull(uid, "expected a numeric UID for the current process on this host")
+        assertTrue(uid >= 0)
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    fun `default posix preflight accepts the current process as same-user`() {
+        // Happy path: attacher checking itself. Uses real ProcessHandle + platform UID lookup.
+        PosixUserPreflight().requireSameUser(ProcessHandle.current().pid())
+    }
+
+    /**
+     * Pure unit helper. UID resolvers default to null so name-path tests do not depend on host
+     * process tables or accidental collisions with [targetPid].
+     */
+    private fun preflight(
+        posix: Boolean,
+        current: String?,
+        target: String?,
+        currentUid: Int? = null,
+        targetUid: Int? = null,
+    ): AttachUserPreflight {
         val currentResolver = { current }
         val targetResolver = { _: Long -> target }
-        return if (posix) PosixUserPreflight(currentResolver, targetResolver)
-        else WindowsUserPreflight(currentResolver, targetResolver)
+        return if (posix) {
+            PosixUserPreflight(
+                currentUser = currentResolver,
+                targetUser = targetResolver,
+                currentUid = { currentUid },
+                targetUid = { targetUid },
+            )
+        } else {
+            WindowsUserPreflight(currentResolver, targetResolver)
+        }
+    }
+}
+
+class PosixProcessUidLookupTest {
+
+    @Test
+    fun `parseProcStatusRealUid reads the real uid field`() {
+        val status =
+            """
+            Name:	java
+            Umask:	0022
+            State:	S (sleeping)
+            Uid:	501	501	501	501
+            Gid:	20	20	20	20
+            """
+                .trimIndent()
+        assertEquals(501, parseProcStatusRealUid(status))
+    }
+
+    @Test
+    fun `parseProcStatusRealUid prefers real over effective when they differ`() {
+        val status = "Uid:\t1000\t0\t0\t0\n"
+        assertEquals(1000, parseProcStatusRealUid(status))
+    }
+
+    @Test
+    fun `parseProcStatusRealUid returns null when Uid line is missing`() {
+        assertEquals(null, parseProcStatusRealUid("Name:\tjava\n"))
+    }
+
+    @Test
+    fun `parseProcStatusRealUid tolerates spaces instead of tabs`() {
+        assertEquals(42, parseProcStatusRealUid("Uid:   42  42  42  42\n"))
+    }
+
+    @Test
+    fun `uid lookup factory selects linux proc vs ps-based for other unix`() {
+        assertTrue(ProcessUidLookup.forOs("Linux") is LinuxProcUidLookup)
+        assertTrue(ProcessUidLookup.forOs("Mac OS X") is PsProcessUidLookup)
+        assertTrue(ProcessUidLookup.forOs("Darwin") is PsProcessUidLookup)
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflightTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUserPreflightTest.kt
@@ -50,8 +50,8 @@ class AttachUserPreflightTest {
                 posix = true,
                 current = "DOMAIN\\rock3r",
                 target = "rock3r",
-                currentUid = 501,
-                targetUid = 501,
+                currentUid = 501L,
+                targetUid = 501L,
             )
             .requireSameUser(targetPid)
     }
@@ -64,8 +64,8 @@ class AttachUserPreflightTest {
                         posix = true,
                         current = "rock3r",
                         target = "rock3r",
-                        currentUid = 501,
-                        targetUid = 0,
+                        currentUid = 501L,
+                        targetUid = 0L,
                     )
                     .requireSameUser(targetPid)
             }
@@ -81,8 +81,8 @@ class AttachUserPreflightTest {
                         posix = true,
                         current = "rock3r",
                         target = "root",
-                        currentUid = 501,
-                        targetUid = 0,
+                        currentUid = 501L,
+                        targetUid = 0L,
                     )
                     .requireSameUser(targetPid)
             }
@@ -113,7 +113,7 @@ class AttachUserPreflightTest {
                     posix = true,
                     current = "rock3r",
                     target = "root",
-                    currentUid = 501,
+                    currentUid = 501L,
                     targetUid = null,
                 )
                 .requireSameUser(targetPid)
@@ -128,6 +128,20 @@ class AttachUserPreflightTest {
                 target = null,
                 currentUid = null,
                 targetUid = null,
+            )
+            .requireSameUser(targetPid)
+    }
+
+    @Test
+    fun `posix preflight accepts large uid_t values above Int MAX`() {
+        // Full unsigned 32-bit uid_t range must not fall back to name equality.
+        val high = 3_000_000_000L
+        preflight(
+                posix = true,
+                current = "DOMAIN\\a",
+                target = "a",
+                currentUid = high,
+                targetUid = high,
             )
             .requireSameUser(targetPid)
     }
@@ -202,8 +216,8 @@ class AttachUserPreflightTest {
         posix: Boolean,
         current: String?,
         target: String?,
-        currentUid: Int? = null,
-        targetUid: Int? = null,
+        currentUid: Long? = null,
+        targetUid: Long? = null,
     ): AttachUserPreflight {
         val currentResolver = { current }
         val targetResolver = { _: Long -> target }
@@ -223,7 +237,7 @@ class AttachUserPreflightTest {
 class PosixProcessUidLookupTest {
 
     @Test
-    fun `parseProcStatusRealUid reads the real uid field`() {
+    fun `parseProcStatusEffectiveUid reads the effective uid field`() {
         val status =
             """
             Name:	java
@@ -233,23 +247,33 @@ class PosixProcessUidLookupTest {
             Gid:	20	20	20	20
             """
                 .trimIndent()
-        assertEquals(501, parseProcStatusRealUid(status))
+        assertEquals(501L, parseProcStatusEffectiveUid(status))
     }
 
     @Test
-    fun `parseProcStatusRealUid prefers real over effective when they differ`() {
+    fun `parseProcStatusEffectiveUid prefers effective over real when they differ`() {
+        // Privilege-dropping wrapper shape: real=1000, effective=0 (or vice versa).
         val status = "Uid:\t1000\t0\t0\t0\n"
-        assertEquals(1000, parseProcStatusRealUid(status))
+        assertEquals(0L, parseProcStatusEffectiveUid(status))
     }
 
     @Test
-    fun `parseProcStatusRealUid returns null when Uid line is missing`() {
-        assertEquals(null, parseProcStatusRealUid("Name:\tjava\n"))
+    fun `parseProcStatusEffectiveUid returns null when Uid line is missing`() {
+        assertEquals(null, parseProcStatusEffectiveUid("Name:\tjava\n"))
     }
 
     @Test
-    fun `parseProcStatusRealUid tolerates spaces instead of tabs`() {
-        assertEquals(42, parseProcStatusRealUid("Uid:   42  42  42  42\n"))
+    fun `parseProcStatusEffectiveUid tolerates spaces instead of tabs`() {
+        assertEquals(42L, parseProcStatusEffectiveUid("Uid:   42  42  42  42\n"))
+    }
+
+    @Test
+    fun `parseProcStatusEffectiveUid accepts full unsigned 32-bit uid_t`() {
+        val high = 4_000_000_000L
+        assertEquals(high, parseProcStatusEffectiveUid("Uid:\t1\t$high\t$high\t$high\n"))
+        assertEquals(high, "$high".toUidOrNull())
+        assertEquals(null, "4294967296".toUidOrNull()) // above uid_t max
+        assertEquals(null, "-1".toUidOrNull())
     }
 
     @Test

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -38,7 +38,8 @@ out of scope.
    ALLOW full-control ACE for the owning user, with inherited ACEs dropped — to both the private
    directory and the socket file. Either way the protection is set explicitly by `IpcServer` to
    defend against permissive umasks or inherited ACLs, and the same-user preflight compares the
-   attacher's and target's process owners (`ProcessHandle`) rather than trusting the socket alone.
+   attacher's and target's process owners (numeric UID on POSIX when available, otherwise
+   `ProcessHandle` usernames; see #166) rather than trusting the socket alone.
    If callers override `AttachOptions.udsPath` with a path under an existing directory, they own
    that parent directory's permissions; Spectre only tightens directories it creates itself.
    Any process running as the same OS user can connect and drive the target. There is no

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -268,9 +268,11 @@ directory's permissions. Spectre creates the default per-attach directory and so
 mode 0700/0600 on POSIX, an owner-only ACL (owner full control, inherited ACEs dropped) on
 Windows — but it does not tighten directories it did not create.
 
-`AgentAttach.attach` runs a **same-user preflight** via `ProcessHandle` and throws
+`AgentAttach.attach` runs a **same-user preflight** and throws
 `AttachPermissionDeniedException` if the target JVM is owned by a different OS user (the
-JDK Attach API only works across attach-compatible same-user processes on POSIX).
+JDK Attach API only works across attach-compatible same-user processes on POSIX). On
+Linux/macOS the preflight prefers numeric UID equality when both sides can be resolved, and
+falls back to `ProcessHandle` usernames when UID lookup is unavailable (#166).
 
 The JEP 451 `-XX:+EnableDynamicAgentLoading` flag is **not** verified by Spectre yet — the
 JVM itself prints a stderr warning if it's missing, which is the source of truth. A follow-up


### PR DESCRIPTION
## Summary

Implements #166 for a small 0.4.1-safe diagnostics polish: `AgentAttach` same-user preflight on POSIX now prefers **numeric UID** equality when both sides resolve, and falls back to `ProcessHandle` usernames when UID lookup is unavailable.

- **Linux:** shell-free `/proc/<pid>/status` real-UID parse
- **macOS / other Unix:** `ps -o uid= -p <pid>` (argv list, no shell)
- **Windows:** unchanged name-based comparison (no SID work in this PR)
- **Advisory only:** undeterminable ownership still does not block attach; OS remains the real boundary
- **Messages:** `AttachPermissionDeniedException` includes `uid=` when known

## Test plan

- [x] TDD unit tests: same-UID / different-name pass, different-UID reject, name fallback, `/proc` parse, factory selection
- [x] Live host UID lookup + self preflight
- [x] E2E through `AgentAttach.attach`: same-UID child JVM accept; different-UID foreign process reject with both UIDs in message
- [x] `./gradlew :agent:test` (targeted preflight + e2e green locally on macOS)
- [x] ktfmt + detekt on agent test sources

Closes #166