### PR TITLE
feat(smoke): versioned release-smoke report schema and preflight (#398)

### DIFF
--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
+"""Contract tests for release-smoke orchestration, report schema, and MCP stdio."""
+from __future__ import annotations
+
+import importlib.util
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -9,6 +14,20 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 MCP_SMOKE = ROOT / "scripts" / "mcp-stdio-smoke.py"
 RELEASE_SMOKE = ROOT / "scripts" / "release-smoke.py"
+SMOKE_LIB = ROOT / "scripts" / "smoke_lib.py"
+
+
+def load_smoke_lib():
+    spec = importlib.util.spec_from_file_location("smoke_lib", SMOKE_LIB)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    # Python 3.9 dataclasses need the module present in sys.modules before exec.
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+smoke_lib = load_smoke_lib()
 
 
 class McpStdioSmokeTest(unittest.TestCase):
@@ -63,6 +82,223 @@ class McpStdioSmokeTest(unittest.TestCase):
         result = self.run_smoke(self.fake_server(version="0.1.0"))
         self.assertNotEqual(0, result.returncode)
         self.assertIn("server version", result.stderr)
+
+
+class SmokeLibSchemaTest(unittest.TestCase):
+    def test_schema_version_constant(self):
+        self.assertEqual(1, smoke_lib.SCHEMA_VERSION)
+
+    def test_required_scenario_ids_are_stable(self):
+        expected = {
+            "preflight",
+            "check",
+            "junit-live",
+            "agent-attach-core",
+            "agent-contract-corpus",
+            "agent-inject",
+            "agent-launch-and-attach",
+            "cli-packaged",
+            "cli-native-helper-layout",
+            "cli-user-flow",
+            "mcp-sdk-flow",
+            "host-native-recording",
+            "maven-local-consumer",
+        }
+        self.assertEqual(expected, set(smoke_lib.REQUIRED_SCENARIO_IDS))
+
+    def test_hard_na_without_reason_becomes_fail(self):
+        result = smoke_lib.scenario_result(
+            "host-native-recording",
+            name="Host native recording",
+            result="n/a",
+            reason="",
+            hard=True,
+        )
+        self.assertEqual("fail", result.result)
+        self.assertIn("without N/A reason", result.detail)
+
+    def test_hard_na_with_reason_allowed(self):
+        result = smoke_lib.scenario_result(
+            "host-native-recording",
+            name="Host native recording",
+            result="n/a",
+            reason="Linux Wayland portal requires real desktop session",
+            hard=True,
+        )
+        self.assertEqual("n/a", result.result)
+        self.assertTrue(result.reason)
+
+    def test_soft_na_without_reason_allowed(self):
+        result = smoke_lib.scenario_result(
+            "soft-cell",
+            name="Soft",
+            result="n/a",
+            reason="",
+            hard=False,
+        )
+        self.assertEqual("n/a", result.result)
+
+    def test_validate_report_requires_schema_fields(self):
+        errors = smoke_lib.validate_report({})
+        self.assertTrue(any("schemaVersion" in e for e in errors))
+        self.assertTrue(any("scenarios" in e for e in errors))
+
+    def test_validate_report_accepts_minimal_good_report(self):
+        preflight = smoke_lib.collect_preflight(ROOT, version="0.5.0", base="v0.4.1")
+        scenarios = [
+            smoke_lib.scenario_result(
+                sid,
+                name=sid,
+                result="pass",
+            )
+            for sid in smoke_lib.REQUIRED_SCENARIO_IDS
+        ]
+        report = smoke_lib.build_report(
+            preflight,
+            scenarios,
+            started_at=smoke_lib.utc_now_iso(),
+        )
+        errors = smoke_lib.validate_report(
+            report, required_ids=smoke_lib.REQUIRED_SCENARIO_IDS
+        )
+        self.assertEqual([], errors, errors)
+        self.assertEqual(1, report["schemaVersion"])
+        self.assertEqual(preflight.sha, report["sha"])
+        self.assertIn("displayMode", report["environment"])
+        self.assertIn("dirty", report)
+
+    def test_validate_report_rejects_hard_na_without_reason(self):
+        preflight = smoke_lib.collect_preflight(ROOT, version="0.5.0")
+        bad = smoke_lib.ScenarioResult(
+            id="check",
+            name="check",
+            result="n/a",
+            reason="",
+            hard=True,
+        )
+        report = smoke_lib.build_report(
+            preflight, [bad], started_at=smoke_lib.utc_now_iso()
+        )
+        # Bypass scenario_result coercion to simulate a hand-written report.
+        report["scenarios"][0]["result"] = "n/a"
+        report["scenarios"][0]["reason"] = ""
+        errors = smoke_lib.validate_report(report)
+        self.assertTrue(any("hard n/a requires" in e for e in errors), errors)
+
+    def test_preflight_records_sha_and_dirty_flag(self):
+        preflight = smoke_lib.collect_preflight(ROOT, version="0.5.0", base="v0.4.1")
+        self.assertEqual(40, len(preflight.sha))
+        self.assertTrue(preflight.sha_short)
+        self.assertIsInstance(preflight.dirty, bool)
+        self.assertEqual("0.5.0", preflight.version)
+        self.assertEqual("v0.4.1", preflight.base)
+        self.assertTrue(preflight.environment.display_mode)
+
+    def test_markdown_table_includes_scenario_ids(self):
+        rows = [
+            smoke_lib.scenario_result("check", name="check gate", result="pass", seconds=3),
+            smoke_lib.scenario_result(
+                "junit-live",
+                name="live junit",
+                result="n/a",
+                reason="no display",
+            ),
+        ]
+        table = smoke_lib.markdown_table(rows)
+        self.assertIn("| check |", table)
+        self.assertIn("| junit-live |", table)
+        self.assertIn("no display", table)
+
+    def test_write_json_and_markdown_roundtrip(self):
+        preflight = smoke_lib.collect_preflight(ROOT, version="0.5.0")
+        scenarios = [
+            smoke_lib.scenario_result("preflight", name="preflight", result="pass"),
+            smoke_lib.scenario_result("check", name="check", result="pass"),
+        ]
+        report = smoke_lib.build_report(
+            preflight, scenarios, started_at=smoke_lib.utc_now_iso()
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            json_path = Path(tmp) / "release-smoke.json"
+            md_path = Path(tmp) / "release-smoke.md"
+            smoke_lib.write_json_report(json_path, report)
+            smoke_lib.write_markdown_report(md_path, report)
+            loaded = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual(1, loaded["schemaVersion"])
+            self.assertEqual(preflight.sha, loaded["sha"])
+            md = md_path.read_text(encoding="utf-8")
+            self.assertIn("schemaVersion", md)
+            self.assertIn("| preflight |", md)
+
+    def test_hard_failures_lists_failed_ids(self):
+        rows = [
+            smoke_lib.scenario_result("check", name="c", result="pass"),
+            smoke_lib.scenario_result("junit-live", name="j", result="fail", detail="exit 1"),
+            smoke_lib.scenario_result(
+                "soft", name="s", result="fail", hard=False, detail="ignored"
+            ),
+        ]
+        self.assertEqual(["junit-live"], smoke_lib.hard_failures(rows))
+
+    def test_run_command_timeout_kills_and_returns_124(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            log = Path(tmp) / "sleep.log"
+            code, detail, _ = smoke_lib.run_command(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+                cwd=ROOT,
+                timeout=1,
+                log_path=log,
+            )
+            self.assertEqual(124, code)
+            self.assertIn("timeout", detail)
+            self.assertTrue(log.is_file())
+
+    def test_detect_display_mode_linux_xvfb(self):
+        # Force Linux path without mutating real platform for other tests.
+        old_display = os.environ.pop("DISPLAY", None)
+        try:
+            mode = smoke_lib.detect_display_mode("Linux")
+            self.assertIn(mode, {"xvfb-auto", "no-display"})
+        finally:
+            if old_display is not None:
+                os.environ["DISPLAY"] = old_display
+
+    def test_gradle_ui_force_args_disable_cache_only_pass(self):
+        args = smoke_lib.gradle_ui_force_args()
+        self.assertIn("--rerun-tasks", args)
+        self.assertIn("--no-build-cache", args)
+
+    def test_release_smoke_script_imports_and_exposes_main(self):
+        self.assertTrue(RELEASE_SMOKE.is_file())
+        text = RELEASE_SMOKE.read_text(encoding="utf-8")
+        self.assertIn("schemaVersion", text or "build_report")
+        self.assertIn("smoke_lib", text)
+        self.assertIn("--version", text)
+        # Structural: PR1 wires these IDs.
+        for scenario_id in (
+            "preflight",
+            "check",
+            "junit-live",
+            "agent-attach-core",
+            "agent-contract-corpus",
+            "agent-inject",
+            "cli-packaged",
+            "cli-user-flow",
+            "mcp-sdk-flow",
+        ):
+            self.assertIn(scenario_id, text, f"missing wired id {scenario_id}")
+
+
+class ReleaseSmokeHelpTest(unittest.TestCase):
+    def test_help_exits_zero(self):
+        result = subprocess.run(
+            [sys.executable, str(RELEASE_SMOKE), "--help"],
+            text=True,
+            capture_output=True,
+            timeout=10,
+        )
+        self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("--version", result.stdout)
 
 
 if __name__ == "__main__":

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -211,6 +211,7 @@ val verifyReleaseSmokeScripts by
         inputs
             .files(
                 "scripts/release-smoke.py",
+                "scripts/smoke_lib.py",
                 "scripts/mcp-stdio-smoke.py",
                 ".github/scripts/test-release-smoke-scripts.py",
                 "docs/RELEASE-SMOKE.md",

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -173,19 +173,71 @@ Run the committed baseline runner from the repository root on macOS and Linux:
 python3 scripts/release-smoke.py --version 0.5.0
 ```
 
-On Linux it supplies `xvfb-run -a` when `DISPLAY` is unset. On Windows use the interactive
-PowerShell runner in the next section. Both runners write machine-readable results and per-step
-logs under `build/smoke/`, bound every external step with a timeout, continue after failures, and
-exit non-zero if any hard scenario is red.
+Optional flags:
+
+| Flag | Effect |
+| --- | --- |
+| `--base v0.4.1` | Record the previous release tag (default: latest git tag) |
+| `--skip-check` | Skip `./gradlew check` (records hard `n/a` with reason) |
+| `--out-dir PATH` | Report/log directory (default `build/smoke`) |
+| `--overall-timeout SECS` | Wall-clock budget for the whole run (default 7200) |
+| `--require-all-ids` | Require every stable scenario ID in `scripts/smoke_lib.py` |
+
+On Linux it supplies `xvfb-run -a` when `DISPLAY` is unset and records `environment.displayMode`
+as `xvfb-auto` or `real-display:$DISPLAY`. On Windows use the interactive PowerShell runner in the
+next section (same stable scenario IDs and `schemaVersion` report shape once parity lands).
+
+### Report artifacts
+
+Every run writes under `build/smoke/` (or `--out-dir`):
+
+| Path | Contents |
+| --- | --- |
+| `release-smoke.json` | Versioned machine-readable report (`schemaVersion`, full SHA, dirty flag, env, scenario rows) |
+| `release-smoke.md` | Markdown results table for the release record |
+| `<scenario-id>-<timestamp>.log` | Per-step stdout/stderr |
+
+Report fields of note: `schemaVersion` (currently `1`), `version`, `base`, `sha` (full), `dirty`,
+`environment.displayMode`, and `scenarios[]` with stable `id`, `result` (`pass` \| `fail` \| `n/a`),
+optional `reason` (required for hard `n/a`), timings, and log path.
+
+**Hard skips are fail-closed:** a hard scenario result of `n/a` without a non-empty `reason` is
+treated as `fail`. Soft cells may use `hard: false`.
+
+### Stable scenario IDs
+
+Shared across macOS / Linux / Windows entrypoints (`scripts/smoke_lib.py` → `REQUIRED_SCENARIO_IDS`):
+
+| ID | Cell |
+| --- | --- |
+| `preflight` | Environment / SHA / clean-tree preflight |
+| `check` | `./gradlew check` |
+| `junit-live` | Live JUnit failure artifacts/video and atomic capture |
+| `agent-attach-core` | Agent attach with preinstalled core |
+| `agent-contract-corpus` | Agent contract corpus |
+| `agent-inject` | Injected attach without preinstalled core |
+| `agent-launch-and-attach` | Launch-and-attach |
+| `cli-packaged` | Release-shaped host CLI packaging |
+| `cli-native-helper-layout` | Native-helper layout in package |
+| `cli-user-flow` | Packaged CLI user flow (ps/attach/tree/input/screenshots/detach) |
+| `mcp-sdk-flow` | Packaged MCP via official SDK / strict stdio |
+| `host-native-recording` | Host native recording smoke |
+| `maven-local-consumer` | Maven Local publication + fresh consumer |
+
+The Unix runner currently wires the baseline subset end-to-end (preflight through
+`cli-user-flow` / `mcp-sdk-flow`). Remaining IDs are expanded toward the full matrix in the
+#398 harness completion; use `--require-all-ids` only when the full set is registered.
 
 The cross-platform runner covers the stable baseline that should not be reinvented per release:
 
+- environment/SHA/dirty-tree preflight recorded in the report
 - the full `check` gate
-- live JUnit validation (failure artifacts/video and capture/wait validation)
-- agent attach with preinstalled core and the contract corpus
+- live JUnit validation (failure artifacts/video and capture/wait validation), forced with
+  `--rerun-tasks --no-build-cache` so cache-only passes cannot skip UI work
+- agent attach with preinstalled core and the contract corpus (separate scenario IDs)
 - injected attach without core
-- release-shaped packaged CLI construction and launcher help
-- strict packaged MCP initialize, `tools/list`, and `list_processes` invocation
+- release-shaped packaged CLI construction
+- packaged CLI fixture user flow + strict packaged MCP initialize / `tools/list` / `list_processes`
 
 Each release still needs delta cells based on `git log <previous-tag>..HEAD`. Add reusable delta
 coverage to the runner rather than leaving a one-release command only in chat.

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -151,8 +151,9 @@ def main(argv: list[str] | None = None) -> int:
     results: list[ScenarioResult] = []
 
     preflight_result = _run_preflight_scenario(preflight, out_dir)
-    if preflight.dirty:
-        # Always surface dirty state in the scenario detail (still pass when collection ok).
+    if preflight.dirty and preflight_result.result == RESULT_PASS:
+        # Annotate dirty state only when preflight checks already passed — never
+        # overwrite a real preflight failure with a synthetic PASS.
         preflight_result = scenario_result(
             "preflight",
             name=preflight_result.name,

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -1,73 +1,383 @@
 #!/usr/bin/env python3
-"""Cross-platform baseline pre-release smoke. Writes build/smoke/release-smoke.json."""
+"""Cross-platform baseline pre-release smoke (macOS / Linux).
+
+Writes versioned machine-readable results under build/smoke/:
+  - release-smoke.json   (schemaVersion report)
+  - release-smoke.md     (Markdown results table)
+  - <scenario>-<stamp>.log per step
+
+Windows: use scripts/windows-release-smoke.ps1 from an interactive desktop
+(especially for WGC). That entrypoint emits the same schemaVersion shape.
+
+See docs/RELEASE-SMOKE.md and scripts/smoke_lib.py for scenario IDs.
+"""
+from __future__ import annotations
+
 import argparse
-import json
 import os
 import platform
-import subprocess
 import sys
 import time
 from pathlib import Path
 
+# Allow `python3 scripts/release-smoke.py` without installing a package.
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from smoke_lib import (  # noqa: E402
+    REQUIRED_SCENARIO_IDS,
+    RESULT_FAIL,
+    RESULT_PASS,
+    ScenarioResult,
+    build_report,
+    collect_preflight,
+    gradle_ui_force_args,
+    hard_failures,
+    host_cli_package_target,
+    packaged_cli_executable,
+    run_callable_scenario,
+    run_scenario,
+    scenario_result,
+    utc_now_iso,
+    validate_report,
+    write_json_report,
+    write_markdown_report,
+    xvfb_prefix,
+)
+
 ROOT = Path(__file__).resolve().parents[1]
 OUT = ROOT / "build" / "smoke"
 
+# Default overall budget for a full baseline (seconds). Overridable via CLI.
+DEFAULT_OVERALL_TIMEOUT = 7200
 
-def run(name: str, command: list[str], timeout: int, env: dict[str, str] | None = None) -> dict:
-    OUT.mkdir(parents=True, exist_ok=True)
-    started = time.monotonic()
-    log = OUT / f"{name}.log"
-    try:
-        completed = subprocess.run(command, cwd=ROOT, env=env, text=True, stdout=subprocess.PIPE,
-                                   stderr=subprocess.STDOUT, timeout=timeout)
-        output, code = completed.stdout, completed.returncode
-        result, detail = ("pass", "") if code == 0 else ("fail", f"exit {code}")
-    except subprocess.TimeoutExpired as error:
-        output = error.stdout or ""
-        result, detail = "fail", f"timeout after {timeout}s"
-    log.write_text(output)
-    print(f"{result.upper():4} {name}: {detail} ({log})")
-    return {"name": name, "result": result, "seconds": int(time.monotonic()-started),
-            "detail": detail, "log": str(log)}
+# Scenarios this PR wires end-to-end. Later trains expand toward REQUIRED_SCENARIO_IDS.
+PR1_WIRED_IDS: tuple[str, ...] = (
+    "preflight",
+    "check",
+    "junit-live",
+    "agent-attach-core",
+    "agent-contract-corpus",
+    "agent-inject",
+    "cli-packaged",
+    "cli-user-flow",
+    "mcp-sdk-flow",
+)
 
 
-def main() -> None:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--version", required=True, help="expected release version, e.g. 0.5.0")
-    parser.add_argument("--skip-check", action="store_true")
-    args = parser.parse_args()
-    gradle = str(ROOT / ("gradlew.bat" if os.name == "nt" else "gradlew"))
+def _print_result(item: ScenarioResult) -> None:
+    note = item.reason or item.detail or ""
+    suffix = f": {note}" if note else ""
+    print(f"{item.result.upper():4} {item.id} ({item.seconds}s){suffix}  {item.log}")
+
+
+def _run_preflight_scenario(preflight, out_dir: Path) -> ScenarioResult:
+    """Encode preflight collection as a hard scenario row."""
+
+    def action() -> None:
+        if not preflight.sha or len(preflight.sha) < 7:
+            raise RuntimeError(f"invalid SHA from preflight: {preflight.sha!r}")
+        if not preflight.version.strip():
+            raise RuntimeError("version is required")
+        # Dirty trees are recorded, not failed — operators may smoke release SHAs with
+        # local untracked plans. Report truthfully so release records stay honest.
+        if not preflight.environment.display_mode:
+            raise RuntimeError("displayMode missing from environment")
+
+    return run_callable_scenario(
+        "preflight",
+        name="Environment / SHA / clean-tree preflight",
+        action=action,
+        out_dir=out_dir,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--version",
+        required=True,
+        help="Expected release version recorded in the report and MCP server check (e.g. 0.5.0)",
+    )
+    parser.add_argument(
+        "--base",
+        default=None,
+        help="Previous release tag / base for the delta inventory (default: latest git tag)",
+    )
+    parser.add_argument("--skip-check", action="store_true", help="Skip ./gradlew check")
+    parser.add_argument(
+        "--allow-dirty",
+        action="store_true",
+        help="Accepted for compatibility; dirty state is always recorded, never auto-failed",
+    )
+    parser.add_argument(
+        "--overall-timeout",
+        type=int,
+        default=DEFAULT_OVERALL_TIMEOUT,
+        help=f"Overall smoke budget in seconds (default {DEFAULT_OVERALL_TIMEOUT})",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Directory for JSON/MD reports and per-step logs (default: build/smoke)",
+    )
+    parser.add_argument(
+        "--require-all-ids",
+        action="store_true",
+        help="Require every REQUIRED_SCENARIO_IDS row (full harness matrix). "
+        "Default requires only wired baseline IDs until scenario expansion lands.",
+    )
+    args = parser.parse_args(argv)
+
     system = platform.system()
     if system == "Windows":
-        raise SystemExit("Use scripts/windows-release-smoke.ps1 from the interactive desktop")
-    prefix = ["xvfb-run", "-a"] if system == "Linux" and not os.environ.get("DISPLAY") else []
-    results = []
-    if not args.skip_check:
-        results.append(run("check", [gradle, "check", "--console=plain"], 1200))
-    results.append(run("junit-live", [*prefix, gradle, ":sample-desktop:validationTest", "--console=plain"], 900))
-    results.append(run("agent-attach", [*prefix, gradle, ":agent:test", "--tests", "*AgentAttachIntegration*", "--tests", "*AgentContractCorpus*", "--console=plain"], 600))
-    results.append(run("agent-inject", [*prefix, gradle, ":agent:test", "--tests", "*AgentInjectAttachIntegration*", "--console=plain"], 600))
-    target = "MacosArm64" if system == "Darwin" and platform.machine() == "arm64" else "LinuxX64"
-    results.append(run("cli-packaged", [gradle, f":cli:package{target}", "--console=plain"], 900))
-    if system == "Darwin":
-        executable = ROOT / "cli/build/construo/macosArm64/Spectre.app/Contents/MacOS/spectre"
+        print(
+            "Use scripts/windows-release-smoke.ps1 from the interactive desktop "
+            "(WGC requires a native console session).",
+            file=sys.stderr,
+        )
+        return 2
+
+    out_dir = args.out_dir if args.out_dir is not None else OUT
+    if not out_dir.is_absolute():
+        out_dir = ROOT / out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    started_at = utc_now_iso()
+    wall_start = time.monotonic()
+    overall_deadline = wall_start + max(60, int(args.overall_timeout))
+
+    preflight = collect_preflight(ROOT, version=args.version, base=args.base)
+    results: list[ScenarioResult] = []
+
+    preflight_result = _run_preflight_scenario(preflight, out_dir)
+    if preflight.dirty:
+        # Always surface dirty state in the scenario detail (still pass when collection ok).
+        preflight_result = scenario_result(
+            "preflight",
+            name=preflight_result.name,
+            result=RESULT_PASS,
+            seconds=preflight_result.seconds,
+            detail=f"dirty worktree: {preflight.dirty_summary}",
+            log=preflight_result.log,
+        )
+    results.append(preflight_result)
+    _print_result(preflight_result)
+
+    gradle = str(ROOT / "gradlew")
+    prefix = xvfb_prefix(system)
+    force = gradle_ui_force_args()
+
+    def add(item: ScenarioResult) -> None:
+        results.append(item)
+        _print_result(item)
+
+    if args.skip_check:
+        add(
+            scenario_result(
+                "check",
+                name="./gradlew check",
+                result="n/a",
+                reason="skipped via --skip-check",
+                hard=True,
+            )
+        )
     else:
-        executable = ROOT / "cli/build/construo/linuxX64/roast/spectre"
-    results.append(run("cli-packaged-help", [str(executable), "--help"], 60))
-    packaged_tests = [
-        *prefix, gradle, ":cli:test",
-        "--tests", "*DaemonFixtureIntegrationTest.CLI binary drives*",
-        "--tests", "*DaemonFixtureIntegrationTest.MCP stdio drives*",
-        "--tests", "*SpectreMcpStdioIntegrationTest*",
-        f"-Dspectre.cli.distributionExecutable={executable}", "--console=plain",
-    ]
-    results.append(run("cli-mcp-packaged-user-flow", packaged_tests, 600))
-    results.append(run("mcp-packaged-strict", [sys.executable, str(ROOT / "scripts/mcp-stdio-smoke.py"), "--expected-version", args.version, "--", str(executable)], 60))
-    report = {"version": args.version, "sha": subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip(), "os": system, "results": results}
-    (OUT / "release-smoke.json").write_text(json.dumps(report, indent=2) + "\n")
-    if any(item["result"] != "pass" for item in results):
-        raise SystemExit(1)
+        add(
+            run_scenario(
+                "check",
+                name="./gradlew check",
+                command=[gradle, "check", "--console=plain"],
+                cwd=ROOT,
+                timeout=1200,
+                out_dir=out_dir,
+                overall_deadline=overall_deadline,
+            )
+        )
+
+    # Live JUnit: failure artifacts/video + capture validation surface.
+    add(
+        run_scenario(
+            "junit-live",
+            name="Live JUnit failure artifacts/video and capture",
+            command=[*prefix, gradle, ":sample-desktop:validationTest", *force],
+            cwd=ROOT,
+            timeout=900,
+            out_dir=out_dir,
+            overall_deadline=overall_deadline,
+        )
+    )
+
+    # Agent attach with preinstalled core (integration suite).
+    add(
+        run_scenario(
+            "agent-attach-core",
+            name="Agent attach with preinstalled core",
+            command=[
+                *prefix,
+                gradle,
+                ":agent:test",
+                "--tests",
+                "*AgentAttachIntegration*",
+                *force,
+            ],
+            cwd=ROOT,
+            timeout=600,
+            out_dir=out_dir,
+            overall_deadline=overall_deadline,
+        )
+    )
+
+    add(
+        run_scenario(
+            "agent-contract-corpus",
+            name="Agent contract corpus",
+            command=[
+                *prefix,
+                gradle,
+                ":agent:test",
+                "--tests",
+                "*AgentContractCorpus*",
+                *force,
+            ],
+            cwd=ROOT,
+            timeout=600,
+            out_dir=out_dir,
+            overall_deadline=overall_deadline,
+        )
+    )
+
+    add(
+        run_scenario(
+            "agent-inject",
+            name="Injected attach without preinstalled core",
+            command=[
+                *prefix,
+                gradle,
+                ":agent:test",
+                "--tests",
+                "*AgentInjectAttachIntegration*",
+                *force,
+            ],
+            cwd=ROOT,
+            timeout=600,
+            out_dir=out_dir,
+            overall_deadline=overall_deadline,
+        )
+    )
+
+    target = host_cli_package_target(system)
+    add(
+        run_scenario(
+            "cli-packaged",
+            name=f"Release-shaped host CLI package (:cli:package{target})",
+            command=[gradle, f":cli:package{target}", "--console=plain"],
+            cwd=ROOT,
+            timeout=900,
+            out_dir=out_dir,
+            overall_deadline=overall_deadline,
+        )
+    )
+
+    executable = packaged_cli_executable(ROOT, system)
+    if not executable.is_file():
+        add(
+            scenario_result(
+                "cli-user-flow",
+                name="Packaged CLI user flow (ps/attach/tree/input/capture/detach)",
+                result=RESULT_FAIL,
+                detail=f"packaged executable missing: {executable}",
+            )
+        )
+        add(
+            scenario_result(
+                "mcp-sdk-flow",
+                name="Packaged MCP via official SDK (initialize/tools/list/…)",
+                result=RESULT_FAIL,
+                detail=f"packaged executable missing: {executable}",
+            )
+        )
+    else:
+        packaged_tests = [
+            *prefix,
+            gradle,
+            ":cli:test",
+            "--tests",
+            "*DaemonFixtureIntegrationTest.CLI binary drives*",
+            "--tests",
+            "*DaemonFixtureIntegrationTest.MCP stdio drives*",
+            "--tests",
+            "*SpectreMcpStdioIntegrationTest*",
+            f"-Dspectre.cli.distributionExecutable={executable}",
+            *force,
+        ]
+        add(
+            run_scenario(
+                "cli-user-flow",
+                name="Packaged CLI user flow (ps/attach/tree/input/capture/detach)",
+                command=packaged_tests,
+                cwd=ROOT,
+                timeout=600,
+                out_dir=out_dir,
+                overall_deadline=overall_deadline,
+            )
+        )
+        add(
+            run_scenario(
+                "mcp-sdk-flow",
+                name="Packaged MCP strict stdio (initialize/tools/list/list_processes)",
+                command=[
+                    sys.executable,
+                    str(ROOT / "scripts" / "mcp-stdio-smoke.py"),
+                    "--expected-version",
+                    args.version,
+                    "--",
+                    str(executable),
+                ],
+                cwd=ROOT,
+                timeout=60,
+                out_dir=out_dir,
+                overall_deadline=overall_deadline,
+            )
+        )
+
+    finished_at = utc_now_iso()
+    overall_seconds = int(time.monotonic() - wall_start)
+    report = build_report(
+        preflight,
+        results,
+        started_at=started_at,
+        finished_at=finished_at,
+        overall_seconds=overall_seconds,
+    )
+
+    required = list(REQUIRED_SCENARIO_IDS) if args.require_all_ids else list(PR1_WIRED_IDS)
+    schema_errors = validate_report(report, required_ids=required)
+    if schema_errors:
+        print("REPORT SCHEMA ERRORS:", file=sys.stderr)
+        for err in schema_errors:
+            print(f"  - {err}", file=sys.stderr)
+        # Still write artifacts so operators can inspect partial runs.
+        write_json_report(out_dir / "release-smoke.json", report)
+        write_markdown_report(out_dir / "release-smoke.md", report)
+        return 2
+
+    json_path = out_dir / "release-smoke.json"
+    md_path = out_dir / "release-smoke.md"
+    write_json_report(json_path, report)
+    write_markdown_report(md_path, report)
+    print(f"Report JSON: {json_path}")
+    print(f"Report MD:   {md_path}")
+    print(f"displayMode: {preflight.environment.display_mode}")
+    print(f"SHA: {preflight.sha}  dirty={preflight.dirty}")
+
+    failed = hard_failures(results)
+    if failed or schema_errors:
+        print(f"HARD FAILURES: {', '.join(failed) if failed else '(schema)'}")
+        return 1
+    print("ALL HARD SCENARIOS PASSED")
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main())

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -484,11 +484,12 @@ def run_command(
 
     remaining = timeout
     if overall_deadline is not None:
-        remaining = min(remaining, max(1, int(overall_deadline - time.monotonic())))
-        if remaining <= 0:
+        budget_left = int(overall_deadline - time.monotonic())
+        if budget_left <= 0:
             message = "overall smoke deadline exceeded before step start"
             log_path.write_text(message + "\n", encoding="utf-8")
             return 124, message, str(log_path)
+        remaining = min(remaining, budget_left)
 
     # start_new_session creates a new process group on POSIX so killpg works.
     popen_kwargs: dict[str, Any] = {
@@ -510,15 +511,24 @@ def run_command(
         if code == 0:
             return 0, "", str(log_path)
         return code, f"exit {code}", str(log_path)
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as error:
         kill_process_tree(proc)
+        # communicate() stashes already-captured stdout on the exception; prefer that
+        # over re-reading the pipe (which is often empty after the timeout).
         partial = ""
-        try:
-            if proc.stdout is not None:
-                partial = proc.stdout.read() or ""
-                proc.stdout.close()
-        except Exception:
-            partial = ""
+        if isinstance(error.stdout, (str, bytes)):
+            partial = (
+                error.stdout.decode("utf-8", errors="replace")
+                if isinstance(error.stdout, bytes)
+                else error.stdout
+            )
+        else:
+            try:
+                if proc.stdout is not None:
+                    partial = proc.stdout.read() or ""
+                    proc.stdout.close()
+            except Exception:
+                partial = ""
         try:
             proc.wait(timeout=5)
         except Exception:

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Shared report model, preflight, skip policy, and process helpers for release smoke.
+
+Used by scripts/release-smoke.py (macOS/Linux). Windows PowerShell emits the same
+schemaVersion report shape; keep field names stable across both entrypoints.
+"""
+from __future__ import annotations
+
+import json
+import os
+import platform
+import signal
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Mapping, MutableMapping, Sequence
+
+# Bump only when report field semantics change incompatibly.
+SCHEMA_VERSION = 1
+
+# Stable scenario IDs shared across macOS / Linux / Windows. Every automated run
+# must emit a result row for each ID that is in scope for that OS entrypoint.
+REQUIRED_SCENARIO_IDS: tuple[str, ...] = (
+    "preflight",
+    "check",
+    "junit-live",
+    "agent-attach-core",
+    "agent-contract-corpus",
+    "agent-inject",
+    "agent-launch-and-attach",
+    "cli-packaged",
+    "cli-native-helper-layout",
+    "cli-user-flow",
+    "mcp-sdk-flow",
+    "host-native-recording",
+    "maven-local-consumer",
+)
+
+RESULT_PASS = "pass"
+RESULT_FAIL = "fail"
+RESULT_NA = "n/a"
+VALID_RESULTS = frozenset({RESULT_PASS, RESULT_FAIL, RESULT_NA})
+
+
+@dataclass
+class ScenarioResult:
+    id: str
+    name: str
+    result: str
+    seconds: int = 0
+    detail: str = ""
+    reason: str = ""
+    log: str = ""
+    hard: bool = True
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "name": self.name,
+            "result": self.result,
+            "seconds": self.seconds,
+            "detail": self.detail,
+            "reason": self.reason,
+            "log": self.log,
+            "hard": self.hard,
+        }
+
+
+@dataclass
+class EnvironmentInfo:
+    os: str
+    os_version: str
+    arch: str
+    hostname: str
+    user: str
+    python: str
+    display_mode: str
+    java: str = ""
+    extra: dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "os": self.os,
+            "osVersion": self.os_version,
+            "arch": self.arch,
+            "hostname": self.hostname,
+            "user": self.user,
+            "python": self.python,
+            "displayMode": self.display_mode,
+            "java": self.java,
+        }
+        if self.extra:
+            payload["extra"] = dict(self.extra)
+        return payload
+
+
+@dataclass
+class PreflightInfo:
+    version: str
+    base: str
+    sha: str
+    sha_short: str
+    dirty: bool
+    dirty_summary: str
+    repo_root: str
+    environment: EnvironmentInfo
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "version": self.version,
+            "base": self.base,
+            "sha": self.sha,
+            "shaShort": self.sha_short,
+            "dirty": self.dirty,
+            "dirtySummary": self.dirty_summary,
+            "repoRoot": self.repo_root,
+            "environment": self.environment.to_dict(),
+        }
+
+
+def utc_now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def git_output(root: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=root,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed ({completed.returncode}): {completed.stderr.strip()}"
+        )
+    return completed.stdout.strip()
+
+
+def detect_display_mode(system: str | None = None) -> str:
+    """Record how the host supplies a display for UI/live cells."""
+    system = system or platform.system()
+    if system == "Windows":
+        # Interactive desktop vs SSH is operator-documented; harness cannot fully
+        # prove WGC session type over the network.
+        session = os.environ.get("SESSIONNAME", "")
+        if session.upper().startswith("RDP") or os.environ.get("SSH_CONNECTION"):
+            return "windows-remote-or-rdp"
+        return "windows-interactive"
+    if system == "Linux":
+        display = os.environ.get("DISPLAY", "").strip()
+        if display:
+            return f"real-display:{display}"
+        if _which("xvfb-run"):
+            return "xvfb-auto"
+        return "no-display"
+    if system == "Darwin":
+        return "macos-native"
+    return f"unknown:{system}"
+
+
+def _which(name: str) -> str | None:
+    path = os.environ.get("PATH", "")
+    for directory in path.split(os.pathsep):
+        candidate = Path(directory) / name
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    return None
+
+
+def detect_java_version() -> str:
+    try:
+        completed = subprocess.run(
+            ["java", "-version"],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=15,
+            check=False,
+        )
+        first = (completed.stdout or "").strip().splitlines()
+        return first[0] if first else ""
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+
+
+def collect_preflight(
+    root: Path,
+    *,
+    version: str,
+    base: str | None = None,
+) -> PreflightInfo:
+    sha = git_output(root, "rev-parse", "HEAD")
+    sha_short = git_output(root, "rev-parse", "--short", "HEAD")
+    status = git_output(root, "status", "--porcelain")
+    dirty = bool(status)
+    dirty_summary = ""
+    if dirty:
+        lines = [line for line in status.splitlines() if line.strip()]
+        dirty_summary = f"{len(lines)} path(s) dirty"
+        if len(lines) <= 8:
+            dirty_summary = "; ".join(lines)
+    resolved_base = base or _default_base_tag(root)
+    env = EnvironmentInfo(
+        os=platform.system(),
+        os_version=platform.version(),
+        arch=platform.machine(),
+        hostname=platform.node(),
+        user=os.environ.get("USER") or os.environ.get("USERNAME") or "",
+        python=sys.version.split()[0],
+        display_mode=detect_display_mode(),
+        java=detect_java_version(),
+    )
+    return PreflightInfo(
+        version=version,
+        base=resolved_base,
+        sha=sha,
+        sha_short=sha_short,
+        dirty=dirty,
+        dirty_summary=dirty_summary,
+        repo_root=str(root.resolve()),
+        environment=env,
+    )
+
+
+def _default_base_tag(root: Path) -> str:
+    try:
+        return git_output(root, "describe", "--tags", "--abbrev=0")
+    except RuntimeError:
+        return ""
+
+
+def scenario_result(
+    scenario_id: str,
+    *,
+    name: str,
+    result: str,
+    seconds: int = 0,
+    detail: str = "",
+    reason: str = "",
+    log: str = "",
+    hard: bool = True,
+) -> ScenarioResult:
+    """Build a scenario row; enforces fail-closed skip policy for hard cells."""
+    if result not in VALID_RESULTS:
+        raise ValueError(f"invalid result {result!r} for {scenario_id}")
+    if result == RESULT_NA and hard and not reason.strip():
+        # Fail-closed: hard N/A without reason becomes fail.
+        return ScenarioResult(
+            id=scenario_id,
+            name=name,
+            result=RESULT_FAIL,
+            seconds=seconds,
+            detail=detail or "hard skip without N/A reason",
+            reason="",
+            log=log,
+            hard=hard,
+        )
+    return ScenarioResult(
+        id=scenario_id,
+        name=name,
+        result=result,
+        seconds=seconds,
+        detail=detail,
+        reason=reason.strip(),
+        log=log,
+        hard=hard,
+    )
+
+
+def validate_scenario_result(item: Mapping[str, Any]) -> list[str]:
+    """Return validation errors for one scenario result dict."""
+    errors: list[str] = []
+    scenario_id = item.get("id")
+    if not isinstance(scenario_id, str) or not scenario_id.strip():
+        errors.append("scenario missing non-empty id")
+        scenario_id = "<missing>"
+    result = item.get("result")
+    if result not in VALID_RESULTS:
+        errors.append(f"{scenario_id}: result must be pass|fail|n/a, got {result!r}")
+    hard = bool(item.get("hard", True))
+    reason = item.get("reason") or ""
+    if result == RESULT_NA and hard and not str(reason).strip():
+        errors.append(f"{scenario_id}: hard n/a requires non-empty reason")
+    if "name" not in item:
+        errors.append(f"{scenario_id}: missing name")
+    return errors
+
+
+def validate_report(
+    report: Mapping[str, Any],
+    *,
+    required_ids: Sequence[str] | None = None,
+) -> list[str]:
+    """Validate versioned release-smoke report. Returns human-readable errors."""
+    errors: list[str] = []
+    if report.get("schemaVersion") != SCHEMA_VERSION:
+        errors.append(
+            f"schemaVersion must be {SCHEMA_VERSION}, got {report.get('schemaVersion')!r}"
+        )
+    for key in ("version", "base", "sha", "startedAt", "finishedAt", "environment", "scenarios"):
+        if key not in report:
+            errors.append(f"missing top-level field {key!r}")
+    env = report.get("environment")
+    if isinstance(env, Mapping):
+        for key in ("os", "arch", "displayMode"):
+            if key not in env:
+                errors.append(f"environment missing {key!r}")
+    else:
+        if "environment" in report:
+            errors.append("environment must be an object")
+    scenarios = report.get("scenarios")
+    if not isinstance(scenarios, list):
+        errors.append("scenarios must be a list")
+        return errors
+    seen: set[str] = set()
+    for item in scenarios:
+        if not isinstance(item, Mapping):
+            errors.append("scenario entry must be an object")
+            continue
+        errors.extend(validate_scenario_result(item))
+        sid = item.get("id")
+        if isinstance(sid, str):
+            if sid in seen:
+                errors.append(f"duplicate scenario id {sid!r}")
+            seen.add(sid)
+    if required_ids is not None:
+        missing = [sid for sid in required_ids if sid not in seen]
+        if missing:
+            errors.append(f"missing required scenario ids: {', '.join(missing)}")
+    return errors
+
+
+def hard_failures(scenarios: Sequence[ScenarioResult | Mapping[str, Any]]) -> list[str]:
+    failed: list[str] = []
+    for item in scenarios:
+        data = item.to_dict() if isinstance(item, ScenarioResult) else dict(item)
+        if not data.get("hard", True):
+            continue
+        if data.get("result") == RESULT_FAIL:
+            failed.append(str(data.get("id", "?")))
+        if data.get("result") == RESULT_NA and not str(data.get("reason", "")).strip():
+            failed.append(str(data.get("id", "?")))
+    return failed
+
+
+def build_report(
+    preflight: PreflightInfo,
+    scenarios: Sequence[ScenarioResult],
+    *,
+    started_at: str,
+    finished_at: str | None = None,
+    overall_seconds: int | None = None,
+) -> dict[str, Any]:
+    finished = finished_at or utc_now_iso()
+    payload: dict[str, Any] = {
+        "schemaVersion": SCHEMA_VERSION,
+        "version": preflight.version,
+        "base": preflight.base,
+        "sha": preflight.sha,
+        "shaShort": preflight.sha_short,
+        "dirty": preflight.dirty,
+        "dirtySummary": preflight.dirty_summary,
+        "repoRoot": preflight.repo_root,
+        "startedAt": started_at,
+        "finishedAt": finished,
+        "environment": preflight.environment.to_dict(),
+        "scenarios": [s.to_dict() for s in scenarios],
+    }
+    if overall_seconds is not None:
+        payload["overallSeconds"] = overall_seconds
+    return payload
+
+
+def write_json_report(path: Path, report: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+
+
+def markdown_table(scenarios: Sequence[ScenarioResult | Mapping[str, Any]]) -> str:
+    lines = [
+        "| ID | Name | Result | Seconds | Note |",
+        "| --- | --- | --- | ---: | --- |",
+    ]
+    for item in scenarios:
+        data = item.to_dict() if isinstance(item, ScenarioResult) else dict(item)
+        note = data.get("reason") or data.get("detail") or ""
+        note = str(note).replace("|", "\\|").replace("\n", " ")
+        lines.append(
+            f"| {data.get('id', '')} | {data.get('name', '')} | {data.get('result', '')} | "
+            f"{data.get('seconds', 0)} | {note} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_markdown_report(
+    path: Path,
+    report: Mapping[str, Any],
+) -> None:
+    scenarios = report.get("scenarios") or []
+    env = report.get("environment") or {}
+    body = [
+        f"# Release smoke report",
+        "",
+        f"- **schemaVersion**: {report.get('schemaVersion')}",
+        f"- **version**: {report.get('version')}",
+        f"- **base**: {report.get('base')}",
+        f"- **sha**: `{report.get('sha')}`",
+        f"- **dirty**: {report.get('dirty')}",
+        f"- **startedAt**: {report.get('startedAt')}",
+        f"- **finishedAt**: {report.get('finishedAt')}",
+        f"- **os**: {env.get('os')} / {env.get('arch')}",
+        f"- **displayMode**: {env.get('displayMode')}",
+        "",
+        markdown_table(scenarios),  # type: ignore[arg-type]
+    ]
+    if report.get("dirtySummary"):
+        body.insert(8, f"- **dirtySummary**: {report.get('dirtySummary')}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(body), encoding="utf-8")
+
+
+def kill_process_tree(proc: subprocess.Popen[Any]) -> None:
+    """Best-effort kill of the process and its descendants."""
+    if proc.poll() is not None:
+        return
+    pid = proc.pid
+    if pid is None:
+        return
+    try:
+        if os.name == "nt":
+            subprocess.run(
+                ["taskkill", "/PID", str(pid), "/T", "/F"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+        else:
+            try:
+                os.killpg(pid, signal.SIGTERM)
+            except (ProcessLookupError, PermissionError, OSError):
+                proc.terminate()
+            deadline = time.monotonic() + 5
+            while proc.poll() is None and time.monotonic() < deadline:
+                time.sleep(0.1)
+            if proc.poll() is None:
+                try:
+                    os.killpg(pid, signal.SIGKILL)
+                except (ProcessLookupError, PermissionError, OSError):
+                    proc.kill()
+    except Exception:
+        try:
+            proc.kill()
+        except Exception:
+            pass
+    try:
+        proc.wait(timeout=10)
+    except Exception:
+        pass
+
+
+def run_command(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    timeout: int,
+    log_path: Path,
+    env: Mapping[str, str] | None = None,
+    overall_deadline: float | None = None,
+) -> tuple[int, str, str]:
+    """Run command with timeout and process-group cleanup.
+
+    Returns (exit_code, detail, log_path_str). detail is empty on success.
+    """
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    merged_env: MutableMapping[str, str] | None = None
+    if env is not None:
+        merged_env = os.environ.copy()
+        merged_env.update(env)
+
+    remaining = timeout
+    if overall_deadline is not None:
+        remaining = min(remaining, max(1, int(overall_deadline - time.monotonic())))
+        if remaining <= 0:
+            message = "overall smoke deadline exceeded before step start"
+            log_path.write_text(message + "\n", encoding="utf-8")
+            return 124, message, str(log_path)
+
+    # start_new_session creates a new process group on POSIX so killpg works.
+    popen_kwargs: dict[str, Any] = {
+        "cwd": str(cwd),
+        "env": merged_env,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.STDOUT,
+        "text": True,
+    }
+    if os.name != "nt":
+        popen_kwargs["start_new_session"] = True
+
+    proc = subprocess.Popen(list(command), **popen_kwargs)
+    try:
+        stdout, _ = proc.communicate(timeout=remaining)
+        code = int(proc.returncode if proc.returncode is not None else -1)
+        output = stdout or ""
+        log_path.write_text(output, encoding="utf-8")
+        if code == 0:
+            return 0, "", str(log_path)
+        return code, f"exit {code}", str(log_path)
+    except subprocess.TimeoutExpired:
+        kill_process_tree(proc)
+        partial = ""
+        try:
+            if proc.stdout is not None:
+                partial = proc.stdout.read() or ""
+                proc.stdout.close()
+        except Exception:
+            partial = ""
+        try:
+            proc.wait(timeout=5)
+        except Exception:
+            pass
+        message = f"timeout after {remaining}s"
+        log_path.write_text((partial or "") + f"\n\n[{message}]\n", encoding="utf-8")
+        return 124, message, str(log_path)
+
+
+def run_scenario(
+    scenario_id: str,
+    *,
+    name: str,
+    command: Sequence[str],
+    cwd: Path,
+    timeout: int,
+    out_dir: Path,
+    env: Mapping[str, str] | None = None,
+    overall_deadline: float | None = None,
+    hard: bool = True,
+    na_reason: str | None = None,
+) -> ScenarioResult:
+    """Execute a hard scenario command, or record explicit N/A."""
+    if na_reason is not None:
+        return scenario_result(
+            scenario_id,
+            name=name,
+            result=RESULT_NA,
+            reason=na_reason,
+            hard=hard,
+        )
+    started = time.monotonic()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    log_path = out_dir / f"{scenario_id}-{stamp}.log"
+    code, detail, log = run_command(
+        command,
+        cwd=cwd,
+        timeout=timeout,
+        log_path=log_path,
+        env=env,
+        overall_deadline=overall_deadline,
+    )
+    seconds = int(time.monotonic() - started)
+    result = RESULT_PASS if code == 0 else RESULT_FAIL
+    return scenario_result(
+        scenario_id,
+        name=name,
+        result=result,
+        seconds=seconds,
+        detail=detail,
+        log=log,
+        hard=hard,
+    )
+
+
+def run_callable_scenario(
+    scenario_id: str,
+    *,
+    name: str,
+    action: Callable[[], None],
+    out_dir: Path,
+    hard: bool = True,
+    na_reason: str | None = None,
+) -> ScenarioResult:
+    """Run a Python action as a scenario (for layout checks, preflight, etc.)."""
+    if na_reason is not None:
+        return scenario_result(
+            scenario_id,
+            name=name,
+            result=RESULT_NA,
+            reason=na_reason,
+            hard=hard,
+        )
+    started = time.monotonic()
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    log_path = out_dir / f"{scenario_id}-{stamp}.log"
+    try:
+        action()
+        log_path.write_text("ok\n", encoding="utf-8")
+        return scenario_result(
+            scenario_id,
+            name=name,
+            result=RESULT_PASS,
+            seconds=int(time.monotonic() - started),
+            log=str(log_path),
+            hard=hard,
+        )
+    except Exception as error:  # noqa: BLE001 — surface any check failure as red cell
+        log_path.write_text(f"{type(error).__name__}: {error}\n", encoding="utf-8")
+        return scenario_result(
+            scenario_id,
+            name=name,
+            result=RESULT_FAIL,
+            seconds=int(time.monotonic() - started),
+            detail=str(error),
+            log=str(log_path),
+            hard=hard,
+        )
+
+
+def gradle_ui_force_args() -> list[str]:
+    """Flags that force live UI tests to re-execute rather than cache-only pass."""
+    return [
+        "--rerun-tasks",
+        "--no-build-cache",
+        "--console=plain",
+    ]
+
+
+def xvfb_prefix(system: str | None = None) -> list[str]:
+    system = system or platform.system()
+    if system == "Linux" and not os.environ.get("DISPLAY", "").strip():
+        if _which("xvfb-run"):
+            return ["xvfb-run", "-a"]
+    return []
+
+
+def host_cli_package_target(system: str | None = None, machine: str | None = None) -> str:
+    system = system or platform.system()
+    machine = machine or platform.machine()
+    if system == "Darwin":
+        return "MacosArm64" if machine in ("arm64", "aarch64") else "MacosX64"
+    if system == "Linux":
+        return "LinuxX64"
+    if system == "Windows":
+        return "WindowsX64"
+    raise RuntimeError(f"unsupported host for CLI packaging: {system}/{machine}")
+
+
+def packaged_cli_executable(root: Path, system: str | None = None, machine: str | None = None) -> Path:
+    system = system or platform.system()
+    machine = machine or platform.machine()
+    if system == "Darwin":
+        if machine in ("arm64", "aarch64"):
+            return root / "cli/build/construo/macosArm64/Spectre.app/Contents/MacOS/spectre"
+        return root / "cli/build/construo/macosX64/Spectre.app/Contents/MacOS/spectre"
+    if system == "Linux":
+        return root / "cli/build/construo/linuxX64/roast/spectre"
+    if system == "Windows":
+        roast = root / "cli/build/construo/windowsX64/roast"
+        for name in ("spectre.exe", "Spectre.exe"):
+            candidate = roast / name
+            if candidate.is_file():
+                return candidate
+        return roast / "spectre.exe"
+    raise RuntimeError(f"unsupported host for CLI executable: {system}")


### PR DESCRIPTION
## Summary

- Introduce `scripts/smoke_lib.py` with `schemaVersion=1`, stable cross-OS scenario IDs, fail-closed hard N/A policy, preflight (full SHA / dirty / env / `displayMode`), timeout + process-group cleanup, and JSON + Markdown report writers.
- Wire `scripts/release-smoke.py` to the shared model for the baseline scenario set; force live UI Gradle tasks with `--rerun-tasks --no-build-cache`.
- Expand `.github/scripts/test-release-smoke-scripts.py` to drive the real helpers (schema fields, hard skip without reason → fail, N/A with reason allowed, timeout kill, preflight SHA/dirty).
- Document report paths, flags, and stable IDs in `docs/RELEASE-SMOKE.md`.

Part of #398 (PR1: schema + preflight + report format). Scenario expansion and Windows parity follow.

## Test plan

- [x] `python3 .github/scripts/test-release-smoke-scripts.py`
- [x] `./gradlew verifyReleaseSmokeScripts`
- [ ] CI green on this PR
- [ ] Follow-up: full scenario matrix + Windows shared schema (PR2/PR3)