### PR TITLE
feat(smoke): Windows schema parity and RELEASE-SMOKE docs (#398)

### DIFF
--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -66,6 +66,22 @@ grep -F -q 'taskkill.exe /PID $p.Id /T /F' "$script" || fail "timeout does not c
 grep -F -q 'timed out after {1}s' "$script" || fail "timeout diagnostic is missing"
 grep -F -q '"--stop"' "$script" || fail "packaged Gradle-ish launch does not reset attach-tainted daemons"
 
+# --- Shared schemaVersion report + stable scenario IDs (#398) ---
+grep -F -q 'schemaVersion' "$script" || fail "Windows report missing schemaVersion"
+grep -F -q 'Save-VersionedSmokeReport' "$script" || fail "Windows report writer missing"
+grep -F -q 'hard skip without N/A reason' "$script" || fail "fail-closed hard N/A policy missing"
+for scenario_id in \
+  preflight check junit-live agent-attach-core agent-contract-corpus agent-inject \
+  agent-launch-and-attach cli-packaged cli-native-helper-layout cli-user-flow \
+  mcp-sdk-flow host-native-recording maven-local-consumer
+do
+  grep -F -q "$scenario_id" "$script" || fail "Windows runner missing stable scenario id: $scenario_id"
+done
+grep -F -q 'windows-ssh' "$script" || fail "SSH displayMode honesty for WGC missing"
+grep -F -q 'WGC requires native interactive console' "$script" || fail "WGC interactive-console N/A reason missing"
+grep -F -q 'displayMode' "$script" || fail "displayMode field missing from Windows harness"
+grep -F -q 'windows-release-smoke.json' "$script" || fail "Windows JSON report path missing"
+
 # --- Optional: parse with pwsh when present (macOS/Linux CI agents may have it) ---
 # Note: this is PowerShell Core parse, not Desktop 5.1; ASCII byte check is the 5.1 stand-in.
 if command -v pwsh >/dev/null 2>&1; then

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -244,13 +244,27 @@ The cross-platform runner covers the stable baseline that should not be reinvent
 Each release still needs delta cells based on `git log <previous-tag>..HEAD`. Add reusable delta
 coverage to the runner rather than leaving a one-release command only in chat.
 
+### Automated vs manual (0.5.0 harness)
+
+| Surface | Automated entrypoint | Manual recipe only |
+| --- | --- | --- |
+| Preflight / check / agent attach·inject·launch / CLI package / MCP SDK / Maven Local | `release-smoke.py` (macOS/Linux); Windows PS shares IDs | — |
+| Live JUnit failure artifacts/video + atomic capture | `release-smoke.py` → `junit-live` | Windows: run on macOS/Linux baseline (hard `n/a` on Windows entrypoint with reason) |
+| Host native recording | macOS SCK + Linux X11 in `release-smoke.py`; WGC in Windows PS when **interactive** | SSH WGC is N/A (not PASS) |
+| TCC / notarization / app seal | — | macOS recipes below |
+| Real Wayland portal | — | Real Wayland session (Xvfb ≠ Wayland) |
+| Public Homebrew / Scoop / archive installs | — | After draft release undraft |
+| Focus / lock keys / multi-monitor / HiDPI | Soft / env-dependent | Operator notes |
+| Stock IntelliJ inject | Soft recipe | Manual when claimed in notes |
+
 ### Manual cells that remain
 
 These cannot currently be made portable and fail-closed by the baseline runner:
 
 - **Windows WGC:** run `windows-release-smoke.ps1` in the logged-in user's native console terminal.
   SSH and even `PsExec -i` can use a service/elevated token that WGC rejects with `0x80070424` or
-  `UnauthorizedAccessException`. Do not accept those runs as visual evidence.
+  `UnauthorizedAccessException`. The Windows harness records hard `n/a` with reason when
+  `displayMode` is `windows-ssh` — do **not** treat SSH runs as visual PASS evidence.
 - **macOS TCC and release seal:** grant Screen Recording to the actual helper identity, exercise one
   live SCK still/record, then verify the signed release app with `codesign --verify --deep --strict`,
   `spctl`, and `xcrun stapler validate`. A local ad-hoc app is not notarization evidence.
@@ -260,9 +274,23 @@ These cannot currently be made portable and fail-closed by the baseline runner:
   package manager and rerun launcher/MCP smoke. Local packaging does not prove channel metadata.
 - **Input focus/lock keys:** real Robot input uses global desktop state. Record focus failures and
   Caps Lock state; restore any modified lock state. Do not silently rerun a case mismatch.
+- **Multi-monitor / HiDPI / stock IntelliJ:** environment-dependent delta cells; keep as recipes when
+  the release delta claims them.
 
-Copy `build/smoke/release-smoke.json` and Windows' `windows-release-smoke.json` into the release
-record. A report from a different SHA or user session is not evidence for the release SHA.
+Copy `build/smoke/release-smoke.json` (+ `.md`) and Windows' `windows-release-smoke.json` (+ `.md`)
+into the release record. A report from a different SHA or user session is not evidence for the
+release SHA.
+
+### Residual gaps for the 0.5.0 cut
+
+- Full multi-OS operator proof still needs a headed Windows interactive console for WGC and a Linux
+  box (Xvfb or real display) for the Unix entrypoint — unit tests + macOS are necessary but not
+  sufficient alone for a GO claim on all three OSes.
+- Windows MCP packaged e2e remains hard `n/a` with reason until
+  `DaemonFixtureIntegrationTest` is EnabledOnOs Windows (or a dedicated Windows MCP cell lands).
+- Issues **#399** (MCP per-session detach) and **#386** (Windows `launch --once` + Gradle
+  `JVM_ATTACHABLE`) are **not** required inside this harness; soft-document only if a scenario
+  already surfaces them.
 
 ## Windows one-liner script
 
