### PR TITLE
fix(cli): keep Homebrew Spectre.app seal intact (#390)

### DIFF
--- a/.github/scripts/generate-cli-package-manifests.py
+++ b/.github/scripts/generate-cli-package-manifests.py
@@ -55,6 +55,9 @@ def main() -> None:
     end
   end
 
+  # Keep jlink @rpath dylib IDs intact during fix_dynamic_linkage (#390).
+  preserve_rpath
+
   def install
     # Homebrew strips a single top-level directory when staging, so accept both
     # nested (archive as shipped) and top-level (post-strip) layouts.
@@ -68,6 +71,32 @@ def main() -> None:
       exec "#{{libexec}}/Spectre.app/Contents/MacOS/spectre" "$@"
     SH
     (bin/"spectre").chmod 0755
+  end
+
+  def post_install
+    # fix_dynamic_linkage runs before post_install and can still rewrite nested
+    # jlink Mach-Os even with preserve_rpath (e.g. stripping duplicate
+    # @loader_path rpaths), then ad-hoc re-sign them. That breaks the outer
+    # Developer ID seal (Gatekeeper "damaged" — #390). Re-stage the notarized
+    # app from the release zip after linkage fix so sealed resources match.
+    restore_signed_app!
+  end
+
+  def restore_signed_app!
+    cached = cached_download
+    odie "missing cached download for Spectre.app seal restore" if cached.nil? || !cached.exist?
+
+    require "tmpdir"
+    Dir.mktmpdir("spectre-app-restore") do |tmpdir|
+      system "ditto", "-x", "-k", cached.to_s, tmpdir
+      restored =
+        Dir["#{{tmpdir}}/spectre-cli-*/Spectre.app"].first || Dir["#{{tmpdir}}/Spectre.app"].first
+      odie "missing Spectre.app in release archive for seal restore" if restored.nil?
+
+      target = libexec/"Spectre.app"
+      rm_r target if target.exist?
+      system "ditto", restored, target.to_s
+    end
   end
 
   test do

--- a/.github/scripts/test-generate-cli-package-manifests.sh
+++ b/.github/scripts/test-generate-cli-package-manifests.sh
@@ -29,6 +29,12 @@ grep -q 'sha256 "ddf7ff5ebd9d66ce161466c1c0262430fa04de32b0e420ee3f489e2e2112e38
 grep -q 'shell_output("#{bin}/spectre --help")' "$generated_formula"
 grep -q '"bin": "spectre-cli-1.2.3/spectre.exe"' "$tmp/out/bucket/spectre.json"
 
+# #390: Homebrew fix_dynamic_linkage must not leave a broken Spectre.app seal.
+grep -q 'preserve_rpath' "$generated_formula"
+grep -q 'def post_install' "$generated_formula"
+grep -q 'restore_signed_app!' "$generated_formula"
+grep -q 'cached_download' "$generated_formula"
+
 # Dual-layout app discovery: Homebrew may leave spectre-cli-*/ or strip it to top-level Spectre.app
 grep -q 'Dir\["spectre-cli-\*/Spectre.app"\]\.first || Dir\["Spectre.app"\]\.first' "$generated_formula"
 
@@ -47,6 +53,9 @@ if [[ ! -f "$committed_formula" ]]; then
   echo "missing committed formula: $committed_formula" >&2
   exit 1
 fi
+grep -q 'preserve_rpath' "$committed_formula"
+grep -q 'def post_install' "$committed_formula"
+grep -q 'restore_signed_app!' "$committed_formula"
 grep -q 'Dir\["spectre-cli-\*/Spectre.app"\]\.first || Dir\["Spectre.app"\]\.first' "$committed_formula"
 if grep -q 'bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"' "$committed_formula"; then
   echo "committed Formula/spectre.rb must not use raw bin.install_symlink of the Roast binary" >&2

--- a/.github/scripts/test-homebrew-formula-install-semantics.rb
+++ b/.github/scripts/test-homebrew-formula-install-semantics.rb
@@ -23,6 +23,14 @@ module SpectreHomebrewInstallSemantics
   FORBIDDEN_SYMLINK = 'bin.install_symlink libexec/"Spectre.app/Contents/MacOS/spectre"'
 
   REQUIRED_SNIPPETS = [
+    # #390: without preserve_rpath, brew rewrites jlink @rpath dylib IDs + ad-hoc re-signs
+    # nested Mach-Os and Gatekeeper reports Spectre.app as "damaged".
+    "preserve_rpath",
+    # #390: re-stage notarized Spectre.app after fix_dynamic_linkage (duplicate rpath strip).
+    "def post_install",
+    "restore_signed_app!",
+    "cached_download",
+    'system "ditto", "-x", "-k"',
     '(bin/"spectre").write',
     "#!/bin/sh",
     'exec "#{libexec}/Spectre.app/Contents/MacOS/spectre" "$@"',

--- a/.github/scripts/test-macos-cli-seal-preservation.sh
+++ b/.github/scripts/test-macos-cli-seal-preservation.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Contract + behavioral proof for #390 (Homebrew post-install seal break).
+#
+# 1) Formula / release workflow must declare the protections that keep the sealed
+#    Spectre.app intact under Homebrew (preserve_rpath) and under release signing
+#    (codesign --verify --deep --strict).
+# 2) On Darwin, when a real Spectre.app is available (SPECTRE_APP or a release zip
+#    extract), prove that rewriting a nested jlink dylib ID + ad-hoc re-sign —
+#    the mutation Homebrew's fix_dynamic_linkage performs without preserve_rpath —
+#    makes codesign --verify --deep --strict fail.
+#
+# Wired into ./gradlew verifyMacosCliBundleReleaseContract (Unix check gate).
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+formula="$root/Formula/spectre.rb"
+workflow="$root/.github/workflows/release.yml"
+verifier="$root/.github/scripts/verify-macos-cli-bundle.sh"
+
+test -f "$formula"
+test -f "$workflow"
+test -x "$verifier"
+
+grep -Fq 'preserve_rpath' "$formula"
+grep -Fq 'codesign --verify --deep --strict --verbose=4 "$app"' "$verifier"
+deep_strict_count="$(
+  grep -c 'codesign --verify --deep --strict --verbose=4 "\$app"' "$workflow" || true
+)"
+if [[ "$deep_strict_count" -lt 2 ]]; then
+  echo "release.yml must deep+strict verify the app at least twice (pre/post staple)" >&2
+  exit 1
+fi
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "test-macos-cli-seal-preservation: non-Darwin host; structural contracts OK"
+  exit 0
+fi
+
+app="${SPECTRE_APP:-}"
+cleanup_workspace=""
+if [[ -z "$app" ]]; then
+  # Prefer a published-shaped extract if the operator left one; otherwise skip the
+  # mutation probe (structural contracts above still run on every host).
+  for candidate in \
+    "${SPECTRE_CLI_ZIP:-}" \
+    "$root/cli/build/construo/distributions/spectre-macosArm64.zip" \
+    "$root/cli/build/construo/distributions/spectre-macosX64.zip"
+  do
+    if [[ -n "$candidate" && -f "$candidate" ]]; then
+      workspace="$(mktemp -d "${TMPDIR:-/tmp}/spectre-seal-probe.XXXXXX")"
+      cleanup_workspace="$workspace"
+      ditto -x -k "$candidate" "$workspace"
+      app="$(find "$workspace" -name 'Spectre.app' -type d | head -1 || true)"
+      break
+    fi
+  done
+fi
+
+if [[ -z "${app:-}" || ! -d "$app" ]]; then
+  echo "test-macos-cli-seal-preservation: no Spectre.app available; structural contracts OK"
+  [[ -n "$cleanup_workspace" ]] && rm -rf "$cleanup_workspace"
+  exit 0
+fi
+
+trap '[[ -n "${cleanup_workspace:-}" ]] && rm -rf "$cleanup_workspace"' EXIT
+
+# Working copy so we never mutate the caller's artifact.
+probe="$(mktemp -d "${TMPDIR:-/tmp}/spectre-seal-mut.XXXXXX")"
+trap 'rm -rf "$probe"; [[ -n "${cleanup_workspace:-}" ]] && rm -rf "$cleanup_workspace"' EXIT
+ditto "$app" "$probe/Spectre.app"
+app="$probe/Spectre.app"
+
+dylib=""
+for candidate in \
+  "$app/Contents/Resources/runtime/lib/libnet.dylib" \
+  "$app/Contents/MacOS/runtime/lib/libnet.dylib"
+do
+  if [[ -f "$candidate" ]]; then
+    dylib="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$dylib" ]]; then
+  echo "test-macos-cli-seal-preservation: Spectre.app has no jlink libnet.dylib; skip mutation probe"
+  exit 0
+fi
+
+# Baseline: may be ad-hoc (local package) or Developer ID (release). Deep verify must
+# still be runnable; if the tree is already unsigned/broken, skip mutation proof.
+if ! codesign --verify --deep --strict "$app" >/dev/null 2>&1; then
+  echo "test-macos-cli-seal-preservation: baseline deep verify failed on $app; skip mutation probe"
+  exit 0
+fi
+
+# Reproduce Homebrew fix_dynamic_linkage's harmful step: absolute dylib id + ad-hoc re-sign.
+install_name_tool -id "/opt/homebrew/opt/spectre/libexec/Spectre.app/Contents/Resources/runtime/lib/libnet.dylib" \
+  "$dylib"
+# Match Homebrew's arm64 ad-hoc re-sign after Mach-O rewrite (ruby-macho MachO.codesign!).
+codesign --force --sign - --options runtime "$dylib"
+
+if codesign --verify --deep --strict "$app" >/dev/null 2>&1; then
+  echo "expected deep+strict verify to FAIL after jlink dylib rewrite + ad-hoc re-sign (#390)" >&2
+  codesign --verify --deep --strict --verbose=2 "$app" >&2 || true
+  exit 1
+fi
+
+echo "test-macos-cli-seal-preservation: OK (deep+strict fails after simulated brew mutation)"

