### PR TITLE
fix(recording): Xvfb capture not hijacked by residual Wayland sockets (#397)

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -17,9 +17,12 @@ name: Validation tests (Linux)
 #
 # `ubuntu-latest` runners ship without a display server, so we install `xvfb` and drive the
 # whole Gradle invocation under `xvfb-run`. That gives us a real Xorg server (NOT XWayland) —
-# framebuffer reads work normally, Robot input works normally, and the LinuxX11Grab Wayland
-# guard from #77 stage 1 stays out of the picture (`XDG_SESSION_TYPE` and `WAYLAND_DISPLAY`
-# are unset in xvfb-run's environment, no `wayland-*` socket exists in `XDG_RUNTIME_DIR`).
+# framebuffer reads work normally, Robot input works normally. This proves Linux **X11**
+# capture under Xvfb only — not Wayland portal/PipeWire. On clean runners
+# `XDG_SESSION_TYPE`/`WAYLAND_DISPLAY` are unset and there is usually no residual
+# `wayland-*` under `XDG_RUNTIME_DIR`; hosts that still carry login-session Wayland
+# sockets (or inherit Wayland env into xvfb-run) rely on #397 session detection so pure
+# X11 `DISPLAY` still routes to `ximagesrc` rather than portal.
 #
 # Counterpart to `validation-windows.yml`. Historically both workflows carried a
 # fail-tolerant + XML-source-of-truth pattern to ride out a Gradle test-executor protocol race

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackend.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackend.kt
@@ -127,12 +127,33 @@ internal fun nativeWindowCaptureBounds(
     )
 }
 
