### PR TITLE
feat(smoke): capture Linux ScreenCast tokens once at run start

### DIFF
--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -581,6 +581,23 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
             )
             self.assertNotIn("SPECTRE_WAYLAND_HELPER", env)
 
+    def test_prepare_linux_portal_token_env_clears_path_override(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out_dir = root / "build" / "smoke"
+            env = smoke_lib.prepare_linux_portal_token_env(root, out_dir)
+            self.assertEqual("", env.get("SPECTRE_WAYLAND_RESTORE_TOKEN_PATH"))
+
+    def test_packaged_cli_env_drops_helper_override(self):
+        env = self.rs._packaged_cli_portal_env(
+            {
+                "SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": "/tmp/tokens",
+                "SPECTRE_WAYLAND_HELPER": "/tmp/helper",
+            }
+        )
+        self.assertEqual("/tmp/tokens", env["SPECTRE_WAYLAND_RESTORE_TOKEN_DIR"])
+        self.assertNotIn("SPECTRE_WAYLAND_HELPER", env)
+
     def test_wayland_portal_ui_prefix_is_empty(self):
         self.assertEqual([], self.rs._ui_prefix("Linux", wayland_portal=True))
         self.assertIsInstance(self.rs._ui_prefix("Linux", wayland_portal=False), list)

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -523,6 +523,37 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
                     }
                 )
             )
+            self.assertFalse(
+                smoke_lib.is_linux_wayland_portal_session(
+                    {
+                        "DISPLAY": ":99",
+                        "XDG_SESSION_TYPE": "wayland",
+                        "WAYLAND_DISPLAY": "wayland-0",
+                        "XDG_RUNTIME_DIR": str(runtime),
+                    },
+                    display_is_pure_x11=lambda _display: True,
+                )
+            )
+            self.assertTrue(
+                smoke_lib.is_linux_wayland_portal_session(
+                    {
+                        "DISPLAY": ":0",
+                        "XDG_SESSION_TYPE": "wayland",
+                        "WAYLAND_DISPLAY": "wayland-0",
+                        "XDG_RUNTIME_DIR": str(runtime),
+                    },
+                    display_is_pure_x11=lambda _display: False,
+                )
+            )
+            self.assertFalse(
+                smoke_lib.is_linux_wayland_portal_session(
+                    {
+                        "SPECTRE_CAPTURE_BACKEND": "x11",
+                        "WAYLAND_DISPLAY": "wayland-0",
+                        "XDG_RUNTIME_DIR": str(runtime),
+                    }
+                )
+            )
 
     def test_prepare_linux_portal_token_env_pins_helper_and_token_dir(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -581,6 +581,21 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
             )
             self.assertNotIn("SPECTRE_WAYLAND_HELPER", env)
 
+    def test_window_hidden_warmup_command_requires_helper(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out_dir = root / "build" / "smoke"
+            env = smoke_lib.prepare_linux_portal_token_env(root, out_dir)
+            with self.assertRaises(RuntimeError):
+                smoke_lib.window_hidden_token_warmup_command(env, root / "shot.png")
+            helper = smoke_lib.linux_wayland_helper_candidates(root)[0]
+            helper.parent.mkdir(parents=True)
+            helper.write_text("#!/bin/sh\n", encoding="utf-8")
+            helper.chmod(0o755)
+            env = smoke_lib.prepare_linux_portal_token_env(root, out_dir)
+            command = smoke_lib.window_hidden_token_warmup_command(env, root / "shot.png")
+            self.assertEqual(str(helper), command[0])
+
     def test_wayland_portal_ui_prefix_is_empty(self):
         self.assertEqual([], self.rs._ui_prefix("Linux", wayland_portal=True))
         self.assertIsInstance(self.rs._ui_prefix("Linux", wayland_portal=False), list)
@@ -596,13 +611,20 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
                     {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)}
                 )
             self.assertIn("monitor-embedded", str(ctx.exception).lower())
-            target = token_dir / "wayland-screencast-restore-token-monitor-embedded"
-            target.write_text("token-abc\n", encoding="utf-8")
-            before = target.stat().st_mtime_ns
+            for key in smoke_lib.WAYLAND_PORTAL_WARMUP_TOKEN_KEYS:
+                path = token_dir / f"wayland-screencast-restore-token-{key}"
+                path.write_text(f"{key}\n", encoding="utf-8")
+            before = {
+                key: (token_dir / f"wayland-screencast-restore-token-{key}").stat().st_mtime_ns
+                for key in smoke_lib.WAYLAND_PORTAL_WARMUP_TOKEN_KEYS
+            }
+            stale = {
+                key: mtime + 1 for key, mtime in before.items()
+            }
             with self.assertRaises(RuntimeError):
                 smoke_lib.assert_linux_portal_tokens_captured(
                     {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)},
-                    expected_mtime_ns=before + 1,
+                    expected_mtime_ns=stale,
                 )
             smoke_lib.assert_linux_portal_tokens_captured(
                 {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)},

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -539,6 +539,21 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
             self.assertEqual(str(helper), env["SPECTRE_WAYLAND_HELPER"])
             self.assertEqual("0700", oct(token_dir.stat().st_mode)[-4:])
 
+    def test_prepare_linux_portal_token_env_without_helper_omits_override(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out_dir = root / "build" / "smoke"
+            env = smoke_lib.prepare_linux_portal_token_env(root, out_dir)
+            self.assertEqual(
+                str(out_dir / "wayland-restore-tokens"),
+                env["SPECTRE_WAYLAND_RESTORE_TOKEN_DIR"],
+            )
+            self.assertNotIn("SPECTRE_WAYLAND_HELPER", env)
+
+    def test_wayland_portal_ui_prefix_is_empty(self):
+        self.assertEqual([], self.rs._ui_prefix("Linux", wayland_portal=True))
+        self.assertIsInstance(self.rs._ui_prefix("Linux", wayland_portal=False), list)
+
     def test_assert_linux_portal_tokens_captured_requires_restore_file(self):
         with tempfile.TemporaryDirectory() as tmp:
             token_dir = Path(tmp) / "tokens"

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -178,6 +178,7 @@ class SmokeLibSchemaTest(unittest.TestCase):
             "mcp-sdk-flow",
             "host-native-recording",
             "maven-local-consumer",
+            "portal-token-warmup",
         }
         self.assertEqual(expected, set(smoke_lib.REQUIRED_SCENARIO_IDS))
 
@@ -356,6 +357,8 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn("gradle_ui_force_args", text)
         self.assertIn("runMacOsSckRegionSmoke", text)
         self.assertIn("runLinuxX11RecordingSmoke", text)
+        self.assertIn("runWaylandPortalSmoke", text)
+        self.assertIn("portal-token-warmup", text)
         self.assertIn("verifyMavenLocalPublication", text)
         self.assertIn("LaunchAndAttachIntegration", text)
         # #414: hard pass requires fixture e2e lifecycle gate, not tools/list alone.
@@ -477,6 +480,10 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
         self.assertEqual(
             ":recording:runLinuxX11RecordingSmoke", self.rs._host_recording_task("Linux")
         )
+        self.assertEqual(
+            ":recording:runWaylandPortalSmoke",
+            self.rs._host_recording_task("Linux", wayland_portal=True),
+        )
         self.assertIsNone(self.rs._host_recording_task("Windows"))
 
     def test_native_helper_layout_check_requires_executable(self):
