### PR TITLE
feat(mcp): per-session detach with CLI-parity cleanup (#399)

### DIFF
--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -43,8 +43,11 @@ class McpStdioSmokeTest(unittest.TestCase):
             "for line in sys.stdin:\n"
             " r=json.loads(line); method=r.get('method')\n"
             " if method=='initialize': result={'protocolVersion':'2025-03-26','capabilities':{'tools':{}},'serverInfo':{'name':'spectre','version':version}}\n"
-            " elif method=='tools/list': result={'tools':[{'name':'list_processes'}]}\n"
-            " elif method=='tools/call': result={'content':[{'type':'text','text':'ok'}]}\n"
+            " elif method=='tools/list': result={'tools':[{'name':'list_processes'},{'name':'detach'}]}\n"
+            " elif method=='tools/call':\n"
+            "  name=(r.get('params') or {}).get('name')\n"
+            "  if name=='detach': result={'isError':True,'content':[{'type':'text','text':'session not found'}]}\n"
+            "  else: result={'content':[{'type':'text','text':'ok'}]}\n"
             " else: continue\n"
             " print(json.dumps({'jsonrpc':'2.0','id':r['id'],'result':result}), flush=True)\n"
         )

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -86,6 +86,18 @@ public object SpectreMcpServer {
                 daemonResponse is DaemonResponse.Attached
             }
         }