@@ -296,26 +324,35 @@ pwsh -NoProfile -ExecutionPolicy Bypass -File C:\src\spectre\scripts\windows-rel
 powershell -NoProfile -ExecutionPolicy Bypass -File C:\src\spectre\scripts\windows-release-smoke.ps1
 ```
 
-What it does (no second terminal):
+What it does (no second terminal), using the **same stable scenario IDs** as
+`scripts/release-smoke.py` / `scripts/smoke_lib.py`:
 
-1. Opt-in agent UI e2e: attach + inject + launch-and-attach  
+1. `preflight` + optional `check`
+2. Agent UI e2e: `agent-attach-core`, `agent-inject`, `agent-launch-and-attach`
    (`-Pspectre.agent.attachE2e.allowWindows=true`, properly quoted for PowerShell)
-2. WGC region smoke (`:recording:runWindowsGraphicsCaptureRegionSmoke`)
-3. `:cli:packageWindowsX64` then packaged `spectre launch --once --app-name ComposeFixtureMain -- gradlew :agent-test-fixture:run`
+3. `host-native-recording` — WGC region smoke only when `displayMode` is interactive
+   (SSH → hard `n/a` with reason, never fake PASS)
+4. `cli-packaged` / `cli-native-helper-layout` / packaged `spectre launch --once` as `cli-user-flow`
+5. optional `maven-local-consumer` via `verifyMavenLocalPublication`
 
-Writes `build/smoke/windows-release-smoke.json` and exits non-zero on any failed step.
+Writes versioned `build/smoke/windows-release-smoke.json` + `.md` (`schemaVersion: 1`, full SHA,
+dirty flag, `environment.displayMode`) and exits non-zero on any hard `fail`.
 
 Flags:
 
 | Flag | Effect |
 | --- | --- |
+| `-Version 0.5.0` | Release version recorded in the report (default `0.5.0`) |
+| `-Base v0.4.1` | Previous tag recorded in the report |
+| `-SkipCheck` | Skip `./gradlew check` (hard `n/a` with reason) |
 | `-SkipAgentE2e` | Skip Gradle attach/inject/launch tests |
 | `-SkipWgc` | Skip region recording smoke |
 | `-SkipCli` | Skip package + `spectre launch` |
 | `-SkipPackageCli` | Reuse existing `spectre.exe` (still runs launch) |
+| `-SkipMavenLocal` | Skip Maven Local publication smoke |
 
 This is **manual, operator-driven** automation — not hosted CI. Use it so release smoke is
-not multi-terminal faff.
+not multi-terminal faff. Prefer the logged-in interactive console for any WGC cell.
 
 ## Recipes (common hard cells)
 

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -31,14 +31,20 @@
 #>
 [CmdletBinding()]
 param(
+    [string] $Version = "0.5.0",
+    [string] $Base = "",
     [switch] $SkipAgentE2e,
     [switch] $SkipWgc,
     [switch] $SkipCli,
     [switch] $SkipPackageCli,
+    [switch] $SkipCheck,
+    [switch] $SkipMavenLocal,
     [ValidateRange(1, 86400)][int] $AgentE2eTimeoutSeconds = 900,
     [ValidateRange(1, 86400)][int] $WgcTimeoutSeconds = 300,
     [ValidateRange(1, 86400)][int] $PackageCliTimeoutSeconds = 900,
-    [ValidateRange(1, 86400)][int] $CliLaunchTimeoutSeconds = 300
+    [ValidateRange(1, 86400)][int] $CliLaunchTimeoutSeconds = 300,
+    [ValidateRange(1, 86400)][int] $CheckTimeoutSeconds = 1200,
+    [ValidateRange(1, 86400)][int] $MavenLocalTimeoutSeconds = 1200
 )
 
 $ErrorActionPreference = "Stop"
@@ -153,41 +159,62 @@ function Invoke-Gradle {
 
 function New-StepResult {
     param(
-        [string] $Name,
-        [string] $Result,
-        [int] $Seconds,
-        [string] $Detail = ""
+        [Parameter(Mandatory = $true)][string] $Id,
+        [Parameter(Mandatory = $true)][string] $Name,
+        [Parameter(Mandatory = $true)][string] $Result,
+        [int] $Seconds = 0,
+        [string] $Detail = "",
+        [string] $Reason = "",
+        [string] $Log = "",
+        [bool] $Hard = $true
     )
+    # Fail-closed: hard n/a without reason becomes fail (matches scripts/smoke_lib.py).
+    $finalResult = $Result
+    $finalDetail = $Detail
+    if ($Result -eq "n/a" -and $Hard -and [string]::IsNullOrWhiteSpace($Reason)) {
+        $finalResult = "fail"
+        $finalDetail = "hard skip without N/A reason"
+    }
     $o = New-Object PSObject
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "id" -Value $Id
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "name" -Value $Name
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "result" -Value $finalResult
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "seconds" -Value $Seconds
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "detail" -Value $finalDetail
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "reason" -Value $Reason
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "log" -Value $Log
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "hard" -Value $Hard
+    # Legacy TitleCase fields kept for older operators grepping Name/Result.
     Add-Member -InputObject $o -MemberType NoteProperty -Name "Name" -Value $Name
-    Add-Member -InputObject $o -MemberType NoteProperty -Name "Result" -Value $Result
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "Result" -Value $finalResult
     Add-Member -InputObject $o -MemberType NoteProperty -Name "Seconds" -Value $Seconds
-    Add-Member -InputObject $o -MemberType NoteProperty -Name "Detail" -Value $Detail
+    Add-Member -InputObject $o -MemberType NoteProperty -Name "Detail" -Value $finalDetail
     return $o
 }
 
 function Invoke-Step {
     param(
+        [Parameter(Mandatory = $true)][string] $Id,
         [Parameter(Mandatory = $true)][string] $Name,
         [Parameter(Mandatory = $true)][scriptblock] $Action
     )
     Write-Host ""
-    Write-Host ("==== {0} ====" -f $Name) -ForegroundColor Cyan
+    Write-Host ("==== {0} ({1}) ====" -f $Id, $Name) -ForegroundColor Cyan
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     try {
         # Swallow success-stream noise from the action so it cannot become our return value.
         $null = . $Action
         $sw.Stop()
         $secs = [int]$sw.Elapsed.TotalSeconds
-        Write-Host ("PASS  {0}  ({1}s)" -f $Name, $secs) -ForegroundColor Green
-        return (New-StepResult -Name $Name -Result "pass" -Seconds $secs)
+        Write-Host ("PASS  {0}  ({1}s)" -f $Id, $secs) -ForegroundColor Green
+        return (New-StepResult -Id $Id -Name $Name -Result "pass" -Seconds $secs)
     }
     catch {
         $sw.Stop()
         $secs = [int]$sw.Elapsed.TotalSeconds
         $msg = [string]$_.Exception.Message
-        Write-Host ("FAIL  {0}  ({1}s): {2}" -f $Name, $secs, $msg) -ForegroundColor Red
-        return (New-StepResult -Name $Name -Result "fail" -Seconds $secs -Detail $msg)
+        Write-Host ("FAIL  {0}  ({1}s): {2}" -f $Id, $secs, $msg) -ForegroundColor Red
+        return (New-StepResult -Id $Id -Name $Name -Result "fail" -Seconds $secs -Detail $msg)
     }
 }
 
@@ -205,21 +232,120 @@ function Get-PackagedSpectre {
     return $null
 }
 
-function Save-SmokeReport {
+function Get-GitText {
+    param([string] $RepoRoot, [string[]] $GitArgs)
+    try {
+        $out = & git -C $RepoRoot @GitArgs 2>$null
+        if ($LASTEXITCODE -ne 0) { return "" }
+        return ([string]$out).Trim()
+    }
+    catch {
+        return ""
+    }
+}
+
+function Get-DisplayModeWindows {
+    if ($env:SSH_CONNECTION) { return "windows-ssh" }
+    $session = [string]$env:SESSIONNAME
+    if ($session -and $session.ToUpper().StartsWith("RDP")) { return "windows-rdp" }
+    return "windows-interactive"
+}
+
+function Save-VersionedSmokeReport {
     param(
         [Parameter(Mandatory = $true)][System.Collections.IList] $Results,
-        [Parameter(Mandatory = $true)][string] $Path
+        [Parameter(Mandatory = $true)][string] $Path,
+        [Parameter(Mandatory = $true)][string] $RepoRoot,
+        [Parameter(Mandatory = $true)][string] $Version,
+        [string] $Base = "",
+        [Parameter(Mandatory = $true)][string] $StartedAt,
+        [Parameter(Mandatory = $true)][string] $FinishedAt,
+        [int] $OverallSeconds = 0
     )
     $dir = Split-Path -Parent $Path
     if (-not (Test-Path -LiteralPath $dir)) {
         New-Item -ItemType Directory -Force -Path $dir | Out-Null
     }
-    # -InputObject with a plain array avoids pipeline enumeration quirks on WinPS 5.1.
-    $payload = @($Results)
-    $json = ConvertTo-Json -InputObject $payload -Depth 6
-    # .NET write avoids Set-Content -Encoding differences between 5.1 and 7+.
+
+    $sha = Get-GitText -RepoRoot $RepoRoot -GitArgs @("rev-parse", "HEAD")
+    $shaShort = Get-GitText -RepoRoot $RepoRoot -GitArgs @("rev-parse", "--short", "HEAD")
+    $status = Get-GitText -RepoRoot $RepoRoot -GitArgs @("status", "--porcelain")
+    $dirty = -not [string]::IsNullOrWhiteSpace($status)
+    $dirtySummary = ""
+    if ($dirty) {
+        $lines = @($status -split "`n" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+        $dirtySummary = ("{0} path(s) dirty" -f $lines.Count)
+    }
+    if ([string]::IsNullOrWhiteSpace($Base)) {
+        $Base = Get-GitText -RepoRoot $RepoRoot -GitArgs @("describe", "--tags", "--abbrev=0")
+    }
+
+    $envObj = New-Object PSObject
+    Add-Member -InputObject $envObj -MemberType NoteProperty -Name "os" -Value "Windows"
+    Add-Member -InputObject $envObj -MemberType NoteProperty -Name "osVersion" -Value ([string][System.Environment]::OSVersion.VersionString)
+    Add-Member -InputObject $envObj -MemberType NoteProperty -Name "arch" -Value ([string]$env:PROCESSOR_ARCHITECTURE)
+    Add-Member -InputObject $envObj -MemberType NoteProperty -Name "hostname" -Value ([string]$env:COMPUTERNAME)
+    Add-Member -InputObject $envObj -MemberType NoteProperty -Name "user" -Value ([string]$env:USERNAME)
+    Add-Member -InputObject $envObj -MemberType NoteProperty -Name "python" -Value ""
+    Add-Member -InputObject $envObj -MemberType NoteProperty -Name "displayMode" -Value (Get-DisplayModeWindows)
+    Add-Member -InputObject $envObj -MemberType NoteProperty -Name "java" -Value ""
+
+    $scenarioList = New-Object System.Collections.ArrayList
+    foreach ($r in @($Results)) {
+        if ($null -eq $r) { continue }
+        $row = New-Object PSObject
+        Add-Member -InputObject $row -MemberType NoteProperty -Name "id" -Value ([string]$r.id)
+        Add-Member -InputObject $row -MemberType NoteProperty -Name "name" -Value ([string]$r.name)
+        Add-Member -InputObject $row -MemberType NoteProperty -Name "result" -Value ([string]$r.result)
+        Add-Member -InputObject $row -MemberType NoteProperty -Name "seconds" -Value ([int]$r.seconds)
+        Add-Member -InputObject $row -MemberType NoteProperty -Name "detail" -Value ([string]$r.detail)
+        Add-Member -InputObject $row -MemberType NoteProperty -Name "reason" -Value ([string]$r.reason)
+        Add-Member -InputObject $row -MemberType NoteProperty -Name "log" -Value ([string]$r.log)
+        Add-Member -InputObject $row -MemberType NoteProperty -Name "hard" -Value ([bool]$r.hard)
+        [void]$scenarioList.Add($row)
+    }
+
+    $report = New-Object PSObject
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "schemaVersion" -Value 1
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "version" -Value $Version
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "base" -Value $Base
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "sha" -Value $sha
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "shaShort" -Value $shaShort
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "dirty" -Value $dirty
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "dirtySummary" -Value $dirtySummary
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "repoRoot" -Value $RepoRoot
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "startedAt" -Value $StartedAt
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "finishedAt" -Value $FinishedAt
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "overallSeconds" -Value $OverallSeconds
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "environment" -Value $envObj
+    Add-Member -InputObject $report -MemberType NoteProperty -Name "scenarios" -Value @($scenarioList)
+
+    $json = ConvertTo-Json -InputObject $report -Depth 8
     $utf8NoBom = New-Object System.Text.UTF8Encoding $false
     [System.IO.File]::WriteAllText($Path, $json, $utf8NoBom)