@@ -494,6 +501,70 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
         with self.assertRaises(RuntimeError) as ctx:
             self.rs._fresh_consumer_check(ROOT, "0.0.0-does-not-exist-smoke")
         self.assertIn("missing", str(ctx.exception).lower())
+
+    def test_linux_portal_session_is_detected_from_wayland_socket(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            runtime = Path(tmp) / "runtime"
+            runtime.mkdir()
+            (runtime / "wayland-0").touch()
+            self.assertTrue(
+                smoke_lib.is_linux_wayland_portal_session(
+                    {
+                        "WAYLAND_DISPLAY": "wayland-0",
+                        "XDG_RUNTIME_DIR": str(runtime),
+                    }
+                )
+            )
+            self.assertFalse(
+                smoke_lib.is_linux_wayland_portal_session(
+                    {
+                        "DISPLAY": ":99",
+                        "XDG_SESSION_TYPE": "x11",
+                    }
+                )
+            )
+
+    def test_prepare_linux_portal_token_env_pins_helper_and_token_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            helper = smoke_lib.linux_wayland_helper_candidates(root)[0]
+            helper.parent.mkdir(parents=True)
+            helper.write_text("#!/bin/sh\n", encoding="utf-8")
+            helper.chmod(0o755)
+            out_dir = root / "build" / "smoke"
+            env = smoke_lib.prepare_linux_portal_token_env(root, out_dir)
+            token_dir = Path(env["SPECTRE_WAYLAND_RESTORE_TOKEN_DIR"])
+            self.assertEqual(out_dir / "wayland-restore-tokens", token_dir)
+            self.assertTrue(token_dir.is_dir())
+            self.assertEqual(str(helper), env["SPECTRE_WAYLAND_HELPER"])
+            self.assertEqual("0700", oct(token_dir.stat().st_mode)[-4:])
+
+    def test_assert_linux_portal_tokens_captured_requires_restore_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            token_dir = Path(tmp) / "tokens"
+            token_dir.mkdir()
+            with self.assertRaises(RuntimeError) as ctx:
+                smoke_lib.assert_linux_portal_tokens_captured(
+                    {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)}
+                )
+            self.assertIn("restore token", str(ctx.exception).lower())
+            (token_dir / "wayland-screencast-restore-token-monitor-embedded").write_text(
+                "token-abc\n", encoding="utf-8"
+            )
+            smoke_lib.assert_linux_portal_tokens_captured(
+                {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)}
+            )
+
+    def test_portal_token_warmup_is_na_on_non_wayland(self):
+        result = smoke_lib.portal_token_warmup_skip_reason(
+            {"DISPLAY": ":99", "XDG_SESSION_TYPE": "x11"},
+            system="Linux",
+        )
+        self.assertIsNotNone(result)
+        self.assertIn("Wayland", result or "")
+        darwin = smoke_lib.portal_token_warmup_skip_reason(system="Darwin")
+        self.assertIsNotNone(darwin)
+        self.assertIn("does not use", darwin or "")
 
 
 class DocsAndSchemaPolicyTest(unittest.TestCase):

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -589,16 +589,24 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             token_dir = Path(tmp) / "tokens"
             token_dir.mkdir()
+            stale = token_dir / "wayland-screencast-restore-token-window-hidden"
+            stale.write_text("old\n", encoding="utf-8")
             with self.assertRaises(RuntimeError) as ctx:
                 smoke_lib.assert_linux_portal_tokens_captured(
                     {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)}
                 )
-            self.assertIn("restore token", str(ctx.exception).lower())
-            (token_dir / "wayland-screencast-restore-token-monitor-embedded").write_text(
-                "token-abc\n", encoding="utf-8"
-            )
+            self.assertIn("monitor-embedded", str(ctx.exception).lower())
+            target = token_dir / "wayland-screencast-restore-token-monitor-embedded"
+            target.write_text("token-abc\n", encoding="utf-8")
+            before = target.stat().st_mtime_ns
+            with self.assertRaises(RuntimeError):
+                smoke_lib.assert_linux_portal_tokens_captured(
+                    {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)},
+                    expected_mtime_ns=before + 1,
+                )
             smoke_lib.assert_linux_portal_tokens_captured(
-                {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)}
+                {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)},
+                expected_mtime_ns=before,
             )
 
     def test_portal_token_warmup_is_na_on_non_wayland(self):

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -596,7 +596,7 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
             }
         )
         self.assertEqual("/tmp/tokens", env["SPECTRE_WAYLAND_RESTORE_TOKEN_DIR"])
-        self.assertNotIn("SPECTRE_WAYLAND_HELPER", env)
+        self.assertEqual("", env["SPECTRE_WAYLAND_HELPER"])
 
     def test_wayland_portal_ui_prefix_is_empty(self):
         self.assertEqual([], self.rs._ui_prefix("Linux", wayland_portal=True))

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -581,21 +581,6 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
             )
             self.assertNotIn("SPECTRE_WAYLAND_HELPER", env)
 
-    def test_window_hidden_warmup_command_requires_helper(self):
-        with tempfile.TemporaryDirectory() as tmp:
-            root = Path(tmp)
-            out_dir = root / "build" / "smoke"
-            env = smoke_lib.prepare_linux_portal_token_env(root, out_dir)
-            with self.assertRaises(RuntimeError):
-                smoke_lib.window_hidden_token_warmup_command(env, root / "shot.png")
-            helper = smoke_lib.linux_wayland_helper_candidates(root)[0]
-            helper.parent.mkdir(parents=True)
-            helper.write_text("#!/bin/sh\n", encoding="utf-8")
-            helper.chmod(0o755)
-            env = smoke_lib.prepare_linux_portal_token_env(root, out_dir)
-            command = smoke_lib.window_hidden_token_warmup_command(env, root / "shot.png")
-            self.assertEqual(str(helper), command[0])
-
     def test_wayland_portal_ui_prefix_is_empty(self):
         self.assertEqual([], self.rs._ui_prefix("Linux", wayland_portal=True))
         self.assertIsInstance(self.rs._ui_prefix("Linux", wayland_portal=False), list)
@@ -611,20 +596,13 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
                     {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)}
                 )
             self.assertIn("monitor-embedded", str(ctx.exception).lower())
-            for key in smoke_lib.WAYLAND_PORTAL_WARMUP_TOKEN_KEYS:
-                path = token_dir / f"wayland-screencast-restore-token-{key}"
-                path.write_text(f"{key}\n", encoding="utf-8")
-            before = {
-                key: (token_dir / f"wayland-screencast-restore-token-{key}").stat().st_mtime_ns
-                for key in smoke_lib.WAYLAND_PORTAL_WARMUP_TOKEN_KEYS
-            }
-            stale = {
-                key: mtime + 1 for key, mtime in before.items()
-            }
+            target = token_dir / "wayland-screencast-restore-token-monitor-embedded"
+            target.write_text("token-abc\n", encoding="utf-8")
+            before = target.stat().st_mtime_ns
             with self.assertRaises(RuntimeError):
                 smoke_lib.assert_linux_portal_tokens_captured(
                     {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)},
-                    expected_mtime_ns=stale,
+                    expected_mtime_ns=before + 1,
                 )
             smoke_lib.assert_linux_portal_tokens_captured(
                 {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)},

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -86,7 +86,7 @@ grep -F -q 'hard skip without N/A reason' "$script" || fail "fail-closed hard N/
 for scenario_id in \
   preflight check junit-live agent-attach-core agent-contract-corpus agent-inject \
   agent-launch-and-attach cli-packaged cli-native-helper-layout cli-user-flow \
