### PR TITLE
fix(cli): gate #415 leftovers MCP e2e on Windows attach opt-in

### DIFF
--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -136,6 +136,7 @@ class DaemonFixtureIntegrationTest {
      */
     @Test
     fun `MCP detach reports real capture leftovers and keeps the daemon alive`() = runBlocking {
+        assumeWindowsDaemonFixtureE2eAllowed()
         assumeFalse(GraphicsEnvironment.isHeadless(), "Requires a Compose Desktop display")
         val daemonUser = "spectre-mcp-detach-leftover-${UUID.randomUUID()}"
         val process = startMcpBinary(daemonUser)
@@ -159,7 +160,9 @@ class DaemonFixtureIntegrationTest {
             process.destroyForcibly()
             process.waitFor()
             runCatching { runCliBinary(daemonUser, "daemon", "kill") }
-            deleteDaemonSocketAndParent(DaemonEndpoint.defaultSocketPath(userName = daemonUser))
+            deleteDaemonSocketAndParent(
+                DaemonEndpoint.defaultSocketPath(userName = socketUserName(daemonUser))
+            )
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #421 (#414): the #415 leftovers MCP fixture test was missing the Windows attach e2e opt-in after the class was enabled on Windows, and its teardown deleted the synthetic-user socket path instead of `socketUserName(daemonUser)`.

## Changes

- Call `assumeWindowsDaemonFixtureE2eAllowed()` so hosted `windows-latest` stays skip-safe
- Teardown via `socketUserName(daemonUser)` so Windows Roast (real `user.name`) does not orphan the real-user daemon socket

## Verification

- Structural scan: every fixture attach test has the gate + correct teardown
- `./gradlew :cli:test --tests '*MCP detach reports real capture leftovers*'` green on macOS