+
+    # Markdown table for the release record (ASCII only).
+    $mdPath = [System.IO.Path]::ChangeExtension($Path, ".md")
+    $md = New-Object System.Text.StringBuilder
+    [void]$md.AppendLine("# Release smoke report (Windows)")
+    [void]$md.AppendLine("")
+    [void]$md.AppendLine(("- **schemaVersion**: {0}" -f 1))
+    [void]$md.AppendLine(("- **version**: {0}" -f $Version))
+    [void]$md.AppendLine(("- **base**: {0}" -f $Base))
+    [void]$md.AppendLine(("- **sha**: ``{0}``" -f $sha))
+    [void]$md.AppendLine(("- **dirty**: {0}" -f $dirty))
+    [void]$md.AppendLine(("- **displayMode**: {0}" -f $envObj.displayMode))
+    [void]$md.AppendLine("")
+    [void]$md.AppendLine("| ID | Name | Result | Seconds | Note |")
+    [void]$md.AppendLine("| --- | --- | --- | ---: | --- |")
+    foreach ($row in @($scenarioList)) {
+        $note = $row.reason
+        if ([string]::IsNullOrWhiteSpace($note)) { $note = $row.detail }
+        $note = ([string]$note).Replace("|", "/").Replace("`n", " ")
+        [void]$md.AppendLine(("| {0} | {1} | {2} | {3} | {4} |" -f $row.id, $row.name, $row.result, $row.seconds, $note))
+    }
+    [System.IO.File]::WriteAllText($mdPath, $md.ToString(), $utf8NoBom)
+    return $mdPath
 }
 
 # --- main ---