+        server.addTool(
+            name = "detach",
+            description =
+                "Detach a Spectre daemon session by session_id and return leftover capture cleanup " +
+                    "summary (count, bytes, paths, prune command, skill hint). Fails closed when " +
+                    "the session is unknown or already detached.",
+            inputSchema = sessionSchema(),
+        ) { call ->
+            request(DaemonRequest.Detach(call.requiredString("session_id"))).asResult {
+                it is DaemonResponse.Detached
+            }
+        }
     }
 
     @Suppress("LongMethod") // Session tool table includes #203 input verbs.

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -109,6 +109,7 @@ class DaemonFixtureIntegrationTest {
                     assertTrue(
                         java.util.Base64.getDecoder().decode(image.data).startsWith(PNG_MAGIC)
                     )
+                    assertMcpDetachReleasesSession(client, attached)
                 }
             } finally {
                 transport.close()
@@ -603,6 +604,48 @@ private suspend fun mcpText(client: Client, tool: String, arguments: Map<String,
     val result = client.callTool(tool, arguments)
     assertTrue(result.isError != true, "MCP $tool failed: ${result.content}")
     return (result.content.single() as TextContent).text
+}
+
+/** #399: detach returns cleanup summary and the daemon session is gone afterward. */
+private suspend fun assertMcpDetachReleasesSession(client: Client, sessionId: String) {
+    val detachText = mcpText(client, "detach", mapOf("session_id" to sessionId))
+    val detached = Json.parseToJsonElement(detachText).jsonObject
+    assertEquals(
+        sessionId,
+        detached.getValue("sessionId").jsonPrimitive.content,
+        "detach summary must echo the released session id",
+    )
+    assertTrue(
+        detached.containsKey("captureCount"),
+        "detach summary must include captureCount: $detachText",
+    )
+    assertTrue(
+        detached.containsKey("captureBytes"),
+        "detach summary must include captureBytes: $detachText",
+    )
+    assertTrue(
+        detached.containsKey("capturePaths"),
+        "detach summary must include capturePaths: $detachText",
+    )
+
+    val afterDetach = client.callTool("tree", mapOf("session_id" to sessionId))
+    assertTrue(
+        afterDetach.isError == true,
+        "session must be gone after detach; tree should fail closed: ${afterDetach.content}",
+    )
+    val afterMessage =
+        afterDetach.content.filterIsInstance<TextContent>().joinToString(" ") { it.text }
+    assertTrue(
+        afterMessage.contains("not found", ignoreCase = true) || afterMessage.contains(sessionId),
+        "post-detach error should mention missing session, was: $afterMessage",
+    )
+
+    // Second detach is fail-closed (not silent success / not daemon kill).
+    val doubleDetach = client.callTool("detach", mapOf("session_id" to sessionId))
+    assertTrue(
+        doubleDetach.isError == true,
+        "already-detached session must fail closed: ${doubleDetach.content}",
+    )
 }
 
 private data class CliBinaryResult(val exitCode: Int, val output: String, val errorOutput: String)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
@@ -2,13 +2,42 @@ package dev.sebastiano.spectre.cli.mcp
 
 import dev.sebastiano.spectre.cli.SpectreBuildMetadata
 import dev.sebastiano.spectre.cli.daemon.DaemonErrorCode
+import dev.sebastiano.spectre.cli.daemon.DaemonRequest
 import dev.sebastiano.spectre.cli.daemon.DaemonResponse
+import io.modelcontextprotocol.kotlin.sdk.server.ClientConnection
+import io.modelcontextprotocol.kotlin.sdk.shared.RequestOptions
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageRequest
+import io.modelcontextprotocol.kotlin.sdk.types.CreateMessageResult
+import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ElicitRequestParams
+import io.modelcontextprotocol.kotlin.sdk.types.ElicitResult
+import io.modelcontextprotocol.kotlin.sdk.types.ElicitationCompleteNotification
+import io.modelcontextprotocol.kotlin.sdk.types.EmptyResult
 import io.modelcontextprotocol.kotlin.sdk.types.ImageContent
+import io.modelcontextprotocol.kotlin.sdk.types.ListRootsRequest
+import io.modelcontextprotocol.kotlin.sdk.types.ListRootsResult
+import io.modelcontextprotocol.kotlin.sdk.types.LoggingMessageNotification
+import io.modelcontextprotocol.kotlin.sdk.types.PingRequest
+import io.modelcontextprotocol.kotlin.sdk.types.RequestId
+import io.modelcontextprotocol.kotlin.sdk.types.ResourceUpdatedNotification
+import io.modelcontextprotocol.kotlin.sdk.types.ServerNotification
 import io.modelcontextprotocol.kotlin.sdk.types.TextContent
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 
 class SpectreMcpServerTest {
     @Test
@@ -48,6 +77,7 @@ class SpectreMcpServerTest {
             setOf(
                 "list_processes",
                 "attach",
+                "detach",
                 "windows",
                 "tree",
                 "find",
@@ -75,6 +105,19 @@ class SpectreMcpServerTest {
             listOf("session_id", "node_key"),
             server.tools.getValue("click").tool.inputSchema.required,
         )
+        assertEquals(
+            listOf("session_id"),
+            server.tools.getValue("detach").tool.inputSchema.required,
+        )
+        assertTrue(
+            server.tools
+                .getValue("detach")
+                .tool
+                .description
+                .orEmpty()
+                .contains("session", ignoreCase = true),
+            "detach description should mention session cleanup",
+        )
         assertTrue(
             server.tools
                 .getValue("screenshot")
@@ -82,6 +125,91 @@ class SpectreMcpServerTest {
                 .description
                 .orEmpty()
                 .contains("inline", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `detach tool returns Detached cleanup summary JSON via daemon protocol`() = runBlocking {
+        val seen = mutableListOf<DaemonRequest>()
+        val server = SpectreMcpServer.create { request ->
+            seen += request
+            when (request) {
+                is DaemonRequest.Detach ->
+                    DaemonResponse.Detached(
+                        sessionId = request.sessionId,
+                        captureCount = 2,
+                        captureBytes = 4_096L,
+                        capturePaths =
+                            listOf(
+                                "/tmp/spectre/captures/session-42/a",
+                                "/tmp/spectre/captures/session-42/b",
+                            ),
+                        pruneCommand = "spectre captures prune --session ${request.sessionId}",
+                        skillHint = "spectre-capture",
+                    )
+                else -> error("unexpected daemon request: $request")
+            }
+        }
+
+        val result =
+            invokeTool(server, "detach", buildJsonObject { put("session_id", "session-42") })
+
+        assertTrue(result.isError != true, "detach success must not set isError: $result")
+        val text = (result.content.single() as TextContent).text
+        val body = Json.parseToJsonElement(text).jsonObject
+        assertEquals("session-42", body.getValue("sessionId").jsonPrimitive.content)
+        assertEquals("2", body.getValue("captureCount").jsonPrimitive.content)
+        assertEquals("4096", body.getValue("captureBytes").jsonPrimitive.content)
+        assertEquals(
+            listOf("/tmp/spectre/captures/session-42/a", "/tmp/spectre/captures/session-42/b"),
+            body.getValue("capturePaths").jsonArray.map { it.jsonPrimitive.content },
+        )
+        assertEquals(
+            "spectre captures prune --session session-42",
+            body.getValue("pruneCommand").jsonPrimitive.content,
+        )
+        assertEquals("spectre-capture", body.getValue("skillHint").jsonPrimitive.content)
+
+        val detachRequest = assertIs<DaemonRequest.Detach>(seen.single())
+        assertEquals("session-42", detachRequest.sessionId)
+    }
+
+    @Test
+    fun `detach tool fails closed for unknown session`() = runBlocking {
+        val server = SpectreMcpServer.create { request ->
+            when (request) {
+                is DaemonRequest.Detach ->
+                    DaemonResponse.Error(
+                        code = DaemonErrorCode.SessionNotFound,
+                        message = "session not found: ${request.sessionId}",
+                    )
+                else -> error("unexpected daemon request: $request")
+            }
+        }
+
+        val result =
+            invokeTool(server, "detach", buildJsonObject { put("session_id", "missing-session") })
+
+        assertTrue(result.isError == true, "unknown session must set isError")
+        assertEquals(
+            "session not found: missing-session",
+            (result.content.single() as TextContent).text,
+        )
+    }
+
+    @Test
+    fun `detach tool requires session_id`() = runBlocking {
+        val server = SpectreMcpServer.create {
+            error("detach must not reach daemon without session_id")
+        }
+
+        val result = invokeTool(server, "detach", buildJsonObject {})
+
+        assertTrue(result.isError == true, "missing session_id must fail closed: $result")
+        val message = (result.content.single() as TextContent).text
+        assertTrue(
+            message.contains("session_id", ignoreCase = true),
+            "error should mention session_id, was: $message",
         )
     }
 
@@ -109,5 +237,84 @@ class SpectreMcpServerTest {
             "session session-42 was not found",
             (result.content.single() as TextContent).text,
         )
+    }
+
+    private suspend fun invokeTool(
+        server: io.modelcontextprotocol.kotlin.sdk.server.Server,
+        name: String,
+        arguments: kotlinx.serialization.json.JsonObject,
+    ): CallToolResult {
+        val registered = assertNotNull(server.tools[name], "tool $name must be registered")
+        // Mirror SDK handleCallTool: tool-body failures become isError results so unit tests
+        // exercise the same surface official clients see over stdio.
+        return try {
+            registered.handler.invoke(
+                UnusedClientConnection,
+                CallToolRequest(CallToolRequestParams(name = name, arguments = arguments)),
+            )
+        } catch (error: Exception) {
+            CallToolResult(
+                content = listOf(TextContent("Error executing tool $name: ${error.message}")),
+                isError = true,
+            )
+        }
+    }
+
+    /**
+     * Tool handlers for Spectre never use the [ClientConnection] receiver; this stub only exists so
+     * unit tests can invoke the registered suspend extension without a live session.
+     */
+    private object UnusedClientConnection : ClientConnection {
+        override val sessionId: String = "unit-test"
+
+        override suspend fun notification(
+            notification: ServerNotification,
+            relatedRequestId: RequestId?,
+        ) = Unit
+
+        override suspend fun ping(request: PingRequest, options: RequestOptions?): EmptyResult =
+            EmptyResult()
+
+        override suspend fun createMessage(
+            request: CreateMessageRequest,
+            options: RequestOptions?,
+        ): CreateMessageResult = error("unused")
+
+        override suspend fun listRoots(
+            request: ListRootsRequest,
+            options: RequestOptions?,
+        ): ListRootsResult = error("unused")
+
+        override suspend fun createElicitation(
+            request: ElicitRequest,
+            options: RequestOptions?,
+        ): ElicitResult = error("unused")
+
+        override suspend fun createElicitation(
+            message: String,
+            requestedSchema: ElicitRequestParams.RequestedSchema,
+            options: RequestOptions?,
+        ): ElicitResult = error("unused")
+
+        override suspend fun createElicitation(
+            message: String,
+            elicitationId: String,
+            url: String,
+            options: RequestOptions?,
+        ): ElicitResult = error("unused")
+
+        override suspend fun sendLoggingMessage(notification: LoggingMessageNotification) = Unit
+
+        override suspend fun sendResourceUpdated(notification: ResourceUpdatedNotification) = Unit
+
+        override suspend fun sendResourceListChanged() = Unit
+
+        override suspend fun sendToolListChanged() = Unit
+
+        override suspend fun sendPromptListChanged() = Unit
+
+        override suspend fun sendElicitationComplete(
+            notification: ElicitationCompleteNotification
+        ) = Unit
     }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -107,6 +107,7 @@ class SpectreMcpStdioIntegrationTest {
                         "attach",
                         "capture",
                         "click",
+                        "detach",
                         "double_click",
                         "find",
                         "find_text",
@@ -128,10 +129,10 @@ class SpectreMcpStdioIntegrationTest {
                     ),
                     client.listTools().tools.map { it.name }.toSet(),
                 )
-                // Tool invocation is proven by scripts/mcp-stdio-smoke.py against packaged
-                // binaries. Calling list_processes here would auto-start the shared per-user
-                // daemon and leave it idle until timeout, which this hermetic protocol test
-                // intentionally avoids.
+                // Tool invocation (attach → op → detach) is proven by
+                // DaemonFixtureIntegrationTest and scripts/mcp-stdio-smoke.py. Calling
+                // list_processes here would auto-start the shared per-user daemon and leave
+                // it idle until timeout, which this hermetic protocol test intentionally avoids.
             }
         } finally {
             transport.close()

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -533,8 +533,10 @@ Restart Claude Code after changing the configuration. It can then use these tool
 5. When the target runs under Compose Hot Reload: call `wait_for_reload_settled` **before**
    triggering a code reload (it must observe the settle chain), then re-run `tree` / `find`
    before further input.
-6. **End the session from the CLI** — MCP has no `detach` tool. Run
-   `spectre detach <sessionId>` or `spectre daemon kill` (drops every session).
+6. **`detach`** with the retained `sessionId` when finished — releases that session and returns
+   leftover capture cleanup summary (count/bytes/paths + prune command when any exist). Unknown
+   or already-detached sessions fail closed (`isError`). Prefer `detach` over
+   `spectre daemon kill` (which drops **every** session).
 
 Full MCP tool names, input/output schemas, filesystem implications, and capture-mode
 distinctions: [CLI — MCP](cli.md#mcp).
@@ -548,5 +550,6 @@ If the agent also has Compose Hot Reload’s MCP configured, do not alternate ra
 > If you have HR available and want quick sanity checks while iterating on a live app, use the
 > HR MCP; in any other case, Spectre is the right choice.
 
-Use `spectre detach <session-id>` to release one session, or `spectre daemon kill` to stop the
-shared daemon and discard all sessions when you are finished.
+Call the MCP **`detach`** tool (or `spectre detach <session-id>` from a shell) to release one
+session, or `spectre daemon kill` to stop the shared daemon and discard all sessions when you are
+finished.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -337,10 +337,11 @@ Spectre for tree, input, capture, and evidence.
 | Attach | `attach` → retain `sessionId` |
 | Drive | `tree` / `find` / input tools / waits |
 | Capture | `screenshot` (inline image), `capture` (paths on daemon FS), `record_*` (paths) |
-| Release session | **No MCP `detach` tool today.** Use `spectre detach <session-id>` from a shell, or `spectre daemon kill` to drop every session. |
+| Release session | **`detach`** with `session_id` — ends that session and returns leftover capture cleanup summary (same honesty as CLI `spectre detach`). Unknown / already-detached sessions **fail closed** (`isError`). Use `spectre daemon kill` only when you intend to drop **every** session. |
 
-Sessions created by MCP remain in the daemon until CLI detach, daemon kill, or daemon
-teardown. Long agent workflows should detach explicitly via CLI when finished.
+Sessions created by MCP remain in the daemon until `detach`, daemon kill, or daemon
+teardown. Long agent workflows should call **`detach`** when finished so session and native
+resources do not leak.
 
 ### Tool inventory
 
@@ -351,6 +352,7 @@ Inputs use snake_case JSON fields. Successful non-screenshot tools return **JSON
 | --- | --- | --- | --- |
 | `list_processes` | — | — | `{ "processes": [ { pid, displayName, … } ] }` |
 | `attach` | `pid` (integer) | — | `{ "sessionId", "targetPid" }` |
+| `detach` | `session_id` | — | `{ "sessionId", "captureCount", "captureBytes", "capturePaths", "pruneCommand"?, "skillHint"? }` — prune/skill present when leftovers exist; unknown session → `isError` |
 | `windows` | `session_id` | — | `{ "sessionId", "windows": […] }` |
 | `tree` | `session_id` | — | `{ "sessionId", "nodes": […] }` |
 | `find` | `session_id`, `test_tag` | — | nodes list (exact test tag) |
@@ -374,7 +376,7 @@ Inputs use snake_case JSON fields. Successful non-screenshot tools return **JSON
 **Swipe (MCP):** pass either `from_node_key` + `to_node_key`, or all of
 `start_x` / `start_y` / `end_x` / `end_y` — not both.
 
-**Example — attach and find:**
+**Example — attach, find, detach:**
 
 ```json
 // tools/call attach
@@ -394,6 +396,9 @@ Inputs use snake_case JSON fields. Successful non-screenshot tools return **JSON
 
 // tools/call record_start
 { "session_id": "…", "fullscreen": true, "output_path": "/tmp/demo.mp4" }
+
+// tools/call detach  (release session; prune leftover captures if the summary says so)
+{ "session_id": "…" }
 ```
 
 ### Paths, filesystem, and capture modes (MCP)

--- a/scripts/mcp-stdio-smoke.py
+++ b/scripts/mcp-stdio-smoke.py
@@ -51,7 +51,25 @@ def main() -> None:
     names = {tool.get("name") for tool in tools}
     if "list_processes" not in names:
         fail(f"tools/list missing list_processes: {sorted(names)}", process)
+    if "detach" not in names:
+        fail(f"tools/list missing detach: {sorted(names)}", process)
     request(3, "tools/call", {"name": "list_processes", "arguments": {}})
+    # Unknown / already-detached session must fail closed (not silent success).
+    process.stdin.write(json.dumps({
+        "jsonrpc": "2.0", "id": 4, "method": "tools/call",
+        "params": {"name": "detach", "arguments": {"session_id": "mcp-smoke-missing-session"}},
+    }) + "\n")
+    process.stdin.flush()
+    detach_line = process.stdout.readline()
+    try:
+        detach_response = json.loads(detach_line)
+    except json.JSONDecodeError:
+        fail(f"non-JSON stdout for detach: {detach_line.rstrip()!r}", process)
+    if detach_response.get("id") != 4 or "result" not in detach_response:
+        fail(f"invalid detach response: {detach_response}", process)
+    detach_result = detach_response["result"]
+    if not detach_result.get("isError"):
+        fail(f"detach of unknown session must set isError: {detach_result}", process)
     process.stdin.close()
     try:
         process.wait(timeout=10)


### PR DESCRIPTION
## Summary

- Add MCP tool `detach` (`session_id`) wired to existing `DaemonRequest.Detach` / `DaemonResponse.Detached` so MCP-only clients can release sessions without CLI shell-out or `daemon kill`.
- Success returns the same useful cleanup summary shape as CLI detach: `sessionId`, `captureCount`, `captureBytes`, `capturePaths`, optional `pruneCommand` / `skillHint`.
- Unknown / already-detached sessions fail closed (`isError` + message); not silent success.
- Docs: MCP lifecycle + inventory in `docs/guide/cli.md` and agent MCP recipe in `docs/guide/agent.md` (replaces “no MCP detach today”).

## Test plan

- [x] Unit: `SpectreMcpServerTest` — tool advertised, required `session_id`, Detached JSON fields, session-not-found `isError`
- [x] Official stdio tools/list includes `detach` (`SpectreMcpStdioIntegrationTest`)
- [x] Fixture e2e: attach → tree/click/screenshot → detach → tree fails closed; double-detach fails closed (`DaemonFixtureIntegrationTest`)
- [x] Packaged smoke: `scripts/mcp-stdio-smoke.py` requires `detach` + unknown-session `isError`; fake server contract updated
- [x] `./gradlew check` green

Closes #399