### PR TITLE
feat(smoke): harden #398 fail-closed matrix, preflight-only, docs

### DIFF
--- a/.agents/skills/spectre-release/SKILL.md
+++ b/.agents/skills/spectre-release/SKILL.md
@@ -16,16 +16,24 @@ promotion, and undrafting.
 [docs/RELEASE-SMOKE.md](../../../docs/RELEASE-SMOKE.md):
 
 1. Diff since previous tag + capability matrix → baseline hard cells + **delta** hard cells.
-2. Run hard cells on macOS, headed Windows, and Linux as scoped.
-3. On Windows, prefer the one-liner (interactive logon session); see
-   [docs/RELEASE-SMOKE.md](../../../docs/RELEASE-SMOKE.md):
-   - `pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1` when PowerShell 7+ is installed
-   - `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1` on stock WinPS 5.1
-4. Produce a results table. **Hard red or empty hard cells → do not tag.**
-5. Soft cells (Experimental matrix, focus flakes, Hot Reload) may be notes only.
+2. Run the committed one-command harness on each OS (shared stable scenario IDs / `schemaVersion`
+   report under `build/smoke/`):
+   - **macOS / Linux:** `python3 scripts/release-smoke.py --version <X.Y.Z>`
+     → `build/smoke/release-smoke.json` + `.md`
+   - **Windows (interactive desktop for WGC):**
+     - `pwsh -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1` when PowerShell 7+ is installed
+     - `powershell -NoProfile -ExecutionPolicy Bypass -File .\scripts\windows-release-smoke.ps1` on stock WinPS 5.1
+     → `build/smoke/windows-release-smoke.json` + `.md`
+   - Optional wiring check (not a GO): `--preflight-only` / `-PreflightOnly`
+3. Produce a results table from the reports. **Hard red or empty hard cells → do not tag.**
+4. Soft cells (Experimental matrix, focus flakes, Hot Reload) may be notes only.
+5. Manual residual only for TCC/notarization/seal, real Wayland portal, public Homebrew/Scoop/archive,
+   focus/lock keys, multi-monitor/HiDPI, stock IntelliJ — see RELEASE-SMOKE residual list.
 
 Every release needs its own scoped plan (new features + permanent CI gaps such as
-Windows agent inject). Do not skip smoke because `main` CI is green.
+Windows agent inject). Do not skip smoke because `main` CI is green. To add a reusable
+scenario ID, follow **Adding a scenario ID** in [docs/RELEASE-SMOKE.md](../../../docs/RELEASE-SMOKE.md)
+(`REQUIRED_SCENARIO_IDS` + both entrypoints + contract tests) — do not leave commands only in chat.
 
 ## Central Portal Check
 

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -361,6 +361,8 @@ class SmokeLibSchemaTest(unittest.TestCase):
         # #414: hard pass requires fixture e2e lifecycle gate, not tools/list alone.
         self.assertIn("assert_mcp_fixture_e2e_executed", text)
         self.assertIn("attach/op/detach", text)