--- a/.github/scripts/test-verify-macos-cli-bundle.sh
+++ b/.github/scripts/test-verify-macos-cli-bundle.sh
@@ -4,10 +4,30 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
 workflow="$repo_root/.github/workflows/release.yml"
 verifier="$repo_root/.github/scripts/verify-macos-cli-bundle.sh"
+seal_probe="$repo_root/.github/scripts/test-macos-cli-seal-preservation.sh"
 
 test -x "$verifier"
+test -x "$seal_probe"
 grep -Fq 'verify-macos-cli-bundle.sh "$archive" "$RELEASE_VERSION"' "$workflow"
 grep -Fq 'app="$workspace/$expected_root/Spectre.app"' "$verifier"
 grep -Fq 'codesign --verify --deep --strict --verbose=4 "$app"' "$verifier"
 grep -Fq 'xcrun stapler validate "$app"' "$verifier"
 grep -Fq 'spctl --assess --type execute --verbose=4 "$app"' "$verifier"
+
+# Intermediate release signing must also deep-verify (not only --strict). A non-deep
+# check can green-pass while nested jlink dylibs under Resources/runtime are already
+# invalid relative to the outer seal (#390).
+deep_strict_count="$(
+  grep -c 'codesign --verify --deep --strict --verbose=4 "\$app"' "$workflow" || true
+)"
+if [[ "$deep_strict_count" -lt 2 ]]; then
+  echo "release.yml must codesign --verify --deep --strict at least twice (pre- and post-staple)" >&2
+  exit 1
+fi
+# Guard against reintroducing non-deep intermediate verifies on the app bundle.
+if grep -E 'codesign --verify --strict --verbose=4 "\$app"' "$workflow" | grep -vq -- '--deep'; then
+  echo "release.yml still has codesign --verify --strict without --deep on \$app" >&2
+  exit 1
+fi
+
+bash "$seal_probe"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -384,10 +384,14 @@ jobs:
                   --sign "$APPLE_DEVELOPER_IDENTITY" "$file"
               fi
             done < <(find "$app" -type f -print0)