-  mcp-sdk-flow host-native-recording maven-local-consumer
+  mcp-sdk-flow host-native-recording maven-local-consumer portal-token-warmup
 do
   grep -F -q "$scenario_id" "$script" || fail "Windows runner missing stable scenario id: $scenario_id"
 done

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -69,8 +69,9 @@ interactive and not automatable. Spectre's `spectre-wayland-helper` uses portal
 
 - **First run** (no token, or compositor rejects a stale token): the portal dialog is
   shown. A human must accept once. Release smoke does this up front as `portal-token-warmup`
-  and pins `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` + `SPECTRE_WAYLAND_HELPER` so later cells reuse
-  the same helper identity and token file.
+  for the **monitor-embedded** grant and pins `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` +
+  `SPECTRE_WAYLAND_HELPER` so later monitor ScreenCast cells reuse that token. Window-source
+  tokens are bound to the picked window and are not pre-warmed against an unrelated window.
 - **Later CLI/agent sessions**: the helper reuses the stored token so no dialog appears
   (validated on GNOME/mutter; other compositors are best-effort). Tokens are single-use at
   the portal: each successful `Start` writes a replacement file. A cancelled dialog never

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -68,9 +68,14 @@ interactive and not automatable. Spectre's `spectre-wayland-helper` uses portal
 `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR`).
 
 - **First run** (no token, or compositor rejects a stale token): the portal dialog is
-  shown. A human must accept once.
+  shown. A human must accept once. Release smoke does this up front as `portal-token-warmup`
+  and pins `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` + `SPECTRE_WAYLAND_HELPER` so later cells reuse
+  the same helper identity and token file.
 - **Later CLI/agent sessions**: the helper reuses the stored token so no dialog appears
