### PR TITLE
fix(scripts): make Windows release smoke reliable on WinPS 5.1 (#385)

### DIFF
--- a/.agents/skills/spectre-release/SKILL.md
+++ b/.agents/skills/spectre-release/SKILL.md
@@ -17,8 +17,10 @@ promotion, and undrafting.
 
 1. Diff since previous tag + capability matrix → baseline hard cells + **delta** hard cells.
 2. Run hard cells on macOS, headed Windows, and Linux as scoped.
-3. On Windows, prefer the one-liner (interactive logon session):
-   `.\scripts\windows-release-smoke.ps1` — see [docs/RELEASE-SMOKE.md](../../../docs/RELEASE-SMOKE.md).
+3. On Windows, prefer the one-liner (interactive logon session); see
+   [docs/RELEASE-SMOKE.md](../../../docs/RELEASE-SMOKE.md):
+   - `pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1` when PowerShell 7+ is installed
+   - `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1` on stock WinPS 5.1
 4. Produce a results table. **Hard red or empty hard cells → do not tag.**
 5. Soft cells (Experimental matrix, focus flakes, Hot Reload) may be notes only.
 

--- a/.agents/skills/spectre-release/SKILL.md
+++ b/.agents/skills/spectre-release/SKILL.md
@@ -19,7 +19,7 @@ promotion, and undrafting.
 2. Run hard cells on macOS, headed Windows, and Linux as scoped.
 3. On Windows, prefer the one-liner (interactive logon session); see
    [docs/RELEASE-SMOKE.md](../../../docs/RELEASE-SMOKE.md):
-   - `pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1` when PowerShell 7+ is installed
+   - `pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1` when PowerShell 7+ is installed
    - `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1` on stock WinPS 5.1
 4. Produce a results table. **Hard red or empty hard cells → do not tag.**
 5. Soft cells (Experimental matrix, focus flakes, Hot Reload) may be notes only.

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Contract tests for scripts/windows-release-smoke.ps1 launch reliability (#385).
+# Proves: ASCII-only source (WinPS 5.1 parse without BOM), documented one-liners present.
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/../.." && pwd)"
+script="$repo_root/scripts/windows-release-smoke.ps1"
+docs="$repo_root/docs/RELEASE-SMOKE.md"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$script" ]] || fail "missing $script"
+[[ -f "$docs" ]] || fail "missing $docs"
+
+# --- ASCII-only (no multi-byte UTF-8; no UTF-8 BOM required) ---
+if command -v python3 >/dev/null 2>&1; then
+  python3 - "$script" <<'PY' || fail "ASCII check failed"
+import sys
+from pathlib import Path
+path = Path(sys.argv[1])
+data = path.read_bytes()
+if data.startswith(b"\xef\xbb\xbf"):
+    # BOM is an allowed alternative for WinPS 5.1, but this tree standardizes on ASCII-only.
+    # Accept BOM only if the rest is valid; still flag non-ASCII payload after BOM.
+    payload = data[3:]
+else:
+    payload = data
+non_ascii = [i for i, b in enumerate(payload) if b > 127]
+if non_ascii:
+    # Report first few offsets for operators.
+    sample = ", ".join(str(i) for i in non_ascii[:8])
+    print(
+        f"scripts/windows-release-smoke.ps1 has non-ASCII bytes at offsets: {sample}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+print("OK: windows-release-smoke.ps1 is ASCII-only (WinPS 5.1-safe without BOM)")
+PY
+else
+  # Fallback without python: reject any high bit via LC_ALL=C grep.
+  if LC_ALL=C grep -n '[^[:print:][:space:]]' "$script" >/dev/null 2>&1; then
+    fail "non-ASCII or non-printable bytes in $script (install python3 for details)"
+  fi
+  # Also reject bytes > 127 that might still be "printable" in some locales: od scan.
+  if od -An -t u1 "$script" | tr -s ' ' '\n' | grep -E '^(1[2-9][0-9]|2[0-9]{2})$' >/dev/null; then
+    fail "byte > 127 found in $script"
+  fi
+  echo "OK: windows-release-smoke.ps1 ASCII check (grep/od fallback)"
+fi
+
+# --- Documented one-liners must exist in script help and RELEASE-SMOKE.md ---
+# Exact operator commands (not loose fragments) so the -File target cannot drift silently.
+for needle in \
+  'pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1' \
+  'powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1'
+do
+  grep -F -q "$needle" "$script" || fail "script missing documented one-liner: $needle"
+  grep -F -q "$needle" "$docs" || fail "docs/RELEASE-SMOKE.md missing documented one-liner: $needle"
+done
+
+# --- Optional: parse with pwsh when present (macOS/Linux CI agents may have it) ---
+# Note: this is PowerShell Core parse, not Desktop 5.1; ASCII byte check is the 5.1 stand-in.
+if command -v pwsh >/dev/null 2>&1; then
+  pwsh -NoProfile -Command "
+    \$path = '$script'
+    \$text = Get-Content -LiteralPath \$path -Raw
+    \$tokens = \$null; \$errors = \$null
+    [void][System.Management.Automation.Language.Parser]::ParseInput(\$text, [ref]\$tokens, [ref]\$errors)
+    if (\$errors -and \$errors.Count -gt 0) {
+      \$errors | ForEach-Object { Write-Host \$_ }
+      exit 1
+    }
+    Write-Host 'OK: pwsh Parser::ParseInput accepted windows-release-smoke.ps1'
+  " || fail "pwsh parse check failed"
+else
+  echo "SKIP: pwsh not installed; ASCII + docs checks only"
+fi
+
+echo "OK: windows-release-smoke.ps1 contract checks passed"

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -50,7 +50,7 @@ fi
 # --- Documented one-liners must exist in script help and RELEASE-SMOKE.md ---
 # Exact operator commands (not loose fragments) so the -File target cannot drift silently.
 for needle in \
-  'pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1' \
+  'pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1' \
   'powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1'
 do
   grep -F -q "$needle" "$script" || fail "script missing documented one-liner: $needle"

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -40,15 +40,11 @@ if non_ascii:
 print("OK: windows-release-smoke.ps1 is ASCII-only (WinPS 5.1-safe without BOM)")
 PY
 else
-  # Fallback without python: reject any high bit via LC_ALL=C grep.
-  if LC_ALL=C grep -n '[^[:print:][:space:]]' "$script" >/dev/null 2>&1; then
-    fail "non-ASCII or non-printable bytes in $script (install python3 for details)"
+  # Fallback without python3: unsigned-byte scan (128-255 only; do not match ASCII 'x'=120).
+  if od -An -t u1 "$script" | tr -s '[:space:]' '\n' | grep -E '^(1[3-9][0-9]|12[89]|2[0-4][0-9]|25[0-5])$' >/dev/null; then
+    fail "byte > 127 found in $script (install python3 for offset details)"
   fi
-  # Also reject bytes > 127 that might still be "printable" in some locales: od scan.
-  if od -An -t u1 "$script" | tr -s ' ' '\n' | grep -E '^(1[2-9][0-9]|2[0-9]{2})$' >/dev/null; then
-    fail "byte > 127 found in $script"
-  fi
-  echo "OK: windows-release-smoke.ps1 ASCII check (grep/od fallback)"
+  echo "OK: windows-release-smoke.ps1 ASCII check (od fallback)"
 fi
 
 # --- Documented one-liners must exist in script help and RELEASE-SMOKE.md ---

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,6 +113,27 @@ val verifyMacosCliBundleReleaseContract by
         outputs.upToDateWhen { false }
     }
 
+val verifyWindowsReleaseSmokeScript by
+    tasks.registering(Exec::class) {
+        description =
+            "Contract tests for scripts/windows-release-smoke.ps1 (ASCII-only for WinPS 5.1, " +
+                "documented Bypass/pwsh one-liners in script + RELEASE-SMOKE.md)."
+        group = "verification"
+        workingDir = rootProject.layout.projectDirectory.asFile
+        commandLine("bash", ".github/scripts/test-windows-release-smoke-script.sh")
+        onlyIf("Unix host with bash") {
+            !System.getProperty("os.name").orEmpty().startsWith("Windows")
+        }
+        inputs
+            .files(
+                "scripts/windows-release-smoke.ps1",
+                "docs/RELEASE-SMOKE.md",
+                ".github/scripts/test-windows-release-smoke-script.sh",
+            )
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+        outputs.upToDateWhen { false }
+    }
+
 // buildSrc is not a project of this build for `dependsOn(":buildSrc:…")`, but its tests
 // cover the shared Windows helper packaging contract. Invoke them via a nested Gradle run
 // on the buildSrc project directory (same pattern as `./gradlew -p buildSrc test`).
@@ -138,6 +159,7 @@ tasks.named("check") {
         verifyCliPackageManifests,
         verifyReleaseVersionScript,
         verifyMacosCliBundleReleaseContract,
+        verifyWindowsReleaseSmokeScript,
         buildSrcUnitTests,
     )
 }

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -167,13 +167,12 @@ Empty hard cells or `n/a` for “no display” on a claimed platform **block the
 
 When you have a Windows desktop for a few minutes, run **one** command from the repo
 root (interactive logon session preferred). Prefer **PowerShell 7+ (`pwsh`)** when
-installed; keep the Windows PowerShell 5.1 form with an explicit process-scoped
-`Bypass` when you only have stock `powershell.exe`.
+installed; both hosts need process-scoped `Bypass` under common **Restricted** policy.
 
 **Preferred (pwsh):**
 
 ```powershell
-pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1
 ```
 
 **Windows PowerShell 5.1 / stock `powershell.exe`:**
@@ -191,7 +190,7 @@ can load it without a BOM).
 From an absolute path (either host; adjust the repo path):
 
 ```powershell
-pwsh -NoProfile -File C:\src\spectre\scripts\windows-release-smoke.ps1
+pwsh -NoProfile -ExecutionPolicy Bypass -File C:\src\spectre\scripts\windows-release-smoke.ps1
 # or:
 powershell -NoProfile -ExecutionPolicy Bypass -File C:\src\spectre\scripts\windows-release-smoke.ps1
 ```

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -166,16 +166,34 @@ Empty hard cells or `n/a` for “no display” on a claimed platform **block the
 ## Windows one-liner script
 
 When you have a Windows desktop for a few minutes, run **one** command from the repo