+            # Nested Mach-Os were signed above; outer seal is the last content mutation
+            # before notarize/staple. Stapling only attaches a ticket under _CodeSignature.
             codesign --force --options runtime --timestamp \
               --entitlements "$entitlements" \
               --sign "$APPLE_DEVELOPER_IDENTITY" "$app"
-            codesign --verify --strict --verbose=4 "$app"
+            # --deep is required: without it nested jlink dylib seal breaks can pass
+            # intermediate checks and only fail on consumer machines / Gatekeeper (#390).
+            codesign --verify --deep --strict --verbose=4 "$app"
 
             # Notarytool receives an app-root archive. The published ZIP keeps its version
             # directory so Homebrew does not strip the application bundle itself on install.
@@ -413,7 +417,7 @@ jobs:
             fi
             xcrun stapler staple "$app"
             xcrun stapler validate "$app"
-            codesign --verify --strict --verbose=4 "$app"
+            codesign --verify --deep --strict --verbose=4 "$app"
             ditto -c -k --sequesterRsrc --keepParent "$root" "$archive"
 
             extracted="$workspace/published"

--- a/Formula/spectre.rb
+++ b/Formula/spectre.rb
@@ -13,6 +13,9 @@ class Spectre < Formula
     end
   end
 
+  # Keep jlink @rpath dylib IDs intact during fix_dynamic_linkage (#390).
+  preserve_rpath
+
   def install
     # Homebrew strips a single top-level directory when staging, so accept both
     # nested (archive as shipped) and top-level (post-strip) layouts.