+        # Package must bake --version so MCP serverInfo matches strict stdio (not SNAPSHOT).
+        self.assertIn("-PVERSION_NAME=", text)
 
     def test_assert_mcp_fixture_e2e_executed_rejects_skipped(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -406,6 +406,46 @@ class ReleaseSmokeHelpTest(unittest.TestCase):
         self.assertIn("--version", result.stdout)
         self.assertIn("--skip-maven-local", result.stdout)
         self.assertIn("--skip-recording", result.stdout)
+        self.assertIn("--preflight-only", result.stdout)
+
+    def test_preflight_only_emits_full_required_matrix_with_na_reason(self):
+        """Drive the real entrypoint: --preflight-only must not invent PASS for hard cells."""
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(RELEASE_SMOKE),
+                    "--version",
+                    "0.5.0",
+                    "--base",
+                    "v0.4.1",
+                    "--preflight-only",
+                    "--out-dir",
+                    str(out),
+                ],
+                text=True,
+                capture_output=True,
+                timeout=30,
+            )
+            self.assertEqual(0, result.returncode, result.stderr + result.stdout)
+            self.assertIn("PREFLIGHT-ONLY", result.stdout)
+            report_path = out / "release-smoke.json"
+            self.assertTrue(report_path.is_file(), result.stdout)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            errors = smoke_lib.validate_report(
+                report, required_ids=smoke_lib.REQUIRED_SCENARIO_IDS
+            )
+            self.assertEqual([], errors, errors)
+            by_id = {row["id"]: row for row in report["scenarios"]}
+            self.assertEqual("pass", by_id["preflight"]["result"])
+            for sid in smoke_lib.REQUIRED_SCENARIO_IDS:
+                if sid == "preflight":
+                    continue
+                self.assertEqual("n/a", by_id[sid]["result"], sid)
+                self.assertIn("preflight-only", by_id[sid]["reason"])
+            # Must not claim a full hard GO.
+            self.assertNotIn("ALL HARD SCENARIOS PASSED", result.stdout)
 
 
 class ReleaseSmokeHelperLogicTest(unittest.TestCase):
@@ -448,6 +488,33 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as ctx:
             self.rs._fresh_consumer_check(ROOT, "0.0.0-does-not-exist-smoke")
         self.assertIn("missing", str(ctx.exception).lower())
+
+
+class DocsAndSchemaPolicyTest(unittest.TestCase):
+    """Docs must document extension + schemaVersion policy so operators need no chat history."""
+
+    def test_release_smoke_docs_extension_and_schema_policy(self):
+        docs = (ROOT / "docs" / "RELEASE-SMOKE.md").read_text(encoding="utf-8")
+        self.assertIn("Adding a scenario ID", docs)
+        self.assertIn("REQUIRED_SCENARIO_IDS", docs)
+        self.assertIn("schemaVersion", docs)
+        self.assertIn("bump", docs.lower())
+        self.assertIn("--preflight-only", docs)
+        self.assertIn("preflight-only", docs)
+
+    def test_validate_report_rejects_missing_required_ids(self):
+        preflight = smoke_lib.collect_preflight(ROOT, version="0.5.0")
+        partial = [
+            smoke_lib.scenario_result("preflight", name="p", result="pass"),
+            smoke_lib.scenario_result("check", name="c", result="pass"),
+        ]
+        report = smoke_lib.build_report(
+            preflight, partial, started_at=smoke_lib.utc_now_iso()
+        )
+        errors = smoke_lib.validate_report(
+            report, required_ids=smoke_lib.REQUIRED_SCENARIO_IDS
+        )
+        self.assertTrue(any("missing required scenario ids" in e for e in errors), errors)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -81,6 +81,12 @@ grep -F -q 'windows-ssh' "$script" || fail "SSH displayMode honesty for WGC miss
 grep -F -q 'WGC requires native interactive console' "$script" || fail "WGC interactive-console N/A reason missing"
 grep -F -q 'displayMode' "$script" || fail "displayMode field missing from Windows harness"
 grep -F -q 'windows-release-smoke.json' "$script" || fail "Windows JSON report path missing"
+# Fail-closed matrix completeness + maven consumer + preflight-only (#398 harden)
+grep -F -q 'RequiredScenarioIds' "$script" || fail "Windows runner missing RequiredScenarioIds constant"
+grep -F -q 'missing required scenario id' "$script" || fail "Windows runner missing fail-closed required-ID validation"
+grep -F -q 'spectre-core-' "$script" || fail "Windows maven-local-consumer missing fresh jar resolve"
+grep -F -q 'PreflightOnly' "$script" || fail "Windows runner missing -PreflightOnly switch"
+grep -F -q 'preflight-only mode' "$script" || fail "Windows preflight-only N/A reason missing"
 
 # --- Optional: parse with pwsh when present (macOS/Linux CI agents may have it) ---
 # Note: this is PowerShell Core parse, not Desktop 5.1; ASCII byte check is the 5.1 stand-in.

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -87,6 +87,7 @@ grep -F -q 'missing required scenario id' "$script" || fail "Windows runner miss
 grep -F -q 'spectre-core-' "$script" || fail "Windows maven-local-consumer missing fresh jar resolve"
 grep -F -q 'PreflightOnly' "$script" || fail "Windows runner missing -PreflightOnly switch"
 grep -F -q 'preflight-only mode' "$script" || fail "Windows preflight-only N/A reason missing"
