### PR TITLE
ci: add on-demand macOS notarization

### DIFF
--- a/.github/scripts/test-ide-uitest-workflow.py
+++ b/.github/scripts/test-ide-uitest-workflow.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""Structural contracts for the IDE UI test workflow."""
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "ide-uitest.yml"
+DIRECT_REPOSITORY_FLAG = "-Dorg.jetbrains.intellij.platform.useCacheRedirector=false"
+
+
+def main() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    count = text.count(DIRECT_REPOSITORY_FLAG)
+    if count != 2:
+        raise SystemExit(
+            "ide-uitest.yml must disable JetBrains Cache Redirector on both Gradle "
+            f"entrypoints (found {count})"
+        )
+    print("test-ide-uitest-workflow: OK")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/test-ide-uitest-workflow.py
+++ b/.github/scripts/test-ide-uitest-workflow.py
@@ -4,11 +4,14 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 WORKFLOW = ROOT / ".github" / "workflows" / "ide-uitest.yml"
-DIRECT_REPOSITORY_FLAG = "-Dorg.jetbrains.intellij.platform.useCacheRedirector=false"
+DIRECT_REPOSITORY_FLAG = "-Porg.jetbrains.intellij.platform.useCacheRedirector=false"
+FORBIDDEN_SYSTEM_PROPERTY = "-Dorg.jetbrains.intellij.platform.useCacheRedirector=false"
 
 
 def main() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
+    if FORBIDDEN_SYSTEM_PROPERTY in text:
+        raise SystemExit("Cache Redirector setting must be a Gradle project property (-P), not -D")
     count = text.count(DIRECT_REPOSITORY_FLAG)
     if count != 2:
         raise SystemExit(

--- a/.github/scripts/test-macos-cli-seal-preservation.sh
+++ b/.github/scripts/test-macos-cli-seal-preservation.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 root="$(cd "$(dirname "$0")/../.." && pwd)"
 formula="$root/Formula/spectre.rb"
-workflow="$root/.github/workflows/release.yml"
+workflow="$root/.github/workflows/macos-release-artifacts.yml"
 verifier="$root/.github/scripts/verify-macos-cli-bundle.sh"
 
 test -f "$formula"
@@ -27,7 +27,7 @@ deep_strict_count="$(
   grep -c 'codesign --verify --deep --strict --verbose=4 "\$app"' "$workflow" || true
 )"
 if [[ "$deep_strict_count" -lt 2 ]]; then
-  echo "release.yml must deep+strict verify the app at least twice (pre/post staple)" >&2
+  echo "macos-release-artifacts.yml must deep+strict verify pre/post staple" >&2
   exit 1
 fi
 

--- a/.github/scripts/test-macos-release-artifact-workflows.sh
+++ b/.github/scripts/test-macos-release-artifact-workflows.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+release="$root/.github/workflows/release.yml"
+reusable="$root/.github/workflows/macos-release-artifacts.yml"
+dispatch="$root/.github/workflows/notarize-macos.yml"
+release_smoke="$root/docs/RELEASE-SMOKE.md"
+publishing="$root/docs/PUBLISHING.md"
+
+fail() {
+  echo "test-macos-release-artifact-workflows: $*" >&2
+  exit 1
+}
+
+[[ -f "$reusable" ]] || fail "missing reusable macOS release-artifact workflow"
+[[ -f "$dispatch" ]] || fail "missing on-demand notarization workflow"
+
+# The tag release and manual pre-tag path must share one signing/notarization implementation.
+grep -Fq 'uses: ./.github/workflows/macos-release-artifacts.yml' "$release" \
+  || fail "release.yml must call the reusable macOS artifact workflow"
+grep -Fq 'uses: rock3r/spectre/.github/workflows/macos-release-artifacts.yml@main' "$dispatch" \
+  || fail "manual workflow must call the reusable workflow from trusted main"
+grep -Fq 'workflow_call:' "$reusable" || fail "reusable workflow must expose workflow_call"
+grep -Fq 'workflow_dispatch:' "$dispatch" || fail "on-demand workflow must expose workflow_dispatch"
+
+# The trusted reusable workflow resolves and validates the requested ref before either privileged
+# job runs. Both privileged jobs must use its full-SHA output, never the caller's raw ref.
+grep -Fq 'ref: ${{ inputs.ref }}' "$reusable" \
+  || fail "validation job must resolve inputs.ref"
+checkout_count="$(grep -Fc 'ref: ${{ needs.validate.outputs.sha }}' "$reusable")"
+[[ "$checkout_count" -eq 2 ]] \
+  || fail "both privileged jobs must check out the validated SHA (found $checkout_count)"
+grep -Fq 'git merge-base --is-ancestor "$sha" "origin/$trusted_branch"' "$reusable" \
+  || fail "reusable workflow must constrain ref to trusted branch history"
+grep -Fq 'derive-release-version.sh "v$REQUESTED_VERSION"' "$reusable" \
+  || fail "reusable workflow must use the release SemVer validator"
+grep -Fq 'ref: ${{ github.sha }}' "$release" \
+  || fail "tag release must pass github.sha"
+grep -Fq 'ref: ${{ inputs.ref }}' "$dispatch" \
+  || fail "manual workflow must pass the requested ref to trusted validation"
+grep -Fq 'version: ${{ inputs.version }}' "$dispatch" \
+  || fail "manual workflow must pass its requested smoke version"
+
+# Callers expose only the seven Apple credentials required by the reusable interface.
+if grep -Fq 'secrets: inherit' "$release" "$dispatch"; then
+  fail "callers must not inherit every repository secret"
+fi
+for secret in \
+  APPLE_DEVELOPER_ID_P12 \
+  APPLE_DEVELOPER_ID_P12_PASSWORD \
+  APPLE_SIGNING_KEYCHAIN_PASSWORD \
+  APPLE_DEVELOPER_IDENTITY \
+  APPLE_NOTARY_API_KEY \
+  APPLE_NOTARY_API_KEY_ID \
+  APPLE_NOTARY_API_ISSUER
+do
+  expected="$secret: \${{ secrets.$secret }}"
+  grep -Fq "$expected" "$release" || fail "release.yml must explicitly pass $secret"
+  grep -Fq "$expected" "$dispatch" || fail "notarize-macos.yml must explicitly pass $secret"
+done
+
+# Manual runs are artifact-only: never publish to Central or mutate a GitHub release.
+if grep -Eq 'publishToMavenCentral|gh release (create|upload|edit)' "$dispatch" "$reusable"; then
+  fail "manual/reusable notarization path must not publish or mutate releases"
+fi
+
+# Preserve the release artifacts and seal checks needed by B8/B16.
+grep -Fq 'name: mac-helper' "$reusable" || fail "reusable workflow must upload mac-helper"
+grep -Fq 'name: mac-cli-bundles' "$reusable" || fail "reusable workflow must upload mac-cli-bundles"
+grep -Fq 'xcrun stapler staple "$app"' "$reusable" || fail "CLI app must be stapled"
+grep -Fq 'xcrun stapler validate "$app"' "$reusable" || fail "CLI app staple must be validated"
+verify_count="$(grep -Fc 'codesign --verify --deep --strict --verbose=4 "$app"' "$reusable")"
+[[ "$verify_count" -ge 2 ]] \
+  || fail "CLI app must be deep+strict verified before and after stapling"
+
+# Operators need a copy/paste pre-tag recipe and an explicit artifact-only safety boundary.
+grep -Fq 'gh workflow run notarize-macos.yml' "$release_smoke" \
+  || fail "RELEASE-SMOKE.md must document the on-demand command"
+grep -Fq 'does not publish to Central or create a GitHub release' "$publishing" \
+  || fail "PUBLISHING.md must document the artifact-only boundary"
+
+echo "test-macos-release-artifact-workflows: OK"

--- a/.github/scripts/test-macos-release-artifact-workflows.sh
+++ b/.github/scripts/test-macos-release-artifact-workflows.sh
@@ -67,6 +67,11 @@ fi
 
 # Preserve the release artifacts and seal checks needed by B8/B16.
 grep -Fq 'name: mac-helper' "$reusable" || fail "reusable workflow must upload mac-helper"
+grep -Fq 'SpectreCaptureHelper.app.tar.gz' "$reusable" \
+  || fail "helper artifact must be archived to preserve executable modes"
+helper_extract_count="$(cat "$release" "$reusable" | grep -Fc 'tar -xzf "$RUNNER_TEMP/mac-helper-artifact/SpectreCaptureHelper.app.tar.gz"')"
+[[ "$helper_extract_count" -eq 2 ]] \
+  || fail "CLI and publish jobs must unpack the helper archive (found $helper_extract_count)"
 grep -Fq 'name: mac-cli-bundles' "$reusable" || fail "reusable workflow must upload mac-cli-bundles"
 grep -Fq 'xcrun stapler staple "$app"' "$reusable" || fail "CLI app must be stapled"
 grep -Fq 'xcrun stapler validate "$app"' "$reusable" || fail "CLI app staple must be validated"
@@ -75,8 +80,10 @@ verify_count="$(grep -Fc 'codesign --verify --deep --strict --verbose=4 "$app"' 
   || fail "CLI app must be deep+strict verified before and after stapling"
 
 # Operators need a copy/paste pre-tag recipe and an explicit artifact-only safety boundary.
-grep -Fq 'gh workflow run notarize-macos.yml' "$release_smoke" \
-  || fail "RELEASE-SMOKE.md must document the on-demand command"
+grep -Fq 'run_url="$(gh workflow run notarize-macos.yml' "$release_smoke" \
+  || fail "RELEASE-SMOKE.md must capture the exact dispatched run URL"
+grep -Fq 'run_id="${run_url##*/}"' "$release_smoke" \
+  || fail "RELEASE-SMOKE.md must derive the run ID from that URL"
 grep -Fq 'does not publish to Central or create a GitHub release' "$publishing" \
   || fail "PUBLISHING.md must document the artifact-only boundary"
 

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -410,6 +410,10 @@ class ReleaseSmokeHelpTest(unittest.TestCase):
         self.assertIn("--skip-recording", result.stdout)
         self.assertIn("--preflight-only", result.stdout)
 
+    @unittest.skipIf(
+        platform.system() == "Windows",
+        "Unix release-smoke entrypoint intentionally rejects Windows",
+    )
     def test_preflight_only_emits_full_required_matrix_with_na_reason(self):
         """Drive the real entrypoint: --preflight-only must not invent PASS for hard cells."""
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/test-verify-macos-cli-bundle.sh
+++ b/.github/scripts/test-verify-macos-cli-bundle.sh
@@ -2,12 +2,14 @@
 set -euo pipefail
 
 repo_root="$(cd "$(dirname "$0")/../.." && pwd)"
-workflow="$repo_root/.github/workflows/release.yml"
+workflow="$repo_root/.github/workflows/macos-release-artifacts.yml"
 verifier="$repo_root/.github/scripts/verify-macos-cli-bundle.sh"
 seal_probe="$repo_root/.github/scripts/test-macos-cli-seal-preservation.sh"
+workflow_contract="$repo_root/.github/scripts/test-macos-release-artifact-workflows.sh"
 
 test -x "$verifier"
 test -x "$seal_probe"
+test -x "$workflow_contract"
 grep -Fq 'verify-macos-cli-bundle.sh "$archive" "$RELEASE_VERSION"' "$workflow"
 grep -Fq 'app="$workspace/$expected_root/Spectre.app"' "$verifier"
 grep -Fq 'codesign --verify --deep --strict --verbose=4 "$app"' "$verifier"
@@ -21,13 +23,14 @@ deep_strict_count="$(
   grep -c 'codesign --verify --deep --strict --verbose=4 "\$app"' "$workflow" || true
 )"
 if [[ "$deep_strict_count" -lt 2 ]]; then
-  echo "release.yml must codesign --verify --deep --strict at least twice (pre- and post-staple)" >&2
+  echo "macos-release-artifacts.yml must deep+strict verify before and after stapling" >&2
   exit 1
 fi
 # Guard against reintroducing non-deep intermediate verifies on the app bundle.
 if grep -E 'codesign --verify --strict --verbose=4 "\$app"' "$workflow" | grep -vq -- '--deep'; then
-  echo "release.yml still has codesign --verify --strict without --deep on \$app" >&2
+  echo "macos-release-artifacts.yml has a non-deep strict verify on \$app" >&2
   exit 1
 fi
 
+bash "$workflow_contract"
 bash "$seal_probe"

--- a/.github/workflows/ide-uitest.yml
+++ b/.github/workflows/ide-uitest.yml
@@ -127,7 +127,7 @@ jobs:
         # per-artifact 502s on cold macOS runners; the plugin documents this fallback property.
         run: |
           ./gradlew :sample-intellij-plugin:uiTest \
-            -Dorg.jetbrains.intellij.platform.useCacheRedirector=false
+            -Porg.jetbrains.intellij.platform.useCacheRedirector=false
         # Use bash explicitly on Windows so the `./gradlew` invocation is identical across the
         # non-Linux legs. Default Windows shell is pwsh which has different path-resolution
         # semantics for `./` prefixes; bash keeps the script identical to ci.yml + windows.yml.
@@ -142,7 +142,7 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           xvfb-run -a ./gradlew :sample-intellij-plugin:uiTest \
-            -Dorg.jetbrains.intellij.platform.useCacheRedirector=false
+            -Porg.jetbrains.intellij.platform.useCacheRedirector=false
         shell: bash
 
       # Capture artefacts on failure so post-mortem doesn't require re-running the test.

--- a/.github/workflows/ide-uitest.yml
+++ b/.github/workflows/ide-uitest.yml
@@ -123,7 +123,11 @@ jobs:
 
       - name: Run IDE UI test (macOS / Windows)
         if: runner.os != 'Linux'
-        run: ./gradlew :sample-intellij-plugin:uiTest
+        # Resolve directly from JetBrains repositories. Cache Redirector can return persistent
+        # per-artifact 502s on cold macOS runners; the plugin documents this fallback property.
+        run: |
+          ./gradlew :sample-intellij-plugin:uiTest \
+            -Dorg.jetbrains.intellij.platform.useCacheRedirector=false
         # Use bash explicitly on Windows so the `./gradlew` invocation is identical across the
         # non-Linux legs. Default Windows shell is pwsh which has different path-resolution
         # semantics for `./` prefixes; bash keeps the script identical to ci.yml + windows.yml.
@@ -136,7 +140,9 @@ jobs:
         # would into a real one — no compositor in the loop, so the failure surface is just
         # skiko-on-software-GL rather than skiko + Mutter / KWin / etc.
         if: runner.os == 'Linux'
-        run: xvfb-run -a ./gradlew :sample-intellij-plugin:uiTest
+        run: |
+          xvfb-run -a ./gradlew :sample-intellij-plugin:uiTest \
+            -Dorg.jetbrains.intellij.platform.useCacheRedirector=false
         shell: bash
 
       # Capture artefacts on failure so post-mortem doesn't require re-running the test.

--- a/.github/workflows/macos-release-artifacts.yml
+++ b/.github/workflows/macos-release-artifacts.yml
@@ -148,15 +148,19 @@ jobs:
               -PuniversalHelper \
               -PnotarizeScreenCaptureKitHelper
 
+      - name: Archive notarised mac helper
+        # upload-artifact normalizes file modes. Wrap the signed app in tar so its executable
+        # bit survives download for publication and the operator's B8 live-SCK smoke.
+        run: |
+          tar -czf "$RUNNER_TEMP/SpectreCaptureHelper.app.tar.gz" \
+            -C recording/build/generated/screenCaptureHelper/native/macos \
+            SpectreCaptureHelper.app
+
       - name: Upload notarised mac helper artefact
         uses: actions/upload-artifact@v4
         with:
           name: mac-helper
-          # Upload the parent `macos/` directory so the artefact root keeps the
-          # `SpectreCaptureHelper.app` name. Passing the `.app` path itself makes
-          # upload-artifact@v4 strip that directory name (Contents/ lands at the
-          # root), which would break `-PprebuiltMacHelperPath=.../SpectreCaptureHelper.app`.
-          path: recording/build/generated/screenCaptureHelper/native/macos/
+          path: ${{ runner.temp }}/SpectreCaptureHelper.app.tar.gz
           if-no-files-found: error
           retention-days: 7
 
@@ -205,7 +209,17 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mac-helper
-          path: ${{ runner.temp }}/mac-helper
+          path: ${{ runner.temp }}/mac-helper-artifact
+
+      - name: Extract notarised mac helper
+        run: |
+          mkdir -p "$RUNNER_TEMP/mac-helper"
+          tar -xzf "$RUNNER_TEMP/mac-helper-artifact/SpectreCaptureHelper.app.tar.gz" \
+            -C "$RUNNER_TEMP/mac-helper"
+          test -x "$RUNNER_TEMP/mac-helper/SpectreCaptureHelper.app/Contents/MacOS/spectre-screencapture"
+          codesign --verify --deep --strict --verbose=4 \
+            "$RUNNER_TEMP/mac-helper/SpectreCaptureHelper.app"
+          xcrun stapler validate "$RUNNER_TEMP/mac-helper/SpectreCaptureHelper.app"
 
       - name: Import Developer ID certificate
         env:

--- a/.github/workflows/macos-release-artifacts.yml
+++ b/.github/workflows/macos-release-artifacts.yml
@@ -1,0 +1,392 @@
+name: macOS release artifacts
+
+# Shared privileged path for tag releases and operator-triggered pre-tag smoke.
+# This workflow only creates signed, notarized, and stapled artifacts; it never publishes.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Version stamped into the CLI bundles.
+        required: true
+        type: string
+      ref:
+        description: Commit or ref resolved to a trusted full SHA before privileged jobs.
+        required: true
+        type: string
+    secrets:
+      APPLE_DEVELOPER_ID_P12:
+        required: true
+      APPLE_DEVELOPER_ID_P12_PASSWORD:
+        required: true
+      APPLE_SIGNING_KEYCHAIN_PASSWORD:
+        required: true
+      APPLE_DEVELOPER_IDENTITY:
+        required: true
+      APPLE_NOTARY_API_KEY:
+        required: true
+      APPLE_NOTARY_API_KEY_ID:
+        required: true
+      APPLE_NOTARY_API_ISSUER:
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate trusted inputs
+    runs-on: ubuntu-latest
+    outputs:
+      sha: ${{ steps.validate.outputs.sha }}
+
+    steps:
+      - name: Check out requested ref
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.ref }}
+
+      - name: Validate version and default-branch ancestry
+        id: validate
+        env:
+          REQUESTED_VERSION: ${{ inputs.version }}
+          TRUSTED_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          sha="$(git rev-parse HEAD)"
+          trusted_branch="$TRUSTED_BRANCH"
+          git fetch --no-tags origin "+refs/heads/$trusted_branch:refs/remotes/origin/$trusted_branch"
+          if ! git merge-base --is-ancestor "$sha" "origin/$trusted_branch"; then
+            echo "$sha is not reachable from the trusted branch $trusted_branch" >&2
+            exit 1
+          fi
+
+          validated_version="$(bash .github/scripts/derive-release-version.sh "v$REQUESTED_VERSION")"
+          if [[ "$validated_version" != "$REQUESTED_VERSION" ]]; then
+            echo "version validation changed the requested value" >&2
+            exit 1
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "Validated $sha at version $validated_version"
+
+  mac-helper:
+    name: Build + notarise macOS helper
+    runs-on: macos-latest
+    needs:
+      - validate
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Verify Swift toolchain
+        run: swift --version
+
+      - name: Import Developer ID certificate
+        env:
+          APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_SIGNING_KEYCHAIN_PASSWORD }}
+        run: |
+          test -n "$APPLE_DEVELOPER_ID_P12"
+          test -n "$APPLE_DEVELOPER_ID_P12_PASSWORD"
+          test -n "$KEYCHAIN_PASSWORD"
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
+
+          echo "$APPLE_DEVELOPER_ID_P12" | base64 --decode > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Build, sign, and notarise the universal SCK helper
+        env:
+          APPLE_DEVELOPER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
+          APPLE_NOTARY_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY }}
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_NOTARY_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER }}
+        run: |
+          test -n "$APPLE_DEVELOPER_IDENTITY"
+          test -n "$APPLE_NOTARY_API_KEY"
+          test -n "$APPLE_NOTARY_API_KEY_ID"
+          test -n "$APPLE_NOTARY_API_ISSUER"
+
+          API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
+          echo "$APPLE_NOTARY_API_KEY" | base64 --decode > "$API_KEY_PATH"
+
+          # `:recording:assembleScreenCaptureKitHelperUniversal` packages, Developer ID
+          # signs, notarizes, staples, and verifies the full `SpectreCaptureHelper.app`.
+          # The publish job downloads the artifact and stages the app tree via
+          # `-PprebuiltMacHelperPath`.
+          APPLE_NOTARY_API_KEY_PATH="$API_KEY_PATH" \
+            ./gradlew :recording:assembleScreenCaptureKitHelperUniversal \
+              -PuniversalHelper \
+              -PnotarizeScreenCaptureKitHelper
+
+      - name: Upload notarised mac helper artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-helper
+          # Upload the parent `macos/` directory so the artefact root keeps the
+          # `SpectreCaptureHelper.app` name. Passing the `.app` path itself makes
+          # upload-artifact@v4 strip that directory name (Contents/ lands at the
+          # root), which would break `-PprebuiltMacHelperPath=.../SpectreCaptureHelper.app`.
+          path: recording/build/generated/screenCaptureHelper/native/macos/
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Clean up Apple credentials + signing keychain
+        # macOS runners are ephemeral, but tearing down the keychain + key files is cheap
+        # defence in depth against any future runner-reuse misconfiguration. `if: always()`
+        # ensures cleanup even if the notary submission failed.
+        if: always()
+        env:
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
+          if [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+          rm -f "$RUNNER_TEMP/developer-id.p12"
+          if [ -n "${APPLE_NOTARY_API_KEY_ID:-}" ]; then
+            rm -f "$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
+          fi
+
+  mac-cli-bundles:
+    name: Build, sign, and notarise macOS CLI bundles
+    runs-on: macos-latest
+    needs:
+      - validate
+      - mac-helper
+    env:
+      RELEASE_VERSION: ${{ inputs.version }}
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.validate.outputs.sha }}
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v5
+
+      - name: Download notarised mac helper artefact
+        uses: actions/download-artifact@v4
+        with:
+          name: mac-helper
+          path: ${{ runner.temp }}/mac-helper
+
+      - name: Import Developer ID certificate
+        env:
+          APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_SIGNING_KEYCHAIN_PASSWORD }}
+        run: |
+          test -n "$APPLE_DEVELOPER_ID_P12"
+          test -n "$APPLE_DEVELOPER_ID_P12_PASSWORD"
+          test -n "$KEYCHAIN_PASSWORD"
+
+          CERTIFICATE_PATH="$RUNNER_TEMP/developer-id.p12"
+          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
+
+          echo "$APPLE_DEVELOPER_ID_P12" | base64 --decode > "$CERTIFICATE_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERTIFICATE_PATH" \
+            -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" \
+            -A \
+            -t cert \
+            -f pkcs12 \
+            -k "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+          security default-keychain -d user -s "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s \
+            -k "$KEYCHAIN_PASSWORD" \
+            "$KEYCHAIN_PATH"
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+
+      - name: Build, sign, and notarise macOS CLI bundles
+        env:
+          APPLE_DEVELOPER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
+          APPLE_NOTARY_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY }}
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_NOTARY_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER }}
+        run: |
+          set -euo pipefail
+          test -n "$APPLE_DEVELOPER_IDENTITY"
+          test -n "$APPLE_NOTARY_API_KEY"
+          test -n "$APPLE_NOTARY_API_KEY_ID"
+          test -n "$APPLE_NOTARY_API_ISSUER"
+
+          API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
+          echo "$APPLE_NOTARY_API_KEY" | base64 --decode > "$API_KEY_PATH"
+
+          ./gradlew \
+            :cli:packageMacosX64 \
+            :cli:packageMacosArm64 \
+            -PVERSION_NAME="$RELEASE_VERSION" \
+            -PprebuiltMacHelperPath="$RUNNER_TEMP/mac-helper/SpectreCaptureHelper.app"
+
+          for target in macosX64 macosArm64; do
+            archive="cli/build/construo/distributions/spectre-${target}.zip"
+            workspace="$RUNNER_TEMP/spectre-${target}"
+            root="$workspace/spectre-cli-$RELEASE_VERSION"
+            app="$root/Spectre.app"
+            entitlements="cli/packaging/macos/jvm-entitlements.plist"
+            rm -rf "$workspace"
+            mkdir -p "$workspace"
+            ditto -x -k "$archive" "$workspace"
+            test -d "$app"
+
+            # Construo's ZIP extraction can leave executable mode bits platform-dependent. Restore
+            # the launchers before signing, then verify the final published ZIP below so a release
+            # cannot contain an app that extracts but will not launch.
+            chmod 755 "$app/Contents/MacOS/spectre"
+            find "$app/Contents/MacOS/runtime/bin" -type f -exec chmod 755 {} +
+            chmod 755 "$app/Contents/MacOS/runtime/lib/jspawnhelper"
+
+            # Roast places its JVM, launcher configuration, and application jar beside the
+            # executable in Contents/MacOS. That location is reserved for code, so codesign
+            # treats every JVM metadata file as a nested code object. Keep Roast's relative
+            # paths intact through symlinks while putting the payload in the standard Resources
+            # location, where the outer bundle can seal it as resources.
+            resources="$app/Contents/Resources"
+            mkdir -p "$resources"
+            for payload in runtime app "cli-$RELEASE_VERSION-all.jar"; do
+              mv "$app/Contents/MacOS/$payload" "$resources/$payload"
+              ln -s "../Resources/$payload" "$app/Contents/MacOS/$payload"
+            done
+
+            # The shaded CLI jar contains Jansi and JNA native libraries. They are scanned by
+            # Apple's notary service even though they live inside a zip, so sign them in place
+            # before repacking the jar and sealing the app.
+            cli_jar="$resources/cli-$RELEASE_VERSION-all.jar"
+            jar_workspace="$workspace/cli-jar"
+            mkdir -p "$jar_workspace"
+            ditto -x -k "$cli_jar" "$jar_workspace"
+            while IFS= read -r -d '' file; do
+              if file -b "$file" | grep -q 'Mach-O'; then
+                codesign --force --options runtime --timestamp \
+                  --entitlements "$entitlements" \
+                  --sign "$APPLE_DEVELOPER_IDENTITY" "$file"
+              fi
+            done < <(find "$jar_workspace" -type f -print0)
+            (cd "$jar_workspace" && zip -qry "$cli_jar" .)
+
+            # jlink carries its own Java launchers and dylibs. The JVM needs these hardened
+            # runtime entitlements for JIT code, native-library loading, and jdk.attach. Sign
+            # all nested Mach-O files first, then seal the outer app bundle.
+            while IFS= read -r -d '' file; do
+              if file -b "$file" | grep -q 'Mach-O'; then
+                codesign --force --options runtime --timestamp \
+                  --entitlements "$entitlements" \
+                  --sign "$APPLE_DEVELOPER_IDENTITY" "$file"
+              fi
+            done < <(find "$app" -type f -print0)
+            # Nested Mach-Os were signed above; outer seal is the last content mutation
+            # before notarize/staple. Stapling only attaches a ticket under _CodeSignature.
+            codesign --force --options runtime --timestamp \
+              --entitlements "$entitlements" \
+              --sign "$APPLE_DEVELOPER_IDENTITY" "$app"
+            # --deep is required: without it nested jlink dylib seal breaks can pass
+            # intermediate checks and only fail on consumer machines / Gatekeeper (#390).
+            codesign --verify --deep --strict --verbose=4 "$app"
+
+            # Notarytool receives an app-root archive. The published ZIP keeps its version
+            # directory so Homebrew does not strip the application bundle itself on install.
+            notarization_archive="$workspace/Spectre.app.zip"
+            ditto -c -k --sequesterRsrc --keepParent "$app" "$notarization_archive"
+            notarization_output=$(xcrun notarytool submit "$notarization_archive" \
+              --key "$API_KEY_PATH" \
+              --key-id "$APPLE_NOTARY_API_KEY_ID" \
+              --issuer "$APPLE_NOTARY_API_ISSUER" \
+              --timeout 30m \
+              --wait 2>&1)
+            printf '%s\n' "$notarization_output"
+            if ! printf '%s\n' "$notarization_output" | grep -q 'status: Accepted'; then
+              submission_id=$(printf '%s\n' "$notarization_output" | awk '/^[[:space:]]*id:/ { print $2; exit }')
+              if [ -n "$submission_id" ]; then
+                echo "Apple notarization rejection report for $submission_id:"
+                xcrun notarytool log "$submission_id" \
+                  --key "$API_KEY_PATH" \
+                  --key-id "$APPLE_NOTARY_API_KEY_ID" \
+                  --issuer "$APPLE_NOTARY_API_ISSUER" || true
+              fi
+              exit 1
+            fi
+            xcrun stapler staple "$app"
+            xcrun stapler validate "$app"
+            codesign --verify --deep --strict --verbose=4 "$app"
+            ditto -c -k --sequesterRsrc --keepParent "$root" "$archive"
+
+            extracted="$workspace/published"
+            ditto -x -k "$archive" "$extracted"
+            published_app="$extracted/spectre-cli-$RELEASE_VERSION/Spectre.app"
+            published_launcher="$published_app/Contents/MacOS/spectre"
+            test -f "$published_launcher"
+            test -x "$published_launcher"
+            .github/scripts/verify-macos-cli-bundle.sh "$archive" "$RELEASE_VERSION"
+            # Do not execute the launcher in CI: macosX64 cannot run on arm64 runners without
+            # Rosetta. The verifier above checks the final extracted archive with codesign,
+            # stapler, and Gatekeeper instead.
+            file "$published_launcher"
+            ls -la "$published_app/Contents/MacOS/"
+          done
+
+      - name: Upload signed and notarised macOS CLI bundles
+        uses: actions/upload-artifact@v4
+        with:
+          name: mac-cli-bundles
+          path: |
+            cli/build/construo/distributions/spectre-macosX64.zip
+            cli/build/construo/distributions/spectre-macosArm64.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Clean up Apple credentials + signing keychain
+        if: always()
+        env:
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+        run: |
+          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
+          if [ -f "$KEYCHAIN_PATH" ]; then
+            security delete-keychain "$KEYCHAIN_PATH" || true
+          fi
+          rm -f "$RUNNER_TEMP/developer-id.p12"
+          if [ -n "${APPLE_NOTARY_API_KEY_ID:-}" ]; then
+            rm -f "$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
+          fi
+

--- a/.github/workflows/notarize-macos.yml
+++ b/.github/workflows/notarize-macos.yml
@@ -1,0 +1,46 @@
+name: Notarize macOS artifacts
+
+# Operator-triggered pre-tag path for release-smoke B8/B16. It calls the trusted main-branch
+# reusable workflow, which validates the requested build ref before running privileged jobs.
+# This path only uploads workflow artifacts: no Central publication and no GitHub release mutation.
+
+run-name: Notarize macOS artifacts for ${{ inputs.ref }} (${{ inputs.version }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: Commit or ref from the repository's default-branch history.
+        required: true
+        default: main
+        type: string
+      version:
+        description: SemVer stamped into smoke CLI bundles (for example 0.5.0-rc.smoke).
+        required: true
+        default: 0.5.0-rc.smoke
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: notarize-macos-${{ inputs.ref }}
+  cancel-in-progress: false
+
+jobs:
+  notarize:
+    name: Sign, notarize, and staple
+    # Pin privileged workflow code to the trusted default branch. Validation also lives inside
+    # that reusable workflow, so dispatching this wrapper from another branch cannot bypass it.
+    uses: rock3r/spectre/.github/workflows/macos-release-artifacts.yml@main
+    with:
+      ref: ${{ inputs.ref }}
+      version: ${{ inputs.version }}
+    secrets:
+      APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+      APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+      APPLE_SIGNING_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_SIGNING_KEYCHAIN_PASSWORD }}
+      APPLE_DEVELOPER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
+      APPLE_NOTARY_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY }}
+      APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+      APPLE_NOTARY_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,28 +20,22 @@ name: Release
 #                            full Gradle `check`, and runs `mkdocs build --strict`
 #                            before any helper build or publish job starts.
 #
-#   2. `mac-helper`       — macOS runner. Builds the universal arm64+x86_64
-#                            `SpectreScreenCapture` Swift helper, codesigns it with
-#                            our Developer ID, and runs `notarytool submit --wait`.
-#                            Uploads the notarised binary as a GitHub Actions
-#                            artifact.
+#   2. `macos-release-artifacts` — Reuses `.github/workflows/macos-release-artifacts.yml`.
+#                            Its macOS jobs build, Developer ID sign, notarize, staple, and
+#                            upload the universal SCK helper and both Roast `.app` bundles.
+#                            The operator-triggered pre-tag workflow uses the exact same path.
 #
-#   3. `mac-cli-bundles`  — macOS runner. Packages both Roast `.app` bundles,
-#                            signs every Mach-O nested in their jlink runtimes,
-#                            notarizes the archives, staples the tickets, and uploads
-#                            the resulting release-ready archives.
-#
-#   4. `linux-helpers`    — Linux runner. Cross-builds the Wayland Rust helper for
+#   3. `linux-helpers`    — Linux runner. Cross-builds the Wayland Rust helper for
 #                            both x86_64 and aarch64 using the same toolchain dance
 #                            `ci.yml` documents (dpkg multi-arch + per-arch libdbus
 #                            sysroot + cross-linker). Uploads the per-arch binaries
 #                            as a GitHub Actions artifact.
 #
-#   5. `windows-helper`   — Windows runner. Builds the .NET Graphics Capture helper for
+#   4. `windows-helper`   — Windows runner. Builds the .NET Graphics Capture helper for
 #                            x64 and arm64 and uploads both helper directories as a
 #                            GitHub Actions artifact.
 #
-#   6. `publish`          — Linux runner. Depends on the gate and all helper jobs. Downloads
+#   5. `publish`          — Linux runner. Depends on the gate and all helper jobs. Downloads
 #                            the artefacts, stages them into the platform helper
 #                            resource jars via `-PprebuiltMacHelperPath=...` and
 #                            `-PprebuiltLinuxHelpersDir=...` and
@@ -51,9 +45,9 @@ name: Release
 #                            cross-targeted Roast CLI bundles to the draft GitHub release.
 #
 # Secrets used (all from repo settings):
-#   APPLE_DEVELOPER_ID_P12 / _PASSWORD                  → keychain import (mac-helper)
-#   APPLE_SIGNING_KEYCHAIN_PASSWORD                     → keychain password (mac-helper)
-#   APPLE_DEVELOPER_IDENTITY                            → codesign identity (mac-helper)
+#   APPLE_DEVELOPER_ID_P12 / _PASSWORD                  → reusable macOS artifact workflow
+#   APPLE_SIGNING_KEYCHAIN_PASSWORD                     → reusable macOS artifact workflow
+#   APPLE_DEVELOPER_IDENTITY                            → reusable macOS artifact workflow
 #   APPLE_NOTARY_API_KEY / _ID / _ISSUER                → App Store Connect API auth
 #   ORG_GRADLE_PROJECT_mavenCentralUsername / _Password → Central Portal token
 #   ORG_GRADLE_PROJECT_signingInMemoryKey               → ASCII-armored PGP private key
@@ -140,323 +134,22 @@ jobs:
       - name: Build docs strictly
         run: mkdocs build --strict
 
-  mac-helper:
-    name: Build + notarise macOS helper
-    runs-on: macos-latest
+  macos-release-artifacts:
+    name: Build signed + notarised macOS artifacts
     needs:
       - release-gate
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Verify Swift toolchain
-        run: swift --version
-
-      - name: Import Developer ID certificate
-        env:
-          APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
-          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_SIGNING_KEYCHAIN_PASSWORD }}
-        run: |
-          test -n "$APPLE_DEVELOPER_ID_P12"
-          test -n "$APPLE_DEVELOPER_ID_P12_PASSWORD"
-          test -n "$KEYCHAIN_PASSWORD"
-
-          CERTIFICATE_PATH="$RUNNER_TEMP/developer-id.p12"
-          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
-
-          echo "$APPLE_DEVELOPER_ID_P12" | base64 --decode > "$CERTIFICATE_PATH"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERTIFICATE_PATH" \
-            -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" \
-            -A \
-            -t cert \
-            -f pkcs12 \
-            -k "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH"
-          security default-keychain -d user -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s \
-            -k "$KEYCHAIN_PASSWORD" \
-            "$KEYCHAIN_PATH"
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
-
-      - name: Build, sign, and notarise the universal SCK helper
-        env:
-          APPLE_DEVELOPER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
-          APPLE_NOTARY_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY }}
-          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
-          APPLE_NOTARY_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER }}
-        run: |
-          test -n "$APPLE_DEVELOPER_IDENTITY"
-          test -n "$APPLE_NOTARY_API_KEY"
-          test -n "$APPLE_NOTARY_API_KEY_ID"
-          test -n "$APPLE_NOTARY_API_ISSUER"
-
-          API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
-          echo "$APPLE_NOTARY_API_KEY" | base64 --decode > "$API_KEY_PATH"
-
-          # `:recording:assembleScreenCaptureKitHelperUniversal` stages
-          # `SpectreCaptureHelper.app` (nested universal binary + Info.plist + icon).
-          # `-PnotarizeScreenCaptureKitHelper` still signs/notarizes the bare universal
-          # Mach-O before wrap (#191 will sign the whole .app). The publish job downloads
-          # the artefact and stages it via `-PprebuiltMacHelperPath`.
-          APPLE_NOTARY_API_KEY_PATH="$API_KEY_PATH" \
-            ./gradlew :recording:assembleScreenCaptureKitHelperUniversal \
-              -PuniversalHelper \
-              -PnotarizeScreenCaptureKitHelper
-
-      - name: Upload notarised mac helper artefact
-        uses: actions/upload-artifact@v4
-        with:
-          name: mac-helper
-          # Upload the parent `macos/` directory so the artefact root keeps the
-          # `SpectreCaptureHelper.app` name. Passing the `.app` path itself makes
-          # upload-artifact@v4 strip that directory name (Contents/ lands at the
-          # root), which would break `-PprebuiltMacHelperPath=.../SpectreCaptureHelper.app`.
-          path: recording/build/generated/screenCaptureHelper/native/macos/
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Clean up Apple credentials + signing keychain
-        # macOS runners are ephemeral, but tearing down the keychain + key files is cheap
-        # defence in depth against any future runner-reuse misconfiguration. `if: always()`
-        # ensures cleanup even if the notary submission failed.
-        if: always()
-        env:
-          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
-        run: |
-          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
-          if [ -f "$KEYCHAIN_PATH" ]; then
-            security delete-keychain "$KEYCHAIN_PATH" || true
-          fi
-          rm -f "$RUNNER_TEMP/developer-id.p12"
-          if [ -n "${APPLE_NOTARY_API_KEY_ID:-}" ]; then
-            rm -f "$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
-          fi
-
-  mac-cli-bundles:
-    name: Build, sign, and notarise macOS CLI bundles
-    runs-on: macos-latest
-    needs:
-      - release-gate
-      - mac-helper
-    env:
-      RELEASE_VERSION: ${{ needs.release-gate.outputs.version }}
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v6
-
-      - name: Set up JDK 21
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: "21"
-
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
-
-      - name: Download notarised mac helper artefact
-        uses: actions/download-artifact@v4
-        with:
-          name: mac-helper
-          path: ${{ runner.temp }}/mac-helper
-
-      - name: Import Developer ID certificate
-        env:
-          APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
-          APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
-          KEYCHAIN_PASSWORD: ${{ secrets.APPLE_SIGNING_KEYCHAIN_PASSWORD }}
-        run: |
-          test -n "$APPLE_DEVELOPER_ID_P12"
-          test -n "$APPLE_DEVELOPER_ID_P12_PASSWORD"
-          test -n "$KEYCHAIN_PASSWORD"
-
-          CERTIFICATE_PATH="$RUNNER_TEMP/developer-id.p12"
-          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
-
-          echo "$APPLE_DEVELOPER_ID_P12" | base64 --decode > "$CERTIFICATE_PATH"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
-          security import "$CERTIFICATE_PATH" \
-            -P "$APPLE_DEVELOPER_ID_P12_PASSWORD" \
-            -A \
-            -t cert \
-            -f pkcs12 \
-            -k "$KEYCHAIN_PATH"
-          security list-keychains -d user -s "$KEYCHAIN_PATH"
-          security default-keychain -d user -s "$KEYCHAIN_PATH"
-          security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s \
-            -k "$KEYCHAIN_PASSWORD" \
-            "$KEYCHAIN_PATH"
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH"
-
-      - name: Build, sign, and notarise macOS CLI bundles
-        env:
-          APPLE_DEVELOPER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
-          APPLE_NOTARY_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY }}
-          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
-          APPLE_NOTARY_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER }}
-        run: |
-          set -euo pipefail
-          test -n "$APPLE_DEVELOPER_IDENTITY"
-          test -n "$APPLE_NOTARY_API_KEY"
-          test -n "$APPLE_NOTARY_API_KEY_ID"
-          test -n "$APPLE_NOTARY_API_ISSUER"
-
-          API_KEY_PATH="$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
-          echo "$APPLE_NOTARY_API_KEY" | base64 --decode > "$API_KEY_PATH"
-
-          ./gradlew \
-            :cli:packageMacosX64 \
-            :cli:packageMacosArm64 \
-            -PVERSION_NAME="$RELEASE_VERSION" \
-            -PprebuiltMacHelperPath="$RUNNER_TEMP/mac-helper/SpectreCaptureHelper.app"
-
-          for target in macosX64 macosArm64; do
-            archive="cli/build/construo/distributions/spectre-${target}.zip"
-            workspace="$RUNNER_TEMP/spectre-${target}"
-            root="$workspace/spectre-cli-$RELEASE_VERSION"
-            app="$root/Spectre.app"
-            entitlements="cli/packaging/macos/jvm-entitlements.plist"
-            rm -rf "$workspace"
-            mkdir -p "$workspace"
-            ditto -x -k "$archive" "$workspace"
-            test -d "$app"
-
-            # Construo's ZIP extraction can leave executable mode bits platform-dependent. Restore
-            # the launchers before signing, then verify the final published ZIP below so a release
-            # cannot contain an app that extracts but will not launch.
-            chmod 755 "$app/Contents/MacOS/spectre"
-            find "$app/Contents/MacOS/runtime/bin" -type f -exec chmod 755 {} +
-            chmod 755 "$app/Contents/MacOS/runtime/lib/jspawnhelper"
-
-            # Roast places its JVM, launcher configuration, and application jar beside the
-            # executable in Contents/MacOS. That location is reserved for code, so codesign
-            # treats every JVM metadata file as a nested code object. Keep Roast's relative
-            # paths intact through symlinks while putting the payload in the standard Resources
-            # location, where the outer bundle can seal it as resources.
-            resources="$app/Contents/Resources"
-            mkdir -p "$resources"
-            for payload in runtime app "cli-$RELEASE_VERSION-all.jar"; do
-              mv "$app/Contents/MacOS/$payload" "$resources/$payload"
-              ln -s "../Resources/$payload" "$app/Contents/MacOS/$payload"
-            done
-
-            # The shaded CLI jar contains Jansi and JNA native libraries. They are scanned by
-            # Apple's notary service even though they live inside a zip, so sign them in place
-            # before repacking the jar and sealing the app.
-            cli_jar="$resources/cli-$RELEASE_VERSION-all.jar"
-            jar_workspace="$workspace/cli-jar"
-            mkdir -p "$jar_workspace"
-            ditto -x -k "$cli_jar" "$jar_workspace"
-            while IFS= read -r -d '' file; do
-              if file -b "$file" | grep -q 'Mach-O'; then
-                codesign --force --options runtime --timestamp \
-                  --entitlements "$entitlements" \
-                  --sign "$APPLE_DEVELOPER_IDENTITY" "$file"
-              fi
-            done < <(find "$jar_workspace" -type f -print0)
-            (cd "$jar_workspace" && zip -qry "$cli_jar" .)
-
-            # jlink carries its own Java launchers and dylibs. The JVM needs these hardened
-            # runtime entitlements for JIT code, native-library loading, and jdk.attach. Sign
-            # all nested Mach-O files first, then seal the outer app bundle.
-            while IFS= read -r -d '' file; do
-              if file -b "$file" | grep -q 'Mach-O'; then
-                codesign --force --options runtime --timestamp \
-                  --entitlements "$entitlements" \
-                  --sign "$APPLE_DEVELOPER_IDENTITY" "$file"
-              fi
-            done < <(find "$app" -type f -print0)
-            # Nested Mach-Os were signed above; outer seal is the last content mutation
-            # before notarize/staple. Stapling only attaches a ticket under _CodeSignature.
-            codesign --force --options runtime --timestamp \
-              --entitlements "$entitlements" \
-              --sign "$APPLE_DEVELOPER_IDENTITY" "$app"
-            # --deep is required: without it nested jlink dylib seal breaks can pass
-            # intermediate checks and only fail on consumer machines / Gatekeeper (#390).
-            codesign --verify --deep --strict --verbose=4 "$app"
-
-            # Notarytool receives an app-root archive. The published ZIP keeps its version
-            # directory so Homebrew does not strip the application bundle itself on install.
-            notarization_archive="$workspace/Spectre.app.zip"
-            ditto -c -k --sequesterRsrc --keepParent "$app" "$notarization_archive"
-            notarization_output=$(xcrun notarytool submit "$notarization_archive" \
-              --key "$API_KEY_PATH" \
-              --key-id "$APPLE_NOTARY_API_KEY_ID" \
-              --issuer "$APPLE_NOTARY_API_ISSUER" \
-              --timeout 30m \
-              --wait 2>&1)
-            printf '%s\n' "$notarization_output"
-            if ! printf '%s\n' "$notarization_output" | grep -q 'status: Accepted'; then
-              submission_id=$(printf '%s\n' "$notarization_output" | awk '/^[[:space:]]*id:/ { print $2; exit }')
-              if [ -n "$submission_id" ]; then
-                echo "Apple notarization rejection report for $submission_id:"
-                xcrun notarytool log "$submission_id" \
-                  --key "$API_KEY_PATH" \
-                  --key-id "$APPLE_NOTARY_API_KEY_ID" \
-                  --issuer "$APPLE_NOTARY_API_ISSUER" || true
-              fi
-              exit 1
-            fi
-            xcrun stapler staple "$app"
-            xcrun stapler validate "$app"
-            codesign --verify --deep --strict --verbose=4 "$app"
-            ditto -c -k --sequesterRsrc --keepParent "$root" "$archive"
-
-            extracted="$workspace/published"
-            ditto -x -k "$archive" "$extracted"
-            published_app="$extracted/spectre-cli-$RELEASE_VERSION/Spectre.app"
-            published_launcher="$published_app/Contents/MacOS/spectre"
-            test -f "$published_launcher"
-            test -x "$published_launcher"
-            .github/scripts/verify-macos-cli-bundle.sh "$archive" "$RELEASE_VERSION"
-            # Do not execute the launcher in CI: macosX64 cannot run on arm64 runners without
-            # Rosetta. The verifier above checks the final extracted archive with codesign,
-            # stapler, and Gatekeeper instead.
-            file "$published_launcher"
-            ls -la "$published_app/Contents/MacOS/"
-          done
-
-      - name: Upload signed and notarised macOS CLI bundles
-        uses: actions/upload-artifact@v4
-        with:
-          name: mac-cli-bundles
-          path: |
-            cli/build/construo/distributions/spectre-macosX64.zip
-            cli/build/construo/distributions/spectre-macosArm64.zip
-          if-no-files-found: error
-          retention-days: 7
-
-      - name: Clean up Apple credentials + signing keychain
-        if: always()
-        env:
-          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
-        run: |
-          KEYCHAIN_PATH="$RUNNER_TEMP/spectre-signing.keychain-db"
-          if [ -f "$KEYCHAIN_PATH" ]; then
-            security delete-keychain "$KEYCHAIN_PATH" || true
-          fi
-          rm -f "$RUNNER_TEMP/developer-id.p12"
-          if [ -n "${APPLE_NOTARY_API_KEY_ID:-}" ]; then
-            rm -f "$RUNNER_TEMP/AuthKey_${APPLE_NOTARY_API_KEY_ID}.p8"
-          fi
+    uses: ./.github/workflows/macos-release-artifacts.yml
+    with:
+      version: ${{ needs.release-gate.outputs.version }}
+      ref: ${{ github.sha }}
+    secrets:
+      APPLE_DEVELOPER_ID_P12: ${{ secrets.APPLE_DEVELOPER_ID_P12 }}
+      APPLE_DEVELOPER_ID_P12_PASSWORD: ${{ secrets.APPLE_DEVELOPER_ID_P12_PASSWORD }}
+      APPLE_SIGNING_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_SIGNING_KEYCHAIN_PASSWORD }}
+      APPLE_DEVELOPER_IDENTITY: ${{ secrets.APPLE_DEVELOPER_IDENTITY }}
+      APPLE_NOTARY_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY }}
+      APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+      APPLE_NOTARY_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER }}
 
   linux-helpers:
     name: Build cross-arch Linux helpers
@@ -573,8 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release-gate
-      - mac-helper
-      - mac-cli-bundles
+      - macos-release-artifacts
       - linux-helpers
       - windows-helper
     # `contents: write` needed for `gh release create / upload`; nothing else opted up.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,7 +299,14 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mac-helper
-          path: ${{ runner.temp }}/mac-helper
+          path: ${{ runner.temp }}/mac-helper-artifact
+
+      - name: Extract notarised mac helper
+        run: |
+          mkdir -p "$RUNNER_TEMP/mac-helper"
+          tar -xzf "$RUNNER_TEMP/mac-helper-artifact/SpectreCaptureHelper.app.tar.gz" \
+            -C "$RUNNER_TEMP/mac-helper"
+          test -x "$RUNNER_TEMP/mac-helper/SpectreCaptureHelper.app/Contents/MacOS/spectre-screencapture"
 
       - name: Download signed and notarised macOS CLI bundles
         uses: actions/download-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -203,6 +203,25 @@ val verifyWindowsReleaseSmokeScript by
         outputs.upToDateWhen { false }
     }
 
+val verifyIdeUiTestWorkflow by
+    tasks.registering(Exec::class) {
+        description = "Asserts the IDE UI workflow uses reliable direct JetBrains repositories."
+        group = "verification"
+        workingDir = rootProject.layout.projectDirectory.asFile
+        commandLine("python3", ".github/scripts/test-ide-uitest-workflow.py")
+        onlyIf("Host with python3") {
+            runCatching { ProcessBuilder("python3", "--version").start().waitFor() == 0 }
+                .getOrDefault(false)
+        }
+        inputs
+            .files(
+                ".github/workflows/ide-uitest.yml",
+                ".github/scripts/test-ide-uitest-workflow.py",
+            )
+            .withPathSensitivity(PathSensitivity.RELATIVE)
+        outputs.upToDateWhen { false }
+    }
+
 val verifyReleaseSmokeScripts by
     tasks.registering(Exec::class) {
         description = "Contract tests for cross-platform release-smoke orchestration and MCP stdio."
@@ -253,6 +272,7 @@ tasks.named("check") {
         verifyReleaseVersionScript,
         verifyMacosCliBundleReleaseContract,
         verifyWindowsReleaseSmokeScript,
+        verifyIdeUiTestWorkflow,
         verifyReleaseSmokeScripts,
         buildSrcUnitTests,
     )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -168,9 +168,14 @@ val verifyMacosCliBundleReleaseContract by
         inputs
             .files(
                 ".github/workflows/release.yml",
+                ".github/workflows/macos-release-artifacts.yml",
+                ".github/workflows/notarize-macos.yml",
                 ".github/scripts/verify-macos-cli-bundle.sh",
                 ".github/scripts/test-verify-macos-cli-bundle.sh",
                 ".github/scripts/test-macos-cli-seal-preservation.sh",
+                ".github/scripts/test-macos-release-artifact-workflows.sh",
+                "docs/PUBLISHING.md",
+                "docs/RELEASE-SMOKE.md",
                 "Formula/spectre.rb",
             )
             .withPathSensitivity(PathSensitivity.RELATIVE)

--- a/docs/NOTARIZATION.md
+++ b/docs/NOTARIZATION.md
@@ -49,6 +49,13 @@ distributed artifact.
 rebuild under the same install path without expecting a re-prompt — keep release identity on the
 release path only.
 
+For pre-tag release smoke, dispatch the artifact-only
+[`notarize-macos.yml`](https://github.com/rock3r/spectre/blob/main/.github/workflows/notarize-macos.yml)
+workflow. It uses the same signing implementation as the tag release and uploads the notarized
+helper plus both stapled CLI bundles without publishing anything. See
+[Release smoke](RELEASE-SMOKE.md#on-demand-pre-tag-macos-notarization) for the command and local
+B8/B16 verification steps.
+
 ## Local setup
 
 Install Xcode or the Xcode Command Line Tools so these commands are available:

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -64,6 +64,21 @@ Jobs on tag push (order simplified; see the workflow for the full graph):
    remains the canonical host for library modules only; the CLI is never uploaded there. Do not
    attach a partial library jar set to the GitHub release.
 
+## On-demand pre-tag macOS artifacts
+
+[`.github/workflows/notarize-macos.yml`](https://github.com/rock3r/spectre/blob/main/.github/workflows/notarize-macos.yml)
+can be dispatched for a commit reachable from `main`. It calls the same reusable macOS helper and
+CLI signing jobs as the tag release, then uploads the `mac-helper` and `mac-cli-bundles` workflow
+artifacts. This path **does not publish to Central or create a GitHub release**. Use it to obtain
+Developer ID signed, notarized, and stapled artifacts for the pre-tag B8/B16 checks documented in
+[Release smoke](RELEASE-SMOKE.md#on-demand-pre-tag-macos-notarization).
+
+The tag workflow passes its exact `${{ github.sha }}` to the reusable workflow. The manual wrapper
+pins the privileged reusable workflow definition to `main`; that trusted workflow resolves the
+requested ref to a full SHA and rejects it unless it is in the default branch's history. Dispatching
+the wrapper from a feature branch therefore cannot redirect privileged Gradle execution to
+unreviewed workflow or build code.
+
 ## CLI package channels
 
 The Spectre repository also hosts its release manifests: `Formula/spectre.rb` is the Homebrew

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -307,10 +307,12 @@ that SHA has landed on `main`:
 
 ```shell
 sha="$(git rev-parse HEAD)"
-gh workflow run notarize-macos.yml \
+run_url="$(gh workflow run notarize-macos.yml \
   --ref main \
   -f ref="$sha" \
-  -f version=0.5.0-rc.smoke
+  -f version=0.5.0-rc.smoke)"
+run_id="${run_url##*/}"
+echo "$run_url"
 ```
 
 The workflow rejects commits that are not reachable from the repository's default branch. It calls
@@ -318,15 +320,19 @@ the same reusable signing jobs as `release.yml`, but it never publishes to Centr
 GitHub release. After the run finishes, download its two artifacts:
 
 ```shell
-run_id="$(gh run list --workflow notarize-macos.yml --branch main --limit 1 \
-  --json databaseId --jq '.[0].databaseId')"
 gh run watch "$run_id"
-gh run download "$run_id" -n mac-helper -D build/notarized-smoke/mac-helper
+gh run download "$run_id" -n mac-helper -D build/notarized-smoke/mac-helper-artifact
 gh run download "$run_id" -n mac-cli-bundles -D build/notarized-smoke/mac-cli-bundles
+mkdir -p build/notarized-smoke/mac-helper
+tar -xzf build/notarized-smoke/mac-helper-artifact/SpectreCaptureHelper.app.tar.gz \
+  -C build/notarized-smoke/mac-helper
+test -x \
+  build/notarized-smoke/mac-helper/SpectreCaptureHelper.app/Contents/MacOS/spectre-screencapture
 ```
 
-Use `build/notarized-smoke/mac-helper/SpectreCaptureHelper.app` for the B8 TCC/live-SCK check. For
-B16, run the committed verifier on the host-architecture archive (replace `macosArm64` with
+The helper is intentionally archived before artifact upload because GitHub normalizes raw artifact
+file modes. Use `build/notarized-smoke/mac-helper/SpectreCaptureHelper.app` for the B8 TCC/live-SCK
+check. For B16, run the committed verifier on the host-architecture archive (replace `macosArm64` with
 `macosX64` on Intel):
 
 ```shell

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -299,6 +299,46 @@ coverage to the runner rather than leaving a one-release command only in chat.
 | Focus / lock keys / multi-monitor / HiDPI | Soft / env-dependent | Operator notes |
 | Stock IntelliJ inject | Soft recipe | Manual when claimed in notes |
 
+### On-demand pre-tag macOS notarization
+
+The tag workflow notarizes the macOS helper and CLI bundles, but B8/B16 need release-signed
+artifacts **before** the tag. Run the artifact-only workflow against the intended release SHA after
+that SHA has landed on `main`:
+
+```shell
+sha="$(git rev-parse HEAD)"
+gh workflow run notarize-macos.yml \
+  --ref main \
+  -f ref="$sha" \
+  -f version=0.5.0-rc.smoke
+```
+
+The workflow rejects commits that are not reachable from the repository's default branch. It calls
+the same reusable signing jobs as `release.yml`, but it never publishes to Central or creates a
+GitHub release. After the run finishes, download its two artifacts:
+
+```shell
+run_id="$(gh run list --workflow notarize-macos.yml --branch main --limit 1 \
+  --json databaseId --jq '.[0].databaseId')"
+gh run watch "$run_id"
+gh run download "$run_id" -n mac-helper -D build/notarized-smoke/mac-helper
+gh run download "$run_id" -n mac-cli-bundles -D build/notarized-smoke/mac-cli-bundles
+```
+
+Use `build/notarized-smoke/mac-helper/SpectreCaptureHelper.app` for the B8 TCC/live-SCK check. For
+B16, run the committed verifier on the host-architecture archive (replace `macosArm64` with
+`macosX64` on Intel):
+
+```shell
+bash .github/scripts/verify-macos-cli-bundle.sh \
+  build/notarized-smoke/mac-cli-bundles/spectre-macosArm64.zip \
+  0.5.0-rc.smoke
+```
+
+Record the workflow run URL and exact resolved SHA in the release smoke results. The workflow proves
+Developer ID signing, notarization, stapling, and archive seal; the local live capture is still
+required because GitHub-hosted macOS runners cannot grant Screen Recording TCC.
+
 ### Manual cells that remain
 
 These cannot currently be made portable and fail-closed by the baseline runner:

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/HostPlatform.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/HostPlatform.kt
@@ -7,12 +7,17 @@ internal object HostPlatform {
 
     fun isLinux(): Boolean = osName().contains("linux")
 
-    fun isWayland(): Boolean = isLinux() && !isActiveX11Display() && FfmpegBackend.detectWaylandSession(System::getenv)
+    fun isWayland(): Boolean =
+        isLinux() && !isActiveX11Display() && FfmpegBackend.detectWaylandSession(System::getenv)
 
     private fun isActiveX11Display(): Boolean {
         val display = System.getenv("DISPLAY")
         if (display.isNullOrBlank()) return false
-        return try { java.awt.GraphicsEnvironment.isHeadless() == false } catch (_: Exception) { false } || display.contains(":")
+        return try {
+            java.awt.GraphicsEnvironment.isHeadless() == false
+        } catch (_: Exception) {
+            false
+        } || display.contains(":")
     }
 
     private fun osName(): String = System.getProperty("os.name").orEmpty().lowercase()

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/HostPlatformTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/HostPlatformTest.kt
@@ -1,6 +1,5 @@
 package dev.sebastiano.spectre.recording
 
-import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertFalse
 


### PR DESCRIPTION
## Summary

- extract macOS helper/CLI signing, notarization, and stapling into a reusable workflow
- add a trusted, artifact-only `workflow_dispatch` path for pre-tag B8/B16 release smoke
- preserve the tag release artifact flow while explicitly limiting Apple secret exposure
- document invocation/download/verification and add fail-closed workflow contracts
- fix the two pre-existing ktfmt failures in the latest recording platform change

## Security boundary

The manual wrapper calls the reusable workflow definition from trusted `main`. That workflow resolves the requested build ref, rejects commits outside default-branch history, validates the version with the release SemVer validator, and makes both privileged macOS jobs check out the validated full SHA.

## Validation

- `./gradlew check`
- `mkdocs build --strict`
- `./gradlew verifyMacosCliBundleReleaseContract`
- workflow YAML parsing and shell syntax checks
- independent read-only review of reusable-workflow artifact flow and trust boundary

## Residual

The workflow cannot be live-dispatched until it exists on `main`; the first real Apple notarization run remains the post-merge validation.