@@ -272,54 +398,131 @@ try {
 
     $repoRoot = Get-RepoRoot
     Set-Location $repoRoot
+    $startedAt = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+    $wall = [System.Diagnostics.Stopwatch]::StartNew()
     Write-Host "Windows release smoke" -ForegroundColor White
     Write-Host ("Repo: {0}" -f $repoRoot)
-    $sha = ""
-    try { $sha = [string](git -C $repoRoot rev-parse --short HEAD 2>$null) } catch { $sha = "" }
+    Write-Host ("Version: {0}" -f $Version)
+    $sha = Get-GitText -RepoRoot $repoRoot -GitArgs @("rev-parse", "--short", "HEAD")
     if ($sha) { Write-Host ("SHA:  {0}" -f $sha) }
     Write-Host ("Host: {0}  User: {1}" -f $env:COMPUTERNAME, $env:USERNAME)
+    Write-Host ("displayMode: {0}" -f (Get-DisplayModeWindows))
     Write-HostGuidance
 
     $results = New-Object System.Collections.ArrayList
 
-    if (-not $SkipAgentE2e) {
-        $step = Invoke-Step -Name "Agent UI e2e (attach + inject + launch)" -Action {
-            Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $AgentE2eTimeoutSeconds -LogName "agent-e2e" -GradleArgs @(
-                ":agent:test",
-                "-Pspectre.agent.attachE2e.allowWindows=true",
-                "--tests", "*AgentAttachIntegration*",
-                "--tests", "*AgentInjectAttachIntegration*",
-                "--tests", "*LaunchAndAttachIntegration*"
-            )
+    # preflight
+    $pre = Invoke-Step -Id "preflight" -Name "Environment / SHA / clean-tree preflight" -Action {
+        $full = Get-GitText -RepoRoot $repoRoot -GitArgs @("rev-parse", "HEAD")
+        if ([string]::IsNullOrWhiteSpace($full) -or $full.Length -lt 7) {
+            throw ("invalid SHA: {0}" -f $full)
+        }
+        if ([string]::IsNullOrWhiteSpace($Version)) { throw "Version is required" }
+    }
+    [void]$results.Add($pre)
+
+    if ($SkipCheck) {
+        [void]$results.Add((New-StepResult -Id "check" -Name "./gradlew check" -Result "n/a" -Reason "skipped via -SkipCheck"))
+    }
+    else {
+        $step = Invoke-Step -Id "check" -Name "./gradlew check" -Action {
+            Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $CheckTimeoutSeconds -LogName "check" -GradleArgs @("check")
         }
         [void]$results.Add($step)
     }
 
-    if (-not $SkipWgc) {
-        $step = Invoke-Step -Name "WGC region smoke" -Action {
-            Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $WgcTimeoutSeconds -LogName "wgc-region" -GradleArgs @(
-                ":recording:runWindowsGraphicsCaptureRegionSmoke"
+    # Live JUnit is Unix-primary in release-smoke.py; on Windows record explicit N/A unless expanded.
+    [void]$results.Add((New-StepResult -Id "junit-live" -Name "Live JUnit failure artifacts/video and atomic capture" -Result "n/a" -Reason "Windows entrypoint prioritizes agent/WGC/CLI; run sample-desktop validationTest on macOS/Linux baseline"))
+
+    if (-not $SkipAgentE2e) {
+        $step = Invoke-Step -Id "agent-attach-core" -Name "Agent attach with preinstalled core" -Action {
+            Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $AgentE2eTimeoutSeconds -LogName "agent-attach" -GradleArgs @(
+                ":agent:test",
+                "-Pspectre.agent.attachE2e.allowWindows=true",
+                "--tests", "*AgentAttachIntegration*",
+                "--rerun-tasks",
+                "--no-build-cache"
             )
-            $mp4 = Join-Path $env:TEMP "spectre-wgc-region-smoke.mp4"
-            if (-not (Test-Path -LiteralPath $mp4)) { throw "Expected output missing: $mp4" }
-            $len = [int64](Get-Item -LiteralPath $mp4).Length
-            if ($len -lt 8192) { throw ("MP4 too small ({0} bytes): {1}" -f $len, $mp4) }
-            Write-Host ("  mp4: {0} ({1} bytes)" -f $mp4, $len) -ForegroundColor DarkGray
         }
         [void]$results.Add($step)
+
+        [void]$results.Add((New-StepResult -Id "agent-contract-corpus" -Name "Agent contract corpus" -Result "n/a" -Reason "Windows agent corpus is covered by attach/inject/launch cells; full AgentContractCorpus stays on Linux/macOS Xvfb matrix"))
+
+        $step = Invoke-Step -Id "agent-inject" -Name "Injected attach without preinstalled core" -Action {
+            Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $AgentE2eTimeoutSeconds -LogName "agent-inject" -GradleArgs @(
+                ":agent:test",
+                "-Pspectre.agent.attachE2e.allowWindows=true",
+                "--tests", "*AgentInjectAttachIntegration*",
+                "--rerun-tasks",
+                "--no-build-cache"
+            )
+        }
+        [void]$results.Add($step)
+
+        $step = Invoke-Step -Id "agent-launch-and-attach" -Name "Launch-and-attach" -Action {
+            Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $AgentE2eTimeoutSeconds -LogName "agent-launch" -GradleArgs @(
+                ":agent:test",
+                "-Pspectre.agent.attachE2e.allowWindows=true",
+                "--tests", "*LaunchAndAttachIntegration*",
+                "--rerun-tasks",
+                "--no-build-cache"
+            )
+        }
+        [void]$results.Add($step)
+    }
+    else {
+        $reason = "skipped via -SkipAgentE2e"
+        [void]$results.Add((New-StepResult -Id "agent-attach-core" -Name "Agent attach with preinstalled core" -Result "n/a" -Reason $reason))
+        [void]$results.Add((New-StepResult -Id "agent-contract-corpus" -Name "Agent contract corpus" -Result "n/a" -Reason $reason))
+        [void]$results.Add((New-StepResult -Id "agent-inject" -Name "Injected attach without preinstalled core" -Result "n/a" -Reason $reason))
+        [void]$results.Add((New-StepResult -Id "agent-launch-and-attach" -Name "Launch-and-attach" -Result "n/a" -Reason $reason))
+    }
+
+    if (-not $SkipWgc) {
+        $displayMode = Get-DisplayModeWindows
+        if ($displayMode -eq "windows-ssh") {
+            [void]$results.Add((New-StepResult -Id "host-native-recording" -Name "Host native recording (WGC)" -Result "n/a" -Reason "WGC requires native interactive console; SSH session cannot provide honest visual evidence (0x80070424 / black frames)"))
+        }
+        else {
+            $step = Invoke-Step -Id "host-native-recording" -Name "Host native recording (WGC region)" -Action {
+                Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $WgcTimeoutSeconds -LogName "wgc-region" -GradleArgs @(
+                    ":recording:runWindowsGraphicsCaptureRegionSmoke"
+                )
+                $mp4 = Join-Path $env:TEMP "spectre-wgc-region-smoke.mp4"
+                if (-not (Test-Path -LiteralPath $mp4)) { throw "Expected output missing: $mp4" }
+                $len = [int64](Get-Item -LiteralPath $mp4).Length
+                if ($len -lt 8192) { throw ("MP4 too small ({0} bytes): {1}" -f $len, $mp4) }
+                Write-Host ("  mp4: {0} ({1} bytes)" -f $mp4, $len) -ForegroundColor DarkGray
+            }
+            [void]$results.Add($step)
+        }
+    }
+    else {
+        [void]$results.Add((New-StepResult -Id "host-native-recording" -Name "Host native recording (WGC)" -Result "n/a" -Reason "skipped via -SkipWgc"))
     }
 
     if (-not $SkipCli) {
         if (-not $SkipPackageCli) {
-            $step = Invoke-Step -Name "Package Windows CLI" -Action {
+            $step = Invoke-Step -Id "cli-packaged" -Name "Release-shaped host CLI package (packageWindowsX64)" -Action {
                 Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $PackageCliTimeoutSeconds -LogName "package-cli" -GradleArgs @(
                     ":cli:packageWindowsX64"
                 )
             }
             [void]$results.Add($step)
         }
+        else {
+            [void]$results.Add((New-StepResult -Id "cli-packaged" -Name "Release-shaped host CLI package (packageWindowsX64)" -Result "n/a" -Reason "skipped via -SkipPackageCli (reusing existing spectre.exe)"))
+        }
 
-        $step = Invoke-Step -Name "Packaged spectre launch --once (fixture)" -Action {
+        $spectrePath = Get-PackagedSpectre -RepoRoot $repoRoot
+        if ($spectrePath) {
+            [void]$results.Add((New-StepResult -Id "cli-native-helper-layout" -Name "Native-helper layout in packaged CLI" -Result "pass" -Detail ("found {0}" -f $spectrePath)))
+        }
+        else {
+            [void]$results.Add((New-StepResult -Id "cli-native-helper-layout" -Name "Native-helper layout in packaged CLI" -Result "fail" -Detail "spectre.exe not found under cli\build\construo\windowsX64\roast\"))
+        }
+
+        $step = Invoke-Step -Id "cli-user-flow" -Name "Packaged spectre launch --once (fixture)" -Action {
             # Agent e2e attaches to Gradle-spawned fixtures. A reused daemon can retain the
             # extracted runtime path and make the next launch hand that path to a fresh JVM while
             # Windows still has transient file state around it. Use a fresh daemon for this
@@ -344,6 +547,30 @@ try {
             )
         }
         [void]$results.Add($step)
+
+        [void]$results.Add((New-StepResult -Id "mcp-sdk-flow" -Name "Packaged MCP via official SDK" -Result "n/a" -Reason "MCP packaged e2e is automated on macOS/Linux release-smoke.py; re-run there or extend Windows when DaemonFixtureIntegration is EnabledOnOs Windows"))
+    }
+    else {
+        $reason = "skipped via -SkipCli"
+        [void]$results.Add((New-StepResult -Id "cli-packaged" -Name "Release-shaped host CLI package" -Result "n/a" -Reason $reason))
+        [void]$results.Add((New-StepResult -Id "cli-native-helper-layout" -Name "Native-helper layout in packaged CLI" -Result "n/a" -Reason $reason))
+        [void]$results.Add((New-StepResult -Id "cli-user-flow" -Name "Packaged CLI user flow" -Result "n/a" -Reason $reason))
+        [void]$results.Add((New-StepResult -Id "mcp-sdk-flow" -Name "Packaged MCP via official SDK" -Result "n/a" -Reason $reason))
+    }
+
+    if ($SkipMavenLocal) {
+        [void]$results.Add((New-StepResult -Id "maven-local-consumer" -Name "Maven Local publication + fresh consumer" -Result "n/a" -Reason "skipped via -SkipMavenLocal"))
+    }
+    else {
+        $smokeVersion = ("{0}-rc.smoke" -f $Version)
+        $step = Invoke-Step -Id "maven-local-consumer" -Name "Maven Local publication + shape verify" -Action {
+            Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $MavenLocalTimeoutSeconds -LogName "maven-local" -GradleArgs @(
+                "verifyMavenLocalPublication",
+                ("-PVERSION_NAME={0}" -f $smokeVersion),
+                "-PstubMacHelperForTesting"
+            )
+        }
+        [void]$results.Add($step)
     }
 
     Write-Host ""
@@ -355,33 +582,44 @@ try {
             $failCount++
             continue
         }
-        $name = [string]$r.Name
-        $result = [string]$r.Result
-        $secs = [int]$r.Seconds
-        $detail = [string]$r.Detail
-        if ($result -ne "pass") { $failCount++ }
+        $id = [string]$r.id
+        $result = [string]$r.result
+        $secs = [int]$r.seconds
+        $detail = [string]$r.detail
+        $reason = [string]$r.reason
+        $hard = [bool]$r.hard
+        if ($hard -and $result -eq "fail") { $failCount++ }
+        if ($hard -and $result -eq "n/a" -and [string]::IsNullOrWhiteSpace($reason)) { $failCount++ }
         $status = $result.ToUpper()
-        $line = "{0,-6} {1,-48} {2,4}s" -f $status, $name, $secs
-        if ($detail) { $line = $line + "  " + $detail }
+        $line = "{0,-6} {1,-28} {2,4}s" -f $status, $id, $secs
+        $note = $reason
+        if ([string]::IsNullOrWhiteSpace($note)) { $note = $detail }
+        if ($note) { $line = $line + "  " + $note }
         if ($result -eq "pass") {
             Write-Host $line -ForegroundColor Green
+        }
+        elseif ($result -eq "n/a") {
+            Write-Host $line -ForegroundColor Yellow
         }
         else {
             Write-Host $line -ForegroundColor Red
         }
     }
 
+    $wall.Stop()
+    $finishedAt = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
     $outDir = Join-Path $repoRoot "build\smoke"
     $reportPath = Join-Path $outDir "windows-release-smoke.json"
-    Save-SmokeReport -Results $results -Path $reportPath
-    Write-Host ("Report: {0}" -f $reportPath)
-    Write-Host ("Logs:   {0}" -f $outDir)
+    $mdPath = Save-VersionedSmokeReport -Results $results -Path $reportPath -RepoRoot $repoRoot -Version $Version -Base $Base -StartedAt $startedAt -FinishedAt $finishedAt -OverallSeconds ([int]$wall.Elapsed.TotalSeconds)
+    Write-Host ("Report JSON: {0}" -f $reportPath)
+    Write-Host ("Report MD:   {0}" -f $mdPath)
+    Write-Host ("Logs:        {0}" -f $outDir)
 
     if ($failCount -gt 0) {
-        Write-Host ("FAILED ({0} step(s))" -f $failCount) -ForegroundColor Red
+        Write-Host ("FAILED ({0} hard step(s))" -f $failCount) -ForegroundColor Red
         exit 1
     }
-    Write-Host "ALL PASSED" -ForegroundColor Green
+    Write-Host "ALL HARD SCENARIOS PASSED (or explicit N/A with reason)" -ForegroundColor Green
     exit 0
 }
 catch {


### PR DESCRIPTION
## Summary

- Align `scripts/windows-release-smoke.ps1` with `schemaVersion=1`, shared stable scenario IDs, fail-closed hard N/A, preflight/SHA/dirty/displayMode, and Markdown+JSON reports under `build/smoke/`.
- Keep WGC honesty: `windows-ssh` displayMode → hard `n/a` with reason (never fake PASS over SSH).
- Expand `docs/RELEASE-SMOKE.md`: one-command per OS, automated vs manual matrix, residual 0.5.0 gaps.
- Contract tests assert every required scenario ID + schema writer present in the Windows entrypoint.

Depends on #406 (scenario matrix) which depends on #405 (schema). Part of #398 (PR3).

## Test plan

- [x] `bash .github/scripts/test-windows-release-smoke-script.sh`
- [x] `./gradlew verifyWindowsReleaseSmokeScript verifyReleaseSmokeScripts`
- [ ] CI green
- [ ] Rebase onto main after #405/#406 merge