+grep -F -q -- '-PVERSION_NAME=' "$script" || fail "Windows CLI package must bake -Version into VERSION_NAME for MCP"
 
 # --- Optional: parse with pwsh when present (macOS/Linux CI agents may have it) ---
 # Note: this is PowerShell Core parse, not Desktop 5.1; ASCII byte check is the 5.1 stand-in.

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -183,11 +183,14 @@ Optional flags:
 | `--overall-timeout SECS` | Wall-clock budget for the whole run (default 7200) |
 | `--skip-maven-local` | Skip Maven Local publish + consumer (hard `n/a` with reason) |
 | `--skip-recording` | Skip host native recording smoke (hard `n/a` with reason) |
+| `--preflight-only` | Run only preflight; remaining required IDs are hard `n/a` with reason `preflight-only mode; scenario not executed`. Validates report schema + matrix wiring without a multi-hour GO. **Not a release smoke GO.** |
 
 On Linux it supplies `xvfb-run -a` when `DISPLAY` is unset and records `environment.displayMode`
 as `xvfb-auto` or `real-display:$DISPLAY`. On Windows use the interactive PowerShell runner in the
 next section (shared stable scenario IDs and `schemaVersion` report shape).
 
+**Xvfb ≠ Wayland:** auto-Xvfb proves the X11 path only. Real portal consent/cancel requires a real
+Wayland session (manual cell below).
 ### Report artifacts
 
 Every run writes under `build/smoke/` (or `--out-dir`):
@@ -203,8 +206,44 @@ Report fields of note: `schemaVersion` (currently `1`), `version`, `base`, `sha`
 optional `reason` (required for hard `n/a`), timings, and log path.
 
 **Hard skips are fail-closed:** a hard scenario result of `n/a` without a non-empty `reason` is
-treated as `fail`. Soft cells may use `hard: false`.
+treated as `fail`. Soft cells may use `hard: false`. Missing a required scenario ID is also fail
+(Unix: `validate_report(..., required_ids=REQUIRED_SCENARIO_IDS)`; Windows: `RequiredScenarioIds`
+completeness check before exit).
 
