### PR TITLE
fix(daemon): multi-session detach isolation and concurrent fail-closed (#413)

### DIFF
--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -192,18 +192,22 @@ public constructor(
                         handshakeComplete = response is DaemonResponse.Hello
                     }
                     val isShutdown = request is DaemonRequest.Shutdown && handshakeComplete
-                    DaemonWireCodec.writeResponse(output, response)
                     if (isShutdown) {
-                        // Defer server close until this client channel is fully released so socket
-                        // ancestor dirs can be unlinked (Shutdown already closed the registry).
+                        // Mark before write: a disconnected client must not leave this process
+                        // listening after Shutdown (registry is already closed by handleRequest).
                         shutdownAfterResponse = true
-                        return
+                    }
+                    try {
+                        DaemonWireCodec.writeResponse(output, response)
+                    } finally {
+                        if (isShutdown) return
                     }
                 }
             }
         } finally {
             activeClients.remove(client)
-            // A disconnected client must not leave this process listening after Shutdown.
+            // Defer server close until this client channel is fully released so socket ancestor
+            // dirs can be unlinked; always run when Shutdown was handled (write may have failed).
             if (shutdownAfterResponse) close()
         }
     }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -25,14 +25,16 @@ import java.security.MessageDigest
 import java.util.EnumSet
 import java.util.HexFormat
 import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Long-lived local daemon endpoint for the CLI/MCP protocol.
  *
