### PR TITLE
fix(check): split CLI package-manifest Ruby dep for clean Linux (#400)

### DIFF
--- a/.github/scripts/test-cli-package-manifest-host-deps.sh
+++ b/.github/scripts/test-cli-package-manifest-host-deps.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Regression guards for package-manifest host dependencies (#400).
+# Ensures structural checks never require Ruby, and missing Ruby yields an
+# actionable preflight on the install-semantics path (not a deep command-not-found).
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+structural="$script_dir/test-generate-cli-package-manifests.sh"
+semantics="$script_dir/test-homebrew-formula-install-semantics.sh"
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+[[ -f "$structural" ]] || fail "missing $structural"
+[[ -f "$semantics" ]] || fail "missing $semantics"
+[[ -x "$structural" && -x "$semantics" ]] || chmod +x "$structural" "$semantics"
+
+# 1) Structural script source must not invoke ruby (comments may mention it).
+if awk '
+  /^[[:space:]]*#/ { next }
+  /(^|[^[:alnum:]_\/.-])ruby([[:space:]]|$)/ { print NR ": " $0; found=1 }
+  END { exit found ? 0 : 1 }
+' "$structural"; then
+  fail "structural script invokes ruby; move Ruby work to install-semantics (#400)"
+fi
+
+# 2) Build a PATH without ruby (and without accidental ruby stubs).
+strip_bin="$(mktemp -d)"
+trap 'rm -rf "$strip_bin"' EXIT
+# Resolve real tools from the current PATH, skipping any ruby binary.
+export PATH="${PATH:-/usr/bin:/bin}"
+for cmd in bash sh python3 grep mktemp rm dirname pwd printf tr cat sed head uname env true false chmod awk; do
+  p="$(command -v "$cmd" 2>/dev/null)" || continue
+  # Skip if this path is the ruby interpreter itself.
+  base="$(basename "$p")"
+  [[ "$base" == ruby || "$base" == ruby3* ]] && continue
+  ln -sf "$p" "$strip_bin/$cmd"
+done
+# Intentionally do not link ruby into strip_bin.
+
+# 3) Structural checks must pass without ruby.
+if ! env PATH="$strip_bin" bash "$structural" >/dev/null; then
+  fail "structural package-manifest checks must pass without ruby on PATH (#400)"
+fi
+
+# 4) Semantics path must fail closed with an actionable preflight (not bare command-not-found).
+sem_out="$(mktemp)"
+set +e
+env PATH="$strip_bin" bash "$semantics" >"$sem_out" 2>&1
+sem_ec=$?
+set -e
+[[ "$sem_ec" -ne 0 ]] || fail "install-semantics must fail when ruby is missing"
+grep -q "ruby" "$sem_out" || fail "preflight must name missing tool 'ruby'"
+grep -qiE "install|apt |brew |required" "$sem_out" || fail "preflight must hint how to install ruby"
+# Must not look like an uncaught shell command-not-found mid-script.
+if grep -qE 'line [0-9]+: ruby: command not found' "$sem_out"; then
+  fail "missing ruby must use preflight, not deep 'ruby: command not found'"
+fi
+grep -q "verifyHomebrewFormulaInstallSemantics\|install-semantics\|Homebrew formula" "$sem_out" \
+  || fail "preflight must name the task or semantics path"
+
+echo "test-cli-package-manifest-host-deps: OK"

--- a/.github/scripts/test-cli-package-manifest-host-deps.sh
+++ b/.github/scripts/test-cli-package-manifest-host-deps.sh
@@ -27,19 +27,68 @@ if awk '
   fail "structural script invokes ruby; move Ruby work to install-semantics (#400)"
 fi
 
-# 2) Build a PATH without ruby (and without accidental ruby stubs).
+# 2) PATH without ruby that still runs real toolchains (not broken shims).
+# Linking `command -v python3` can point at a pyenv/asdf shim that needs the rest of
+# PATH; resolve the real interpreter via the current python3 instead.
 strip_bin="$(mktemp -d)"
 trap 'rm -rf "$strip_bin"' EXIT
-# Resolve real tools from the current PATH, skipping any ruby binary.
-export PATH="${PATH:-/usr/bin:/bin}"
-for cmd in bash sh python3 grep mktemp rm dirname pwd printf tr cat sed head uname env true false chmod awk; do
-  p="$(command -v "$cmd" 2>/dev/null)" || continue
-  # Skip if this path is the ruby interpreter itself.
-  base="$(basename "$p")"
-  [[ "$base" == ruby || "$base" == ruby3* ]] && continue
-  ln -sf "$p" "$strip_bin/$cmd"
+
+link_abs() {
+  local name="$1"
+  local target="$2"
+  [[ -n "$target" && -e "$target" ]] || return 1
+  ln -sf "$target" "$strip_bin/$name"
+}
+
+# Core shell utilities: prefer absolute paths from the live PATH, resolve symlinks
+# when possible so we get the real binary (Homebrew cellar, not a thin wrapper).
+resolve_bin() {
+  local cmd="$1"
+  local p
+  p="$(command -v "$cmd" 2>/dev/null)" || return 1
+  # Prefer a real filesystem path over shell builtins (pwd, true, …).
+  if [[ "$p" != /* ]]; then
+    return 1
+  fi
+  if command -v realpath >/dev/null 2>&1; then
+    realpath "$p" 2>/dev/null || echo "$p"
+  elif command -v readlink >/dev/null 2>&1 && readlink -f "$p" >/dev/null 2>&1; then
+    readlink -f "$p"
+  else
+    echo "$p"
+  fi
+}
+
+for cmd in bash sh grep mktemp rm dirname tr cat sed head uname env chmod awk ln mkdir; do
+  target="$(resolve_bin "$cmd" 2>/dev/null)" || continue
+  link_abs "$cmd" "$target" || true
 done
-# Intentionally do not link ruby into strip_bin.
+
+# python3: use the running interpreter's sys.executable (real binary, not pyenv shim).
+if command -v python3 >/dev/null 2>&1; then
+  real_py="$(python3 -c 'import sys; print(sys.executable)' 2>/dev/null || true)"
+  if [[ -n "${real_py:-}" && -x "$real_py" ]]; then
+    link_abs python3 "$real_py"
+  else
+    target="$(resolve_bin python3)" && link_abs python3 "$target"
+  fi
+fi
+
+# printf / true / false may be builtins only — provide tiny sh wrappers if missing.
+for builtin_cmd in printf true false pwd; do
+  if [[ ! -e "$strip_bin/$builtin_cmd" ]]; then
+    case "$builtin_cmd" in
+      printf) printf '%s\n' '#!/bin/sh' 'builtin printf "$@"' >"$strip_bin/printf" ;;
+      true) printf '%s\n' '#!/bin/sh' 'exit 0' >"$strip_bin/true" ;;
+      false) printf '%s\n' '#!/bin/sh' 'exit 1' >"$strip_bin/false" ;;
+      pwd) printf '%s\n' '#!/bin/sh' 'echo "$PWD"' >"$strip_bin/pwd" ;;
+    esac
+    chmod +x "$strip_bin/$builtin_cmd"
+  fi
+done
+
+# Intentionally do not provide ruby.
+[[ ! -e "$strip_bin/ruby" ]] || fail "strip PATH must not include ruby"
 
 # 3) Structural checks must pass without ruby.
 if ! env PATH="$strip_bin" bash "$structural" >/dev/null; then

--- a/.github/scripts/test-generate-cli-package-manifests.sh
+++ b/.github/scripts/test-generate-cli-package-manifests.sh
@@ -1,9 +1,27 @@
 #!/usr/bin/env bash
-# Contract + behavioral tests for Homebrew/Scoop package manifest generation.
-# Wired into ./gradlew check (verifyCliPackageManifests) and CI.
+# Structural + generator contracts for Homebrew/Scoop package manifests.
+# Wired into ./gradlew check via verifyCliPackageManifests (Unix).
+#
+# No Ruby: install-semantics live in verifyHomebrewFormulaInstallSemantics
+# (test-homebrew-formula-install-semantics.sh). See docs/TESTING.md (#400).
 set -euo pipefail
 
 root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+require_cmd() {
+  local cmd="$1"
+  local hint="$2"
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "error: '$cmd' is required for verifyCliPackageManifests (CLI package-manifest structural checks)." >&2
+    echo "  Install: $hint" >&2
+    echo "  Task: ./gradlew verifyCliPackageManifests" >&2
+    echo "  Docs: docs/TESTING.md (Package-channel contracts)" >&2
+    exit 1
+  fi
+}
+
+require_cmd python3 "apt install python3  |  brew install python3  |  https://www.python.org/downloads/"
+
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
@@ -21,7 +39,6 @@ python3 "$root/.github/scripts/generate-cli-package-manifests.py" \
 generated_formula="$tmp/out/Formula/spectre.rb"
 committed_formula="$root/Formula/spectre.rb"
 
-ruby -c "$generated_formula"
 python3 -m json.tool "$tmp/out/bucket/spectre.json" >/dev/null
 
 grep -q 'version "1.2.3"' "$generated_formula"
@@ -67,20 +84,30 @@ grep -q '(bin/"spectre").chmod 0755' "$committed_formula"
 
 # Install-method bodies (excluding version/url/sha) must stay aligned between generator output
 # and the committed formula so regenerating manifests cannot silently diverge from main.
+# Python (not Ruby) so clean Linux ./gradlew check has no undeclared Ruby dependency (#400).
 extract_install_body() {
-  # From "def install" through the matching "end" of that method (indent-aware enough for this formula).
-  ruby -e '
-    text = File.read(ARGV[0])
-    start = text.index(/^  def install\n/)
-    abort "no def install in #{ARGV[0]}" unless start
-    rest = text[start..]
-    # Method ends at the first line that is exactly "  end" after the def (formula style).
-    body = rest[/\A  def install\n.*?\n  end\n/m]
-    abort "could not extract install method from #{ARGV[0]}" unless body
-    # Drop Ruby comment lines (indent + "#" + space/end) so comment-only drift
-    # does not fail the gate. Keep shebangs inside the wrapper heredoc (#!/bin/sh).
-    puts body.lines.reject { |l| l.match?(/^\s+#(\s|$)/) }.join
-  ' "$1"
+  python3 - "$1" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+start = text.find("  def install\n")
+if start < 0:
+    sys.exit(f"no def install in {path}")
+rest = text[start:]
+# Method ends at the first line that is exactly "  end" after the def (formula style).
+match = re.match(r"  def install\n.*?\n  end\n", rest, flags=re.DOTALL)
+if not match:
+    sys.exit(f"could not extract install method from {path}")
+body = match.group(0)
+# Drop Ruby comment lines (indent + "#" + space/end) so comment-only drift
+# does not fail the gate. Keep shebangs inside the wrapper heredoc (#!/bin/sh).
+for line in body.splitlines(keepends=True):
+    if re.match(r"^\s+#(\s|$)", line):
+        continue
+    sys.stdout.write(line)
+PY
 }
 
 generated_install="$(extract_install_body "$generated_formula")"
@@ -93,10 +120,5 @@ if [[ "$generated_install" != "$committed_install" ]]; then
   echo "$committed_install" >&2
   exit 1
 fi
-
-# Behavioral semantics (layouts + wrapper vs symlink) against both formula texts.
-ruby "$root/.github/scripts/test-homebrew-formula-install-semantics.rb" \
-  "$generated_formula" \
-  "$committed_formula"
 
 echo "test-generate-cli-package-manifests: OK"

--- a/.github/scripts/test-homebrew-formula-install-semantics.rb
+++ b/.github/scripts/test-homebrew-formula-install-semantics.rb
@@ -10,8 +10,10 @@
 # App discovery is evaluated from the formula source (not a reimplemented ideal), so a
 # nested-only glob regresses the stripped-layout case.
 #
-# Run via test-generate-cli-package-manifests.sh or directly:
+# Run via test-homebrew-formula-install-semantics.sh (Gradle:
+# verifyHomebrewFormulaInstallSemantics) or directly:
 #   ruby .github/scripts/test-homebrew-formula-install-semantics.rb [formula.rb ...]
+# Structural/generator checks (no Ruby) live in test-generate-cli-package-manifests.sh.
 
 require "fileutils"
 require "tmpdir"

--- a/.github/scripts/test-homebrew-formula-install-semantics.sh
+++ b/.github/scripts/test-homebrew-formula-install-semantics.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Host-appropriate wrapper for Homebrew formula install-semantics (Ruby).
+# Wired into ./gradlew check as verifyHomebrewFormulaInstallSemantics when Ruby
+# is on PATH, or always under CI (fail-closed preflight if Ruby is missing).
+#
+# Structural/generator contracts stay in test-generate-cli-package-manifests.sh
+# and do not require Ruby (#400).
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+
+if ! command -v ruby >/dev/null 2>&1; then
+  echo "error: 'ruby' is required for verifyHomebrewFormulaInstallSemantics" >&2
+  echo "  (Homebrew formula install-semantics: dual-layout Spectre.app + wrapper bin)." >&2
+  echo "  Install: apt install ruby  |  brew install ruby  |  https://www.ruby-lang.org/en/documentation/installation/" >&2
+  echo "  Task: ./gradlew verifyHomebrewFormulaInstallSemantics" >&2
+  echo "  Note: structural package-manifest checks do not need Ruby:" >&2
+  echo "        ./gradlew verifyCliPackageManifests" >&2
+  echo "  Docs: docs/TESTING.md (Package-channel contracts)" >&2
+  exit 1
+fi
+
+formula_args=("$@")
+if [[ ${#formula_args[@]} -eq 0 ]]; then
+  # Match previous combined-script behaviour: exercise generated-layout contracts
+  # against fixture archives plus the committed Formula/spectre.rb.
+  tmp="$(mktemp -d)"
+  trap 'rm -rf "$tmp"' EXIT
+  printf arm > "$tmp/spectre-macosArm64.zip"
+  printf intel > "$tmp/spectre-macosX64.zip"
+  printf windows > "$tmp/spectre-windowsX64.zip"
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "error: 'python3' is required to generate fixture formulas for install-semantics." >&2
+    echo "  Install: apt install python3  |  brew install python3" >&2
+    exit 1
+  fi
+  python3 "$root/.github/scripts/generate-cli-package-manifests.py" \
+    --version 1.2.3 \
+    --macos-arm64 "$tmp/spectre-macosArm64.zip" \
+    --macos-x64 "$tmp/spectre-macosX64.zip" \
+    --windows-x64 "$tmp/spectre-windowsX64.zip" \
+    --output-dir "$tmp/out"
+  # ruby -c: syntax-check generated formula before behavioral tests.
+  ruby -c "$tmp/out/Formula/spectre.rb" >/dev/null
+  formula_args=("$tmp/out/Formula/spectre.rb" "$root/Formula/spectre.rb")
+fi
+
+ruby "$root/.github/scripts/test-homebrew-formula-install-semantics.rb" "${formula_args[@]}"
+echo "test-homebrew-formula-install-semantics: OK"

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -32,9 +32,22 @@ class McpStdioSmokeTest(unittest.TestCase):
         return script
 
     def run_smoke(self, server: Path):
+        # Launch the fake server via the same interpreter: Windows cannot exec a
+        # shebang-only .py (WinError 193). Production smoke still passes a real
+        # packaged spectre binary as the command.
         return subprocess.run(
-            [sys.executable, str(MCP_SMOKE), "--expected-version", "0.5.0", "--", str(server)],
-            text=True, capture_output=True, timeout=10,
+            [
+                sys.executable,
+                str(MCP_SMOKE),
+                "--expected-version",
+                "0.5.0",
+                "--",
+                sys.executable,
+                str(server),
+            ],
+            text=True,
+            capture_output=True,
+            timeout=10,
         )
 
     def test_clean_server_passes(self):

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,16 +46,19 @@ configure<DetektExtension> {
     basePath.set(rootProject.layout.projectDirectory)
 }
 
-// Homebrew/Scoop package-manifest contracts + install semantics (#283/#284).
-// Cheap (python + ruby + bash). Wired into check on Unix only: Windows CI has no
-// bash/WSL, and Homebrew install semantics are not a Windows concern (Linux CI
-// already runs ./gradlew check with bash).
+// Homebrew/Scoop package-manifest contracts (#283/#284/#400).
+//
+// Strategy (issue #400): structural/generator checks need only python3 + bash and
+// stay on every Unix `./gradlew check`. Ruby install-semantics are a separate
+// host-appropriate task so clean Linux without Ruby is not a surprise failure.
+// under CI (or when Ruby is present), the semantics task runs; missing Ruby on
+// CI fails closed via an actionable preflight in the shell wrapper.
 // onlyIf lambdas must not close over the Gradle script object (configuration cache).
 val verifyCliPackageManifests by
     tasks.registering(Exec::class) {
         description =
-            "Generates CLI package manifests and asserts Homebrew install contracts " +
-                "(dual-layout Spectre.app discovery, wrapper bin entry, install-body sync)."
+            "Generates CLI package manifests and asserts structural Homebrew/Scoop " +
+                "contracts (wrapper bin entry, install-body sync). Requires python3; no Ruby."
         group = "verification"
         workingDir = rootProject.layout.projectDirectory.asFile
         commandLine("bash", ".github/scripts/test-generate-cli-package-manifests.sh")
@@ -66,11 +69,70 @@ val verifyCliPackageManifests by
             .files(
                 ".github/scripts/generate-cli-package-manifests.py",
                 ".github/scripts/test-generate-cli-package-manifests.sh",
-                ".github/scripts/test-homebrew-formula-install-semantics.rb",
                 "Formula/spectre.rb",
             )
             .withPathSensitivity(PathSensitivity.RELATIVE)
         // Always re-run: generator is pure but failures are cheap to catch on every check.
+        outputs.upToDateWhen { false }
+    }
+
+// Homebrew formula *behavioral* install-semantics (Ruby). Not required on every
+// clean Linux contributor host; always required under CI so #283/#284/#390 cannot
+// be orphaned by a silent skip.
+val verifyHomebrewFormulaInstallSemantics by
+    tasks.registering(Exec::class) {
+        description =
+            "Homebrew formula install-semantics (dual-layout Spectre.app discovery, " +
+                "wrapper vs symlink). Requires Ruby; actionable preflight if missing."
+        group = "verification"
+        workingDir = rootProject.layout.projectDirectory.asFile
+        commandLine("bash", ".github/scripts/test-homebrew-formula-install-semantics.sh")
+        onlyIf("Unix host with bash, and Ruby present or CI") {
+            val isWindows = System.getProperty("os.name").orEmpty().startsWith("Windows")
+            if (isWindows) {
+                false
+            } else {
+                val ci = !System.getenv("CI").isNullOrBlank()
+                val hasRuby =
+                    runCatching { ProcessBuilder("ruby", "--version").start().waitFor() == 0 }
+                        .getOrDefault(false)
+                hasRuby || ci
+            }
+        }
+        inputs
+            .files(
+                ".github/scripts/generate-cli-package-manifests.py",
+                ".github/scripts/test-homebrew-formula-install-semantics.sh",
+                ".github/scripts/test-homebrew-formula-install-semantics.rb",
+                "Formula/spectre.rb",
+            )
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+        outputs.upToDateWhen { false }
+    }
+
+// Regression guard: structural path never requires Ruby; missing Ruby on the
+// semantics path fails with a preflight message (#400).
+val verifyCliPackageManifestHostDeps by
+    tasks.registering(Exec::class) {
+        description =
+            "Asserts package-manifest host-dep split: no undeclared Ruby on structural " +
+                "checks; actionable preflight when Ruby is missing for install-semantics."
+        group = "verification"
+        workingDir = rootProject.layout.projectDirectory.asFile
+        commandLine("bash", ".github/scripts/test-cli-package-manifest-host-deps.sh")
+        onlyIf("Unix host with bash") {
+            !System.getProperty("os.name").orEmpty().startsWith("Windows")
+        }
+        inputs
+            .files(
+                ".github/scripts/test-cli-package-manifest-host-deps.sh",
+                ".github/scripts/test-generate-cli-package-manifests.sh",
+                ".github/scripts/test-homebrew-formula-install-semantics.sh",
+                ".github/scripts/test-homebrew-formula-install-semantics.rb",
+                ".github/scripts/generate-cli-package-manifests.py",
+                "Formula/spectre.rb",
+            )
+            .withPathSensitivity(PathSensitivity.RELATIVE)
         outputs.upToDateWhen { false }
     }
 
@@ -180,6 +242,8 @@ tasks.named("check") {
         "detekt",
         "ktfmtCheck",
         verifyCliPackageManifests,
+        verifyHomebrewFormulaInstallSemantics,
+        verifyCliPackageManifestHostDeps,
         verifyReleaseVersionScript,
         verifyMacosCliBundleReleaseContract,
         verifyWindowsReleaseSmokeScript,

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -71,11 +71,19 @@ tap formula and `bucket/spectre.json` is the Scoop bucket manifest. Publishing t
 release regenerates both from its public CLI archives and their SHA-256 values, then commits them
 to `main`.
 
-Package-manifest generation and Homebrew install contracts are gated by
-`./gradlew verifyCliPackageManifests` (part of `./gradlew check`): the generator is exercised with
-fixture archives, the committed formula's `install` body must stay aligned with the generator, and
-behavioral tests cover dual-layout `Spectre.app` discovery (Homebrew strip) plus the wrapper bin
-entry (Roast is argv[0]-sensitive and cannot be exposed via `bin.install_symlink`).
+Package-manifest generation and Homebrew install contracts are gated on Unix
+`./gradlew check` in two tasks (issue #400 — clean Linux must not need undeclared Ruby):
+
+- `verifyCliPackageManifests` — generator + structural contracts (`python3` + `bash` only):
+  fixture archives, Scoop JSON, committed `Formula/spectre.rb` install-body alignment with
+  the generator, wrapper bin entry text contracts.
+- `verifyHomebrewFormulaInstallSemantics` — behavioral install-semantics (**Ruby**): dual-layout
+  `Spectre.app` discovery (Homebrew strip) plus wrapper-vs-symlink behaviour (Roast is
+  argv[0]-sensitive and cannot be exposed via `bin.install_symlink`). Runs when Ruby is on
+  `PATH`, and **always under CI** (actionable preflight if Ruby is missing). Host-dep
+  regression: `verifyCliPackageManifestHostDeps`.
+
+See [Testing — Package-channel contracts](TESTING.md#package-channel-homebrew--scoop-contracts).
 
 On macOS, use the repository as an explicit tap because its name is `spectre`, not Homebrew's
 `homebrew-*` shorthand:

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -67,6 +67,7 @@ These are structural, not one-release accidents:
 
 | Surface | Hosted CI | Physical smoke |
 | --- | --- | --- |
+| CLI package-channel (Homebrew/Scoop) contracts | Structural on every Unix `check` (`python3`); install-semantics when Ruby present or under `CI` (issue #400) | Optional: install Ruby on a clean Linux box and run `./gradlew verifyHomebrewFormulaInstallSemantics` if claiming formula behaviour beyond CI |
 | Agent attach + contract corpus (live UI) | Linux Xvfb + macOS desktop; Windows **transport/ACL** unit tests | **Windows headed desktop** (not SSH-only for capture) |
 | Agent Windows UI e2e | Opt-in only: `-Pspectre.agent.attachE2e.allowWindows=true` | Run that property on Mattone-class boxes |
 | Agent **inject** attach | Linux + macOS e2e | **Windows** inject fixture (no preinstalled core) |

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -36,15 +36,40 @@ Before marking testing work complete:
 
 ## Package-channel (Homebrew / Scoop) contracts
 
-CLI package manifests are not optional docs — they are install paths. Keep them on the
-`./gradlew check` graph via `verifyCliPackageManifests`:
+CLI package manifests are not optional docs — they are install paths. They are split so
+a clean Linux host without Ruby can still run `./gradlew check` (issue #400):
 
-- generator smoke: `.github/scripts/test-generate-cli-package-manifests.sh`
-- install semantics: `.github/scripts/test-homebrew-formula-install-semantics.rb`
+| Gradle task | Host tools | On `check` when |
+|---|---|---|
+| `verifyCliPackageManifests` | `bash`, `python3` | Every Unix host |
+| `verifyHomebrewFormulaInstallSemantics` | `bash`, `python3`, **Ruby** | Unix **and** (Ruby on `PATH` **or** `CI` is set) |
+| `verifyCliPackageManifestHostDeps` | `bash`, `python3` | Every Unix host (regression: no undeclared Ruby on the structural path; missing Ruby on the semantics path fails with a preflight message) |
 
-Those tests evaluate the formula's real `app = Dir[...]` expression against nested and
-Homebrew-stripped layouts, require a wrapper (not a Roast `bin.install_symlink`), and
-assert the committed `Formula/spectre.rb` `install` body stays aligned with the generator.
+Scripts:
+
+- structural/generator: `.github/scripts/test-generate-cli-package-manifests.sh`
+- install semantics (Ruby): `.github/scripts/test-homebrew-formula-install-semantics.sh` → `.rb`
+- host-dep regression: `.github/scripts/test-cli-package-manifest-host-deps.sh`
+
+**Structural** checks generate fixture manifests, assert Scoop JSON + formula text contracts
+(wrapper bin entry, dual-layout `Spectre.app` discovery snippets, install-body alignment
+between generator output and committed `Formula/spectre.rb`). They must **not** invoke Ruby.
+
+**Install-semantics** evaluate the formula's real `app = Dir[...]` expression against nested
+and Homebrew-stripped layouts and require a wrapper (not a Roast `bin.install_symlink`).
+They need Ruby. Locally, if Ruby is absent the task is skipped (structural + host-dep
+guards still run). Under CI (`CI` env set), the task always runs and **fails closed** with
+an actionable preflight if Ruby is missing:
+
+```text
+error: 'ruby' is required for verifyHomebrewFormulaInstallSemantics
+  Install: apt install ruby  |  brew install ruby  |  …
+```
+
+GitHub `ubuntu-latest` typically ships Ruby; if that ever changes, install Ruby in
+`.github/workflows/ci.yml` before `./gradlew check` (do not re-merge semantics into the
+structural script). For a full local package-channel gate on Linux: `apt install ruby`
+(or equivalent), then `./gradlew verifyHomebrewFormulaInstallSemantics`.
 
 ## Cross-Boundary Contract Tests
 


### PR DESCRIPTION
## Summary

- **Strategy 2** for [#400](https://github.com/rock3r/spectre/issues/400): clean Linux `./gradlew check` no longer requires undeclared Ruby.
- Structural/generator contracts (`verifyCliPackageManifests`) stay on every Unix `check` with **python3 + bash only**.
- Homebrew install-semantics (`verifyHomebrewFormulaInstallSemantics`) run when Ruby is on `PATH`, and **always under CI** (actionable preflight if Ruby is missing — not a deep `command not found`).
- Host-dep regression task (`verifyCliPackageManifestHostDeps`) fails if structural scripts re-introduce Ruby or if missing Ruby does not preflight cleanly.
- Docs: `docs/TESTING.md`, `docs/PUBLISHING.md`, `docs/RELEASE-SMOKE.md`.

## Proof

| Gate | Result |
| --- | --- |
| Red without Ruby (origin/main path) | `ruby: command not found` mid-script |
| Structural without Ruby | OK |
| Semantics preflight without Ruby | actionable message + exit 1 |
| Host-dep regression script | OK |
| Clean Ubuntu 26 Hyper-V (`NO_RUBY`) `./gradlew check` | **BUILD SUCCESSFUL** (semantics SKIPPED; structural + host-deps ran) |
| Local macOS package tasks + semantics with Ruby | OK |

## Test plan

- [x] `bash .github/scripts/test-generate-cli-package-manifests.sh` without Ruby
- [x] `bash .github/scripts/test-cli-package-manifest-host-deps.sh`
- [x] `bash .github/scripts/test-homebrew-formula-install-semantics.sh` with/without Ruby
- [x] `./gradlew check` on clean Ubuntu 26 (Hyper-V via Mattone)
- [x] `./gradlew verifyCliPackageManifests verifyHomebrewFormulaInstallSemantics verifyCliPackageManifestHostDeps` on macOS

## Residual risks (0.5.0)

- Local Linux without Ruby skips install-semantics (documented; CI fail-closed). Full formula behavioural gate still needs Ruby in CI / optional operator install.
- If GitHub `ubuntu-latest` ever drops preinstalled Ruby, CI must install Ruby before `./gradlew check` (preflight will fail loudly).

Closes #400