### PR TITLE
feat(mcp): detach leftover summary parity, fail-closed session_id, Detached docs (#415)

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -91,10 +91,11 @@ public object SpectreMcpServer {
             description =
                 "Detach a Spectre daemon session by session_id and return leftover capture cleanup " +
                     "summary (count, bytes, paths, prune command, skill hint). Fails closed when " +
-                    "the session is unknown or already detached.",
+                    "the session is unknown or already detached. Does not delete capture files; " +
+                    "prune stays explicit via pruneCommand when leftovers exist.",
             inputSchema = sessionSchema(),
         ) { call ->
-            request(DaemonRequest.Detach(call.requiredString("session_id"))).asResult {
+            request(DaemonRequest.Detach(call.requiredSessionId())).asResult {
                 it is DaemonResponse.Detached
             }
         }
@@ -570,10 +571,29 @@ public object SpectreMcpServer {
     private fun sessionSchema(): ToolSchema = schema("session_id" to "string")
 
     private fun CallToolRequest.callString(name: String): String =
-        arguments?.get(name)?.jsonPrimitive?.content
+        arguments?.get(name)?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
             ?: throw IllegalArgumentException("MCP tool requires a non-empty '$name' argument")
 
     private fun CallToolRequest.requiredString(name: String): String = callString(name)
+
+    /**
+     * session_id for detach (and similar fail-closed tools): must be a JSON string token that is
+     * non-blank. Numbers/booleans/objects must not stringify into a fabricated daemon lookup.
+     */
+    private fun CallToolRequest.requiredSessionId(): String {
+        val element =
+            arguments?.get("session_id")
+                ?: throw IllegalArgumentException(
+                    "MCP tool requires a non-empty 'session_id' argument"
+                )
+        val primitive =
+            element as? kotlinx.serialization.json.JsonPrimitive
+                ?: throw IllegalArgumentException("MCP tool argument 'session_id' must be a string")
+        require(primitive.isString) { "MCP tool argument 'session_id' must be a string" }
+        val content = primitive.content
+        require(content.isNotBlank()) { "MCP tool requires a non-empty 'session_id' argument" }
+        return content
+    }
 
     private fun CallToolRequest.optionalString(name: String): String? {
         val element = arguments?.get(name) ?: return null

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -571,7 +571,9 @@ public object SpectreMcpServer {
     private fun sessionSchema(): ToolSchema = schema("session_id" to "string")
 
     private fun CallToolRequest.callString(name: String): String =
-        arguments?.get(name)?.jsonPrimitive?.content?.takeIf { it.isNotBlank() }
+        // Empty string is a valid payload for some args (e.g. find_text exact "" for empty
+        // EditableText — #202). Presence is required; blank rejection is only for session_id.
+        arguments?.get(name)?.jsonPrimitive?.content
             ?: throw IllegalArgumentException("MCP tool requires a non-empty '$name' argument")
 
     private fun CallToolRequest.requiredString(name: String): String = callString(name)
@@ -579,6 +581,7 @@ public object SpectreMcpServer {
     /**
      * session_id for detach (and similar fail-closed tools): must be a JSON string token that is
      * non-blank. Numbers/booleans/objects must not stringify into a fabricated daemon lookup.
+     * Unlike [callString], deliberately rejects `""` and whitespace-only values.
      */
     private fun CallToolRequest.requiredSessionId(): String {
         val element =

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -108,7 +108,7 @@ public object SpectreMcpServer {
             description = "List top-level windows and popup roots for an attached session.",
             inputSchema = sessionSchema(),
         ) { call ->
-            request(DaemonRequest.Windows(call.requiredString("session_id"))).asResult {
+            request(DaemonRequest.Windows(call.requiredSessionId())).asResult {
                 it is DaemonResponse.Windows
             }
         }
@@ -118,7 +118,7 @@ public object SpectreMcpServer {
                 "Dump the current semantics tree. Node keys are valid only until the UI changes.",
             inputSchema = sessionSchema(),
         ) { call ->
-            request(DaemonRequest.AllNodes(call.requiredString("session_id"))).asResult {
+            request(DaemonRequest.AllNodes(call.requiredSessionId())).asResult {
                 it is DaemonResponse.Nodes
             }
         }
@@ -130,7 +130,7 @@ public object SpectreMcpServer {
         ) { call ->
             request(
                     DaemonRequest.FindByTestTag(
-                        call.requiredString("session_id"),
+                        call.requiredSessionId(),
                         call.requiredString("test_tag"),
                     )
                 )
@@ -158,13 +158,12 @@ public object SpectreMcpServer {
                             "MCP tool argument 'exact' must be true or false"
                         )
                 }
-            request(
-                    DaemonRequest.FindByText(
-                        call.requiredString("session_id"),
-                        call.requiredString("text"),
-                        exact = exact,
-                    )
-                )
+            val text = call.requiredString("text")
+            // Empty text is valid (#202 empty EditableText); whitespace-only is not.
+            require(text.isEmpty() || text.isNotBlank()) {
+                "MCP tool argument 'text' must not be whitespace-only"
+            }
+            request(DaemonRequest.FindByText(call.requiredSessionId(), text, exact = exact))
                 .asResult { it is DaemonResponse.Nodes }
         }
         server.addTool(
@@ -182,7 +181,7 @@ public object SpectreMcpServer {
         ) { call ->
             request(
                     DaemonRequest.WaitForNode(
-                        sessionId = call.requiredString("session_id"),
+                        sessionId = call.requiredSessionId(),
                         tag = call.optionalString("tag"),
                         text = call.optionalString("text"),
                         timeoutMs = call.optionalLong("timeout_ms") ?: 5_000L,
@@ -202,7 +201,7 @@ public object SpectreMcpServer {
         ) { call ->
             request(
                     DaemonRequest.WaitForVisualIdle(
-                        sessionId = call.requiredString("session_id"),
+                        sessionId = call.requiredSessionId(),
                         timeoutMs = call.optionalLong("timeout_ms") ?: 5_000L,
                     )
                 )
@@ -224,7 +223,7 @@ public object SpectreMcpServer {
         ) { call ->
             request(
                     DaemonRequest.WaitForReloadSettled(
-                        sessionId = call.requiredString("session_id"),
+                        sessionId = call.requiredSessionId(),
                         timeoutMs = call.optionalLong("timeout_ms") ?: 60_000L,
                     )
                 )
@@ -236,12 +235,7 @@ public object SpectreMcpServer {
                 "Click a visible semantics node by its node key. Refresh the tree after UI changes.",
             inputSchema = schema("session_id" to "string", "node_key" to "string"),
         ) { call ->
-            request(
-                    DaemonRequest.Click(
-                        call.requiredString("session_id"),
-                        call.requiredString("node_key"),
-                    )
-                )
+            request(DaemonRequest.Click(call.requiredSessionId(), call.requiredString("node_key")))
                 .asResult { it is DaemonResponse.Completed }
         }
         server.addTool(
@@ -251,7 +245,7 @@ public object SpectreMcpServer {
         ) { call ->
             request(
                     DaemonRequest.DoubleClick(
-                        call.requiredString("session_id"),
+                        call.requiredSessionId(),
                         call.requiredString("node_key"),
                     )
                 )
@@ -271,7 +265,7 @@ public object SpectreMcpServer {
             val hold = call.optionalLong("hold_for_ms") ?: 500L
             request(
                     DaemonRequest.LongClick(
-                        call.requiredString("session_id"),
+                        call.requiredSessionId(),
                         call.requiredString("node_key"),
                         holdForMs = hold,
                     )
@@ -299,7 +293,7 @@ public object SpectreMcpServer {
         ) { call ->
             request(
                     DaemonRequest.Swipe(
-                        sessionId = call.requiredString("session_id"),
+                        sessionId = call.requiredSessionId(),
                         fromNodeKey = call.optionalString("from_node_key"),
                         toNodeKey = call.optionalString("to_node_key"),
                         startX = call.optionalInt("start_x"),
@@ -325,7 +319,7 @@ public object SpectreMcpServer {
         ) { call ->
             request(
                     DaemonRequest.ScrollWheel(
-                        call.requiredString("session_id"),
+                        call.requiredSessionId(),
                         call.requiredString("node_key"),
                         call.requiredInt("wheel_clicks"),
                     )
@@ -346,7 +340,7 @@ public object SpectreMcpServer {
         ) { call ->
             request(
                     DaemonRequest.PressKey(
-                        call.requiredString("session_id"),
+                        call.requiredSessionId(),
                         call.requiredInt("key_code"),
                         call.optionalInt("modifiers") ?: 0,
                     )
@@ -359,12 +353,7 @@ public object SpectreMcpServer {
                 "Type text through the real operating-system input path into the focused target UI.",
             inputSchema = schema("session_id" to "string", "text" to "string"),
         ) { call ->
-            request(
-                    DaemonRequest.TypeText(
-                        call.requiredString("session_id"),
-                        call.requiredString("text"),
-                    )
-                )
+            request(DaemonRequest.TypeText(call.requiredSessionId(), call.requiredString("text")))
                 .asResult { it is DaemonResponse.Completed }
         }
         registerScreenshotTool(server, request)
@@ -400,7 +389,7 @@ public object SpectreMcpServer {
         call: CallToolRequest,
         request: (DaemonRequest) -> DaemonResponse,
     ): CallToolResult {
-        val sessionId = call.requiredString("session_id")
+        val sessionId = call.requiredSessionId()
         val windowIndexArg = call.arguments?.get("window_index")?.jsonPrimitive?.content
         val windowIndex =
             if (windowIndexArg == null) {
@@ -526,7 +515,7 @@ public object SpectreMcpServer {
             }
             request(
                     DaemonRequest.StartRecording(
-                        sessionId = call.requiredString("session_id"),
+                        sessionId = call.requiredSessionId(),
                         outputPath = outputRaw?.let(::normalizeRecordingOutputPath),
                         windowIndex = windowIndex ?: 0,
                         fullscreen = fullscreen,
@@ -539,7 +528,7 @@ public object SpectreMcpServer {
             description = "Stop the active recording and return its final output path.",
             inputSchema = sessionSchema(),
         ) { call ->
-            request(DaemonRequest.StopRecording(call.requiredString("session_id"))).asResult {
+            request(DaemonRequest.StopRecording(call.requiredSessionId())).asResult {
                 it is DaemonResponse.RecordingStopped
             }
         }
@@ -548,7 +537,7 @@ public object SpectreMcpServer {
             description = "Report whether a session has an active recording and its output path.",
             inputSchema = sessionSchema(),
         ) { call ->
-            request(DaemonRequest.RecordingStatus(call.requiredString("session_id"))).asResult {
+            request(DaemonRequest.RecordingStatus(call.requiredSessionId())).asResult {
                 it is DaemonResponse.RecordingStatus
             }
         }
@@ -572,31 +561,11 @@ public object SpectreMcpServer {
 
     private fun CallToolRequest.callString(name: String): String =
         // Empty string is a valid payload for some args (e.g. find_text exact "" for empty
-        // EditableText — #202). Presence is required; blank rejection is only for session_id.
+        // EditableText — #202). Presence is required; non-blank session_id uses requiredSessionId.
         arguments?.get(name)?.jsonPrimitive?.content
             ?: throw IllegalArgumentException("MCP tool requires a non-empty '$name' argument")
 
     private fun CallToolRequest.requiredString(name: String): String = callString(name)
-
-    /**
-     * session_id for detach (and similar fail-closed tools): must be a JSON string token that is
-     * non-blank. Numbers/booleans/objects must not stringify into a fabricated daemon lookup.
-     * Unlike [callString], deliberately rejects `""` and whitespace-only values.
-     */
-    private fun CallToolRequest.requiredSessionId(): String {
-        val element =
-            arguments?.get("session_id")
-                ?: throw IllegalArgumentException(
-                    "MCP tool requires a non-empty 'session_id' argument"
-                )
-        val primitive =
-            element as? kotlinx.serialization.json.JsonPrimitive
-                ?: throw IllegalArgumentException("MCP tool argument 'session_id' must be a string")
-        require(primitive.isString) { "MCP tool argument 'session_id' must be a string" }
-        val content = primitive.content
-        require(content.isNotBlank()) { "MCP tool requires a non-empty 'session_id' argument" }
-        return content
-    }
 
     private fun CallToolRequest.optionalString(name: String): String? {
         val element = arguments?.get(name) ?: return null
@@ -662,6 +631,20 @@ internal fun DaemonResponse.screenshotResult(): CallToolResult =
             )
     }
 
+/** Non-blank JSON string session_id; rejects empty/whitespace and non-string tokens. */
+private fun CallToolRequest.requiredSessionId(): String {
+    val element =
+        arguments?.get("session_id")
+            ?: throw IllegalArgumentException("MCP tool requires a non-empty 'session_id' argument")
+    val primitive =
+        element as? kotlinx.serialization.json.JsonPrimitive
+            ?: throw IllegalArgumentException("MCP tool argument 'session_id' must be a string")
+    require(primitive.isString) { "MCP tool argument 'session_id' must be a string" }
+    val content = primitive.content
+    require(content.isNotBlank()) { "MCP tool requires a non-empty 'session_id' argument" }
+    return content
+}
+
 private fun registerScreenshotTool(server: Server, request: (DaemonRequest) -> DaemonResponse) {
     val properties = buildJsonObject {
         put("session_id", buildJsonObject { put("type", "string") })
@@ -689,12 +672,14 @@ private fun handleScreenshotTool(
     request: (DaemonRequest) -> DaemonResponse,
 ): CallToolResult {
     val sessionId =
-        call.arguments?.get("session_id")?.jsonPrimitive?.content
-            ?: return CallToolResult(
-                content =
-                    listOf(TextContent("MCP tool requires a non-empty 'session_id' argument")),
+        try {
+            call.requiredSessionId()
+        } catch (error: IllegalArgumentException) {
+            return CallToolResult(
+                content = listOf(TextContent(error.message ?: "invalid session_id")),
                 isError = true,
             )
+        }
     val windowIndexArg = call.arguments?.get("window_index")?.jsonPrimitive?.content
     val windowIndex =
         if (windowIndexArg == null) {

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureSessionReportTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/CaptureSessionReportTest.kt
@@ -1,0 +1,96 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CaptureSessionReportTest {
+    @Test
+    fun `forDetach reports zero leftovers when the session wrote nothing`() {
+        val root = Files.createTempDirectory("spectre-detach-empty")
+        val ledger = CaptureLedger(root.resolve("ledger.jsonl"))
+
+        val detached = CaptureSessionReport.forDetach("session-empty", ledger)
+
+        assertEquals("session-empty", detached.sessionId)
+        assertEquals(0, detached.captureCount)
+        assertEquals(0L, detached.captureBytes)
+        assertEquals(emptyList(), detached.capturePaths)
+        assertNull(detached.pruneCommand)
+        assertNull(detached.skillHint)
+    }
+
+    @Test
+    fun `forDetach reports real leftover paths bytes and prune hints`() {
+        val root = Files.createTempDirectory("spectre-detach-leftovers")
+        val ledger = CaptureLedger(root.resolve("ledger.jsonl"))
+        val first = Files.createDirectories(root.resolve("cap-a"))
+        val second = Files.createDirectories(root.resolve("cap-b"))
+        // sizeBytes in the ledger is what detach reports (not a live re-scan of directory size).
+        ledger.append(
+            CaptureLedgerEntry(
+                sessionId = "session-42",
+                path = first.toString(),
+                createdAtEpochMs = 1,
+                sizeBytes = 1_024,
+                explicitOutDir = false,
+            )
+        )
+        ledger.append(
+            CaptureLedgerEntry(
+                sessionId = "session-42",
+                path = second.toString(),
+                createdAtEpochMs = 2,
+                sizeBytes = 2_048,
+                explicitOutDir = false,
+            )
+        )
+        // Other sessions must not pollute this session's detach report.
+        ledger.append(
+            CaptureLedgerEntry(
+                sessionId = "other",
+                path = Files.createDirectories(root.resolve("other")).toString(),
+                createdAtEpochMs = 3,
+                sizeBytes = 99,
+                explicitOutDir = false,
+            )
+        )
+
+        val detached = CaptureSessionReport.forDetach("session-42", ledger)
+
+        assertEquals("session-42", detached.sessionId)
+        assertEquals(2, detached.captureCount)
+        assertEquals(3_072L, detached.captureBytes)
+        assertEquals(listOf(first.toString(), second.toString()), detached.capturePaths)
+        assertEquals("spectre captures prune --session session-42", detached.pruneCommand)
+        assertEquals(CaptureSessionReport.CAPTURE_SKILL_NAME, detached.skillHint)
+        assertTrue(detached.capturePaths.all { Files.isDirectory(java.nio.file.Path.of(it)) })
+    }
+
+    @Test
+    fun `forDetach ignores ledger rows whose capture directory no longer exists`() {
+        val root = Files.createTempDirectory("spectre-detach-missing-dir")
+        val ledger = CaptureLedger(root.resolve("ledger.jsonl"))
+        val gone = root.resolve("gone")
+        // Deliberately do not create `gone` on disk.
+        ledger.append(
+            CaptureLedgerEntry(
+                sessionId = "session-gone",
+                path = gone.toString(),
+                createdAtEpochMs = 1,
+                sizeBytes = 500,
+                explicitOutDir = false,
+            )
+        )
+
+        val detached = CaptureSessionReport.forDetach("session-gone", ledger)
+
+        assertEquals(0, detached.captureCount)
+        assertEquals(0L, detached.captureBytes)
+        assertEquals(emptyList(), detached.capturePaths)
+        assertNull(detached.pruneCommand)
+        assertNull(detached.skillHint)
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -120,6 +120,40 @@ class DaemonFixtureIntegrationTest {
             }
         }
 
+    /**
+     * #415: attach → real MCP atomic capture (ledger leftover on disk) → MCP detach reports
+     * non-zero count/bytes/paths + prune/skill hints; daemon stays alive for list_processes and a
+     * second attach. Screenshot alone is not enough — it returns inline image without ledger rows.
+     */
+    @Test
+    fun `MCP detach reports real capture leftovers and keeps the daemon alive`() = runBlocking {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
+        val daemonUser = "spectre-mcp-detach-leftover-${UUID.randomUUID()}"
+        val process = startMcpBinary(daemonUser)
+        val transport =
+            StdioClientTransport(
+                input = process.inputStream.asSource().buffered(),
+                output = process.outputStream.asSink().buffered(),
+            )
+
+        try {
+            spawnComposeFixture().use { fixture ->
+                val client = Client(Implementation(name = "spectre-test", version = "1"))
+                withTimeout(MCP_CONNECTION_TIMEOUT_MILLIS) { client.connect(transport) }
+                val attached = mcpAttachSession(client, fixture.pid)
+                val captureDir = mcpCaptureAndAssertOnDisk(client, attached)
+                assertMcpDetachReportsLeftovers(client, attached, captureDir)
+                assertMcpDaemonAliveAfterDetach(client, fixture.pid)
+            }
+        } finally {
+            transport.close()
+            process.destroyForcibly()
+            process.waitFor()
+            runCatching { runCliBinary(daemonUser, "daemon", "kill") }
+            deleteDaemonSocketAndParent(DaemonEndpoint.defaultSocketPath(userName = daemonUser))
+        }
+    }
+
     @Test
     fun `CLI binary drives a Compose fixture through ps attach find click and screenshot`() {
         assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
@@ -604,6 +638,99 @@ private suspend fun mcpText(client: Client, tool: String, arguments: Map<String,
     val result = client.callTool(tool, arguments)
     assertTrue(result.isError != true, "MCP $tool failed: ${result.content}")
     return (result.content.single() as TextContent).text
+}
+
+private suspend fun mcpAttachSession(client: Client, pid: Long): String =
+    mcpText(client, "attach", mapOf("pid" to pid)).let { response ->
+        Json.parseToJsonElement(response).jsonObject.getValue("sessionId").jsonPrimitive.content
+    }
+
+/** Product path that appends the capture ledger (not inline screenshot). */
+private suspend fun mcpCaptureAndAssertOnDisk(client: Client, sessionId: String): String {
+    val captureText =
+        mcpText(client, "capture", mapOf("session_id" to sessionId, "window_index" to 0))
+    val captureBody = Json.parseToJsonElement(captureText).jsonObject
+    val captureDir = captureBody.getValue("directory").jsonPrimitive.content
+    assertTrue(
+        Files.isDirectory(Path.of(captureDir)),
+        "capture must land a directory on disk: $captureText",
+    )
+    val screenshotPng = captureBody.getValue("screenshotPngPath").jsonPrimitive.content
+    assertTrue(
+        Files.isRegularFile(Path.of(screenshotPng)) && Files.size(Path.of(screenshotPng)) > 0,
+        "capture must write a non-empty screenshot.png: $captureText",
+    )
+    return captureDir
+}
+
+/** #415: detach success body is honest about real leftovers and does not auto-prune. */
+private suspend fun assertMcpDetachReportsLeftovers(
+    client: Client,
+    sessionId: String,
+    expectedCaptureDir: String,
+) {
+    val detachText = mcpText(client, "detach", mapOf("session_id" to sessionId))
+    val detached = Json.parseToJsonElement(detachText).jsonObject
+    assertEquals(
+        sessionId,
+        detached.getValue("sessionId").jsonPrimitive.content,
+        "detach must echo sessionId (daemon Detached field, not CLI --json id): $detachText",
+    )
+    val captureCount = detached.getValue("captureCount").jsonPrimitive.content.toInt()
+    val captureBytes = detached.getValue("captureBytes").jsonPrimitive.content.toLong()
+    val capturePaths = detached.getValue("capturePaths").jsonArray.map { it.jsonPrimitive.content }
+    assertTrue(
+        captureCount >= 1,
+        "leftover detach must report captureCount >= 1, was $captureCount: $detachText",
+    )
+    assertTrue(
+        captureBytes > 0,
+        "leftover detach must report captureBytes > 0, was $captureBytes: $detachText",
+    )
+    assertTrue(
+        capturePaths.isNotEmpty(),
+        "leftover detach must report non-empty capturePaths: $detachText",
+    )
+    assertTrue(
+        capturePaths.any { it == expectedCaptureDir || Path.of(it) == Path.of(expectedCaptureDir) },
+        "detach paths must include the capture directory $expectedCaptureDir, was $capturePaths",
+    )
+    capturePaths.forEach { path ->
+        assertTrue(
+            Files.isDirectory(Path.of(path)),
+            "detach must not invent paths; expected existing dir: $path",
+        )
+    }
+    val pruneCommand = detached["pruneCommand"]?.jsonPrimitive?.content
+    assertTrue(
+        !pruneCommand.isNullOrBlank(),
+        "leftover detach must populate pruneCommand: $detachText",
+    )
+    checkNotNull(pruneCommand)
+    assertTrue(
+        pruneCommand.contains(sessionId),
+        "pruneCommand must target this session, was: $pruneCommand",
+    )
+    val skillHint = detached["skillHint"]?.jsonPrimitive?.content
+    assertTrue(!skillHint.isNullOrBlank(), "leftover detach must populate skillHint: $detachText")
+    assertTrue(
+        Files.isDirectory(Path.of(expectedCaptureDir)),
+        "detach must leave capture artifacts on disk (no auto-prune): $expectedCaptureDir",
+    )
+}
+
+/** After detach, the shared daemon must still serve list_processes and a new attach. */
+private suspend fun assertMcpDaemonAliveAfterDetach(client: Client, fixturePid: Long) {
+    val processesText = mcpText(client, "list_processes", emptyMap())
+    assertTrue(
+        processesText.contains("processes") || processesText.contains("pid"),
+        "list_processes after detach must succeed: $processesText",
+    )
+    val reattached = mcpAttachSession(client, fixturePid)
+    assertTrue(reattached.isNotBlank(), "reattach must return a session id")
+    val tree = mcpText(client, "tree", mapOf("session_id" to reattached))
+    assertTrue(tree.contains(TAG_LABEL), "tree after reattach: $tree")
+    assertMcpDetachReleasesSession(client, reattached)
 }
 
 /** #399: detach returns cleanup summary and the daemon session is gone afterward. */

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
@@ -214,6 +214,95 @@ class SpectreMcpServerTest {
     }
 
     @Test
+    fun `detach tool fails closed for empty session_id without reaching daemon`() = runBlocking {
+        var daemonReached = false
+        val server = SpectreMcpServer.create {
+            daemonReached = true
+            error("detach must not reach daemon with empty session_id")
+        }
+
+        val result = invokeTool(server, "detach", buildJsonObject { put("session_id", "") })
+
+        assertTrue(result.isError == true, "empty session_id must fail closed: $result")
+        assertTrue(!daemonReached, "empty session_id must fail at the tool boundary: $result")
+        val message = (result.content.single() as TextContent).text
+        assertTrue(
+            message.contains("session_id", ignoreCase = true),
+            "error should mention session_id, was: $message",
+        )
+    }
+
+    @Test
+    fun `detach tool fails closed for whitespace-only session_id without reaching daemon`() =
+        runBlocking {
+            var daemonReached = false
+            val server = SpectreMcpServer.create {
+                daemonReached = true
+                error("detach must not reach daemon with blank session_id")
+            }
+
+            val result =
+                invokeTool(server, "detach", buildJsonObject { put("session_id", "   \t") })
+
+            assertTrue(result.isError == true, "blank session_id must fail closed: $result")
+            assertTrue(!daemonReached, "blank session_id must fail at the tool boundary: $result")
+            val message = (result.content.single() as TextContent).text
+            assertTrue(
+                message.contains("session_id", ignoreCase = true),
+                "error should mention session_id, was: $message",
+            )
+        }
+
+    @Test
+    fun `detach tool fails closed for non-string session_id without reaching daemon`() =
+        runBlocking {
+            var daemonReached = false
+            val server = SpectreMcpServer.create {
+                daemonReached = true
+                error("detach must not reach daemon with non-string session_id")
+            }
+
+            val result = invokeTool(server, "detach", buildJsonObject { put("session_id", 42) })
+
+            assertTrue(result.isError == true, "numeric session_id must fail closed: $result")
+            assertTrue(
+                !daemonReached,
+                "non-string session_id must fail at the tool boundary: $result",
+            )
+            val message = (result.content.single() as TextContent).text
+            assertTrue(
+                message.contains("session_id", ignoreCase = true),
+                "error should mention session_id, was: $message",
+            )
+        }
+
+    @Test
+    fun `detach tool fails closed for object session_id without reaching daemon`() = runBlocking {
+        var daemonReached = false
+        val server = SpectreMcpServer.create {
+            daemonReached = true
+            error("detach must not reach daemon with object session_id")
+        }
+
+        val result =
+            invokeTool(
+                server,
+                "detach",
+                buildJsonObject { put("session_id", buildJsonObject { put("nested", "value") }) },
+            )
+
+        assertTrue(result.isError == true, "object session_id must fail closed: $result")
+        assertTrue(!daemonReached, "object session_id must fail at the tool boundary: $result")
+        val message = (result.content.single() as TextContent).text
+        assertTrue(
+            message.contains("session_id", ignoreCase = true) ||
+                message.contains("string", ignoreCase = true) ||
+                message.contains("Error executing tool", ignoreCase = true),
+            "error should identify bad session_id input, was: $message",
+        )
+    }
+
+    @Test
     fun `screenshot tool returns daemon PNG bytes as inline MCP image content`() {
         val result =
             DaemonResponse.Screenshot("session-42", byteArrayOf(1, 2, 3)).screenshotResult()

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
@@ -303,6 +303,62 @@ class SpectreMcpServerTest {
     }
 
     @Test
+    fun `tree tool fails closed for blank session_id without reaching daemon`() = runBlocking {
+        var daemonReached = false
+        val server = SpectreMcpServer.create {
+            daemonReached = true
+            error("tree must not reach daemon with blank session_id")
+        }
+
+        val result = invokeTool(server, "tree", buildJsonObject { put("session_id", "  ") })
+
+        assertTrue(result.isError == true, "blank session_id on tree must fail closed: $result")
+        assertTrue(!daemonReached, "blank session_id must fail at the tool boundary: $result")
+    }
+
+    @Test
+    fun `find_text allows empty text but rejects whitespace-only text`() = runBlocking {
+        var seenText: String? = null
+        val server = SpectreMcpServer.create { request ->
+            when (request) {
+                is DaemonRequest.FindByText -> {
+                    seenText = request.text
+                    DaemonResponse.Nodes(sessionId = request.sessionId, nodes = emptyList())
+                }
+                else -> error("unexpected: $request")
+            }
+        }
+
+        val emptyOk =
+            invokeTool(
+                server,
+                "find_text",
+                buildJsonObject {
+                    put("session_id", "session-1")
+                    put("text", "")
+                },
+            )
+        assertTrue(emptyOk.isError != true, "empty text must reach daemon: $emptyOk")
+        assertEquals("", seenText)
+
+        seenText = null
+        val blankRejected =
+            invokeTool(
+                server,
+                "find_text",
+                buildJsonObject {
+                    put("session_id", "session-1")
+                    put("text", "  \t")
+                },
+            )
+        assertTrue(
+            blankRejected.isError == true,
+            "whitespace-only text must fail closed: $blankRejected",
+        )
+        assertEquals(null, seenText, "whitespace-only text must not reach the daemon")
+    }
+
+    @Test
     fun `screenshot tool returns daemon PNG bytes as inline MCP image content`() {
         val result =
             DaemonResponse.Screenshot("session-42", byteArrayOf(1, 2, 3)).screenshotResult()

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -535,11 +535,15 @@ Restart Claude Code after changing the configuration. It can then use these tool
    before further input.
 6. **`detach`** with the retained `sessionId` when finished — releases that session and returns
    leftover capture cleanup summary (count/bytes/paths + prune command when any exist). Unknown
-   or already-detached sessions fail closed (`isError`). Prefer `detach` over
-   `spectre daemon kill` (which drops **every** session).
+   or already-detached sessions fail closed (`isError`). Detach does **not** delete capture files;
+   run the summary’s `pruneCommand` when you want cleanup. Prefer `detach` over
+   `spectre daemon kill` (which drops **every** session). The shared daemon stays up after a
+   successful detach so you can `list_processes` / `attach` again.
 
 Full MCP tool names, input/output schemas, filesystem implications, and capture-mode
-distinctions: [CLI — MCP](cli.md#mcp).
+distinctions: [CLI — MCP](cli.md#mcp). MCP detach success JSON is the daemon `Detached` shape
+(`sessionId`, not CLI `--json` `id`) — see
+[Detach success body (MCP vs CLI)](cli.md#detach-success-body-mcp-vs-cli).
 
 Node keys are short-lived: get a fresh key with `tree` or `find` after an interaction changes the
 UI. On reload-aware sessions, keys are also invalidated after a successful hot reload settle —

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -337,11 +337,12 @@ Spectre for tree, input, capture, and evidence.
 | Attach | `attach` → retain `sessionId` |
 | Drive | `tree` / `find` / input tools / waits |
 | Capture | `screenshot` (inline image), `capture` (paths on daemon FS), `record_*` (paths) |
-| Release session | **`detach`** with `session_id` — ends that session and returns leftover capture cleanup summary (same honesty as CLI `spectre detach`). Unknown / already-detached sessions **fail closed** (`isError`). Use `spectre daemon kill` only when you intend to drop **every** session. |
+| Release session | **`detach`** with `session_id` — ends that session and returns leftover capture cleanup summary (same honesty as CLI `spectre detach`). Unknown / already-detached / blank `session_id` **fail closed** (`isError`). Detach does **not** delete capture files; prune stays explicit. Use `spectre daemon kill` only when you intend to drop **every** session. |
 
 Sessions created by MCP remain in the daemon until `detach`, daemon kill, or daemon
 teardown. Long agent workflows should call **`detach`** when finished so session and native
-resources do not leak.
+resources do not leak. Successful detach leaves the **shared daemon running** so
+`list_processes` and a new `attach` still work.
 
 ### Tool inventory
 
@@ -352,7 +353,7 @@ Inputs use snake_case JSON fields. Successful non-screenshot tools return **JSON
 | --- | --- | --- | --- |
 | `list_processes` | — | — | `{ "processes": [ { pid, displayName, … } ] }` |
 | `attach` | `pid` (integer) | — | `{ "sessionId", "targetPid" }` |
-| `detach` | `session_id` | — | `{ "sessionId", "captureCount", "captureBytes", "capturePaths", "pruneCommand"?, "skillHint"? }` — prune/skill present when leftovers exist; unknown session → `isError` |
+| `detach` | `session_id` (non-blank JSON string) | — | Daemon `Detached` JSON — see [Detach success body](#detach-success-body-mcp-vs-cli) below |
 | `windows` | `session_id` | — | `{ "sessionId", "windows": […] }` |
 | `tree` | `session_id` | — | `{ "sessionId", "nodes": […] }` |
 | `find` | `session_id`, `test_tag` | — | nodes list (exact test tag) |
@@ -397,9 +398,37 @@ Inputs use snake_case JSON fields. Successful non-screenshot tools return **JSON
 // tools/call record_start
 { "session_id": "…", "fullscreen": true, "output_path": "/tmp/demo.mp4" }
 
-// tools/call detach  (release session; prune leftover captures if the summary says so)
+// tools/call detach  (release session; does not delete files — run pruneCommand if needed)
 { "session_id": "…" }
 ```
+
+### Detach success body (MCP vs CLI)
+
+MCP `detach` success content is the daemon’s serialized **`DaemonResponse.Detached`** payload
+(with `encodeDefaults`, plus the sealed-type discriminator field the codec emits). Field names
+match the daemon protocol, not the CLI human line and not necessarily CLI `--json`:
+
+| Field | MCP detach success | CLI `spectre detach --json` | Notes |
+| --- | --- | --- | --- |
+| Session id | `sessionId` | `id` | Same value; different key |
+| Leftover count | `captureCount` | `captureCount` | Existing ledger dirs for that session only |
+| Leftover bytes | `captureBytes` | `captureBytes` | Sum of ledger `sizeBytes` |
+| Leftover paths | `capturePaths` | `capturePaths` | Absolute dirs still on disk |
+| Prune command | `pruneCommand` (when leftovers) | `pruneCommand` | e.g. `spectre captures prune --session …` |
+| Skill hint | `skillHint` (when leftovers) | `skillHint` | `spectre-capture` when leftovers exist |
+
+Do **not** treat MCP text and CLI `--json` as byte-identical envelopes. CLI human output is a
+prose line (`Detached <id>.` plus optional leftover lines), not this JSON.
+
+**Honesty rules (shared with CLI detach):** when the session left capture artifacts on disk,
+`captureCount` / `captureBytes` / `capturePaths` are non-zero and paths are real; `pruneCommand`
+and `skillHint` are populated. Empty sessions report zeros and omit prune/skill. Detach never
+auto-deletes files — run the reported prune command (or `spectre captures prune …`) explicitly.
+Malformed `session_id` (missing, empty, whitespace-only, non-string) fails closed at the MCP tool
+boundary without fabricating a summary.
+
+Full tool row: [Tool inventory](#tool-inventory) above. Capture retention and prune flags:
+[CLI capture](capture.md).
 
 ### Paths, filesystem, and capture modes (MCP)
 


### PR DESCRIPTION
## Summary

Closes #415 (absorbs closed #417).

- **Real leftovers:** fixture integration attaches, runs MCP atomic `capture` (ledger-writing path), detaches, and asserts non-zero `captureCount` / `captureBytes` / `capturePaths` plus populated `pruneCommand` / `skillHint`; artifacts remain on disk (no auto-prune).
- **Daemon liveness:** after detach, `list_processes` and a new `attach` (+ cheap `tree`) still succeed on the same MCP/daemon process.
- **Fail-closed `session_id`:** empty, whitespace-only, numeric, and object values fail at the MCP tool boundary without reaching the daemon (`requiredSessionId` + blank-aware `callString`).
- **Docs:** MCP success body is daemon `Detached` JSON (`sessionId`, encodeDefaults, type discriminator) — not the CLI human line and not byte-identical to CLI `--json` (`id`); inventory pointer; explicit prune.

Capture path used for leftovers: **MCP `capture` tool** (atomic capture → `CaptureArtifactStore` ledger).

### Doc pages
- `docs/guide/cli.md` — lifecycle, inventory row, new “Detach success body (MCP vs CLI)” section
- `docs/guide/agent.md` — detach lifecycle notes + link

### Tests
- `DaemonFixtureIntegrationTest` — leftover + liveness (headed macOS/Linux)
- `SpectreMcpServerTest` — malformed `session_id` boundary
- `CaptureSessionReportTest` — ledger honesty for `forDetach`

### Non-goals (unchanged)
- Auto-prune on detach
- Multi-session races (#413)
- Windows packaged matrix (#414)

## Test plan
- [x] `./gradlew check` on macOS
- [x] Targeted fixture test: attach → capture → detach leftovers + reattach
- [x] Unit: empty / whitespace / non-string `session_id` fail closed without daemon call
- [x] Unit: `CaptureSessionReport.forDetach` leftover + empty + missing-dir rows