### PR TITLE
feat(cli): R8 optimize canary and narrower keeps (#354)

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -134,24 +134,45 @@ tasks.shadowJar {
     dependsOn(agentRuntimeJar)
     archiveClassifier = "all"
     manifest { attributes["Main-Class"] = application.mainClass.get() }
-    // Keep Spectre's entrypoints readable and callable by name while R8 removes dead code from
-    // the merged third-party runtime. The nested agent runtime is copied as an opaque resource
-    // below, so its reflection-based attach contract stays outside the shrinker's scope.
+    // R8 on the CLI fat jar only (#354): shrink + optimize third-party bytecode while keeping
+    // human stack traces (`-dontobfuscate` + line numbers). Nested agent-runtime is copied as an
+    // opaque resource below, so its reflection attach contract stays outside the shrinker.
     minimize {
         r8 {
+            // Shadow defaults to shrink-only (`-dontoptimize`). Opt into optimize as the #354
+            // canary; verifyCliShadowJar / MCP / daemon main must stay green. If a future R8
+            // upgrade breaks canary, remove enableOptimization() rather than invent obfuscation.
+            enableOptimization()
             keepRules.addAll(
-                "-dontobfuscate",
-                "-dontoptimize",
-                // kotlin-logging ships adapters for optional logging backends. The CLI does not
-                // bundle Logback, so R8 must not treat those unused adapter references as an
-                // unresolved runtime dependency.
+                // Supportable traces; no name mangling (hard non-goal for #354).
+                // Shadow already passes --no-minification unless enableObfuscation() is called.
                 "-dontwarn ch.qos.logback.classic.**",
-                "-keepattributes SourceFile,LineNumberTable",
-                "-keep class dev.sebastiano.spectre.cli.** { *; }",
-                // Compose Hot Reload orchestration uses reflection + service loaders for message
-                // encoders; keep the public client surface used by waitForReloadSettled (#211).
-                "-keep class org.jetbrains.compose.reload.** { *; }",
+                "-keepattributes SourceFile,LineNumberTable,InnerClasses,EnclosingMethod," +
+                    "RuntimeVisibleAnnotations,AnnotationDefault,Signature",
+                // `java -jar` Main-Class and the daemon spawn launched by string class name
+                // (DaemonProcessLauncher / DaemonJvmProcessDiscovery).
+                "-keep class dev.sebastiano.spectre.cli.SpectreCliKt { " +
+                    "public static void main(java.lang.String[]); }",
+                "-keep class dev.sebastiano.spectre.cli.daemon.DaemonMainKt { " +
+                    "public static void main(java.lang.String[]); }",
+                "-keep class dev.sebastiano.spectre.cli.daemon.DaemonMain { *; }",
+                // Clikt builds the command tree from constructed classes; keep command types and
+                // their members so options/arguments and run() survive shrinking without a blanket
+                // keep of every helper in the package.
+                "-keep class * extends com.github.ajalt.clikt.core.CliktCommand { *; }",
+                // kotlinx.serialization consumer rules ship in dependency META-INF; keep Spectre
+                // serializable models that the daemon/MCP wire protocol uses by name.
+                "-if @kotlinx.serialization.Serializable class dev.sebastiano.spectre.cli.**",
+                "-keepclassmembers class <1> { *** Companion; }",
+                "-keepclasseswithmembers class dev.sebastiano.spectre.cli.** { " +
+                    "kotlinx.serialization.KSerializer serializer(...); }",
+                // Compose Hot Reload (#211): only the orchestration client + core types used by
+                // waitForReloadSettled / port discovery — not the full compose.reload tree.
+                "-keep class org.jetbrains.compose.reload.orchestration.** { *; }",
+                "-keep class org.jetbrains.compose.reload.core.** { *; }",
                 "-dontwarn org.jetbrains.compose.reload.**",
+                // Ktor ServiceLoader entry verified by verifyCliShadowJar.
+                "-keep class * implements io.ktor.server.config.ConfigLoader { *; }",
             )
         }
     }


### PR DESCRIPTION
## Summary

Second half of #354 (Train P): tighten CLI fat-jar R8 after [per-target natives (#391)](https://github.com/rock3r/spectre/pull/391).

- Call Shadow `enableOptimization()` so the default **`-dontoptimize` is dropped** (canary).
- Keep **no obfuscation** (Shadow `--no-minification` / no `enableObfuscation()`).
- Keep **line numbers** (+ InnerClasses/EnclosingMethod/annotations/Signature).
- Narrow keeps: `SpectreCliKt` / `DaemonMainKt` mains, Clikt commands, kotlinx.serialization serializers for `cli.**`, Hot Reload **orchestration + core only**, Ktor `ConfigLoader` ServiceLoader.
- Nested **`spectre/agent-runtime.jar` stays opaque** (not R8-processed).

## R8 rules intent (before → after)

| Before | After |
| --- | --- |
| Shadow injects `-dontoptimize` | `enableOptimization()` — no `-dontoptimize` in effective rules |
| `-keep class dev.sebastiano.spectre.cli.** { *; }` | entrypoints + Clikt subclasses + serializable companions |
| `-keep class org.jetbrains.compose.reload.** { *; }` | `orchestration.**` + `core.**` only |
| line numbers only | line numbers + InnerClasses/EnclosingMethod/annotations/Signature |

Evidence: scratch `r8-rules/intent-delta.md` + effective `rules.pro` (no `-dontoptimize`; human class names retained).

## Size note (host mac, no Windows prebuilts)

| Metric | Pre-optimize (this host) | Post-optimize |
| --- | ---: | ---: |
| Fat jar compressed | ~19 MiB | **~18 MiB** (18.6 MiB) |
| `.class` entries | ~5693 | **~5010** |

Dominant zip win remains PR1 natives (~18 MiB off Linux/macOS Roast zips when multi-OS helpers are staged). R8 optimize is incremental on bytecode.

## Verification

| Gate | Result |
| --- | --- |
| `verifyCliShadowJar` (`--help` + MCP tools/list) | green |
| `./gradlew :cli:check` | green |
| `./gradlew check` | green |
| No name mangling / agent-runtime present | asserted |
| Roast host layout + launcher | green |

## Residual risks (0.5.0 release smoke)

- Optimize canary is green on local macOS + CI path; re-confirm Roast attach + MCP on macOS/Linux release-smoke cells.
- Zip native-layout hard cells: covered by #391 `verifyRoastCliNativeLayout*` finalizedBy package*.
- No tag/publish from this train.

Closes #354 when both natives (#391) and this PR land.