### PR TITLE
feat(cli): per-target native helpers in Roast zips (#354)

### DIFF
--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/CliRoastNativePackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/CliRoastNativePackagingContract.kt
@@ -1,0 +1,100 @@
+package dev.sebastiano.spectre.build
+
+/**
+ * Packaging contract for per-target recording helpers inside Roast CLI zips (#354).
+ *
+ * The multi-platform CLI shadow jar may still carry helpers for every OS (library Maven jars
+ * remain multi-arch). Each Construo/Roast platform zip must embed a filtered application jar
+ * that retains only that target OS's `native/<os>/` tree so Windows dual-arch WGC (~66 MiB
+ * uncompressed) is not shipped inside every Linux/macOS zip.
+ */
+object CliRoastNativePackagingContract {
+    const val NATIVE_ROOT: String = "native/"
+    const val LINUX_PREFIX: String = "native/linux/"
+    const val MACOS_PREFIX: String = "native/macos/"
+    const val WINDOWS_PREFIX: String = "native/windows/"
+
+    /** Known OS-level helper roots that must not leak across Roast targets. */
+    val OS_NATIVE_PREFIXES: List<String> = listOf(LINUX_PREFIX, MACOS_PREFIX, WINDOWS_PREFIX)
+
+    /**
+     * Returns the single `native/<os>/` prefix retained for a Construo target name
+     * (`linuxX64`, `macosArm64`, `windowsX64`, …).
+     */
+    fun keepNativePrefixForRoastTarget(targetName: String): String =
+        when {
+            targetName.startsWith("linux") -> LINUX_PREFIX
+            targetName.startsWith("macos") -> MACOS_PREFIX
+            targetName.startsWith("windows") -> WINDOWS_PREFIX
+            else ->
+                error(
+                    "Unsupported Roast target for native filtering: $targetName " +
+                        "(expected linux*, macos*, or windows*)"
+                )
+        }
+
+    /**
+     * Whether a jar entry should be copied into a target-filtered CLI application jar.
+     * Non-native entries are always kept (bytecode, agent-runtime resource, services).
+     */
+    fun shouldIncludeJarEntry(entryName: String, keepNativePrefix: String): Boolean {
+        if (!entryName.startsWith(NATIVE_ROOT)) {
+            return true
+        }
+        // Directory markers under native/ that are ancestors of the keep prefix stay so zip
+        // tools retain a coherent tree; foreign OS roots are dropped.
+        if (entryName.endsWith("/")) {
+            return keepNativePrefix.startsWith(entryName) || entryName.startsWith(keepNativePrefix)
+        }
+        return entryName.startsWith(keepNativePrefix)
+    }
+
+    /**
+     * Foreign native file entries that must not appear in a Roast-embedded application jar for
+     * [keepNativePrefix].
+     */
+    fun foreignNativeEntries(
+        entryNames: Iterable<String>,
+        keepNativePrefix: String,
+    ): List<String> =
+        entryNames
+            .filter { name ->
+                !name.endsWith("/") &&
+                    name.startsWith(NATIVE_ROOT) &&
+                    !name.startsWith(keepNativePrefix)
+            }
+            .sorted()
+
+    /**
+     * Validates that [entryNames] from a Roast-embedded CLI jar satisfy the per-target native
+     * layout. Returns human-readable errors (empty when valid).
+     *
+     * Does not require that host helpers are present — a Mac-only CI build may lack Windows
+     * prebuilts in the unfiltered jar, and a filtered zip may therefore contain zero natives for
+     * a foreign OS build host. The hard rule is **no foreign OS helpers**.
+     */
+    fun validateEmbeddedJarEntries(
+        entryNames: Iterable<String>,
+        keepNativePrefix: String,
+    ): List<String> {
+        val foreign = foreignNativeEntries(entryNames, keepNativePrefix)
+        if (foreign.isEmpty()) {
+            return emptyList()
+        }
+        val sample = foreign.take(MAX_FOREIGN_SAMPLES)
+        val more =
+            if (foreign.size > MAX_FOREIGN_SAMPLES) {
+                " (+${foreign.size - MAX_FOREIGN_SAMPLES} more)"
+            } else {
+                ""
+            }
+        return listOf(
+            "Roast-embedded CLI jar must only retain helpers under $keepNativePrefix; " +
+                "found ${foreign.size} foreign native entr${if (foreign.size == 1) "y" else "ies"}: " +
+                sample.joinToString() +
+                more
+        )
+    }
+
+    private const val MAX_FOREIGN_SAMPLES: Int = 8
+}

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/CliRoastNativePackagingContract.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/CliRoastNativePackagingContract.kt
@@ -33,20 +33,29 @@ object CliRoastNativePackagingContract {
                 )
         }
 