+### schemaVersion bump policy
+
+`schemaVersion` lives in `scripts/smoke_lib.py` (`SCHEMA_VERSION`) and is mirrored as `1` in
+`scripts/windows-release-smoke.ps1`. **Bump only when report field names or semantics change
+incompatibly** (rename/remove a field, change meaning of an existing value). Additive optional
+fields and new scenario IDs do **not** require a bump — keep existing field names stable so older
+report consumers still parse. When you bump:
+
+1. Update `SCHEMA_VERSION` in `smoke_lib.py` and the Windows report writer.
+2. Extend `validate_report` / contract tests for the new shape.
+3. Note the bump in the release record so operators do not compare v1 and v2 rows as identical.
+
+### Adding a scenario ID (per-release delta or permanent baseline)
+
+Do **not** leave a one-release command only in chat. To add a reusable cell:
+
+1. Append a stable kebab-case ID to `REQUIRED_SCENARIO_IDS` in `scripts/smoke_lib.py` (or document
+   it as a **soft / delta-only** cell if it is not required on every cut — soft cells use
+   `hard: false` and need not be in `REQUIRED_SCENARIO_IDS`).
+2. Register the same ID on **both** entrypoints:
+   - Unix: `scripts/release-smoke.py` (`run_scenario` / `run_callable_scenario` / explicit
+     hard `n/a` with reason).
+   - Windows: `scripts/windows-release-smoke.ps1` (`RequiredScenarioIds` array + step that emits
+     the row; environment-impossible → hard `n/a` with reason, never silent omit).
+3. Extend contract tests:
+   - `.github/scripts/test-release-smoke-scripts.py` (`test_required_scenario_ids_are_stable`,
+     wiring asserts, any new fail-closed rule).
+   - `.github/scripts/test-windows-release-smoke-script.sh` (ID presence + any new policy needles).
+4. Document the cell in the stable scenario table above and in the automated-vs-manual matrix.
+5. Prefer forcing live UI with `gradle_ui_force_args()` / `--rerun-tasks --no-build-cache` when the
+   cell is UI-backed so cache-only cannot fake PASS.
+
+Per-release **delta** cells that will not stay permanent may live in
+`.plans/<version>-smoke.md` as manual recipes; promote them into the runner when they repeat.
 ### Stable scenario IDs
 
 Shared across macOS / Linux / Windows entrypoints (`scripts/smoke_lib.py` → `REQUIRED_SCENARIO_IDS`):
@@ -364,7 +403,7 @@ Flags:
 | `-SkipCli` | Skip package + `spectre launch` |
 | `-SkipPackageCli` | Reuse existing `spectre.exe` (still runs launch) |
 | `-SkipMavenLocal` | Skip Maven Local publication smoke |
-
+| `-PreflightOnly` | Preflight + full required-ID matrix as hard `n/a` with reason (schema self-check). **Not a release GO.** |
 This is **manual, operator-driven** automation — not hosted CI. Use it so release smoke is
 not multi-terminal faff. Prefer the logged-in interactive console for any WGC cell.
 

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -323,16 +323,21 @@ release SHA.
 
 ### Residual gaps for the 0.5.0 cut
 
-- Full multi-OS operator proof still needs a headed Windows interactive console for WGC and a Linux
-  box (Xvfb or real display) for the Unix entrypoint — unit tests + macOS are necessary but not
-  sufficient alone for a GO claim on all three OSes.
+- **Harness baseline (#398):** committed one-command entrypoints + shared `REQUIRED_SCENARIO_IDS`
+  + fail-closed reports are on main. Operator multi-OS proof for a given SHA should attach
+  `build/smoke/release-smoke.json` / `.md` (macOS + Linux) and `windows-release-smoke.json` /
+  `.md` (Windows) — not chat-only PASS. Use `--preflight-only` / `-PreflightOnly` only to
+  validate wiring; it is **not** a release GO.
+- **WGC / host-native-recording on Windows:** hard pass only from an **interactive desktop**
+  console. SSH runs must record hard `n/a` with reason (`displayMode: windows-ssh`) — never
+  treat SSH as visual PASS evidence.
 - **MCP lifecycle (#399 / #414)** is a **hard cell** on all three entrypoints when packaging is
   claimed: Unix `release-smoke.py` and Windows `windows-release-smoke.ps1` both require
   attach → cheap op → detach → session-gone (DaemonFixture MCP e2e) plus strict
-  `mcp-stdio-smoke.py` (tools/list includes `detach`; unknown detach is `isError`). Windows fixture
-  e2e is opt-in with the same `-Pspectre.agent.attachE2e.allowWindows=true` gate as agent UI e2e
-  (hosted `windows-latest` stays skip-safe; Mattone-class interactive desktops hard-pass). Soft
-  hard-`n/a` for “run MCP on Unix only” is no longer valid when packaging is claimed on Windows.
+  `mcp-stdio-smoke.py` (tools/list includes `detach`; unknown detach is `isError`). Packaging and
+  the MCP Gradle leg bake `-PVERSION_NAME=<smoke --version>` so `serverInfo.version` matches
+  `--expected-version`. Windows fixture e2e is opt-in with
+  `-Pspectre.agent.attachE2e.allowWindows=true` (hosted `windows-latest` stays skip-safe).
   Environment-impossible cases (no display, missing Python for the stdio leg, packaging skipped)
   remain hard `n/a` or `fail` with an explicit reason — never a fake PASS.
 - Optional `mcp-stdio-smoke.py --attach-pid <pid>` proves the same lifecycle over raw stdio when a
@@ -344,6 +349,9 @@ release SHA.
   `cli-user-flow` may still use Gradle with `--app-name ComposeFixtureMain`; prefer a healthy
   UP-TO-DATE fixture build so cold daemon start alone fits the budget. Prod-like launch remains
   the troubleshooting recommendation when Gradle is slow or flaky.
+- **Manual residual (not auto-green):** TCC / notarization / app seal; real Wayland portal
+  (Xvfb ≠ Wayland); public Homebrew/Scoop/archive after undraft; focus/lock keys; multi-monitor /
+  HiDPI; stock IntelliJ inject.
 
 ## Windows one-liner script
 

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -220,6 +220,14 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Skip host native recording smoke (records hard n/a with reason)",
     )
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help=(
+            "Run only preflight and emit a full required-ID report with remaining "
+            "scenarios as hard n/a (reason: preflight-only). Not a release GO."
+        ),
+    )
     args = parser.parse_args(argv)
 
     system = platform.system()
