### PR TITLE
fix(agent): expand Gradle-ish JVM_ATTACHABLE default to 120s (#386)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -294,6 +294,7 @@ public final class dev/sebastiano/spectre/agent/launch/LaunchStageTimeouts {
 	public static final field Companion Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts$Companion;
 	public static final field DEFAULT_AGENT_BOOTSTRAP_MS J
 	public static final field DEFAULT_FIRST_WINDOW_MS J
+	public static final field DEFAULT_GRADLE_JVM_ATTACHABLE_MS J
 	public static final field DEFAULT_JVM_ATTACHABLE_MS J
 	public static final field DEFAULT_PROCESS_ALIVE_MS J
 	public fun <init> ()V
@@ -306,6 +307,7 @@ public final class dev/sebastiano/spectre/agent/launch/LaunchStageTimeouts {
 	public final fun copy (JJJJ)Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;
 	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;JJJJILjava/lang/Object;)Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun forGradleishLaunch ()Ldev/sebastiano/spectre/agent/launch/LaunchStageTimeouts;
 	public final fun getAgentBootstrapMs ()J
 	public final fun getFirstWindowMs ()J
 	public final fun getJvmAttachableMs ()J

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
@@ -128,13 +128,21 @@ public object LaunchAndAttach {
         spec: LaunchSpec,
     ): LaunchedSession {
         val launchedPid = process.pid()
+        // Gradle-ish: expand default JVM_ATTACHABLE budget (15s → 120s) so cold daemon + compile
+        // can finish before the app JVM is listed. Explicit timeouts (tests, callers) stay as-is.
+        val stageTimeouts =
+            if (prepared.gradleish) {
+                spec.stageTimeouts.forGradleishLaunch()
+            } else {
+                spec.stageTimeouts
+            }
         var attachedPid: Long? = null
         var automator: AttachedAutomator? = null
         var ready = false
         try {
             LaunchReadiness.awaitProcessAlive(
                 process,
-                spec.stageTimeouts.processAliveMs,
+                stageTimeouts.processAliveMs,
                 prepared.stdoutPath,
                 prepared.stderrPath,
             )
@@ -144,7 +152,7 @@ public object LaunchAndAttach {
                     launchedPid = launchedPid,
                     gradleish = prepared.gradleish,
                     nameFilter = spec.appJvmNameFilter,
-                    timeoutMs = spec.stageTimeouts.jvmAttachableMs,
+                    timeoutMs = stageTimeouts.jvmAttachableMs,
                     stdoutPath = prepared.stdoutPath,
                     stderrPath = prepared.stderrPath,
                 )
@@ -154,14 +162,14 @@ public object LaunchAndAttach {
                     attachedPid = attachedPid,
                     gradleish = prepared.gradleish,
                     attachOptions = spec.attachOptions,
-                    bootstrapTimeoutMs = spec.stageTimeouts.agentBootstrapMs,
+                    bootstrapTimeoutMs = stageTimeouts.agentBootstrapMs,
                     stdoutPath = prepared.stdoutPath,
                     stderrPath = prepared.stderrPath,
                 )
             LaunchReadiness.awaitFirstWindow(
                 automator = automator,
                 attachedPid = attachedPid,
-                timeoutMs = spec.stageTimeouts.firstWindowMs,
+                timeoutMs = stageTimeouts.firstWindowMs,
                 stdoutPath = prepared.stdoutPath,
                 stderrPath = prepared.stderrPath,
             )

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -106,7 +106,12 @@ internal object LaunchReadiness {
                             "daemon children)"
                     } else {
                         ""
-                    }),
+                    }) +
+                    // Cold daemon / compile often exceeds a tight budget while the client stays
+                    // alive — prefer prod-like launch when you control the build (#386).
+                    " Prefer a prod-like launch (java -jar / installDist) over ./gradlew when " +
+                    "possible; for Gradle, ensure the app has started (cold daemon + compile " +
+                    "can take >15s) and that --app-name matches the main class.",
         )
     }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchStageTimeouts.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchStageTimeouts.kt
@@ -7,6 +7,11 @@ import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
  *
  * Defaults favour CI-friendly Compose Desktop fixture boots without sleep-and-pray polling of the
  * whole pipeline as one opaque budget.