@@ -26,6 +29,32 @@ class Spectre < Formula
       exec "#{libexec}/Spectre.app/Contents/MacOS/spectre" "$@"
     SH
     (bin/"spectre").chmod 0755
+  end
+
+  def post_install
+    # fix_dynamic_linkage runs before post_install and can still rewrite nested
+    # jlink Mach-Os even with preserve_rpath (e.g. stripping duplicate
+    # @loader_path rpaths), then ad-hoc re-sign them. That breaks the outer
+    # Developer ID seal (Gatekeeper "damaged" — #390). Re-stage the notarized
+    # app from the release zip after linkage fix so sealed resources match.
+    restore_signed_app!
+  end
+
+  def restore_signed_app!
+    cached = cached_download
+    odie "missing cached download for Spectre.app seal restore" if cached.nil? || !cached.exist?
+
+    require "tmpdir"
+    Dir.mktmpdir("spectre-app-restore") do |tmpdir|
+      system "ditto", "-x", "-k", cached.to_s, tmpdir
+      restored =
+        Dir["#{tmpdir}/spectre-cli-*/Spectre.app"].first || Dir["#{tmpdir}/Spectre.app"].first
+      odie "missing Spectre.app in release archive for seal restore" if restored.nil?
+
+      target = libexec/"Spectre.app"
+      rm_r target if target.exist?
+      system "ditto", restored, target.to_s
+    end
   end
 
   test do

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,8 @@ val verifyMacosCliBundleReleaseContract by
                 ".github/workflows/release.yml",
                 ".github/scripts/verify-macos-cli-bundle.sh",
                 ".github/scripts/test-verify-macos-cli-bundle.sh",
+                ".github/scripts/test-macos-cli-seal-preservation.sh",
+                "Formula/spectre.rb",
             )
             .withPathSensitivity(PathSensitivity.RELATIVE)
         outputs.upToDateWhen { false }

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -49,9 +49,13 @@ Jobs on tag push (order simplified; see the workflow for the full graph):
 5. **`mac-cli-bundles`** (macOS runner, depends on the gate and `mac-helper`) — builds the
    x64 and arm64 Roast `.app` CLI bundles with the notarised screen-capture helper, signs every
    Mach-O component in their jlink runtimes with the Developer ID and JVM hardened-runtime