-  (validated on GNOME/mutter; other compositors are best-effort).
+  (validated on GNOME/mutter; other compositors are best-effort). Tokens are single-use at
+  the portal: each successful `Start` writes a replacement file. A cancelled dialog never
+  stores a token. JBR `java.awt.Robot` ScreenCast / Remote Desktop prompts use a different
+  app identity and are not covered by this file.
 - **Invalidation**: if Start/SelectSources rejects the token, Spectre clears the file and
   retries interactively once, printing a clear message on stderr.
 

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -265,6 +265,7 @@ Shared across macOS / Linux / Windows entrypoints (`scripts/smoke_lib.py` → `R
 | `mcp-sdk-flow` | Packaged MCP attach/op/detach lifecycle + strict stdio |
 | `host-native-recording` | Host native recording smoke |
 | `maven-local-consumer` | Maven Local publication + fresh consumer |
+| `portal-token-warmup` | Linux Wayland: one interactive ScreenCast grant at run start, then reuse the stored restore token. Hard `n/a` on macOS/Windows/Xvfb. |
 
 The Unix runner registers **every** required ID end-to-end (fail-closed). Environment-impossible
 cells must be explicit hard `n/a` with reason — never a silent omit or fake `pass`.
@@ -282,6 +283,7 @@ The cross-platform runner covers the stable baseline that should not be reinvent
   pass) + strict stdio (version / tools/list including `detach` / unknown-session detach `isError`)
 - host native recording smoke (macOS SCK region / Linux X11; Windows WGC via interactive PS script)
 - Maven Local `verifyMavenLocalPublication` + fresh consumer jar resolve
+- Linux Wayland `portal-token-warmup`: one `:recording:runWaylandPortalSmoke` with a pinned `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` under `build/smoke/wayland-restore-tokens/`. Approve **Share** + **Remember** once; later Gradle cells inherit that env so they reuse the token instead of prompting again. Xvfb / macOS / Windows record hard `n/a`.
 
 Each release still needs delta cells based on `git log <previous-tag>..HEAD`. Add reusable delta
 coverage to the runner rather than leaving a one-release command only in chat.
@@ -356,8 +358,11 @@ These cannot currently be made portable and fail-closed by the baseline runner:
 - **macOS TCC and release seal:** grant Screen Recording to the actual helper identity, exercise one
   live SCK still/record, then verify the signed release app with `codesign --verify --deep --strict`,
   `spctl`, and `xcrun stapler validate`. A local ad-hoc app is not notarization evidence.
-- **Wayland portal:** Xvfb proves X11 only. When Wayland is claimed or changed, run from a real
-  Wayland desktop and record portal consent/cancel behaviour.
+- **Wayland portal:** Xvfb proves X11 only. On a real Wayland desktop the Unix harness now runs
+  `portal-token-warmup` first (`:recording:runWaylandPortalSmoke`) and pins
+  `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` for the rest of the run. Approve
+  **Share** + **Remember** once at that prompt; later ScreenCast cells should reuse the token.
+  JBR `java.awt.Robot` / Remote Desktop prompts are a separate app identity and may still appear.
 - **Homebrew/Scoop/public archives:** after the draft artifacts exist, install through the real
   package manager and rerun launcher/MCP smoke. Local packaging does not prove channel metadata.
 - **Input focus/lock keys:** real Robot input uses global desktop state. Record focus failures and
@@ -401,9 +406,10 @@ release SHA.
   `cli-user-flow` may still use Gradle with `--app-name ComposeFixtureMain`; prefer a healthy
   UP-TO-DATE fixture build so cold daemon start alone fits the budget. Prod-like launch remains
   the troubleshooting recommendation when Gradle is slow or flaky.
-- **Manual residual (not auto-green):** TCC / notarization / app seal; real Wayland portal
-  (Xvfb ≠ Wayland); public Homebrew/Scoop/archive after undraft; focus/lock keys; multi-monitor /
-  HiDPI; stock IntelliJ inject.
+- **Manual residual (not auto-green):** TCC / notarization / app seal; first Wayland ScreenCast
+  consent during `portal-token-warmup` (later cells reuse the restore token); public
+  Homebrew/Scoop/archive after undraft; focus/lock keys; multi-monitor / HiDPI; stock IntelliJ
+  inject. Xvfb still does not prove Wayland portal behaviour.
 
 ## Windows one-liner script
 

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -283,7 +283,7 @@ The cross-platform runner covers the stable baseline that should not be reinvent
   pass) + strict stdio (version / tools/list including `detach` / unknown-session detach `isError`)
 - host native recording smoke (macOS SCK region / Linux X11; Windows WGC via interactive PS script)
 - Maven Local `verifyMavenLocalPublication` + fresh consumer jar resolve
-- Linux Wayland `portal-token-warmup`: one `:recording:runWaylandPortalSmoke` with a pinned `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` under `build/smoke/wayland-restore-tokens/`. Approve **Share** + **Remember** once; later Gradle cells inherit that env so they reuse the token instead of prompting again. Xvfb / macOS / Windows record hard `n/a`.
+- Linux Wayland `portal-token-warmup`: one `:recording:runWaylandPortalSmoke` with a pinned `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` under `build/smoke/wayland-restore-tokens/`. Approve **Share** + **Remember** for the **whole screen**; later monitor ScreenCast cells reuse that token. Window-source prompts are per-window and may still appear. Xvfb / macOS / Windows record hard `n/a`.
 
 Each release still needs delta cells based on `git log <previous-tag>..HEAD`. Add reusable delta
 coverage to the runner rather than leaving a one-release command only in chat.
@@ -361,8 +361,9 @@ These cannot currently be made portable and fail-closed by the baseline runner:
 - **Wayland portal:** Xvfb proves X11 only. On a real Wayland desktop the Unix harness now runs
   `portal-token-warmup` first (`:recording:runWaylandPortalSmoke`) and pins
   `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` for the rest of the run. Approve
-  **Share** + **Remember** once at that prompt; later ScreenCast cells should reuse the token.
-  JBR `java.awt.Robot` / Remote Desktop prompts are a separate app identity and may still appear.
+  **Share** + **Remember** for the whole screen; later monitor ScreenCast cells reuse that token.
+  Window-source, JBR `java.awt.Robot`, and Remote Desktop prompts are separate identities and may
+  still appear.
 - **Homebrew/Scoop/public archives:** after the draft artifacts exist, install through the real
   package manager and rerun launcher/MCP smoke. Local packaging does not prove channel metadata.
 - **Input focus/lock keys:** real Robot input uses global desktop state. Record focus failures and

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -15,7 +15,6 @@ See docs/RELEASE-SMOKE.md and scripts/smoke_lib.py for scenario IDs.
 from __future__ import annotations
 
 import argparse
-import os
 import platform
 import subprocess
 import sys
@@ -35,8 +34,6 @@ from smoke_lib import (  # noqa: E402
     assert_mcp_fixture_e2e_executed,
     WAYLAND_PORTAL_WARMUP_TOKEN_KEYS,
     linux_portal_token_path,
-    window_hidden_token_warmup_command,
-    window_hidden_token_warmup_payload,
     build_report,
     collect_preflight,
     gradle_ui_force_args,
@@ -349,7 +346,9 @@ def main(argv: list[str] | None = None) -> int:
         )
     else:
         print(
-            "portal-token-warmup: approve Share + Remember once; later cells reuse the token",
+            "portal-token-warmup: approve Share + Remember for the whole screen; "
+            "later monitor ScreenCast cells reuse that token. Window-source prompts "
+            "are per-window and may still appear.",
             flush=True,
         )
         scenario_env = prepare_linux_portal_token_env(ROOT, out_dir)
@@ -388,43 +387,6 @@ def main(argv: list[str] | None = None) -> int:
                 env=scenario_env,
                 overall_deadline=overall_deadline,
             )
-            if warmup.result == RESULT_PASS:
-                shot = out_dir / "wayland-window-hidden-warmup.png"
-
-                def warm_window_hidden() -> None:
-                    command = window_hidden_token_warmup_command(scenario_env, shot)
-                    completed = subprocess.run(
-                        command,
-                        input=window_hidden_token_warmup_payload(shot),
-                        text=True,
-                        cwd=ROOT,
-                        env={**os.environ, **scenario_env},
-                        stdout=subprocess.PIPE,
-                        stderr=subprocess.STDOUT,
-                        timeout=120,
-                        check=False,
-                    )
-                    if completed.returncode != 0:
-                        raise RuntimeError(
-                            "window-hidden helper warmup failed: "
-                            f"exit {completed.returncode}\n{completed.stdout}"
-                        )
-
-                window_warmup = run_callable_scenario(
-                    "portal-token-warmup",
-                    name="Capture window-hidden ScreenCast restore token",
-                    action=warm_window_hidden,
-                    out_dir=out_dir,
-                )
-                if window_warmup.result != RESULT_PASS:
-                    warmup = scenario_result(
-                        "portal-token-warmup",
-                        name=window_warmup.name,
-                        result=RESULT_FAIL,
-                        seconds=warmup.seconds + window_warmup.seconds,
-                        detail=window_warmup.detail or "window-hidden token warmup failed",
-                        log=window_warmup.log or warmup.log,
-                    )
             if warmup.result == RESULT_PASS:
                 try:
                     assert_linux_portal_tokens_captured(

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -167,6 +167,15 @@ def _ui_prefix(system: str, *, wayland_portal: bool = False) -> list[str]:
     return xvfb_prefix(system)
 
 
+def _packaged_cli_portal_env(env: dict[str, str] | None) -> dict[str, str] | None:
+    """Keep the restore-token dir, but use the packaged helper rather than the staged binary."""
+    if env is None:
+        return None
+    packaged = dict(env)
+    packaged.pop("SPECTRE_WAYLAND_HELPER", None)
+    return packaged
+
+
 def _maven_local_version(release_version: str) -> str:
     # Keep smoke publication off the SNAPSHOT and release coordinates consumers might already have.
     return f"{release_version}-rc.smoke"
@@ -601,7 +610,7 @@ def main(argv: list[str] | None = None) -> int:
                 cwd=ROOT,
                 timeout=600,
                 out_dir=out_dir,
-                env=scenario_env,
+                env=_packaged_cli_portal_env(scenario_env),
                 overall_deadline=overall_deadline,
             )
         )
@@ -628,7 +637,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
-            env=scenario_env,
+            env=_packaged_cli_portal_env(scenario_env),
             overall_deadline=overall_deadline,
         )
         if mcp_sdk.result == RESULT_PASS:

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -15,6 +15,7 @@ See docs/RELEASE-SMOKE.md and scripts/smoke_lib.py for scenario IDs.
 from __future__ import annotations
 
 import argparse
+import os
 import platform
 import subprocess
 import sys
@@ -32,7 +33,10 @@ from smoke_lib import (  # noqa: E402
     ScenarioResult,
     assert_linux_portal_tokens_captured,
     assert_mcp_fixture_e2e_executed,
+    WAYLAND_PORTAL_WARMUP_TOKEN_KEYS,
     linux_portal_token_path,
+    window_hidden_token_warmup_command,
+    window_hidden_token_warmup_payload,
     build_report,
     collect_preflight,
     gradle_ui_force_args,
@@ -366,8 +370,14 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 scenario_env = prepare_linux_portal_token_env(ROOT, out_dir)
         if scenario_env is not None:
-            token_path = linux_portal_token_path(scenario_env)
-            before_mtime = token_path.stat().st_mtime_ns + 1 if token_path.is_file() else 0
+            before_mtime = {
+                key: (
+                    linux_portal_token_path(scenario_env, key).stat().st_mtime_ns + 1
+                    if linux_portal_token_path(scenario_env, key).is_file()
+                    else 0
+                )
+                for key in WAYLAND_PORTAL_WARMUP_TOKEN_KEYS
+            }
             warmup = run_scenario(
                 "portal-token-warmup",
                 name="Capture persistent ScreenCast restore token",
@@ -378,6 +388,43 @@ def main(argv: list[str] | None = None) -> int:
                 env=scenario_env,
                 overall_deadline=overall_deadline,
             )
+            if warmup.result == RESULT_PASS:
+                shot = out_dir / "wayland-window-hidden-warmup.png"
+
+                def warm_window_hidden() -> None:
+                    command = window_hidden_token_warmup_command(scenario_env, shot)
+                    completed = subprocess.run(
+                        command,
+                        input=window_hidden_token_warmup_payload(shot),
+                        text=True,
+                        cwd=ROOT,
+                        env={**os.environ, **scenario_env},
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                        timeout=120,
+                        check=False,
+                    )
+                    if completed.returncode != 0:
+                        raise RuntimeError(
+                            "window-hidden helper warmup failed: "
+                            f"exit {completed.returncode}\n{completed.stdout}"
+                        )
+
+                window_warmup = run_callable_scenario(
+                    "portal-token-warmup",
+                    name="Capture window-hidden ScreenCast restore token",
+                    action=warm_window_hidden,
+                    out_dir=out_dir,
+                )
+                if window_warmup.result != RESULT_PASS:
+                    warmup = scenario_result(
+                        "portal-token-warmup",
+                        name=window_warmup.name,
+                        result=RESULT_FAIL,
+                        seconds=warmup.seconds + window_warmup.seconds,
+                        detail=window_warmup.detail or "window-hidden token warmup failed",
+                        log=window_warmup.log or warmup.log,
+                    )
             if warmup.result == RESULT_PASS:
                 try:
                     assert_linux_portal_tokens_captured(

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -30,6 +30,7 @@ from smoke_lib import (  # noqa: E402
     RESULT_FAIL,
     RESULT_PASS,
     ScenarioResult,
+    assert_linux_portal_tokens_captured,
     assert_mcp_fixture_e2e_executed,
     build_report,
     collect_preflight,
@@ -37,6 +38,8 @@ from smoke_lib import (  # noqa: E402
     hard_failures,
     host_cli_package_target,
     packaged_cli_executable,
+    portal_token_warmup_skip_reason,
+    prepare_linux_portal_token_env,
     run_callable_scenario,
     run_scenario,
     scenario_result,
@@ -145,10 +148,12 @@ def _assert_helper_near_executable(executable: Path, system: str) -> None:
             raise RuntimeError(f"Linux launcher unexpectedly tiny: {executable}")
 
 
-def _host_recording_task(system: str) -> str | None:
+def _host_recording_task(system: str, *, wayland_portal: bool = False) -> str | None:
     if system == "Darwin":
         return ":recording:runMacOsSckRegionSmoke"
     if system == "Linux":
+        if wayland_portal:
+            return ":recording:runWaylandPortalSmoke"
         return ":recording:runLinuxX11RecordingSmoke"
     return None
 
@@ -314,9 +319,67 @@ def main(argv: list[str] | None = None) -> int:
     gradle = str(ROOT / "gradlew")
     prefix = xvfb_prefix(system)
     force = gradle_ui_force_args()
+    scenario_env: dict[str, str] | None = None
     def add(item: ScenarioResult) -> None:
         results.append(item)
         _print_result(item)
+
+    # --- Linux Wayland portal token warmup ---
+    portal_skip = portal_token_warmup_skip_reason(system=system)
+    if portal_skip is not None:
+        add(
+            scenario_result(
+                "portal-token-warmup",
+                name="Capture persistent ScreenCast restore token",
+                result="n/a",
+                reason=portal_skip,
+                hard=True,
+            )
+        )
+    else:
+        print(
+            "portal-token-warmup: approve Share + Remember once; later cells reuse the token",
+            flush=True,
+        )
+        try:
+            scenario_env = prepare_linux_portal_token_env(ROOT, out_dir)
+        except RuntimeError as error:
+            add(
+                scenario_result(
+                    "portal-token-warmup",
+                    name="Capture persistent ScreenCast restore token",
+                    result="fail",
+                    detail=str(error),
+                    hard=True,
+                )
+            )
+        else:
+            warmup = run_scenario(
+                "portal-token-warmup",
+                name="Capture persistent ScreenCast restore token",
+                command=[gradle, ":recording:runWaylandPortalSmoke", "--console=plain"],
+                cwd=ROOT,
+                timeout=180,
+                out_dir=out_dir,
+                env=scenario_env,
+                overall_deadline=overall_deadline,
+            )
+            if warmup.result == RESULT_PASS:
+                try:
+                    assert_linux_portal_tokens_captured(scenario_env)
+                except RuntimeError as error:
+                    warmup = scenario_result(
+                        "portal-token-warmup",
+                        name=warmup.name,
+                        result=RESULT_FAIL,
+                        seconds=warmup.seconds,
+                        detail=str(error),
+                        log=warmup.log,
+                    )
+                    scenario_env = None
+            else:
+                scenario_env = None
+            add(warmup)
 
     # --- check ---
     if args.skip_check:
@@ -338,6 +401,7 @@ def main(argv: list[str] | None = None) -> int:
                 cwd=ROOT,
                 timeout=1200,
                 out_dir=out_dir,
+                env=scenario_env,
                 overall_deadline=overall_deadline,
             )
         )
@@ -351,6 +415,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=900,
             out_dir=out_dir,
+            env=scenario_env,
             overall_deadline=overall_deadline,
         )
     )
@@ -371,6 +436,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
+            env=scenario_env,
             overall_deadline=overall_deadline,
         )
     )
@@ -389,6 +455,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
+            env=scenario_env,
             overall_deadline=overall_deadline,
         )
     )
@@ -407,6 +474,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
+            env=scenario_env,
             overall_deadline=overall_deadline,
         )
     )
@@ -425,6 +493,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
+            env=scenario_env,
             overall_deadline=overall_deadline,
         )
     )
@@ -445,6 +514,7 @@ def main(argv: list[str] | None = None) -> int:
         cwd=ROOT,
         timeout=900,
         out_dir=out_dir,
+        env=scenario_env,
         overall_deadline=overall_deadline,
     )
     add(package_result)
@@ -504,6 +574,7 @@ def main(argv: list[str] | None = None) -> int:
                 cwd=ROOT,
                 timeout=600,
                 out_dir=out_dir,
+                env=scenario_env,
                 overall_deadline=overall_deadline,
             )
         )
@@ -530,6 +601,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
+            env=scenario_env,
             overall_deadline=overall_deadline,
         )
         if mcp_sdk.result == RESULT_PASS:
@@ -560,6 +632,7 @@ def main(argv: list[str] | None = None) -> int:
                     cwd=ROOT,
                     timeout=60,
                     out_dir=out_dir,
+                    env=scenario_env,
                     overall_deadline=overall_deadline,
                 )
                 # Merge seconds/detail: fail closed if either leg fails.
@@ -587,7 +660,9 @@ def main(argv: list[str] | None = None) -> int:
         add(mcp_sdk)
 
     # --- host native recording ---
-    recording_task = _host_recording_task(system)
+    recording_task = _host_recording_task(
+        system, wayland_portal=scenario_env is not None
+    )
     if args.skip_recording:
         add(
             scenario_result(
@@ -617,6 +692,7 @@ def main(argv: list[str] | None = None) -> int:
                 cwd=ROOT,
                 timeout=300,
                 out_dir=out_dir,
+                env=scenario_env,
                 overall_deadline=overall_deadline,
             )
         )
@@ -653,6 +729,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=1200,
             out_dir=out_dir,
+            env=scenario_env,
             overall_deadline=overall_deadline,
         )
         if maven_result.result == RESULT_PASS:

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -172,7 +172,7 @@ def _packaged_cli_portal_env(env: dict[str, str] | None) -> dict[str, str] | Non
     if env is None:
         return None
     packaged = dict(env)
-    packaged.pop("SPECTRE_WAYLAND_HELPER", None)
+    packaged["SPECTRE_WAYLAND_HELPER"] = ""
     return packaged
 
 

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -158,6 +158,13 @@ def _host_recording_task(system: str, *, wayland_portal: bool = False) -> str | 
     return None
 
 
+def _ui_prefix(system: str, *, wayland_portal: bool = False) -> list[str]:
+    """Xvfb only for X11 Linux. A real Wayland portal JFrame must stay on the seat."""
+    if wayland_portal:
+        return []
+    return xvfb_prefix(system)
+
+
 def _maven_local_version(release_version: str) -> str:
     # Keep smoke publication off the SNAPSHOT and release coordinates consumers might already have.
     return f"{release_version}-rc.smoke"
@@ -317,7 +324,6 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     gradle = str(ROOT / "gradlew")
-    prefix = xvfb_prefix(system)
     force = gradle_ui_force_args()
     scenario_env: dict[str, str] | None = None
     def add(item: ScenarioResult) -> None:
@@ -341,19 +347,24 @@ def main(argv: list[str] | None = None) -> int:
             "portal-token-warmup: approve Share + Remember once; later cells reuse the token",
             flush=True,
         )
-        try:
-            scenario_env = prepare_linux_portal_token_env(ROOT, out_dir)
-        except RuntimeError as error:
-            add(
-                scenario_result(
-                    "portal-token-warmup",
-                    name="Capture persistent ScreenCast restore token",
-                    result="fail",
-                    detail=str(error),
-                    hard=True,
-                )
+        scenario_env = prepare_linux_portal_token_env(ROOT, out_dir)
+        if "SPECTRE_WAYLAND_HELPER" not in scenario_env:
+            staged = run_scenario(
+                "portal-token-warmup",
+                name="Stage spectre-wayland-helper for token warmup",
+                command=[gradle, ":recording:assembleWaylandHelper", "--console=plain"],
+                cwd=ROOT,
+                timeout=600,
+                out_dir=out_dir,
+                env=scenario_env,
+                overall_deadline=overall_deadline,
             )
-        else:
+            if staged.result != RESULT_PASS:
+                add(staged)
+                scenario_env = None
+            else:
+                scenario_env = prepare_linux_portal_token_env(ROOT, out_dir)
+        if scenario_env is not None:
             warmup = run_scenario(
                 "portal-token-warmup",
                 name="Capture persistent ScreenCast restore token",
@@ -380,6 +391,8 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 scenario_env = None
             add(warmup)
+
+    prefix = _ui_prefix(system, wayland_portal=scenario_env is not None)
 
     # --- check ---
     if args.skip_check:

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -32,6 +32,7 @@ from smoke_lib import (  # noqa: E402
     ScenarioResult,
     assert_linux_portal_tokens_captured,
     assert_mcp_fixture_e2e_executed,
+    linux_portal_token_path,
     build_report,
     collect_preflight,
     gradle_ui_force_args,
@@ -365,6 +366,8 @@ def main(argv: list[str] | None = None) -> int:
             else:
                 scenario_env = prepare_linux_portal_token_env(ROOT, out_dir)
         if scenario_env is not None:
+            token_path = linux_portal_token_path(scenario_env)
+            before_mtime = token_path.stat().st_mtime_ns + 1 if token_path.is_file() else 0
             warmup = run_scenario(
                 "portal-token-warmup",
                 name="Capture persistent ScreenCast restore token",
@@ -377,7 +380,9 @@ def main(argv: list[str] | None = None) -> int:
             )
             if warmup.result == RESULT_PASS:
                 try:
-                    assert_linux_portal_tokens_captured(scenario_env)
+                    assert_linux_portal_tokens_captured(
+                        scenario_env, expected_mtime_ns=before_mtime
+                    )
                 except RuntimeError as error:
                     warmup = scenario_result(
                         "portal-token-warmup",

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -42,6 +42,7 @@ REQUIRED_SCENARIO_IDS: tuple[str, ...] = (
     "mcp-sdk-flow",
     "host-native-recording",
     "maven-local-consumer",
+    "portal-token-warmup",
 )
 
 RESULT_PASS = "pass"
@@ -641,6 +642,108 @@ def gradle_ui_force_args() -> list[str]:
         "--no-build-cache",
         "--console=plain",
     ]
+
+
+WAYLAND_RESTORE_TOKEN_PREFIX = "wayland-screencast-restore-token-"
+WAYLAND_HELPER_NAME = "spectre-wayland-helper"
+
+
+def is_linux_wayland_portal_session(
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    """True when this process can talk to a seated Wayland portal."""
+    environ = env or os.environ
+    session = (environ.get("XDG_SESSION_TYPE") or "").strip().lower()
+    if session == "x11":
+        return False
+    wayland_display = (environ.get("WAYLAND_DISPLAY") or "").strip()
+    runtime_dir = (environ.get("XDG_RUNTIME_DIR") or "").strip()
+    if wayland_display:
+        if runtime_dir:
+            socket_path = Path(runtime_dir) / wayland_display
+            if socket_path.exists():
+                return True
+            return False
+        return True
+    return session == "wayland"
+
+
+def portal_token_warmup_skip_reason(
+    env: Mapping[str, str] | None = None,
+    system: str | None = None,
+) -> str | None:
+    """Hard N/A reason when ScreenCast restore-token warmup cannot run."""
+    host = system or platform.system()
+    if host != "Linux":
+        return f"{host} does not use xdg-desktop-portal ScreenCast restore tokens"
+    if not is_linux_wayland_portal_session(env):
+        return "Linux Wayland portal token warmup requires a real Wayland session"
+    return None
+
+
+def linux_wayland_helper_candidates(root: Path) -> list[Path]:
+    machine = platform.machine()
+    arch = "aarch64" if machine in {"arm64", "aarch64"} else "x86_64"
+    return [
+        root
+        / "recording"
+        / "build"
+        / "generated"
+        / "waylandHelper"
+        / "native"
+        / "linux"
+        / arch
+        / WAYLAND_HELPER_NAME,
+        root / "recording" / "native" / "linux" / "target" / "release" / WAYLAND_HELPER_NAME,
+        root
+        / "recording-linux"
+        / "build"
+        / "resources"
+        / "main"
+        / "native"
+        / "linux"
+        / arch
+        / WAYLAND_HELPER_NAME,
+    ]
+
+
+def linux_wayland_helper_path(root: Path) -> Path:
+    for candidate in linux_wayland_helper_candidates(root):
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    searched = ", ".join(str(path) for path in linux_wayland_helper_candidates(root))
+    raise RuntimeError(f"spectre-wayland-helper not found; searched: {searched}")
+
+
+def prepare_linux_portal_token_env(root: Path, out_dir: Path) -> dict[str, str]:
+    """Pin one helper binary + restore-token dir for the whole smoke run."""
+    token_dir = Path(out_dir) / "wayland-restore-tokens"
+    token_dir.mkdir(parents=True, exist_ok=True)
+    token_dir.chmod(0o700)
+    helper = linux_wayland_helper_path(root)
+    return {
+        "SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir),
+        "SPECTRE_WAYLAND_HELPER": str(helper),
+    }
+
+
+def assert_linux_portal_tokens_captured(env: Mapping[str, str]) -> None:
+    token_dir = Path(env.get("SPECTRE_WAYLAND_RESTORE_TOKEN_DIR") or "")
+    if not token_dir.is_dir():
+        raise RuntimeError(
+            "ScreenCast restore token dir missing: "
+            f"{token_dir or '(SPECTRE_WAYLAND_RESTORE_TOKEN_DIR unset)'}"
+        )
+    captured = [
+        path
+        for path in token_dir.glob(f"{WAYLAND_RESTORE_TOKEN_PREFIX}*")
+        if path.is_file() and path.read_text(encoding="utf-8").strip()
+    ]
+    if not captured:
+        raise RuntimeError(
+            f"no ScreenCast restore token under {token_dir}; approve Share + Remember "
+            "once during portal-token-warmup"
+        )
 
 
 def xvfb_prefix(system: str | None = None) -> list[str]:

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -707,24 +707,23 @@ def linux_wayland_helper_candidates(root: Path) -> list[Path]:
     ]
 
 
-def linux_wayland_helper_path(root: Path) -> Path:
+def linux_wayland_helper_path(root: Path) -> Path | None:
     for candidate in linux_wayland_helper_candidates(root):
         if candidate.is_file() and os.access(candidate, os.X_OK):
             return candidate
-    searched = ", ".join(str(path) for path in linux_wayland_helper_candidates(root))
-    raise RuntimeError(f"spectre-wayland-helper not found; searched: {searched}")
+    return None
 
 
 def prepare_linux_portal_token_env(root: Path, out_dir: Path) -> dict[str, str]:
-    """Pin one helper binary + restore-token dir for the whole smoke run."""
+    """Pin a restore-token dir, and a helper binary when one is already staged."""
     token_dir = Path(out_dir) / "wayland-restore-tokens"
     token_dir.mkdir(parents=True, exist_ok=True)
     token_dir.chmod(0o700)
+    env = {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)}
     helper = linux_wayland_helper_path(root)
-    return {
-        "SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir),
-        "SPECTRE_WAYLAND_HELPER": str(helper),
-    }
+    if helper is not None:
+        env["SPECTRE_WAYLAND_HELPER"] = str(helper)
+    return env
 
 
 def assert_linux_portal_tokens_captured(env: Mapping[str, str]) -> None:

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -645,6 +645,7 @@ def gradle_ui_force_args() -> list[str]:
 
 
 WAYLAND_RESTORE_TOKEN_PREFIX = "wayland-screencast-restore-token-"
+WAYLAND_PORTAL_SMOKE_TOKEN_KEY = "monitor-embedded"
 WAYLAND_HELPER_NAME = "spectre-wayland-helper"
 
 
@@ -757,22 +758,35 @@ def prepare_linux_portal_token_env(root: Path, out_dir: Path) -> dict[str, str]:
     return env
 
 
-def assert_linux_portal_tokens_captured(env: Mapping[str, str]) -> None:
+def linux_portal_token_path(
+    env: Mapping[str, str],
+    token_key: str = WAYLAND_PORTAL_SMOKE_TOKEN_KEY,
+) -> Path:
+    token_dir = Path(env.get("SPECTRE_WAYLAND_RESTORE_TOKEN_DIR") or "")
+    return token_dir / f"{WAYLAND_RESTORE_TOKEN_PREFIX}{token_key}"
+
+
+def assert_linux_portal_tokens_captured(
+    env: Mapping[str, str],
+    *,
+    token_key: str = WAYLAND_PORTAL_SMOKE_TOKEN_KEY,
+    expected_mtime_ns: int | None = None,
+) -> None:
     token_dir = Path(env.get("SPECTRE_WAYLAND_RESTORE_TOKEN_DIR") or "")
     if not token_dir.is_dir():
         raise RuntimeError(
             "ScreenCast restore token dir missing: "
             f"{token_dir or '(SPECTRE_WAYLAND_RESTORE_TOKEN_DIR unset)'}"
         )
-    captured = [
-        path
-        for path in token_dir.glob(f"{WAYLAND_RESTORE_TOKEN_PREFIX}*")
-        if path.is_file() and path.read_text(encoding="utf-8").strip()
-    ]
-    if not captured:
+    path = linux_portal_token_path(env, token_key)
+    if not path.is_file() or not path.read_text(encoding="utf-8").strip():
         raise RuntimeError(
-            f"no ScreenCast restore token under {token_dir}; approve Share + Remember "
+            f"missing {path.name} under {token_dir}; approve Share + Remember "
             "once during portal-token-warmup"
+        )
+    if expected_mtime_ns is not None and path.stat().st_mtime_ns < expected_mtime_ns:
+        raise RuntimeError(
+            f"{path.name} was not refreshed by this warmup; later cells may prompt again"
         )
 
 

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -650,22 +650,53 @@ WAYLAND_HELPER_NAME = "spectre-wayland-helper"
 
 def is_linux_wayland_portal_session(
     env: Mapping[str, str] | None = None,
+    *,
+    display_is_pure_x11: Callable[[str], bool] | None = None,
 ) -> bool:
-    """True when this process can talk to a seated Wayland portal."""
+    """True when this process should use seated Wayland portal warmup."""
     environ = env or os.environ
+    override = (environ.get("SPECTRE_CAPTURE_BACKEND") or "").strip().lower()
+    if override in {"x11", "xorg", "xvfb"}:
+        return False
+    if override in {"wayland", "portal"}:
+        return True
     session = (environ.get("XDG_SESSION_TYPE") or "").strip().lower()
     if session == "x11":
+        return False
+    display = (environ.get("DISPLAY") or "").strip()
+    probe = display_is_pure_x11 or linux_display_is_pure_x11
+    if display and probe(display):
+        # Nested xvfb-run on a Wayland login inherits WAYLAND_DISPLAY, but windows live
+        # on the Xvfb DISPLAY. Real Wayland+XWayland (XWAYLAND extension) stays portal.
         return False
     wayland_display = (environ.get("WAYLAND_DISPLAY") or "").strip()
     runtime_dir = (environ.get("XDG_RUNTIME_DIR") or "").strip()
     if wayland_display:
         if runtime_dir:
-            socket_path = Path(runtime_dir) / wayland_display
-            if socket_path.exists():
-                return True
-            return False
+            return (Path(runtime_dir) / wayland_display).exists()
         return True
     return session == "wayland"
+
+
+def linux_display_is_pure_x11(display: str) -> bool:
+    """Best-effort Xvfb / non-XWayland probe. Unknown displays are not treated as Xvfb."""
+    if not display:
+        return False
+    try:
+        completed = subprocess.run(
+            ["xdpyinfo", "-display", display],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=2,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    output = completed.stdout or ""
+    if completed.returncode != 0 or not output.strip():
+        return False
+    return "XWAYLAND" not in output.upper()
 
 
 def portal_token_warmup_skip_reason(

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -646,6 +646,11 @@ def gradle_ui_force_args() -> list[str]:
 
 WAYLAND_RESTORE_TOKEN_PREFIX = "wayland-screencast-restore-token-"
 WAYLAND_PORTAL_SMOKE_TOKEN_KEY = "monitor-embedded"
+WAYLAND_PORTAL_WINDOW_TOKEN_KEY = "window-hidden"
+WAYLAND_PORTAL_WARMUP_TOKEN_KEYS: tuple[str, ...] = (
+    WAYLAND_PORTAL_SMOKE_TOKEN_KEY,
+    WAYLAND_PORTAL_WINDOW_TOKEN_KEY,
+)
 WAYLAND_HELPER_NAME = "spectre-wayland-helper"
 
 
@@ -758,6 +763,33 @@ def prepare_linux_portal_token_env(root: Path, out_dir: Path) -> dict[str, str]:
     return env
 
 
+def window_hidden_token_warmup_command(
+    env: Mapping[str, str],
+    output: Path,
+) -> list[str]:
+    helper = env.get("SPECTRE_WAYLAND_HELPER") or ""
+    if not helper or not Path(helper).is_file():
+        raise RuntimeError(
+            "SPECTRE_WAYLAND_HELPER is required to warm the window-hidden restore token"
+        )
+    return [helper]
+
+
+def window_hidden_token_warmup_payload(output: Path) -> str:
+    return json.dumps(
+        {
+            "command": "screenshot",
+            "backend": "wayland_portal",
+            "target": "window",
+            "source_types": ["window"],
+            "cursor_mode": "hidden",
+            "region": {"x": 0, "y": 0, "width": 64, "height": 64},
+            "output": str(output),
+        },
+        separators=(",", ":"),
+    ) + "\n"
+
+
 def linux_portal_token_path(
     env: Mapping[str, str],
     token_key: str = WAYLAND_PORTAL_SMOKE_TOKEN_KEY,
@@ -769,8 +801,8 @@ def linux_portal_token_path(
 def assert_linux_portal_tokens_captured(
     env: Mapping[str, str],
     *,
-    token_key: str = WAYLAND_PORTAL_SMOKE_TOKEN_KEY,
-    expected_mtime_ns: int | None = None,
+    token_keys: Sequence[str] = WAYLAND_PORTAL_WARMUP_TOKEN_KEYS,
+    expected_mtime_ns: Mapping[str, int] | int | None = None,
 ) -> None:
     token_dir = Path(env.get("SPECTRE_WAYLAND_RESTORE_TOKEN_DIR") or "")
     if not token_dir.is_dir():
@@ -778,15 +810,32 @@ def assert_linux_portal_tokens_captured(
             "ScreenCast restore token dir missing: "
             f"{token_dir or '(SPECTRE_WAYLAND_RESTORE_TOKEN_DIR unset)'}"
         )
-    path = linux_portal_token_path(env, token_key)
-    if not path.is_file() or not path.read_text(encoding="utf-8").strip():
-        raise RuntimeError(
-            f"missing {path.name} under {token_dir}; approve Share + Remember "
-            "once during portal-token-warmup"
+    missing: list[str] = []
+    stale: list[str] = []
+    for token_key in token_keys:
+        path = linux_portal_token_path(env, token_key)
+        if not path.is_file() or not path.read_text(encoding="utf-8").strip():
+            missing.append(path.name)
+            continue
+        if expected_mtime_ns is None:
+            continue
+        required = (
+            expected_mtime_ns.get(token_key)
+            if isinstance(expected_mtime_ns, Mapping)
+            else expected_mtime_ns
         )
-    if expected_mtime_ns is not None and path.stat().st_mtime_ns < expected_mtime_ns:
+        if required is not None and path.stat().st_mtime_ns < required:
+            stale.append(path.name)
+    if missing:
         raise RuntimeError(
-            f"{path.name} was not refreshed by this warmup; later cells may prompt again"
+            "missing ScreenCast restore token(s) "
+            f"{', '.join(missing)} under {token_dir}; approve Share + Remember "
+            "for monitor and window during portal-token-warmup"
+        )
+    if stale:
+        raise RuntimeError(
+            "ScreenCast restore token(s) not refreshed by this warmup: "
+            f"{', '.join(stale)}; later cells may prompt again"
         )
 
 

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -646,11 +646,7 @@ def gradle_ui_force_args() -> list[str]:
 
 WAYLAND_RESTORE_TOKEN_PREFIX = "wayland-screencast-restore-token-"
 WAYLAND_PORTAL_SMOKE_TOKEN_KEY = "monitor-embedded"
-WAYLAND_PORTAL_WINDOW_TOKEN_KEY = "window-hidden"
-WAYLAND_PORTAL_WARMUP_TOKEN_KEYS: tuple[str, ...] = (
-    WAYLAND_PORTAL_SMOKE_TOKEN_KEY,
-    WAYLAND_PORTAL_WINDOW_TOKEN_KEY,
-)
+WAYLAND_PORTAL_WARMUP_TOKEN_KEYS: tuple[str, ...] = (WAYLAND_PORTAL_SMOKE_TOKEN_KEY,)
 WAYLAND_HELPER_NAME = "spectre-wayland-helper"
 
 
@@ -761,33 +757,6 @@ def prepare_linux_portal_token_env(root: Path, out_dir: Path) -> dict[str, str]:
     if helper is not None:
         env["SPECTRE_WAYLAND_HELPER"] = str(helper)
     return env
-
-
-def window_hidden_token_warmup_command(
-    env: Mapping[str, str],
-    output: Path,
-) -> list[str]:
-    helper = env.get("SPECTRE_WAYLAND_HELPER") or ""
-    if not helper or not Path(helper).is_file():
-        raise RuntimeError(
-            "SPECTRE_WAYLAND_HELPER is required to warm the window-hidden restore token"
-        )
-    return [helper]
-
-
-def window_hidden_token_warmup_payload(output: Path) -> str:
-    return json.dumps(
-        {
-            "command": "screenshot",
-            "backend": "wayland_portal",
-            "target": "window",
-            "source_types": ["window"],
-            "cursor_mode": "hidden",
-            "region": {"x": 0, "y": 0, "width": 64, "height": 64},
-            "output": str(output),
-        },
-        separators=(",", ":"),
-    ) + "\n"
 
 
 def linux_portal_token_path(

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -487,6 +487,10 @@ def run_command(
     if env is not None:
         merged_env = os.environ.copy()
         merged_env.update(env)
+        # Empty values unset inherited overrides (e.g. SPECTRE_WAYLAND_RESTORE_TOKEN_PATH).
+        for key, value in list(merged_env.items()):
+            if key in env and value == "":
+                del merged_env[key]
 
     remaining = timeout
     if overall_deadline is not None:
@@ -752,7 +756,11 @@ def prepare_linux_portal_token_env(root: Path, out_dir: Path) -> dict[str, str]:
     token_dir = Path(out_dir) / "wayland-restore-tokens"
     token_dir.mkdir(parents=True, exist_ok=True)
     token_dir.chmod(0o700)
-    env = {"SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir)}
+    env = {
+        "SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": str(token_dir),
+        # PATH takes precedence over DIR in the helper. Unset any inherited override.
+        "SPECTRE_WAYLAND_RESTORE_TOKEN_PATH": "",
+    }
     helper = linux_wayland_helper_path(root)
     if helper is not None:
         env["SPECTRE_WAYLAND_HELPER"] = str(helper)

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -64,7 +64,8 @@ $script:RequiredScenarioIds = @(
     "cli-user-flow",
     "mcp-sdk-flow",
     "host-native-recording",
-    "maven-local-consumer"
+    "maven-local-consumer",
+    "portal-token-warmup"
 )
 $ErrorActionPreference = "Stop"
 # Avoid StrictMode edge cases with dynamic PSCustomObject / native interop on WinPS 5.1.
@@ -715,6 +716,8 @@ try {
         [void]$results.Add((New-StepResult -Id "cli-user-flow" -Name "Packaged CLI user flow" -Result "n/a" -Reason $reason))
         [void]$results.Add((New-StepResult -Id "mcp-sdk-flow" -Name "Packaged MCP attach/op/detach lifecycle + strict stdio" -Result "n/a" -Reason $reason))
     }
+
+    [void]$results.Add((New-StepResult -Id "portal-token-warmup" -Name "Capture persistent ScreenCast restore token" -Result "n/a" -Reason "Windows does not use xdg-desktop-portal ScreenCast restore tokens"))
 
     if ($SkipMavenLocal) {
         [void]$results.Add((New-StepResult -Id "maven-local-consumer" -Name "Maven Local publication + fresh consumer" -Result "n/a" -Reason "skipped via -SkipMavenLocal"))


### PR DESCRIPTION
## Summary
- Add `portal-token-warmup` so Linux Wayland smoke asks for ScreenCast once at the start, then reuses the restore token.
- Pin `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` for later Gradle cells; use portal recording on Wayland instead of X11.
- Windows/macOS/Xvfb record hard `n/a`. Docs and contract tests updated.

## Test plan
- [x] `python3 .github/scripts/test-release-smoke-scripts.py`
- [x] `bash .github/scripts/test-windows-release-smoke-script.sh`
- [x] `./gradlew check`
- [ ] After merge: rerun Linux `release-smoke.py` on jbr-bench and approve Share+Remember once