### PR TITLE
fix(core): typeText case independent of ambient Caps Lock (#396)

### DIFF
--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -559,6 +559,11 @@ class AgentAttachIntegrationTest {
      * Wait for the typed character, or on CI skip the remainder of the typeText assertion when
      * Xvfb/Robot delivers a no-op keystroke (same class of flakiness as
      * [typeTextOrSkipCiFocusLoss]).
+     *
+     * **#396:** a wrong-case receipt (e.g. `X` when we typed `x`) is a product input bug, not an
+     * environmental focus failure. Fail hard even on CI when the case-insensitive character arrived
+     * but the exact-case character did not. Soft CI skip is reserved for true no-op delivery (empty
+     * / unchanged text).
      */
     private fun AttachedAutomator.waitForTextFieldToReceiveTypedCharacterOrSkipCi(
         textFieldKey: String,
@@ -567,6 +572,9 @@ class AgentAttachIntegrationTest {
     ): NodeSnapshotDto? {
         val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(FOCUS_TIMEOUT_MS)
         val previousTypedCount = previousEditableText.count { it == TYPED_CHARACTER }
+        val previousCaseInsensitiveCount = previousEditableText.count {
+            it.equals(TYPED_CHARACTER, ignoreCase = true)
+        }
         var lastText: String? = null
         while (System.nanoTime() < deadline) {
             val match = findByTestTag(TAG_TEXT_FIELD).firstOrNull { it.key == textFieldKey }
@@ -578,6 +586,19 @@ class AgentAttachIntegrationTest {
                 return match
             }
             sleepBetweenFocusPolls()
+        }
+        val last = lastText.orEmpty()
+        val caseInsensitiveArrived =
+            last.count { it.equals(TYPED_CHARACTER, ignoreCase = true) } >
+                previousCaseInsensitiveCount
+        val exactCaseArrived = last.count { it == TYPED_CHARACTER } > previousTypedCount
+        if (caseInsensitiveArrived && !exactCaseArrived) {
+            // Product bug: ambient Caps Lock / case mapping flipped the character. Never soft-skip.
+            error(
+                "iteration $iteration: fixture text field $textFieldKey received wrong letter " +
+                    "case after typeText (product input bug, not focus loss). " +
+                    "Expected exact '$TYPED_CHARACTER', Before='$previousEditableText', last='$lastText'"
+            )
         }
         val message =
             "iteration $iteration: fixture text field $textFieldKey did not receive " +

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -37,6 +37,10 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
+    // Forward live-AWT opt-in into the test JVM (macOS AppKit is opt-in; see LiveAwtAssumptions).
+    providers.systemProperty("spectre.test.liveAwt").orNull?.let { value ->
+        systemProperty("spectre.test.liveAwt", value)
+    }
     // Docs contract tests read repo-root markdown at runtime; register them as inputs so
     // :core:test is not UP-TO-DATE/cache-hit after spike/guide docs change (#209).
     val docsRoot = rootProject.layout.projectDirectory.dir("docs")

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -37,9 +37,14 @@ dependencies {
 
 tasks.withType<Test>().configureEach {
     useJUnitPlatform()
-    // Forward live-AWT opt-in into the test JVM (macOS AppKit is opt-in; see LiveAwtAssumptions).
+    // Forward live-AWT / physical typeText opt-ins into the test JVM (macOS AppKit is opt-in;
+    // physical Robot Caps Lock tests must not run unguarded on hosted CI — see
+    // RobotDriverTypeTextCapsPhysicalTest).
     providers.systemProperty("spectre.test.liveAwt").orNull?.let { value ->
         systemProperty("spectre.test.liveAwt", value)
+    }
+    providers.systemProperty("spectre.test.physicalTypeText").orNull?.let { value ->
+        systemProperty("spectre.test.physicalTypeText", value)
     }
     // Docs contract tests read repo-root markdown at runtime; register them as inputs so
     // :core:test is not UP-TO-DATE/cache-hit after spike/guide docs change (#209).

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -152,18 +152,39 @@ internal constructor(
      * ASCII letters, digits, space, newline, and common US-keyboard punctuation. Use [pasteText]
      * when you need arbitrary Unicode text.
      *
+     * **Caps Lock.** Requested letter case is independent of ambient Caps Lock (#396). When the
+     * adapter can write locking-key state, Spectre temporarily clears Caps Lock for the duration of
+     * this call and restores the prior state in a `finally` (including after mid-string failures).
+     * When Caps Lock is on but cannot be cleared, letter strokes invert Shift so the OS still emits
+     * the requested case. Non-letter characters are unaffected by Caps Lock on standard keyboards.
+     *
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun typeText(text: String) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            for (char in text) {
-                val stroke = keyStrokeForChar(char)
-                for (modifier in stroke.modifiers) robot.keyPress(modifier)
-                robot.keyPress(stroke.keyCode)
-                robot.keyRelease(stroke.keyCode)
-                for (modifier in stroke.modifiers.asReversed()) robot.keyRelease(modifier)
+            val capsLockWasOn = robot.getLockingKeyState(KeyEvent.VK_CAPS_LOCK) == true
+            var capsLockCleared = false
+            try {
+                if (capsLockWasOn) {
+                    capsLockCleared = robot.setLockingKeyState(KeyEvent.VK_CAPS_LOCK, on = false)
+                }
+                // Prefer a cleared lock so strokes match the pure US-keyboard map. If the adapter
+                // cannot clear Caps Lock, invert Shift on letters so requested case still lands.
+                val compensateCapsLock = capsLockWasOn && !capsLockCleared
+                for (char in text) {
+                    val stroke = keyStrokeForChar(char, capsLockOn = compensateCapsLock)
+                    for (modifier in stroke.modifiers) robot.keyPress(modifier)
+                    robot.keyPress(stroke.keyCode)
+                    robot.keyRelease(stroke.keyCode)
+                    for (modifier in stroke.modifiers.asReversed()) robot.keyRelease(modifier)
+                }
+            } finally {
+                if (capsLockCleared) {
+                    // Fail-closed: never leave the host Caps Lock inverted after typeText.
+                    runCatching { robot.setLockingKeyState(KeyEvent.VK_CAPS_LOCK, on = true) }
+                }
             }
         }
     }
@@ -484,6 +505,20 @@ internal interface RobotAdapter : ScreenCaptureAdapter {
 
     fun waitForIdle()
 
+    /**
+     * Reads a locking-key LED state (`KeyEvent.VK_CAPS_LOCK`, `VK_NUM_LOCK`, `VK_SCROLL_LOCK`).
+     * Returns `null` when the backend cannot report the key (unsupported on this platform/JVM, or a
+     * pure test fake that does not model locks). Default is `null` so headless/synthetic adapters
+     * do not initialise AWT.
+     */
+    fun getLockingKeyState(keyCode: Int): Boolean? = null
+
+    /**
+     * Attempts to set a locking-key LED state. Returns `true` when the write is believed to have
+     * taken effect; `false` when unsupported. Default is `false`.
+     */
+    fun setLockingKeyState(keyCode: Int, on: Boolean): Boolean = false
+
     override fun createScreenCapture(region: Rectangle): BufferedImage =
         throw UnsupportedOperationException("This robot adapter does not support screen capture")
 
@@ -548,6 +583,30 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) :
     override fun keyRelease(keyCode: Int) = robot.keyRelease(keyCode)
 
     override fun mouseWheel(wheelClicks: Int) = robot.mouseWheel(wheelClicks)
+
+    // Locking-key LEDs are a Toolkit API (not Robot). Unsupported on some platforms/JVMs —
+    // treat as "unknown" / "write failed" so typeText can fall back to Shift compensation.
+    override fun getLockingKeyState(keyCode: Int): Boolean? =
+        try {
+            Toolkit.getDefaultToolkit().getLockingKeyState(keyCode)
+        } catch (_: UnsupportedOperationException) {
+            null
+        } catch (_: IllegalArgumentException) {
+            null
+        }
+
+    override fun setLockingKeyState(keyCode: Int, on: Boolean): Boolean =
+        try {
+            Toolkit.getDefaultToolkit().setLockingKeyState(keyCode, on)
+            // Some platforms accept the call without throwing but leave the LED unchanged.
+            // Only report success when read-back matches so typeText can fall back to Shift
+            // compensation for letters under ambient Caps Lock.
+            getLockingKeyState(keyCode) == on
+        } catch (_: UnsupportedOperationException) {
+            false
+        } catch (_: IllegalArgumentException) {
+            false
+        }
 
     override fun createScreenCapture(region: Rectangle): BufferedImage =
         robot.createScreenCapture(region)
@@ -664,7 +723,19 @@ internal fun modifierMaskToKeyCodes(mask: Int): List<Int> = buildList {
 
 internal data class KeyStrokeSpec(val keyCode: Int, val modifiers: List<Int> = emptyList())
 
-internal fun keyStrokeForChar(char: Char): KeyStrokeSpec {
+/**
+ * Maps [char] to a US-keyboard key code and optional Shift modifiers.
+ *
+ * When [capsLockOn] is true, letter strokes invert Shift so the OS still produces the requested
+ * case under ambient Caps Lock (used only when Caps Lock cannot be temporarily cleared).
+ */
+internal fun keyStrokeForChar(char: Char, capsLockOn: Boolean = false): KeyStrokeSpec {
+    val base = baseKeyStrokeForChar(char)
+    if (!capsLockOn || !char.isLetter()) return base
+    return invertShift(base)
+}
+
+private fun baseKeyStrokeForChar(char: Char): KeyStrokeSpec {
     unmodifiedCharKeyCodes[char]?.let {
         return KeyStrokeSpec(it)
     }
@@ -676,6 +747,15 @@ internal fun keyStrokeForChar(char: Char): KeyStrokeSpec {
         in 'A'..'Z' -> KeyStrokeSpec(KeyEvent.VK_A + (char - 'A'), listOf(KeyEvent.VK_SHIFT))
         in '0'..'9' -> KeyStrokeSpec(KeyEvent.VK_0 + (char - '0'))
         else -> unsupportedTypeTextChar(char)
+    }
+}
+
+private fun invertShift(stroke: KeyStrokeSpec): KeyStrokeSpec {
+    val hasShift = stroke.modifiers.contains(KeyEvent.VK_SHIFT)
+    return if (hasShift) {
+        KeyStrokeSpec(stroke.keyCode, stroke.modifiers.filterNot { it == KeyEvent.VK_SHIFT })
+    } else {
+        KeyStrokeSpec(stroke.keyCode, stroke.modifiers + KeyEvent.VK_SHIFT)
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -152,11 +152,12 @@ internal constructor(
      * ASCII letters, digits, space, newline, and common US-keyboard punctuation. Use [pasteText]
      * when you need arbitrary Unicode text.
      *
-     * **Caps Lock.** Requested letter case is independent of ambient Caps Lock (#396). When the
-     * adapter can write locking-key state, Spectre temporarily clears Caps Lock for the duration of
-     * this call and restores the prior state in a `finally` (including after mid-string failures).
-     * When Caps Lock is on but cannot be cleared, letter strokes invert Shift so the OS still emits
-     * the requested case. Non-letter characters are unaffected by Caps Lock on standard keyboards.
+     * **Caps Lock.** Requested letter case is independent of ambient Caps Lock (#396). Spectre
+     * reads the Caps Lock LED via the adapter and, when it is on, inverts Shift on letter strokes
+     * so the OS still emits the requested case. Global locking-key state is **not** mutated
+     * (Toolkit `setLockingKeyState` is unsupported or a silent no-op on several desktop JVMs, and a
+     * false "cleared" read-back still left host key events inverted in physical Windows
+     * validation). Non-letter characters are unaffected by Caps Lock on standard keyboards.
      *
      * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
@@ -164,27 +165,15 @@ internal constructor(
     public suspend fun typeText(text: String) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            val capsLockWasOn = robot.getLockingKeyState(KeyEvent.VK_CAPS_LOCK) == true
-            var capsLockCleared = false
-            try {
-                if (capsLockWasOn) {
-                    capsLockCleared = robot.setLockingKeyState(KeyEvent.VK_CAPS_LOCK, on = false)
-                }
-                // Prefer a cleared lock so strokes match the pure US-keyboard map. If the adapter
-                // cannot clear Caps Lock, invert Shift on letters so requested case still lands.
-                val compensateCapsLock = capsLockWasOn && !capsLockCleared
-                for (char in text) {
-                    val stroke = keyStrokeForChar(char, capsLockOn = compensateCapsLock)
-                    for (modifier in stroke.modifiers) robot.keyPress(modifier)
-                    robot.keyPress(stroke.keyCode)
-                    robot.keyRelease(stroke.keyCode)
-                    for (modifier in stroke.modifiers.asReversed()) robot.keyRelease(modifier)
-                }
-            } finally {
-                if (capsLockCleared) {
-                    // Fail-closed: never leave the host Caps Lock inverted after typeText.
-                    runCatching { robot.setLockingKeyState(KeyEvent.VK_CAPS_LOCK, on = true) }
-                }
+            // Read once per call: ambient Caps Lock is stable for a short typeText burst, and we
+            // intentionally do not write locking-key state (see KDoc).
+            val capsLockOn = robot.getLockingKeyState(KeyEvent.VK_CAPS_LOCK) == true
+            for (char in text) {
+                val stroke = keyStrokeForChar(char, capsLockOn = capsLockOn)
+                for (modifier in stroke.modifiers) robot.keyPress(modifier)
+                robot.keyPress(stroke.keyCode)
+                robot.keyRelease(stroke.keyCode)
+                for (modifier in stroke.modifiers.asReversed()) robot.keyRelease(modifier)
             }
         }
     }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -95,6 +95,22 @@ class RobotDriverTest {
     }
 
     @Test
+    fun `keyStrokeForChar inverts letter shift when Caps Lock is on`() {
+        // Ambient Caps Lock inverts letter case at the OS; compensate by flipping Shift.
+        assertEquals(
+            KeyStrokeSpec(KeyEvent.VK_A, listOf(KeyEvent.VK_SHIFT)),
+            keyStrokeForChar('a', capsLockOn = true),
+        )
+        assertEquals(KeyStrokeSpec(KeyEvent.VK_A), keyStrokeForChar('A', capsLockOn = true))
+        // Non-letters are unaffected by Caps Lock.
+        assertEquals(KeyStrokeSpec(KeyEvent.VK_1), keyStrokeForChar('1', capsLockOn = true))
+        assertEquals(
+            KeyStrokeSpec(KeyEvent.VK_1, listOf(KeyEvent.VK_SHIFT)),
+            keyStrokeForChar('!', capsLockOn = true),
+        )
+    }
+
+    @Test
     fun `typeText dispatches key events without touching the clipboard`() = runTest {
         val robot = RecordingRobotAdapter()
         val clipboard = RecordingClipboardAdapter()
@@ -117,6 +133,90 @@ class RobotDriverTest {
                 "keyPress(${KeyEvent.VK_1})",
                 "keyRelease(${KeyEvent.VK_1})",
                 "keyRelease(${KeyEvent.VK_SHIFT})",
+            ),
+            robot.events,
+        )
+    }
+
+    @Test
+    fun `typeText with Caps Lock on clears lock types lowercase and restores`() = runTest {
+        // #396: ambient Caps Lock must not invert requested letter case. Prefer clear→type→restore
+        // so the per-char mapping stays pure US-keyboard when the adapter can write lock state.
+        val robot = RecordingRobotAdapter(initialCapsLockOn = true)
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.typeText("xY")
+
+        assertEquals(
+            listOf(false, true),
+            robot.capsLockWrites,
+            "typeText must clear Caps Lock before typing and restore it afterward",
+        )
+        assertTrue(robot.capsLockOn, "Caps Lock must be restored to the prior on state")
+        assertEquals(
+            listOf(
+                "keyPress(${KeyEvent.VK_X})",
+                "keyRelease(${KeyEvent.VK_X})",
+                "keyPress(${KeyEvent.VK_SHIFT})",
+                "keyPress(${KeyEvent.VK_Y})",
+                "keyRelease(${KeyEvent.VK_Y})",
+                "keyRelease(${KeyEvent.VK_SHIFT})",
+            ),
+            robot.events,
+            "With Caps Lock cleared, strokes must match the requested case without ambient invert",
+        )
+    }
+
+    @Test
+    fun `typeText with Caps Lock off does not mutate lock state`() = runTest {
+        val robot = RecordingRobotAdapter(initialCapsLockOn = false)
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.typeText("x")
+
+        assertEquals(emptyList(), robot.capsLockWrites)
+        assertEquals(false, robot.capsLockOn)
+        assertEquals(
+            listOf("keyPress(${KeyEvent.VK_X})", "keyRelease(${KeyEvent.VK_X})"),
+            robot.events,
+        )
+    }
+
+    @Test
+    fun `typeText restores Caps Lock after a mid-type failure`() = runTest {
+        val robot = RecordingRobotAdapter(initialCapsLockOn = true)
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        val error = assertFailsWith<IllegalArgumentException> { driver.typeText("xé") }
+        assertTrue(error.message?.contains("pasteText") == true)
+        assertTrue(
+            robot.capsLockOn,
+            "Fail-closed: Caps Lock must be restored even when typeText throws mid-string",
+        )
+        assertEquals(listOf(false, true), robot.capsLockWrites)
+    }
+
+    @Test
+    fun `typeText compensates with Shift when Caps Lock cannot be cleared`() = runTest {
+        // Some JVMs/platforms refuse setLockingKeyState for Caps Lock. Fall back to inverting
+        // Shift on letters so the requested case still lands.
+        val robot = RecordingRobotAdapter(initialCapsLockOn = true, allowCapsLockWrite = false)
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.typeText("xY")
+
+        assertEquals(emptyList(), robot.capsLockWrites)
+        assertTrue(robot.capsLockOn)
+        assertEquals(
+            listOf(
+                // lowercase 'x' needs Shift while Caps Lock is stuck on
+                "keyPress(${KeyEvent.VK_SHIFT})",
+                "keyPress(${KeyEvent.VK_X})",
+                "keyRelease(${KeyEvent.VK_X})",
+                "keyRelease(${KeyEvent.VK_SHIFT})",
+                // uppercase 'Y' needs no Shift while Caps Lock is stuck on
+                "keyPress(${KeyEvent.VK_Y})",
+                "keyRelease(${KeyEvent.VK_Y})",
             ),
             robot.events,
         )
@@ -403,9 +503,13 @@ private class RecordingRobotAdapter(
     override val autoDelayMs: Int = 0,
     private val sharedLog: MutableList<String>? = null,
     private val drainAfterPaste: Boolean = false,
+    initialCapsLockOn: Boolean = false,
+    private val allowCapsLockWrite: Boolean = true,
 ) : RobotAdapter {
     override val requiresOffEdt: Boolean = false
     val events = mutableListOf<String>()
+    val capsLockWrites = mutableListOf<Boolean>()
+    var capsLockOn: Boolean = initialCapsLockOn
     var captureCalls: Int = 0
         private set
 
@@ -425,6 +529,16 @@ private class RecordingRobotAdapter(
     override fun keyRelease(keyCode: Int) = log("keyRelease($keyCode)")
 
     override fun mouseWheel(wheelClicks: Int) = log("mouseWheel($wheelClicks)")
+
+    override fun getLockingKeyState(keyCode: Int): Boolean? =
+        if (keyCode == KeyEvent.VK_CAPS_LOCK) capsLockOn else null
+
+    override fun setLockingKeyState(keyCode: Int, on: Boolean): Boolean {
+        if (keyCode != KeyEvent.VK_CAPS_LOCK || !allowCapsLockWrite) return false
+        capsLockWrites += on
+        capsLockOn = on
+        return true
+    }
 
     override fun createScreenCapture(region: Rectangle): BufferedImage {
         captureCalls++

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -139,31 +139,32 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `typeText with Caps Lock on clears lock types lowercase and restores`() = runTest {
-        // #396: ambient Caps Lock must not invert requested letter case. Prefer clear→type→restore
-        // so the per-char mapping stays pure US-keyboard when the adapter can write lock state.
+    fun `typeText with Caps Lock on compensates letter Shift and does not mutate lock`() = runTest {
+        // #396: ambient Caps Lock must not invert requested letter case. Spectre does not write
+        // locking-key state (unreliable across JVMs); it inverts Shift on letters instead.
         val robot = RecordingRobotAdapter(initialCapsLockOn = true)
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
 
         driver.typeText("xY")
 
         assertEquals(
-            listOf(false, true),
+            emptyList(),
             robot.capsLockWrites,
-            "typeText must clear Caps Lock before typing and restore it afterward",
+            "typeText must not mutate global Caps Lock state",
         )
-        assertTrue(robot.capsLockOn, "Caps Lock must be restored to the prior on state")
+        assertTrue(robot.capsLockOn, "ambient Caps Lock must remain as the host left it")
         assertEquals(
             listOf(
+                // lowercase 'x' needs Shift while Caps Lock is on
+                "keyPress(${KeyEvent.VK_SHIFT})",
                 "keyPress(${KeyEvent.VK_X})",
                 "keyRelease(${KeyEvent.VK_X})",
-                "keyPress(${KeyEvent.VK_SHIFT})",
+                "keyRelease(${KeyEvent.VK_SHIFT})",
+                // uppercase 'Y' needs no Shift while Caps Lock is on
                 "keyPress(${KeyEvent.VK_Y})",
                 "keyRelease(${KeyEvent.VK_Y})",
-                "keyRelease(${KeyEvent.VK_SHIFT})",
             ),
             robot.events,
-            "With Caps Lock cleared, strokes must match the requested case without ambient invert",
         )
     }
 
@@ -183,7 +184,7 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `typeText restores Caps Lock after a mid-type failure`() = runTest {
+    fun `typeText leaves Caps Lock unchanged after a mid-type failure`() = runTest {
         val robot = RecordingRobotAdapter(initialCapsLockOn = true)
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
 
@@ -191,35 +192,9 @@ class RobotDriverTest {
         assertTrue(error.message?.contains("pasteText") == true)
         assertTrue(
             robot.capsLockOn,
-            "Fail-closed: Caps Lock must be restored even when typeText throws mid-string",
+            "Fail-closed: typeText must not leave Caps Lock inverted after a mid-string throw",
         )
-        assertEquals(listOf(false, true), robot.capsLockWrites)
-    }
-
-    @Test
-    fun `typeText compensates with Shift when Caps Lock cannot be cleared`() = runTest {
-        // Some JVMs/platforms refuse setLockingKeyState for Caps Lock. Fall back to inverting
-        // Shift on letters so the requested case still lands.
-        val robot = RecordingRobotAdapter(initialCapsLockOn = true, allowCapsLockWrite = false)
-        val driver = RobotDriver(robot, RecordingClipboardAdapter())
-
-        driver.typeText("xY")
-
         assertEquals(emptyList(), robot.capsLockWrites)
-        assertTrue(robot.capsLockOn)
-        assertEquals(
-            listOf(
-                // lowercase 'x' needs Shift while Caps Lock is stuck on
-                "keyPress(${KeyEvent.VK_SHIFT})",
-                "keyPress(${KeyEvent.VK_X})",
-                "keyRelease(${KeyEvent.VK_X})",
-                "keyRelease(${KeyEvent.VK_SHIFT})",
-                // uppercase 'Y' needs no Shift while Caps Lock is stuck on
-                "keyPress(${KeyEvent.VK_Y})",
-                "keyRelease(${KeyEvent.VK_Y})",
-            ),
-            robot.events,
-        )
     }
 
     @Test

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTypeTextCapsPhysicalTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTypeTextCapsPhysicalTest.kt
@@ -21,11 +21,12 @@ import org.junit.jupiter.api.Timeout
 
 /**
  * Physical coverage for #396: real [RobotDriver.typeText] must land the requested letter case under
- * Caps Lock off and (when the host can force it) Caps Lock on, and must restore Caps Lock when it
- * temporarily clears the lock.
+ * Caps Lock off and (when the host can force it) Caps Lock on, without mutating ambient Caps Lock.
  *
- * Gating:
- * - [assumeLiveAwtAvailable] — needs a display; macOS requires `-Dspectre.test.liveAwt=true`.
+ * Gating (must stay opt-in — not part of default `./gradlew check` / hosted CI):
+ * - Requires `-Dspectre.test.physicalTypeText=true` on every OS (hosted runners cannot reliably
+ *   drive real Robot + Caps Lock).
+ * - [assumeLiveAwtAvailable] — needs a display; macOS also requires `-Dspectre.test.liveAwt=true`.
  * - Caps Lock **on** is attempted via Toolkit then Robot toggle; if neither works the on scenario
  *   is assumption-skipped (macOS Toolkit cannot set Caps Lock; synthetic HID often cannot either).
  */
@@ -34,6 +35,7 @@ class RobotDriverTypeTextCapsPhysicalTest {
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `typeText lands requested case with Caps Lock off`() {
+        assumePhysicalTypeTextEnabled()
         assumeLiveAwtAvailable()
         withTextFieldFixture { field, robot, toolkit ->
             ensureCaps(robot, toolkit, on = false)
@@ -60,6 +62,7 @@ class RobotDriverTypeTextCapsPhysicalTest {
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `typeText lands requested case with Caps Lock on without mutating lock`() {
+        assumePhysicalTypeTextEnabled()
         assumeLiveAwtAvailable()
         withTextFieldFixture { field, robot, toolkit ->
             val original = readCaps(toolkit)
@@ -91,6 +94,14 @@ class RobotDriverTypeTextCapsPhysicalTest {
                 ensureCaps(robot, toolkit, on = original)
             }
         }
+    }
+
+    private fun assumePhysicalTypeTextEnabled() {
+        assumeTrue(
+            System.getProperty(PHYSICAL_TYPE_TEXT_PROPERTY).toBoolean(),
+            "Physical Caps Lock typeText tests require -$PHYSICAL_TYPE_TEXT_PROPERTY=true " +
+                "(not part of default check / hosted CI; use an interactive desktop).",
+        )
     }
 
     private fun withTextFieldFixture(block: (JTextField, Robot, Toolkit) -> Unit) {
@@ -179,6 +190,7 @@ class RobotDriverTypeTextCapsPhysicalTest {
     }
 
     private companion object {
+        const val PHYSICAL_TYPE_TEXT_PROPERTY: String = "spectre.test.physicalTypeText"
         const val TIMEOUT_SECONDS: Long = 30
         const val FOCUS_SETTLE_MS: Long = 400
         const val CAPS_TOGGLE_SETTLE_MS: Long = 200

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTypeTextCapsPhysicalTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTypeTextCapsPhysicalTest.kt
@@ -1,0 +1,186 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.BorderLayout
+import java.awt.Point
+import java.awt.Robot
+import java.awt.Toolkit
+import java.awt.event.InputEvent
+import java.awt.event.KeyEvent
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JFrame
+import javax.swing.JTextField
+import javax.swing.SwingUtilities
+import javax.swing.WindowConstants
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Physical coverage for #396: real [RobotDriver.typeText] must land the requested letter case under
+ * Caps Lock off and (when the host can force it) Caps Lock on, and must restore Caps Lock when it
+ * temporarily clears the lock.
+ *
+ * Gating:
+ * - [assumeLiveAwtAvailable] — needs a display; macOS requires `-Dspectre.test.liveAwt=true`.
+ * - Caps Lock **on** is attempted via Toolkit then Robot toggle; if neither works the on scenario
+ *   is assumption-skipped (macOS Toolkit cannot set Caps Lock; synthetic HID often cannot either).
+ */
+class RobotDriverTypeTextCapsPhysicalTest {
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `typeText lands requested case with Caps Lock off`() {
+        assumeLiveAwtAvailable()
+        withTextFieldFixture { field, robot, toolkit ->
+            ensureCaps(robot, toolkit, on = false)
+            assumeTrue(!readCaps(toolkit), "Could not clear Caps Lock for off scenario")
+            val before = readCaps(toolkit)
+            val typed = "xYz"
+            clearAndFocus(field, robot)
+            runBlocking { RobotDriver().typeText(typed) }
+            val got = readText(field)
+            val after = readCaps(toolkit)
+            assertEquals(
+                typed,
+                got,
+                "Caps Lock off: typeText must produce requested case (beforeCaps=$before afterCaps=$after)",
+            )
+            assertEquals(
+                before,
+                after,
+                "typeText must not leave Caps Lock inverted when it was off",
+            )
+        }
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `typeText lands requested case with Caps Lock on and restores lock`() {
+        assumeLiveAwtAvailable()
+        withTextFieldFixture { field, robot, toolkit ->
+            val original = readCaps(toolkit)
+            try {
+                ensureCaps(robot, toolkit, on = true)
+                assumeTrue(
+                    readCaps(toolkit),
+                    "Host cannot force Caps Lock on (Toolkit set / Robot toggle unsupported); " +
+                        "Caps Lock on physical path skipped. Unit tests cover clear+compensate.",
+                )
+                val before = readCaps(toolkit)
+                assertTrue(before, "precondition: Caps Lock on")
+                val typed = "xYz"
+                clearAndFocus(field, robot)
+                runBlocking { RobotDriver().typeText(typed) }
+                val got = readText(field)
+                val after = readCaps(toolkit)
+                assertEquals(
+                    typed,
+                    got,
+                    "Caps Lock on: typeText must produce requested case independent of ambient lock " +
+                        "(beforeCaps=$before afterCaps=$after)",
+                )
+                assertTrue(
+                    after,
+                    "Fail-closed: Caps Lock must be restored after typeText when it was on",
+                )
+            } finally {
+                ensureCaps(robot, toolkit, on = original)
+            }
+        }
+    }
+
+    private fun withTextFieldFixture(block: (JTextField, Robot, Toolkit) -> Unit) {
+        val toolkit = Toolkit.getDefaultToolkit()
+        val robot =
+            Robot().apply {
+                autoDelay = 20
+                isAutoWaitForIdle = true
+            }
+        val fieldRef = AtomicReference<JTextField>()
+        val frameRef = AtomicReference<JFrame>()
+        SwingUtilities.invokeAndWait {
+            val field = JTextField(24)
+            val frame = JFrame("Spectre #396 typeText Caps Lock physical")
+            frame.defaultCloseOperation = WindowConstants.DISPOSE_ON_CLOSE
+            frame.layout = BorderLayout()
+            frame.add(field, BorderLayout.CENTER)
+            frame.setSize(480, 120)
+            frame.setLocation(140, 140)
+            frame.isAlwaysOnTop = true
+            frame.isVisible = true
+            frame.toFront()
+            field.requestFocusInWindow()
+            fieldRef.set(field)
+            frameRef.set(frame)
+        }
+        try {
+            Thread.sleep(FOCUS_SETTLE_MS)
+            block(fieldRef.get(), robot, toolkit)
+        } finally {
+            SwingUtilities.invokeAndWait { frameRef.get()?.dispose() }
+        }
+    }
+
+    private fun clearAndFocus(field: JTextField, robot: Robot) {
+        SwingUtilities.invokeAndWait {
+            field.text = ""
+            field.requestFocusInWindow()
+        }
+        val loc = AtomicReference<Point>()
+        SwingUtilities.invokeAndWait {
+            val p = field.locationOnScreen
+            loc.set(Point(p.x + field.width / 2, p.y + field.height / 2))
+        }
+        val p = loc.get()
+        robot.mouseMove(p.x, p.y)
+        robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+        robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+        Thread.sleep(FOCUS_SETTLE_MS / 2)
+    }
+
+    private fun readText(field: JTextField): String {
+        val ref = AtomicReference<String>()
+        SwingUtilities.invokeAndWait { ref.set(field.text) }
+        return ref.get()
+    }
+
+    private fun readCaps(toolkit: Toolkit): Boolean =
+        try {
+            toolkit.getLockingKeyState(KeyEvent.VK_CAPS_LOCK)
+        } catch (_: UnsupportedOperationException) {
+            false
+        } catch (_: IllegalArgumentException) {
+            false
+        }
+
+    private fun trySetCaps(toolkit: Toolkit, on: Boolean): Boolean =
+        try {
+            toolkit.setLockingKeyState(KeyEvent.VK_CAPS_LOCK, on)
+            readCaps(toolkit) == on
+        } catch (_: UnsupportedOperationException) {
+            false
+        } catch (_: IllegalArgumentException) {
+            false
+        }
+
+    private fun ensureCaps(robot: Robot, toolkit: Toolkit, on: Boolean) {
+        if (readCaps(toolkit) == on) return
+        if (trySetCaps(toolkit, on)) return
+        repeat(3) {
+            if (readCaps(toolkit) == on) return
+            robot.keyPress(KeyEvent.VK_CAPS_LOCK)
+            robot.keyRelease(KeyEvent.VK_CAPS_LOCK)
+            Thread.sleep(CAPS_TOGGLE_SETTLE_MS)
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_SECONDS: Long = 30
+        const val FOCUS_SETTLE_MS: Long = 400
+        const val CAPS_TOGGLE_SETTLE_MS: Long = 200
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTypeTextCapsPhysicalTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTypeTextCapsPhysicalTest.kt
@@ -59,7 +59,7 @@ class RobotDriverTypeTextCapsPhysicalTest {
 
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
-    fun `typeText lands requested case with Caps Lock on and restores lock`() {
+    fun `typeText lands requested case with Caps Lock on without mutating lock`() {
         assumeLiveAwtAvailable()
         withTextFieldFixture { field, robot, toolkit ->
             val original = readCaps(toolkit)
@@ -68,7 +68,7 @@ class RobotDriverTypeTextCapsPhysicalTest {
                 assumeTrue(
                     readCaps(toolkit),
                     "Host cannot force Caps Lock on (Toolkit set / Robot toggle unsupported); " +
-                        "Caps Lock on physical path skipped. Unit tests cover clear+compensate.",
+                        "Caps Lock on physical path skipped. Unit tests cover Shift compensation.",
                 )
                 val before = readCaps(toolkit)
                 assertTrue(before, "precondition: Caps Lock on")
@@ -85,7 +85,7 @@ class RobotDriverTypeTextCapsPhysicalTest {
                 )
                 assertTrue(
                     after,
-                    "Fail-closed: Caps Lock must be restored after typeText when it was on",
+                    "typeText must not clear ambient Caps Lock (before was on; after must stay on)",
                 )
             } finally {
                 ensureCaps(robot, toolkit, on = original)

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -89,7 +89,10 @@ mask into the right modifier-key presses around the main `keyCode`.
 
 `typeText` dispatches key press/release pairs and does not touch the clipboard. It is
 intentionally conservative: ASCII letters, digits, space, newline, and common
-US-keyboard punctuation. Use `pasteText` for large strings or arbitrary Unicode; it
+US-keyboard punctuation. Requested letter case is independent of ambient Caps Lock:
+when the platform allows, Spectre temporarily clears Caps Lock for the call and
+restores it afterward; otherwise letter strokes invert Shift so the OS still emits
+the requested case. Use `pasteText` for large strings or arbitrary Unicode; it
 stashes the previous clipboard contents, writes the requested text, dispatches the
 platform paste shortcut (<kbd>Cmd</kbd>+<kbd>V</kbd> on macOS,
 <kbd>Ctrl</kbd>+<kbd>V</kbd> elsewhere), waits for the paste handler to drain, then

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -90,11 +90,10 @@ mask into the right modifier-key presses around the main `keyCode`.
 `typeText` dispatches key press/release pairs and does not touch the clipboard. It is
 intentionally conservative: ASCII letters, digits, space, newline, and common
 US-keyboard punctuation. Requested letter case is independent of ambient Caps Lock:
-when the platform allows, Spectre temporarily clears Caps Lock for the call and
-restores it afterward; otherwise letter strokes invert Shift so the OS still emits
-the requested case. Use `pasteText` for large strings or arbitrary Unicode; it
-stashes the previous clipboard contents, writes the requested text, dispatches the
-platform paste shortcut (<kbd>Cmd</kbd>+<kbd>V</kbd> on macOS,
+Spectre reads the Caps Lock LED and inverts Shift on letter strokes when it is on
+(global lock state is left unchanged). Use `pasteText` for large strings or arbitrary
+Unicode; it stashes the previous clipboard contents, writes the requested text,
+dispatches the platform paste shortcut (<kbd>Cmd</kbd>+<kbd>V</kbd> on macOS,
 <kbd>Ctrl</kbd>+<kbd>V</kbd> elsewhere), waits for the paste handler to drain, then
 restores the previous clipboard contents. See [Troubleshooting](troubleshooting.md) for
 macOS clipboard and `apple.awt.UIElement=true` caveats.


### PR DESCRIPTION
## Summary

- **Root cause:** `RobotDriver.typeText` mapped letters to bare key codes (Shift only for uppercase) and ignored ambient Caps Lock, so OS case inversion made `typeText("x")` land as `X` during 0.5.0 physical smoke.
- **Fix:** Read Caps Lock via `RobotAdapter.getLockingKeyState` / AWT Toolkit; when on, invert Shift on letter strokes (`keyStrokeForChar(..., capsLockOn)`). Do **not** mutate global lock state (Toolkit `setLockingKeyState` is unsupported or a silent no-op on several JVMs; a false “cleared” read-back still inverted keys on physical Windows).
- **Assertions:** Agent attach wait fails hard on wrong-case receipts (product bug) instead of CI soft-skip; soft-skip remains for true no-op / focus-loss.
- **Docs:** `docs/guide/interactions.md` notes Caps Lock case independence.

## Test plan

- [x] Unit: Caps Lock on/off, mid-type failure leaves lock unchanged, Shift compensation (`RobotDriverTest`)
- [x] Physical macOS: Caps Lock off via real `RobotDriver` (`RobotDriverTypeTextCapsPhysicalTest`, `-Dspectre.test.liveAwt=true`); Caps Lock on cannot be forced on this host (unit coverage for compensate path)
- [x] Physical Windows (Mattone interactive `schtasks /IT`): both Caps Lock off and on PASS on SHA of this PR
- [x] `./gradlew check` green locally
- [x] Linux: no dedicated physical Caps cell (not claimed); unit tests cover logic

Closes #396