-root (interactive logon session preferred):
+root (interactive logon session preferred). Prefer **PowerShell 7+ (`pwsh`)** when
+installed; keep the Windows PowerShell 5.1 form with an explicit process-scoped
+`Bypass` when you only have stock `powershell.exe`.
+
+**Preferred (pwsh):**
 
 ```powershell
-.\scripts\windows-release-smoke.ps1
+pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1
 ```
 
-Or from anywhere:
+**Windows PowerShell 5.1 / stock `powershell.exe`:**
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1
+```
+
+`Bypass` applies only to that process; it does not weaken machine policy. A bare
+`.\scripts\windows-release-smoke.ps1` often fails under the common default
+`LocalMachine` **Restricted** policy, and UTF-8 multi-byte punctuation in the
+script historically broke WinPS 5.1 parse (the script is kept **ASCII-only** so 5.1
+can load it without a BOM).
+
+From an absolute path (either host; adjust the repo path):
 
 ```powershell
 pwsh -NoProfile -File C:\src\spectre\scripts\windows-release-smoke.ps1
+# or:
+powershell -NoProfile -ExecutionPolicy Bypass -File C:\src\spectre\scripts\windows-release-smoke.ps1
 ```
 
 What it does (no second terminal):

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -209,28 +209,33 @@ function Write-HostGuidance {
     $ver = $PSVersionTable.PSVersion
     $edition = if ($PSVersionTable.ContainsKey("PSEdition")) { [string]$PSVersionTable.PSEdition } else { "Desktop" }
     Write-Host ("PowerShell: {0} ({1})" -f $ver, $edition) -ForegroundColor DarkGray
-    $processPolicy = $null
-    try { $processPolicy = Get-ExecutionPolicy -Scope Process -ErrorAction SilentlyContinue } catch { $processPolicy = $null }
-    if ($processPolicy -and $processPolicy -ne "Undefined") {
+    # Stringify policy enums: Unrestricted is enum value 0 and is falsy under PowerShell
+    # boolean coercion, so never use bare `$policy` in truthiness checks -- always [string].
+    $processRaw = $null
+    try { $processRaw = Get-ExecutionPolicy -Scope Process -ErrorAction SilentlyContinue } catch { $processRaw = $null }
+    $processPolicy = if ($null -eq $processRaw) { "Undefined" } else { [string]$processRaw }
+    if ($processPolicy -ne "Undefined") {
         Write-Host ("ExecutionPolicy (Process): {0}" -f $processPolicy) -ForegroundColor DarkGray
     }
     # Bare .\script.ps1 uses effective policy without Process override. Scope order:
     # CurrentUser outranks LocalMachine when CurrentUser is not Undefined.
-    $userPolicy = $null
-    $machinePolicy = $null
-    try { $userPolicy = Get-ExecutionPolicy -Scope CurrentUser -ErrorAction SilentlyContinue } catch { $userPolicy = $null }
-    try { $machinePolicy = Get-ExecutionPolicy -Scope LocalMachine -ErrorAction SilentlyContinue } catch { $machinePolicy = $null }
+    $userRaw = $null
+    $machineRaw = $null
+    try { $userRaw = Get-ExecutionPolicy -Scope CurrentUser -ErrorAction SilentlyContinue } catch { $userRaw = $null }
+    try { $machineRaw = Get-ExecutionPolicy -Scope LocalMachine -ErrorAction SilentlyContinue } catch { $machineRaw = $null }
+    $userPolicy = if ($null -eq $userRaw) { "Undefined" } else { [string]$userRaw }
+    $machinePolicy = if ($null -eq $machineRaw) { "Undefined" } else { [string]$machineRaw }
     $bareScope = $null
     $barePolicy = $null
-    if ($userPolicy -and $userPolicy -ne "Undefined") {
+    if ($userPolicy -ne "Undefined") {
         $bareScope = "CurrentUser"
         $barePolicy = $userPolicy
     }
-    elseif ($machinePolicy -and $machinePolicy -ne "Undefined") {
+    elseif ($machinePolicy -ne "Undefined") {
         $bareScope = "LocalMachine"
         $barePolicy = $machinePolicy
     }
-    if ($barePolicy -and ($barePolicy -eq "Restricted" -or $barePolicy -eq "AllSigned")) {
+    if ($barePolicy -eq "Restricted" -or $barePolicy -eq "AllSigned") {
         Write-Host ("ExecutionPolicy ({0}): {1} -- bare .\script.ps1 may fail. Prefer:" -f $bareScope, $barePolicy) -ForegroundColor Yellow
         Write-Host "  pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1" -ForegroundColor Yellow
         Write-Host "  powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1" -ForegroundColor Yellow

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -15,19 +15,19 @@
   (WinPS 5.1 defaults to the system ANSI code page for BOM-less sources).
 
   Invocation: prefer one of the .EXAMPLE one-liners below. Direct `.\scripts\...` often fails under
-  the default LocalMachine Restricted ExecutionPolicy. Use -ExecutionPolicy Bypass on the process
-  (does not change machine policy) or run via pwsh, which typically allows local scripts.
+  the default LocalMachine Restricted ExecutionPolicy. Always pass -ExecutionPolicy Bypass on the
+  process (does not change machine policy) for both pwsh and Windows PowerShell 5.1.
 
 .EXAMPLE
-  # Preferred when PowerShell 7+ is installed (local scripts usually allowed):
-  pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1
+  # Preferred when PowerShell 7+ is installed (Bypass is process-scoped only):
+  pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1
 
 .EXAMPLE
-  # Windows PowerShell 5.1 / stock powershell.exe (Bypass is process-scoped only):
+  # Windows PowerShell 5.1 / stock powershell.exe:
   powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1
 
 .EXAMPLE
-  pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1 -SkipWgc -SkipCli
+  pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1 -SkipWgc -SkipCli
 #>
 [CmdletBinding()]
 param(
@@ -214,20 +214,25 @@ function Write-HostGuidance {
     if ($processPolicy -and $processPolicy -ne "Undefined") {
         Write-Host ("ExecutionPolicy (Process): {0}" -f $processPolicy) -ForegroundColor DarkGray
     }
-    $blockingScope = $null
-    $blockingValue = $null
-    foreach ($scope in @("LocalMachine", "CurrentUser")) {
-        $value = $null
-        try { $value = Get-ExecutionPolicy -Scope $scope -ErrorAction SilentlyContinue } catch { $value = $null }
-        if ($value -and ($value -eq "Restricted" -or $value -eq "AllSigned")) {
-            $blockingScope = $scope
-            $blockingValue = $value
-            break
-        }
+    # Bare .\script.ps1 uses effective policy without Process override. Scope order:
+    # CurrentUser outranks LocalMachine when CurrentUser is not Undefined.
+    $userPolicy = $null
+    $machinePolicy = $null
+    try { $userPolicy = Get-ExecutionPolicy -Scope CurrentUser -ErrorAction SilentlyContinue } catch { $userPolicy = $null }
+    try { $machinePolicy = Get-ExecutionPolicy -Scope LocalMachine -ErrorAction SilentlyContinue } catch { $machinePolicy = $null }
+    $bareScope = $null
+    $barePolicy = $null
+    if ($userPolicy -and $userPolicy -ne "Undefined") {
+        $bareScope = "CurrentUser"
+        $barePolicy = $userPolicy
     }
-    if ($blockingScope) {
-        Write-Host ("ExecutionPolicy ({0}): {1} -- bare .\script.ps1 may fail. Prefer:" -f $blockingScope, $blockingValue) -ForegroundColor Yellow
-        Write-Host "  pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1" -ForegroundColor Yellow
+    elseif ($machinePolicy -and $machinePolicy -ne "Undefined") {
+        $bareScope = "LocalMachine"
+        $barePolicy = $machinePolicy
+    }
+    if ($barePolicy -and ($barePolicy -eq "Restricted" -or $barePolicy -eq "AllSigned")) {
+        Write-Host ("ExecutionPolicy ({0}): {1} -- bare .\script.ps1 may fail. Prefer:" -f $bareScope, $barePolicy) -ForegroundColor Yellow
+        Write-Host "  pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1" -ForegroundColor Yellow
         Write-Host "  powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1" -ForegroundColor Yellow
     }
 }

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -9,16 +9,25 @@
 
   PowerShell note: Gradle -P properties with dots must be quoted (this script does that).
 
-  `spectre launch -- … gradlew …` prints a Gradle-ish warning by design — still a valid smoke.
+  `spectre launch -- ... gradlew ...` prints a Gradle-ish warning by design -- still a valid smoke.
+
+  Encoding: this file is ASCII-only so Windows PowerShell 5.1 can parse it without a UTF-8 BOM
+  (WinPS 5.1 defaults to the system ANSI code page for BOM-less sources).
+
+  Invocation: prefer one of the .EXAMPLE one-liners below. Direct `.\scripts\...` often fails under
+  the default LocalMachine Restricted ExecutionPolicy. Use -ExecutionPolicy Bypass on the process
+  (does not change machine policy) or run via pwsh, which typically allows local scripts.
 
 .EXAMPLE
-  .\scripts\windows-release-smoke.ps1
+  # Preferred when PowerShell 7+ is installed (local scripts usually allowed):
+  pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1
 
 .EXAMPLE
-  pwsh -NoProfile -File C:\src\spectre\scripts\windows-release-smoke.ps1
+  # Windows PowerShell 5.1 / stock powershell.exe (Bypass is process-scoped only):
+  powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1
 
 .EXAMPLE
-  .\scripts\windows-release-smoke.ps1 -SkipWgc -SkipCli
+  pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1 -SkipWgc -SkipCli
 #>
 [CmdletBinding()]
 param(
@@ -192,6 +201,31 @@ function Save-SmokeReport {
 
 # --- main ---
 
+function Write-HostGuidance {
+    # Operator-facing reminder when the host is stock WinPS under a blocking policy.
+    # Encoding/parse failures happen before any of this runs; keep the file ASCII-only.
+    $ver = $PSVersionTable.PSVersion
+    $edition = if ($PSVersionTable.ContainsKey("PSEdition")) { [string]$PSVersionTable.PSEdition } else { "Desktop" }
+    Write-Host ("PowerShell: {0} ({1})" -f $ver, $edition) -ForegroundColor DarkGray
+    $processPolicy = $null
+    try { $processPolicy = Get-ExecutionPolicy -Scope Process -ErrorAction SilentlyContinue } catch { $processPolicy = $null }
+    $effectivePolicy = $null
+    try { $effectivePolicy = Get-ExecutionPolicy -ErrorAction SilentlyContinue } catch { $effectivePolicy = $null }
+    if ($processPolicy -and $processPolicy -ne "Undefined") {
+        Write-Host ("ExecutionPolicy (Process): {0}" -f $processPolicy) -ForegroundColor DarkGray
+    }
+    elseif ($effectivePolicy -and $effectivePolicy -ne "Undefined") {
+        Write-Host ("ExecutionPolicy: {0}" -f $effectivePolicy) -ForegroundColor DarkGray
+    }
+    # Only steer when the effective policy would block a bare .\script.ps1 re-run.
+    # (Encoding/parse death cannot be recovered here -- keep the file ASCII-only.)
+    if ($effectivePolicy -and ($effectivePolicy -eq "Restricted" -or $effectivePolicy -eq "AllSigned")) {
+        Write-Host "ExecutionPolicy is $effectivePolicy; bare .\script.ps1 may fail next time. Prefer:" -ForegroundColor Yellow
+        Write-Host "  pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1" -ForegroundColor Yellow
+        Write-Host "  powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1" -ForegroundColor Yellow
+    }
+}
+
 try {
     if ($env:OS -ne "Windows_NT") {
         throw "This script is Windows-only (current OS: $([System.Environment]::OSVersion.VersionString))"
@@ -205,6 +239,7 @@ try {
     try { $sha = [string](git -C $repoRoot rev-parse --short HEAD 2>$null) } catch { $sha = "" }
     if ($sha) { Write-Host ("SHA:  {0}" -f $sha) }
     Write-Host ("Host: {0}  User: {1}" -f $env:COMPUTERNAME, $env:USERNAME)
+    Write-HostGuidance
 
     $results = New-Object System.Collections.ArrayList
 
@@ -248,7 +283,7 @@ try {
         $step = Invoke-Step -Name "Packaged spectre launch --once (fixture)" -Action {
             $spectre = Get-PackagedSpectre -RepoRoot $repoRoot
             if (-not $spectre) {
-                throw "spectre.exe not found under cli\build\construo\windowsX64\roast\ — run without -SkipPackageCli"
+                throw "spectre.exe not found under cli\build\construo\windowsX64\roast\ -- run without -SkipPackageCli"
             }
             Write-Host ("  using {0}" -f $spectre) -ForegroundColor DarkGray
             Write-Host "  note: Gradle-ish launch warning is expected for ':agent-test-fixture:run'" -ForegroundColor DarkGray

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -202,25 +202,31 @@ function Save-SmokeReport {
 # --- main ---
 
 function Write-HostGuidance {
-    # Operator-facing reminder when the host is stock WinPS under a blocking policy.
-    # Encoding/parse failures happen before any of this runs; keep the file ASCII-only.
+    # Operator-facing reminder. Encoding/parse failures happen before any of this runs
+    # (keep the file ASCII-only). Process-scoped Bypass makes effective policy Bypass, so
+    # inspect LocalMachine/CurrentUser scopes for the stock Restricted case operators hit
+    # with bare .\script.ps1.
     $ver = $PSVersionTable.PSVersion
     $edition = if ($PSVersionTable.ContainsKey("PSEdition")) { [string]$PSVersionTable.PSEdition } else { "Desktop" }
     Write-Host ("PowerShell: {0} ({1})" -f $ver, $edition) -ForegroundColor DarkGray
     $processPolicy = $null
     try { $processPolicy = Get-ExecutionPolicy -Scope Process -ErrorAction SilentlyContinue } catch { $processPolicy = $null }
-    $effectivePolicy = $null
-    try { $effectivePolicy = Get-ExecutionPolicy -ErrorAction SilentlyContinue } catch { $effectivePolicy = $null }
     if ($processPolicy -and $processPolicy -ne "Undefined") {
         Write-Host ("ExecutionPolicy (Process): {0}" -f $processPolicy) -ForegroundColor DarkGray
     }
-    elseif ($effectivePolicy -and $effectivePolicy -ne "Undefined") {
-        Write-Host ("ExecutionPolicy: {0}" -f $effectivePolicy) -ForegroundColor DarkGray
+    $blockingScope = $null
+    $blockingValue = $null
+    foreach ($scope in @("LocalMachine", "CurrentUser")) {
+        $value = $null
+        try { $value = Get-ExecutionPolicy -Scope $scope -ErrorAction SilentlyContinue } catch { $value = $null }
+        if ($value -and ($value -eq "Restricted" -or $value -eq "AllSigned")) {
+            $blockingScope = $scope
+            $blockingValue = $value
+            break
+        }
     }
-    # Only steer when the effective policy would block a bare .\script.ps1 re-run.
-    # (Encoding/parse death cannot be recovered here -- keep the file ASCII-only.)
-    if ($effectivePolicy -and ($effectivePolicy -eq "Restricted" -or $effectivePolicy -eq "AllSigned")) {
-        Write-Host "ExecutionPolicy is $effectivePolicy; bare .\script.ps1 may fail next time. Prefer:" -ForegroundColor Yellow
+    if ($blockingScope) {
+        Write-Host ("ExecutionPolicy ({0}): {1} -- bare .\script.ps1 may fail. Prefer:" -f $blockingScope, $blockingValue) -ForegroundColor Yellow
         Write-Host "  pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1" -ForegroundColor Yellow
         Write-Host "  powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1" -ForegroundColor Yellow
     }


### PR DESCRIPTION
## Summary

Makes the Windows pre-tag release smoke one-liner work on stock Mattone-class boxes under **Windows PowerShell 5.1** and common **Restricted** ExecutionPolicy, without changing the three smoke steps.

- **Encoding:** `scripts/windows-release-smoke.ps1` is now **ASCII-only** (removed ellipsis/em dash). WinPS 5.1 no longer mis-parses BOM-less UTF-8 multi-byte punctuation as the system ANSI code page.
- **Invocation:** Documented one-liners prefer `pwsh -NoProfile -File …` when present, and `powershell -NoProfile -ExecutionPolicy Bypass -File …` for stock 5.1 (process-scoped only; does not weaken machine policy). Bare `.\scripts\…` is demoted.
- **Operator guidance:** After successful load, print PS version/policy; if effective policy is Restricted/AllSigned, print the preferred re-run commands.
- **Docs/skill:** `docs/RELEASE-SMOKE.md` and `spectre-release` skill match the working commands.
- **Contract:** `.github/scripts/test-windows-release-smoke-script.sh` (ASCII + exact one-liners) wired into `./gradlew check` as `verifyWindowsReleaseSmokeScript`.

Fixes #385.

## Test plan

- [x] Local: `bash .github/scripts/test-windows-release-smoke-script.sh` (ASCII + docs needles)
- [x] Local: `./gradlew verifyWindowsReleaseSmokeScript`
- [x] Windows Mattone (`ssh rock3r@192.168.1.8`):
  - Main script with non-ASCII under `powershell -ExecutionPolicy Bypass -File` → parse fail at em dash (reproduced)
  - Fixed script: `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1 -SkipAgentE2e -SkipWgc -SkipCli` → starts, **ALL PASSED** (empty steps) on WinPS 5.1.26100
  - Fixed script: `pwsh -NoProfile -File .\scripts\windows-release-smoke.ps1 -SkipAgentE2e -SkipWgc -SkipCli` → **ALL PASSED** on pwsh 7.6.3
- [ ] CI: `check` green on this PR

## Non-goals (unchanged)

Agent attach / WGC / CLI product behaviour; rewrite of the three smoke step bodies beyond launch reliability.