+/**
+ * Returns true when still/window capture should use the Linux Wayland/portal path.
+ *
+ * Mirrors [dev.sebastiano.spectre.recording.FfmpegBackend.detectWaylandSession] (recording cannot
+ * depend on core and core cannot depend on recording — keep both in lockstep; #397).
+ *
+ * Order: explicit `SPECTRE_CAPTURE_BACKEND` → pure-X11 DISPLAY (Xvfb) wins over inherited Wayland
+ * env → session type / WAYLAND_DISPLAY → residual wayland-* socket only when DISPLAY is unset.
+ */
+@Suppress("ReturnCount")
 internal fun isWaylandSession(
     getenv: (String) -> String? = System::getenv,
     runtimeDirHasWaylandSocket: (Path) -> Boolean = ::runtimeDirHasWaylandSocket,
+    displayIsPureX11: (String) -> Boolean = ::defaultDisplayIsPureX11,
 ): Boolean {
+    when (getenv("SPECTRE_CAPTURE_BACKEND")?.trim()?.lowercase()) {
+        "x11",
+        "xorg",
+        "xvfb" -> return false
+        "wayland",
+        "portal" -> return true
+    }
+    val display = getenv("DISPLAY")?.takeIf { it.isNotBlank() }
+    if (display != null && displayIsPureX11(display)) return false
     if (getenv("XDG_SESSION_TYPE").equals("wayland", ignoreCase = true)) return true
     if (!getenv("WAYLAND_DISPLAY").isNullOrBlank()) return true
+    if (display != null) return false
     return getenv("XDG_RUNTIME_DIR")?.let(Path::of)?.let {
         runCatching { runtimeDirHasWaylandSocket(it) }.getOrDefault(false)
     } == true
@@ -143,6 +164,68 @@ private fun runtimeDirHasWaylandSocket(runtimeDir: Path): Boolean =
         Files.list(runtimeDir).use { entries ->
             entries.anyMatch { it.fileName.toString().startsWith("wayland-") }
         }
+
+/** True when [display] is served by Xvfb or a non-XWayland X server (see recording twin). */
+@Suppress("TooGenericExceptionCaught")
+internal fun defaultDisplayIsPureX11(display: String): Boolean {
+    if (linuxDisplayMatchesXvfbProcess(display)) return true
+    return runCatching { xdpyinfoReportsPureX11(display) }.getOrDefault(false)
+}
+
+/** Scans Linux /proc pid cmdlines for an Xvfb process serving [display]. */
+@Suppress("TooGenericExceptionCaught")
+internal fun linuxDisplayMatchesXvfbProcess(display: String): Boolean {
+    val displayToken = normalizeDisplayToken(display) ?: return false
+    val proc = Path.of("/proc")
+    if (!Files.isDirectory(proc)) return false
+    return runCatching {
+            Files.list(proc).use { stream ->
+                stream.anyMatch { entry ->
+                    val name = entry.fileName.toString()
+                    if (name.toLongOrNull() == null) return@anyMatch false
+                    val cmdline =
+                        runCatching { Files.readAllBytes(entry.resolve("cmdline")) }.getOrNull()
+                            ?: return@anyMatch false
+                    val args =
+                        cmdline.toString(Charsets.UTF_8).split('\u0000').filter { it.isNotEmpty() }
+                    if (args.none { it == "Xvfb" || it.endsWith("/Xvfb") }) return@anyMatch false
+                    args.any { arg ->
+                        val token = normalizeDisplayToken(arg) ?: return@anyMatch false
+                        token == displayToken
+                    }
+                }
+            }
+        }
+        .getOrDefault(false)
+}
+
+internal fun normalizeDisplayToken(raw: String): String? {
+    val trimmed = raw.trim()
+    if (trimmed.isEmpty()) return null
+    val afterHost =
+        when {
+            trimmed.startsWith(":") -> trimmed
+            trimmed.contains(':') -> trimmed.substringAfterLast(':').let { ":$it" }
+            else -> return null
+        }
+    val num =
+        afterHost.removePrefix(":").substringBefore('.').takeIf { it.isNotEmpty() } ?: return null
+    if (num.toIntOrNull() == null) return null
+    return ":$num"
+}
+
+@Suppress("TooGenericExceptionCaught")
+private fun xdpyinfoReportsPureX11(display: String): Boolean {
+    val process = ProcessBuilder("xdpyinfo", "-display", display).redirectErrorStream(true).start()
+    val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+    val finished = process.waitFor(3, java.util.concurrent.TimeUnit.SECONDS)
+    if (!finished) {
+        process.destroyForcibly()
+        return false
+    }
+    if (process.exitValue() != 0) return false
+    return !output.contains("XWAYLAND", ignoreCase = true)
+}
 
 /**
  * Loads the optional recording-owned native capture bridge without linking it into core.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackend.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackend.kt
@@ -188,15 +188,20 @@ internal fun linuxDisplayMatchesXvfbProcess(display: String): Boolean {
                             ?: return@anyMatch false
                     val args =
                         cmdline.toString(Charsets.UTF_8).split('\u0000').filter { it.isNotEmpty() }
-                    if (args.none { it == "Xvfb" || it.endsWith("/Xvfb") }) return@anyMatch false
-                    args.any { arg ->
-                        val token = normalizeDisplayToken(arg) ?: return@anyMatch false
-                        token == displayToken
-                    }
+                    cmdlineMatchesXvfbDisplay(args, displayToken)
                 }
             }
         }
         .getOrDefault(false)
+}
+
+/**
+ * True when [args] is an Xvfb argv serving [displayToken]. Non-display args are skipped — do not
+ * abort when [normalizeDisplayToken] returns null for the binary path or flags.
+ */
+internal fun cmdlineMatchesXvfbDisplay(args: List<String>, displayToken: String): Boolean {
+    if (args.none { it == "Xvfb" || it.endsWith("/Xvfb") }) return false
+    return args.any { normalizeDisplayToken(it) == displayToken }
 }
 
 internal fun normalizeDisplayToken(raw: String): String? {
@@ -214,18 +219,47 @@ internal fun normalizeDisplayToken(raw: String): String? {
     return ":$num"
 }
 
+/** Bounded `xdpyinfo` probe; never blocks forever on a hung DISPLAY. */
 @Suppress("TooGenericExceptionCaught")
 private fun xdpyinfoReportsPureX11(display: String): Boolean {
     val process = ProcessBuilder("xdpyinfo", "-display", display).redirectErrorStream(true).start()
-    val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
-    val finished = process.waitFor(3, java.util.concurrent.TimeUnit.SECONDS)
-    if (!finished) {
+    return try {
+        val outputRef = java.util.concurrent.atomic.AtomicReference("")
+        val reader =
+            Thread(
+                    {
+                        runCatching {
+                            outputRef.set(
+                                process.inputStream.bufferedReader(Charsets.UTF_8).use {
+                                    it.readText()
+                                }
+                            )
+                        }
+                    },
+                    "spectre-xdpyinfo-reader",
+                )
+                .apply {
+                    isDaemon = true
+                    start()
+                }
+        val finished =
+            process.waitFor(XDPYINFO_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+        if (!finished) {
+            process.destroyForcibly()
+            reader.join(XDPYINFO_READER_JOIN_MS)
+            return false
+        }
+        reader.join(XDPYINFO_READER_JOIN_MS)
+        if (process.exitValue() != 0) return false
+        !outputRef.get().contains("XWAYLAND", ignoreCase = true)
+    } catch (_: Exception) {
         process.destroyForcibly()
-        return false
+        false
     }
-    if (process.exitValue() != 0) return false
-    return !output.contains("XWAYLAND", ignoreCase = true)
 }
+
+private const val XDPYINFO_TIMEOUT_MS: Long = 3_000
+private const val XDPYINFO_READER_JOIN_MS: Long = 500
 
 /**
  * Loads the optional recording-owned native capture bridge without linking it into core.

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackendTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackendTest.kt
@@ -209,6 +209,21 @@ class ScreenCaptureBackendTest {
     }
 
     @Test
+    fun `cmdlineMatchesXvfbDisplay accepts real Xvfb argv shape`() {
+        // Non-display args must not abort the match (see recording twin + Bugbot #401).
+        assertTrue(
+            cmdlineMatchesXvfbDisplay(listOf("Xvfb", ":99", "-screen", "0", "1280x1024x24"), ":99")
+        )
+        assertFalse(cmdlineMatchesXvfbDisplay(listOf("Xorg", ":0"), ":0"))
+    }
+
+    @Test
+    fun `normalizeDisplayToken handles Xvfb-style names`() {
+        assertEquals(":99", normalizeDisplayToken(":99.0"))
+        assertEquals(null, normalizeDisplayToken("Xvfb"))
+    }
+
+    @Test
     fun `tracked Frame capture prefers the native window backend`() {
         assumeLiveAwtAvailable()
         val frame =

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackendTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackendTest.kt
@@ -105,11 +105,95 @@ class ScreenCaptureBackendTest {
     }
 
     @Test
-    fun `Wayland detection recognizes a runtime-directory socket`() {
+    fun `Wayland detection recognizes a runtime-directory socket without DISPLAY`() {
+        // SSH into a Wayland host: no DISPLAY, residual compositor socket → Wayland.
         assertTrue(
             isWaylandSession(
                 getenv = { if (it == "XDG_RUNTIME_DIR") "/run/user/1000" else null },
                 runtimeDirHasWaylandSocket = { it == Path.of("/run/user/1000") },
+            )
+        )
+    }
+
+    @Test
+    fun `Wayland detection ignores residual socket when Xvfb DISPLAY is set`() {
+        // #397: Xvfb + leftover wayland-* under XDG_RUNTIME_DIR must not route to portal.
+        assertFalse(
+            isWaylandSession(
+                getenv = { key ->
+                    when (key) {
+                        "DISPLAY" -> ":99"
+                        "XDG_RUNTIME_DIR" -> "/run/user/1000"
+                        else -> null
+                    }
+                },
+                runtimeDirHasWaylandSocket = { true },
+                displayIsPureX11 = { false },
+            )
+        )
+    }
+
+    @Test
+    fun `Wayland detection prefers pure X11 DISPLAY over inherited Wayland env`() {
+        assertFalse(
+            isWaylandSession(
+                getenv = { key ->
+                    when (key) {
+                        "DISPLAY" -> ":99"
+                        "XDG_SESSION_TYPE" -> "wayland"
+                        "WAYLAND_DISPLAY" -> "wayland-0"
+                        "XDG_RUNTIME_DIR" -> "/run/user/1000"
+                        else -> null
+                    }
+                },
+                runtimeDirHasWaylandSocket = { true },
+                displayIsPureX11 = { it == ":99" },
+            )
+        )
+    }
+
+    @Test
+    fun `Wayland detection keeps portal routing for XWayland DISPLAY`() {
+        assertTrue(
+            isWaylandSession(
+                getenv = { key ->
+                    when (key) {
+                        "DISPLAY" -> ":0"
+                        "XDG_SESSION_TYPE" -> "wayland"
+                        "WAYLAND_DISPLAY" -> "wayland-0"
+                        else -> null
+                    }
+                },
+                runtimeDirHasWaylandSocket = { true },
+                displayIsPureX11 = { false },
+            )
+        )
+    }
+
+    @Test
+    fun `Wayland detection honors SPECTRE_CAPTURE_BACKEND override`() {
+        assertFalse(
+            isWaylandSession(
+                getenv = { key ->
+                    when (key) {
+                        "SPECTRE_CAPTURE_BACKEND" -> "x11"
+                        "XDG_SESSION_TYPE" -> "wayland"
+                        "WAYLAND_DISPLAY" -> "wayland-0"
+                        else -> null
+                    }
+                }
+            )
+        )
+        assertTrue(
+            isWaylandSession(
+                getenv = { key ->
+                    when (key) {
+                        "SPECTRE_CAPTURE_BACKEND" -> "wayland"
+                        "DISPLAY" -> ":99"
+                        else -> null
+                    }
+                },
+                displayIsPureX11 = { true },
             )
         )
     }

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -104,10 +104,25 @@ interactive and not automatable. Spectre's `spectre-wayland-helper` uses portal
   `"x264enc"`; unsupported codec strings fail at `start(...)` with a targeted error rather
   than building a broken GStreamer pipeline. The explicit ffmpeg classes remain available
   only as deprecated compatibility escape hatches.
+
+  **Xvfb validation proves Linux X11 capture only** — not Wayland portal/PipeWire consent,
+  restore-token reuse, or compositor-specific portal behaviour. CI and release-smoke under
+  `xvfb-run` exercise the X11 helper path (`ximagesrc`). Keep a separate real Wayland
+  desktop run when claiming portal capture.
+
+  Session detection (#397): residual `wayland-*` sockets under `XDG_RUNTIME_DIR` (or
+  inherited `WAYLAND_DISPLAY` / `XDG_SESSION_TYPE=wayland` from a login session) must not
+  hijack an active pure-X11 `DISPLAY` such as Xvfb. Spectre prefers a pure-X11 display
+  probe (Xvfb process match or `xdpyinfo` without the `XWAYLAND` extension) and only treats
+  a residual compositor socket as Wayland when `DISPLAY` is unset (SSH into a Wayland host).
+  Real Wayland+XWayland still routes to the portal. Override with
+  `SPECTRE_CAPTURE_BACKEND=x11` or `wayland` when probes cannot decide.
+
   Native Wayland sessions with XWayland are different: Mutter does not expose the composited
   desktop through the XWayland root framebuffer, so root-region `ximagesrc` capture can be black
   except for the cursor. `AutoRecorder` detects Wayland before this backend and routes region
-  capture through the portal; do not force the X11 backend in that environment.
+  capture through the portal; do not force the X11 backend in that environment
+  (`SPECTRE_CAPTURE_BACKEND=x11` is an escape hatch for nested Xvfb only).
 - **Linux Wayland sessions** — `gst-launch-1.0` driven through the
   `xdg-desktop-portal` ScreenCast interface, with the PipeWire FD passed to the encoder by a
   small Rust helper binary from `spectre-recording-linux` (`spectre-wayland-helper`, sources at

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -141,6 +141,13 @@ no signature check, hash check, or path constraint. Never set it in an environme
 ingests untrusted input. The published platform helper artifacts are the only supported
 configuration for non-dev use.
 
+`SPECTRE_CAPTURE_BACKEND` forces Linux still/video routing when auto-detection is wrong for a
+nested setup: `x11` / `xorg` / `xvfb` → X11 helper path; `wayland` / `portal` → portal path;
+unset or any other value → auto (pure-X11 `DISPLAY` probe, then session type /
+`WAYLAND_DISPLAY`, then residual `wayland-*` sockets only if `DISPLAY` is unset — see #397).
+Prefer fixing the environment (run under `xvfb-run` with a real Xvfb `DISPLAY`) over leaving
+the override set in CI.
+
 ## Out of scope for this review
 
 The R5 review explicitly did not cover:

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -21,6 +21,14 @@ tasks.withType<Test>().configureEach {
 Linux a display server, but it cannot help if the JVM has already decided to run headless and
 ignore `DISPLAY`.
 
+**Honesty:** `xvfb-run` proves the Linux **X11** capture path (helper `ximagesrc`, JUnit
+failure screenshots, agent screenshots, visual idle under a virtual framebuffer). It does
+**not** prove Wayland portal consent, PipeWire one-frame capture, or restore-token behaviour.
+When the host also has residual Wayland sockets or inherited Wayland env vars, Spectre still
+routes to X11 for an Xvfb `DISPLAY` (#397). For portal coverage, run on a real Wayland
+session separately. If detection ever disagrees with your setup, set
+`SPECTRE_CAPTURE_BACKEND=x11` (or `wayland`) explicitly.
+
 `-Dskiko.renderApi=SOFTWARE_COMPAT` is required on GPU-less Linux runners. Without it, Skiko's
 default OpenGL path can throw `RenderException: Cannot create Linux GL context`. The semantics
 tree may still compose, so selectors such as `findByTestTag` can pass, but typed input can

--- a/docs/guide/recording.md
+++ b/docs/guide/recording.md
@@ -108,6 +108,9 @@ Expected results by platform:
   PNG and confirm it contains the smoke window. Do not force this smoke through XWayland
   inside a native Wayland compositor: Mutter's XWayland root framebuffer is black even though
   the pointer is visible. Normal Wayland sessions should validate the portal route below.
+  **`xvfb-run` proves X11 only** — not portal/PipeWire. Nested Xvfb on a host that still
+  exports Wayland env or `wayland-*` sockets is handled by session detection (#397); set
+  `SPECTRE_CAPTURE_BACKEND=x11` if you need an explicit override.
 - **Linux Wayland** — run with `WAYLAND_DISPLAY`, `XDG_RUNTIME_DIR`, and the D-Bus session
   bus visible to the JVM. The task asks the compositor portal for a window stream and writes
   a one-frame PNG after you accept the dialog. If the dialog is hidden or rejected, the helper

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegBackend.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegBackend.kt
@@ -102,43 +102,54 @@ internal sealed interface FfmpegBackend {
         }
 
         /**
-         * Returns true when the host is running a Wayland session, false otherwise.
+         * Returns true when capture should use the Linux Wayland/portal path, false for X11/Xvfb.
          *
-         * Three signals checked in order; any one positive returns true:
-         * 1. `XDG_SESSION_TYPE=wayland` — set by systemd-logind / GDM for graphical sessions that
-         *    started under Wayland.
-         * 2. `WAYLAND_DISPLAY` non-blank (typically `wayland-0`) — set when a Wayland compositor
-         *    socket is reachable. Catches manually-started compositors and user-namespace setups
-         *    where `XDG_SESSION_TYPE` may be missing.
-         * 3. A `wayland-*` socket file under `XDG_RUNTIME_DIR` — catches the SSH-into-Wayland-host
-         *    case that #1 and #2 miss. SSH's `XDG_SESSION_TYPE` reports `tty` (not `wayland`) and
-         *    `WAYLAND_DISPLAY` is unset, but the user's Wayland compositor is still running and
-         *    leaves a socket at `/run/user/<uid>/wayland-0`. Without this tier, recording a Wayland
-         *    host over SSH would silently produce a black mp4 even though we have ample signal that
-         *    Wayland is in play.
+         * Order of signals (#397 — Xvfb must not be hijacked by residual Wayland env/sockets):
+         * 0. `SPECTRE_CAPTURE_BACKEND=x11|wayland` — explicit override (also accepts `xorg` /
+         *    `xvfb` → X11, `portal` → Wayland). Use when nested Xvfb probes are unavailable.
+         * 1. Active pure-X11 [DISPLAY] (Xvfb / non-XWayland Xorg) — process windows live on that
+         *    server; prefer `ximagesrc` even if the login session exported Wayland vars.
+         * 2. `XDG_SESSION_TYPE=wayland` — logind/GDM graphical Wayland session.
+         * 3. `WAYLAND_DISPLAY` non-blank — compositor socket name for this session.
+         * 4. A `wayland-*` socket under `XDG_RUNTIME_DIR` **only when DISPLAY is unset** — SSH into
+         *    a Wayland host without X11 forwarding. Residual sockets must not override an active
+         *    Xvfb/Xorg DISPLAY (that was the #397 misroute).
          *
-         * The pure form (taking `getenv` and a filesystem-probe lambda as parameters rather than
-         * reading [System.getenv] / [Files] directly) lets unit tests cover the signal matrix
-         * deterministically without mucking with process-level env vars (which the JVM can't modify
-         * at runtime anyway) or per-test temp directories.
+         * Real Wayland+XWayland still returns true: pure-X11 probe is false for XWayland, and tiers
+         * 2–3 fire. Do not treat "DISPLAY is set" alone as X11 — XWayland always has DISPLAY.
+         *
+         * Injectable [getenv] / probes keep the matrix unit-testable without process env mutation.
          */
         @Suppress("ReturnCount")
         internal fun detectWaylandSession(
             getenv: (String) -> String?,
             runtimeDirHasWaylandSocket: (Path) -> Boolean = ::defaultRuntimeDirHasWaylandSocket,
+            displayIsPureX11: (String) -> Boolean = ::defaultDisplayIsPureX11,
         ): Boolean {
+            when (getenv("SPECTRE_CAPTURE_BACKEND")?.trim()?.lowercase()) {
+                "x11",
+                "xorg",
+                "xvfb" -> return false
+                "wayland",
+                "portal" -> return true
+            }
+            val display = getenv("DISPLAY")?.takeIf { it.isNotBlank() }
+            if (display != null && displayIsPureX11(display)) return false
             val sessionType = getenv("XDG_SESSION_TYPE")?.lowercase()
             if (sessionType == "wayland") return true
             val waylandDisplay = getenv("WAYLAND_DISPLAY")
             if (!waylandDisplay.isNullOrBlank()) return true
+            // Tier 4: residual compositor socket. Only when this process has no X11 DISPLAY —
+            // otherwise Xvfb-under-SSH would misroute to portal (#397).
+            if (display != null) return false
             val runtimeDir = getenv("XDG_RUNTIME_DIR")?.takeIf { it.isNotBlank() } ?: return false
             return runtimeDirHasWaylandSocket(Path.of(runtimeDir))
         }
 
         /**
-         * Default filesystem probe for tier 3 of [detectWaylandSession]. Returns true if
-         * [runtimeDir] is a readable directory and contains any entry whose name starts with
-         * `wayland-` (matching the compositor's socket file convention).
+         * Default filesystem probe for the residual-socket tier of [detectWaylandSession]. Returns
+         * true if [runtimeDir] is a readable directory and contains any entry whose name starts
+         * with `wayland-` (matching the compositor's socket file convention).
          *
          * Wrapped in [runCatching] because the directory may exist but be unreadable due to a mount
          * race or permission glitch — in that case we'd rather treat the host as non-Wayland (and
@@ -156,6 +167,85 @@ internal sealed interface FfmpegBackend {
         }
 
         /**
+         * True when [display] talks to a pure X11 server (Xvfb / Xorg), not XWayland.
+         *
+         * Used so `xvfb-run` on a host that still exports Wayland session vars routes capture to
+         * X11. Prefer an Xvfb process match for [display]; fall back to `xdpyinfo` and treat the
+         * presence of the `XWAYLAND` extension as "not pure X11". Probe failures return false (do
+         * not claim pure X11 without evidence).
+         */
+        @Suppress("TooGenericExceptionCaught")
+        internal fun defaultDisplayIsPureX11(display: String): Boolean {
+            if (linuxDisplayMatchesXvfbProcess(display)) return true
+            return runCatching { xdpyinfoReportsPureX11(display) }.getOrDefault(false)
+        }
+
+        /**
+         * Scans Linux `/proc/<pid>/cmdline` entries for an `Xvfb` process serving [display] (e.g.
+         * `:99`). Returns false on other OSes or when `/proc` is unavailable.
+         */
+        @Suppress("TooGenericExceptionCaught")
+        internal fun linuxDisplayMatchesXvfbProcess(display: String): Boolean {
+            val displayToken = normalizeDisplayToken(display) ?: return false
+            val proc = Path.of("/proc")
+            if (!Files.isDirectory(proc)) return false
+            return runCatching {
+                    Files.list(proc).use { stream ->
+                        stream.anyMatch { entry ->
+                            val name = entry.fileName.toString()
+                            if (name.toLongOrNull() == null) return@anyMatch false
+                            val cmdline =
+                                runCatching { Files.readAllBytes(entry.resolve("cmdline")) }
+                                    .getOrNull() ?: return@anyMatch false
+                            val args =
+                                cmdline.toString(Charsets.UTF_8).split('\u0000').filter {
+                                    it.isNotEmpty()
+                                }
+                            if (args.none { it == "Xvfb" || it.endsWith("/Xvfb") })
+                                return@anyMatch false
+                            args.any { arg ->
+                                val token = normalizeDisplayToken(arg) ?: return@anyMatch false
+                                token == displayToken
+                            }
+                        }
+                    }
+                }
+                .getOrDefault(false)
+        }
+
+        /** `:99.0` / `host:99` → `:99` for comparison with Xvfb argv. */
+        internal fun normalizeDisplayToken(raw: String): String? {
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty()) return null
+            val afterHost =
+                when {
+                    trimmed.startsWith(":") -> trimmed
+                    trimmed.contains(':') -> trimmed.substringAfterLast(':').let { ":$it" }
+                    else -> return null
+                }
+            val num =
+                afterHost.removePrefix(":").substringBefore('.').takeIf { it.isNotEmpty() }
+                    ?: return null
+            if (num.toIntOrNull() == null) return null
+            return ":$num"
+        }
+
+        @Suppress("TooGenericExceptionCaught")
+        private fun xdpyinfoReportsPureX11(display: String): Boolean {
+            val process =
+                ProcessBuilder("xdpyinfo", "-display", display).redirectErrorStream(true).start()
+            val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            val finished = process.waitFor(3, java.util.concurrent.TimeUnit.SECONDS)
+            if (!finished) {
+                process.destroyForcibly()
+                return false
+            }
+            if (process.exitValue() != 0) return false
+            // XWayland advertises an "XWAYLAND" extension; Xvfb/Xorg do not.
+            return !output.contains("XWAYLAND", ignoreCase = true)
+        }
+
+        /**
          * Throws [UnsupportedOperationException] if [getenv] reports a Wayland session.
          *
          * Internal so tests can drive it with a fake [getenv]. The real call site is
@@ -167,14 +257,14 @@ internal sealed interface FfmpegBackend {
                 "ffmpeg's x11grab silently captures black frames on Wayland sessions even with " +
                     "XWayland in the loop — Wayland's security model blocks framebuffer reads " +
                     "by clients other than the compositor. Detected via XDG_SESSION_TYPE / " +
-                    "WAYLAND_DISPLAY / XDG_RUNTIME_DIR/wayland-* socket. " +
+                    "WAYLAND_DISPLAY / residual wayland-* socket (only when DISPLAY is unset). " +
                     "Use Wayland-native capture instead: construct " +
                     "`dev.sebastiano.spectre.recording.AutoRecorder` (which routes Wayland " +
                     "sessions through xdg-desktop-portal + PipeWire automatically), or " +
                     "instantiate `WaylandPortalRecorder` directly. Alternatively, switch to an " +
                     "Xorg session (set `WaylandEnable=false` in /etc/gdm3/custom.conf and " +
-                    "restart gdm, or pick \"Ubuntu on Xorg\" at the GDM login screen), or run " +
-                    "under Xvfb."
+                    "restart gdm, or pick \"Ubuntu on Xorg\" at the GDM login screen), run " +
+                    "under Xvfb, or set SPECTRE_CAPTURE_BACKEND=x11 for nested Xvfb only."
             )
         }
     }

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegBackend.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/FfmpegBackend.kt
@@ -201,16 +201,21 @@ internal sealed interface FfmpegBackend {
                                 cmdline.toString(Charsets.UTF_8).split('\u0000').filter {
                                     it.isNotEmpty()
                                 }
-                            if (args.none { it == "Xvfb" || it.endsWith("/Xvfb") })
-                                return@anyMatch false
-                            args.any { arg ->
-                                val token = normalizeDisplayToken(arg) ?: return@anyMatch false
-                                token == displayToken
-                            }
+                            cmdlineMatchesXvfbDisplay(args, displayToken)
                         }
                     }
                 }
                 .getOrDefault(false)
+        }
+
+        /**
+         * True when [args] is an Xvfb argv that serves [displayToken] (normalized, e.g. `:99`).
+         * Non-display args (binary path, `-screen`, geometry) are skipped — must not abort the scan
+         * when `normalizeDisplayToken` returns null.
+         */
+        internal fun cmdlineMatchesXvfbDisplay(args: List<String>, displayToken: String): Boolean {
+            if (args.none { it == "Xvfb" || it.endsWith("/Xvfb") }) return false
+            return args.any { normalizeDisplayToken(it) == displayToken }
         }
 
         /** `:99.0` / `host:99` → `:99` for comparison with Xvfb argv. */
@@ -230,20 +235,53 @@ internal sealed interface FfmpegBackend {
             return ":$num"
         }
 
+        /**
+         * Queries `xdpyinfo` for [display]; true when the server responds without advertising the
+         * `XWAYLAND` extension. Bounded by [XDPYINFO_TIMEOUT_MS] including output drain — never
+         * blocks forever on a hung X connection.
+         */
         @Suppress("TooGenericExceptionCaught")
         private fun xdpyinfoReportsPureX11(display: String): Boolean {
             val process =
                 ProcessBuilder("xdpyinfo", "-display", display).redirectErrorStream(true).start()
-            val output = process.inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
-            val finished = process.waitFor(3, java.util.concurrent.TimeUnit.SECONDS)
-            if (!finished) {
+            return try {
+                val outputRef = java.util.concurrent.atomic.AtomicReference("")
+                val reader =
+                    Thread(
+                            {
+                                runCatching {
+                                    outputRef.set(
+                                        process.inputStream.bufferedReader(Charsets.UTF_8).use {
+                                            it.readText()
+                                        }
+                                    )
+                                }
+                            },
+                            "spectre-xdpyinfo-reader",
+                        )
+                        .apply {
+                            isDaemon = true
+                            start()
+                        }
+                val finished =
+                    process.waitFor(XDPYINFO_TIMEOUT_MS, java.util.concurrent.TimeUnit.MILLISECONDS)
+                if (!finished) {
+                    process.destroyForcibly()
+                    reader.join(READER_JOIN_MS)
+                    return false
+                }
+                reader.join(READER_JOIN_MS)
+                if (process.exitValue() != 0) return false
+                // XWayland advertises an "XWAYLAND" extension; Xvfb/Xorg do not.
+                !outputRef.get().contains("XWAYLAND", ignoreCase = true)
+            } catch (_: Exception) {
                 process.destroyForcibly()
-                return false
+                false
             }
-            if (process.exitValue() != 0) return false
-            // XWayland advertises an "XWAYLAND" extension; Xvfb/Xorg do not.
-            return !output.contains("XWAYLAND", ignoreCase = true)
         }
+
+        private const val XDPYINFO_TIMEOUT_MS: Long = 3_000
+        private const val READER_JOIN_MS: Long = 500
 
         /**
          * Throws [UnsupportedOperationException] if [getenv] reports a Wayland session.

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegBackendTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegBackendTest.kt
@@ -77,11 +77,103 @@ class FfmpegBackendTest {
     @Test
     fun `detectWaylandSession returns true when XDG_RUNTIME_DIR has a wayland socket`() {
         // Simulates SSH-into-Wayland-host: env signals tier 1 + 2 are absent (XDG_SESSION_TYPE
-        // would be "tty" for SSH, WAYLAND_DISPLAY unset), but the runtime dir contains the
-        // compositor's socket.
+        // would be "tty" for SSH, WAYLAND_DISPLAY unset), DISPLAY is unset, but the runtime dir
+        // contains the compositor's socket. Tier 3 only fires without an active X11 DISPLAY
+        // (#397 — residual sockets must not hijack Xvfb).
         val sshEnv = fakeEnv("XDG_SESSION_TYPE" to "tty", "XDG_RUNTIME_DIR" to "/run/user/1000")
         val socketPresent: (Path) -> Boolean = { _ -> true }
         assertTrue(FfmpegBackend.detectWaylandSession(sshEnv, socketPresent))
+    }
+
+    @Test
+    fun `detectWaylandSession ignores residual wayland socket when DISPLAY is set - Xvfb case`() {
+        // #397: xvfb-run sets DISPLAY to a pure X11 server, but a live or stale wayland-*
+        // socket often remains under XDG_RUNTIME_DIR from the login session / host compositor.
+        // Capture must route to X11, not portal (portal fails on Xvfb; ximagesrc works).
+        val xvfbEnv =
+            fakeEnv(
+                "DISPLAY" to ":99",
+                "XDG_SESSION_TYPE" to "tty",
+                "XDG_RUNTIME_DIR" to "/run/user/1000",
+            )
+        val socketPresent: (Path) -> Boolean = { _ -> true }
+        assertFalse(
+            FfmpegBackend.detectWaylandSession(
+                getenv = xvfbEnv,
+                runtimeDirHasWaylandSocket = socketPresent,
+                displayIsPureX11 = { false }, // even without pure-X11 confirmation
+            )
+        )
+    }
+
+    @Test
+    fun `detectWaylandSession prefers pure X11 DISPLAY over inherited Wayland env - nested Xvfb`() {
+        // xvfb-run from a Wayland desktop inherits XDG_SESSION_TYPE=wayland and WAYLAND_DISPLAY,
+        // but the process's windows live on the Xvfb DISPLAY. A pure-X11 probe (no XWAYLAND
+        // extension / Xvfb process) must win so capture uses ximagesrc, not portal.
+        val nestedXvfb =
+            fakeEnv(
+                "DISPLAY" to ":99",
+                "XDG_SESSION_TYPE" to "wayland",
+                "WAYLAND_DISPLAY" to "wayland-0",
+                "XDG_RUNTIME_DIR" to "/run/user/1000",
+            )
+        assertFalse(
+            FfmpegBackend.detectWaylandSession(
+                getenv = nestedXvfb,
+                runtimeDirHasWaylandSocket = { true },
+                displayIsPureX11 = { display -> display == ":99" },
+            )
+        )
+    }
+
+    @Test
+    fun `detectWaylandSession keeps Wayland when DISPLAY is XWayland`() {
+        // Real Wayland session with XWayland: DISPLAY is set, but the server is XWayland.
+        // Pure-X11 probe returns false → session type / WAYLAND_DISPLAY still route to portal.
+        val waylandXwayland =
+            fakeEnv(
+                "DISPLAY" to ":0",
+                "XDG_SESSION_TYPE" to "wayland",
+                "WAYLAND_DISPLAY" to "wayland-0",
+                "XDG_RUNTIME_DIR" to "/run/user/1000",
+            )
+        assertTrue(
+            FfmpegBackend.detectWaylandSession(
+                getenv = waylandXwayland,
+                runtimeDirHasWaylandSocket = { true },
+                displayIsPureX11 = { false },
+            )
+        )
+    }
+
+    @Test
+    fun `detectWaylandSession honors SPECTRE_CAPTURE_BACKEND x11 override`() {
+        val env =
+            fakeEnv(
+                "SPECTRE_CAPTURE_BACKEND" to "x11",
+                "XDG_SESSION_TYPE" to "wayland",
+                "WAYLAND_DISPLAY" to "wayland-0",
+            )
+        assertFalse(
+            FfmpegBackend.detectWaylandSession(
+                getenv = env,
+                runtimeDirHasWaylandSocket = { true },
+                displayIsPureX11 = { false },
+            )
+        )
+    }
+
+    @Test
+    fun `detectWaylandSession honors SPECTRE_CAPTURE_BACKEND wayland override`() {
+        val env = fakeEnv("SPECTRE_CAPTURE_BACKEND" to "wayland", "DISPLAY" to ":99")
+        assertTrue(
+            FfmpegBackend.detectWaylandSession(
+                getenv = env,
+                runtimeDirHasWaylandSocket = { false },
+                displayIsPureX11 = { true },
+            )
+        )
     }
 
     @Test

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegBackendTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/FfmpegBackendTest.kt
@@ -211,6 +211,39 @@ class FfmpegBackendTest {
     }
 
     // -----------------------------------------------------------------------
+    // cmdlineMatchesXvfbDisplay — pure argv matcher used by pure-X11 probe.
+    // -----------------------------------------------------------------------
+
+    @Test
+    fun `cmdlineMatchesXvfbDisplay accepts typical Xvfb argv with display after binary`() {
+        // Real xvfb-run shape: Xvfb :99 -screen 0 1280x1024x24 …
+        // Non-display tokens must not abort the scan (Bugbot: return@anyMatch on null).
+        val args = listOf("Xvfb", ":99", "-screen", "0", "1280x1024x24")
+        assertTrue(FfmpegBackend.cmdlineMatchesXvfbDisplay(args, ":99"))
+        assertFalse(FfmpegBackend.cmdlineMatchesXvfbDisplay(args, ":0"))
+    }
+
+    @Test
+    fun `cmdlineMatchesXvfbDisplay accepts absolute Xvfb path and dotted display`() {
+        val args = listOf("/usr/bin/Xvfb", ":99.0", "-ac")
+        assertTrue(FfmpegBackend.cmdlineMatchesXvfbDisplay(args, ":99"))
+    }
+
+    @Test
+    fun `cmdlineMatchesXvfbDisplay rejects non-Xvfb processes`() {
+        assertFalse(FfmpegBackend.cmdlineMatchesXvfbDisplay(listOf("Xorg", ":0"), ":0"))
+    }
+
+    @Test
+    fun `normalizeDisplayToken strips host and screen index`() {
+        assertEquals(":99", FfmpegBackend.normalizeDisplayToken(":99"))
+        assertEquals(":99", FfmpegBackend.normalizeDisplayToken(":99.0"))
+        assertEquals(":0", FfmpegBackend.normalizeDisplayToken("localhost:0.0"))
+        assertEquals(null, FfmpegBackend.normalizeDisplayToken("Xvfb"))
+        assertEquals(null, FfmpegBackend.normalizeDisplayToken("-screen"))
+    }
+
+    // -----------------------------------------------------------------------
     // checkNotWayland — throws-if-Wayland wrapper. The error message is part
     // of the contract because users will see it directly (this is what they
     // hit when they try to record on a Wayland session).


### PR DESCRIPTION
## Summary

- Fixes shared Linux Xvfb pixel-capture misroute that broke JUnit failure artifacts, atomic capture, agent screenshots, visual idle, and related suites (#397).
- Session detection no longer treats residual `wayland-*` under `XDG_RUNTIME_DIR` as Wayland when the process has an active pure-X11 `DISPLAY` (Xvfb). Pure-X11 probes (Xvfb process match / `xdpyinfo` without `XWAYLAND`) win over inherited Wayland env from nested `xvfb-run` on a Wayland host. Residual sockets only count when `DISPLAY` is unset (SSH into Wayland). Optional `SPECTRE_CAPTURE_BACKEND=x11|wayland` override.
- Docs state clearly that Xvfb proves X11 capture, not Wayland portal behaviour.

## Root cause

`HostPlatform.isWayland()` / dual `detectWaylandSession` + core `isWaylandSession` tier-3 socket probes routed capture to `WAYLAND_PORTAL` under Xvfb when a login-session compositor left sockets in `XDG_RUNTIME_DIR`. Portal + `_GTK_FRAME_EXTENTS` then failed for pure X11 Compose windows.

## Test plan

- [x] Unit matrix in `FfmpegBackendTest` + `ScreenCaptureBackendTest` (Xvfb+socket, nested Xvfb, XWayland, SSH, overrides)
- [x] `./gradlew :recording:test --tests '*FfmpegBackendTest*' :core:test --tests '*ScreenCaptureBackendTest*'` green on macOS
- [ ] Full acceptance command under Ubuntu `xvfb-run` with residual socket (Docker Ubuntu 26.04 / validation host / GHA `validation-linux`)
- [ ] Confirm capture suites executed (not display/helper skips)

## Residual risks

- HiDPI / multi-monitor X11 edges remain separate
- Wayland portal still needs a real Wayland desktop for product proof
- Dual detectors (core vs recording) must stay in lockstep (no shared module)

Closes #397