- * The server accepts one request/response connection at a time. Automation sessions are inherently
- * serial, and the registry supplies deterministic lifecycle semantics for every connection.
+ * Each accepted client is handled on its own worker thread so a long wait on one connection does
+ * not block detach / attach / ps from another client (#201 / #413). Session lifecycle remains
+ * deterministic in [DaemonSessionRegistry].
  */
 public class DaemonServer
 @Throws(IOException::class)
@@ -45,9 +47,12 @@ public constructor(
     }
     private val running: AtomicBoolean = AtomicBoolean(true)
     private val closed: AtomicBoolean = AtomicBoolean(false)
+    /** Signaled when [close] finishes socket/parent teardown (accept may exit earlier). */
+    private val closeFinished: CountDownLatch = CountDownLatch(1)
     private val activityLock: Any = Any()
     private var lastActivityNanos: Long = System.nanoTime()
-    private val activeClient: AtomicReference<SocketChannel?> = AtomicReference(null)
+    /** Live client channels; connection close does not detach registry sessions (#413). */
+    private val activeClients: MutableSet<SocketChannel> = ConcurrentHashMap.newKeySet()
     private val socketProtection: DaemonSocketProtection =
         DaemonSocketProtection.forPath(socketPath)
     private val createdParents: List<Path> = socketProtection.createMissingParents(socketPath)
@@ -89,13 +94,23 @@ public constructor(
     public val listeningAt: Path
         get() = socketPath
 
-    /** Waits for the accept thread to exit, returning false only when [timeoutMillis] elapses. */
+    /**
+     * Waits for the accept thread to exit and for [close] teardown to finish (socket unlink +
+     * parent removal), returning false only when [timeoutMillis] elapses.
+     */
     @Throws(InterruptedException::class)
     public fun awaitTermination(timeoutMillis: Long = DEFAULT_TERMINATION_TIMEOUT_MILLIS): Boolean {
         require(timeoutMillis >= 0) { "timeoutMillis must be non-negative" }
-        if (timeoutMillis == 0L) return !acceptThread.isAlive
+        if (timeoutMillis == 0L) {
+            return !acceptThread.isAlive && (!closed.get() || closeFinished.count == 0L)
+        }
+        val deadlineNs = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis)
         acceptThread.join(timeoutMillis)
-        return !acceptThread.isAlive
+        if (acceptThread.isAlive) return false
+        if (!closed.get()) return true
+        val remainingMs =
+            TimeUnit.NANOSECONDS.toMillis((deadlineNs - System.nanoTime()).coerceAtLeast(0))
+        return closeFinished.await(remainingMs, TimeUnit.MILLISECONDS)
     }
 
     /** Milliseconds elapsed since the most recently received daemon request. */
@@ -106,7 +121,7 @@ public constructor(
         require(timeoutMillis > 0) { "timeoutMillis must be positive" }
         synchronized(activityLock) {
             if (
-                activeClient.get() != null ||
+                activeClients.isNotEmpty() ||
                     registry.hasSessions ||
                     idleMillisLocked() < timeoutMillis
             ) {
@@ -136,24 +151,34 @@ public constructor(
                     if (!running.get()) {
                         false
                     } else {
-                        activeClient.set(client)
+                        activeClients.add(client)
                         true
                     }
                 }
             if (!accepted) {
-                client.close()
+                runCatching { client.close() }
                 return
             }
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                handleConnection(client)
-            } catch (exception: Exception) {
-                if (running.get()) logConnectionFailure(exception)
-            }
+            Thread(
+                    {
+                        @Suppress("TooGenericExceptionCaught")
+                        try {
+                            handleConnection(client)
+                        } catch (exception: Exception) {
+                            if (running.get()) logConnectionFailure(exception)
+                        }
+                    },
+                    "spectre-daemon-client",
+                )
+                .apply {
+                    isDaemon = true
+                    start()
+                }
         }
     }
 
     private fun handleConnection(client: SocketChannel) {
+        var shutdownAfterResponse = false
         try {
             client.use { channel ->
                 val input = Channels.newInputStream(channel)
@@ -167,18 +192,19 @@ public constructor(
                         handshakeComplete = response is DaemonResponse.Hello
                     }
                     val isShutdown = request is DaemonRequest.Shutdown && handshakeComplete
-                    try {
-                        DaemonWireCodec.writeResponse(output, response)
-                    } finally {
-                        // The registry transitions before the response is written. A disconnected
-                        // client must not leave this process listening in that shut-down state.
-                        if (isShutdown) close()
+                    DaemonWireCodec.writeResponse(output, response)
+                    if (isShutdown) {
+                        // Defer server close until this client channel is fully released so socket
+                        // ancestor dirs can be unlinked (Shutdown already closed the registry).
+                        shutdownAfterResponse = true
+                        return
                     }
-                    if (isShutdown) return
                 }
             }
         } finally {
-            synchronized(activityLock) { activeClient.compareAndSet(client, null) }
+            activeClients.remove(client)
+            // A disconnected client must not leave this process listening after Shutdown.
+            if (shutdownAfterResponse) close()
         }
     }
 
@@ -285,28 +311,46 @@ public constructor(
 
     /** Stops accepting clients and attempts to remove the socket plus server-created parents. */
     override fun close() {
-        if (!closed.compareAndSet(false, true)) return
-        running.set(false)
-        runCatching { registry.close() }
-        runCatching { activeClient.getAndSet(null)?.close() }
-        val removedSocket =
+        if (!closed.compareAndSet(false, true)) {
+            // Another closer is in progress or finished; wait so callers observe full teardown.
             runCatching {
-                    // Hold the same lock as stale recovery before closing the channel. Otherwise a
-                    // successor can bind after close and before this server unlinks the path.
-                    withStaleSocketRecoveryLock {
-                        try {
-                            serverChannel.close()
-                        } finally {
-                            // Keep the recovery lock until the delete has at least been attempted.
-                            // Retrying after releasing the lock could unlink a successor daemon.
-                            runCatching { Files.deleteIfExists(socketPath) }
+                closeFinished.await(DEFAULT_TERMINATION_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS)
+            }
+            return
+        }
+        try {
+            running.set(false)
+            runCatching { registry.close() }
+            // Snapshot before close: client workers may remove themselves concurrently during
+            // shutdown.
+            val clients = ArrayList<SocketChannel>(activeClients.size)
+            activeClients.forEach { channel -> clients.add(channel) }
+            activeClients.clear()
+            clients.forEach { channel -> runCatching { channel.close() } }
+            val removedSocket =
+                runCatching {
+                        // Hold the same lock as stale recovery before closing the channel.
+                        // Otherwise a
+                        // successor can bind after close and before this server unlinks the path.
+                        withStaleSocketRecoveryLock {
+                            try {
+                                serverChannel.close()
+                            } finally {
+                                // Keep the recovery lock until the delete has at least been
+                                // attempted.
+                                // Retrying after releasing the lock could unlink a successor
+                                // daemon.
+                                runCatching { Files.deleteIfExists(socketPath) }
+                            }
                         }
                     }
-                }
-                .isSuccess
-        if (!removedSocket) runCatching { serverChannel.close() }
-        removeCreatedParents()
-        acceptThread.interrupt()
+                    .isSuccess
+            if (!removedSocket) runCatching { serverChannel.close() }
+            removeCreatedParents()
+            acceptThread.interrupt()
+        } finally {
+            closeFinished.countDown()
+        }
     }
 
     private fun removeCreatedParents() {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -197,11 +197,8 @@ public constructor(
                         // listening after Shutdown (registry is already closed by handleRequest).
                         shutdownAfterResponse = true
                     }
-                    try {
-                        DaemonWireCodec.writeResponse(output, response)
-                    } finally {
-                        if (isShutdown) return
-                    }
+                    runCatching { DaemonWireCodec.writeResponse(output, response) }
+                    if (isShutdown) break
                 }
             }
         } finally {

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -38,14 +38,16 @@ internal constructor(
     private var shutdown: Boolean = false
 
     /**
-     * Dispatches a daemon request. Long waits (#201) run **outside** the registry monitor so a
-     * multi-second `waitForNode` does not freeze attach/ps for other clients.
+     * Dispatches a daemon request. Long waits (#201) and detach teardown (#413) run **outside** the
+     * registry monitor so a multi-second `waitForNode` / wait-drain does not freeze attach/ps (or
+     * sibling-session ops) for other clients.
      */
     public fun handle(request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.WaitForNode,
             is DaemonRequest.WaitForVisualIdle,
             is DaemonRequest.WaitForReloadSettled -> handleWaitOutsideLock(request)
+            is DaemonRequest.Detach -> handleDetachOutsideLock(request.sessionId)
             else -> handleSynchronized(request)
         }
 
@@ -55,7 +57,7 @@ internal constructor(
             is DaemonRequest.Hello ->
                 DaemonResponse.Hello(daemonVersion = DaemonProtocol.CurrentVersion)
             is DaemonRequest.Attach -> attach(request.targetPid)
-            is DaemonRequest.Detach -> detach(request.sessionId)
+            is DaemonRequest.Detach -> error("detach must use handleDetachOutsideLock")
             DaemonRequest.ListSessions ->
                 DaemonResponse.Sessions(
                     sessions = sessionsByPid.values.map { it.summary }.sortedBy { it.targetPid }
@@ -312,21 +314,37 @@ internal constructor(
         )
     }
 
-    private fun detach(sessionId: String): DaemonResponse {
-        val removed =
-            sessionsByPid.entries.firstOrNull { (_, session) -> session.sessionId == sessionId }
-                ?: return DaemonResponse.Error(
-                    code = DaemonErrorCode.SessionNotFound,
-                    message = "session not found: $sessionId",
-                )
-        val remainingLive = sessionsByPid.values.map { it.sessionId }.toSet() - sessionId
-        val session = sessionsByPid.remove(removed.key)
-        // Let in-flight waits finish before tearing down the automator (see handleWaitOutsideLock).
-        session?.awaitIdleWaits()
-        // Finalize recording while other sessions are still known live (#185 review).
-        session?.automator?.finalizeRecording(remainingLive)
-        session?.hotReloadSession?.close()
-        session?.automator?.close()
+    /**
+     * Per-session detach (#399 / #413): remove the session under the monitor so sibling sessions
+     * stay operable, then tear down outside the lock so concurrent waits fail closed without
+     * freezing attach/ps for other clients.
+     *
+     * Order: drop from table → finalize recording → close automator (aborts in-flight waits) →
+     * drain wait counters. Preferred agent ordering is still stop recording → finish waits →
+     * detach; concurrent ops during detach fail closed.
+     */
+    private fun handleDetachOutsideLock(sessionId: String): DaemonResponse {
+        val (session, remainingLive) =
+            synchronized(this) {
+                if (shutdown) {
+                    return DaemonResponse.Error(
+                        code = DaemonErrorCode.ShutdownInProgress,
+                        message = "daemon is shutting down",
+                    )
+                }
+                val removed =
+                    sessionsByPid.entries.firstOrNull { (_, candidate) ->
+                        candidate.sessionId == sessionId
+                    } ?: return sessionNotFound(sessionId)
+                val live = sessionsByPid.values.map { it.sessionId }.toSet() - sessionId
+                checkNotNull(sessionsByPid.remove(removed.key)) to live
+            }
+        // Finalize while other sessions remain known live (#185); then close so in-flight waits
+        // observe a closed automator and fail closed instead of hanging on the full wait budget.
+        session.automator.finalizeRecording(remainingLive)
+        session.hotReloadSession?.close()
+        session.automator.close()
+        session.awaitIdleWaits()
         return CaptureSessionReport.forDetach(sessionId)
     }
 
@@ -476,16 +494,20 @@ internal constructor(
         return DaemonResponse.ShuttingDown
     }
 
-    @Synchronized
     override fun close() {
-        shutdown = true
-        val snapshot = sessionsByPid.values.toList()
-        sessionsByPid.clear()
-        // Outside the monitor after clear so wait finally-blocks can finish.
+        val snapshot =
+            synchronized(this) {
+                shutdown = true
+                val sessions = sessionsByPid.values.toList()
+                sessionsByPid.clear()
+                sessions
+            }
+        // Outside the monitor after clear so wait finally-blocks and sibling work can finish.
         snapshot.forEach { session ->
-            session.awaitIdleWaits()
+            runCatching { session.automator.finalizeRecording(emptySet()) }
             session.hotReloadSession?.close()
             session.automator.close()
+            session.awaitIdleWaits()
         }
     }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -56,6 +56,11 @@ internal constructor(
             is DaemonRequest.WaitForReloadSettled -> handleWaitOutsideLock(request)
             is DaemonRequest.Attach -> attach(request.targetPid)
             is DaemonRequest.Detach -> handleDetachOutsideLock(request.sessionId)
+            // close() tears down outside the monitor; must not run under @Synchronized.
+            DaemonRequest.Shutdown -> {
+                close()
+                DaemonResponse.ShuttingDown
+            }
             else -> handleSynchronized(request)
         }
 
@@ -90,15 +95,12 @@ internal constructor(
             is DaemonRequest.StartRecording,
             is DaemonRequest.StopRecording,
             is DaemonRequest.RecordingStatus -> handleSessionCommand(request)
-            // Wait ops are dispatched by [handle] outside the monitor.
+            // Wait ops / detach / shutdown / attach are dispatched by [handle] outside the monitor.
             is DaemonRequest.WaitForNode,
             is DaemonRequest.WaitForVisualIdle,
             is DaemonRequest.WaitForReloadSettled ->
                 error("wait ops must use handleWaitOutsideLock")
-            DaemonRequest.Shutdown -> {
-                close()
-                DaemonResponse.ShuttingDown
-            }
+            DaemonRequest.Shutdown -> error("shutdown must use handle() outside the monitor")
         }
 
     private fun handleWaitOutsideLock(request: DaemonRequest): DaemonResponse {
@@ -565,7 +567,12 @@ internal constructor(
 private const val WAIT_DRAIN_TIMEOUT_MS: Long = 90_000
 private const val WAIT_DRAIN_MARGIN_MS: Long = 5_000
 private const val WAIT_DRAIN_POLL_MS: Long = 10
-private const val ATTACH_WAIT_DETACH_TIMEOUT_MS: Long = 90_000
+/**
+ * Attach must outlive detach's [DaemonSession.awaitIdleWaits] budget: max(default drain, tracked
+ * wait remaining + margin). Headroom covers long client wait timeouts still draining after close.
+ */
+private const val ATTACH_WAIT_DETACH_TIMEOUT_MS: Long =
+    WAIT_DRAIN_TIMEOUT_MS + WAIT_DRAIN_MARGIN_MS + 120_000
 private const val NANOS_PER_MS: Long = 1_000_000
 
 private data class DaemonSession(

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -11,6 +11,8 @@ import dev.sebastiano.spectre.cli.hotreload.ReloadSettleErrorCategory
 import dev.sebastiano.spectre.cli.hotreload.mapReloadSettleOutcome
 import dev.sebastiano.spectre.cli.jdkPreflightError
 import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 /** In-memory session table for one daemon process. */
 @OptIn(ExperimentalSpectreAgentApi::class)
@@ -28,6 +30,11 @@ internal constructor(
     },
 ) : AutoCloseable {
     private val sessionsByPid: MutableMap<Long, DaemonSession> = linkedMapOf()
+    /**
+     * PIDs whose agent teardown is still running after the session left [sessionsByPid]. Same-PID
+     * re-attach waits on these latches so it does not race an in-flight agent Detach (#413).
+     */
+    private val detachingByPid: MutableMap<Long, CountDownLatch> = linkedMapOf()
 
     public val isShutdown: Boolean
         get() = shutdown
@@ -38,15 +45,16 @@ internal constructor(
     private var shutdown: Boolean = false
 
     /**
-     * Dispatches a daemon request. Long waits (#201) and detach teardown (#413) run **outside** the
-     * registry monitor so a multi-second `waitForNode` / wait-drain does not freeze attach/ps (or
-     * sibling-session ops) for other clients.
+     * Dispatches a daemon request. Long waits (#201), attach (may wait on same-PID detach), and
+     * detach teardown (#413) run **outside** the registry monitor so sibling-session ops stay
+     * responsive.
      */
     public fun handle(request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.WaitForNode,
             is DaemonRequest.WaitForVisualIdle,
             is DaemonRequest.WaitForReloadSettled -> handleWaitOutsideLock(request)
+            is DaemonRequest.Attach -> attach(request.targetPid)
             is DaemonRequest.Detach -> handleDetachOutsideLock(request.sessionId)
             else -> handleSynchronized(request)
         }
@@ -56,7 +64,7 @@ internal constructor(
         when (request) {
             is DaemonRequest.Hello ->
                 DaemonResponse.Hello(daemonVersion = DaemonProtocol.CurrentVersion)
-            is DaemonRequest.Attach -> attach(request.targetPid)
+            is DaemonRequest.Attach -> error("attach must use attach() outside the monitor")
             is DaemonRequest.Detach -> error("detach must use handleDetachOutsideLock")
             DaemonRequest.ListSessions ->
                 DaemonResponse.Sessions(
@@ -87,7 +95,10 @@ internal constructor(
             is DaemonRequest.WaitForVisualIdle,
             is DaemonRequest.WaitForReloadSettled ->
                 error("wait ops must use handleWaitOutsideLock")
-            DaemonRequest.Shutdown -> shutdown()
+            DaemonRequest.Shutdown -> {
+                close()
+                DaemonResponse.ShuttingDown
+            }
         }
 
     private fun handleWaitOutsideLock(request: DaemonRequest): DaemonResponse {
@@ -264,18 +275,36 @@ internal constructor(
         attachPreflightFailure()?.let {
             return it
         }
-        if (shutdown) {
-            return DaemonResponse.Error(
-                code = DaemonErrorCode.ShutdownInProgress,
-                message = "daemon shutdown is already in progress",
+        // Wait outside the monitor so detach teardown can finish (same-PID re-attach race, #413).
+        val waited =
+            awaitCountDownLatch(
+                timeoutMs = ATTACH_WAIT_DETACH_TIMEOUT_MS,
+                latch = { synchronized(this) { detachingByPid[targetPid] } },
             )
+        if (!waited) return stillDetachingError(targetPid)
+        return synchronized(this) {
+            if (shutdown) {
+                return@synchronized DaemonResponse.Error(
+                    code = DaemonErrorCode.ShutdownInProgress,
+                    message = "daemon shutdown is already in progress",
+                )
+            }
+            sessionsByPid[targetPid]?.let { session ->
+                return@synchronized DaemonResponse.Attached(
+                    sessionId = session.summary.sessionId,
+                    targetPid = session.summary.targetPid,
+                )
+            }
+            // Another detach may have started after we waited; re-check under the monitor.
+            if (detachingByPid.containsKey(targetPid)) {
+                return@synchronized stillDetachingError(targetPid)
+            }
+            openAttachedSession(targetPid)
         }
-        sessionsByPid[targetPid]?.let { session ->
-            return DaemonResponse.Attached(
-                sessionId = session.summary.sessionId,
-                targetPid = session.summary.targetPid,
-            )
-        }
+    }
+
+    /** Create the automator/session row. Caller holds the registry monitor. */
+    private fun openAttachedSession(targetPid: Long): DaemonResponse {
         val attached =
             try {
                 attachAutomator(targetPid)
@@ -319,33 +348,46 @@ internal constructor(
      * stay operable, then tear down outside the lock so concurrent waits fail closed without
      * freezing attach/ps for other clients.
      *
-     * Order: drop from table → finalize recording → close automator (aborts in-flight waits) →
-     * drain wait counters. Preferred agent ordering is still stop recording → finish waits →
+     * Order: drop from table → register detaching gate → finalize recording → close automator →
+     * drain waits → clear gate. Preferred agent ordering is still stop recording → finish waits →
      * detach; concurrent ops during detach fail closed.
      */
     private fun handleDetachOutsideLock(sessionId: String): DaemonResponse {
-        val (session, remainingLive) =
-            synchronized(this) {
-                if (shutdown) {
-                    return DaemonResponse.Error(
-                        code = DaemonErrorCode.ShutdownInProgress,
-                        message = "daemon is shutting down",
-                    )
-                }
-                val removed =
-                    sessionsByPid.entries.firstOrNull { (_, candidate) ->
-                        candidate.sessionId == sessionId
-                    } ?: return sessionNotFound(sessionId)
-                val live = sessionsByPid.values.map { it.sessionId }.toSet() - sessionId
-                checkNotNull(sessionsByPid.remove(removed.key)) to live
+        val targetPid: Long
+        val session: DaemonSession
+        val remainingLive: Set<String>
+        val gate = CountDownLatch(1)
+        synchronized(this) {
+            if (shutdown) {
+                return DaemonResponse.Error(
+                    code = DaemonErrorCode.ShutdownInProgress,
+                    message = "daemon is shutting down",
+                )
             }
-        // Finalize while other sessions remain known live (#185); then close so in-flight waits
-        // observe a closed automator and fail closed instead of hanging on the full wait budget.
-        session.automator.finalizeRecording(remainingLive)
-        session.hotReloadSession?.close()
-        session.automator.close()
-        session.awaitIdleWaits()
-        return CaptureSessionReport.forDetach(sessionId)
+            val removed =
+                sessionsByPid.entries.firstOrNull { (_, candidate) ->
+                    candidate.sessionId == sessionId
+                } ?: return sessionNotFound(sessionId)
+            targetPid = removed.key
+            remainingLive = sessionsByPid.values.map { it.sessionId }.toSet() - sessionId
+            session = checkNotNull(sessionsByPid.remove(targetPid))
+            detachingByPid[targetPid] = gate
+        }
+        try {
+            // Finalize while other sessions remain known live (#185); then close so in-flight waits
+            // observe a closed automator and fail closed instead of hanging on the full wait
+            // budget.
+            session.automator.finalizeRecording(remainingLive)
+            session.hotReloadSession?.close()
+            session.automator.close()
+            session.awaitIdleWaits()
+            return CaptureSessionReport.forDetach(sessionId)
+        } finally {
+            synchronized(this) {
+                if (detachingByPid[targetPid] === gate) detachingByPid.remove(targetPid)
+            }
+            gate.countDown()
+        }
     }
 
     private fun handleQuerySessionCommand(request: DaemonRequest): DaemonResponse =
@@ -489,25 +531,33 @@ internal constructor(
         }
     }
 
-    private fun shutdown(): DaemonResponse {
-        close()
-        return DaemonResponse.ShuttingDown
-    }
-
     override fun close() {
-        val snapshot =
-            synchronized(this) {
-                shutdown = true
-                val sessions = sessionsByPid.values.toList()
-                sessionsByPid.clear()
-                sessions
+        val snapshot: List<Pair<Long, DaemonSession>>
+        val gates: List<Pair<Long, CountDownLatch>>
+        synchronized(this) {
+            shutdown = true
+            snapshot = sessionsByPid.entries.map { it.key to it.value }
+            sessionsByPid.clear()
+            gates = snapshot.map { (pid, _) ->
+                val gate = CountDownLatch(1)
+                detachingByPid[pid] = gate
+                pid to gate
             }
+        }
         // Outside the monitor after clear so wait finally-blocks and sibling work can finish.
-        snapshot.forEach { session ->
-            runCatching { session.automator.finalizeRecording(emptySet()) }
-            session.hotReloadSession?.close()
-            session.automator.close()
-            session.awaitIdleWaits()
+        snapshot.forEach { (pid, session) ->
+            try {
+                runCatching { session.automator.finalizeRecording(emptySet()) }
+                session.hotReloadSession?.close()
+                session.automator.close()
+                session.awaitIdleWaits()
+            } finally {
+                val gate = gates.firstOrNull { it.first == pid }?.second
+                synchronized(this) {
+                    if (gate != null && detachingByPid[pid] === gate) detachingByPid.remove(pid)
+                }
+                gate?.countDown()
+            }
         }
     }
 }
@@ -515,6 +565,7 @@ internal constructor(
 private const val WAIT_DRAIN_TIMEOUT_MS: Long = 90_000
 private const val WAIT_DRAIN_MARGIN_MS: Long = 5_000
 private const val WAIT_DRAIN_POLL_MS: Long = 10
+private const val ATTACH_WAIT_DETACH_TIMEOUT_MS: Long = 90_000
 private const val NANOS_PER_MS: Long = 1_000_000
 
 private data class DaemonSession(
@@ -601,6 +652,26 @@ private fun sessionNotFound(sessionId: String): DaemonResponse.Error =
         code = DaemonErrorCode.SessionNotFound,
         message = "session not found: $sessionId",
     )
+
+private fun stillDetachingError(targetPid: Long): DaemonResponse.Error =
+    DaemonResponse.Error(
+        code = DaemonErrorCode.AttachFailed,
+        message = "previous session for pid $targetPid is still detaching; retry attach shortly",
+    )
+
+/**
+ * Waits until [latch] returns null, or until [timeoutMs] elapses. Returns false on timeout while a
+ * latch is still present.
+ */
+private fun awaitCountDownLatch(timeoutMs: Long, latch: () -> CountDownLatch?): Boolean {
+    val deadlineNs = System.nanoTime() + timeoutMs * NANOS_PER_MS
+    while (true) {
+        val gate = latch() ?: return true
+        val remainingMs = ((deadlineNs - System.nanoTime()) / NANOS_PER_MS).coerceAtLeast(0)
+        if (remainingMs == 0L) return false
+        if (!gate.await(remainingMs, TimeUnit.MILLISECONDS)) return false
+    }
+}
 
 private fun sessionSummaryFor(targetPid: Long): DaemonSessionSummary =
     DaemonSessionSummary(sessionId = "pid-$targetPid", targetPid = targetPid)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -535,31 +535,44 @@ internal constructor(
 
     override fun close() {
         val snapshot: List<Pair<Long, DaemonSession>>
-        val gates: List<Pair<Long, CountDownLatch>>
+        val ownedGates: List<Pair<Long, CountDownLatch>>
+        val waitGates: List<CountDownLatch>
         synchronized(this) {
             shutdown = true
             snapshot = sessionsByPid.entries.map { it.key to it.value }
             sessionsByPid.clear()
-            gates = snapshot.map { (pid, _) ->
-                val gate = CountDownLatch(1)
-                detachingByPid[pid] = gate
-                pid to gate
+            val owned = mutableListOf<Pair<Long, CountDownLatch>>()
+            for ((pid, _) in snapshot) {
+                // Do not overwrite a gate owned by an in-flight per-session detach.
+                if (!detachingByPid.containsKey(pid)) {
+                    val gate = CountDownLatch(1)
+                    detachingByPid[pid] = gate
+                    owned += pid to gate
+                }
             }
+            ownedGates = owned
+            waitGates = detachingByPid.values.toList()
         }
+        val ownedPids = ownedGates.map { it.first }.toSet()
         // Outside the monitor after clear so wait finally-blocks and sibling work can finish.
         snapshot.forEach { (pid, session) ->
+            if (pid !in ownedPids) return@forEach
+            val ownedGate = ownedGates.first { it.first == pid }.second
             try {
                 runCatching { session.automator.finalizeRecording(emptySet()) }
                 session.hotReloadSession?.close()
                 session.automator.close()
                 session.awaitIdleWaits()
             } finally {
-                val gate = gates.firstOrNull { it.first == pid }?.second
                 synchronized(this) {
-                    if (gate != null && detachingByPid[pid] === gate) detachingByPid.remove(pid)
+                    if (detachingByPid[pid] === ownedGate) detachingByPid.remove(pid)
                 }
-                gate?.countDown()
+                ownedGate.countDown()
             }
+        }
+        // Join concurrent detach teardowns so Shutdown does not race agent close.
+        waitGates.forEach { gate ->
+            runCatching { gate.await(ATTACH_WAIT_DETACH_TIMEOUT_MS, TimeUnit.MILLISECONDS) }
         }
     }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -460,6 +460,211 @@ class DaemonServerTest {
             deleteTemporarySocketPath(socketPath)
         }
     }
+
+    // region #413 disconnect ≠ detach + concurrent multi-client detach
+
+    @Test
+    fun `client disconnect does not detach registry sessions`() {
+        val socketPath = temporarySocketPath()
+        val registry = DaemonSessionRegistry { TestDaemonSessionAutomator() }
+        val server = DaemonServer(socketPath, registry = registry)
+
+        try {
+            // One-shot attach (DaemonClient closes the connection after the response).
+            val attached =
+                assertIs<DaemonResponse.Attached>(
+                    DaemonClient(socketPath).request(DaemonRequest.Attach(4242))
+                )
+            assertEquals("pid-4242", attached.sessionId)
+
+            // New client after front-end death still sees the session and can operate it.
+            val listed =
+                assertIs<DaemonResponse.Sessions>(
+                    DaemonClient(socketPath).request(DaemonRequest.ListSessions)
+                )
+            assertEquals(
+                listOf(DaemonSessionSummary(sessionId = "pid-4242", targetPid = 4242)),
+                listed.sessions,
+            )
+            assertIs<DaemonResponse.Windows>(
+                DaemonClient(socketPath).request(DaemonRequest.Windows("pid-4242"))
+            )
+
+            // Explicit detach remains the recovery path.
+            assertIs<DaemonResponse.Detached>(
+                DaemonClient(socketPath).request(DaemonRequest.Detach("pid-4242"))
+            )
+            val after =
+                assertIs<DaemonResponse.Sessions>(
+                    DaemonClient(socketPath).request(DaemonRequest.ListSessions)
+                )
+            assertTrue(after.sessions.isEmpty())
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
+    fun `mid-request client disconnect does not detach the target session`() {
+        val socketPath = temporarySocketPath()
+        val waitEntered = java.util.concurrent.CountDownLatch(1)
+        val holdWait = java.util.concurrent.CountDownLatch(1)
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(
+                waitForNodeResult = { _, _, _, _ ->
+                    waitEntered.countDown()
+                    // Hold until the test finishes assertions, then fail closed.
+                    holdWait.await(5, java.util.concurrent.TimeUnit.SECONDS)
+                    throw java.io.IOException("client abandoned wait")
+                }
+            )
+        }
+        val server = DaemonServer(socketPath, registry = registry)
+
+        try {
+            assertIs<DaemonResponse.Attached>(
+                DaemonClient(socketPath).request(DaemonRequest.Attach(777))
+            )
+
+            val waitThread =
+                Thread(
+                    {
+                        SocketChannel.open(java.net.StandardProtocolFamily.UNIX).use { channel ->
+                            channel.connect(java.net.UnixDomainSocketAddress.of(socketPath))
+                            val input = Channels.newInputStream(channel)
+                            val output = Channels.newOutputStream(channel)
+                            DaemonWireCodec.writeRequest(
+                                output,
+                                DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
+                            )
+                            DaemonWireCodec.readResponse(input)
+                            DaemonWireCodec.writeRequest(
+                                output,
+                                DaemonRequest.WaitForNode(
+                                    sessionId = "pid-777",
+                                    tag = "never",
+                                    timeoutMs = 60_000,
+                                ),
+                            )
+                            // Drop the front-end before reading a response (#413).
+                            check(waitEntered.await(5, java.util.concurrent.TimeUnit.SECONDS))
+                            // Channel closes on use{} exit while the daemon wait is still held.
+                        }
+                    },
+                    "spectre-test-mid-disconnect",
+                )
+            waitThread.start()
+            check(waitEntered.await(5, java.util.concurrent.TimeUnit.SECONDS))
+            waitThread.join(5_000)
+
+            // While the abandoned wait is still in flight, the session must remain operable.
+            val listed =
+                assertIs<DaemonResponse.Sessions>(
+                    DaemonClient(socketPath).request(DaemonRequest.ListSessions)
+                )
+            assertEquals(
+                listOf(DaemonSessionSummary(sessionId = "pid-777", targetPid = 777)),
+                listed.sessions,
+                "front-end disconnect must not silently detach the daemon session",
+            )
+            assertIs<DaemonResponse.Windows>(
+                DaemonClient(socketPath).request(DaemonRequest.Windows("pid-777"))
+            )
+
+            holdWait.countDown()
+            assertIs<DaemonResponse.Detached>(
+                DaemonClient(socketPath).request(DaemonRequest.Detach("pid-777"))
+            )
+        } finally {
+            holdWait.countDown()
+            server.close()
+            assertTrue(server.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
+    fun `concurrent wait and detach from separate clients fail closed without hang`() {
+        val socketPath = temporarySocketPath()
+        val waitEntered = java.util.concurrent.CountDownLatch(1)
+        val closedDuringWait = java.util.concurrent.CountDownLatch(1)
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(
+                waitForNodeResult = { _, _, _, _ ->
+                    waitEntered.countDown()
+                    check(closedDuringWait.await(5, java.util.concurrent.TimeUnit.SECONDS)) {
+                        "detach did not close automator while wait was in flight"
+                    }
+                    throw java.io.IOException("session closed during waitForNode")
+                },
+                closeAction = { closedDuringWait.countDown() },
+            )
+        }
+        val server = DaemonServer(socketPath, registry = registry)
+
+        try {
+            assertIs<DaemonResponse.Attached>(
+                DaemonClient(socketPath).request(DaemonRequest.Attach(888))
+            )
+
+            val pool = java.util.concurrent.Executors.newFixedThreadPool(2)
+            try {
+                val waitFuture =
+                    pool.submit<DaemonResponse> {
+                        DaemonClient(socketPath)
+                            .request(
+                                DaemonRequest.WaitForNode(
+                                    sessionId = "pid-888",
+                                    tag = "never",
+                                    timeoutMs = 60_000,
+                                )
+                            )
+                    }
+                check(waitEntered.await(5, java.util.concurrent.TimeUnit.SECONDS))
+
+                val detachStarted = System.nanoTime()
+                val detached =
+                    assertIs<DaemonResponse.Detached>(
+                        DaemonClient(socketPath).request(DaemonRequest.Detach("pid-888"))
+                    )
+                assertEquals("pid-888", detached.sessionId)
+                val detachMs =
+                    java.util.concurrent.TimeUnit.NANOSECONDS.toMillis(
+                        System.nanoTime() - detachStarted
+                    )
+                assertTrue(
+                    detachMs < 10_000,
+                    "multi-client detach must not hang on the full wait budget (took ${detachMs}ms)",
+                )
+
+                val waitError =
+                    assertIs<DaemonResponse.Error>(
+                        waitFuture.get(5, java.util.concurrent.TimeUnit.SECONDS)
+                    )
+                assertEquals(DaemonErrorCode.OperationFailed, waitError.code)
+
+                val listed =
+                    assertIs<DaemonResponse.Sessions>(
+                        DaemonClient(socketPath).request(DaemonRequest.ListSessions)
+                    )
+                assertTrue(listed.sessions.isEmpty())
+
+                assertIs<DaemonResponse.Attached>(
+                    DaemonClient(socketPath).request(DaemonRequest.Attach(999))
+                )
+            } finally {
+                pool.shutdownNow()
+            }
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    // endregion
 }
 
 private fun temporarySocketPath(): Path =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
@@ -609,6 +609,47 @@ class DaemonSessionRegistryTest {
     }
 
     @Test
+    fun `same-PID re-attach waits for detach teardown to finish`() {
+        val closeEntered = CountDownLatch(1)
+        val releaseClose = CountDownLatch(1)
+        val closes = AtomicInteger(0)
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(
+                closeAction = {
+                    closes.incrementAndGet()
+                    closeEntered.countDown()
+                    check(releaseClose.await(5, TimeUnit.SECONDS))
+                }
+            )
+        }
+        assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(4242)))
+
+        val pool = Executors.newFixedThreadPool(2)
+        try {
+            val detachFuture =
+                pool.submit<DaemonResponse> { registry.handle(DaemonRequest.Detach("pid-4242")) }
+            check(closeEntered.await(5, TimeUnit.SECONDS)) { "detach close did not start" }
+
+            val reattachFuture =
+                pool.submit<DaemonResponse> { registry.handle(DaemonRequest.Attach(4242)) }
+
+            // Re-attach must not complete while the previous automator is still closing.
+            Thread.sleep(100)
+            assertTrue(!reattachFuture.isDone, "re-attach raced ahead of detach teardown")
+
+            releaseClose.countDown()
+            assertIs<DaemonResponse.Detached>(detachFuture.get(5, TimeUnit.SECONDS))
+            val reattached =
+                assertIs<DaemonResponse.Attached>(reattachFuture.get(5, TimeUnit.SECONDS))
+            assertEquals("pid-4242", reattached.sessionId)
+            assertEquals(1, closes.get(), "first session must close once before re-attach")
+        } finally {
+            releaseClose.countDown()
+            pool.shutdownNow()
+        }
+    }
+
+    @Test
     fun `concurrent detach finalizes an active recording once without leak`() {
         val finalizeLive = AtomicReference<Set<String>?>(null)
         val stopCount = AtomicInteger(0)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistryTest.kt
@@ -9,9 +9,15 @@ import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
 @OptIn(ExperimentalSpectreAgentApi::class)
@@ -414,6 +420,244 @@ class DaemonSessionRegistryTest {
         val rejected = assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Attach(5678)))
         assertEquals(DaemonErrorCode.ShutdownInProgress, rejected.code)
     }
+
+    // region #413 multi-session isolation, double-detach, post-detach, concurrent detach
+
+    @Test
+    fun `detach of one session leaves sibling session operable and fail-closes the detached id`() {
+        val automators = mutableMapOf<Long, TestDaemonSessionAutomator>()
+        val registry = DaemonSessionRegistry { pid ->
+            TestDaemonSessionAutomator(
+                    windowsResult = {
+                        listOf(
+                            WindowSummaryDto(
+                                index = 0,
+                                surfaceId = "main-$pid",
+                                title = "Session $pid",
+                                isPopup = false,
+                                bounds = RectDto(0, 0, 10, 10),
+                            )
+                        )
+                    },
+                    nodesResult = {
+                        listOf(
+                            NodeSnapshotDto(
+                                key = "node-$pid",
+                                testTag = "tag-$pid",
+                                texts = emptyList(),
+                                role = "Button",
+                                contentDescription = null,
+                                isVisible = true,
+                                bounds = RectDto(0, 0, 1, 1),
+                            )
+                        )
+                    },
+                    screenshotResult = { _, _, _ -> byteArrayOf(pid.toByte()) },
+                )
+                .also { automators[pid] = it }
+        }
+
+        val sessionA =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(100))).sessionId
+        val sessionB =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(200))).sessionId
+        assertNotEquals(sessionA, sessionB)
+
+        val detached =
+            assertIs<DaemonResponse.Detached>(registry.handle(DaemonRequest.Detach(sessionA)))
+        assertEquals(sessionA, detached.sessionId)
+
+        // Sibling still works.
+        val windowsB =
+            assertIs<DaemonResponse.Windows>(registry.handle(DaemonRequest.Windows(sessionB)))
+        assertEquals("main-200", windowsB.windows.single().surfaceId)
+        val nodesB =
+            assertIs<DaemonResponse.Nodes>(registry.handle(DaemonRequest.AllNodes(sessionB)))
+        assertEquals("node-200", nodesB.nodes.single().key)
+
+        // Detached session fail-closed (not empty success).
+        assertSessionNotFound(registry.handle(DaemonRequest.Windows(sessionA)), sessionA)
+        assertSessionNotFound(registry.handle(DaemonRequest.AllNodes(sessionA)), sessionA)
+        assertSessionNotFound(registry.handle(DaemonRequest.Click(sessionA, "node-100")), sessionA)
+        assertSessionNotFound(registry.handle(DaemonRequest.Screenshot(sessionA)), sessionA)
+
+        // Detach never killed the daemon table for remaining sessions.
+        val listed = assertIs<DaemonResponse.Sessions>(registry.handle(DaemonRequest.ListSessions))
+        assertEquals(
+            listOf(DaemonSessionSummary(sessionId = sessionB, targetPid = 200)),
+            listed.sessions,
+        )
+        assertEquals(1, automators.getValue(100).closeCount.get())
+        assertEquals(0, automators.getValue(200).closeCount.get())
+
+        // New attach still healthy.
+        val sessionC =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(300))).sessionId
+        assertEquals("pid-300", sessionC)
+    }
+
+    @Test
+    fun `double detach fails closed with session-not-found honesty and no second side-effect`() {
+        val automator = TestDaemonSessionAutomator()
+        val registry = DaemonSessionRegistry { automator }
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(42))).sessionId
+
+        val first =
+            assertIs<DaemonResponse.Detached>(registry.handle(DaemonRequest.Detach(sessionId)))
+        assertEquals(sessionId, first.sessionId)
+        assertEquals(1, automator.closeCount.get())
+        assertEquals(1, automator.finalizeCount.get())
+
+        val second =
+            assertIs<DaemonResponse.Error>(registry.handle(DaemonRequest.Detach(sessionId)))
+        assertEquals(DaemonErrorCode.SessionNotFound, second.code)
+        assertTrue(
+            second.message.contains("not found", ignoreCase = true) &&
+                second.message.contains(sessionId),
+            "double-detach message should match unknown-session honesty, was: ${second.message}",
+        )
+        // No second finalize/close on already-released resources.
+        assertEquals(1, automator.closeCount.get())
+        assertEquals(1, automator.finalizeCount.get())
+    }
+
+    @Test
+    fun `post-detach tree click and screenshot fail closed with actionable session not found`() {
+        val registry = testRegistry()
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(77))).sessionId
+        assertIs<DaemonResponse.Detached>(registry.handle(DaemonRequest.Detach(sessionId)))
+
+        assertSessionNotFound(registry.handle(DaemonRequest.AllNodes(sessionId)), sessionId)
+        assertSessionNotFound(registry.handle(DaemonRequest.Click(sessionId, "any-key")), sessionId)
+        assertSessionNotFound(registry.handle(DaemonRequest.Screenshot(sessionId)), sessionId)
+        assertSessionNotFound(
+            registry.handle(DaemonRequest.FindByTestTag(sessionId, "tag")),
+            sessionId,
+        )
+    }
+
+    @Test
+    fun `concurrent detach while wait is in flight fails closed without hang or leak`() {
+        val waitEntered = CountDownLatch(1)
+        val closedDuringWait = CountDownLatch(1)
+        val waitResult = AtomicReference<DaemonResponse?>(null)
+        val automator =
+            TestDaemonSessionAutomator(
+                waitForNodeResult = { _, _, _, _ ->
+                    waitEntered.countDown()
+                    // Block until detach closes the automator, then fail closed (no full timeout
+                    // hang).
+                    check(closedDuringWait.await(5, TimeUnit.SECONDS)) {
+                        "detach did not close automator while wait was in flight"
+                    }
+                    throw IOException("session closed during waitForNode")
+                },
+                closeAction = { closedDuringWait.countDown() },
+            )
+        val registry = DaemonSessionRegistry { automator }
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(9001))).sessionId
+
+        val pool = Executors.newFixedThreadPool(2)
+        try {
+            val waitFuture =
+                pool.submit<DaemonResponse> {
+                    registry.handle(
+                        DaemonRequest.WaitForNode(
+                            sessionId = sessionId,
+                            tag = "never-appears",
+                            timeoutMs = 60_000,
+                        )
+                    )
+                }
+            check(waitEntered.await(5, TimeUnit.SECONDS)) { "wait did not start" }
+
+            val detachStarted = System.nanoTime()
+            val detached =
+                assertIs<DaemonResponse.Detached>(registry.handle(DaemonRequest.Detach(sessionId)))
+            assertEquals(sessionId, detached.sessionId)
+            val detachMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - detachStarted)
+            assertTrue(
+                detachMs < 10_000,
+                "detach must not hang waiting for the full wait timeout (took ${detachMs}ms)",
+            )
+
+            waitResult.set(waitFuture.get(5, TimeUnit.SECONDS))
+            val waitError = assertIs<DaemonResponse.Error>(waitResult.get())
+            assertEquals(DaemonErrorCode.OperationFailed, waitError.code)
+            assertTrue(
+                waitError.message.contains("closed", ignoreCase = true) ||
+                    waitError.message.contains("session", ignoreCase = true),
+                "waiter should fail closed, was: ${waitError.message}",
+            )
+
+            assertEquals(
+                DaemonResponse.Sessions(emptyList()),
+                registry.handle(DaemonRequest.ListSessions),
+            )
+            assertEquals(1, automator.closeCount.get())
+
+            // Daemon remains healthy for a new attach after concurrent detach.
+            val next =
+                assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(9002)))
+            assertEquals("pid-9002", next.sessionId)
+        } finally {
+            pool.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `concurrent detach finalizes an active recording once without leak`() {
+        val finalizeLive = AtomicReference<Set<String>?>(null)
+        val stopCount = AtomicInteger(0)
+        val automator =
+            TestDaemonSessionAutomator(
+                startRecordingAction = { path, _, _ -> path ?: "/tmp/rec.mp4" },
+                stopRecordingResult = { live ->
+                    stopCount.incrementAndGet()
+                    finalizeLive.set(live)
+                    "/tmp/rec.mp4"
+                },
+                finalizeRecordingAction = { live ->
+                    // Mirror production: finalize stops an active recording.
+                    if (stopCount.get() == 0) {
+                        stopCount.incrementAndGet()
+                        finalizeLive.set(live)
+                    }
+                },
+            )
+        val registry = DaemonSessionRegistry { automator }
+        val sessionId =
+            assertIs<DaemonResponse.Attached>(registry.handle(DaemonRequest.Attach(55))).sessionId
+        assertIs<DaemonResponse.RecordingStarted>(
+            registry.handle(DaemonRequest.StartRecording(sessionId, "/tmp/rec.mp4"))
+        )
+
+        val detached =
+            assertIs<DaemonResponse.Detached>(registry.handle(DaemonRequest.Detach(sessionId)))
+        assertEquals(sessionId, detached.sessionId)
+        assertEquals(1, automator.finalizeCount.get())
+        assertEquals(1, automator.closeCount.get())
+        assertEquals(
+            DaemonResponse.Sessions(emptyList()),
+            registry.handle(DaemonRequest.ListSessions),
+        )
+        // Sibling table empty → remaining live set empty.
+        assertEquals(emptySet<String>(), finalizeLive.get())
+    }
+
+    // endregion
+}
+
+private fun assertSessionNotFound(response: DaemonResponse, sessionId: String) {
+    val error = assertIs<DaemonResponse.Error>(response)
+    assertEquals(DaemonErrorCode.SessionNotFound, error.code)
+    assertTrue(
+        error.message.contains("not found", ignoreCase = true) && error.message.contains(sessionId),
+        "expected actionable session-not-found for $sessionId, was: ${error.message}",
+    )
 }
 
 @OptIn(ExperimentalSpectreAgentApi::class)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
@@ -4,6 +4,8 @@ import dev.sebastiano.spectre.agent.AtomicCaptureResult
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicInteger
 
 @OptIn(ExperimentalSpectreAgentApi::class)
 internal class TestDaemonSessionAutomator(
@@ -38,13 +40,33 @@ internal class TestDaemonSessionAutomator(
         error("no recording is in progress")
     },
     private val recordingStatusResult: () -> RecordingStatus = { RecordingStatus(active = false) },
+    private val waitForNodeResult:
+        (tag: String?, text: String?, timeoutMs: Long, pollIntervalMs: Long) -> NodeSnapshotDto =
+        { _, _, _, _ ->
+            error("waitForNode not stubbed")
+        },
+    private val finalizeRecordingAction: (Set<String>) -> Unit = {},
     private val closeAction: () -> Unit = {},
 ) : DaemonSessionAutomator {
-    override fun windows(): List<WindowSummaryDto> = windowsResult()
+    val closeCount: AtomicInteger = AtomicInteger(0)
+    val finalizeCount: AtomicInteger = AtomicInteger(0)
 
-    override fun allNodes(): List<NodeSnapshotDto> = nodesResult()
+    @Volatile private var closed: Boolean = false
 
-    override fun findByTestTag(tag: String): List<NodeSnapshotDto> = findByTestTagResult(tag)
+    override fun windows(): List<WindowSummaryDto> {
+        ensureOpen("windows")
+        return windowsResult()
+    }
+
+    override fun allNodes(): List<NodeSnapshotDto> {
+        ensureOpen("allNodes")
+        return nodesResult()
+    }
+
+    override fun findByTestTag(tag: String): List<NodeSnapshotDto> {
+        ensureOpen("findByTestTag")
+        return findByTestTagResult(tag)
+    }
 
     override fun findByText(text: String, exact: Boolean): List<NodeSnapshotDto> = emptyList()
 
@@ -57,12 +79,18 @@ internal class TestDaemonSessionAutomator(
         text: String?,
         timeoutMs: Long,
         pollIntervalMs: Long,
-    ): NodeSnapshotDto = error("waitForNode not stubbed")
+    ): NodeSnapshotDto {
+        ensureOpen("waitForNode")
+        return waitForNodeResult(tag, text, timeoutMs, pollIntervalMs)
+    }
 
     override fun waitForVisualIdle(timeoutMs: Long, stableFrames: Int, pollIntervalMs: Long): Unit =
         Unit
 
-    override fun click(nodeKey: String): Unit = clickAction(nodeKey)
+    override fun click(nodeKey: String) {
+        ensureOpen("click")
+        clickAction(nodeKey)
+    }
 
     override fun doubleClick(nodeKey: String): Unit = Unit
 
@@ -85,8 +113,10 @@ internal class TestDaemonSessionAutomator(
 
     override fun typeText(text: String): Unit = typeTextAction(text)
 
-    override fun screenshot(windowIndex: Int?, surfaceId: String?, fullscreen: Boolean): ByteArray =
-        screenshotResult(windowIndex, surfaceId, fullscreen)
+    override fun screenshot(windowIndex: Int?, surfaceId: String?, fullscreen: Boolean): ByteArray {
+        ensureOpen("screenshot")
+        return screenshotResult(windowIndex, surfaceId, fullscreen)
+    }
 
     override fun capture(windowIndex: Int): AtomicCaptureResult = captureResult(windowIndex)
 
@@ -101,7 +131,18 @@ internal class TestDaemonSessionAutomator(
 
     override fun recordingStatus(): RecordingStatus = recordingStatusResult()
 
-    override fun finalizeRecording(remainingLiveSessionIds: Set<String>): Unit = Unit
+    override fun finalizeRecording(remainingLiveSessionIds: Set<String>) {
+        finalizeCount.incrementAndGet()
+        finalizeRecordingAction(remainingLiveSessionIds)
+    }
 
-    override fun close(): Unit = closeAction()
+    override fun close() {
+        closed = true
+        closeCount.incrementAndGet()
+        closeAction()
+    }
+
+    private fun ensureOpen(op: String) {
+        if (closed) throw IOException("session automator closed during $op")
+    }
 }

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -413,9 +413,12 @@ connection.
 - Long work (future waits, heavy capture) runs on a **worker thread**, not the accept loop —
   so cancel/detach stay responsive.
 - **Cancel** is an explicit wire op (`cancel` with the target `opId`), not socket-close.
-- Closing a CLI/MCP front-end during a long-poll should cancel the front-end's op via the
-  daemon without detaching the target session (daemon cancel-on-frontend-loss); the agent
-  transport itself only detaches on an explicit `detach` or handshake failure teardown.
+- Closing a CLI/MCP front-end during a long-poll cancels only that **front-end** connection's
+  in-flight work. The **daemon session stays attached** until an explicit `detach` (or daemon
+  kill / crash). Reconnect or use the CLI against the same session id — disconnect is not
+  detach and does not leave an undocumented zombie without a recovery path (see lifecycle
+  below). The agent transport itself only detaches on an explicit `detach` or handshake
+  failure teardown.
 
 
 Clients should branch on `category` (see `AgentErrorCategory` / `SpectreAgentException`),
@@ -533,12 +536,28 @@ Restart Claude Code after changing the configuration. It can then use these tool
 5. When the target runs under Compose Hot Reload: call `wait_for_reload_settled` **before**
    triggering a code reload (it must observe the settle chain), then re-run `tree` / `find`
    before further input.
-6. **`detach`** with the retained `sessionId` when finished — releases that session and returns
-   leftover capture cleanup summary (count/bytes/paths + prune command when any exist). Unknown
-   or already-detached sessions fail closed (`isError`). Detach does **not** delete capture files;
+6. **`detach`** with the retained `sessionId` when finished — releases **that** session only and
+   returns leftover capture cleanup summary (count/bytes/paths + prune command when any exist).
+   Unknown or already-detached sessions fail closed (`isError`). Sibling sessions stay attached;
+   `detach` is never “kill the daemon” or “release all.” Detach does **not** delete capture files;
    run the summary’s `pruneCommand` when you want cleanup. Prefer `detach` over
    `spectre daemon kill` (which drops **every** session). The shared daemon stays up after a
    successful detach so you can `list_processes` / `attach` again.
+
+### Agent session lifecycle (multi-session + disconnect)
+
+- **Preferred cleanup order:** stop any active recording (`record_stop`) → finish or abandon
+  long `wait_for_*` calls → **`detach`** that `sessionId`. Concurrent ops while detach runs
+  **fail closed** (actionable errors; no hang); do not rely on them succeeding mid-teardown.
+- **Two sessions:** attach A and B independently; detaching A leaves B usable. Post-detach
+  `tree` / `click` / `screenshot` on A fail closed with session-not-found honesty.
+- **Client disconnect ≠ detach.** Killing or restarting the MCP front-end (stdio death, agent
+  process exit) cancels in-flight **front-end** work only. The daemon keeps the target session
+  until an explicit `detach`, CLI `spectre detach <session-id>`, or `spectre daemon kill`. After
+  reconnect, list sessions / reuse the same `sessionId`, or detach deliberately — disconnect
+  does not create undocumented zombies and does not silently detach.
+- **Recovery after front-end death:** `spectre` CLI against the same user daemon
+  (`ps` / attach if needed / `tree` / `detach`), or a new MCP client talking to the same daemon.
 
 Full MCP tool names, input/output schemas, filesystem implications, and capture-mode
 distinctions: [CLI — MCP](cli.md#mcp). MCP detach success JSON is the daemon `Detached` shape

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -337,12 +337,22 @@ Spectre for tree, input, capture, and evidence.
 | Attach | `attach` → retain `sessionId` |
 | Drive | `tree` / `find` / input tools / waits |
 | Capture | `screenshot` (inline image), `capture` (paths on daemon FS), `record_*` (paths) |
-| Release session | **`detach`** with `session_id` — ends that session and returns leftover capture cleanup summary (same honesty as CLI `spectre detach`). Unknown / already-detached / blank `session_id` **fail closed** (`isError`). Detach does **not** delete capture files; prune stays explicit. Use `spectre daemon kill` only when you intend to drop **every** session. |
+| Release session | **`detach`** with `session_id` — ends **that** session only and returns leftover capture cleanup summary (same honesty as CLI `spectre detach`). Unknown / already-detached / blank `session_id` **fail closed** (`isError`). Sibling sessions stay attached. Detach does **not** delete capture files; prune stays explicit. Use `spectre daemon kill` only when you intend to drop **every** session. |
 
-Sessions created by MCP remain in the daemon until `detach`, daemon kill, or daemon
-teardown. Long agent workflows should call **`detach`** when finished so session and native
-resources do not leak. Successful detach leaves the **shared daemon running** so
-`list_processes` and a new `attach` still work.
+Sessions created by MCP remain in the daemon until **`detach`**, daemon kill, or daemon
+teardown. **MCP front-end exit does not detach** — kill/restart the MCP client or drop stdio
+and the daemon session stays until explicit `detach` / CLI / kill. Long agent workflows should
+call **`detach`** when finished so session and native resources do not leak. Successful detach
+leaves the **shared daemon running** so `list_processes` and a new `attach` still work.
+
+**Preferred cleanup order (multi-step agents):**
+
+1. **`record_stop`** if recording is active  
+2. Finish or abandon long **`wait_for_*`** calls  
+3. **`detach`** that `session_id`  
+
+Concurrent tools on a session while `detach` runs **fail closed** (actionable errors; no hang).
+Double-`detach` is the same fail-closed class as an unknown session.
 
 ### Tool inventory
 


### PR DESCRIPTION
## Summary

Hardens MCP/daemon **per-session detach** lifecycle after #399/#411 for multi-session agent workflows ([#413](https://github.com/rock3r/spectre/issues/413), absorbs closed #418).

### Behaviour
- **Two-session isolation:** detach A leaves B operable; A fail-closed; never “kill daemon” / release all.
- **Double-detach / post-detach ops:** second detach and `tree`/`click`/`screenshot` on a released id are `SessionNotFound` with actionable text; no second finalize/close side-effect.
- **Concurrent wait + detach:** detach completes outside the registry monitor after closing the automator so in-flight waits fail closed (no full-budget hang); session gone; new attach healthy. Cheap recording finalize-on-detach covered once.
- **Client disconnect ≠ detach:** one-shot and mid-wait front-end death leave the daemon session listed/operable until explicit detach.
- **Daemon concurrency:** multi-client worker threads so another call can detach while a wait is in flight (unlocks the wait-outside-lock design).
- **Docs:** agent ordering `record_stop` → finish waits → `detach`; disconnect recovery path.

### Non-goals (unchanged)
No detach-all / auto-detach-on-idle; no global cancel product; no #414 Windows matrix; no tag/publish.

## Scenario matrix

| # | Scenario | Result | Where |
|---|---|---|---|
| 1 | Two-session isolation (attach A+B, detach A) | **pass** | `DaemonSessionRegistryTest` |
| 2 | Double-detach honesty + no second side-effect | **pass** | `DaemonSessionRegistryTest` (+ fixture e2e from #399) |
| 3 | Post-detach tree/click/screenshot fail-closed | **pass** | `DaemonSessionRegistryTest` |
| 4 | Concurrent long wait + detach (registry + multi-client) | **pass** | `DaemonSessionRegistryTest`, `DaemonServerTest` |
| 4b | Active recording finalize on detach (unit fake) | **pass** | `DaemonSessionRegistryTest` |
| 5 | Client disconnect ≠ detach (one-shot + mid-wait) | **pass** | `DaemonServerTest` |
| — | `./gradlew check` | **pass** | local |

## Residual risks
- **Recording finalize timing:** concurrent live OS recording during detach is still platform/backend-sensitive; unit path proves finalize-once + no leak. Live multi-fixture recording race is residual (same class as #185 kill-target).
- **Wait fail-closed depends on automator close** propagating (agent IPC / closed handle). Controllable fakes prove the registry contract; a stuck native wait that ignores close could still approach the drain budget (bounded, not infinite).
- **No product-wide wait cancel API** — intentional; close-then-drain only.

## Test plan
- [x] Registry multi-session / double-detach / post-detach / concurrent wait+recording
- [x] DaemonServer disconnect + concurrent multi-client wait/detach
- [x] `./gradlew check` (detekt/ktfmt/tests)
- [x] Docs: `docs/guide/agent.md`, `docs/guide/cli.md` lifecycle

Closes #413