### PR TITLE
feat(testing): JUnit failure-video policy off | onFailureKeep | always (#206)

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -254,7 +254,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest NewInteractionsValidationTest SampleAppFixtureStartupDiagnosticsTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest NewInteractionsValidationTest SampleAppFixtureStartupDiagnosticsTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -164,7 +164,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest SampleAppFixtureStartupDiagnosticsTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest SampleAppFixtureStartupDiagnosticsTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -28,6 +28,13 @@ dependencies {
     testImplementation(projects.core)
     // Shared automator contract corpus + capability matrix (#198).
     testImplementation(projects.testing)
+    // `:testing` implementation-depends on `:recording` for failure-video (#206). That puts
+    // the native-window-capture bridge on the test/fixture classpath; without the platform
+    // helper jars, window screenshots fail with "Bundled helper app not found" instead of
+    // falling back. Match sample-desktop's runtime helper wiring for attach e2e.
+    testRuntimeOnly(projects.recordingMacos)
+    testRuntimeOnly(projects.recordingLinux)
+    testRuntimeOnly(projects.recordingWindows)
     testImplementation(libs.kotlinx.coroutines.core)
     testImplementation(libs.kotlin.testJunit5)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -22,9 +22,8 @@ spectre
 sample-desktop          ─┐
 sample-intellij-plugin   ├──> core
 server                   │
-testing                 ─┘
-
-recording                (isolated desktop/native integration API)
+testing                 ─┴──> recording   (failure-video #206 uses AutoRecorder)
+                               ↑
 recording-macos    ─┐
 recording-linux     ├──> recording (runtime helper artifacts)
 recording-windows  ─┘

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -272,6 +272,28 @@ compositor and not raw framebuffer reads.
 - The handle MUST be stopped (`RecordingHandle.stop(...)`) for the file to be flushed cleanly. A
   JVM exit without stop leaves a partial/non-finalised file and an orphaned subprocess.
 
+## JUnit failure-video policy (#206)
+
+`ComposeAutomatorExtension` / `ComposeAutomatorRule` can record the whole test and keep or
+delete the file at the end (`FailureVideoPolicy`: `Off` | `OnFailureKeep` | `Always`). See
+[JUnit integration — Failure video](guide/junit.md#failure-video).
+
+Honest overhead notes (policy defaults to **`Off`** for a reason):
+
+- **Per-OS cost** — the same backends as `AutoRecorder` run for the full test duration
+  (ScreenCaptureKit helper on macOS, Windows Graphics Capture helper on Windows, GStreamer
+  X11 / Wayland portal on Linux). CPU, encoder, and helper-process cost scale with test
+  length and resolution; capability and permission limits on this page still apply.
+- **Disk under `OnFailureKeep`** — the video file is written during **every** invocation
+  (including green tests) and only deleted after stop+finalize on pass. Parallel suites and
+  long-running tests can therefore spike disk use during the run even when nothing remains
+  after a green suite.
+- **Stop before delete** — Spectre always stops the recorder and finalizes the file before
+  applying keep/delete. A JVM exit without teardown can still leave a partial file and an
+  orphaned helper (same as any other `RecordingHandle` — see process lifecycle above).
+- **In-process JUnit only** — this policy does not cover agent/attach / CLI `spectre record`
+  paths; those remain separate entry points.
+
 ## Current non-limitations
 
 - Cursor capture is configurable via `RecordingOptions.captureCursor` and works under the region

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -318,6 +318,82 @@ On JUnit 5, each written window directory is published as a report entry under t
 
 Point CI at the reports tree with a single upload glob — see [Running on CI](ci.md#failure-artifacts).
 
+## Failure video
+
+You cannot record a failure retroactively, so video-of-a-failure means recording the **whole
+test** and deciding at the end whether to keep the file. Configure this with
+`FailureVideoConfig` next to stills config on `ComposeAutomatorExtension` /
+`ComposeAutomatorRule`.
+
+Default is **`FailureVideoPolicy.Off`** — no recorder overhead on green CI. Opt in per suite:
+
+| Policy | Behaviour |
+| --- | --- |
+| `Off` | Default. No recording starts. |
+| `OnFailureKeep` | Record the whole test; **delete** the finalized file on pass; **keep** on fail. |
+| `Always` | Keep the finalized video on pass and fail. |
+
+```kotlin
+import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
+import dev.sebastiano.spectre.testing.FailureVideoConfig
+import dev.sebastiano.spectre.testing.FailureVideoPolicy
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@JvmField
+@RegisterExtension
+val automatorExt =
+    ComposeAutomatorExtension(
+        failureVideo =
+            FailureVideoConfig(policy = FailureVideoPolicy.OnFailureKeep),
+    )
+```
+
+```kotlin
+import dev.sebastiano.spectre.testing.ComposeAutomatorRule
+import dev.sebastiano.spectre.testing.FailureVideoConfig
+import dev.sebastiano.spectre.testing.FailureVideoPolicy
+import org.junit.Rule
+
+@get:Rule
+val automatorRule =
+    ComposeAutomatorRule(
+        failureVideo =
+            FailureVideoConfig(policy = FailureVideoPolicy.OnFailureKeep),
+    )
+```
+
+### Layout
+
+Videos land under the **same reports tree** as stills (same class/method/invocation/`attempt-N`
+nesting), as a sibling file:
+
+```text
+build/reports/spectre/<test-class>/<test-method>[/<invocation>][/attempt-N]/
+  failure-video.mp4          ← when the policy keeps the file
+  run-*/window-<i>/…         ← stills (#205), independent of video policy
+```
+
+Stills stay default-on and are independent of the video policy. Aborted tests (JUnit assumptions)
+never keep a failure video — same skip semantics as stills. On JUnit 5, a kept video is published
+as a report entry under `spectre.failureVideo`.
+
+### Overhead (honest)
+
+Recording every test is real cost. Prefer `Off` on CI unless you need video for a flaky suite.
+
+- **CPU / helper process** — a platform recorder runs for the full test duration (ScreenCaptureKit
+  helper on macOS, Windows Graphics Capture helper on Windows, GStreamer / portal paths on Linux).
+  See [Recording limitations](../RECORDING-LIMITATIONS.md) for per-OS backend behaviour and
+  permissions.
+- **Disk under `OnFailureKeep`** — the file is written for **every** invocation (including green
+  tests) and only deleted after the recorder stops and finalizes. Parallel suites and long tests
+  can spike disk during the run even when nothing is left on pass.
+- **Permissions** — macOS Screen Recording TCC, Windows helper packaging, and Wayland portal
+  consent still apply; if the backend cannot start, video is skipped best-effort (the test
+  outcome is never replaced by a recorder error).
+- **Scope** — this policy is for **in-process** JUnit wrappers only. Agent/attach recording stays
+  on the CLI/daemon path (`spectre record`), not this config.
+
 ## Custom `AutomatorFactory`
 
 Both wrappers default to `ComposeAutomator.inProcess()`. Pass your own factory when you

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/FailureVideoValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/FailureVideoValidationTest.kt
@@ -1,0 +1,325 @@
+package dev.sebastiano.spectre.sample.validation
+
+import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
+import dev.sebastiano.spectre.testing.ComposeAutomatorRule
+import dev.sebastiano.spectre.testing.FailureArtifactsConfig
+import dev.sebastiano.spectre.testing.FailureVideoConfig
+import dev.sebastiano.spectre.testing.FailureVideoPolicy
+import java.awt.GraphicsEnvironment
+import java.lang.reflect.AnnotatedElement
+import java.lang.reflect.Method
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.Optional
+import java.util.concurrent.ConcurrentHashMap
+import java.util.function.Function
+import kotlin.io.path.isRegularFile
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.ExecutableInvoker
+import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.jupiter.api.extension.TestInstances
+import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.api.parallel.ExecutionMode
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+/**
+ * Live acceptance for failure-video (#206) on a headed display with real
+ * [dev.sebastiano.spectre.recording.AutoRecorder] backends.
+ *
+ * Skips cleanly when headless or when the platform recorder cannot start (TCC / missing helper) —
+ * unit tests cover policy/lifecycle with a fake starter.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class FailureVideoValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre failure-video validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `JUnit 4 onFailureKeep keeps playable video on fail and deletes on pass`(
+        @TempDir reportsRoot: Path
+    ): Unit = runBlocking {
+        settleFixture()
+        val failRoot = reportsRoot.resolve("fail")
+        Files.createDirectories(failRoot)
+        val failRule =
+            ComposeAutomatorRule(
+                factory = { fixture.automator },
+                failureArtifacts = FailureArtifactsConfig(enabled = false, reportsRoot = failRoot),
+                failureVideo =
+                    FailureVideoConfig(
+                        policy = FailureVideoPolicy.OnFailureKeep,
+                        reportsRoot = failRoot,
+                        invocationId = "validation-fail",
+                    ),
+            )
+        val failStatement =
+            failRule.apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        // Hold the recording open long enough for backends to write frames.
+                        Thread.sleep(1_200)
+                        error("intentional failure for failure-video")
+                    }
+                },
+                Description.createTestDescription(
+                    FailureVideoValidationTest::class.java.name,
+                    "intentionalFailVideoJ4",
+                ),
+            )
+        try {
+            failStatement.evaluate()
+            error("expected intentional failure")
+        } catch (expected: IllegalStateException) {
+            assertEquals("intentional failure for failure-video", expected.message)
+        }
+        val kept = findVideos(failRoot)
+        assumeTrue(
+            kept.isNotEmpty(),
+            "recorder did not produce a file (TCC / helper / platform backend unavailable)",
+        )
+        assertEquals(1, kept.size)
+        assertTrue(Files.size(kept.single()) > 0, "kept video must be non-empty: ${kept.single()}")
+
+        val passRoot = reportsRoot.resolve("pass")
+        Files.createDirectories(passRoot)
+        val passRule =
+            ComposeAutomatorRule(
+                factory = { fixture.automator },
+                failureArtifacts = FailureArtifactsConfig(enabled = false, reportsRoot = passRoot),
+                failureVideo =
+                    FailureVideoConfig(
+                        policy = FailureVideoPolicy.OnFailureKeep,
+                        reportsRoot = passRoot,
+                        invocationId = "validation-pass",
+                    ),
+            )
+        passRule
+            .apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        Thread.sleep(400)
+                    }
+                },
+                Description.createTestDescription(
+                    FailureVideoValidationTest::class.java.name,
+                    "intentionalPassVideoJ4",
+                ),
+            )
+            .evaluate()
+        assertTrue(
+            findVideos(passRoot).isEmpty(),
+            "onFailureKeep must delete video on pass under $passRoot",
+        )
+    }
+
+    @Test
+    fun `JUnit 5 Always keeps video on pass`(@TempDir reportsRoot: Path): Unit = runBlocking {
+        settleFixture()
+        val extension =
+            ComposeAutomatorExtension(
+                factory = { fixture.automator },
+                failureArtifacts =
+                    FailureArtifactsConfig(enabled = false, reportsRoot = reportsRoot),
+                failureVideo =
+                    FailureVideoConfig(
+                        policy = FailureVideoPolicy.Always,
+                        reportsRoot = reportsRoot,
+                        invocationId = "validation-always",
+                    ),
+            )
+        val context =
+            VideoRecordingExtensionContext(
+                failure = null,
+                testClass = FailureVideoValidationTest::class.java,
+                methodName = "alwaysPassMarker",
+            )
+        extension.beforeEach(context)
+        Thread.sleep(1_200)
+        extension.afterEach(context)
+        val kept = findVideos(reportsRoot)
+        assumeTrue(
+            kept.isNotEmpty(),
+            "recorder did not produce a file (TCC / helper / platform backend unavailable)",
+        )
+        assertTrue(Files.size(kept.single()) > 0)
+    }
+
+    @Test
+    fun `Off policy leaves no video even on failure`(@TempDir reportsRoot: Path): Unit =
+        runBlocking {
+            settleFixture()
+            val rule =
+                ComposeAutomatorRule(
+                    factory = { fixture.automator },
+                    failureArtifacts =
+                        FailureArtifactsConfig(enabled = false, reportsRoot = reportsRoot),
+                    failureVideo =
+                        FailureVideoConfig(
+                            policy = FailureVideoPolicy.Off,
+                            reportsRoot = reportsRoot,
+                        ),
+                )
+            val statement =
+                rule.apply(
+                    object : Statement() {
+                        override fun evaluate() {
+                            error("fail with video off")
+                        }
+                    },
+                    Description.createTestDescription(
+                        FailureVideoValidationTest::class.java.name,
+                        "offPolicyFail",
+                    ),
+                )
+            try {
+                statement.evaluate()
+            } catch (_: IllegalStateException) {
+                // expected
+            }
+            assertFalse(
+                Files.walk(reportsRoot).use { s -> s.anyMatch { Files.isRegularFile(it) } },
+                "Off must not write under $reportsRoot",
+            )
+        }
+
+    @Suppress("unused") fun alwaysPassMarker() {}
+
+    private suspend fun settleFixture() {
+        with(fixture.automator) {
+            refreshWindows()
+            waitForIdle()
+        }
+        assertTrue(fixture.automator.surfaceIds().isNotEmpty(), "fixture must track a window")
+    }
+
+    private fun findVideos(root: Path): List<Path> {
+        if (!Files.exists(root)) return emptyList()
+        return Files.walk(root).use { stream ->
+            stream
+                .filter { path ->
+                    path.isRegularFile() && path.fileName.toString() == "failure-video.mp4"
+                }
+                .toList()
+        }
+    }
+}
+
+/** Minimal [ExtensionContext] for live validation of failure-video lifecycle. */
+internal class VideoRecordingExtensionContext(
+    private val failure: Throwable?,
+    private val testClass: Class<*>,
+    private val methodName: String,
+    val reportEntries: MutableList<Map<String, String>> = mutableListOf(),
+) : ExtensionContext {
+
+    private val stores = ConcurrentHashMap<ExtensionContext.Namespace, ExtensionContext.Store>()
+    private val uniqueId = "[engine:junit-jupiter]/class:${testClass.name}][method:$methodName()]"
+
+    override fun getParent(): Optional<ExtensionContext> = Optional.empty()
+
+    override fun getRoot(): ExtensionContext = this
+
+    override fun getUniqueId(): String = uniqueId
+
+    override fun getDisplayName(): String = methodName
+
+    override fun getTags(): Set<String> = emptySet()
+
+    override fun getElement(): Optional<AnnotatedElement> = Optional.empty()
+
+    override fun getTestClass(): Optional<Class<*>> = Optional.of(testClass)
+
+    override fun getTestInstanceLifecycle(): Optional<TestInstance.Lifecycle> =
+        Optional.of(TestInstance.Lifecycle.PER_CLASS)
+
+    override fun getTestInstance(): Optional<Any> = Optional.empty()
+
+    override fun getTestInstances(): Optional<TestInstances> = Optional.empty()
+
+    override fun getTestMethod(): Optional<Method> =
+        Optional.of(testClass.getDeclaredMethod(methodName))
+
+    override fun getExecutionException(): Optional<Throwable> = Optional.ofNullable(failure)
+
+    override fun getConfigurationParameter(key: String): Optional<String> = Optional.empty()
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : Any?> getConfigurationParameter(
+        key: String,
+        transformer: Function<String, T>,
+    ): Optional<T> = Optional.empty<Any>() as Optional<T>
+
+    override fun publishReportEntry(map: Map<String, String>) {
+        reportEntries += map
+    }
+
+    override fun getStore(namespace: ExtensionContext.Namespace): ExtensionContext.Store =
+        stores.computeIfAbsent(namespace) { MapBackedVideoStore() }
+
+    override fun getExecutionMode(): ExecutionMode = ExecutionMode.SAME_THREAD
+
+    override fun getExecutableInvoker(): ExecutableInvoker =
+        object : ExecutableInvoker {
+            override fun invoke(method: Method, target: Any?): Any =
+                throw UnsupportedOperationException("not used")
+
+            override fun <T : Any?> invoke(
+                constructor: java.lang.reflect.Constructor<T>,
+                outerInstance: Any?,
+            ): T = throw UnsupportedOperationException("not used")
+        }
+}
+
+private class MapBackedVideoStore : ExtensionContext.Store {
+    private val map = ConcurrentHashMap<Any, Any?>()
+
+    override fun get(key: Any): Any? = map[key]
+
+    override fun <V : Any?> get(key: Any, requiredType: Class<V>): V? {
+        val value = map[key] ?: return null
+        return requiredType.cast(value)
+    }
+
+    override fun <K : Any?, V : Any?> getOrComputeIfAbsent(
+        key: K,
+        defaultCreator: Function<K, V>,
+    ): Any? {
+        @Suppress("UNCHECKED_CAST")
+        return map.computeIfAbsent(key as Any) { defaultCreator.apply(key) }
+    }
+
+    override fun <K : Any?, V : Any?> getOrComputeIfAbsent(
+        key: K,
+        defaultCreator: Function<K, V>,
+        requiredType: Class<V>,
+    ): V = requiredType.cast(getOrComputeIfAbsent(key, defaultCreator))
+
+    override fun put(key: Any, value: Any?) {
+        if (value == null) map.remove(key) else map[key] = value
+    }
+
+    override fun remove(key: Any): Any? = map.remove(key)
+
+    override fun <V : Any?> remove(key: Any, requiredType: Class<V>): V? {
+        val value = map.remove(key) ?: return null
+        return requiredType.cast(value)
+    }
+}

--- a/skills/spectre/references/junit.md
+++ b/skills/spectre/references/junit.md
@@ -96,6 +96,21 @@ val automatorExt = ComposeAutomatorExtension {
 
 The JUnit 4 rule is identical: `ComposeAutomatorRule { ComposeAutomator.inProcess(...) }`.
 
+## Failure video (#206)
+
+Optional whole-test recording via `FailureVideoConfig` (default
+`FailureVideoPolicy.Off`). Policies: `Off` | `OnFailureKeep` (delete on pass,
+keep on fail) | `Always`. Output: `build/reports/spectre/<class>/<method>/failure-video.mp4`
+next to stills. Independent of still failure artifacts. In-process JUnit only —
+see the user guide (`docs/guide/junit.md#failure-video`) and
+`docs/RECORDING-LIMITATIONS.md` for overhead.
+
+```kotlin
+ComposeAutomatorExtension(
+    failureVideo = FailureVideoConfig(policy = FailureVideoPolicy.OnFailureKeep),
+)
+```
+
 ## Lifecycle notes
 
 - The extension/rule does **not** open a Compose window for you. Launch your

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -5,6 +5,7 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : or
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
 	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun afterTestExecution (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
@@ -22,6 +23,7 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/jun
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
 	public fun after ()V
 	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
 	public fun before ()V

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -5,6 +5,7 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : or
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
 	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun afterTestExecution (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
@@ -23,6 +24,7 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/jun
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
 	public fun after ()V
 	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -1,8 +1,10 @@
 public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/AfterTestExecutionCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/LifecycleMethodExecutionExceptionHandler, org/junit/jupiter/api/extension/ParameterResolver {
 	public fun <init> ()V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun afterTestExecution (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
@@ -16,8 +18,10 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : or
 public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/junit/rules/ExternalResource {
 	public fun <init> ()V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
-	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun after ()V
 	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
 	public fun before ()V
@@ -54,6 +58,34 @@ public final class dev/sebastiano/spectre/testing/FailureArtifactsConfig {
 	public final fun getReportsRoot ()Ljava/nio/file/Path;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/testing/FailureVideoConfig {
+	public fun <init> ()V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureVideoPolicy;Ljava/nio/file/Path;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureVideoPolicy;Ljava/nio/file/Path;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/sebastiano/spectre/testing/FailureVideoPolicy;
+	public final fun component2 ()Ljava/nio/file/Path;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ldev/sebastiano/spectre/testing/FailureVideoPolicy;Ljava/nio/file/Path;Ljava/lang/Integer;Ljava/lang/String;)Ldev/sebastiano/spectre/testing/FailureVideoConfig;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/testing/FailureVideoConfig;Ldev/sebastiano/spectre/testing/FailureVideoPolicy;Ljava/nio/file/Path;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/testing/FailureVideoConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttemptIndex ()Ljava/lang/Integer;
+	public final fun getInvocationId ()Ljava/lang/String;
+	public final fun getPolicy ()Ldev/sebastiano/spectre/testing/FailureVideoPolicy;
+	public final fun getReportsRoot ()Ljava/nio/file/Path;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/testing/FailureVideoPolicy : java/lang/Enum {
+	public static final field Always Ldev/sebastiano/spectre/testing/FailureVideoPolicy;
+	public static final field Off Ldev/sebastiano/spectre/testing/FailureVideoPolicy;
+	public static final field OnFailureKeep Ldev/sebastiano/spectre/testing/FailureVideoPolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/testing/FailureVideoPolicy;
+	public static fun values ()[Ldev/sebastiano/spectre/testing/FailureVideoPolicy;
 }
 
 public final class dev/sebastiano/spectre/testing/LaunchAndAttachExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/ParameterResolver {

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -40,11 +40,9 @@ dependencies {
     testRuntimeOnly(libs.junit5.vintageEngine)
     // Runtime jar path for attach e2es that launch fixtures via the harness.
     testRuntimeOnly(projects.agentRuntime)
-    // Platform helpers only needed when unit tests exercise the real AutoFailureVideoStarter;
-    // fake-starter tests do not need them. sample-desktop validation supplies its own runtimeOnly.
-    testRuntimeOnly(projects.recordingMacos)
-    testRuntimeOnly(projects.recordingLinux)
-    testRuntimeOnly(projects.recordingWindows)
+    // Do not testRuntimeOnly recording platform helpers here: unit tests inject fake
+    // FailureVideoStarters and must not force cargo/Swift/.NET helper builds on check.
+    // Live recording uses sample-desktop validation runtimeOnly and :agent testRuntimeOnly.
 }
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     // Launch-and-attach JUnit surface (#208) composes over the experimental agent launch API.
     // Kept as `api` so consumers see `LaunchSpec` / `LaunchedSession` types from the extension.
     api(projects.agent)
+    // Failure-video (#206) uses AutoRecorder / RecordingHandle; implementation so public API stays
+    // FailureVideoConfig/Policy only (not a re-export of the full recording surface).
+    implementation(projects.recording)
     // Public runSpectreTest surface exposes CoroutineScope / CoroutineContext; core only
     // implementation()-depends on coroutines, so re-export here for consumers of :testing.
     api(libs.kotlinx.coroutines.core)
@@ -37,6 +40,11 @@ dependencies {
     testRuntimeOnly(libs.junit5.vintageEngine)
     // Runtime jar path for attach e2es that launch fixtures via the harness.
     testRuntimeOnly(projects.agentRuntime)
+    // Platform helpers only needed when unit tests exercise the real AutoFailureVideoStarter;
+    // fake-starter tests do not need them. sample-desktop validation supplies its own runtimeOnly.
+    testRuntimeOnly(projects.recordingMacos)
+    testRuntimeOnly(projects.recordingLinux)
+    testRuntimeOnly(projects.recordingWindows)
 }
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutoFailureVideoStarter.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutoFailureVideoStarter.kt
@@ -70,26 +70,14 @@ internal object AutoFailureVideoStarter : FailureVideoStarter {
         identity: WindowIdentitySnapshot,
         output: Path,
     ): RecordingHandle? {
-        val userSpace =
+        // Pass AWT user-space bounds unchanged — same contract as startFullscreenRegion and
+        // other AutoRecorder.startRegion callers (locationOnScreen / GraphicsConfiguration.bounds).
+        // Do not multiply by scaleX/scaleY; that double-scales on HiDPI.
+        val bounds =
             identity.surfaceBoundsOnScreen.takeIf { it.width > 0 && it.height > 0 }
                 ?: identity.windowBoundsOnScreen.takeIf { it.width > 0 && it.height > 0 }
                 ?: return null
-        // Region recorders consume device-pixel coordinates; WindowIdentitySnapshot bounds are
-        // AWT user space. Convert with the snapshot transform (same formula as window-identity
-        // docs) so HiDPI/Retina fallbacks target the correct monitor rect.
-        val region = toDevicePixels(userSpace, identity)
-        if (region.width <= 0 || region.height <= 0) return null
-        return runCatching { recorder.startRegion(region = region, output = output) }.getOrNull()
-    }
-
-    private fun toDevicePixels(userSpace: Rectangle, identity: WindowIdentitySnapshot): Rectangle {
-        val scaleX = identity.scaleX.takeIf { it > 0.0 } ?: 1.0
-        val scaleY = identity.scaleY.takeIf { it > 0.0 } ?: 1.0
-        val x = (userSpace.x * scaleX + identity.translateX).toInt()
-        val y = (userSpace.y * scaleY + identity.translateY).toInt()
-        val width = (userSpace.width * scaleX).toInt().coerceAtLeast(1)
-        val height = (userSpace.height * scaleY).toInt().coerceAtLeast(1)
-        return Rectangle(x.coerceAtLeast(0), y.coerceAtLeast(0), width, height)
+        return runCatching { recorder.startRegion(region = bounds, output = output) }.getOrNull()
     }
 
     private fun startFullscreenRegion(recorder: AutoRecorder, output: Path): RecordingHandle? {

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutoFailureVideoStarter.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutoFailureVideoStarter.kt
@@ -1,0 +1,83 @@
+@file:OptIn(dev.sebastiano.spectre.core.InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.WindowIdentitySnapshot
+import dev.sebastiano.spectre.recording.AutoRecorder
+import dev.sebastiano.spectre.recording.RecordingHandle
+import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+import java.lang.ProcessHandle
+import java.nio.file.Path
+
+/**
+ * Production [FailureVideoStarter]: routes through [AutoRecorder] (window-targeted when a unique
+ * non-blank title is available, otherwise region using the surface/window bounds or primary
+ * display). Best-effort — returns null when no backend can start so the test outcome is unaffected.
+ */
+internal object AutoFailureVideoStarter : FailureVideoStarter {
+
+    override fun start(output: Path, automator: ComposeAutomator): RecordingHandle? =
+        runCatching {
+                val recorder = AutoRecorder()
+                val identities =
+                    runCatching { automator.windowIdentities() }.getOrDefault(emptyList())
+                val primary = identities.firstOrNull { !it.isPopup }
+                if (primary != null) {
+                    startForIdentity(recorder, primary, output)
+                        ?: startRegionFallback(recorder, primary, output)
+                } else {
+                    startFullscreenRegion(recorder, output)
+                }
+            }
+            .getOrNull()
+
+    private fun startForIdentity(
+        recorder: AutoRecorder,
+        identity: WindowIdentitySnapshot,
+        output: Path,
+    ): RecordingHandle? {
+        val title = identity.title?.takeIf { it.isNotBlank() } ?: return null
+        val crop =
+            if (identity.cropRequired) {
+                Rectangle(identity.surfaceBoundsInWindow)
+            } else {
+                null
+            }
+        return runCatching {
+                recorder.startWindowByTitle(
+                    title = title,
+                    windowOwnerPid = ProcessHandle.current().pid(),
+                    output = output,
+                    cropInWindow = crop,
+                    scaleX = identity.scaleX,
+                    scaleY = identity.scaleY,
+                )
+            }
+            .getOrNull()
+    }
+
+    private fun startRegionFallback(
+        recorder: AutoRecorder,
+        identity: WindowIdentitySnapshot,
+        output: Path,
+    ): RecordingHandle? {
+        val bounds =
+            identity.surfaceBoundsOnScreen.takeIf { it.width > 0 && it.height > 0 }
+                ?: identity.windowBoundsOnScreen.takeIf { it.width > 0 && it.height > 0 }
+                ?: return null
+        return runCatching { recorder.startRegion(region = bounds, output = output) }.getOrNull()
+    }
+
+    private fun startFullscreenRegion(recorder: AutoRecorder, output: Path): RecordingHandle? {
+        if (GraphicsEnvironment.isHeadless()) return null
+        val bounds =
+            GraphicsEnvironment.getLocalGraphicsEnvironment()
+                .defaultScreenDevice
+                .defaultConfiguration
+                .bounds
+        if (bounds.width <= 0 || bounds.height <= 0) return null
+        return runCatching { recorder.startRegion(region = bounds, output = output) }.getOrNull()
+    }
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutoFailureVideoStarter.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutoFailureVideoStarter.kt
@@ -25,7 +25,7 @@ internal object AutoFailureVideoStarter : FailureVideoStarter {
                     runCatching { automator.windowIdentities() }.getOrDefault(emptyList())
                 val primary = identities.firstOrNull { !it.isPopup }
                 if (primary != null) {
-                    startForIdentity(recorder, primary, output)
+                    startForIdentity(recorder, primary, identities, output)
                         ?: startRegionFallback(recorder, primary, output)
                 } else {
                     startFullscreenRegion(recorder, output)
@@ -36,9 +36,16 @@ internal object AutoFailureVideoStarter : FailureVideoStarter {
     private fun startForIdentity(
         recorder: AutoRecorder,
         identity: WindowIdentitySnapshot,
+        allIdentities: List<WindowIdentitySnapshot>,
         output: Path,
     ): RecordingHandle? {
         val title = identity.title?.takeIf { it.isNotBlank() } ?: return null
+        // Helpers match by title among all same-PID windows (including popups). Only use
+        // window-targeted mode when the title uniquely identifies the selected surface.
+        val titleMatches = allIdentities.count { candidate ->
+            candidate.title.orEmpty().contains(title) || candidate.title == title
+        }
+        if (titleMatches != 1) return null
         val crop =
             if (identity.cropRequired) {
                 Rectangle(identity.surfaceBoundsInWindow)

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutoFailureVideoStarter.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutoFailureVideoStarter.kt
@@ -70,11 +70,26 @@ internal object AutoFailureVideoStarter : FailureVideoStarter {
         identity: WindowIdentitySnapshot,
         output: Path,
     ): RecordingHandle? {
-        val bounds =
+        val userSpace =
             identity.surfaceBoundsOnScreen.takeIf { it.width > 0 && it.height > 0 }
                 ?: identity.windowBoundsOnScreen.takeIf { it.width > 0 && it.height > 0 }
                 ?: return null
-        return runCatching { recorder.startRegion(region = bounds, output = output) }.getOrNull()
+        // Region recorders consume device-pixel coordinates; WindowIdentitySnapshot bounds are
+        // AWT user space. Convert with the snapshot transform (same formula as window-identity
+        // docs) so HiDPI/Retina fallbacks target the correct monitor rect.
+        val region = toDevicePixels(userSpace, identity)
+        if (region.width <= 0 || region.height <= 0) return null
+        return runCatching { recorder.startRegion(region = region, output = output) }.getOrNull()
+    }
+
+    private fun toDevicePixels(userSpace: Rectangle, identity: WindowIdentitySnapshot): Rectangle {
+        val scaleX = identity.scaleX.takeIf { it > 0.0 } ?: 1.0
+        val scaleY = identity.scaleY.takeIf { it > 0.0 } ?: 1.0
+        val x = (userSpace.x * scaleX + identity.translateX).toInt()
+        val y = (userSpace.y * scaleY + identity.translateY).toInt()
+        val width = (userSpace.width * scaleX).toInt().coerceAtLeast(1)
+        val height = (userSpace.height * scaleY).toInt().coerceAtLeast(1)
+        return Rectangle(x.coerceAtLeast(0), y.coerceAtLeast(0), width, height)
     }
 
     private fun startFullscreenRegion(recorder: AutoRecorder, output: Path): RecordingHandle? {

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -227,7 +227,14 @@ internal constructor(
         val session = store.remove(VIDEO_SESSION_KEY, FailureVideoSession::class.java)
         store.put(VIDEO_FINALIZED_KEY, true)
         if (session == null) return
-        val outcome = FailureVideoDecisions.outcomeFromThrowable(failure)
+        // Prefer the worst outcome: a failed test method must keep video even if a later
+        // @AfterEach aborts (handleAfterEach only sees the AfterEach throwable).
+        val executionFailure = context.executionException.orElse(null)
+        val outcome =
+            FailureVideoDecisions.worseOutcome(
+                FailureVideoDecisions.outcomeFromThrowable(executionFailure),
+                FailureVideoDecisions.outcomeFromThrowable(failure),
+            )
         session.finalizeAndApply(outcome) { key, value -> context.publishReportEntry(key, value) }
     }
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -95,6 +95,14 @@ internal constructor(
     ) : this(failureArtifacts = failureArtifacts, factory = { ComposeAutomator.inProcess() })
 
     public constructor(
+        failureVideo: FailureVideoConfig
+    ) : this(
+        failureArtifacts = FailureArtifactsConfig(),
+        failureVideo = failureVideo,
+        factory = { ComposeAutomator.inProcess() },
+    )
+
+    public constructor(
         failureArtifacts: FailureArtifactsConfig,
         factory: AutomatorFactory,
     ) : this(

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -40,6 +40,13 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * false)`. Paths are published as JUnit report entries under
  * [FailureArtifactHooks.REPORT_ENTRY_KEY].
  *
+ * ## Failure video (#206)
+ *
+ * Optional whole-test recording via [FailureVideoConfig] (default [FailureVideoPolicy.Off]). When
+ * the policy is not off, recording starts in [beforeEach] and is stopped+finalized in [afterEach]
+ * before the keep/delete decision (`onFailureKeep` deletes on pass; `always` keeps pass and fail).
+ * Non-failure aborts use the same rules as stills and do not leave a kept video.
+ *
  * The [factory] defaults to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
  * or focused unit testing can supply their own factory.
  *
@@ -49,13 +56,16 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * typical sequential `@RegisterExtension` flow; callers running tests in parallel should rely on
  * parameter injection instead.
  */
-public class ComposeAutomatorExtension(
-    // `factory` MUST stay last. It is function-typed, so Kotlin's trailing-lambda convention
-    // binds `ComposeAutomatorExtension { … }` to whichever parameter comes last; putting an
-    // optional non-function parameter after it silently breaks every trailing-lambda call site
-    // with "argument type mismatch: … but 'FailureArtifactsConfig' was expected".
-    // AutomatorFactoryTrailingLambdaTest stops compiling if this order is changed again.
+public class ComposeAutomatorExtension
+internal constructor(
+    // `factory` MUST stay last among public-facing construction parameters. It is function-typed,
+    // so Kotlin's trailing-lambda convention binds `ComposeAutomatorExtension { … }` to whichever
+    // parameter comes last; putting an optional non-function parameter after it silently breaks
+    // every trailing-lambda call site. AutomatorFactoryTrailingLambdaTest stops compiling if this
+    // order is changed again.
     private val failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+    private val failureVideo: FailureVideoConfig = FailureVideoConfig(),
+    private val videoStarter: FailureVideoStarter = AutoFailureVideoStarter,
     private val factory: AutomatorFactory,
 ) :
     BeforeEachCallback,
@@ -64,6 +74,17 @@ public class ComposeAutomatorExtension(
     LifecycleMethodExecutionExceptionHandler,
     ParameterResolver {
 
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+        failureVideo: FailureVideoConfig = FailureVideoConfig(),
+        factory: AutomatorFactory,
+    ) : this(
+        failureArtifacts = failureArtifacts,
+        failureVideo = failureVideo,
+        videoStarter = AutoFailureVideoStarter,
+        factory = factory,
+    )
+
     // Explicit no-arg secondary constructor so JUnit 5's @ExtendWith — which reflectively
     // calls the no-arg constructor — can instantiate the extension. Kotlin's default-parameter
     // primary constructor does not emit a true JVM no-arg overload without @JvmOverloads.
@@ -71,7 +92,25 @@ public class ComposeAutomatorExtension(
 
     public constructor(
         failureArtifacts: FailureArtifactsConfig
-    ) : this(failureArtifacts, { ComposeAutomator.inProcess() })
+    ) : this(failureArtifacts = failureArtifacts, factory = { ComposeAutomator.inProcess() })
+
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig,
+        factory: AutomatorFactory,
+    ) : this(
+        failureArtifacts = failureArtifacts,
+        failureVideo = FailureVideoConfig(),
+        factory = factory,
+    )
+
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig,
+        failureVideo: FailureVideoConfig,
+    ) : this(
+        failureArtifacts = failureArtifacts,
+        failureVideo = failureVideo,
+        factory = { ComposeAutomator.inProcess() },
+    )
 
     @Volatile private var lastInstance: ComposeAutomator? = null
 
@@ -83,8 +122,10 @@ public class ComposeAutomatorExtension(
 
     override fun beforeEach(context: ExtensionContext) {
         val automator = factory()
-        context.getStore(NAMESPACE).put(STORE_KEY, automator)
+        val store = context.getStore(NAMESPACE)
+        store.put(STORE_KEY, automator)
         lastInstance = automator
+        startFailureVideo(context, automator)
     }
 
     override fun afterTestExecution(context: ExtensionContext) {
@@ -110,6 +151,8 @@ public class ComposeAutomatorExtension(
     ) {
         // Automator may already exist if factory ran; capture is best-effort.
         captureFailureArtifacts(context, throwable)
+        // Video may have started; finalize with abort/fail outcome so we never leave an orphan.
+        finalizeFailureVideo(context, throwable)
         throw throwable
     }
 
@@ -140,10 +183,37 @@ public class ComposeAutomatorExtension(
     }
 
     override fun afterEach(context: ExtensionContext) {
-        // Future hook: when the automator gains lifecycle-aware resources (recordings,
-        // background pollers, etc.) tear them down here.
+        // Finalize video before clearing the automator so window-targeted backends still see
+        // live windows during stop if needed; then drop the automator.
+        val failure = context.executionException.orElse(null)
+        finalizeFailureVideo(context, failure)
         context.getStore(NAMESPACE).remove(STORE_KEY)
         lastInstance = null
+    }
+
+    private fun startFailureVideo(context: ExtensionContext, automator: ComposeAutomator) {
+        if (!FailureVideoDecisions.shouldStart(failureVideo.policy)) return
+        val store = context.getStore(NAMESPACE)
+        val testClass = context.testClass.map { it.name }.orElse("UnknownClass")
+        val testMethod = context.testMethod.map { it.name }.orElseGet { context.displayName }
+        val videoConfig =
+            failureVideo.copy(
+                invocationId =
+                    failureVideo.invocationId?.takeIf { it.isNotBlank() } ?: context.uniqueId
+            )
+        val session = FailureVideoSession(config = videoConfig, starter = videoStarter)
+        session.start(automator = automator, testClassName = testClass, testMethodName = testMethod)
+        store.put(VIDEO_SESSION_KEY, session)
+    }
+
+    private fun finalizeFailureVideo(context: ExtensionContext, failure: Throwable?) {
+        val store = context.getStore(NAMESPACE)
+        if (store.get(VIDEO_FINALIZED_KEY) == true) return
+        val session = store.remove(VIDEO_SESSION_KEY, FailureVideoSession::class.java)
+        store.put(VIDEO_FINALIZED_KEY, true)
+        if (session == null) return
+        val outcome = FailureVideoDecisions.outcomeFromThrowable(failure)
+        session.finalizeAndApply(outcome) { key, value -> context.publishReportEntry(key, value) }
     }
 
     override fun supportsParameter(
@@ -184,3 +254,5 @@ public class ComposeAutomatorExtension(
 // static field on the file's facade class and stays out of the public ABI surface.
 private const val STORE_KEY: String = "automator"
 private const val CAPTURED_KEY: String = "failureArtifactsCaptured"
+private const val VIDEO_SESSION_KEY: String = "failureVideoSession"
+private const val VIDEO_FINALIZED_KEY: String = "failureVideoFinalized"

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -86,8 +86,7 @@ internal constructor(
     )
 
     // Explicit no-arg secondary constructor so JUnit 5's @ExtendWith — which reflectively
-    // calls the no-arg constructor — can instantiate the extension. Kotlin's default-parameter
-    // primary constructor does not emit a true JVM no-arg overload without @JvmOverloads.
+    // calls the no-arg constructor — can instantiate the extension.
     public constructor() : this(factory = { ComposeAutomator.inProcess() })
 
     public constructor(
@@ -102,9 +101,14 @@ internal constructor(
         factory = { ComposeAutomator.inProcess() },
     )
 
+    /**
+     * Pre-#206 shape with default args so already-compiled Kotlin callers that used default
+     * parameters / trailing-lambda factories still resolve `(FailureArtifactsConfig, Function0,
+     * int, DefaultConstructorMarker)` binary-compatibly.
+     */
     public constructor(
-        failureArtifacts: FailureArtifactsConfig,
-        factory: AutomatorFactory,
+        failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+        factory: AutomatorFactory = { ComposeAutomator.inProcess() },
     ) : this(
         failureArtifacts = failureArtifacts,
         failureVideo = FailureVideoConfig(),
@@ -150,6 +154,9 @@ internal constructor(
         throwable: Throwable,
     ) {
         captureFailureArtifacts(context, throwable)
+        // @AfterEach failures are not always visible on executionException when afterEach runs;
+        // finalize with this throwable so OnFailureKeep keeps video for lifecycle failures.
+        finalizeFailureVideo(context, throwable)
         throw throwable
     }
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -32,6 +32,12 @@ import org.junit.runners.model.Statement
  * **after** the failure and **before** the automator is cleared. Default-on; opt out with
  * `FailureArtifactsConfig(enabled = false)`.
  *
+ * ## Failure video (#206)
+ *
+ * Optional whole-test recording via [FailureVideoConfig] (default [FailureVideoPolicy.Off]). When
+ * the policy is not off, recording starts with the automator and is stopped+finalized in teardown
+ * before the keep/delete decision. Non-failure aborts align with stills rules.
+ *
  * ### RuleChain
  *
  * Keep this rule **innermost** (last `.around(...)` in a [org.junit.rules.RuleChain]) so failure
@@ -49,13 +55,28 @@ import org.junit.runners.model.Statement
  * Prefer [ComposeAutomatorExtension] when using JUnit 5 — JUnit 5's parameter-injection model is a
  * better fit for parallel test execution.
  */
-public class ComposeAutomatorRule(
-    // `factory` MUST stay last — see the matching note on ComposeAutomatorExtension. Kotlin's
-    // trailing-lambda convention binds `ComposeAutomatorRule { … }` to the last parameter, so an
-    // optional non-function parameter after it breaks every trailing-lambda call site.
+public class ComposeAutomatorRule
+internal constructor(
+    // `factory` MUST stay last among public-facing construction parameters — see the matching note
+    // on ComposeAutomatorExtension. Kotlin's trailing-lambda convention binds
+    // `ComposeAutomatorRule { … }` to the last parameter, so an optional non-function parameter
+    // after it breaks every trailing-lambda call site.
     private val failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+    private val failureVideo: FailureVideoConfig = FailureVideoConfig(),
+    private val videoStarter: FailureVideoStarter = AutoFailureVideoStarter,
     private val factory: AutomatorFactory,
 ) : ExternalResource() {
+
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+        failureVideo: FailureVideoConfig = FailureVideoConfig(),
+        factory: AutomatorFactory,
+    ) : this(
+        failureArtifacts = failureArtifacts,
+        failureVideo = failureVideo,
+        videoStarter = AutoFailureVideoStarter,
+        factory = factory,
+    )
 
     // Explicit no-arg secondary constructor so JUnit 4 callers can write
     // `@get:Rule val r = ComposeAutomatorRule()` without relying on Kotlin's
@@ -64,9 +85,29 @@ public class ComposeAutomatorRule(
 
     public constructor(
         failureArtifacts: FailureArtifactsConfig
-    ) : this(failureArtifacts, { ComposeAutomator.inProcess() })
+    ) : this(failureArtifacts = failureArtifacts, factory = { ComposeAutomator.inProcess() })
+
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig,
+        factory: AutomatorFactory,
+    ) : this(
+        failureArtifacts = failureArtifacts,
+        failureVideo = FailureVideoConfig(),
+        factory = factory,
+    )
+
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig,
+        failureVideo: FailureVideoConfig,
+    ) : this(
+        failureArtifacts = failureArtifacts,
+        failureVideo = failureVideo,
+        factory = { ComposeAutomator.inProcess() },
+    )
 
     private var instance: ComposeAutomator? = null
+    private var videoSession: FailureVideoSession? = null
+    private var lastDescription: Description? = null
 
     public val automator: ComposeAutomator
         get() =
@@ -82,20 +123,34 @@ public class ComposeAutomatorRule(
     override fun apply(base: Statement, description: Description): Statement {
         return object : Statement() {
             override fun evaluate() {
+                lastDescription = description
                 before()
                 try {
                     // runCatching so both Exception and AssertionError (JUnit 4 failures) are
                     // captured without a broad catch-Throwable detekt hit at this boundary.
                     val outcome = runCatching { base.evaluate() }
                     outcome.exceptionOrNull()?.let { failure ->
-                        // Assumptions abort without a "failure"; skip artifacts (same as JUnit 5).
+                        // Assumptions abort without a "failure"; skip stills (same as JUnit 5).
                         if (!FailureArtifactHooks.isNonFailureAbort(failure)) {
                             captureOnFailure(description)
                         }
                     }
+                    // Finalize before rethrow so keep/delete runs while the automator is live.
+                    // If finalize itself fails, abandon so we never leave an orphaned recorder.
+                    val videoOutcome =
+                        FailureVideoDecisions.outcomeFromThrowable(outcome.exceptionOrNull())
+                    runCatching { finalizeVideo(videoOutcome) }
+                        .onFailure {
+                            videoSession?.abandon()
+                            videoSession = null
+                        }
                     outcome.getOrThrow()
                 } finally {
+                    // Safety net: never leave an active recorder if evaluate exits oddly.
+                    videoSession?.abandon()
+                    videoSession = null
                     after()
+                    lastDescription = null
                 }
             }
         }
@@ -103,12 +158,31 @@ public class ComposeAutomatorRule(
 
     public override fun before() {
         instance = factory()
+        startFailureVideo(lastDescription)
     }
 
     public override fun after() {
-        // Future hook: when the automator gains lifecycle-aware resources (recordings,
-        // background pollers, etc.) tear them down here.
         instance = null
+    }
+
+    private fun startFailureVideo(description: Description?) {
+        if (!FailureVideoDecisions.shouldStart(failureVideo.policy)) return
+        val automator = instance ?: return
+        val testClass = description?.className ?: "UnknownClass"
+        val testMethod = description?.methodName ?: description?.displayName ?: "unknown"
+        val invocation =
+            failureVideo.invocationId?.takeIf { it.isNotBlank() }
+                ?: "${testClass}#${testMethod}#${System.nanoTime()}"
+        val videoConfig = failureVideo.copy(invocationId = invocation)
+        val session = FailureVideoSession(config = videoConfig, starter = videoStarter)
+        session.start(automator = automator, testClassName = testClass, testMethodName = testMethod)
+        videoSession = session
+    }
+
+    private fun finalizeVideo(outcome: FailureVideoOutcome) {
+        val session = videoSession ?: return
+        videoSession = null
+        session.finalizeAndApply(outcome)
     }
 
     private fun captureOnFailure(description: Description) {

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -88,6 +88,14 @@ internal constructor(
     ) : this(failureArtifacts = failureArtifacts, factory = { ComposeAutomator.inProcess() })
 
     public constructor(
+        failureVideo: FailureVideoConfig
+    ) : this(
+        failureArtifacts = FailureArtifactsConfig(),
+        failureVideo = failureVideo,
+        factory = { ComposeAutomator.inProcess() },
+    )
+
+    public constructor(
         failureArtifacts: FailureArtifactsConfig,
         factory: AutomatorFactory,
     ) : this(

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -95,9 +95,13 @@ internal constructor(
         factory = { ComposeAutomator.inProcess() },
     )
 
+    /**
+     * Pre-#206 shape with default args so already-compiled Kotlin callers that used default
+     * parameters / trailing-lambda factories stay binary-compatible.
+     */
     public constructor(
-        failureArtifacts: FailureArtifactsConfig,
-        factory: AutomatorFactory,
+        failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+        factory: AutomatorFactory = { ComposeAutomator.inProcess() },
     ) : this(
         failureArtifacts = failureArtifacts,
         failureVideo = FailureVideoConfig(),
@@ -116,6 +120,8 @@ internal constructor(
     private var instance: ComposeAutomator? = null
     private var videoSession: FailureVideoSession? = null
     private var lastDescription: Description? = null
+    /** Shared per-evaluate invocation id for stills + video when callers leave both null. */
+    private var evaluateInvocationId: String? = null
 
     public val automator: ComposeAutomator
         get() =
@@ -132,6 +138,14 @@ internal constructor(
         return object : Statement() {
             override fun evaluate() {
                 lastDescription = description
+                // One invocation id for this evaluate() so stills and video share a method dir
+                // when callers leave invocationId null on both configs.
+                val testClass = description.className ?: "UnknownClass"
+                val testMethod = description.methodName ?: description.displayName ?: "unknown"
+                evaluateInvocationId =
+                    failureVideo.invocationId?.takeIf { it.isNotBlank() }
+                        ?: failureArtifacts.invocationId?.takeIf { it.isNotBlank() }
+                        ?: "${testClass}#${testMethod}#${System.nanoTime()}"
                 before()
                 try {
                     // runCatching so both Exception and AssertionError (JUnit 4 failures) are
@@ -159,6 +173,7 @@ internal constructor(
                     videoSession = null
                     after()
                     lastDescription = null
+                    evaluateInvocationId = null
                 }
             }
         }
@@ -180,6 +195,7 @@ internal constructor(
         val testMethod = description?.methodName ?: description?.displayName ?: "unknown"
         val invocation =
             failureVideo.invocationId?.takeIf { it.isNotBlank() }
+                ?: evaluateInvocationId
                 ?: "${testClass}#${testMethod}#${System.nanoTime()}"
         val videoConfig = failureVideo.copy(invocationId = invocation)
         val session = FailureVideoSession(config = videoConfig, starter = videoStarter)
@@ -197,12 +213,13 @@ internal constructor(
         val automator = instance ?: return
         val testClass = description.className ?: "UnknownClass"
         val testMethod = description.methodName ?: description.displayName
-        // JUnit 4 has no ExtensionContext.uniqueId; synthesize an invocation id so parallel or
-        // repeated runs of the same method do not share artifact directories.
+        // JUnit 4 has no ExtensionContext.uniqueId; reuse the per-evaluate invocation id so
+        // stills and video land as siblings under the same method directory.
         val config =
             failureArtifacts.copy(
                 invocationId =
                     failureArtifacts.invocationId?.takeIf { it.isNotBlank() }
+                        ?: evaluateInvocationId
                         ?: "${testClass}#${testMethod}#${System.nanoTime()}"
             )
         FailureArtifactHooks.recordFailure(

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoConfig.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoConfig.kt
@@ -1,0 +1,26 @@
+package dev.sebastiano.spectre.testing
+
+import java.nio.file.Path
+
+/**
+ * Configuration for recording video during a Spectre-driven JUnit test (#206).
+ *
+ * Independent of [FailureArtifactsConfig] (stills stay default-on; video defaults to
+ * [FailureVideoPolicy.Off]). Paths share the same reports tree layout as stills via
+ * [FailureArtifactPaths.methodDirectory] parameters ([reportsRoot], [attemptIndex],
+ * [invocationId]).
+ *
+ * Wire next to stills config on [ComposeAutomatorExtension] / [ComposeAutomatorRule].
+ */
+public data class FailureVideoConfig(
+    public val policy: FailureVideoPolicy = FailureVideoPolicy.Off,
+    public val reportsRoot: Path = FailureArtifactPaths.defaultReportsRoot(),
+    public val attemptIndex: Int? = null,
+    public val invocationId: String? = null,
+) {
+    init {
+        require(attemptIndex == null || attemptIndex >= 1) {
+            "attemptIndex must be null or >= 1 (1-based), was $attemptIndex"
+        }
+    }
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoDecisions.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoDecisions.kt
@@ -33,4 +33,17 @@ internal object FailureVideoDecisions {
             FailureArtifactHooks.isNonFailureAbort(throwable) -> FailureVideoOutcome.Aborted
             else -> FailureVideoOutcome.Failed
         }
+
+    /**
+     * Prefer [FailureVideoOutcome.Failed] over abort over pass. Used when combining the test-method
+     * exception with a later lifecycle throwable (e.g. `@AfterEach` abort after a real failure).
+     */
+    fun worseOutcome(a: FailureVideoOutcome, b: FailureVideoOutcome): FailureVideoOutcome =
+        when {
+            a == FailureVideoOutcome.Failed || b == FailureVideoOutcome.Failed ->
+                FailureVideoOutcome.Failed
+            a == FailureVideoOutcome.Aborted || b == FailureVideoOutcome.Aborted ->
+                FailureVideoOutcome.Aborted
+            else -> FailureVideoOutcome.Passed
+        }
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoDecisions.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoDecisions.kt
@@ -1,0 +1,36 @@
+package dev.sebastiano.spectre.testing
+
+/** Outcome used to decide keep vs delete after a failure-video session is finalized. */
+internal enum class FailureVideoOutcome {
+    Passed,
+    Failed,
+    Aborted,
+}
+
+/**
+ * Pure policy table for #206. Separated from OS recorder I/O so unit tests drive the real decision
+ * functions without headed capture.
+ */
+internal object FailureVideoDecisions {
+
+    fun shouldStart(policy: FailureVideoPolicy): Boolean = policy != FailureVideoPolicy.Off
+
+    fun shouldKeep(policy: FailureVideoPolicy, outcome: FailureVideoOutcome): Boolean =
+        when (policy) {
+            FailureVideoPolicy.Off -> false
+            FailureVideoPolicy.OnFailureKeep -> outcome == FailureVideoOutcome.Failed
+            FailureVideoPolicy.Always ->
+                outcome == FailureVideoOutcome.Passed || outcome == FailureVideoOutcome.Failed
+        }
+
+    /**
+     * Maps a JUnit throwable (or null for a clean pass) to a [FailureVideoOutcome], using the same
+     * non-failure-abort rules as [FailureArtifactHooks.isNonFailureAbort].
+     */
+    fun outcomeFromThrowable(throwable: Throwable?): FailureVideoOutcome =
+        when {
+            throwable == null -> FailureVideoOutcome.Passed
+            FailureArtifactHooks.isNonFailureAbort(throwable) -> FailureVideoOutcome.Aborted
+            else -> FailureVideoOutcome.Failed
+        }
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoPolicy.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoPolicy.kt
@@ -1,0 +1,29 @@
+package dev.sebastiano.spectre.testing
+
+/**
+ * Recording policy for failure-video on Spectre-driven JUnit tests (#206).
+ *
+ * You cannot record retroactively, so video-of-a-failure means recording the whole test and
+ * deciding at the end whether to keep the finalized file.
+ *
+ * - [Off] — default; no recorder overhead
+ * - [OnFailureKeep] — record the whole test; delete the finalized file on pass; keep on fail
+ * - [Always] — keep the finalized video on pass and fail (not on assumption/abort skips)
+ */
+public enum class FailureVideoPolicy {
+    /** No recording. Default for CI cost. */
+    Off,
+
+    /**
+     * Record for the duration of the test invocation. After the recorder is stopped and the file is
+     * finalized, keep the video only when the test failed (not on pass or non-failure abort).
+     */
+    OnFailureKeep,
+
+    /**
+     * Record for the duration of the test invocation and keep the finalized video on pass and fail.
+     * Non-failure aborts (assumptions) still discard the video so skip suites do not leave
+     * misleading “failure” artifacts.
+     */
+    Always,
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoSession.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoSession.kt
@@ -1,0 +1,133 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.recording.RecordingHandle
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * One test-invocation failure-video lifecycle: optional start, mandatory stop+finalize before
+ * keep/delete, and [abandon] for crash/abort teardown that must not leave an orphaned recorder.
+ *
+ * Always best-effort: start/stop/delete failures must not replace the original test outcome.
+ */
+internal class FailureVideoSession(
+    private val config: FailureVideoConfig,
+    private val starter: FailureVideoStarter,
+) {
+    private var handle: RecordingHandle? = null
+    private var outputPath: Path? = null
+
+    val activeOutput: Path?
+        get() = outputPath
+
+    val hasActiveRecorder: Boolean
+        get() = handle != null
+
+    fun start(automator: ComposeAutomator, testClassName: String, testMethodName: String) {
+        if (!FailureVideoDecisions.shouldStart(config.policy)) return
+        if (handle != null) return
+        val methodDir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = testClassName,
+                testMethodName = testMethodName,
+                config =
+                    FailureArtifactsConfig(
+                        // enabled flag unused for path layout
+                        enabled = false,
+                        reportsRoot = config.reportsRoot,
+                        attemptIndex = config.attemptIndex,
+                        invocationId = config.invocationId,
+                    ),
+            )
+        val output = methodDir.resolve(VIDEO_FILE_NAME)
+        runCatching {
+                Files.createDirectories(methodDir)
+                val started = starter.start(output, automator) ?: return
+                handle = started
+                outputPath = started.output
+            }
+            .onFailure {
+                handle = null
+                outputPath = null
+            }
+    }
+
+    /**
+     * Stop the recorder (finalize the file), then keep or delete according to [policy] and
+     * [outcome]. Safe when nothing was started.
+     */
+    fun finalizeAndApply(
+        outcome: FailureVideoOutcome,
+        publishReport: (key: String, value: String) -> Unit = { _, _ -> },
+    ) {
+        val active = handle
+        val path = outputPath
+        handle = null
+        outputPath = null
+        if (active == null) return
+        runCatching { if (!active.isStopped) active.stop() }
+        val finalized = path ?: active.output
+        val keep = FailureVideoDecisions.shouldKeep(config.policy, outcome)
+        if (keep) {
+            if (Files.isRegularFile(finalized)) {
+                publishReport(REPORT_ENTRY_KEY, finalized.toAbsolutePath().normalize().toString())
+            }
+        } else {
+            deleteQuietly(finalized)
+        }
+    }
+
+    /**
+     * Force stop + delete for crash/teardown paths where there is no normal outcome decision yet.
+     * Leaves no active recorder.
+     */
+    fun abandon() {
+        val active = handle
+        val path = outputPath
+        handle = null
+        outputPath = null
+        if (active != null) {
+            runCatching { if (!active.isStopped) active.stop() }
+        }
+        val target = path ?: active?.output
+        if (target != null) deleteQuietly(target)
+    }
+
+    private fun deleteQuietly(path: Path) {
+        runCatching {
+            Files.deleteIfExists(path)
+            removeEmptyParentsTowardReportsRoot(path.parent)
+        }
+    }
+
+    /** Best-effort remove empty parents up to reports root (never delete reports root). */
+    private fun removeEmptyParentsTowardReportsRoot(start: Path?) {
+        val root = config.reportsRoot.toAbsolutePath().normalize()
+        var parent = start
+        while (parent != null) {
+            val normalized = parent.toAbsolutePath().normalize()
+            val stop =
+                normalized == root || !normalized.startsWith(root) || !isEmptyDirectory(parent)
+            if (stop) return
+            Files.deleteIfExists(parent)
+            parent = parent.parent
+        }
+    }
+
+    private fun isEmptyDirectory(directory: Path): Boolean =
+        runCatching {
+                Files.isDirectory(directory) && Files.list(directory).use { it.findFirst().isEmpty }
+            }
+            .getOrDefault(false)
+
+    internal companion object {
+        const val VIDEO_FILE_NAME: String = "failure-video.mp4"
+        const val REPORT_ENTRY_KEY: String = "spectre.failureVideo"
+    }
+}
+
+/** Starts a [RecordingHandle] writing to [output] for the current [automator] windows. */
+internal fun interface FailureVideoStarter {
+    fun start(output: Path, automator: ComposeAutomator): RecordingHandle?
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoSession.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoSession.kt
@@ -72,9 +72,11 @@ internal class FailureVideoSession(
         handle = null
         outputPath = null
         if (active == null) return
-        runCatching { if (!active.isStopped) active.stop() }
         val finalized = path ?: active.output
-        val keep = FailureVideoDecisions.shouldKeep(config.policy, outcome)
+        val stopOk = runCatching { if (!active.isStopped) active.stop() }.isSuccess
+        // Only keep after a successful stop: a failed finalize can leave a truncated file that
+        // must not be published as failure evidence (treat like abandon/delete).
+        val keep = stopOk && FailureVideoDecisions.shouldKeep(config.policy, outcome)
         if (keep) {
             if (Files.isRegularFile(finalized)) {
                 publishReport(REPORT_ENTRY_KEY, finalized.toAbsolutePath().normalize().toString())

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoSession.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/FailureVideoSession.kt
@@ -41,16 +41,22 @@ internal class FailureVideoSession(
                     ),
             )
         val output = methodDir.resolve(VIDEO_FILE_NAME)
-        runCatching {
-                Files.createDirectories(methodDir)
-                val started = starter.start(output, automator) ?: return
-                handle = started
-                outputPath = started.output
-            }
-            .onFailure {
-                handle = null
-                outputPath = null
-            }
+        val started =
+            runCatching {
+                    Files.createDirectories(methodDir)
+                    starter.start(output, automator)
+                }
+                .getOrNull()
+        if (started == null) {
+            // Starter may have created a partial file before failing; never leave it for a later
+            // pass/abort to look like kept failure-video evidence.
+            handle = null
+            outputPath = null
+            deleteQuietly(output)
+            return
+        }
+        handle = started
+        outputPath = started.output
     }
 
     /**

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorFailureVideoTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorFailureVideoTest.kt
@@ -159,6 +159,45 @@ class ComposeAutomatorFailureVideoTest {
     }
 
     @Test
+    fun `failureVideo-only constructor uses default factory and stills config`(
+        @TempDir temp: Path
+    ) {
+        val starts = AtomicInteger(0)
+        // Documented form: ComposeAutomatorExtension(failureVideo = …) with default factory.
+        val extension =
+            ComposeAutomatorExtension(
+                failureVideo =
+                    FailureVideoConfig(policy = FailureVideoPolicy.Off, reportsRoot = temp)
+            )
+        val context =
+            RecordingExtensionContext(
+                failure = null,
+                testClass = VideoSample::class.java,
+                methodName = "passes",
+            )
+        // Replace is not possible on the public overload; just construct + lifecycle with Off.
+        extension.beforeEach(context)
+        extension.afterEach(context)
+        assertEquals(0, starts.get())
+        // Rule mirror.
+        val rule =
+            ComposeAutomatorRule(
+                failureVideo =
+                    FailureVideoConfig(policy = FailureVideoPolicy.Off, reportsRoot = temp)
+            )
+        rule
+            .apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        // pass
+                    }
+                },
+                Description.createTestDescription("com.example.VideoCtor", "ok"),
+            )
+            .evaluate()
+    }
+
+    @Test
     fun `trailing lambda factory still compiles with failureVideo param present`() {
         // Compile-time guard (mirrors AutomatorFactoryTrailingLambdaTest): factory remains last.
         // If this file fails to compile, factory is no longer the last parameter.

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorFailureVideoTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorFailureVideoTest.kt
@@ -1,0 +1,227 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.recording.RecordingHandle
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import org.opentest4j.TestAbortedException
+
+/**
+ * Wires failure-video policy through the real [ComposeAutomatorExtension] and
+ * [ComposeAutomatorRule] entry points with a fake [FailureVideoStarter] (I/O boundary only).
+ */
+class ComposeAutomatorFailureVideoTest {
+
+    @Test
+    fun `extension default Off never starts recorder`(@TempDir temp: Path) {
+        val starts = AtomicInteger(0)
+        val extension =
+            ComposeAutomatorExtension(
+                failureArtifacts = FailureArtifactsConfig(enabled = false, reportsRoot = temp),
+                failureVideo = FailureVideoConfig(reportsRoot = temp),
+                videoStarter = { _, _ ->
+                    starts.incrementAndGet()
+                    error("must not start")
+                },
+                factory = { ComposeAutomator.inProcess(robotDriver = RobotDriver.headless()) },
+            )
+        val context =
+            RecordingExtensionContext(
+                failure = null,
+                testClass = VideoSample::class.java,
+                methodName = "passes",
+            )
+        extension.beforeEach(context)
+        extension.afterEach(context)
+        assertEquals(0, starts.get())
+    }
+
+    @Test
+    fun `extension onFailureKeep keeps video on fail and deletes on pass`(@TempDir temp: Path) {
+        val failRoot = temp.resolve("fail-root")
+        Files.createDirectories(failRoot)
+        val failExt = videoExtension(failRoot, FailureVideoPolicy.OnFailureKeep)
+        val failCtx =
+            RecordingExtensionContext(
+                failure = AssertionError("boom"),
+                testClass = VideoSample::class.java,
+                methodName = "fails",
+            )
+        failExt.beforeEach(failCtx)
+        val failPath = requireActiveVideo(failRoot)
+        failExt.afterTestExecution(failCtx)
+        failExt.afterEach(failCtx)
+        assertTrue(Files.isRegularFile(failPath), "failure must keep video: $failPath")
+        assertTrue(
+            failCtx.reportEntries.any { it.containsKey(FailureVideoSession.REPORT_ENTRY_KEY) }
+        )
+
+        val passRoot = temp.resolve("pass-root")
+        Files.createDirectories(passRoot)
+        val passExt = videoExtension(passRoot, FailureVideoPolicy.OnFailureKeep)
+        val passCtx =
+            RecordingExtensionContext(
+                failure = null,
+                testClass = VideoSample::class.java,
+                methodName = "passes",
+            )
+        passExt.beforeEach(passCtx)
+        val passPath = requireActiveVideo(passRoot)
+        passExt.afterEach(passCtx)
+        assertFalse(Files.exists(passPath), "pass must delete video under onFailureKeep")
+    }
+
+    @Test
+    fun `extension Always keeps video on pass`(@TempDir temp: Path) {
+        val extension = videoExtension(temp, FailureVideoPolicy.Always)
+        val context =
+            RecordingExtensionContext(
+                failure = null,
+                testClass = VideoSample::class.java,
+                methodName = "passes",
+            )
+        extension.beforeEach(context)
+        val path = requireActiveVideo(temp)
+        extension.afterEach(context)
+        assertTrue(Files.isRegularFile(path))
+    }
+
+    @Test
+    fun `extension abort does not keep video`(@TempDir temp: Path) {
+        val extension = videoExtension(temp, FailureVideoPolicy.OnFailureKeep)
+        val context =
+            RecordingExtensionContext(
+                failure = TestAbortedException("skip"),
+                testClass = VideoSample::class.java,
+                methodName = "assumed",
+            )
+        extension.beforeEach(context)
+        val path = requireActiveVideo(temp)
+        extension.afterTestExecution(context)
+        extension.afterEach(context)
+        assertFalse(Files.exists(path))
+    }
+
+    @Test
+    fun `rule onFailureKeep keeps on fail deletes on pass`(@TempDir temp: Path) {
+        val failRule = videoRule(temp, FailureVideoPolicy.OnFailureKeep)
+        val failStatement =
+            failRule.apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        error("intentional failure")
+                    }
+                },
+                Description.createTestDescription("com.example.VideoFail", "blowsUp"),
+            )
+        try {
+            failStatement.evaluate()
+            error("expected failure")
+        } catch (expected: IllegalStateException) {
+            assertEquals("intentional failure", expected.message)
+        }
+        val kept =
+            Files.walk(temp).use { stream ->
+                stream
+                    .filter { it.fileName.toString() == FailureVideoSession.VIDEO_FILE_NAME }
+                    .toList()
+            }
+        assertEquals(1, kept.size, "expected one kept video after fail")
+        assertTrue(Files.isRegularFile(kept.single()))
+
+        val passRoot = temp.resolve("pass-root")
+        Files.createDirectories(passRoot)
+        val passRule = videoRule(passRoot, FailureVideoPolicy.OnFailureKeep)
+        passRule
+            .apply(
+                object : Statement() {
+                    override fun evaluate() {
+                        // pass
+                    }
+                },
+                Description.createTestDescription("com.example.VideoPass", "ok"),
+            )
+            .evaluate()
+        assertFalse(
+            Files.walk(passRoot).use { s ->
+                s.anyMatch { it.fileName.toString() == FailureVideoSession.VIDEO_FILE_NAME }
+            }
+        )
+    }
+
+    @Test
+    fun `trailing lambda factory still compiles with failureVideo param present`() {
+        // Compile-time guard (mirrors AutomatorFactoryTrailingLambdaTest): factory remains last.
+        // If this file fails to compile, factory is no longer the last parameter.
+        val extension = ComposeAutomatorExtension {
+            ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+        }
+        val rule = ComposeAutomatorRule {
+            ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+        }
+        // Touch the instances so the constructions are not dead code.
+        assertEquals("ComposeAutomatorExtension", extension::class.simpleName)
+        assertEquals("ComposeAutomatorRule", rule::class.simpleName)
+    }
+
+    private fun videoExtension(temp: Path, policy: FailureVideoPolicy): ComposeAutomatorExtension =
+        ComposeAutomatorExtension(
+            failureArtifacts = FailureArtifactsConfig(enabled = false, reportsRoot = temp),
+            failureVideo = FailureVideoConfig(policy = policy, reportsRoot = temp),
+            videoStarter = { output, _ -> fakeStarter(output) },
+            factory = { ComposeAutomator.inProcess(robotDriver = RobotDriver.headless()) },
+        )
+
+    private fun videoRule(temp: Path, policy: FailureVideoPolicy): ComposeAutomatorRule =
+        ComposeAutomatorRule(
+            failureArtifacts = FailureArtifactsConfig(enabled = false, reportsRoot = temp),
+            failureVideo = FailureVideoConfig(policy = policy, reportsRoot = temp),
+            videoStarter = { output, _ -> fakeStarter(output) },
+            factory = { ComposeAutomator.inProcess(robotDriver = RobotDriver.headless()) },
+        )
+
+    private fun fakeStarter(output: Path): RecordingHandle {
+        Files.createDirectories(output.parent)
+        Files.writeString(output, "partial")
+        return object : RecordingHandle {
+            override val output: Path = output
+            override var isStopped: Boolean = false
+                private set
+
+            override fun stop() {
+                isStopped = true
+                Files.writeString(output, "finalized-video")
+            }
+        }
+    }
+
+    private fun requireActiveVideo(temp: Path): Path {
+        val found =
+            Files.walk(temp).use { stream ->
+                stream
+                    .filter { Files.isRegularFile(it) }
+                    .filter { it.fileName.toString() == FailureVideoSession.VIDEO_FILE_NAME }
+                    .findFirst()
+                    .orElse(null)
+            }
+        checkNotNull(found) { "expected active video under $temp" }
+        return found
+    }
+
+    class VideoSample {
+        fun passes(): Long = System.nanoTime()
+
+        fun fails(): Long = System.nanoTime()
+
+        fun assumed(): Long = System.nanoTime()
+    }
+}

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorFailureVideoTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorFailureVideoTest.kt
@@ -159,42 +159,20 @@ class ComposeAutomatorFailureVideoTest {
     }
 
     @Test
-    fun `failureVideo-only constructor uses default factory and stills config`(
-        @TempDir temp: Path
-    ) {
-        val starts = AtomicInteger(0)
-        // Documented form: ComposeAutomatorExtension(failureVideo = …) with default factory.
+    fun `failureVideo-only constructor is source-compatible for documented form`() {
+        // Construction-only guard for ComposeAutomatorExtension(failureVideo = …) and the matching
+        // Rule overload. Do not run beforeEach/apply here: the default factory uses RobotDriver(),
+        // which fails on headless CI. Lifecycle coverage uses headless factories elsewhere.
         val extension =
             ComposeAutomatorExtension(
-                failureVideo =
-                    FailureVideoConfig(policy = FailureVideoPolicy.Off, reportsRoot = temp)
+                failureVideo = FailureVideoConfig(policy = FailureVideoPolicy.OnFailureKeep)
             )
-        val context =
-            RecordingExtensionContext(
-                failure = null,
-                testClass = VideoSample::class.java,
-                methodName = "passes",
-            )
-        // Replace is not possible on the public overload; just construct + lifecycle with Off.
-        extension.beforeEach(context)
-        extension.afterEach(context)
-        assertEquals(0, starts.get())
-        // Rule mirror.
         val rule =
             ComposeAutomatorRule(
-                failureVideo =
-                    FailureVideoConfig(policy = FailureVideoPolicy.Off, reportsRoot = temp)
+                failureVideo = FailureVideoConfig(policy = FailureVideoPolicy.Always)
             )
-        rule
-            .apply(
-                object : Statement() {
-                    override fun evaluate() {
-                        // pass
-                    }
-                },
-                Description.createTestDescription("com.example.VideoCtor", "ok"),
-            )
-            .evaluate()
+        assertEquals("ComposeAutomatorExtension", extension::class.simpleName)
+        assertEquals("ComposeAutomatorRule", rule::class.simpleName)
     }
 
     @Test

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoPolicyTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoPolicyTest.kt
@@ -1,0 +1,88 @@
+package dev.sebastiano.spectre.testing
+
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+/**
+ * Pure decision table for #206 failure-video policy. No recorder I/O — only whether to start and
+ * whether to keep the finalized file after an outcome.
+ */
+class FailureVideoPolicyTest {
+
+    @Test
+    fun `default policy is Off`() {
+        assertEquals(FailureVideoPolicy.Off, FailureVideoConfig().policy)
+    }
+
+    @Test
+    fun `shouldStart is false only for Off`() {
+        assertFalse(FailureVideoDecisions.shouldStart(FailureVideoPolicy.Off))
+        assertTrue(FailureVideoDecisions.shouldStart(FailureVideoPolicy.OnFailureKeep))
+        assertTrue(FailureVideoDecisions.shouldStart(FailureVideoPolicy.Always))
+    }
+
+    @Test
+    fun `Off never keeps`() {
+        for (outcome in FailureVideoOutcome.entries) {
+            assertFalse(FailureVideoDecisions.shouldKeep(FailureVideoPolicy.Off, outcome))
+        }
+    }
+
+    @Test
+    fun `OnFailureKeep keeps only real failures`() {
+        assertFalse(
+            FailureVideoDecisions.shouldKeep(
+                FailureVideoPolicy.OnFailureKeep,
+                FailureVideoOutcome.Passed,
+            )
+        )
+        assertTrue(
+            FailureVideoDecisions.shouldKeep(
+                FailureVideoPolicy.OnFailureKeep,
+                FailureVideoOutcome.Failed,
+            )
+        )
+        assertFalse(
+            FailureVideoDecisions.shouldKeep(
+                FailureVideoPolicy.OnFailureKeep,
+                FailureVideoOutcome.Aborted,
+            )
+        )
+    }
+
+    @Test
+    fun `Always keeps pass and fail but not abort`() {
+        assertTrue(
+            FailureVideoDecisions.shouldKeep(FailureVideoPolicy.Always, FailureVideoOutcome.Passed)
+        )
+        assertTrue(
+            FailureVideoDecisions.shouldKeep(FailureVideoPolicy.Always, FailureVideoOutcome.Failed)
+        )
+        assertFalse(
+            FailureVideoDecisions.shouldKeep(FailureVideoPolicy.Always, FailureVideoOutcome.Aborted)
+        )
+    }
+
+    @Test
+    fun `outcomeFromThrowable maps abort types like stills hooks`() {
+        assertEquals(FailureVideoOutcome.Passed, FailureVideoDecisions.outcomeFromThrowable(null))
+        assertEquals(
+            FailureVideoOutcome.Failed,
+            FailureVideoDecisions.outcomeFromThrowable(AssertionError("boom")),
+        )
+        assertEquals(
+            FailureVideoOutcome.Aborted,
+            FailureVideoDecisions.outcomeFromThrowable(
+                org.opentest4j.TestAbortedException("assumption")
+            ),
+        )
+        assertEquals(
+            FailureVideoOutcome.Aborted,
+            FailureVideoDecisions.outcomeFromThrowable(
+                org.junit.AssumptionViolatedException("skip")
+            ),
+        )
+    }
+}

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoPolicyTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoPolicyTest.kt
@@ -66,6 +66,38 @@ class FailureVideoPolicyTest {
     }
 
     @Test
+    fun `worseOutcome prefers Failed over Aborted over Passed`() {
+        assertEquals(
+            FailureVideoOutcome.Failed,
+            FailureVideoDecisions.worseOutcome(
+                FailureVideoOutcome.Failed,
+                FailureVideoOutcome.Aborted,
+            ),
+        )
+        assertEquals(
+            FailureVideoOutcome.Failed,
+            FailureVideoDecisions.worseOutcome(
+                FailureVideoOutcome.Aborted,
+                FailureVideoOutcome.Failed,
+            ),
+        )
+        assertEquals(
+            FailureVideoOutcome.Aborted,
+            FailureVideoDecisions.worseOutcome(
+                FailureVideoOutcome.Passed,
+                FailureVideoOutcome.Aborted,
+            ),
+        )
+        assertEquals(
+            FailureVideoOutcome.Passed,
+            FailureVideoDecisions.worseOutcome(
+                FailureVideoOutcome.Passed,
+                FailureVideoOutcome.Passed,
+            ),
+        )
+    }
+
+    @Test
     fun `outcomeFromThrowable maps abort types like stills hooks`() {
         assertEquals(FailureVideoOutcome.Passed, FailureVideoDecisions.outcomeFromThrowable(null))
         assertEquals(

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoSessionTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoSessionTest.kt
@@ -224,6 +224,41 @@ class FailureVideoSessionTest {
     }
 
     @Test
+    fun `stop failure deletes video even under Always`(@TempDir temp: Path) {
+        val session =
+            FailureVideoSession(
+                config =
+                    FailureVideoConfig(
+                        policy = FailureVideoPolicy.Always,
+                        reportsRoot = temp,
+                        invocationId = "stop-fail",
+                    ),
+                starter = { path, _ ->
+                    Files.createDirectories(path.parent)
+                    Files.writeString(path, "partial")
+                    object : RecordingHandle {
+                        override val output: Path = path
+                        override var isStopped: Boolean = false
+                            private set
+
+                        override fun stop() {
+                            error("helper crashed during stop")
+                        }
+                    }
+                },
+            )
+        session.start(
+            automator = newHeadlessAutomator(),
+            testClassName = "com.example.T",
+            testMethodName = "m",
+        )
+        val active = checkNotNull(session.activeOutput)
+        session.finalizeAndApply(FailureVideoOutcome.Failed)
+        assertFalse(Files.exists(active), "failed stop must not keep partial video")
+        assertFalse(session.hasActiveRecorder)
+    }
+
+    @Test
     fun `start failure is best-effort and leaves no active recorder`(@TempDir temp: Path) {
         val session =
             FailureVideoSession(

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoSessionTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoSessionTest.kt
@@ -1,0 +1,272 @@
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.recording.RecordingHandle
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Lifecycle for failure-video sessions: start when policy ≠ off, always stop+finalize before
+ * keep/delete, no orphaned handle after finalize or abandon.
+ */
+class FailureVideoSessionTest {
+
+    @Test
+    fun `Off does not start the recorder`(@TempDir temp: Path) {
+        val starts = AtomicInteger(0)
+        val session =
+            FailureVideoSession(
+                config = FailureVideoConfig(policy = FailureVideoPolicy.Off, reportsRoot = temp),
+                starter = { _, _ ->
+                    starts.incrementAndGet()
+                    error("must not start")
+                },
+            )
+        session.start(
+            automator = newHeadlessAutomator(),
+            testClassName = "com.example.T",
+            testMethodName = "m",
+        )
+        assertEquals(0, starts.get())
+        assertNull(session.activeOutput)
+        session.finalizeAndApply(FailureVideoOutcome.Failed)
+        assertFalse(Files.walk(temp).use { s -> s.anyMatch { Files.isRegularFile(it) } })
+    }
+
+    @Test
+    fun `OnFailureKeep finalizes before delete on pass`(@TempDir temp: Path) {
+        val events = mutableListOf<String>()
+        val session =
+            FailureVideoSession(
+                config =
+                    FailureVideoConfig(
+                        policy = FailureVideoPolicy.OnFailureKeep,
+                        reportsRoot = temp,
+                        invocationId = "inv-1",
+                    ),
+                starter = { path, _ ->
+                    events += "start:${path.fileName}"
+                    Files.createDirectories(path.parent)
+                    Files.writeString(path, "partial")
+                    object : RecordingHandle {
+                        override val output: Path = path
+                        override var isStopped: Boolean = false
+                            private set
+
+                        override fun stop() {
+                            events += "stop"
+                            isStopped = true
+                            Files.writeString(path, "finalized")
+                        }
+                    }
+                },
+            )
+        session.start(
+            automator = newHeadlessAutomator(),
+            testClassName = "com.example.T",
+            testMethodName = "passes",
+        )
+        assertTrue(events.first().startsWith("start:"))
+        val active = session.activeOutput
+        checkNotNull(active)
+        assertTrue(Files.exists(active))
+
+        session.finalizeAndApply(FailureVideoOutcome.Passed)
+        assertEquals(listOf(events[0], "stop"), events)
+        assertFalse(Files.exists(active), "pass must delete finalized video under onFailureKeep")
+        assertNull(session.activeOutput)
+        assertFalse(session.hasActiveRecorder)
+    }
+
+    @Test
+    fun `OnFailureKeep keeps finalized video on fail`(@TempDir temp: Path) {
+        val reports = mutableListOf<Pair<String, String>>()
+        val session =
+            sessionWithFakeFile(
+                temp = temp,
+                policy = FailureVideoPolicy.OnFailureKeep,
+                contentAfterStop = "playable",
+            )
+        session.start(
+            automator = newHeadlessAutomator(),
+            testClassName = "com.example.T",
+            testMethodName = "fails",
+        )
+        val active = checkNotNull(session.activeOutput)
+        session.finalizeAndApply(FailureVideoOutcome.Failed) { k, v -> reports += k to v }
+        assertTrue(Files.exists(active))
+        assertEquals("playable", Files.readString(active))
+        assertEquals(FailureVideoSession.REPORT_ENTRY_KEY, reports.single().first)
+        assertTrue(reports.single().second.contains("failure-video.mp4"))
+        assertNull(session.activeOutput)
+    }
+
+    @Test
+    fun `Always keeps on pass`(@TempDir temp: Path) {
+        val session =
+            sessionWithFakeFile(
+                temp = temp,
+                policy = FailureVideoPolicy.Always,
+                contentAfterStop = "always",
+            )
+        session.start(
+            automator = newHeadlessAutomator(),
+            testClassName = "com.example.T",
+            testMethodName = "ok",
+        )
+        val active = checkNotNull(session.activeOutput)
+        session.finalizeAndApply(FailureVideoOutcome.Passed)
+        assertTrue(Files.exists(active))
+        assertEquals("always", Files.readString(active))
+    }
+
+    @Test
+    fun `abort deletes video even under Always`(@TempDir temp: Path) {
+        val session =
+            sessionWithFakeFile(
+                temp = temp,
+                policy = FailureVideoPolicy.Always,
+                contentAfterStop = "abort",
+            )
+        session.start(
+            automator = newHeadlessAutomator(),
+            testClassName = "com.example.T",
+            testMethodName = "assumed",
+        )
+        val active = checkNotNull(session.activeOutput)
+        session.finalizeAndApply(FailureVideoOutcome.Aborted)
+        assertFalse(Files.exists(active))
+    }
+
+    @Test
+    fun `abandon stops and deletes without leaving an active recorder`(@TempDir temp: Path) {
+        val stopped = AtomicInteger(0)
+        val session =
+            FailureVideoSession(
+                config =
+                    FailureVideoConfig(
+                        policy = FailureVideoPolicy.OnFailureKeep,
+                        reportsRoot = temp,
+                        invocationId = "inv",
+                    ),
+                starter = { path, _ ->
+                    Files.createDirectories(path.parent)
+                    Files.writeString(path, "partial")
+                    object : RecordingHandle {
+                        override val output: Path = path
+                        override var isStopped: Boolean = false
+                            private set
+
+                        override fun stop() {
+                            stopped.incrementAndGet()
+                            isStopped = true
+                            Files.writeString(path, "finalized")
+                        }
+                    }
+                },
+            )
+        session.start(
+            automator = newHeadlessAutomator(),
+            testClassName = "com.example.T",
+            testMethodName = "crash",
+        )
+        val active = checkNotNull(session.activeOutput)
+        session.abandon()
+        assertEquals(1, stopped.get())
+        assertFalse(Files.exists(active))
+        assertFalse(session.hasActiveRecorder)
+        assertNull(session.activeOutput)
+    }
+
+    @Test
+    fun `paths nest attempt and invocation like stills`(@TempDir temp: Path) {
+        var startedAt: Path? = null
+        val session =
+            FailureVideoSession(
+                config =
+                    FailureVideoConfig(
+                        policy = FailureVideoPolicy.Always,
+                        reportsRoot = temp,
+                        attemptIndex = 2,
+                        invocationId = "inv-xyz",
+                    ),
+                starter = { path, _ ->
+                    startedAt = path
+                    Files.createDirectories(path.parent)
+                    Files.writeString(path, "x")
+                    fakeHandle(path, "x")
+                },
+            )
+        session.start(
+            automator = newHeadlessAutomator(),
+            testClassName = "com.example.Retry",
+            testMethodName = "flaky",
+        )
+        val expectedDir =
+            FailureArtifactPaths.methodDirectory(
+                testClassName = "com.example.Retry",
+                testMethodName = "flaky",
+                config =
+                    FailureArtifactsConfig(
+                        reportsRoot = temp,
+                        attemptIndex = 2,
+                        invocationId = "inv-xyz",
+                    ),
+            )
+        assertEquals(expectedDir.resolve(FailureVideoSession.VIDEO_FILE_NAME), startedAt)
+        session.finalizeAndApply(FailureVideoOutcome.Passed)
+    }
+
+    @Test
+    fun `start failure is best-effort and leaves no active recorder`(@TempDir temp: Path) {
+        val session =
+            FailureVideoSession(
+                config =
+                    FailureVideoConfig(
+                        policy = FailureVideoPolicy.OnFailureKeep,
+                        reportsRoot = temp,
+                    ),
+                starter = { _, _ -> error("helper missing") },
+            )
+        session.start(
+            automator = newHeadlessAutomator(),
+            testClassName = "com.example.T",
+            testMethodName = "m",
+        )
+        assertFalse(session.hasActiveRecorder)
+        session.finalizeAndApply(FailureVideoOutcome.Failed)
+        assertFalse(session.hasActiveRecorder)
+    }
+
+    private fun sessionWithFakeFile(
+        temp: Path,
+        policy: FailureVideoPolicy,
+        contentAfterStop: String,
+    ): FailureVideoSession =
+        FailureVideoSession(
+            config = FailureVideoConfig(policy = policy, reportsRoot = temp, invocationId = "inv"),
+            starter = { path, _ ->
+                Files.createDirectories(path.parent)
+                Files.writeString(path, "partial")
+                fakeHandle(path, contentAfterStop)
+            },
+        )
+
+    private fun fakeHandle(path: Path, contentAfterStop: String): RecordingHandle =
+        object : RecordingHandle {
+            override val output: Path = path
+            override var isStopped: Boolean = false
+                private set
+
+            override fun stop() {
+                isStopped = true
+                Files.writeString(path, contentAfterStop)
+            }
+        }
+}

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoSessionTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/FailureVideoSessionTest.kt
@@ -231,8 +231,14 @@ class FailureVideoSessionTest {
                     FailureVideoConfig(
                         policy = FailureVideoPolicy.OnFailureKeep,
                         reportsRoot = temp,
+                        invocationId = "start-fail",
                     ),
-                starter = { _, _ -> error("helper missing") },
+                starter = { path, _ ->
+                    // Simulate a helper that creates a partial file then fails.
+                    Files.createDirectories(path.parent)
+                    Files.writeString(path, "partial-orphan")
+                    error("helper missing")
+                },
             )
         session.start(
             automator = newHeadlessAutomator(),
@@ -240,6 +246,12 @@ class FailureVideoSessionTest {
             testMethodName = "m",
         )
         assertFalse(session.hasActiveRecorder)
+        assertFalse(
+            Files.walk(temp).use { s ->
+                s.anyMatch { it.fileName.toString() == FailureVideoSession.VIDEO_FILE_NAME }
+            },
+            "failed start must delete partial video",
+        )
         session.finalizeAndApply(FailureVideoOutcome.Failed)
         assertFalse(session.hasActiveRecorder)
     }


### PR DESCRIPTION
## Summary

Implements [#206](https://github.com/rock3r/spectre/issues/206): optional whole-test failure video on `ComposeAutomatorExtension` / `ComposeAutomatorRule`.

| Policy | Behaviour |
| --- | --- |
| `Off` | **Default** — no recorder start, no video side effects |
| `OnFailureKeep` | Record whole test; **delete** finalized file on pass; **keep** on fail |
| `Always` | Keep finalized video on pass and fail |

- Config: `FailureVideoConfig` next to `FailureArtifactsConfig` (`factory` remains last for trailing-lambda call sites).
- Output: `build/reports/spectre/<class>/<method>[/invocation][/attempt-N]/failure-video.mp4` (same nesting as stills).
- Lifecycle: start when policy ≠ Off; always stop+finalize before keep/delete; `abandon` on crash/teardown; aborts use `FailureArtifactHooks.isNonFailureAbort` (no kept “failure” video).
- Backend: existing `AutoRecorder` (window-by-title when available, region fallback) — no new platform backend.
- Scope: **in-process JUnit only** (no agent/attach video path).
- Capture schema stays **v1**.

## Test plan

- [x] Unit: `FailureVideoPolicyTest`, `FailureVideoSessionTest` (fake `RecordingHandle` at I/O boundary), `ComposeAutomatorFailureVideoTest` (real Extension/Rule entry points)
- [x] TDD: policy/lifecycle tests red → production green (see PR notes)
- [x] `./gradlew check` green (detekt + ktfmt + tests)
- [x] Headed e2e: `:sample-desktop:validationTest --tests FailureVideoValidationTest` on macOS
  - OnFailureKeep fail → non-empty `failure-video.mp4` (SCK frames accepted)
  - OnFailureKeep pass → no leftover video
  - Always pass → video kept
  - Off fail → no files
- [x] Trailing-lambda `ComposeAutomatorExtension { … }` / `Rule { … }` still compiles
- [ ] CI multi-OS (Windows/Linux inherit capability matrix; helpers + portal/TCC limits apply)

## Residual risks for 0.5.0 smoke

- Disk pressure under `OnFailureKeep` on long/parallel CI (documented; default remains Off).
- Platform capability matrix: window vs region; Linux Wayland portal consent; macOS TCC.
- Agent attach tests now need recording platform helper jars on the test classpath (because `:testing` implementation-depends on `:recording` for the default starter) — wired as `testRuntimeOnly` on `:agent`.

Closes #206