### PR TITLE
feat(smoke): hard-fail multi-OS MCP attach/op/detach lifecycle (#414)

### DIFF
--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -32,21 +32,50 @@ smoke_lib = load_smoke_lib()
 
 
 class McpStdioSmokeTest(unittest.TestCase):
-    def fake_server(self, *, banner: bool = False, version: str = "0.5.0") -> Path:
+    def fake_server(
+        self,
+        *,
+        banner: bool = False,
+        version: str = "0.5.0",
+        tools: list[str] | None = None,
+        lifecycle: bool = False,
+    ) -> Path:
         directory = Path(tempfile.mkdtemp())
         script = directory / "fake.py"
+        # Minimal tool surface for hard-pass without --attach-pid: list + detach + attach + tree.
+        default_tools = ["list_processes", "detach", "attach", "tree"]
+        tool_names = tools if tools is not None else default_tools
+        tools_json = json.dumps([{"name": n} for n in tool_names])
+        # When lifecycle=True, attach returns a session; tree succeeds once; detach ok then gone.
         script.write_text(
             "#!/usr/bin/env python3\n"
             "import json, sys\n"
             f"banner={banner!r}; version={version!r}\n"
+            f"tools={tools_json}\n"
+            f"lifecycle={lifecycle!r}\n"
+            "session=None\n"
+            "detached=False\n"
             "if banner: print('not-json', flush=True)\n"
             "for line in sys.stdin:\n"
             " r=json.loads(line); method=r.get('method')\n"
             " if method=='initialize': result={'protocolVersion':'2025-03-26','capabilities':{'tools':{}},'serverInfo':{'name':'spectre','version':version}}\n"
-            " elif method=='tools/list': result={'tools':[{'name':'list_processes'},{'name':'detach'}]}\n"
+            " elif method=='tools/list': result={'tools':tools}\n"
             " elif method=='tools/call':\n"
             "  name=(r.get('params') or {}).get('name')\n"
-            "  if name=='detach': result={'isError':True,'content':[{'type':'text','text':'session not found'}]}\n"
+            "  args=(r.get('params') or {}).get('arguments') or {}\n"
+            "  if name=='list_processes': result={'content':[{'type':'text','text':'[]'}]}\n"
+            "  elif name=='attach' and lifecycle:\n"
+            "   session='sess-1'; detached=False\n"
+            "   result={'content':[{'type':'text','text':json.dumps({'sessionId':session})}]}\n"
+            "  elif name=='tree' and lifecycle:\n"
+            "   if session and not detached: result={'content':[{'type':'text','text':'tree-ok'}]}\n"
+            "   else: result={'isError':True,'content':[{'type':'text','text':'session not found'}]}\n"
+            "  elif name=='detach':\n"
+            "   sid=args.get('session_id')\n"
+            "   if lifecycle and sid==session and not detached:\n"
+            "    detached=True\n"
+            "    result={'content':[{'type':'text','text':json.dumps({'sessionId':sid,'captureCount':0,'captureBytes':0,'capturePaths':[]})}]}\n"
+            "   else: result={'isError':True,'content':[{'type':'text','text':'session not found'}]}\n"
             "  else: result={'content':[{'type':'text','text':'ok'}]}\n"
             " else: continue\n"
             " print(json.dumps({'jsonrpc':'2.0','id':r['id'],'result':result}), flush=True)\n"
@@ -54,7 +83,7 @@ class McpStdioSmokeTest(unittest.TestCase):
         script.chmod(0o755)
         return script
 
-    def run_smoke(self, server: Path):
+    def run_smoke(self, server: Path, *extra_args: str):
         # Launch the fake server via the same interpreter: Windows cannot exec a
         # shebang-only .py (WinError 193). Production smoke still passes a real
         # packaged spectre binary as the command.
@@ -64,6 +93,7 @@ class McpStdioSmokeTest(unittest.TestCase):
                 str(MCP_SMOKE),
                 "--expected-version",
                 "0.5.0",
+                *extra_args,
                 "--",
                 sys.executable,
                 str(server),
@@ -76,6 +106,8 @@ class McpStdioSmokeTest(unittest.TestCase):
     def test_clean_server_passes(self):
         result = self.run_smoke(self.fake_server())
         self.assertEqual(0, result.returncode, result.stderr)
+        self.assertIn("MCP SMOKE PASS", result.stdout)
+        self.assertIn("tools+unknown-detach", result.stdout)
 
     def test_stdout_pollution_fails(self):
         result = self.run_smoke(self.fake_server(banner=True))
@@ -86,6 +118,45 @@ class McpStdioSmokeTest(unittest.TestCase):
         result = self.run_smoke(self.fake_server(version="0.1.0"))
         self.assertNotEqual(0, result.returncode)
         self.assertIn("server version", result.stderr)
+
+    def test_missing_detach_fails(self):
+        result = self.run_smoke(
+            self.fake_server(tools=["list_processes", "attach", "tree"])
+        )
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("detach", result.stderr)
+
+    def test_unknown_detach_must_be_is_error(self):
+        directory = Path(tempfile.mkdtemp())
+        script = directory / "silent-detach.py"
+        # detach of unknown session silently succeeds — must fail closed.
+        script.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, sys\n"
+            "for line in sys.stdin:\n"
+            " r=json.loads(line); method=r.get('method')\n"
+            " if method=='initialize': result={'protocolVersion':'2025-03-26','capabilities':{'tools':{}},'serverInfo':{'name':'spectre','version':'0.5.0'}}\n"
+            " elif method=='tools/list': result={'tools':[{'name':'list_processes'},{'name':'detach'},{'name':'attach'},{'name':'tree'}]}\n"
+            " elif method=='tools/call':\n"
+            "  result={'content':[{'type':'text','text':'ok'}]}\n"
+            " else: continue\n"
+            " print(json.dumps({'jsonrpc':'2.0','id':r['id'],'result':result}), flush=True)\n"
+        )
+        script.chmod(0o755)
+        result = self.run_smoke(script)
+        self.assertNotEqual(0, result.returncode)
+        self.assertIn("isError", result.stderr)
+
+    def test_attach_pid_lifecycle_passes(self):
+        result = self.run_smoke(
+            self.fake_server(lifecycle=True),
+            "--attach-pid",
+            "12345",
+            "--daemon-user",
+            "mcp-smoke-test-user",
+        )
+        self.assertEqual(0, result.returncode, result.stderr + result.stdout)
+        self.assertIn("attach/tree/detach/session-gone", result.stdout)
 
 
 class SmokeLibSchemaTest(unittest.TestCase):
@@ -287,6 +358,40 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn("runLinuxX11RecordingSmoke", text)
         self.assertIn("verifyMavenLocalPublication", text)
         self.assertIn("LaunchAndAttachIntegration", text)
+        # #414: hard pass requires fixture e2e lifecycle gate, not tools/list alone.
+        self.assertIn("assert_mcp_fixture_e2e_executed", text)
+        self.assertIn("attach/op/detach", text)
+
+    def test_assert_mcp_fixture_e2e_executed_rejects_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            results = root / "cli" / "build" / "test-results" / "test"
+            results.mkdir(parents=True)
+            (results / "TEST-mcp.xml").write_text(
+                '<?xml version="1.0"?>\n'
+                '<testsuite name="DaemonFixture" tests="1" failures="0" errors="0" skipped="1">\n'
+                '  <testcase name="MCP stdio drives a Compose fixture" classname="x">'
+                "<skipped/></testcase>\n"
+                "</testsuite>\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(RuntimeError) as ctx:
+                smoke_lib.assert_mcp_fixture_e2e_executed(root)
+            self.assertIn("skipped", str(ctx.exception).lower())
+
+    def test_assert_mcp_fixture_e2e_executed_accepts_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            results = root / "cli" / "build" / "test-results" / "test"
+            results.mkdir(parents=True)
+            (results / "TEST-mcp.xml").write_text(
+                '<?xml version="1.0"?>\n'
+                '<testsuite name="DaemonFixture" tests="1" failures="0" errors="0" skipped="0">\n'
+                '  <testcase name="MCP stdio drives a Compose fixture" classname="x" time="1.0"/>\n'
+                "</testsuite>\n",
+                encoding="utf-8",
+            )
+            smoke_lib.assert_mcp_fixture_e2e_executed(root)
 
 
 class ReleaseSmokeHelpTest(unittest.TestCase):

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -15,6 +15,7 @@ import org.gradle.api.tasks.application.CreateStartScripts
 import org.gradle.api.tasks.bundling.Zip
 import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.jvm.toolchain.JavaToolchainService
+import org.gradle.process.CommandLineArgumentProvider
 
 plugins {
     application
@@ -476,4 +477,23 @@ tasks.withType<Test>().configureEach {
     providers.systemProperty("spectre.cli.distributionExecutable").orNull?.let { executable ->
         systemProperty("spectre.cli.distributionExecutable", executable)
     }
+    // Same opt-in as :agent:test Windows attach UI e2e. Hosted windows-latest stays skip-safe;
+    // Mattone / interactive desktops pass -Pspectre.agent.attachE2e.allowWindows=true for
+    // DaemonFixtureIntegrationTest MCP/CLI fixture cells (#414).
+    val allowWindowsAttachE2e =
+        providers
+            .gradleProperty("spectre.agent.attachE2e.allowWindows")
+            .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.attachE2e.allowWindows"))
+            .orElse("")
+    inputs.property("spectre.agent.attachE2e.allowWindows", allowWindowsAttachE2e)
+    jvmArgumentProviders.add(
+        CommandLineArgumentProvider {
+            val allowWin = allowWindowsAttachE2e.get().takeIf { it.isNotBlank() }
+            if (allowWin != null) {
+                listOf("-Ddev.sebastiano.spectre.agent.attachE2e.allowWindows=$allowWin")
+            } else {
+                emptyList()
+            }
+        }
+    )
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -39,12 +39,19 @@ import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.condition.EnabledOnOs
 import org.junit.jupiter.api.condition.OS
 
-/** Verifies the daemon owns a real attached agent session across client connections. */
-@EnabledOnOs(OS.LINUX, OS.MAC)
+/**
+ * Verifies the daemon owns a real attached agent session across client connections.
+ *
+ * Linux/macOS run under normal CI when a display is available. Windows fixture attach is opt-in
+ * (same property as agent UI e2e: `-Pspectre.agent.attachE2e.allowWindows=true`) so hosted
+ * `windows-latest` stays skip-safe while Mattone-class desktops can hard-pass MCP lifecycle.
+ */
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
 class DaemonFixtureIntegrationTest {
     @Test
     fun `MCP stdio drives a Compose fixture through attach tree click and inline screenshot`() =
         runBlocking {
+            assumeWindowsDaemonFixtureE2eAllowed()
             assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
             val daemonUser = "spectre-mcp-e2e-${UUID.randomUUID()}"
             val process = startMcpBinary(daemonUser)
@@ -122,6 +129,7 @@ class DaemonFixtureIntegrationTest {
 
     @Test
     fun `CLI binary drives a Compose fixture through ps attach find click and screenshot`() {
+        assumeWindowsDaemonFixtureE2eAllowed()
         assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
         val daemonUser = "spectre-cli-e2e-${UUID.randomUUID()}"
         val screenshot = Files.createTempFile("spectre-cli-e2e-", ".png")
@@ -215,6 +223,7 @@ class DaemonFixtureIntegrationTest {
 
     @Test
     fun `daemon attaches to a real Compose fixture and dispatches operations`() {
+        assumeWindowsDaemonFixtureE2eAllowed()
         assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
         val socketPath = temporaryDaemonFixtureSocketPath()
         var daemon: Process? = null
@@ -480,9 +489,7 @@ private fun runCliBinary(daemonUser: String, vararg arguments: String): CliBinar
                     // Roast launches the bundled JVM directly rather than through Gradle's
                     // generated start script, so it cannot consume SPECTRE_OPTS. The JVM
                     // itself consumes JAVA_TOOL_OPTIONS before application startup.
-                    val daemonHome = Path.of("/tmp", daemonUser)
-                    environment()["JAVA_TOOL_OPTIONS"] =
-                        "-Duser.name=$daemonUser -Duser.home=$daemonHome -Djava.awt.headless=false"
+                    environment()["JAVA_TOOL_OPTIONS"] = daemonIsolationJvmToolOptions(daemonUser)
                 }
             }
             .start()
@@ -527,7 +534,19 @@ private fun runCliBinary(daemonUser: String, vararg arguments: String): CliBinar
     )
 }
 
+/**
+ * Starts the MCP stdio server. When `spectre.cli.distributionExecutable` is set (release-smoke /
+ * packaged path), drives the real Roast binary; otherwise uses the test runtime classpath.
+ */
 private fun startMcpBinary(daemonUser: String): Process {
+    val distributionExecutable = System.getProperty("spectre.cli.distributionExecutable")
+    if (distributionExecutable != null) {
+        return ProcessBuilder(distributionExecutable, "mcp")
+            .apply {
+                environment()["JAVA_TOOL_OPTIONS"] = daemonIsolationJvmToolOptions(daemonUser)
+            }
+            .start()
+    }
     val javaExe =
         if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) "java.exe"
         else "java"
@@ -541,6 +560,42 @@ private fun startMcpBinary(daemonUser: String): Process {
             "mcp",
         )
         .start()
+}
+
+/**
+ * Per-user home for Roast isolation via JAVA_TOOL_OPTIONS.
+ *
+ * Unix uses `/tmp/...` so daemon lock/socket ancestor checks stay within the macOS `/tmp` →
+ * `/private/tmp` symlink exception. [java.io.tmpdir] on macOS is under `/var/folders`, and `/var`
+ * is a symlink that DaemonSocketProtection rejects. Windows has no `/tmp` convention; use the
+ * process temp directory instead.
+ */
+private fun daemonIsolationJvmToolOptions(daemonUser: String): String {
+    val osName = System.getProperty("os.name").orEmpty()
+    val daemonHome =
+        if (osName.startsWith("Windows", ignoreCase = true)) {
+            Path.of(System.getProperty("java.io.tmpdir"), "spectre-daemon-home-$daemonUser")
+        } else {
+            Path.of("/tmp", "spectre-daemon-home-$daemonUser")
+        }
+    Files.createDirectories(daemonHome)
+    return "-Duser.name=$daemonUser -Duser.home=$daemonHome -Djava.awt.headless=false"
+}
+
+/**
+ * Same opt-in as agent attach UI e2e (`WindowsAttachE2eGate`): hosted Windows CI stays skip-safe;
+ * physical desktops pass `-Pspectre.agent.attachE2e.allowWindows=true`.
+ */
+private fun assumeWindowsDaemonFixtureE2eAllowed() {
+    val osName = System.getProperty("os.name").orEmpty()
+    if (!osName.startsWith("Windows", ignoreCase = true)) return
+    assumeTrue(
+        System.getProperty(WINDOWS_ATTACH_E2E_ALLOW_PROP) == "true",
+        "Windows daemon/MCP fixture e2e is opt-in (hosted CI has no reliable interactive desktop). " +
+            "On a physical desktop re-run with " +
+            "\"-Pspectre.agent.attachE2e.allowWindows=true\" " +
+            "(or -D$WINDOWS_ATTACH_E2E_ALLOW_PROP=true on the test JVM).",
+    )
 }
 
 /** Cast attach responses with a useful message when the daemon returns [DaemonResponse.Error]. */
@@ -678,5 +733,8 @@ private const val RECORD_START_TIMEOUT_SECONDS: Long = 10
 private const val RECORD_START_POLL_MILLIS: Long = 100
 private const val RECORD_AFTER_KILL_SETTLE_MILLIS: Long = 1_500
 private const val MIN_PNG_BYTES: Int = 100
+/** Must match agent module `WindowsAttachE2eGate.ALLOW_PROP` / cli test JVM forwarding. */
+private const val WINDOWS_ATTACH_E2E_ALLOW_PROP: String =
+    "dev.sebastiano.spectre.agent.attachE2e.allowWindows"
 private val PNG_MAGIC: ByteArray =
     byteArrayOf(0x89.toByte(), 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -123,7 +123,9 @@ class DaemonFixtureIntegrationTest {
                 process.destroyForcibly()
                 process.waitFor()
                 runCatching { runCliBinary(daemonUser, "daemon", "kill") }
-                deleteDaemonSocketAndParent(DaemonEndpoint.defaultSocketPath(userName = daemonUser))
+                deleteDaemonSocketAndParent(
+                    DaemonEndpoint.defaultSocketPath(userName = socketUserName(daemonUser))
+                )
             }
         }
 
@@ -217,7 +219,9 @@ class DaemonFixtureIntegrationTest {
         } finally {
             runCatching { runCliBinary(daemonUser, "daemon", "kill") }
             Files.deleteIfExists(screenshot)
-            deleteDaemonSocketAndParent(DaemonEndpoint.defaultSocketPath(userName = daemonUser))
+            deleteDaemonSocketAndParent(
+                DaemonEndpoint.defaultSocketPath(userName = socketUserName(daemonUser))
+            )
         }
     }
 
@@ -563,23 +567,44 @@ private fun startMcpBinary(daemonUser: String): Process {
 }
 
 /**
- * Per-user home for Roast isolation via JAVA_TOOL_OPTIONS.
+ * Roast isolation via JAVA_TOOL_OPTIONS.
  *
- * Unix uses `/tmp/...` so daemon lock/socket ancestor checks stay within the macOS `/tmp` →
- * `/private/tmp` symlink exception. [java.io.tmpdir] on macOS is under `/var/folders`, and `/var`
- * is a symlink that DaemonSocketProtection rejects. Windows has no `/tmp` convention; use the
- * process temp directory instead.
+ * Unix uses `/tmp/...` for user.home so daemon lock/socket ancestor checks stay within the macOS
+ * `/tmp` → `/private/tmp` symlink exception (java.io.tmpdir under `/var/folders` is rejected). Fake
+ * `-Duser.name=` isolates the daemon socket (hashed into the path).
+ *
+ * Windows must keep the real OS user.name: EmbeddedAgentRuntime grants ACL read access by looking
+ * up that principal, and a synthetic name fails with "Failed to prepare the agent runtime". Isolate
+ * only via a dedicated temp user.home; teardown still kills the daemon.
  */
 private fun daemonIsolationJvmToolOptions(daemonUser: String): String {
     val osName = System.getProperty("os.name").orEmpty()
+    val windows = osName.startsWith("Windows", ignoreCase = true)
     val daemonHome =
-        if (osName.startsWith("Windows", ignoreCase = true)) {
+        if (windows) {
             Path.of(System.getProperty("java.io.tmpdir"), "spectre-daemon-home-$daemonUser")
         } else {
             Path.of("/tmp", "spectre-daemon-home-$daemonUser")
         }
     Files.createDirectories(daemonHome)
-    return "-Duser.name=$daemonUser -Duser.home=$daemonHome -Djava.awt.headless=false"
+    return if (windows) {
+        "-Duser.home=$daemonHome -Djava.awt.headless=false"
+    } else {
+        "-Duser.name=$daemonUser -Duser.home=$daemonHome -Djava.awt.headless=false"
+    }
+}
+
+/**
+ * Socket-path user for teardown. On Windows Roast isolation keeps the real OS user.name (see
+ * [daemonIsolationJvmToolOptions]); Unix tests hash the synthetic [daemonUser].
+ */
+private fun socketUserName(daemonUser: String): String {
+    val osName = System.getProperty("os.name").orEmpty()
+    return if (osName.startsWith("Windows", ignoreCase = true)) {
+        System.getProperty("user.name")
+    } else {
+        daemonUser
+    }
 }
 
 /**

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -129,8 +129,9 @@ class SpectreMcpStdioIntegrationTest {
                     ),
                     client.listTools().tools.map { it.name }.toSet(),
                 )
-                // Tool invocation (attach → op → detach) is proven by
-                // DaemonFixtureIntegrationTest and scripts/mcp-stdio-smoke.py. Calling
+                // Tool invocation (attach → op → detach → session-gone) is proven by
+                // DaemonFixtureIntegrationTest (including Windows opt-in) and by
+                // scripts/mcp-stdio-smoke.py when --attach-pid is provided. Calling
                 // list_processes here would auto-start the shared per-user daemon and leave
                 // it idle until timeout, which this hermetic protocol test intentionally avoids.
             }

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -221,7 +221,7 @@ Shared across macOS / Linux / Windows entrypoints (`scripts/smoke_lib.py` → `R
 | `cli-packaged` | Release-shaped host CLI packaging |
 | `cli-native-helper-layout` | Native-helper layout in package |
 | `cli-user-flow` | Packaged CLI user flow (ps/attach/tree/input/screenshots/detach) |
-| `mcp-sdk-flow` | Packaged MCP via official SDK / strict stdio |
+| `mcp-sdk-flow` | Packaged MCP attach/op/detach lifecycle + strict stdio |
 | `host-native-recording` | Host native recording smoke |
 | `maven-local-consumer` | Maven Local publication + fresh consumer |
 
@@ -237,7 +237,8 @@ The cross-platform runner covers the stable baseline that should not be reinvent
 - agent attach with preinstalled core, contract corpus, inject, and launch-and-attach
 - release-shaped packaged CLI construction + host native-helper layout checks
 - packaged CLI fixture user flow (ps/attach/find/input/fail-closed window screenshot/fullscreen/detach)
-- packaged MCP via official SDK e2e + strict stdio banner/version smoke
+- packaged MCP via official SDK e2e (**attach → op → detach → session-gone** required for hard
+  pass) + strict stdio (version / tools/list including `detach` / unknown-session detach `isError`)
 - host native recording smoke (macOS SCK region / Linux X11; Windows WGC via interactive PS script)
 - Maven Local `verifyMavenLocalPublication` + fresh consumer jar resolve
 
@@ -286,10 +287,19 @@ release SHA.
 - Full multi-OS operator proof still needs a headed Windows interactive console for WGC and a Linux
   box (Xvfb or real display) for the Unix entrypoint — unit tests + macOS are necessary but not
   sufficient alone for a GO claim on all three OSes.
-- Windows MCP packaged e2e remains hard `n/a` with reason until
-  `DaemonFixtureIntegrationTest` is EnabledOnOs Windows (or a dedicated Windows MCP cell lands).
-- Issue **#399** (MCP per-session detach) is **not** required inside this harness; soft-document
-  only if a scenario already surfaces it.
+- **MCP lifecycle (#399 / #414)** is a **hard cell** on all three entrypoints when packaging is
+  claimed: Unix `release-smoke.py` and Windows `windows-release-smoke.ps1` both require
+  attach → cheap op → detach → session-gone (DaemonFixture MCP e2e) plus strict
+  `mcp-stdio-smoke.py` (tools/list includes `detach`; unknown detach is `isError`). Windows fixture
+  e2e is opt-in with the same `-Pspectre.agent.attachE2e.allowWindows=true` gate as agent UI e2e
+  (hosted `windows-latest` stays skip-safe; Mattone-class interactive desktops hard-pass). Soft
+  hard-`n/a` for “run MCP on Unix only” is no longer valid when packaging is claimed on Windows.
+  Environment-impossible cases (no display, missing Python for the stdio leg, packaging skipped)
+  remain hard `n/a` or `fail` with an explicit reason — never a fake PASS.
+- Optional `mcp-stdio-smoke.py --attach-pid <pid>` proves the same lifecycle over raw stdio when a
+  live fixture PID is available; without a PID the script still fails closed on tools + unknown
+  detach. Release hard pass always rests on the fixture e2e leg for session-gone, not tools/list
+  alone.
 - **#386** (Windows packaged `launch --once` + Gradle `JVM_ATTACHABLE`): product default for
   Gradle-ish launches expands JVM_ATTACHABLE to 120s (matching agent e2e). The Windows one-liner
   `cli-user-flow` may still use Gradle with `--app-name ComposeFixtureMain`; prefer a healthy

--- a/scripts/mcp-stdio-smoke.py
+++ b/scripts/mcp-stdio-smoke.py
@@ -125,20 +125,23 @@ def main() -> None:
 
     env: dict[str, str] | None = None
     if args.daemon_user:
-        # Match DaemonFixture isolation: Unix prefers /tmp (macOS symlink exception);
-        # Windows uses the process temp directory.
+        # Match DaemonFixture isolation:
+        # - Unix: /tmp home + synthetic user.name (socket hash isolation; macOS /tmp symlink OK)
+        # - Windows: dedicated temp home only — keep real user.name so EmbeddedAgentRuntime
+        #   ACL principal lookup succeeds (synthetic names fail agent-runtime install).
         if sys.platform.startswith("win"):
             home = Path(tempfile.gettempdir()) / f"spectre-mcp-smoke-home-{args.daemon_user}"
+            isolation = f"-Duser.home={home} -Djava.awt.headless=false"
         else:
             home = Path("/tmp") / f"spectre-mcp-smoke-home-{args.daemon_user}"
+            isolation = (
+                f"-Duser.name={args.daemon_user} "
+                f"-Duser.home={home} "
+                f"-Djava.awt.headless=false"
+            )
         home.mkdir(parents=True, exist_ok=True)
         env = os.environ.copy()
         existing = env.get("JAVA_TOOL_OPTIONS", "").strip()
-        isolation = (
-            f"-Duser.name={args.daemon_user} "
-            f"-Duser.home={home} "
-            f"-Djava.awt.headless=false"
-        )
         env["JAVA_TOOL_OPTIONS"] = f"{existing} {isolation}".strip()
 
     process = subprocess.Popen(

--- a/scripts/mcp-stdio-smoke.py
+++ b/scripts/mcp-stdio-smoke.py
@@ -1,81 +1,287 @@
 #!/usr/bin/env python3
-"""Fail-closed smoke for a packaged Spectre MCP stdio server."""
+"""Fail-closed smoke for a packaged Spectre MCP stdio server.
+
+Always proves:
+  - initialize serverInfo.version
+  - tools/list includes list_processes + detach
+  - unknown/already-detached detach returns isError (not silent success)
+
+When --attach-pid is provided (live fixture/target), also proves:
+  - attach → cheap session op (tree and/or windows) → detach
+  - subsequent op on that session fails closed (session gone)
+  - second detach on the same id is isError
+  - teardown via `daemon kill` (no leaked idle daemon for the smoke user)
+
+Release-smoke hard cells require the full lifecycle via DaemonFixture e2e (#414);
+this script's fixture path is the portable stdio leg when a PID is available.
+"""
+from __future__ import annotations
+
 import argparse
 import json
+import os
 import subprocess
 import sys
+import tempfile
+from pathlib import Path
+from typing import Any
 
 
-def fail(message: str, process: subprocess.Popen[str]) -> None:
-    process.kill()
+def fail(message: str, process: subprocess.Popen[str] | None = None) -> None:
+    if process is not None and process.poll() is None:
+        process.kill()
     print(f"MCP SMOKE FAIL: {message}", file=sys.stderr)
     raise SystemExit(1)
 
 
+def _read_json_line(process: subprocess.Popen[str], context: str) -> dict[str, Any]:
+    assert process.stdout is not None
+    line = process.stdout.readline()
+    if not line:
+        fail(f"empty stdout while waiting for {context}", process)
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        fail(f"non-JSON stdout for {context}: {line.rstrip()!r}", process)
+        raise  # unreachable; fail() exits
+
+
+def _tool_call(
+    process: subprocess.Popen[str],
+    identifier: int,
+    name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    assert process.stdin is not None
+    process.stdin.write(
+        json.dumps(
+            {
+                "jsonrpc": "2.0",
+                "id": identifier,
+                "method": "tools/call",
+                "params": {"name": name, "arguments": arguments},
+            }
+        )
+        + "\n"
+    )
+    process.stdin.flush()
+    response = _read_json_line(process, f"tools/call {name}")
+    if response.get("id") != identifier or "result" not in response:
+        fail(f"invalid tools/call {name} response: {response}", process)
+    return response["result"]
+
+
+def _assert_tool_ok(result: dict[str, Any], name: str) -> dict[str, Any]:
+    if result.get("isError"):
+        fail(f"{name} must succeed, got isError: {result}")
+    return result
+
+
+def _text_content(result: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for item in result.get("content") or []:
+        if isinstance(item, dict) and item.get("type") == "text":
+            parts.append(str(item.get("text") or ""))
+        elif isinstance(item, dict) and "text" in item:
+            parts.append(str(item["text"]))
+    return "\n".join(parts)
+
+
+def _daemon_kill(command: list[str], env: dict[str, str] | None) -> None:
+    """Best-effort teardown so smoke does not leave an idle daemon for the isolation user."""
+    try:
+        subprocess.run(
+            [*command, "daemon", "kill"],
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=30,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        pass
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--expected-version", required=True)
+    parser.add_argument(
+        "--attach-pid",
+        type=int,
+        default=None,
+        help="When set, prove attach → tree/windows → detach → session-gone on this PID",
+    )
+    parser.add_argument(
+        "--daemon-user",
+        default=None,
+        help="Isolate daemon via JAVA_TOOL_OPTIONS -Duser.name (recommended with --attach-pid)",
+    )
     parser.add_argument("command", nargs=argparse.REMAINDER)
     args = parser.parse_args()
     command = args.command[1:] if args.command[:1] == ["--"] else args.command
     if not command:
         parser.error("executable command required after --")
+
+    env: dict[str, str] | None = None
+    if args.daemon_user:
+        # Match DaemonFixture isolation: Unix prefers /tmp (macOS symlink exception);
+        # Windows uses the process temp directory.
+        if sys.platform.startswith("win"):
+            home = Path(tempfile.gettempdir()) / f"spectre-mcp-smoke-home-{args.daemon_user}"
+        else:
+            home = Path("/tmp") / f"spectre-mcp-smoke-home-{args.daemon_user}"
+        home.mkdir(parents=True, exist_ok=True)
+        env = os.environ.copy()
+        existing = env.get("JAVA_TOOL_OPTIONS", "").strip()
+        isolation = (
+            f"-Duser.name={args.daemon_user} "
+            f"-Duser.home={home} "
+            f"-Djava.awt.headless=false"
+        )
+        env["JAVA_TOOL_OPTIONS"] = f"{existing} {isolation}".strip()
+
     process = subprocess.Popen(
-        [*command, "mcp"], stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE, text=True, bufsize=1,
+        [*command, "mcp"],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        bufsize=1,
+        env=env,
     )
     assert process.stdin and process.stdout
 
-    def request(identifier: int, method: str, params: dict) -> dict:
-        process.stdin.write(json.dumps({"jsonrpc": "2.0", "id": identifier, "method": method, "params": params}) + "\n")
+    def request(identifier: int, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        process.stdin.write(
+            json.dumps({"jsonrpc": "2.0", "id": identifier, "method": method, "params": params})
+            + "\n"
+        )
         process.stdin.flush()
-        line = process.stdout.readline()
-        try:
-            response = json.loads(line)
-        except json.JSONDecodeError:
-            fail(f"non-JSON stdout before {method}: {line.rstrip()!r}", process)
+        response = _read_json_line(process, method)
         if response.get("id") != identifier or "result" not in response:
             fail(f"invalid {method} response: {response}", process)
         return response["result"]
 
-    initialized = request(1, "initialize", {
-        "protocolVersion": "2025-03-26", "capabilities": {},
-        "clientInfo": {"name": "spectre-release-smoke", "version": "1"},
-    })
-    actual = initialized.get("serverInfo", {}).get("version")
-    if actual != args.expected_version:
-        fail(f"server version {actual!r}, expected {args.expected_version!r}", process)
-    process.stdin.write(json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}}) + "\n")
-    process.stdin.flush()
-    tools = request(2, "tools/list", {}).get("tools", [])
-    names = {tool.get("name") for tool in tools}
-    if "list_processes" not in names:
-        fail(f"tools/list missing list_processes: {sorted(names)}", process)
-    if "detach" not in names:
-        fail(f"tools/list missing detach: {sorted(names)}", process)
-    request(3, "tools/call", {"name": "list_processes", "arguments": {}})
-    # Unknown / already-detached session must fail closed (not silent success).
-    process.stdin.write(json.dumps({
-        "jsonrpc": "2.0", "id": 4, "method": "tools/call",
-        "params": {"name": "detach", "arguments": {"session_id": "mcp-smoke-missing-session"}},
-    }) + "\n")
-    process.stdin.flush()
-    detach_line = process.stdout.readline()
     try:
-        detach_response = json.loads(detach_line)
-    except json.JSONDecodeError:
-        fail(f"non-JSON stdout for detach: {detach_line.rstrip()!r}", process)
-    if detach_response.get("id") != 4 or "result" not in detach_response:
-        fail(f"invalid detach response: {detach_response}", process)
-    detach_result = detach_response["result"]
-    if not detach_result.get("isError"):
-        fail(f"detach of unknown session must set isError: {detach_result}", process)
-    process.stdin.close()
-    try:
-        process.wait(timeout=10)
-    except subprocess.TimeoutExpired:
-        fail("server did not exit after stdin closed", process)
-    print(f"MCP SMOKE PASS: version={actual} tools={len(tools)}")
+        initialized = request(
+            1,
+            "initialize",
+            {
+                "protocolVersion": "2025-03-26",
+                "capabilities": {},
+                "clientInfo": {"name": "spectre-release-smoke", "version": "1"},
+            },
+        )
+        actual = initialized.get("serverInfo", {}).get("version")
+        if actual != args.expected_version:
+            fail(f"server version {actual!r}, expected {args.expected_version!r}", process)
+        process.stdin.write(
+            json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized", "params": {}})
+            + "\n"
+        )
+        process.stdin.flush()
+        tools = request(2, "tools/list", {}).get("tools", [])
+        names = {tool.get("name") for tool in tools}
+        if "list_processes" not in names:
+            fail(f"tools/list missing list_processes: {sorted(names)}", process)
+        if "detach" not in names:
+            fail(f"tools/list missing detach: {sorted(names)}", process)
+        if "attach" not in names:
+            fail(f"tools/list missing attach: {sorted(names)}", process)
+        if "tree" not in names and "windows" not in names:
+            fail(f"tools/list missing tree/windows: {sorted(names)}", process)
+
+        next_id = 3
+        _assert_tool_ok(
+            _tool_call(process, next_id, "list_processes", {}),
+            "list_processes",
+        )
+        next_id += 1
+
+        lifecycle = "tools+unknown-detach"
+        if args.attach_pid is not None:
+            attach_result = _assert_tool_ok(
+                _tool_call(process, next_id, "attach", {"pid": args.attach_pid}),
+                "attach",
+            )
+            next_id += 1
+            attach_text = _text_content(attach_result)
+            try:
+                attach_payload = json.loads(attach_text)
+                session_id = attach_payload["sessionId"]
+            except (json.JSONDecodeError, KeyError, TypeError):
+                fail(f"attach did not return sessionId JSON: {attach_text!r}", process)
+                return
+
+            # Cheap session op: prefer tree, fall back to windows.
+            if "tree" in names:
+                _assert_tool_ok(
+                    _tool_call(process, next_id, "tree", {"session_id": session_id}),
+                    "tree",
+                )
+                next_id += 1
+                cheap_op = "tree"
+            else:
+                _assert_tool_ok(
+                    _tool_call(process, next_id, "windows", {"session_id": session_id}),
+                    "windows",
+                )
+                next_id += 1
+                cheap_op = "windows"
+
+            detach_result = _assert_tool_ok(
+                _tool_call(process, next_id, "detach", {"session_id": session_id}),
+                "detach",
+            )
+            next_id += 1
+            detach_text = _text_content(detach_result)
+            try:
+                detach_payload = json.loads(detach_text)
+            except json.JSONDecodeError:
+                fail(f"detach did not return JSON summary: {detach_text!r}", process)
+                return
+            if detach_payload.get("sessionId") != session_id:
+                fail(f"detach summary sessionId mismatch: {detach_payload}", process)
+
+            # Session must be gone: subsequent op fails closed.
+            after = _tool_call(process, next_id, cheap_op, {"session_id": session_id})
+            next_id += 1
+            if not after.get("isError"):
+                fail(f"post-detach {cheap_op} must set isError (session gone): {after}", process)
+
+            double = _tool_call(process, next_id, "detach", {"session_id": session_id})
+            next_id += 1
+            if not double.get("isError"):
+                fail(f"already-detached detach must set isError: {double}", process)
+
+            lifecycle = f"attach/{cheap_op}/detach/session-gone"
+
+        # Unknown / never-attached session must fail closed (not silent success).
+        unknown = _tool_call(
+            process,
+            next_id,
+            "detach",
+            {"session_id": "mcp-smoke-missing-session"},
+        )
+        if not unknown.get("isError"):
+            fail(f"detach of unknown session must set isError: {unknown}", process)
+
+        process.stdin.close()
+        try:
+            process.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            fail("server did not exit after stdin closed", process)
+        print(
+            f"MCP SMOKE PASS: version={actual} tools={len(tools)} lifecycle={lifecycle}",
+            flush=True,
+        )
+    finally:
+        if process.poll() is None:
+            process.kill()
+            process.wait(timeout=5)
+        # Tear down any daemon started by list_processes / attach for the isolation user.
+        _daemon_kill(command, env)
 
 
 if __name__ == "__main__":

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -30,6 +30,7 @@ from smoke_lib import (  # noqa: E402
     RESULT_FAIL,
     RESULT_PASS,
     ScenarioResult,
+    assert_mcp_fixture_e2e_executed,
     build_report,
     collect_preflight,
     gradle_ui_force_args,
@@ -421,7 +422,7 @@ def main(argv: list[str] | None = None) -> int:
         add(
             scenario_result(
                 "mcp-sdk-flow",
-                name="Packaged MCP via official SDK (initialize/tools/list/attach/tree/input/capture)",
+                name="Packaged MCP attach/op/detach lifecycle + strict stdio",
                 result=RESULT_FAIL,
                 detail=f"packaged executable missing: {executable}",
             )
@@ -447,10 +448,12 @@ def main(argv: list[str] | None = None) -> int:
                 overall_deadline=overall_deadline,
             )
         )
-        # MCP via official Kotlin SDK (fixture e2e) + fail-closed stdio banner/version smoke.
+        # MCP via official Kotlin SDK: fixture attach → op → detach session-gone is required
+        # for hard pass after #399/#414 (tools/list + unknown-detach alone is insufficient).
+        mcp_name = "Packaged MCP attach/op/detach lifecycle + strict stdio"
         mcp_sdk = run_scenario(
             "mcp-sdk-flow",
-            name="Packaged MCP via official SDK (initialize/tools/list/attach/tree/input/capture)",
+            name=mcp_name,
             command=[
                 *prefix,
                 gradle,
@@ -468,41 +471,57 @@ def main(argv: list[str] | None = None) -> int:
             overall_deadline=overall_deadline,
         )
         if mcp_sdk.result == RESULT_PASS:
-            strict = run_scenario(
-                "mcp-sdk-flow",
-                name="Packaged MCP strict stdio (banner/version/tools/list)",
-                command=[
-                    sys.executable,
-                    str(ROOT / "scripts" / "mcp-stdio-smoke.py"),
-                    "--expected-version",
-                    args.version,
-                    "--",
-                    str(executable),
-                ],
-                cwd=ROOT,
-                timeout=60,
-                out_dir=out_dir,
-                overall_deadline=overall_deadline,
-            )
-            # Merge seconds/detail: fail closed if either leg fails.
-            if strict.result != RESULT_PASS:
+            # Fail closed if the fixture e2e was assumption-skipped (Gradle exit 0).
+            try:
+                assert_mcp_fixture_e2e_executed(ROOT)
+            except RuntimeError as exc:
                 mcp_sdk = scenario_result(
                     "mcp-sdk-flow",
-                    name=mcp_sdk.name,
+                    name=mcp_name,
                     result=RESULT_FAIL,
-                    seconds=mcp_sdk.seconds + strict.seconds,
-                    detail=f"strict stdio smoke: {strict.detail or strict.result}",
-                    log=strict.log or mcp_sdk.log,
-                )
-            else:
-                mcp_sdk = scenario_result(
-                    "mcp-sdk-flow",
-                    name=mcp_sdk.name,
-                    result=RESULT_PASS,
-                    seconds=mcp_sdk.seconds + strict.seconds,
-                    detail="SDK e2e + strict stdio",
+                    seconds=mcp_sdk.seconds,
+                    detail=str(exc),
                     log=mcp_sdk.log,
                 )
+            else:
+                strict = run_scenario(
+                    "mcp-sdk-flow",
+                    name="Packaged MCP strict stdio (version/tools/list/unknown-detach)",
+                    command=[
+                        sys.executable,
+                        str(ROOT / "scripts" / "mcp-stdio-smoke.py"),
+                        "--expected-version",
+                        args.version,
+                        "--",
+                        str(executable),
+                    ],
+                    cwd=ROOT,
+                    timeout=60,
+                    out_dir=out_dir,
+                    overall_deadline=overall_deadline,
+                )
+                # Merge seconds/detail: fail closed if either leg fails.
+                if strict.result != RESULT_PASS:
+                    mcp_sdk = scenario_result(
+                        "mcp-sdk-flow",
+                        name=mcp_name,
+                        result=RESULT_FAIL,
+                        seconds=mcp_sdk.seconds + strict.seconds,
+                        detail=f"strict stdio smoke: {strict.detail or strict.result}",
+                        log=strict.log or mcp_sdk.log,
+                    )
+                else:
+                    mcp_sdk = scenario_result(
+                        "mcp-sdk-flow",
+                        name=mcp_name,
+                        result=RESULT_PASS,
+                        seconds=mcp_sdk.seconds + strict.seconds,
+                        detail=(
+                            "SDK e2e attach/op/detach session-gone + strict stdio "
+                            "(tools + unknown detach isError)"
+                        ),
+                        log=mcp_sdk.log,
+                    )
         add(mcp_sdk)
 
     # --- host native recording ---

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 import os
 import platform
+import re
 import signal
 import subprocess
 import sys
@@ -656,6 +657,48 @@ def host_cli_package_target(system: str | None = None, machine: str | None = Non
     if system == "Windows":
         return "WindowsX64"
     raise RuntimeError(f"unsupported host for CLI packaging: {system}/{machine}")
+
+
+def assert_mcp_fixture_e2e_executed(root: Path) -> None:
+    """Fail closed if DaemonFixture MCP e2e did not execute attach/op/detach.
+
+    JUnit assumption-skips still yield Gradle exit 0; tools/list-only is not enough for
+    hard mcp-sdk-flow pass after #414. Looks for the MCP fixture testcase in
+    cli/build/test-results/test/TEST-*.xml and rejects skipped/failed runs.
+    """
+    results_dir = root / "cli" / "build" / "test-results" / "test"
+    if not results_dir.is_dir():
+        raise RuntimeError(
+            f"MCP e2e test results missing under {results_dir} (Gradle did not write JUnit XML)"
+        )
+    xml_files = sorted(results_dir.glob("TEST-*.xml"))
+    if not xml_files:
+        raise RuntimeError(f"MCP e2e produced no TEST-*.xml under {results_dir}")
+    found_mcp = False
+    for path in xml_files:
+        try:
+            raw = path.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            raise RuntimeError(f"unable to read {path}: {exc}") from exc
+        if "MCP stdio drives" not in raw:
+            continue
+        found_mcp = True
+        if "<skipped" in raw:
+            raise RuntimeError(
+                "MCP fixture e2e was skipped (assumption); hard pass requires "
+                "attach→op→detach on a headed display (Windows also needs "
+                "-Pspectre.agent.attachE2e.allowWindows=true)"
+            )
+        # failures/errors attributes on testsuite
+        for attr in ("failures", "errors"):
+            match = re.search(rf'{attr}="(\d+)"', raw)
+            if match and int(match.group(1)) > 0:
+                raise RuntimeError(
+                    f"MCP fixture e2e reported {attr}={match.group(1)} in {path.name}"
+                )
+        break
+    if not found_mcp:
+        raise RuntimeError(f"MCP fixture e2e testcase not found in JUnit XML under {results_dir}")
 
 
 def packaged_cli_executable(root: Path, system: str | None = None, machine: str | None = None) -> Path:

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -229,6 +229,63 @@ function Get-PackagedSpectre {
     return $null
 }
 
+function Get-PythonForSmoke {
+    # Prefer a real python.exe (Mattone: Local\Programs\Python\Python313). The `py` launcher
+    # is resolved to sys.executable so Invoke-Native can run the smoke script without -3.
+    $candidates = @("python", "python3", "py")
+    foreach ($name in $candidates) {
+        $cmd = Get-Command $name -ErrorAction SilentlyContinue
+        if ($null -eq $cmd) { continue }
+        $path = [string]$cmd.Source
+        if ([string]::IsNullOrWhiteSpace($path)) { continue }
+        try {
+            if ($name -eq "py") {
+                $exe = & $path -3 -c "import sys; print(sys.executable)" 2>$null
+            }
+            else {
+                $exe = & $path -c "import sys; print(sys.executable)" 2>$null
+            }
+            if ($LASTEXITCODE -ne 0) { continue }
+            $resolved = ([string]$exe).Trim()
+            if (-not [string]::IsNullOrWhiteSpace($resolved) -and (Test-Path -LiteralPath $resolved)) {
+                return $resolved
+            }
+        }
+        catch { }
+    }
+    return $null
+}
+
+function Assert-McpFixtureE2eExecuted {
+    param([Parameter(Mandatory = $true)][string] $RepoRoot)
+    # JUnit XML under cli/build/test-results/test - require the MCP fixture testcase ran
+    # (not skipped). tools/list-only is insufficient for hard pass after #414.
+    $resultsDir = Join-Path $RepoRoot "cli\build\test-results\test"
+    if (-not (Test-Path -LiteralPath $resultsDir)) {
+        throw "MCP e2e test results missing under $resultsDir (Gradle did not write JUnit XML)"
+    }
+    $xmlFiles = @(Get-ChildItem -LiteralPath $resultsDir -Filter "TEST-*.xml" -ErrorAction SilentlyContinue)
+    if ($xmlFiles.Count -eq 0) {
+        throw "MCP e2e produced no TEST-*.xml under $resultsDir"
+    }
+    $foundMcp = $false
+    foreach ($f in $xmlFiles) {
+        $raw = [string](Get-Content -LiteralPath $f.FullName -Raw -ErrorAction SilentlyContinue)
+        if ([string]::IsNullOrWhiteSpace($raw)) { continue }
+        if ($raw -notmatch "MCP stdio drives") { continue }
+        $foundMcp = $true
+        if ($raw -match "<skipped") {
+            throw "MCP fixture e2e was skipped (assumption); hard pass requires attach/op/detach on a headed desktop with -Pspectre.agent.attachE2e.allowWindows=true"
+        }
+        if ($raw -match 'failures="[1-9]' -or $raw -match 'errors="[1-9]') {
+            throw "MCP fixture e2e reported failures/errors in $($f.Name)"
+        }
+    }
+    if (-not $foundMcp) {
+        throw "MCP fixture e2e testcase not found in JUnit XML under $resultsDir"
+    }
+}
+
 function Get-GitText {
     param([string] $RepoRoot, [string[]] $GitArgs)
     try {
@@ -550,14 +607,54 @@ try {
         }
         [void]$results.Add($step)
 
-        [void]$results.Add((New-StepResult -Id "mcp-sdk-flow" -Name "Packaged MCP via official SDK" -Result "n/a" -Reason "MCP packaged e2e is automated on macOS/Linux release-smoke.py; re-run there or extend Windows when DaemonFixtureIntegration is EnabledOnOs Windows"))
+        # #414: hard mcp-sdk-flow when packaging is claimed - attach/op/detach lifecycle via
+        # DaemonFixture MCP e2e (Windows opt-in attach gate) + strict mcp-stdio-smoke.py.
+        $mcpName = "Packaged MCP attach/op/detach lifecycle + strict stdio"
+        if (-not $spectrePath) {
+            [void]$results.Add((New-StepResult -Id "mcp-sdk-flow" -Name $mcpName -Result "fail" -Detail "packaged spectre.exe missing; cannot run MCP lifecycle"))
+        }
+        else {
+            $mcpStep = Invoke-Step -Id "mcp-sdk-flow" -Name $mcpName -Action {
+                # Fixture attach e2e (same opt-in as agent UI cells). Forces re-run so a prior
+                # assumption-skip cannot UP-TO-DATE into a false hard pass.
+                Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $AgentE2eTimeoutSeconds -LogName "mcp-sdk-e2e" -GradleArgs @(
+                    ":cli:test",
+                    "-Pspectre.agent.attachE2e.allowWindows=true",
+                    "--tests", "*DaemonFixtureIntegrationTest.MCP stdio drives*",
+                    "--tests", "*SpectreMcpStdioIntegrationTest*",
+                    ("-Dspectre.cli.distributionExecutable={0}" -f $spectrePath),
+                    "--rerun-tasks",
+                    "--no-build-cache"
+                )
+                # Fail closed if the MCP fixture test was assumption-skipped (no fake PASS).
+                Assert-McpFixtureE2eExecuted -RepoRoot $repoRoot
+                $python = Get-PythonForSmoke
+                if (-not $python) {
+                    throw "Python 3 not found (python/py/python3); required for mcp-stdio-smoke.py strict leg"
+                }
+                $smokeScript = Join-Path $repoRoot "scripts\mcp-stdio-smoke.py"
+                if (-not (Test-Path -LiteralPath $smokeScript)) {
+                    throw "mcp-stdio-smoke.py missing at $smokeScript"
+                }
+                Invoke-Native -FilePath $python -WorkingDirectory $repoRoot -TimeoutSeconds 60 -LogName "mcp-stdio-smoke" -Arguments @(
+                    $smokeScript,
+                    "--expected-version", $Version,
+                    "--",
+                    $spectrePath
+                )
+            }
+            if ($mcpStep.result -eq "pass") {
+                $mcpStep.detail = "SDK e2e attach/op/detach session-gone + strict stdio (tools + unknown detach isError)"
+            }
+            [void]$results.Add($mcpStep)
+        }
     }
     else {
         $reason = "skipped via -SkipCli"
         [void]$results.Add((New-StepResult -Id "cli-packaged" -Name "Release-shaped host CLI package" -Result "n/a" -Reason $reason))
         [void]$results.Add((New-StepResult -Id "cli-native-helper-layout" -Name "Native-helper layout in packaged CLI" -Result "n/a" -Reason $reason))
         [void]$results.Add((New-StepResult -Id "cli-user-flow" -Name "Packaged CLI user flow" -Result "n/a" -Reason $reason))
-        [void]$results.Add((New-StepResult -Id "mcp-sdk-flow" -Name "Packaged MCP via official SDK" -Result "n/a" -Reason $reason))
+        [void]$results.Add((New-StepResult -Id "mcp-sdk-flow" -Name "Packaged MCP attach/op/detach lifecycle + strict stdio" -Result "n/a" -Reason $reason))
     }
 
     if ($SkipMavenLocal) {


### PR DESCRIPTION
## Summary

- Make `mcp-sdk-flow` a hard cell that requires packaged MCP **attach → cheap op → detach → session-gone**, not tools/list alone (absorbs closed #416).
- Enable `DaemonFixtureIntegrationTest` on Windows under the existing `-Pspectre.agent.attachE2e.allowWindows=true` opt-in; drive packaged Roast via `spectre.cli.distributionExecutable`.
- Extend `scripts/mcp-stdio-smoke.py` with optional `--attach-pid` lifecycle + always fail-closed unknown detach; fail closed if `detach`/`attach`/`tree|windows` missing.
- Unix `release-smoke.py` and Windows `windows-release-smoke.ps1` both hard-fail if fixture e2e is assumption-skipped (JUnit XML gate) or strict stdio fails.
- Update `docs/RELEASE-SMOKE.md` residual gaps: MCP lifecycle is no longer soft-document-only; Windows packaged MCP is no longer permanent hard-n/a.

## Proven

| OS | Evidence |
| --- | --- |
| macOS host | Packaged Roast MCP e2e + `mcp-stdio-smoke` (tools+unknown-detach and `--attach-pid` attach/tree/detach/session-gone) |
| Windows Mattone | Packaged `spectre.exe` DaemonFixture MCP e2e (`skipped=0 failures=0`) + `mcp-stdio-smoke`; no leftover spectre process |
| Linux | Same Unix harness wiring as macOS (Xvfb when needed); not re-run this session |

## How to run

See PR comments / `docs/RELEASE-SMOKE.md`. Short form:

```bash
# Unix
./gradlew :cli:packageMacosArm64  # or packageLinuxX64
./gradlew :cli:test --tests '*DaemonFixtureIntegrationTest.MCP stdio drives*' \
  -Dspectre.cli.distributionExecutable=$PWD/cli/build/construo/macosArm64/Spectre.app/Contents/MacOS/spectre
python3 scripts/mcp-stdio-smoke.py --expected-version 0.1.0-SNAPSHOT -- <packaged-spectre>
```

```powershell
# Windows (interactive desktop; Mattone-class)
.\gradlew.bat :cli:packageWindowsX64
.\gradlew.bat :cli:test "-Pspectre.agent.attachE2e.allowWindows=true" `
  --tests "*DaemonFixtureIntegrationTest.MCP stdio drives*" `
  "-Dspectre.cli.distributionExecutable=$PWD\cli\build\construo\windowsX64\roast\spectre.exe"
python scripts\mcp-stdio-smoke.py --expected-version 0.1.0-SNAPSHOT -- .\cli\build\construo\windowsX64\roast\spectre.exe
```

## Residual risks for 0.5.0 three-OS MCP claim

- Hosted `windows-latest` stays skip-safe without opt-in (by design).
- Windows Roast isolation keeps real `user.name` (ACL); concurrent smoke sharing one desktop can contend on the default daemon socket — teardown kills daemon.
- Linux Hyper-V not re-executed here; harness path is identical to macOS Unix entrypoint.
- Multi-session races (#413) and capture-field deep-dive (#415) are out of scope.

Closes #414