@@ -258,10 +266,54 @@ def main(argv: list[str] | None = None) -> int:
     results.append(preflight_result)
     _print_result(preflight_result)
 
+    if args.preflight_only:
+        # Schema/orchestration self-check: every required ID present, none silently omitted.
+        # Remaining cells are explicit hard n/a so validate_report(required_ids=...) holds.
+        for sid in REQUIRED_SCENARIO_IDS:
+            if sid == "preflight":
+                continue
+            results.append(
+                scenario_result(
+                    sid,
+                    name=f"{sid} (not executed)",
+                    result="n/a",
+                    reason="preflight-only mode; scenario not executed",
+                    hard=True,
+                )
+            )
+            _print_result(results[-1])
+        finished_at = utc_now_iso()
+        overall_seconds = int(time.monotonic() - wall_start)
+        report = build_report(
+            preflight,
+            results,
+            started_at=started_at,
+            finished_at=finished_at,
+            overall_seconds=overall_seconds,
+        )
+        schema_errors = validate_report(report, required_ids=list(REQUIRED_SCENARIO_IDS))
+        json_path = out_dir / "release-smoke.json"
+        md_path = out_dir / "release-smoke.md"
+        write_json_report(json_path, report)
+        write_markdown_report(md_path, report)
+        print(f"Report JSON: {json_path}")
+        print(f"Report MD:   {md_path}")
+        print(f"displayMode: {preflight.environment.display_mode}")
+        print(f"SHA: {preflight.sha}  dirty={preflight.dirty}")
+        if schema_errors:
+            print("REPORT SCHEMA ERRORS:", file=sys.stderr)
+            for err in schema_errors:
+                print(f"  - {err}", file=sys.stderr)
+            return 2
+        if preflight_result.result == RESULT_FAIL:
+            print("PREFLIGHT-ONLY FAILED")
+            return 1
+        print("PREFLIGHT-ONLY OK (not a full release smoke GO)")
+        return 0
+
     gradle = str(ROOT / "gradlew")
     prefix = xvfb_prefix(system)
     force = gradle_ui_force_args()