+    /** Rejects malformed keep prefixes that would over-keep or under-keep helper trees. */
+    fun requireKnownKeepNativePrefix(keepNativePrefix: String): String {
+        check(keepNativePrefix in OS_NATIVE_PREFIXES) {
+            "keepNativePrefix must be one of $OS_NATIVE_PREFIXES, got: $keepNativePrefix"
+        }
+        return keepNativePrefix
+    }
+
     /**
      * Whether a jar entry should be copied into a target-filtered CLI application jar.
      * Non-native entries are always kept (bytecode, agent-runtime resource, services).
      */
     fun shouldIncludeJarEntry(entryName: String, keepNativePrefix: String): Boolean {
+        val keep = requireKnownKeepNativePrefix(keepNativePrefix)
         if (!entryName.startsWith(NATIVE_ROOT)) {
             return true
         }
         // Directory markers under native/ that are ancestors of the keep prefix stay so zip
         // tools retain a coherent tree; foreign OS roots are dropped.
         if (entryName.endsWith("/")) {
-            return keepNativePrefix.startsWith(entryName) || entryName.startsWith(keepNativePrefix)
+            return keep.startsWith(entryName) || entryName.startsWith(keep)
         }
-        return entryName.startsWith(keepNativePrefix)
+        return entryName.startsWith(keep)
     }
 
     /**

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/FilterCliShadowJarNatives.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/FilterCliShadowJarNatives.kt
@@ -1,0 +1,97 @@
+package dev.sebastiano.spectre.build
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Produces a target-filtered copy of the multi-platform CLI shadow jar for Construo/Roast
+ * packaging. Keeps all non-native entries and only `native/<os>/…` helpers for one Roast OS.
+ *
+ * The unfiltered shadow jar remains the artifact used by `verifyCliShadowJar` and local
+ * `java -jar` workflows; Maven recording modules stay multi-arch for Central.
+ */
+@CacheableTask
+abstract class FilterCliShadowJarNatives : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NONE)
+    abstract val inputJar: RegularFileProperty
+
+    @get:OutputFile abstract val outputJar: RegularFileProperty
+
+    /**
+     * OS native prefix to retain, e.g. `native/macos/`. Must match
+     * [CliRoastNativePackagingContract.keepNativePrefixForRoastTarget] for the Roast target.
+     */
+    @get:Input abstract val keepNativePrefix: Property<String>
+
+    @TaskAction
+    fun filter() {
+        filterJar(
+            inputJar = inputJar.get().asFile,
+            outputJar = outputJar.get().asFile,
+            keepNativePrefix = keepNativePrefix.get(),
+        )
+    }
+
+    companion object {
+        /**
+         * Pure filter used by the Gradle task and unit tests. Streams entries without loading the
+         * whole archive; preserves STORED entries (with CRC/size) when the source used STORED.
+         */
+        fun filterJar(
+            inputJar: java.io.File,
+            outputJar: java.io.File,
+            keepNativePrefix: String,
+        ) {
+            require(keepNativePrefix.startsWith(CliRoastNativePackagingContract.NATIVE_ROOT)) {
+                "keepNativePrefix must start with ${CliRoastNativePackagingContract.NATIVE_ROOT}, got: $keepNativePrefix"
+            }
+            outputJar.parentFile?.mkdirs()
+            JarFile(inputJar).use { source ->
+                JarOutputStream(BufferedOutputStream(outputJar.outputStream())).use { dest ->
+                    val entries = source.entries()
+                    while (entries.hasMoreElements()) {
+                        val entry = entries.nextElement()
+                        if (
+                            !CliRoastNativePackagingContract.shouldIncludeJarEntry(
+                                entry.name,
+                                keepNativePrefix,
+                            )
+                        ) {
+                            continue
+                        }
+                        val copy = JarEntry(entry.name)
+                        copy.time = entry.time
+                        copy.method = entry.method
+                        if (entry.method == ZipEntry.STORED) {
+                            copy.size = entry.size
+                            copy.compressedSize = entry.compressedSize
+                            copy.crc = entry.crc
+                        }
+                        dest.putNextEntry(copy)
+                        if (!entry.isDirectory) {
+                            BufferedInputStream(source.getInputStream(entry)).use { input ->
+                                input.copyTo(dest)
+                            }
+                        }
+                        dest.closeEntry()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/FilterCliShadowJarNatives.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/FilterCliShadowJarNatives.kt
@@ -57,9 +57,8 @@ abstract class FilterCliShadowJarNatives : DefaultTask() {
             outputJar: java.io.File,
             keepNativePrefix: String,
         ) {
-            require(keepNativePrefix.startsWith(CliRoastNativePackagingContract.NATIVE_ROOT)) {
-                "keepNativePrefix must start with ${CliRoastNativePackagingContract.NATIVE_ROOT}, got: $keepNativePrefix"
-            }
+            val keep =
+                CliRoastNativePackagingContract.requireKnownKeepNativePrefix(keepNativePrefix)
             outputJar.parentFile?.mkdirs()
             JarFile(inputJar).use { source ->
                 JarOutputStream(BufferedOutputStream(outputJar.outputStream())).use { dest ->
@@ -69,7 +68,7 @@ abstract class FilterCliShadowJarNatives : DefaultTask() {
                         if (
                             !CliRoastNativePackagingContract.shouldIncludeJarEntry(
                                 entry.name,
-                                keepNativePrefix,
+                                keep,
                             )
                         ) {
                             continue
@@ -78,8 +77,17 @@ abstract class FilterCliShadowJarNatives : DefaultTask() {
                         copy.time = entry.time
                         copy.method = entry.method
                         if (entry.method == ZipEntry.STORED) {
-                            copy.size = entry.size
-                            copy.compressedSize = entry.compressedSize
+                            // ZipOutputStream requires size == compressedSize for STORED. Repair
+                            // incomplete source metadata rather than failing mid-filter.
+                            val size = entry.size
+                            val compressed =
+                                if (entry.compressedSize >= 0 && entry.compressedSize == size) {
+                                    entry.compressedSize
+                                } else {
+                                    size
+                                }
+                            copy.size = size
+                            copy.compressedSize = compressed
                             copy.crc = entry.crc
                         }
                         dest.putNextEntry(copy)

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
@@ -52,21 +52,10 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
 
     private fun validateNativeLayout(zip: ZipFile, applicationRoot: String) {
         val keepPrefix = keepNativePrefix.get()
-        val applicationJar =
-            zip.entries()
-                .asSequence()
-                .map { it.name }
-                .filter { name ->
-                    name.startsWith("$applicationRoot/") &&
-                        name.endsWith(".jar") &&
-                        !name.contains("/runtime/") &&
-                        !name.contains("/app/")
-                }
-                .sortedByDescending { name -> zip.getEntry(name).size }
-                .firstOrNull()
-                ?: error(
-                    "${zip.name ?: "Roast zip"} does not contain an application jar under $applicationRoot"
-                )
+        val applicationJar = VerifyRoastCliNativeLayout.resolveApplicationJarEntry(zip)
+        check(applicationJar.startsWith("$applicationRoot/") || !applicationRoot.contains('/')) {
+            "${zip.name ?: "Roast zip"} application jar $applicationJar is outside launcher root $applicationRoot"
+        }
         val entryNames =
             zip.getInputStream(zip.getEntry(applicationJar)).use { input ->
                 JarInputStream(input).use { jar ->
@@ -86,8 +75,9 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
             "${zip.name ?: "Roast zip"} embedded jar $applicationJar fails per-target native layout:\n" +
                 errors.joinToString("\n") { "  - $it" }
         }
-        check(AGENT_RUNTIME_ENTRY in entryNames) {
-            "${zip.name ?: "Roast zip"} embedded jar $applicationJar is missing $AGENT_RUNTIME_ENTRY"
+        check(VerifyRoastCliNativeLayout.AGENT_RUNTIME_ENTRY in entryNames) {
+            "${zip.name ?: "Roast zip"} embedded jar $applicationJar is missing " +
+                VerifyRoastCliNativeLayout.AGENT_RUNTIME_ENTRY
         }
     }
 
@@ -165,7 +155,6 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
     private companion object {
         const val EXTRACTION_TIMEOUT_SECONDS = 30L
         const val LAUNCH_TIMEOUT_SECONDS = 20L
-        const val AGENT_RUNTIME_ENTRY = "spectre/agent-runtime.jar"
         val ANSI_ESCAPE_SEQUENCE = Regex("\\u001B\\[[0-?]*[ -/]*[@-~]")
     }
 

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliDistribution.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.build
 import java.io.File
 import java.nio.file.Files
 import java.util.concurrent.TimeUnit
+import java.util.jar.JarInputStream
 import java.util.zip.ZipFile
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.RegularFileProperty
@@ -18,6 +19,12 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
     @get:Input abstract val launcherPath: Property<String>
 
     @get:Input abstract val runtimeJavaPath: Property<String>
+
+    /**
+     * OS native prefix the embedded CLI application jar must retain exclusively (e.g.
+     * `native/macos/`). See [CliRoastNativePackagingContract].
+     */
+    @get:Input abstract val keepNativePrefix: Property<String>
 
     @TaskAction
     fun verify() {
@@ -35,11 +42,53 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
             check(zip.getEntry("$applicationRoot/app/spectre.json") != null) {
                 "${archive.name} does not contain Roast's application configuration"
             }
+            validateNativeLayout(zip, applicationRoot)
             validateEntries(zip)
             extract(archive, zip)
         }
         verifyLauncher(File(temporaryDir, launcher))
         verifyRuntimeJava(File(temporaryDir, runtimeJavaPath.get()))
+    }
+
+    private fun validateNativeLayout(zip: ZipFile, applicationRoot: String) {
+        val keepPrefix = keepNativePrefix.get()
+        val applicationJar =
+            zip.entries()
+                .asSequence()
+                .map { it.name }
+                .filter { name ->
+                    name.startsWith("$applicationRoot/") &&
+                        name.endsWith(".jar") &&
+                        !name.contains("/runtime/") &&
+                        !name.contains("/app/")
+                }
+                .sortedByDescending { name -> zip.getEntry(name).size }
+                .firstOrNull()
+                ?: error(
+                    "${zip.name ?: "Roast zip"} does not contain an application jar under $applicationRoot"
+                )
+        val entryNames =
+            zip.getInputStream(zip.getEntry(applicationJar)).use { input ->
+                JarInputStream(input).use { jar ->
+                    buildList {
+                        var entry = jar.nextJarEntry
+                        while (entry != null) {
+                            add(entry.name)
+                            jar.closeEntry()
+                            entry = jar.nextJarEntry
+                        }
+                    }
+                }
+            }
+        val errors =
+            CliRoastNativePackagingContract.validateEmbeddedJarEntries(entryNames, keepPrefix)
+        check(errors.isEmpty()) {
+            "${zip.name ?: "Roast zip"} embedded jar $applicationJar fails per-target native layout:\n" +
+                errors.joinToString("\n") { "  - $it" }
+        }
+        check(AGENT_RUNTIME_ENTRY in entryNames) {
+            "${zip.name ?: "Roast zip"} embedded jar $applicationJar is missing $AGENT_RUNTIME_ENTRY"
+        }
     }
 
     private fun validateEntries(zip: ZipFile) {
@@ -116,6 +165,7 @@ abstract class VerifyRoastCliDistribution : DefaultTask() {
     private companion object {
         const val EXTRACTION_TIMEOUT_SECONDS = 30L
         const val LAUNCH_TIMEOUT_SECONDS = 20L
+        const val AGENT_RUNTIME_ENTRY = "spectre/agent-runtime.jar"
         val ANSI_ESCAPE_SEQUENCE = Regex("\\u001B\\[[0-?]*[ -/]*[@-~]")
     }
 

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliNativeLayout.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyRoastCliNativeLayout.kt
@@ -1,0 +1,85 @@
+package dev.sebastiano.spectre.build
+
+import java.util.jar.JarInputStream
+import java.util.zip.ZipFile
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Layout-only contract for a Roast CLI zip: the embedded application jar must retain only that
+ * target's OS native helpers and still embed `spectre/agent-runtime.jar`. Does not extract or
+ * launch the bundle, so non-host targets can be verified on any builder OS.
+ */
+abstract class VerifyRoastCliNativeLayout : DefaultTask() {
+    @get:InputFile abstract val artifact: RegularFileProperty
+
+    /** Construo target name (`linuxX64`, `macosArm64`, …) used to derive the keep prefix. */
+    @get:Input abstract val roastTargetName: Property<String>
+
+    @TaskAction
+    fun verify() {
+        val archive = artifact.get().asFile
+        val keepPrefix =
+            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget(roastTargetName.get())
+        ZipFile(archive).use { zip ->
+            val applicationJar = resolveApplicationJarEntry(zip)
+            val entryNames =
+                zip.getInputStream(zip.getEntry(applicationJar)).use { input ->
+                    JarInputStream(input).use { jar ->
+                        buildList {
+                            var entry = jar.nextJarEntry
+                            while (entry != null) {
+                                add(entry.name)
+                                jar.closeEntry()
+                                entry = jar.nextJarEntry
+                            }
+                        }
+                    }
+                }
+            val errors =
+                CliRoastNativePackagingContract.validateEmbeddedJarEntries(entryNames, keepPrefix)
+            check(errors.isEmpty()) {
+                "${archive.name} embedded jar $applicationJar fails per-target native layout:\n" +
+                    errors.joinToString("\n") { "  - $it" }
+            }
+            check(AGENT_RUNTIME_ENTRY in entryNames) {
+                "${archive.name} embedded jar $applicationJar is missing $AGENT_RUNTIME_ENTRY"
+            }
+        }
+    }
+
+    companion object {
+        const val AGENT_RUNTIME_ENTRY: String = "spectre/agent-runtime.jar"
+
+        /**
+         * Prefer a single `*-all.jar` application payload; fail if zero or multiple candidates
+         * remain after excluding the jlink runtime and Roast config directories.
+         */
+        fun resolveApplicationJarEntry(zip: ZipFile): String {
+            val candidates =
+                zip.entries()
+                    .asSequence()
+                    .map { it.name }
+                    .filter { name ->
+                        name.endsWith(".jar") &&
+                            !name.contains("/runtime/") &&
+                            !name.contains("/app/") &&
+                            !name.endsWith("jrt-fs.jar")
+                    }
+                    .filter { name -> name.endsWith("-all.jar") || name.contains("/cli-") }
+                    .sorted()
+                    .toList()
+            check(candidates.isNotEmpty()) {
+                "${zip.name ?: "Roast zip"} does not contain an application *-all.jar"
+            }
+            check(candidates.size == 1) {
+                "${zip.name ?: "Roast zip"} has multiple application jar candidates: $candidates"
+            }
+            return candidates.single()
+        }
+    }
+}

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/CliRoastNativePackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/CliRoastNativePackagingContractTest.kt
@@ -3,15 +3,19 @@ package dev.sebastiano.spectre.build
 import java.util.jar.JarEntry
 import java.util.jar.JarFile
 import java.util.jar.JarOutputStream
+import java.util.zip.CRC32
 import java.util.zip.ZipEntry
 import kotlin.io.path.createTempFile
 import kotlin.io.path.deleteIfExists
-import kotlin.io.path.outputStream
+import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.ValueSource
 
 /**
  * Proves the shared Roast native-layout contract used by filtered Construo application jars and
@@ -19,23 +23,18 @@ import org.junit.jupiter.api.assertThrows
  */
 class CliRoastNativePackagingContractTest {
 
-    @Test
-    fun `keep prefix maps Construo target names to OS roots`() {
+    @ParameterizedTest
+    @CsvSource(
+        "linuxX64,native/linux/",
+        "linuxArm64,native/linux/",
+        "macosX64,native/macos/",
+        "macosArm64,native/macos/",
+        "windowsX64,native/windows/",
+    )
+    fun `keep prefix maps Construo target names to OS roots`(target: String, expected: String) {
         assertEquals(
-            CliRoastNativePackagingContract.LINUX_PREFIX,
-            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("linuxX64"),
-        )
-        assertEquals(
-            CliRoastNativePackagingContract.LINUX_PREFIX,
-            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("linuxArm64"),
-        )
-        assertEquals(
-            CliRoastNativePackagingContract.MACOS_PREFIX,
-            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("macosArm64"),
-        )
-        assertEquals(
-            CliRoastNativePackagingContract.WINDOWS_PREFIX,
-            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("windowsX64"),
+            expected,
+            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget(target),
         )
     }
 
@@ -43,6 +42,16 @@ class CliRoastNativePackagingContractTest {
     fun `unknown Roast target is rejected`() {
         assertThrows<IllegalStateException> {
             CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("freebsdX64")
+        }
+    }
+
+    @Test
+    fun `malformed keep prefix is rejected`() {
+        assertThrows<IllegalStateException> {
+            CliRoastNativePackagingContract.requireKnownKeepNativePrefix("native/mac")
+        }
+        assertThrows<IllegalStateException> {
+            CliRoastNativePackagingContract.requireKnownKeepNativePrefix("native/linux")
         }
     }
 
@@ -127,10 +136,11 @@ class CliRoastNativePackagingContractTest {
         )
     }
 
-    @Test
-    fun `filterJar copies only allowed native roots and preserves agent-runtime`() {
+    @ParameterizedTest
+    @ValueSource(strings = ["native/linux/", "native/macos/", "native/windows/"])
+    fun `filterJar keeps only the requested OS root and preserves agent-runtime`(keep: String) {
         val input = createTempFile(prefix = "cli-multi-", suffix = ".jar")
-        val output = createTempFile(prefix = "cli-mac-", suffix = ".jar")
+        val output = createTempFile(prefix = "cli-filtered-", suffix = ".jar")
         try {
             writeJar(
                 input.toFile(),
@@ -140,28 +150,76 @@ class CliRoastNativePackagingContractTest {
                     "native/macos/helper.bin" to byteArrayOf(9),
                     "native/windows/x64/spectre-window-capture.exe" to ByteArray(1024) { 7 },
                     "native/linux/x86_64/spectre-wayland-helper" to ByteArray(64) { 5 },
-                    "dev/sebastiano/spectre/cli/Main.class" to byteArrayOf(0xCA.toByte(), 0xFE.toByte()),
+                    "dev/sebastiano/spectre/cli/Main.class" to
+                        byteArrayOf(0xCA.toByte(), 0xFE.toByte()),
                 ),
             )
             FilterCliShadowJarNatives.filterJar(
                 inputJar = input.toFile(),
                 outputJar = output.toFile(),
-                keepNativePrefix = CliRoastNativePackagingContract.MACOS_PREFIX,
+                keepNativePrefix = keep,
             )
             JarFile(output.toFile()).use { jar ->
-                val names = jar.entries().asSequence().map { it.name }.filter { !it.endsWith("/") }.toSet()
+                val names =
+                    jar.entries().asSequence().map { it.name }.filter { !it.endsWith("/") }.toSet()
                 assertTrue("spectre/agent-runtime.jar" in names)
-                assertTrue("native/macos/helper.bin" in names)
                 assertTrue("dev/sebastiano/spectre/cli/Main.class" in names)
-                assertFalse(names.any { it.startsWith("native/windows/") })
-                assertFalse(names.any { it.startsWith("native/linux/") })
+                for (prefix in CliRoastNativePackagingContract.OS_NATIVE_PREFIXES) {
+                    val present = names.any { it.startsWith(prefix) }
+                    if (prefix == keep) {
+                        assertTrue(present, "expected natives under $keep; names=$names")
+                    } else {
+                        assertFalse(present, "foreign natives under $prefix; names=$names")
+                    }
+                }
                 assertEquals(
                     emptyList<String>(),
-                    CliRoastNativePackagingContract.validateEmbeddedJarEntries(
-                        names,
-                        CliRoastNativePackagingContract.MACOS_PREFIX,
-                    ),
+                    CliRoastNativePackagingContract.validateEmbeddedJarEntries(names, keep),
                 )
+            }
+        } finally {
+            input.deleteIfExists()
+            output.deleteIfExists()
+        }
+    }
+
+    @Test
+    fun `filterJar preserves STORED agent-runtime bytes and CRC`() {
+        val input = createTempFile(prefix = "cli-stored-in-", suffix = ".jar")
+        val output = createTempFile(prefix = "cli-stored-out-", suffix = ".jar")
+        val agentBytes = ByteArray(4096) { i -> (i % 251).toByte() }
+        val nativeBytes = ByteArray(512) { 42 }
+        try {
+            writeJarWithStored(
+                input.toFile(),
+                stored =
+                    mapOf(
+                        "spectre/agent-runtime.jar" to agentBytes,
+                        "native/windows/x64/spectre-window-capture.exe" to nativeBytes,
+                    ),
+                deflated =
+                    mapOf(
+                        "META-INF/MANIFEST.MF" to "Manifest-Version: 1.0\n".toByteArray(),
+                        "native/macos/helper.bin" to byteArrayOf(1),
+                    ),
+            )
+            FilterCliShadowJarNatives.filterJar(
+                inputJar = input.toFile(),
+                outputJar = output.toFile(),
+                keepNativePrefix = CliRoastNativePackagingContract.WINDOWS_PREFIX,
+            )
+            JarFile(output.toFile()).use { jar ->
+                val agent = jar.getJarEntry("spectre/agent-runtime.jar")
+                assertEquals(ZipEntry.STORED, agent.method)
+                assertEquals(agentBytes.size.toLong(), agent.size)
+                assertEquals(agentBytes.size.toLong(), agent.compressedSize)
+                val crc = CRC32().also { it.update(agentBytes) }.value
+                assertEquals(crc, agent.crc)
+                assertArrayEquals(agentBytes, jar.getInputStream(agent).readBytes())
+                val names =
+                    jar.entries().asSequence().map { it.name }.filter { !it.endsWith("/") }.toSet()
+                assertTrue(names.any { it.startsWith("native/windows/") })
+                assertFalse(names.any { it.startsWith("native/macos/") })
             }
         } finally {
             input.deleteIfExists()
@@ -172,6 +230,33 @@ class CliRoastNativePackagingContractTest {
     private fun writeJar(file: java.io.File, entries: Map<String, ByteArray>) {
         JarOutputStream(file.outputStream()).use { out ->
             for ((name, bytes) in entries) {
+                out.putNextEntry(JarEntry(name).apply { method = ZipEntry.DEFLATED })
+                out.write(bytes)
+                out.closeEntry()
+            }
+        }
+    }
+
+    private fun writeJarWithStored(
+        file: java.io.File,
+        stored: Map<String, ByteArray>,
+        deflated: Map<String, ByteArray>,
+    ) {
+        JarOutputStream(file.outputStream()).use { out ->
+            for ((name, bytes) in stored) {
+                val crc = CRC32().also { it.update(bytes) }.value
+                val entry =
+                    JarEntry(name).apply {
+                        method = ZipEntry.STORED
+                        size = bytes.size.toLong()
+                        compressedSize = bytes.size.toLong()
+                        this.crc = crc
+                    }
+                out.putNextEntry(entry)
+                out.write(bytes)
+                out.closeEntry()
+            }
+            for ((name, bytes) in deflated) {
                 out.putNextEntry(JarEntry(name).apply { method = ZipEntry.DEFLATED })
                 out.write(bytes)
                 out.closeEntry()

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/CliRoastNativePackagingContractTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/CliRoastNativePackagingContractTest.kt
@@ -1,0 +1,181 @@
+package dev.sebastiano.spectre.build
+
+import java.util.jar.JarEntry
+import java.util.jar.JarFile
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+import kotlin.io.path.createTempFile
+import kotlin.io.path.deleteIfExists
+import kotlin.io.path.outputStream
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+/**
+ * Proves the shared Roast native-layout contract used by filtered Construo application jars and
+ * [VerifyRoastCliDistribution]: each platform zip keeps only that OS's helper tree.
+ */
+class CliRoastNativePackagingContractTest {
+
+    @Test
+    fun `keep prefix maps Construo target names to OS roots`() {
+        assertEquals(
+            CliRoastNativePackagingContract.LINUX_PREFIX,
+            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("linuxX64"),
+        )
+        assertEquals(
+            CliRoastNativePackagingContract.LINUX_PREFIX,
+            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("linuxArm64"),
+        )
+        assertEquals(
+            CliRoastNativePackagingContract.MACOS_PREFIX,
+            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("macosArm64"),
+        )
+        assertEquals(
+            CliRoastNativePackagingContract.WINDOWS_PREFIX,
+            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("windowsX64"),
+        )
+    }
+
+    @Test
+    fun `unknown Roast target is rejected`() {
+        assertThrows<IllegalStateException> {
+            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget("freebsdX64")
+        }
+    }
+
+    @Test
+    fun `filter keeps bytecode agent-runtime and only one OS native tree`() {
+        val keep = CliRoastNativePackagingContract.MACOS_PREFIX
+        assertTrue(
+            CliRoastNativePackagingContract.shouldIncludeJarEntry(
+                "dev/sebastiano/spectre/cli/SpectreCliKt.class",
+                keep,
+            )
+        )
+        assertTrue(
+            CliRoastNativePackagingContract.shouldIncludeJarEntry("spectre/agent-runtime.jar", keep)
+        )
+        assertTrue(
+            CliRoastNativePackagingContract.shouldIncludeJarEntry(
+                "native/macos/SpectreCaptureHelper.app/Contents/MacOS/spectre-screencapture",
+                keep,
+            )
+        )
+        assertFalse(
+            CliRoastNativePackagingContract.shouldIncludeJarEntry(
+                "native/windows/x64/spectre-window-capture.exe",
+                keep,
+            )
+        )
+        assertFalse(
+            CliRoastNativePackagingContract.shouldIncludeJarEntry(
+                "native/linux/x86_64/spectre-wayland-helper",
+                keep,
+            )
+        )
+    }
+
+    @Test
+    fun `foreign native entries are reported for multi-OS payload`() {
+        val entries =
+            listOf(
+                "META-INF/MANIFEST.MF",
+                "native/macos/SpectreCaptureHelper.app/Contents/Info.plist",
+                "native/windows/x64/spectre-window-capture.exe",
+                "native/linux/x86_64/spectre-wayland-helper",
+                "spectre/agent-runtime.jar",
+            )
+        val foreign =
+            CliRoastNativePackagingContract.foreignNativeEntries(
+                entries,
+                CliRoastNativePackagingContract.MACOS_PREFIX,
+            )
+        assertEquals(
+            listOf(
+                "native/linux/x86_64/spectre-wayland-helper",
+                "native/windows/x64/spectre-window-capture.exe",
+            ),
+            foreign,
+        )
+        val errors =
+            CliRoastNativePackagingContract.validateEmbeddedJarEntries(
+                entries,
+                CliRoastNativePackagingContract.MACOS_PREFIX,
+            )
+        assertTrue(errors.isNotEmpty())
+        assertTrue(errors.single().contains("native/macos/"))
+        assertTrue(errors.single().contains("foreign"))
+    }
+
+    @Test
+    fun `mac-only payload validates for macos target`() {
+        val entries =
+            listOf(
+                "dev/sebastiano/spectre/cli/SpectreCliKt.class",
+                "native/macos/SpectreCaptureHelper.app/Contents/MacOS/spectre-screencapture",
+                "spectre/agent-runtime.jar",
+            )
+        assertEquals(
+            emptyList<String>(),
+            CliRoastNativePackagingContract.validateEmbeddedJarEntries(
+                entries,
+                CliRoastNativePackagingContract.MACOS_PREFIX,
+            ),
+        )
+    }
+
+    @Test
+    fun `filterJar copies only allowed native roots and preserves agent-runtime`() {
+        val input = createTempFile(prefix = "cli-multi-", suffix = ".jar")
+        val output = createTempFile(prefix = "cli-mac-", suffix = ".jar")
+        try {
+            writeJar(
+                input.toFile(),
+                mapOf(
+                    "META-INF/MANIFEST.MF" to "Manifest-Version: 1.0\n".toByteArray(),
+                    "spectre/agent-runtime.jar" to byteArrayOf(1, 2, 3),
+                    "native/macos/helper.bin" to byteArrayOf(9),
+                    "native/windows/x64/spectre-window-capture.exe" to ByteArray(1024) { 7 },
+                    "native/linux/x86_64/spectre-wayland-helper" to ByteArray(64) { 5 },
+                    "dev/sebastiano/spectre/cli/Main.class" to byteArrayOf(0xCA.toByte(), 0xFE.toByte()),
+                ),
+            )
+            FilterCliShadowJarNatives.filterJar(
+                inputJar = input.toFile(),
+                outputJar = output.toFile(),
+                keepNativePrefix = CliRoastNativePackagingContract.MACOS_PREFIX,
+            )
+            JarFile(output.toFile()).use { jar ->
+                val names = jar.entries().asSequence().map { it.name }.filter { !it.endsWith("/") }.toSet()
+                assertTrue("spectre/agent-runtime.jar" in names)
+                assertTrue("native/macos/helper.bin" in names)
+                assertTrue("dev/sebastiano/spectre/cli/Main.class" in names)
+                assertFalse(names.any { it.startsWith("native/windows/") })
+                assertFalse(names.any { it.startsWith("native/linux/") })
+                assertEquals(
+                    emptyList<String>(),
+                    CliRoastNativePackagingContract.validateEmbeddedJarEntries(
+                        names,
+                        CliRoastNativePackagingContract.MACOS_PREFIX,
+                    ),
+                )
+            }
+        } finally {
+            input.deleteIfExists()
+            output.deleteIfExists()
+        }
+    }
+
+    private fun writeJar(file: java.io.File, entries: Map<String, ByteArray>) {
+        JarOutputStream(file.outputStream()).use { out ->
+            for ((name, bytes) in entries) {
+                out.putNextEntry(JarEntry(name).apply { method = ZipEntry.DEFLATED })
+                out.write(bytes)
+                out.closeEntry()
+            }
+        }
+    }
+}

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,4 +1,6 @@
+import dev.sebastiano.spectre.build.CliRoastNativePackagingContract
 import dev.sebastiano.spectre.build.CreateCliRuntimeImage
+import dev.sebastiano.spectre.build.FilterCliShadowJarNatives
 import dev.sebastiano.spectre.build.PatchStartScripts
 import dev.sebastiano.spectre.build.VerifyCliDistributionZip
 import dev.sebastiano.spectre.build.VerifyCliRuntimeImage
@@ -6,6 +8,7 @@ import dev.sebastiano.spectre.build.VerifyCliShadowJar
 import dev.sebastiano.spectre.build.VerifyRoastCliDistribution
 import io.github.fourlastor.construo.Target
 import io.github.fourlastor.construo.task.jvm.CreateRuntimeImageTask as ConstruoCreateRuntimeImageTask
+import io.github.fourlastor.construo.task.jvm.RoastTask
 import org.gradle.api.tasks.Copy
 import org.gradle.api.tasks.application.CreateStartScripts
 import org.gradle.api.tasks.bundling.Zip
@@ -116,6 +119,10 @@ preserveRuntimeJavaLauncher("macosX64", macBundle = true)
 preserveRuntimeJavaLauncher("macosArm64", macBundle = true)
 
 preserveRuntimeJavaLauncher("windowsX64")
+
+// Each Roast target embeds a filtered copy of the multi-platform shadow jar so platform zips
+// only ship that OS's recording helpers (#354). Maven recording jars stay multi-arch.
+wirePerTargetRoastNativeFiltering()
 
 tasks.shadowJar {
     val agentRuntimeJar = project(":agent-runtime").tasks.named<Jar>("jar")
@@ -232,6 +239,9 @@ val verifyRoastCliDistribution =
         )
         launcherPath.set(hostTarget.launcherPath(project.version.toString()))
         runtimeJavaPath.set(hostTarget.runtimeJavaPath(project.version.toString()))
+        keepNativePrefix.set(
+            CliRoastNativePackagingContract.keepNativePrefixForRoastTarget(hostTarget.name)
+        )
     }
 
 tasks.assemble { dependsOn(verifyCliShadowJar, verifyCliRuntimeImage) }
@@ -303,6 +313,36 @@ private fun preserveRuntimeJavaLauncher(target: String, macBundle: Boolean = fal
             filePermissions { unix("rwxr-xr-x") }
         }
     tasks.named("roast$taskSuffix") { dependsOn(preserveLauncher) }
+}
+
+/**
+ * Construo uses a single [jarTask] for every Roast target. After the multi-platform shadow jar is
+ * built, filter natives per OS and rewire each [RoastTask.jarFile] so package* zips never embed
+ * foreign recording helpers.
+ */
+private fun wirePerTargetRoastNativeFiltering() {
+    val roastTargets = listOf("linuxX64", "linuxArm64", "macosX64", "macosArm64", "windowsX64")
+    for (target in roastTargets) {
+        val taskSuffix = target.replaceFirstChar(Char::uppercase)
+        val keepPrefix = CliRoastNativePackagingContract.keepNativePrefixForRoastTarget(target)
+        val filterTask =
+            tasks.register<FilterCliShadowJarNatives>("filterShadowJarNatives$taskSuffix") {
+                description =
+                    "Filters the multi-platform CLI shadow jar so Roast $target keeps only $keepPrefix helpers."
+                group = "distribution"
+                inputJar.set(tasks.shadowJar.flatMap { it.archiveFile })
+                outputJar.set(
+                    layout.buildDirectory.file(
+                        "construo/filtered-jars/cli-$target-${project.version}-all.jar"
+                    )
+                )
+                keepNativePrefix.set(keepPrefix)
+            }
+        tasks.named<RoastTask>("roast$taskSuffix") {
+            dependsOn(filterTask)
+            jarFile.set(filterTask.flatMap { it.outputJar })
+        }
+    }
 }
 
 private data class RoastTarget(

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -336,10 +336,16 @@ private fun wirePerTargetRoastNativeFiltering(roastTargets: List<String>) {
                     "Filters the multi-platform CLI shadow jar so Roast $target keeps only $keepPrefix helpers."
                 group = "distribution"
                 inputJar.set(tasks.shadowJar.flatMap { it.archiveFile })
+                // Keep the unfiltered shadow jar basename (`cli-$version-all.jar`). Roast copies
+                // that name into the bundle and release.yml signs
+                // `Contents/MacOS/cli-$RELEASE_VERSION-all.jar` on macOS — a target-suffixed
+                // basename would break notarization under `set -euo pipefail`.
                 outputJar.set(
-                    layout.buildDirectory.file(
-                        "construo/filtered-jars/cli-$target-${project.version}-all.jar"
-                    )
+                    tasks.shadowJar.flatMap { shadow ->
+                        layout.buildDirectory.file(
+                            "construo/filtered-jars/$target/${shadow.archiveFile.get().asFile.name}"
+                        )
+                    }
                 )
                 keepNativePrefix.set(keepPrefix)
             }

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -6,6 +6,7 @@ import dev.sebastiano.spectre.build.VerifyCliDistributionZip
 import dev.sebastiano.spectre.build.VerifyCliRuntimeImage
 import dev.sebastiano.spectre.build.VerifyCliShadowJar
 import dev.sebastiano.spectre.build.VerifyRoastCliDistribution
+import dev.sebastiano.spectre.build.VerifyRoastCliNativeLayout
 import io.github.fourlastor.construo.Target
 import io.github.fourlastor.construo.task.jvm.CreateRuntimeImageTask as ConstruoCreateRuntimeImageTask
 import io.github.fourlastor.construo.task.jvm.RoastTask
@@ -120,9 +121,13 @@ preserveRuntimeJavaLauncher("macosArm64", macBundle = true)
 
 preserveRuntimeJavaLauncher("windowsX64")
 
+// Keep in sync with the `construo { targets { create… } }` block above. Declared before
+// wirePerTargetRoastNativeFiltering() so configuration-time iteration is non-null.
+val roastPackageTargets = listOf("linuxX64", "linuxArm64", "macosX64", "macosArm64", "windowsX64")
+
 // Each Roast target embeds a filtered copy of the multi-platform shadow jar so platform zips
 // only ship that OS's recording helpers (#354). Maven recording jars stay multi-arch.
-wirePerTargetRoastNativeFiltering()
+wirePerTargetRoastNativeFiltering(roastPackageTargets)
 
 tasks.shadowJar {
     val agentRuntimeJar = project(":agent-runtime").tasks.named<Jar>("jar")
@@ -318,10 +323,10 @@ private fun preserveRuntimeJavaLauncher(target: String, macBundle: Boolean = fal
 /**
  * Construo uses a single [jarTask] for every Roast target. After the multi-platform shadow jar is
  * built, filter natives per OS and rewire each [RoastTask.jarFile] so package* zips never embed
- * foreign recording helpers.
+ * foreign recording helpers. Each package* is finalized by a launcher-free layout verify so
+ * non-host release packages fail closed on foreign natives without running the target launcher.
  */
-private fun wirePerTargetRoastNativeFiltering() {
-    val roastTargets = listOf("linuxX64", "linuxArm64", "macosX64", "macosArm64", "windowsX64")
+private fun wirePerTargetRoastNativeFiltering(roastTargets: List<String>) {
     for (target in roastTargets) {
         val taskSuffix = target.replaceFirstChar(Char::uppercase)
         val keepPrefix = CliRoastNativePackagingContract.keepNativePrefixForRoastTarget(target)
@@ -342,6 +347,21 @@ private fun wirePerTargetRoastNativeFiltering() {
             dependsOn(filterTask)
             jarFile.set(filterTask.flatMap { it.outputJar })
         }
+        val packageTask = tasks.named("package$taskSuffix")
+        val layoutVerify =
+            tasks.register<VerifyRoastCliNativeLayout>("verifyRoastCliNativeLayout$taskSuffix") {
+                description =
+                    "Verifies Roast $target embeds only $keepPrefix helpers (no launcher)."
+                group = "verification"
+                dependsOn(packageTask)
+                artifact.set(
+                    layout.buildDirectory.file("construo/distributions/spectre-$target.zip")
+                )
+                roastTargetName.set(target)
+            }
+        // finalizedBy so any explicit package* (release matrix, local cross-build) still runs
+        // the layout gate without pulling every target into :cli:check.
+        packageTask.configure { finalizedBy(layoutVerify) }
     }
 }
 


### PR DESCRIPTION
## Summary

Stop shipping multi-OS recording helpers inside **every** Roast CLI zip. Construo still builds from the multi-platform shadow jar for local `java -jar` workflows, but each `package*` target now embeds a filtered application jar that retains only that OS’s `native/<os>/` tree. Maven/library recording jars stay multi-arch for Central.

This is PR1 of #354 (Train P): **baseline + per-target natives**. R8 tighten/optimize canary is intentionally deferred to a follow-up PR.

Closes part of #354 (natives lever). R8 goals remain open.

## Approach

1. Multi-platform `shadowJar` unchanged (R8 shrink-only, nested `spectre/agent-runtime.jar` opaque).
2. `FilterCliShadowJarNatives` produces `cli/build/construo/filtered-jars/cli-<target>-…-all.jar`.
3. Each Construo `roast*` task’s `jarFile` is rewired to the filtered jar.
4. `VerifyRoastCliDistribution` + launcher-free `VerifyRoastCliNativeLayout` (finalizedBy every `package*`) assert no foreign `native/` entries and agent-runtime presence.
5. `buildSrc` unit tests drive the real `filterJar` (including STORED agent-runtime CRC/size).

## Size table (before → after)

Measured on multi-OS prebuilt rebuild (Windows dual-arch WGC + Linux helpers + host macOS helper staged). Unfiltered multi-platform fat jar stays **37.64 MiB** compressed (local/dev artifact).

| Artifact | Before (multi-OS jar in every zip) | After (per-target filtered jar) | Delta |
| --- | ---: | ---: | ---: |
| Fat jar compressed (unfiltered shadowJar) | 37.64 MiB | 37.64 MiB (unchanged by design) | — |
| `native/windows/**` uncompressed in multi jar | 66.44 MiB | still in multi jar only | — |
| Filtered app jar `linuxX64` / `linuxArm64` | 37.64 MiB | **19.35 MiB** | −18.3 MiB |
| Filtered app jar `macosX64` / `macosArm64` | 37.64 MiB | **18.82 MiB** | −18.8 MiB |
| Filtered app jar `windowsX64` | 37.64 MiB | **36.46 MiB** | −1.2 MiB |
| `spectre-linuxX64.zip` | ~64.5 MiB (est.) | **46.24 MiB** | ~−18 MiB |
| `spectre-linuxArm64.zip` | ~63.9 MiB (est.) | **45.59 MiB** | ~−18 MiB |
| `spectre-macosX64.zip` | ~61.6 MiB (est.) | **42.79 MiB** | ~−19 MiB |
| `spectre-macosArm64.zip` | ~60.4 MiB (est.) | **41.60 MiB** | ~−19 MiB |
| `spectre-windowsX64.zip` | ~60.4 MiB (est.) | **59.20 MiB** | ~−1 MiB |

### Fat-jar entry buckets (unfiltered multi jar, baseline)

| Bucket | Uncompressed |
| --- | ---: |
| `native/windows/**` | 66.44 MiB |
| bytecode (kotlin/com/org/io/…) | ~tens of MiB |
| `spectre/agent-runtime` | 5.05 MiB |
| `native/linux/**` | 2.11 MiB |
| `native/macos/**` | 0.77 MiB |

### Roast zip native layout (all five)

| Target | Allowed prefix | Foreign natives | agent-runtime |
| --- | --- | ---: | --- |
| linuxX64 | `native/linux/` | 0 | yes |
| linuxArm64 | `native/linux/` | 0 | yes |
| macosX64 | `native/macos/` | 0 | yes |
| macosArm64 | `native/macos/` | 0 | yes |
| windowsX64 | `native/windows/` | 0 | yes |

## Verification / smoke

| Gate | Where | Result |
| --- | --- | --- |
| `./gradlew :buildSrc:test` (contract + filterJar + STORED) | macOS host | green |
| `./gradlew :cli:check` (shadow/R8, Roast host, layout verify) | macOS host | green |
| `./gradlew check` | macOS host | green |
| Packaged Roast `--help` + MCP stdio | macOS arm64 zip | green |
| Packaged Roast `--help` + MCP + jar layout | Linux x64 zip via WSL on `rock3r@192.168.1.8` | green |
| All five zip layouts inspected | macOS builder | PASS (no foreign natives) |
| Windows interactive attach | not fully exercised this PR | layout PASS via zip inspection; residual for 0.5.0 smoke |

## Residual risks for 0.5.0 release smoke

- **Zip native-layout hard cells** on the release matrix builders (each OS packages its own + cross packages): layout verify is finalizedBy `package*`, so green package implies green layout; still re-confirm on release cut.
- **macOS notarize / helper layout** path unchanged (helpers still under `native/macos/SpectreCaptureHelper.app` when present).
- **R8 optimize / keep narrowing** not in this PR — still open for #354 PR2.
- No release tag/publish from this train.

## Test plan

- [x] Contract unit tests red→green for filter + keep prefixes
- [x] `:cli:check` / full `check`
- [x] Host Roast `--help` + MCP
- [x] Linux packaged smoke (WSL)
- [x] Five-target zip native layout
- [ ] Release-smoke ritual later (attach e2e multi-OS) — out of this PR’s ship bar