### PR TITLE
fix(smoke): Windows SSH attach n/a + symlink-guard assume

### DIFF
--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -79,6 +79,7 @@ do
 done
 grep -F -q 'windows-ssh' "$script" || fail "SSH displayMode honesty for WGC missing"
 grep -F -q 'WGC requires native interactive console' "$script" || fail "WGC interactive-console N/A reason missing"
+grep -F -q 'AgentAttachIntegration e2e includes WGC node screenshots' "$script" || fail "SSH agent-attach-core hard n/a reason missing"
 grep -F -q 'displayMode' "$script" || fail "displayMode field missing from Windows harness"
 grep -F -q 'windows-release-smoke.json' "$script" || fail "Windows JSON report path missing"
 # Fail-closed matrix completeness + maven consumer + preflight-only (#398 harden)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -677,19 +677,19 @@ class DaemonServerTest {
  */
 private fun assumeCanCreateSymbolicLinks() {
     val probeDir = Files.createTempDirectory("spectre-symlink-probe")
-    val canCreate =
-        try {
-            val link = probeDir.resolve("link")
-            Files.createSymbolicLink(link, probeDir.resolve("target-does-not-need-to-exist"))
-            Files.deleteIfExists(link)
-            true
-        } catch (_: java.nio.file.FileSystemException) {
-            false
-        } catch (_: UnsupportedOperationException) {
-            false
-        } finally {
-            Files.deleteIfExists(probeDir)
-        }
+    var canCreate = false
+    try {
+        val link = probeDir.resolve("link")
+        Files.createSymbolicLink(link, probeDir.resolve("target-does-not-need-to-exist"))
+        Files.deleteIfExists(link)
+        canCreate = true
+    } catch (_: java.nio.file.FileSystemException) {
+        canCreate = false
+    } catch (_: UnsupportedOperationException) {
+        canCreate = false
+    } finally {
+        Files.deleteIfExists(probeDir)
+    }
     assumeTrue(
         canCreate,
         "Host cannot create symbolic links (Windows: enable Developer Mode or grant " +

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -15,6 +15,7 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
 
 @OptIn(ExperimentalSpectreAgentApi::class)
 class DaemonServerTest {
@@ -347,6 +348,7 @@ class DaemonServerTest {
 
     @Test
     fun `preserves a dangling symlink in the socket path`() {
+        assumeCanCreateSymbolicLinks()
         val temporaryDirectory = Files.createTempDirectory("spectre-daemon-test")
         val danglingLink = temporaryDirectory.resolve("link")
         Files.createSymbolicLink(danglingLink, temporaryDirectory.resolve("missing-target"))
@@ -364,6 +366,7 @@ class DaemonServerTest {
 
     @Test
     fun `refuses a socket parent that is a symbolic link`() {
+        assumeCanCreateSymbolicLinks()
         val temporaryDirectory = Files.createTempDirectory("spectre-daemon-test")
         val socketDirectory = Files.createDirectory(temporaryDirectory.resolve("socket-directory"))
         val socketLink = temporaryDirectory.resolve("socket-link")
@@ -665,6 +668,34 @@ class DaemonServerTest {
     }
 
     // endregion
+}
+
+/**
+ * Windows requires Developer Mode or SeCreateSymbolicLinkPrivilege for [Files.createSymbolicLink].
+ * Without it the probe throws [java.nio.file.FileSystemException] and symlink-guard unit tests must
+ * assumption-skip rather than fail closed the whole `check` gate.
+ */
+private fun assumeCanCreateSymbolicLinks() {
+    val probeDir = Files.createTempDirectory("spectre-symlink-probe")
+    val canCreate =
+        try {
+            val link = probeDir.resolve("link")
+            Files.createSymbolicLink(link, probeDir.resolve("target-does-not-need-to-exist"))
+            Files.deleteIfExists(link)
+            true
+        } catch (_: java.nio.file.FileSystemException) {
+            false
+        } catch (_: UnsupportedOperationException) {
+            false
+        } finally {
+            Files.deleteIfExists(probeDir)
+        }
+    assumeTrue(
+        canCreate,
+        "Host cannot create symbolic links (Windows: enable Developer Mode or grant " +
+            "SeCreateSymbolicLinkPrivilege). Symlink socket-parent guards stay covered on hosts " +
+            "that can create links.",
+    )
 }
 
 private fun temporarySocketPath(): Path =

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -331,6 +331,10 @@ release SHA.
 - **WGC / host-native-recording on Windows:** hard pass only from an **interactive desktop**
   console. SSH runs must record hard `n/a` with reason (`displayMode: windows-ssh`) — never
   treat SSH as visual PASS evidence.
+- **`agent-attach-core` on Windows SSH:** `AgentAttachIntegration` e2e includes WGC node
+  screenshots (#362). Under `windows-ssh` the harness records hard `n/a` with reason (same class
+  as WGC recording). Re-run from an interactive console for hard PASS of attach screenshot parity.
+  Inject / launch-and-attach remain SSH-runnable semantics cells.
 - **MCP lifecycle (#399 / #414)** is a **hard cell** on all three entrypoints when packaging is
   claimed: Unix `release-smoke.py` and Windows `windows-release-smoke.ps1` both require
   attach → cheap op → detach → session-gone (DaemonFixture MCP e2e) plus strict

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -517,16 +517,24 @@ try {
     [void]$results.Add((New-StepResult -Id "junit-live" -Name "Live JUnit failure artifacts/video and atomic capture" -Result "n/a" -Reason "Windows entrypoint prioritizes agent/WGC/CLI; run sample-desktop validationTest on macOS/Linux baseline"))
 
     if (-not $SkipAgentE2e) {
-        $step = Invoke-Step -Id "agent-attach-core" -Name "Agent attach with preinstalled core" -Action {
-            Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $AgentE2eTimeoutSeconds -LogName "agent-attach" -GradleArgs @(
-                ":agent:test",
-                "-Pspectre.agent.attachE2e.allowWindows=true",
-                "--tests", "*AgentAttachIntegration*",
-                "--rerun-tasks",
-                "--no-build-cache"
-            )
+        # AgentAttachIntegration e2e includes WGC node screenshots (#362). Under SSH that is the
+        # same environment-impossible class as host-native-recording -- hard n/a, never fake PASS.
+        $attachDisplayMode = Get-DisplayModeWindows
+        if ($attachDisplayMode -eq "windows-ssh") {
+            [void]$results.Add((New-StepResult -Id "agent-attach-core" -Name "Agent attach with preinstalled core" -Result "n/a" -Reason "AgentAttachIntegration e2e includes WGC node screenshots; SSH cannot provide honest visual evidence (exit 5 / 0x80070424). Re-run from interactive console for hard PASS"))
         }
-        [void]$results.Add($step)
+        else {
+            $step = Invoke-Step -Id "agent-attach-core" -Name "Agent attach with preinstalled core" -Action {
+                Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $AgentE2eTimeoutSeconds -LogName "agent-attach" -GradleArgs @(
+                    ":agent:test",
+                    "-Pspectre.agent.attachE2e.allowWindows=true",
+                    "--tests", "*AgentAttachIntegration*",
+                    "--rerun-tasks",
+                    "--no-build-cache"
+                )
+            }
+            [void]$results.Add($step)
+        }
 
         [void]$results.Add((New-StepResult -Id "agent-contract-corpus" -Name "Agent contract corpus" -Result "n/a" -Reason "Windows agent corpus is covered by attach/inject/launch cells; full AgentContractCorpus stays on Linux/macOS Xvfb matrix"))
 


### PR DESCRIPTION
## Summary

Follow-up for #398 multi-OS proof honesty:

1. **Windows SSH `agent-attach-core`:** hard `n/a` with explicit reason when `displayMode` is `windows-ssh` — the e2e includes WGC node screenshots which cannot provide honest visual evidence over SSH (same class as `host-native-recording`).
2. **DaemonServer symlink tests:** `assumeCanCreateSymbolicLinks()` so hosts without symlink privilege (common Windows without Developer Mode) assumption-skip rather than fail `./gradlew check`.

Interactive Mattone console already proved `agent-attach-core` + `host-native-recording` PASS at `6099594`.

## Test plan

- [x] `:cli:test --tests DaemonServerTest`
- [x] `bash .github/scripts/test-windows-release-smoke-script.sh`
- [ ] Windows interactive re-smoke after merge for full green report