+ *
+ * Direct `java` launches use [DEFAULT_JVM_ATTACHABLE_MS] (15s). Gradle-ish launches that leave
+ * [jvmAttachableMs] at that default are expanded via [forGradleishLaunch] to
+ * [DEFAULT_GRADLE_JVM_ATTACHABLE_MS] (120s) so cold daemon start + compile can finish before the
+ * app JVM appears (#386). Explicit non-default values are never expanded.
  */
 @ExperimentalSpectreAgentApi
 public data class LaunchStageTimeouts(
@@ -19,9 +24,27 @@ public data class LaunchStageTimeouts(
     /** How long after attach to wait for a non-empty `AttachedAutomator.windows()` list. */
     public val firstWindowMs: Long = DEFAULT_FIRST_WINDOW_MS,
 ) {
+    /**
+     * Effective timeouts for a Gradle-ish launch. When [jvmAttachableMs] is still the direct-launch
+     * default, expand it to [DEFAULT_GRADLE_JVM_ATTACHABLE_MS]. Explicit overrides (including short
+     * budgets used by failure-classification tests) are returned unchanged.
+     */
+    public fun forGradleishLaunch(): LaunchStageTimeouts =
+        if (jvmAttachableMs == DEFAULT_JVM_ATTACHABLE_MS) {
+            copy(jvmAttachableMs = DEFAULT_GRADLE_JVM_ATTACHABLE_MS)
+        } else {
+            this
+        }
+
     public companion object {
         public const val DEFAULT_PROCESS_ALIVE_MS: Long = 5_000
         public const val DEFAULT_JVM_ATTACHABLE_MS: Long = 15_000
+        /**
+         * Default JVM_ATTACHABLE budget for Gradle-ish launches that did not set an explicit
+         * [jvmAttachableMs]. Matches [LaunchAndAttachGradleIntegrationTest] and covers cold daemon
+         * + compile after `gradlew --stop` on Windows headed smoke (#386).
+         */
+        public const val DEFAULT_GRADLE_JVM_ATTACHABLE_MS: Long = 120_000
         public const val DEFAULT_AGENT_BOOTSTRAP_MS: Long = 15_000
         public const val DEFAULT_FIRST_WINDOW_MS: Long = 30_000
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachJvmAttachableTimeoutTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachJvmAttachableTimeoutTest.kt
@@ -1,0 +1,79 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.nio.file.Files
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * #386: Gradle-ish JVM_ATTACHABLE timeout remains actionable — stage name, name filter, and
+ * prod-like launch guidance. Uses a short-lived sleep client so the test stays fast; the expanded
+ * default 120s budget is covered by [LaunchStageTimeoutsTest] + [LaunchAndAttach] wiring.
+ */
+class LaunchAndAttachJvmAttachableTimeoutTest {
+
+    @Test
+    fun `gradleish live client timeout message is actionable`() {
+        val captureDir = Files.createTempDirectory("spectre-launch-jvm-attach-timeout-")
+        val isWindows =
+            System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)
+        // Stay alive longer than the stage budget so we hit JVM_ATTACHABLE (client live, no
+        // matching app), not PROCESS_ALIVE. Command basename must look Gradle-ish.
+        val command =
+            if (isWindows) {
+                val bat =
+                    Paths.get(captureDir.toString(), "gradlew.bat").also {
+                        Files.writeString(it, "@echo off\r\ntimeout /t 30 /nobreak >nul\r\n")
+                    }
+                listOf(bat.toString(), ":app:run")
+            } else {
+                val sh =
+                    Paths.get(captureDir.toString(), "gradlew").also {
+                        Files.writeString(it, "#!/bin/sh\nsleep 30\n")
+                        it.toFile().setExecutable(true)
+                    }
+                listOf(sh.toString(), ":app:run")
+            }
+        val filter = "NoSuchMainClass_issue386_timeout"
+        val ex =
+            assertFailsWith<JvmNotAttachableException> {
+                LaunchAndAttach.launch(
+                    LaunchSpec(
+                        command = command,
+                        captureDirectory = captureDir,
+                        appJvmNameFilter = filter,
+                        stageTimeouts =
+                            LaunchStageTimeouts(
+                                processAliveMs = 2_000,
+                                jvmAttachableMs = 1_500,
+                                agentBootstrapMs = 2_000,
+                                firstWindowMs = 2_000,
+                            ),
+                    )
+                )
+            }
+        assertEquals(LaunchStage.JVM_ATTACHABLE, ex.stage)
+        assertEquals(1_500, ex.timeoutMs)
+        val msg = ex.message!!
+        assertTrue(msg.contains("JVM_ATTACHABLE"), "stage in message: $msg")
+        assertTrue(msg.contains("1500") || msg.contains("1_500"), "timeout in message: $msg")
+        assertTrue(msg.contains(filter) || msg.contains("nameFilter"), "name filter: $msg")
+        assertTrue(
+            msg.contains("prod-like", ignoreCase = true) ||
+                msg.contains("java -jar", ignoreCase = true) ||
+                msg.contains("installDist", ignoreCase = true),
+            "prefer non-Gradle guidance: $msg",
+        )
+        assertTrue(
+            msg.contains("app-name", ignoreCase = true) ||
+                msg.contains("--app-name") ||
+                msg.contains("nameFilter"),
+            "app-name guidance: $msg",
+        )
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachJvmAttachableTimeoutTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttachJvmAttachableTimeoutTest.kt
@@ -28,7 +28,18 @@ class LaunchAndAttachJvmAttachableTimeoutTest {
             if (isWindows) {
                 val bat =
                     Paths.get(captureDir.toString(), "gradlew.bat").also {
-                        Files.writeString(it, "@echo off\r\ntimeout /t 30 /nobreak >nul\r\n")
+                        // Prefer ping over `timeout`: under non-console redirected I/O, Windows
+                        // `timeout` can abort immediately (same as
+                        // LaunchAndAttachGradleClientDeathTest).
+                        // ~30s live client so we hit JVM_ATTACHABLE, not PROCESS_ALIVE.
+                        Files.writeString(
+                            it,
+                            """
+                            @echo off
+                            ping -n 31 127.0.0.1 >nul
+                            """
+                                .trimIndent() + "\r\n",
+                        )
                     }
                 listOf(bat.toString(), ":app:run")
             } else {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchStageTimeoutsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchStageTimeoutsTest.kt
@@ -1,0 +1,52 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * #386: Gradle-ish launches need a longer JVM_ATTACHABLE budget than direct `java` (cold daemon +
+ * compile routinely exceed 15s while the client stays alive). Explicit overrides must stay honoured
+ * so short-timeout tests keep classifying failures quickly.
+ */
+class LaunchStageTimeoutsTest {
+
+    @Test
+    fun `gradleish with default jvmAttachable expands to gradle default`() {
+        val defaults = LaunchStageTimeouts()
+        val effective = defaults.forGradleishLaunch()
+        assertEquals(
+            LaunchStageTimeouts.DEFAULT_GRADLE_JVM_ATTACHABLE_MS,
+            effective.jvmAttachableMs,
+        )
+        assertEquals(defaults.processAliveMs, effective.processAliveMs)
+        assertEquals(defaults.agentBootstrapMs, effective.agentBootstrapMs)
+        assertEquals(defaults.firstWindowMs, effective.firstWindowMs)
+    }
+
+    @Test
+    fun `gradleish with explicit jvmAttachable is not expanded`() {
+        val short = LaunchStageTimeouts(jvmAttachableMs = 2_000)
+        val effective = short.forGradleishLaunch()
+        assertEquals(2_000, effective.jvmAttachableMs)
+        assertSame(short, effective)
+    }
+
+    @Test
+    fun `gradleish with explicit 120s stays 120s`() {
+        val long = LaunchStageTimeouts(jvmAttachableMs = 120_000)
+        val effective = long.forGradleishLaunch()
+        assertEquals(120_000, effective.jvmAttachableMs)
+        // Already at the gradle budget — no need to copy when value differs from default 15s.
+        assertSame(long, effective)
+    }
+
+    @Test
+    fun `direct launch path leaves defaults unchanged via no gradle expansion`() {
+        val defaults = LaunchStageTimeouts()
+        assertEquals(LaunchStageTimeouts.DEFAULT_JVM_ATTACHABLE_MS, defaults.jvmAttachableMs)
+    }
+}

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -288,9 +288,13 @@ release SHA.
   sufficient alone for a GO claim on all three OSes.
 - Windows MCP packaged e2e remains hard `n/a` with reason until
   `DaemonFixtureIntegrationTest` is EnabledOnOs Windows (or a dedicated Windows MCP cell lands).
-- Issues **#399** (MCP per-session detach) and **#386** (Windows `launch --once` + Gradle
-  `JVM_ATTACHABLE`) are **not** required inside this harness; soft-document only if a scenario
-  already surfaces them.
+- Issue **#399** (MCP per-session detach) is **not** required inside this harness; soft-document
+  only if a scenario already surfaces it.
+- **#386** (Windows packaged `launch --once` + Gradle `JVM_ATTACHABLE`): product default for
+  Gradle-ish launches expands JVM_ATTACHABLE to 120s (matching agent e2e). The Windows one-liner
+  `cli-user-flow` may still use Gradle with `--app-name ComposeFixtureMain`; prefer a healthy
+  UP-TO-DATE fixture build so cold daemon start alone fits the budget. Prod-like launch remains
+  the troubleshooting recommendation when Gradle is slow or flaky.
 
 ## Windows one-liner script
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -24,6 +24,13 @@ found in time. Pass `LaunchSpec.appJvmNameFilter` / `spectre launch --app-name
 <MainClass>` so discovery can match the app among daemon children. Never kill the
 Gradle daemon to "fix" teardown — the harness only tears down the discovered app JVM.
 
+Cold Gradle daemons (for example after `./gradlew --stop`) and first-time compile of
+the app module can take longer than a direct `java` boot. Spectre expands the default
+JVM_ATTACHABLE budget to **120s** for Gradle-ish launches that leave stage timeouts at
+defaults; set `LaunchStageTimeouts.jvmAttachableMs` explicitly if you need a different
+budget. If the timeout still fires, check captured stdout/stderr for compile errors
+before assuming a name-filter miss.
+
 You will also see a loud **Gradle-ish** warning naming daemon, sandbox, and JEP 451
 caveats. Prefer a prod-like launch (`java -jar`, installDist) when you control the build.
 

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -524,6 +524,11 @@ try {
             # extracted runtime path and make the next launch hand that path to a fresh JVM while
             # Windows still has transient file state around it. Use a fresh daemon for this
             # independent packaged-CLI cell.
+            #
+            # Product (#386): Gradle-ish launch expands default JVM_ATTACHABLE to 120s so cold
+            # daemon start after --stop can finish before the app JVM is listed. Outer
+            # CliLaunchTimeoutSeconds (default 300) must stay above that product budget.
+            # Prefer UP-TO-DATE :agent-test-fixture classes (agent e2e above usually ensures this).
             $gradlew = Join-Path $repoRoot "gradlew.bat"
             Invoke-Native -FilePath $gradlew -WorkingDirectory $repoRoot -TimeoutSeconds 60 -LogName "gradle-stop-before-cli" -Arguments @(
                 "--stop"
@@ -533,7 +538,7 @@ try {
                 throw "spectre.exe not found under cli\build\construo\windowsX64\roast\ -- run without -SkipPackageCli"
             }
             Write-Host ("  using {0}" -f $spectre) -ForegroundColor DarkGray
-            Write-Host "  note: Gradle-ish launch warning is expected for ':agent-test-fixture:run'" -ForegroundColor DarkGray
+            Write-Host "  note: Gradle-ish launch warning is expected for ':agent-test-fixture:run' (product JVM_ATTACHABLE budget 120s for Gradle)" -ForegroundColor DarkGray
             Invoke-Native -FilePath $spectre -WorkingDirectory $repoRoot -TimeoutSeconds $CliLaunchTimeoutSeconds -LogName "spectre-launch" -Arguments @(
                 "launch",
                 "--once",


### PR DESCRIPTION
## Summary

Resolves [#386](https://github.com/rock3r/spectre/issues/386): Windows packaged `spectre launch --once` through Gradle timed out at `JVM_ATTACHABLE`.

### Root cause (Mattone repro)

**Class: timeout too low** (not name-filter miss / Windows attach visibility / daemon-child layout bug).

| Scenario | Result |
| --- | --- |
| Stale/broken build after hard reset | Cold+warm fail ~16s at 15s product budget; client still compiling; no app JVM yet |
| Healthy UP-TO-DATE fixture | Cold pass ~12.7s, warm pass ~5.0s; `ComposeFixtureMainKt` discoverable |
| Timing probe (warm, clean classes) | App JVM in jps at ~3.3s |

Smoke forces `gradlew --stop` before packaged launch (cold daemon by design). Product default was **15s**; Linux/mac Gradle e2e already uses **120s**. CLI uses default `LaunchStageTimeouts` with no override.

### Decision: **Option A** (minimal product fix)

- `LaunchStageTimeouts.forGradleishLaunch()` expands default `jvmAttachableMs` 15s → **120s** for Gradle-ish launches only when still at the direct default.
- Explicit timeouts (including short test budgets) are never expanded.
- Timeout detail + troubleshooting strengthened (prod-like preference, cold daemon/compile, `--app-name`).
- Smoke script / RELEASE-SMOKE comments aligned; hard path remains Gradle one-liner with honest 120s budget.

Not Option B (prod-like hard cell only) because discovery works on Windows once the app exists; the gap was budget.

## Validation

- `./gradlew check` green locally
- New tests: `LaunchStageTimeoutsTest`, `LaunchAndAttachJvmAttachableTimeoutTest`
- Mattone: cold/warm packaged Gradle launch success after clean compile (pre-fix binary still within 15s when healthy); product change covers cold+compile margin

## Residual 0.5.0 risks

- Extremely cold first compile of large modules can still exceed 120s
- Prefer UP-TO-DATE fixture (agent e2e before `cli-user-flow`)
- Packaged CLI must be rebuilt to ship the agent library change

## Test plan

- [x] Unit/integration: timeout expansion + actionable message
- [x] `./gradlew check`
- [ ] CI green
- [ ] Optional: Mattone package + cold `launch --once` with rebuilt binary