-
     def add(item: ScenarioResult) -> None:
         results.append(item)
         _print_result(item)

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -430,11 +430,18 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     # --- CLI package + native helper layout ---
+    # Bake --version into the package so MCP serverInfo.version matches strict stdio
+    # (default gradle.properties VERSION_NAME is 0.1.0-SNAPSHOT on main).
     target = host_cli_package_target(system)
     package_result = run_scenario(
         "cli-packaged",
         name=f"Release-shaped host CLI package (:cli:package{target})",
-        command=[gradle, f":cli:package{target}", "--console=plain"],
+        command=[
+            gradle,
+            f":cli:package{target}",
+            f"-PVERSION_NAME={args.version}",
+            "--console=plain",
+        ],
         cwd=ROOT,
         timeout=900,
         out_dir=out_dir,

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -517,6 +517,9 @@ def main(argv: list[str] | None = None) -> int:
                 *prefix,
                 gradle,
                 ":cli:test",
+                # Same VERSION_NAME as package so SpectreMcpStdioIntegrationTest
+                # expectedMcpVersion() matches packaged serverInfo.version.
+                f"-PVERSION_NAME={args.version}",
                 "--tests",
                 "*DaemonFixtureIntegrationTest.MCP stdio drives*",
                 "--tests",

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -19,7 +19,10 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Mapping, MutableMapping, Sequence
 
-# Bump only when report field semantics change incompatibly.
+# Bump only when report field names/semantics change incompatibly (rename/remove a field,
+# or change meaning of an existing value). Additive optional fields and new scenario IDs
+# do not require a bump — keep field names stable. Mirror the integer in
+# scripts/windows-release-smoke.ps1 and update contract tests + docs/RELEASE-SMOKE.md.
 SCHEMA_VERSION = 1
 
 # Stable scenario IDs shared across macOS / Linux / Windows. Every automated run

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -650,6 +650,9 @@ try {
                 # assumption-skip cannot UP-TO-DATE into a false hard pass.
                 Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $AgentE2eTimeoutSeconds -LogName "mcp-sdk-e2e" -GradleArgs @(
                     ":cli:test",
+                    # Same VERSION_NAME as package so SpectreMcpStdioIntegrationTest
+                    # expectedMcpVersion() matches packaged serverInfo.version.
+                    ("-PVERSION_NAME={0}" -f $Version),
                     "-Pspectre.agent.attachE2e.allowWindows=true",
                     "--tests", "*DaemonFixtureIntegrationTest.MCP stdio drives*",
                     "--tests", "*SpectreMcpStdioIntegrationTest*",

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -39,6 +39,9 @@ param(
     [switch] $SkipPackageCli,
     [switch] $SkipCheck,
     [switch] $SkipMavenLocal,
+    # Schema/preflight self-check only: remaining required IDs are hard n/a with reason.
+    # Not a release GO.
+    [switch] $PreflightOnly,
     [ValidateRange(1, 86400)][int] $AgentE2eTimeoutSeconds = 900,
     [ValidateRange(1, 86400)][int] $WgcTimeoutSeconds = 300,
     [ValidateRange(1, 86400)][int] $PackageCliTimeoutSeconds = 900,
@@ -47,6 +50,22 @@ param(
     [ValidateRange(1, 86400)][int] $MavenLocalTimeoutSeconds = 1200
 )
 
+# Must match scripts/smoke_lib.py REQUIRED_SCENARIO_IDS (fail-closed matrix completeness).
+$script:RequiredScenarioIds = @(
+    "preflight",
+    "check",
+    "junit-live",
+    "agent-attach-core",
+    "agent-contract-corpus",
+    "agent-inject",
+    "agent-launch-and-attach",
+    "cli-packaged",
+    "cli-native-helper-layout",
+    "cli-user-flow",
+    "mcp-sdk-flow",
+    "host-native-recording",
+    "maven-local-consumer"
+)
 $ErrorActionPreference = "Stop"
 # Avoid StrictMode edge cases with dynamic PSCustomObject / native interop on WinPS 5.1.
 Set-StrictMode -Version 1
@@ -475,7 +494,15 @@ try {
     }
     [void]$results.Add($pre)
 
-    if ($SkipCheck) {
+    if ($PreflightOnly) {
+        # Schema/orchestration self-check: every required ID present; none silently omitted.
+        foreach ($sid in $script:RequiredScenarioIds) {
+            if ($sid -eq "preflight") { continue }
+            [void]$results.Add((New-StepResult -Id $sid -Name ("{0} (not executed)" -f $sid) -Result "n/a" -Reason "preflight-only mode; scenario not executed"))
+        }
+        Write-Host "PREFLIGHT-ONLY: remaining scenarios recorded as hard n/a (not a full release smoke GO)" -ForegroundColor Yellow
+    }
+    elseif ($SkipCheck) {
         [void]$results.Add((New-StepResult -Id "check" -Name "./gradlew check" -Result "n/a" -Reason "skipped via -SkipCheck"))
     }
     else {
@@ -485,6 +512,7 @@ try {
         [void]$results.Add($step)
     }
 
+    if (-not $PreflightOnly) {
     # Live JUnit is Unix-primary in release-smoke.py; on Windows record explicit N/A unless expanded.
     [void]$results.Add((New-StepResult -Id "junit-live" -Name "Live JUnit failure artifacts/video and atomic capture" -Result "n/a" -Reason "Windows entrypoint prioritizes agent/WGC/CLI; run sample-desktop validationTest on macOS/Linux baseline"))
 
@@ -662,19 +690,32 @@ try {
     }
     else {
         $smokeVersion = ("{0}-rc.smoke" -f $Version)
-        $step = Invoke-Step -Id "maven-local-consumer" -Name "Maven Local publication + shape verify" -Action {
+        $step = Invoke-Step -Id "maven-local-consumer" -Name "Maven Local publication + fresh consumer" -Action {
             Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $MavenLocalTimeoutSeconds -LogName "maven-local" -GradleArgs @(
                 "verifyMavenLocalPublication",
                 ("-PVERSION_NAME={0}" -f $smokeVersion),
                 "-PstubMacHelperForTesting"
             )
+            # Fresh consumer: resolve published core jar from Maven Local (parity with Unix).
+            $jar = Join-Path $env:USERPROFILE (".m2\repository\dev\sebastiano\spectre\spectre-core\{0}\spectre-core-{0}.jar" -f $smokeVersion)
+            if (-not (Test-Path -LiteralPath $jar)) {
+                throw ("Maven Local core jar missing after publish: {0}" -f $jar)
+            }
+            $len = [int64](Get-Item -LiteralPath $jar).Length
+            if ($len -lt 1024) {
+                throw ("Maven Local core jar unexpectedly tiny ({0} bytes): {1}" -f $len, $jar)
+            }
+            Write-Host ("  maven local jar: {0} ({1} bytes)" -f $jar, $len) -ForegroundColor DarkGray
         }
         [void]$results.Add($step)
     }
 
+    } # end -not $PreflightOnly
+
     Write-Host ""
     Write-Host "==== Summary ====" -ForegroundColor White
     $failCount = 0
+    $seenIds = @{}
     foreach ($r in $results) {
         if ($null -eq $r) {
             Write-Host "FAIL   <null step result>" -ForegroundColor Red
@@ -682,6 +723,7 @@ try {
             continue
         }
         $id = [string]$r.id
+        if (-not [string]::IsNullOrWhiteSpace($id)) { $seenIds[$id] = $true }
         $result = [string]$r.result
         $secs = [int]$r.seconds
         $detail = [string]$r.detail
@@ -705,6 +747,16 @@ try {
         }
     }
 
+    # Fail-closed: every required stable ID must appear (no silent omit). Matches Unix validate_report.
+    $missingIds = @()
+    foreach ($req in $script:RequiredScenarioIds) {
+        if (-not $seenIds.ContainsKey($req)) {
+            $missingIds += $req
+            Write-Host ("FAIL   missing required scenario id: {0}" -f $req) -ForegroundColor Red
+            $failCount++
+        }
+    }
+
     $wall.Stop()
     $finishedAt = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
     $outDir = Join-Path $repoRoot "build\smoke"
@@ -715,8 +767,17 @@ try {
     Write-Host ("Logs:        {0}" -f $outDir)
 
     if ($failCount -gt 0) {
-        Write-Host ("FAILED ({0} hard step(s))" -f $failCount) -ForegroundColor Red
+        if ($missingIds.Count -gt 0) {
+            Write-Host ("FAILED (missing required scenario id(s): {0})" -f ($missingIds -join ", ")) -ForegroundColor Red
+        }
+        else {
+            Write-Host ("FAILED ({0} hard step(s))" -f $failCount) -ForegroundColor Red
+        }
         exit 1
+    }
+    if ($PreflightOnly) {
+        Write-Host "PREFLIGHT-ONLY OK (not a full release smoke GO)" -ForegroundColor Yellow
+        exit 0
     }
     Write-Host "ALL HARD SCENARIOS PASSED (or explicit N/A with reason)" -ForegroundColor Green
     exit 0

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -586,8 +586,11 @@ try {
     if (-not $SkipCli) {
         if (-not $SkipPackageCli) {
             $step = Invoke-Step -Id "cli-packaged" -Name "Release-shaped host CLI package (packageWindowsX64)" -Action {
+                # Bake -Version into the package so MCP serverInfo.version matches strict stdio
+                # (default gradle.properties VERSION_NAME is 0.1.0-SNAPSHOT on main).
                 Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $PackageCliTimeoutSeconds -LogName "package-cli" -GradleArgs @(
-                    ":cli:packageWindowsX64"
+                    ":cli:packageWindowsX64",
+                    ("-PVERSION_NAME={0}" -f $Version)
                 )
             }
             [void]$results.Add($step)


### PR DESCRIPTION
## Summary

Finishes #398 harness hardening on the existing foundation (#405/#409/#410/#414) — not a rewrite.

- **Windows fail-closed matrix:** `RequiredScenarioIds` completeness check before exit (no silent omit); matches Unix `validate_report(..., required_ids=...)`.
- **Windows maven-local-consumer:** after `verifyMavenLocalPublication`, resolve `spectre-core-*-rc.smoke.jar` from Maven Local (parity with Unix `_fresh_consumer_check`).
- **`--preflight-only` / `-PreflightOnly`:** schema + preflight self-check; remaining required IDs are hard `n/a` with explicit reason — **not** a release GO.
- **Docs:** schemaVersion bump policy, “Adding a scenario ID” extension steps, Xvfb ≠ Wayland note, flag tables; spectre-release skill one-command paths for all OSes.
- **Contract tests:** drive real `--preflight-only` entrypoint; missing-ID validation; docs needles; Windows script policy greps.

## Audit → harden (brief)

| Gap | Fix |
| --- | --- |
| Windows exit without required-ID set check | `RequiredScenarioIds` + fail if missing |
| Windows maven no jar consumer | jar existence + size after publish |
| No dry-run for wiring | `--preflight-only` / `-PreflightOnly` |
| Docs missing extension/schema policy | RELEASE-SMOKE sections + skill |

## Test plan

- [x] `python3 .github/scripts/test-release-smoke-scripts.py` (32 tests)
- [x] `bash .github/scripts/test-windows-release-smoke-script.sh`
- [x] Linux + Windows preflight-only on lab hosts @ `82251ce`
- [ ] Full multi-OS smoke (macOS host, Linux Hyper-V sebnux, Windows Mattone) — running; reports archived for issue close

## Residual manual (unchanged class)

TCC/notarization/seal, real Wayland portal, public Homebrew/Scoop/archive, focus/lock keys, multi-monitor/HiDPI, stock IntelliJ; WGC requires interactive desktop (SSH → hard n/a).

Closes nothing until multi-OS proof is attached — recommendation in issue comment after runs.