-   entitlements, submits each archive to `notarytool` with a 30-minute bound, staples the
-   resulting ticket, then verifies the exact extracted ZIP with `codesign`, `stapler`, and
-   `spctl` before uploading it as a workflow artefact.
+   entitlements (nested first, outer bundle last), submits each archive to `notarytool` with a
+   30-minute bound, staples the ticket, then verifies the exact extracted ZIP with
+   `codesign --verify --deep --strict`, `stapler`, and `spctl` before upload. Intermediate
+   post-sign checks also use `--deep --strict` so a nested jlink seal break cannot green-pass
+   (#390). The Homebrew formula must keep `preserve_rpath` and a `post_install` that re-stages
+   the notarized `Spectre.app` from the release zip after `fix_dynamic_linkage` (which can still
+   strip duplicate jlink rpaths and ad-hoc re-sign nested dylibs, breaking the outer seal).
 6. **`publish`** (Linux runner, depends on the gate and all helper/bundle jobs) — downloads the
    helper and signed macOS CLI artefacts, runs `:verifyMavenLocalPublication` to assert the
    publication shape, builds the Linux x64/Linux arm64/Windows x64 Roast CLI bundles, and runs

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -120,6 +120,7 @@ Run these for **every** release unless a cell is explicitly N/A with reason
 | B6 | macOS | Agent inject | Compose-only target; inject bootstrap; non-empty tree; detach |
 | B7 | macOS | CLI daemon fixture | `spectre attach` (or package binary) → tree/capture against live fixture |
 | B8 | macOS | Capture helper + TCC | Helper is app-bundle identity; `spectre permissions check`; one screenshot/record |
+| B16 | macOS | CLI app seal (packaged) | Release-shaped or Homebrew `Spectre.app`: `codesign --verify --deep --strict` exit 0; `xcrun stapler validate` when notarized; launcher `--help` prints Usage (not silent exit 0 / Gatekeeper “damaged”). Prefer brew install of the formula after undraft when claiming Homebrew. See [#390](https://github.com/rock3r/spectre/issues/390). |
 | B9 | Windows | Agent attach (core) | Same as B5; prefer opt-in e2e (recipe below). SSH OK if semantics-only. |
 | B10 | Windows | Agent inject | Same as B6 — **does not ship “three OS agent” without this** |
 | B11 | Windows | Launch-and-attach | Direct `java` launch + attach (Gradle optional) |


### PR DESCRIPTION
## Summary

Fixes [#390](https://github.com/rock3r/spectre/issues/390): Homebrew-installed `Spectre.app` is rejected by Gatekeeper as **“damaged”**.

### Root cause (one paragraph)

The **published release zip** already seals correctly (`codesign --verify --deep --strict` is green on a clean extract of v0.4.0/v0.4.1). The break happens **after** `brew install`: Homebrew’s `Keg#fix_dynamic_linkage` rewrites jlink nested dylibs (historically `@rpath` → absolute cellar IDs; even with `preserve_rpath`, some dylibs still lose a duplicate `@loader_path` rpath) and **ad-hoc re-signs** them. The outer bundle keeps Developer ID + staple, but sealed resource hashes under `Contents/Resources/runtime/**` no longer match → Gatekeeper “damaged” and silent wrapper launches. This is **not** a capture-helper notarization issue (#191).

### Fix

1. **Homebrew formula** (`Formula/spectre.rb` + generator):
   - `preserve_rpath` so `@rpath` dylib IDs are left alone
   - `post_install` re-stages the notarized `Spectre.app` from the cached release zip **after** `fix_dynamic_linkage` (definitive seal restore)
2. **Release** (`.github/workflows/release.yml`): intermediate post-sign verifies use `codesign --verify --deep --strict` (final `verify-macos-cli-bundle.sh` already did)
3. **Contracts**: formula snippets + `test-macos-cli-seal-preservation.sh` (red on simulated brew mutation when a signed app is available)
4. **Docs**: RELEASE-SMOKE **B16** hard cell; PUBLISHING note on deep verify + formula restore

### Proof (this machine, macOS 26.5.2)

| Check | Result |
| --- | --- |
| Clean zip extract 0.4.1 | `codesign --verify --deep --strict` green; `spectre --help` prints Usage |
| `brew install` **without** fix (0.4.0 cellar) | deep+strict **fails** on ~28 runtime dylibs; nested signatures become ad-hoc |
| `brew reinstall` with fixed formula | deep+strict **green**; stapler validate; spctl accepted; nested dylibs stay Developer ID; `spectre --help` prints Usage |
| `./gradlew check` | green (incl. package/manifest/release contracts) |

### Residual risks for 0.5.0 smoke

- Full Developer ID re-sign path remains CI-only (local ad-hoc packages skip the mutation probe when baseline deep verify fails).
- Homebrew formula on `main` only helps after the **package-channels** refresh ships a formula with this body (or users `brew install` from a checkout that has the fix). Until the next undrafted release regenerates manifests, tap consumers of 0.4.x still need a formula update.
- No second Mac used; quarantine/`spctl` exercised on the build Mac.
- Capture helper path untouched; Roast attach/`java` nest unchanged in release packaging.

## Test plan

- [x] Reproduce brew-induced deep-verify failure on Cellar install
- [x] Prove fixed formula reinstall: deep+strict + stapler + spctl + `--help`
- [x] `./gradlew check` + `verifyCliPackageManifests` + `verifyMacosCliBundleReleaseContract`
- [x] Mutation probe: install_name_tool + ad-hoc re-sign of nested dylib → deep+strict fails
- [ ] CI green on this PR