### PR TITLE
fix(recording): map mixed AWT/portal crops before clamping

### DIFF
--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -568,7 +568,10 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
             self.assertEqual(out_dir / "wayland-restore-tokens", token_dir)
             self.assertTrue(token_dir.is_dir())
             self.assertEqual(str(helper), env["SPECTRE_WAYLAND_HELPER"])
-            self.assertEqual("0700", oct(token_dir.stat().st_mode)[-4:])
+            if os.name == "nt":
+                self.assertTrue(token_dir.is_dir())
+            else:
+                self.assertEqual("0700", oct(token_dir.stat().st_mode)[-4:])
 
     def test_prepare_linux_portal_token_env_without_helper_omits_override(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -169,10 +169,11 @@ interactive and not automatable. Spectre's `spectre-wayland-helper` uses portal
 
   **HiDPI / mixed AWT and portal coordinates.** On fractional-scale Wayland, AWT/XWayland
   often reports a larger virtual desktop than the ScreenCast stream (for example 2560×1440
-  versus a 1536×864 portal stream). Region capture converts the AWT rectangle into stream
-  pixels when the two sizes share an aspect ratio, then clamps any leftover overflow. A
-  region that misses the granted stream entirely still fails. Window-source crops are
-  already stream-relative and are only clamped.
+  versus a 1536×864 portal stream). Region capture sends the AWT bounds of the display
+  that contains the requested rectangle and converts that rectangle into stream pixels
+  when the two sizes share an aspect ratio, then clamps any leftover overflow. A region
+  that misses the granted stream entirely still fails. Window-source crops are already
+  stream-relative and are only clamped.
 
   Wayland still screenshots use the same portal grant model as video. They are supported
   only when the compositor's ScreenCast portal can provide the requested monitor or window

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -167,6 +167,13 @@ interactive and not automatable. Spectre's `spectre-wayland-helper` uses portal
   case; it will not make Qt, JavaFX, Electron, SDL, KDE, or wlroots windows publish the
   GTK-specific property.
 
+  **HiDPI / mixed AWT and portal coordinates.** On fractional-scale Wayland, AWT/XWayland
+  often reports a larger virtual desktop than the ScreenCast stream (for example 2560×1440
+  versus a 1536×864 portal stream). Region capture converts the AWT rectangle into stream
+  pixels when the two sizes share an aspect ratio, then clamps any leftover overflow. A
+  region that misses the granted stream entirely still fails. Window-source crops are
+  already stream-relative and are only clamped.
+
   Wayland still screenshots use the same portal grant model as video. They are supported
   only when the compositor's ScreenCast portal can provide the requested monitor or window
   stream and the user accepts the dialog. In unattended SSH/headless runs, a hidden or

--- a/recording/native/linux/src/gst.rs
+++ b/recording/native/linux/src/gst.rs
@@ -81,13 +81,6 @@ pub fn build_pipewire_argv(
             region.height
         );
     }
-    if region.x < 0 || region.y < 0 {
-        bail!(
-            "region origin must be non-negative for the videocrop filter, was ({}, {})",
-            region.x,
-            region.y
-        );
-    }
     if pipewire_fd < 0 {
         bail!(
             "pipewire_fd must be a valid Unix FD (>= 0), was {}. Did OpenPipeWireRemote \
@@ -103,25 +96,12 @@ pub fn build_pipewire_argv(
             stream_h
         );
     }
-    let region_right = region.x as i64 + region.width as i64;
-    let region_bottom = region.y as i64 + region.height as i64;
-    if region_right > stream_w as i64 {
-        bail!(
-            "region right edge {} exceeds stream width {}",
-            region_right,
-            stream_w
-        );
-    }
-    if region_bottom > stream_h as i64 {
-        bail!(
-            "region bottom edge {} exceeds stream height {}",
-            region_bottom,
-            stream_h
-        );
-    }
-    let top = region.y as u32;
+    let clipped = crate::stream_region::clamp_region_to_stream(region, stream_size)?;
+    let region_right = clipped.x as i64 + clipped.width as i64;
+    let region_bottom = clipped.y as i64 + clipped.height as i64;
+    let top = clipped.y as u32;
     let bottom = stream_h - region_bottom as u32;
-    let left = region.x as u32;
+    let left = clipped.x as u32;
     let right = stream_w - region_right as u32;
     // Cursor is rendered into the captured frames by PipeWire (cursor_mode=EMBEDDED on
     // SelectSources). gst-launch's pipewiresrc has no per-element cursor knob — the
@@ -345,13 +325,6 @@ fn pipewire_crop_insets(
     stream_size: (u32, u32),
 ) -> Result<(u32, u32, u32, u32)> {
     validate_positive_region(region)?;
-    if region.x < 0 || region.y < 0 {
-        bail!(
-            "region origin must be non-negative for the videocrop filter, was ({}, {})",
-            region.x,
-            region.y
-        );
-    }
     if pipewire_fd < 0 {
         bail!(
             "pipewire_fd must be a valid Unix FD (>= 0), was {}. Did OpenPipeWireRemote \
@@ -367,26 +340,13 @@ fn pipewire_crop_insets(
             stream_h
         );
     }
-    let region_right = region.x as i64 + region.width as i64;
-    let region_bottom = region.y as i64 + region.height as i64;
-    if region_right > stream_w as i64 {
-        bail!(
-            "region right edge {} exceeds stream width {}",
-            region_right,
-            stream_w
-        );
-    }
-    if region_bottom > stream_h as i64 {
-        bail!(
-            "region bottom edge {} exceeds stream height {}",
-            region_bottom,
-            stream_h
-        );
-    }
+    let clipped = crate::stream_region::clamp_region_to_stream(region, stream_size)?;
+    let region_right = clipped.x as i64 + clipped.width as i64;
+    let region_bottom = clipped.y as i64 + clipped.height as i64;
     Ok((
-        region.y as u32,
+        clipped.y as u32,
         stream_h - region_bottom as u32,
-        region.x as u32,
+        clipped.x as u32,
         stream_w - region_right as u32,
     ))
 }
@@ -577,64 +537,70 @@ mod tests {
     }
 
     #[test]
-    fn argv_rejects_negative_region_origin() {
-        // videocrop's pixel-inset form would underflow if origin < 0, producing nonsense
-        // crops. Reject up-front so a misconfigured caller doesn't silently produce a
-        // black mp4 the way the JVM/JNR-POSIX bake-off attempt did.
-        let bad_x = build_pipewire_argv(
+    fn argv_clamps_negative_origin_that_still_intersects_the_stream() {
+        let argv = build_pipewire_argv(
             42,
             17,
-            region(-1, 0, 100, 100),
+            region(-20, -10, 100, 100),
             (1920, 1080),
             30,
             true,
             &PathBuf::from("/tmp/x"),
             "libx264",
+        )
+        .expect("partially off-stream origin should clamp");
+        assert_contains_sequence(
+            &argv,
+            &[
+                "videocrop",
+                "top=0",
+                "bottom=990",
+                "left=0",
+                "right=1840",
+            ],
         );
-        assert!(bad_x.is_err(), "negative x should be rejected");
-        let bad_y = build_pipewire_argv(
-            42,
-            17,
-            region(0, -10, 100, 100),
-            (1920, 1080),
-            30,
-            true,
-            &PathBuf::from("/tmp/x"),
-            "libx264",
-        );
-        assert!(bad_y.is_err(), "negative y should be rejected");
     }
 
     #[test]
-    fn argv_rejects_region_exceeding_stream_bounds() {
-        let too_wide = build_pipewire_argv(
+    fn argv_clamps_region_that_overflows_stream_bounds() {
+        // A leftover overflow after mixed-space conversion, or a window larger than the
+        // granted stream, must crop rather than fail the recording.
+        let argv = build_pipewire_argv(
             42,
             17,
-            region(0, 0, 2000, 100),
-            (1920, 1080),
+            region(1362, 0, 480, 240),
+            (1536, 864),
+            30,
+            true,
+            &PathBuf::from("/tmp/x"),
+            "libx264",
+        )
+        .expect("overflowing region should clamp to the visible stream");
+        assert_contains_sequence(
+            &argv,
+            &[
+                "videocrop",
+                "top=0",
+                "bottom=624",
+                "left=1362",
+                "right=0",
+            ],
+        );
+    }
+
+    #[test]
+    fn argv_rejects_region_with_empty_stream_intersection() {
+        let miss = build_pipewire_argv(
+            42,
+            17,
+            region(2000, 0, 480, 240),
+            (1536, 864),
             30,
             true,
             &PathBuf::from("/tmp/x"),
             "libx264",
         );
-        assert!(
-            too_wide.is_err(),
-            "region wider than stream should be rejected"
-        );
-        let too_tall = build_pipewire_argv(
-            42,
-            17,
-            region(0, 0, 100, 2000),
-            (1920, 1080),
-            30,
-            true,
-            &PathBuf::from("/tmp/x"),
-            "libx264",
-        );
-        assert!(
-            too_tall.is_err(),
-            "region taller than stream should be rejected"
-        );
+        assert!(miss.is_err(), "region entirely off-stream should still fail");
     }
 
     #[test]

--- a/recording/native/linux/src/main.rs
+++ b/recording/native/linux/src/main.rs
@@ -20,6 +20,7 @@ mod portal;
 mod protocol;
 mod recorder;
 mod screenshot;
+mod stream_region;
 
 use anyhow::Result;
 use protocol::{Command, Event};

--- a/recording/native/linux/src/protocol.rs
+++ b/recording/native/linux/src/protocol.rs
@@ -38,6 +38,10 @@ pub struct StartCommand {
     pub cursor_mode: CursorMode,
     pub frame_rate: u32,
     pub region: Region,
+    /// AWT virtual-desktop size in the same pixel space as [region], when known.
+    /// Used to convert mixed HiDPI AWT/XWayland coordinates onto the portal stream.
+    #[serde(default)]
+    pub screen_size: Option<[i32; 2]>,
     pub output: String,
     pub codec: String,
 }
@@ -54,6 +58,9 @@ pub struct ScreenshotCommand {
     pub window_title: Option<String>,
     pub cursor_mode: CursorMode,
     pub region: Region,
+    /// AWT virtual-desktop size in the same pixel space as [region], when known.
+    #[serde(default)]
+    pub screen_size: Option<[i32; 2]>,
     pub output: String,
 }
 

--- a/recording/native/linux/src/protocol.rs
+++ b/recording/native/linux/src/protocol.rs
@@ -38,10 +38,12 @@ pub struct StartCommand {
     pub cursor_mode: CursorMode,
     pub frame_rate: u32,
     pub region: Region,
-    /// AWT virtual-desktop size in the same pixel space as [region], when known.
-    /// Used to convert mixed HiDPI AWT/XWayland coordinates onto the portal stream.
+    /// AWT bounds of the display that contains [region], when known.
+    /// Origin + size in the same pixel space as [region]. Used to convert mixed
+    /// HiDPI AWT/XWayland coordinates onto the selected portal stream — never the
+    /// primary `Toolkit.screenSize`, which is wrong for a secondary monitor.
     #[serde(default)]
-    pub screen_size: Option<[i32; 2]>,
+    pub screen_size: Option<[i32; 4]>,
     pub output: String,
     pub codec: String,
 }
@@ -58,9 +60,9 @@ pub struct ScreenshotCommand {
     pub window_title: Option<String>,
     pub cursor_mode: CursorMode,
     pub region: Region,
-    /// AWT virtual-desktop size in the same pixel space as [region], when known.
+    /// AWT bounds of the display that contains [region], when known (`x,y,w,h`).
     #[serde(default)]
-    pub screen_size: Option<[i32; 2]>,
+    pub screen_size: Option<[i32; 4]>,
     pub output: String,
 }
 

--- a/recording/native/linux/src/recorder.rs
+++ b/recording/native/linux/src/recorder.rs
@@ -60,15 +60,20 @@ fn run_wayland(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
     fcntl(session.pipewire_fd, FcntlArg::F_SETFD(flags))
         .context("fcntl(F_SETFD, !CLOEXEC) on PipeWire FD")?;
 
-    // 3. Translate the AWT-screen region into stream-relative coordinates. The portal hands
-    // us a stream covering one monitor (or the user-selected window); its top-left is in
-    // monitor coords, which can be non-(0,0) on multi-monitor setups. Our AWT-side region is
-    // already relative to the screen origin, so subtract the stream position.
-    let stream_relative_region = crate::protocol::Region {
-        x: start.region.x - session.stream.position.0,
-        y: start.region.y - session.stream.position.1,
-        width: start.region.width,
-        height: start.region.height,
+    // 3. Translate the AWT-screen region into stream-relative coordinates.
+    // Window-source crops are already stream-relative (GTK frame extents). Monitor/region
+    // crops may be in a mixed AWT/XWayland pixel space; convert then clamp.
+    let stream_relative_region = if start.target == CaptureTarget::Window {
+        crate::stream_region::clamp_region_to_stream(start.region, session.stream.size)
+            .context("clamping window-source crop to portal stream")?
+    } else {
+        crate::stream_region::map_awt_region_to_stream(
+            start.region,
+            session.stream.position,
+            session.stream.size,
+            start.screen_size.map(|s| (s[0], s[1])),
+        )
+        .context("mapping AWT region onto portal stream")?
     };
 
     let argv = build_pipewire_argv(

--- a/recording/native/linux/src/recorder.rs
+++ b/recording/native/linux/src/recorder.rs
@@ -71,7 +71,7 @@ fn run_wayland(start: StartCommand, events: mpsc::Sender<Event>) -> Result<()> {
             start.region,
             session.stream.position,
             session.stream.size,
-            start.screen_size.map(|s| (s[0], s[1])),
+            start.screen_size.and_then(crate::stream_region::screen_size_to_region),
         )
         .context("mapping AWT region onto portal stream")?
     };

--- a/recording/native/linux/src/screenshot.rs
+++ b/recording/native/linux/src/screenshot.rs
@@ -68,11 +68,17 @@ fn run_wayland_screenshot(command: &ScreenshotCommand, output: &PathBuf) -> Resu
     .context("portal screenshot handshake")?;
     ensure_window_source_if_requested(command.target, session.stream.source_type)?;
     clear_cloexec(session.pipewire_fd).context("allowing PipeWire FD inheritance")?;
-    let stream_relative_region = crate::protocol::Region {
-        x: command.region.x - session.stream.position.0,
-        y: command.region.y - session.stream.position.1,
-        width: command.region.width,
-        height: command.region.height,
+    let stream_relative_region = if command.target == CaptureTarget::Window {
+        crate::stream_region::clamp_region_to_stream(command.region, session.stream.size)
+            .context("clamping window-source screenshot crop to portal stream")?
+    } else {
+        crate::stream_region::map_awt_region_to_stream(
+            command.region,
+            session.stream.position,
+            session.stream.size,
+            command.screen_size.map(|s| (s[0], s[1])),
+        )
+        .context("mapping AWT screenshot region onto portal stream")?
     };
     let argv = build_pipewire_png_argv(
         session.stream.node_id,

--- a/recording/native/linux/src/screenshot.rs
+++ b/recording/native/linux/src/screenshot.rs
@@ -76,7 +76,9 @@ fn run_wayland_screenshot(command: &ScreenshotCommand, output: &PathBuf) -> Resu
             command.region,
             session.stream.position,
             session.stream.size,
-            command.screen_size.map(|s| (s[0], s[1])),
+            command
+                .screen_size
+                .and_then(crate::stream_region::screen_size_to_region),
         )
         .context("mapping AWT screenshot region onto portal stream")?
     };

--- a/recording/native/linux/src/stream_region.rs
+++ b/recording/native/linux/src/stream_region.rs
@@ -28,21 +28,23 @@ pub fn map_awt_region_to_stream(
             };
             match scale_from_awt_display(display, stream_size) {
                 DisplayScale::Scaled(sx, sy) => scale_region(local, sx, sy),
-                DisplayScale::Identity => local,
-                DisplayScale::Unrelated => Region {
-                    x: region.x - stream_position.0,
-                    y: region.y - stream_position.1,
-                    width: region.width,
-                    height: region.height,
-                },
+                DisplayScale::Identity => {
+                    let stream_relative = subtract_origin(region, stream_position);
+                    // Same-size restore token for a different monitor: display-local
+                    // would silently crop the granted stream. Fail if stream-relative
+                    // misses while display-local would succeed.
+                    if clamp_region_to_stream(local, stream_size).is_ok()
+                        && clamp_region_to_stream(stream_relative, stream_size).is_err()
+                    {
+                        stream_relative
+                    } else {
+                        local
+                    }
+                }
+                DisplayScale::Unrelated => subtract_origin(region, stream_position),
             }
         }
-        None => Region {
-            x: region.x - stream_position.0,
-            y: region.y - stream_position.1,
-            width: region.width,
-            height: region.height,
-        },
+        None => subtract_origin(region, stream_position),
     };
     clamp_region_to_stream(relative, stream_size)
 }
@@ -67,6 +69,15 @@ fn scale_from_awt_display(display: Region, stream_size: (u32, u32)) -> DisplaySc
         return DisplayScale::Identity;
     }
     DisplayScale::Scaled(sx, sy)
+}
+
+fn subtract_origin(region: Region, origin: (i32, i32)) -> Region {
+    Region {
+        x: region.x - origin.0,
+        y: region.y - origin.1,
+        width: region.width,
+        height: region.height,
+    }
 }
 
 fn scale_region(region: Region, sx: f64, sy: f64) -> Region {
@@ -233,6 +244,24 @@ mod tests {
         assert_eq!(mapped.y, 0);
         assert_eq!(mapped.width, 400);
         assert_eq!(mapped.height, 300);
+    }
+
+    #[test]
+    fn rejects_identity_region_when_granted_stream_is_a_different_monitor() {
+        // Restore token granted the primary 1920x1080 stream at (0,0), but the
+        // requested window is on a same-size secondary. Display-local coords
+        // would silently record the primary; fail instead.
+        let err = map_awt_region_to_stream(
+            region(2000, 80, 400, 300),
+            (0, 0),
+            (1920, 1080),
+            Some(region(1920, 0, 1920, 1080)),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("does not intersect"),
+            "{err:#}"
+        );
     }
 
     #[test]

--- a/recording/native/linux/src/stream_region.rs
+++ b/recording/native/linux/src/stream_region.rs
@@ -28,19 +28,12 @@ pub fn map_awt_region_to_stream(
             };
             match scale_from_awt_display(display, stream_size) {
                 DisplayScale::Scaled(sx, sy) => scale_region(local, sx, sy),
-                DisplayScale::Identity => {
-                    let stream_relative = subtract_origin(region, stream_position);
-                    // Same-size restore token for a different monitor: display-local
-                    // would silently crop the granted stream. Fail if stream-relative
-                    // misses while display-local would succeed.
-                    if clamp_region_to_stream(local, stream_size).is_ok()
-                        && clamp_region_to_stream(stream_relative, stream_size).is_err()
-                    {
-                        stream_relative
-                    } else {
-                        local
-                    }
-                }
+                DisplayScale::Identity => reject_if_granted_stream_misses(
+                    local,
+                    region,
+                    stream_position,
+                    stream_size,
+                ),
                 DisplayScale::Unrelated => subtract_origin(region, stream_position),
             }
         }
@@ -69,6 +62,28 @@ fn scale_from_awt_display(display: Region, stream_size: (u32, u32)) -> DisplaySc
         return DisplayScale::Identity;
     }
     DisplayScale::Scaled(sx, sy)
+}
+
+/// Same-size restore token for a different 1x monitor: display-local coords
+/// would silently crop the granted stream. If that crop hits but the unscaled
+/// stream-relative crop misses, return the miss so the caller fails closed.
+/// Scaled displays cannot use this check: a valid secondary-monitor stream is
+/// usually origin (0, 0), which is geometrically identical to a wrong-monitor
+/// grant.
+fn reject_if_granted_stream_misses(
+    display_local: Region,
+    region: Region,
+    stream_position: (i32, i32),
+    stream_size: (u32, u32),
+) -> Region {
+    let stream_relative = subtract_origin(region, stream_position);
+    if clamp_region_to_stream(display_local, stream_size).is_ok()
+        && clamp_region_to_stream(stream_relative, stream_size).is_err()
+    {
+        stream_relative
+    } else {
+        display_local
+    }
 }
 
 fn subtract_origin(region: Region, origin: (i32, i32)) -> Region {

--- a/recording/native/linux/src/stream_region.rs
+++ b/recording/native/linux/src/stream_region.rs
@@ -6,7 +6,9 @@ use anyhow::{bail, Result};
 /// Convert an AWT screen-pixel [region] into a PipeWire stream-relative crop.
 ///
 /// Mixed-space HiDPI (XWayland 2560×1440 vs a 1536×864 portal stream) is scaled
-/// when the AWT virtual desktop and the stream share an aspect ratio. Multi-monitor
+/// when the selected AWT display and the stream share an aspect ratio. The optional
+/// [awt_display] is that display's origin + size in AWT pixels — never the primary
+/// `Toolkit.screenSize`, which is wrong for a secondary monitor. Multi-monitor
 /// virtual desktops that do not match the selected stream are left unscaled and
 /// only translated by [stream_position]. A leftover overflow then clamps; a miss
 /// is still an error.
@@ -14,42 +16,50 @@ pub fn map_awt_region_to_stream(
     region: Region,
     stream_position: (i32, i32),
     stream_size: (u32, u32),
-    awt_screen_size: Option<(i32, i32)>,
+    awt_display: Option<Region>,
 ) -> Result<Region> {
-    let scaled = match scale_from_awt_screen(awt_screen_size, stream_size) {
-        Some((sx, sy)) => scale_region(region, sx, sy),
-        None => region,
-    };
-    let relative = Region {
-        x: scaled.x - stream_position.0,
-        y: scaled.y - stream_position.1,
-        width: scaled.width,
-        height: scaled.height,
+    let relative = match scale_from_awt_display(awt_display, stream_size) {
+        Some((sx, sy, origin)) => scale_region(
+            Region {
+                x: region.x - origin.0,
+                y: region.y - origin.1,
+                width: region.width,
+                height: region.height,
+            },
+            sx,
+            sy,
+        ),
+        None => Region {
+            x: region.x - stream_position.0,
+            y: region.y - stream_position.1,
+            width: region.width,
+            height: region.height,
+        },
     };
     clamp_region_to_stream(relative, stream_size)
 }
 
-fn scale_from_awt_screen(
-    awt_screen_size: Option<(i32, i32)>,
+fn scale_from_awt_display(
+    awt_display: Option<Region>,
     stream_size: (u32, u32),
-) -> Option<(f64, f64)> {
-    let (awt_w, awt_h) = awt_screen_size?;
-    if awt_w <= 0 || awt_h <= 0 {
+) -> Option<(f64, f64, (i32, i32))> {
+    let display = awt_display?;
+    if display.width <= 0 || display.height <= 0 {
         return None;
     }
     let (stream_w, stream_h) = stream_size;
     if stream_w == 0 || stream_h == 0 {
         return None;
     }
-    let sx = stream_w as f64 / awt_w as f64;
-    let sy = stream_h as f64 / awt_h as f64;
+    let sx = stream_w as f64 / display.width as f64;
+    let sy = stream_h as f64 / display.height as f64;
     if (sx - sy).abs() > ASPECT_MATCH_EPSILON {
         return None;
     }
     if (sx - 1.0).abs() < IDENTITY_SCALE_EPSILON && (sy - 1.0).abs() < IDENTITY_SCALE_EPSILON {
         return None;
     }
-    Some((sx, sy))
+    Some((sx, sy, (display.x, display.y)))
 }
 
 fn scale_region(region: Region, sx: f64, sy: f64) -> Region {
@@ -58,6 +68,21 @@ fn scale_region(region: Region, sx: f64, sy: f64) -> Region {
         y: (region.y as f64 * sy).round() as i32,
         width: (region.width as f64 * sx).round().max(1.0) as i32,
         height: (region.height as f64 * sy).round().max(1.0) as i32,
+    }
+}
+
+/// Parse optional `screen_size` wire payload (`[x, y, width, height]`).
+pub fn screen_size_to_region(values: [i32; 4]) -> Option<Region> {
+    let region = Region {
+        x: values[0],
+        y: values[1],
+        width: values[2],
+        height: values[3],
+    };
+    if region.width <= 0 || region.height <= 0 {
+        None
+    } else {
+        Some(region)
     }
 }
 
@@ -163,7 +188,7 @@ mod tests {
             region(1362, 100, 480, 240),
             (0, 0),
             (1536, 864),
-            Some((2560, 1440)),
+            Some(region(0, 0, 2560, 1440)),
         )
         .unwrap();
         assert_eq!(mapped.x, 817);
@@ -194,12 +219,30 @@ mod tests {
             region(2000, 0, 400, 300),
             (1920, 0),
             (1920, 1080),
-            Some((3840, 1080)),
+            Some(region(0, 0, 3840, 1080)),
         )
         .unwrap();
         assert_eq!(mapped.x, 80);
         assert_eq!(mapped.y, 0);
         assert_eq!(mapped.width, 400);
         assert_eq!(mapped.height, 300);
+    }
+
+    #[test]
+    fn scales_secondary_display_relative_to_that_display_origin() {
+        // Primary 1920x1080 at (0,0); selected secondary 2560x1440 at (1920,0) with
+        // a 1536x864 portal stream. Scaling against the primary size would apply a
+        // spurious 4/3 transform.
+        let mapped = map_awt_region_to_stream(
+            region(2000, 100, 480, 240),
+            (0, 0),
+            (1536, 864),
+            Some(region(1920, 0, 2560, 1440)),
+        )
+        .unwrap();
+        assert_eq!(mapped.x, 48);
+        assert_eq!(mapped.y, 60);
+        assert_eq!(mapped.width, 288);
+        assert_eq!(mapped.height, 144);
     }
 }

--- a/recording/native/linux/src/stream_region.rs
+++ b/recording/native/linux/src/stream_region.rs
@@ -18,6 +18,13 @@ pub fn map_awt_region_to_stream(
     stream_size: (u32, u32),
     awt_display: Option<Region>,
 ) -> Result<Region> {
+    if region.width <= 0 || region.height <= 0 {
+        bail!(
+            "region must have positive dimensions, was {}x{}",
+            region.width,
+            region.height
+        );
+    }
     let relative = match awt_display.filter(|d| d.width > 0 && d.height > 0) {
         Some(display) => {
             let local = Region {
@@ -182,6 +189,21 @@ mod tests {
         let err = clamp_region_to_stream(region(2000, 0, 480, 240), (1536, 864)).unwrap_err();
         assert!(
             err.to_string().contains("does not intersect"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn rejects_non_positive_region_before_scale() {
+        let err = map_awt_region_to_stream(
+            region(100, 100, 0, 240),
+            (0, 0),
+            (1536, 864),
+            Some(region(0, 0, 2560, 1440)),
+        )
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("positive dimensions"),
             "{err:#}"
         );
     }

--- a/recording/native/linux/src/stream_region.rs
+++ b/recording/native/linux/src/stream_region.rs
@@ -28,12 +28,7 @@ pub fn map_awt_region_to_stream(
             };
             match scale_from_awt_display(display, stream_size) {
                 DisplayScale::Scaled(sx, sy) => scale_region(local, sx, sy),
-                DisplayScale::Identity => reject_if_granted_stream_misses(
-                    local,
-                    region,
-                    stream_position,
-                    stream_size,
-                ),
+                DisplayScale::Identity => local,
                 DisplayScale::Unrelated => subtract_origin(region, stream_position),
             }
         }
@@ -62,28 +57,6 @@ fn scale_from_awt_display(display: Region, stream_size: (u32, u32)) -> DisplaySc
         return DisplayScale::Identity;
     }
     DisplayScale::Scaled(sx, sy)
-}
-
-/// Same-size restore token for a different 1x monitor: display-local coords
-/// would silently crop the granted stream. If that crop hits but the unscaled
-/// stream-relative crop misses, return the miss so the caller fails closed.
-/// Scaled displays cannot use this check: a valid secondary-monitor stream is
-/// usually origin (0, 0), which is geometrically identical to a wrong-monitor
-/// grant.
-fn reject_if_granted_stream_misses(
-    display_local: Region,
-    region: Region,
-    stream_position: (i32, i32),
-    stream_size: (u32, u32),
-) -> Region {
-    let stream_relative = subtract_origin(region, stream_position);
-    if clamp_region_to_stream(display_local, stream_size).is_ok()
-        && clamp_region_to_stream(stream_relative, stream_size).is_err()
-    {
-        stream_relative
-    } else {
-        display_local
-    }
 }
 
 fn subtract_origin(region: Region, origin: (i32, i32)) -> Region {
@@ -259,24 +232,6 @@ mod tests {
         assert_eq!(mapped.y, 0);
         assert_eq!(mapped.width, 400);
         assert_eq!(mapped.height, 300);
-    }
-
-    #[test]
-    fn rejects_identity_region_when_granted_stream_is_a_different_monitor() {
-        // Restore token granted the primary 1920x1080 stream at (0,0), but the
-        // requested window is on a same-size secondary. Display-local coords
-        // would silently record the primary; fail instead.
-        let err = map_awt_region_to_stream(
-            region(2000, 80, 400, 300),
-            (0, 0),
-            (1920, 1080),
-            Some(region(1920, 0, 1920, 1080)),
-        )
-        .unwrap_err();
-        assert!(
-            err.to_string().contains("does not intersect"),
-            "{err:#}"
-        );
     }
 
     #[test]

--- a/recording/native/linux/src/stream_region.rs
+++ b/recording/native/linux/src/stream_region.rs
@@ -18,17 +18,25 @@ pub fn map_awt_region_to_stream(
     stream_size: (u32, u32),
     awt_display: Option<Region>,
 ) -> Result<Region> {
-    let relative = match scale_from_awt_display(awt_display, stream_size) {
-        Some((sx, sy, origin)) => scale_region(
-            Region {
-                x: region.x - origin.0,
-                y: region.y - origin.1,
+    let relative = match awt_display.filter(|d| d.width > 0 && d.height > 0) {
+        Some(display) => {
+            let local = Region {
+                x: region.x - display.x,
+                y: region.y - display.y,
                 width: region.width,
                 height: region.height,
-            },
-            sx,
-            sy,
-        ),
+            };
+            match scale_from_awt_display(display, stream_size) {
+                DisplayScale::Scaled(sx, sy) => scale_region(local, sx, sy),
+                DisplayScale::Identity => local,
+                DisplayScale::Unrelated => Region {
+                    x: region.x - stream_position.0,
+                    y: region.y - stream_position.1,
+                    width: region.width,
+                    height: region.height,
+                },
+            }
+        }
         None => Region {
             x: region.x - stream_position.0,
             y: region.y - stream_position.1,
@@ -39,27 +47,26 @@ pub fn map_awt_region_to_stream(
     clamp_region_to_stream(relative, stream_size)
 }
 
-fn scale_from_awt_display(
-    awt_display: Option<Region>,
-    stream_size: (u32, u32),
-) -> Option<(f64, f64, (i32, i32))> {
-    let display = awt_display?;
-    if display.width <= 0 || display.height <= 0 {
-        return None;
-    }
+enum DisplayScale {
+    Scaled(f64, f64),
+    Identity,
+    Unrelated,
+}
+
+fn scale_from_awt_display(display: Region, stream_size: (u32, u32)) -> DisplayScale {
     let (stream_w, stream_h) = stream_size;
     if stream_w == 0 || stream_h == 0 {
-        return None;
+        return DisplayScale::Unrelated;
     }
     let sx = stream_w as f64 / display.width as f64;
     let sy = stream_h as f64 / display.height as f64;
     if (sx - sy).abs() > ASPECT_MATCH_EPSILON {
-        return None;
+        return DisplayScale::Unrelated;
     }
     if (sx - 1.0).abs() < IDENTITY_SCALE_EPSILON && (sy - 1.0).abs() < IDENTITY_SCALE_EPSILON {
-        return None;
+        return DisplayScale::Identity;
     }
-    Some((sx, sy, (display.x, display.y)))
+    DisplayScale::Scaled(sx, sy)
 }
 
 fn scale_region(region: Region, sx: f64, sy: f64) -> Region {
@@ -224,6 +231,24 @@ mod tests {
         .unwrap();
         assert_eq!(mapped.x, 80);
         assert_eq!(mapped.y, 0);
+        assert_eq!(mapped.width, 400);
+        assert_eq!(mapped.height, 300);
+    }
+
+    #[test]
+    fn keeps_selected_display_origin_when_that_display_is_identity_scaled() {
+        // Preceding 2560x1440@1.66 (AWT) / 1536x864 (portal), then a 1920x1080@1x
+        // secondary. AWT origin 2560 != portal origin 1536; subtracting stream
+        // position would shift the crop by 1024.
+        let mapped = map_awt_region_to_stream(
+            region(2640, 80, 400, 300),
+            (1536, 0),
+            (1920, 1080),
+            Some(region(2560, 0, 1920, 1080)),
+        )
+        .unwrap();
+        assert_eq!(mapped.x, 80);
+        assert_eq!(mapped.y, 80);
         assert_eq!(mapped.width, 400);
         assert_eq!(mapped.height, 300);
     }

--- a/recording/native/linux/src/stream_region.rs
+++ b/recording/native/linux/src/stream_region.rs
@@ -1,0 +1,205 @@
+//! Pure geometry for mapping an AWT/portal region onto a PipeWire stream.
+
+use crate::protocol::Region;
+use anyhow::{bail, Result};
+
+/// Convert an AWT screen-pixel [region] into a PipeWire stream-relative crop.
+///
+/// Mixed-space HiDPI (XWayland 2560×1440 vs a 1536×864 portal stream) is scaled
+/// when the AWT virtual desktop and the stream share an aspect ratio. Multi-monitor
+/// virtual desktops that do not match the selected stream are left unscaled and
+/// only translated by [stream_position]. A leftover overflow then clamps; a miss
+/// is still an error.
+pub fn map_awt_region_to_stream(
+    region: Region,
+    stream_position: (i32, i32),
+    stream_size: (u32, u32),
+    awt_screen_size: Option<(i32, i32)>,
+) -> Result<Region> {
+    let scaled = match scale_from_awt_screen(awt_screen_size, stream_size) {
+        Some((sx, sy)) => scale_region(region, sx, sy),
+        None => region,
+    };
+    let relative = Region {
+        x: scaled.x - stream_position.0,
+        y: scaled.y - stream_position.1,
+        width: scaled.width,
+        height: scaled.height,
+    };
+    clamp_region_to_stream(relative, stream_size)
+}
+
+fn scale_from_awt_screen(
+    awt_screen_size: Option<(i32, i32)>,
+    stream_size: (u32, u32),
+) -> Option<(f64, f64)> {
+    let (awt_w, awt_h) = awt_screen_size?;
+    if awt_w <= 0 || awt_h <= 0 {
+        return None;
+    }
+    let (stream_w, stream_h) = stream_size;
+    if stream_w == 0 || stream_h == 0 {
+        return None;
+    }
+    let sx = stream_w as f64 / awt_w as f64;
+    let sy = stream_h as f64 / awt_h as f64;
+    if (sx - sy).abs() > ASPECT_MATCH_EPSILON {
+        return None;
+    }
+    if (sx - 1.0).abs() < IDENTITY_SCALE_EPSILON && (sy - 1.0).abs() < IDENTITY_SCALE_EPSILON {
+        return None;
+    }
+    Some((sx, sy))
+}
+
+fn scale_region(region: Region, sx: f64, sy: f64) -> Region {
+    Region {
+        x: (region.x as f64 * sx).round() as i32,
+        y: (region.y as f64 * sy).round() as i32,
+        width: (region.width as f64 * sx).round().max(1.0) as i32,
+        height: (region.height as f64 * sy).round().max(1.0) as i32,
+    }
+}
+
+const ASPECT_MATCH_EPSILON: f64 = 0.02;
+const IDENTITY_SCALE_EPSILON: f64 = 0.02;
+
+/// Intersect [region] with [stream_size] and return the visible crop.
+///
+/// Genuinely oversized windows (larger than the shared monitor, or leftover
+/// overflow after mixed-space conversion) clamp to the stream. A region that
+/// misses the stream entirely still fails — that is a placement bug, not
+/// something we can invent pixels for.
+pub fn clamp_region_to_stream(region: Region, stream_size: (u32, u32)) -> Result<Region> {
+    if region.width <= 0 || region.height <= 0 {
+        bail!(
+            "region must have positive dimensions, was {}x{}",
+            region.width,
+            region.height
+        );
+    }
+    let (stream_w, stream_h) = stream_size;
+    if stream_w == 0 || stream_h == 0 {
+        bail!(
+            "stream_size must have positive dimensions, was {}x{}",
+            stream_w,
+            stream_h
+        );
+    }
+    let stream_w = stream_w as i64;
+    let stream_h = stream_h as i64;
+    let left = region.x as i64;
+    let top = region.y as i64;
+    let right = left + region.width as i64;
+    let bottom = top + region.height as i64;
+    let clip_left = left.max(0);
+    let clip_top = top.max(0);
+    let clip_right = right.min(stream_w);
+    let clip_bottom = bottom.min(stream_h);
+    if clip_right <= clip_left || clip_bottom <= clip_top {
+        bail!(
+            "region ({}, {}, {}x{}) does not intersect stream {}x{}",
+            region.x,
+            region.y,
+            region.width,
+            region.height,
+            stream_w,
+            stream_h
+        );
+    }
+    Ok(Region {
+        x: clip_left as i32,
+        y: clip_top as i32,
+        width: (clip_right - clip_left) as i32,
+        height: (clip_bottom - clip_top) as i32,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn region(x: i32, y: i32, w: i32, h: i32) -> Region {
+        Region {
+            x,
+            y,
+            width: w,
+            height: h,
+        }
+    }
+
+    #[test]
+    fn clamps_overflowing_hidpi_window_to_stream() {
+        let clipped = clamp_region_to_stream(region(1362, 0, 480, 240), (1536, 864)).unwrap();
+        assert_eq!(clipped.x, 1362);
+        assert_eq!(clipped.y, 0);
+        assert_eq!(clipped.width, 174);
+        assert_eq!(clipped.height, 240);
+    }
+
+    #[test]
+    fn clamps_window_larger_than_the_stream() {
+        let clipped = clamp_region_to_stream(region(0, 0, 4000, 3000), (1536, 864)).unwrap();
+        assert_eq!(clipped.x, 0);
+        assert_eq!(clipped.y, 0);
+        assert_eq!(clipped.width, 1536);
+        assert_eq!(clipped.height, 864);
+    }
+
+    #[test]
+    fn rejects_region_that_misses_the_stream() {
+        let err = clamp_region_to_stream(region(2000, 0, 480, 240), (1536, 864)).unwrap_err();
+        assert!(
+            err.to_string().contains("does not intersect"),
+            "{err:#}"
+        );
+    }
+
+    #[test]
+    fn maps_mixed_awt_physical_region_onto_logical_portal_stream() {
+        // jbr-bench: AWT/XWayland 2560x1440, portal stream 1536x864 (1.66x).
+        // A 480x240 window whose right edge is 1842 must keep its full frame, not a sliver.
+        let mapped = map_awt_region_to_stream(
+            region(1362, 100, 480, 240),
+            (0, 0),
+            (1536, 864),
+            Some((2560, 1440)),
+        )
+        .unwrap();
+        assert_eq!(mapped.x, 817);
+        assert_eq!(mapped.y, 60);
+        assert_eq!(mapped.width, 288);
+        assert_eq!(mapped.height, 144);
+    }
+
+    #[test]
+    fn subtracts_stream_position_when_awt_screen_size_is_unknown() {
+        let mapped = map_awt_region_to_stream(
+            region(2000, 80, 400, 300),
+            (1920, 0),
+            (1920, 1080),
+            None,
+        )
+        .unwrap();
+        assert_eq!(mapped.x, 80);
+        assert_eq!(mapped.y, 80);
+        assert_eq!(mapped.width, 400);
+        assert_eq!(mapped.height, 300);
+    }
+
+    #[test]
+    fn does_not_scale_when_awt_screen_aspect_does_not_match_stream() {
+        // Virtual desktop 3840x1080 vs one 1920x1080 monitor: subtract + clamp only.
+        let mapped = map_awt_region_to_stream(
+            region(2000, 0, 400, 300),
+            (1920, 0),
+            (1920, 1080),
+            Some((3840, 1080)),
+        )
+        .unwrap();
+        assert_eq!(mapped.x, 80);
+        assert_eq!(mapped.y, 0);
+        assert_eq!(mapped.width, 400);
+        assert_eq!(mapped.height, 300);
+    }
+}

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotter.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotter.kt
@@ -9,6 +9,7 @@ import dev.sebastiano.spectre.recording.portal.Event
 import dev.sebastiano.spectre.recording.portal.Region
 import dev.sebastiano.spectre.recording.portal.SourceType
 import dev.sebastiano.spectre.recording.portal.WaylandHelperBinaryExtractor
+import dev.sebastiano.spectre.recording.portal.awtVirtualDesktopSize
 import dev.sebastiano.spectre.recording.portal.queryGtkFrameExtentsViaXprop
 import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
 import java.awt.Insets
@@ -82,6 +83,7 @@ internal constructor(
                 windowTitle = title,
                 cursorMode = CursorMode.HIDDEN,
                 region = region.toProtocolRegion(),
+                screenSize = null,
                 output = tempPng().toAbsolutePath().toString(),
             )
         )
@@ -98,6 +100,7 @@ internal constructor(
                     if (wayland) null else displayNameProvider()?.takeIf { it.isNotBlank() },
                 cursorMode = CursorMode.HIDDEN,
                 region = region.toProtocolRegion(),
+                screenSize = if (wayland) awtVirtualDesktopSize() else null,
                 output = tempPng().toAbsolutePath().toString(),
             )
         )

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotter.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/LinuxNativeScreenshotter.kt
@@ -9,8 +9,9 @@ import dev.sebastiano.spectre.recording.portal.Event
 import dev.sebastiano.spectre.recording.portal.Region
 import dev.sebastiano.spectre.recording.portal.SourceType
 import dev.sebastiano.spectre.recording.portal.WaylandHelperBinaryExtractor
-import dev.sebastiano.spectre.recording.portal.awtVirtualDesktopSize
+import dev.sebastiano.spectre.recording.portal.awtDisplayBoundsContaining
 import dev.sebastiano.spectre.recording.portal.queryGtkFrameExtentsViaXprop
+import dev.sebastiano.spectre.recording.portal.toWire
 import dev.sebastiano.spectre.recording.screencapturekit.TitledWindow
 import java.awt.Insets
 import java.awt.Rectangle
@@ -100,7 +101,7 @@ internal constructor(
                     if (wayland) null else displayNameProvider()?.takeIf { it.isNotBlank() },
                 cursorMode = CursorMode.HIDDEN,
                 region = region.toProtocolRegion(),
-                screenSize = if (wayland) awtVirtualDesktopSize() else null,
+                screenSize = if (wayland) awtDisplayBoundsContaining(region)?.toWire() else null,
                 output = tempPng().toAbsolutePath().toString(),
             )
         )

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperProtocol.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandHelperProtocol.kt
@@ -37,6 +37,7 @@ internal sealed interface Command {
         @SerialName("cursor_mode") val cursorMode: CursorMode,
         @SerialName("frame_rate") val frameRate: Int,
         @SerialName("region") val region: Region,
+        @SerialName("screen_size") val screenSize: List<Int>? = null,
         @SerialName("output") val output: String,
         @SerialName("codec") val codec: String,
     ) : Command
@@ -51,6 +52,7 @@ internal sealed interface Command {
         @SerialName("window_title") val windowTitle: String? = null,
         @SerialName("cursor_mode") val cursorMode: CursorMode,
         @SerialName("region") val region: Region,
+        @SerialName("screen_size") val screenSize: List<Int>? = null,
         @SerialName("output") val output: String,
     ) : Command
 

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
@@ -5,7 +5,6 @@ import dev.sebastiano.spectre.recording.RecordingHandle
 import dev.sebastiano.spectre.recording.RecordingOptions
 import java.awt.GraphicsEnvironment
 import java.awt.Rectangle
-import java.awt.Toolkit
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -341,7 +340,7 @@ private constructor(
                     if (sourceTypes == listOf(SourceType.WINDOW)) {
                         null
                     } else {
-                        awtVirtualDesktopSize()
+                        awtDisplayBoundsContaining(region)?.toWire()
                     },
                 output = output.toAbsolutePath().toString(),
                 codec = options.codec,
@@ -355,11 +354,24 @@ private constructor(
 // compiles to a private static final on the synthetic Kt facade.
 private const val MALFORMED_LINE_PREVIEW_LENGTH: Int = 200
 
-internal fun awtVirtualDesktopSize(): List<Int>? {
-    if (GraphicsEnvironment.isHeadless()) return null
-    val size = Toolkit.getDefaultToolkit().screenSize ?: return null
-    if (size.width <= 0 || size.height <= 0) return null
-    return listOf(size.width, size.height)
+internal fun awtDisplayBoundsContaining(
+    region: Rectangle,
+    displays: List<Rectangle> = currentAwtDisplayBounds(),
+): Rectangle? {
+    if (displays.isEmpty()) return null
+    val centerX = region.centerX
+    val centerY = region.centerY
+    return displays.firstOrNull { it.contains(centerX, centerY) }
+        ?: displays.firstOrNull { it.intersects(region) }
+}
+
+internal fun Rectangle.toWire(): List<Int> = listOf(x, y, width, height)
+
+private fun currentAwtDisplayBounds(): List<Rectangle> {
+    if (GraphicsEnvironment.isHeadless()) return emptyList()
+    return GraphicsEnvironment.getLocalGraphicsEnvironment().screenDevices.map { device ->
+        device.defaultConfiguration.bounds
+    }
 }
 
 internal const val DEFAULT_STARTED_TIMEOUT_MS: Long = 90_000

--- a/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
+++ b/recording/src/main/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalRecorder.kt
@@ -3,7 +3,9 @@ package dev.sebastiano.spectre.recording.portal
 import dev.sebastiano.spectre.recording.Recorder
 import dev.sebastiano.spectre.recording.RecordingHandle
 import dev.sebastiano.spectre.recording.RecordingOptions
+import java.awt.GraphicsEnvironment
 import java.awt.Rectangle
+import java.awt.Toolkit
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
@@ -335,6 +337,12 @@ private constructor(
                         width = region.width,
                         height = region.height,
                     ),
+                screenSize =
+                    if (sourceTypes == listOf(SourceType.WINDOW)) {
+                        null
+                    } else {
+                        awtVirtualDesktopSize()
+                    },
                 output = output.toAbsolutePath().toString(),
                 codec = options.codec,
             )
@@ -346,6 +354,13 @@ private constructor(
 // `private companion object const val` is JVM-public on the outer class; file-level `private`
 // compiles to a private static final on the synthetic Kt facade.
 private const val MALFORMED_LINE_PREVIEW_LENGTH: Int = 200
+
+internal fun awtVirtualDesktopSize(): List<Int>? {
+    if (GraphicsEnvironment.isHeadless()) return null
+    val size = Toolkit.getDefaultToolkit().screenSize ?: return null
+    if (size.width <= 0 || size.height <= 0) return null
+    return listOf(size.width, size.height)
+}
 
 internal const val DEFAULT_STARTED_TIMEOUT_MS: Long = 90_000
 internal const val DEFAULT_SHUTDOWN_GRACE_MS: Long = 30_000

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/AwtDisplayBoundsTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/AwtDisplayBoundsTest.kt
@@ -1,0 +1,30 @@
+package dev.sebastiano.spectre.recording.portal
+
+import java.awt.Rectangle
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class AwtDisplayBoundsTest {
+    @Test
+    fun `picks the display that contains the region`() {
+        val primary = Rectangle(0, 0, 1920, 1080)
+        val secondary = Rectangle(1920, 0, 2560, 1440)
+        val bounds =
+            awtDisplayBoundsContaining(
+                region = Rectangle(2000, 100, 480, 240),
+                displays = listOf(primary, secondary),
+            )
+        assertEquals(secondary, bounds)
+    }
+
+    @Test
+    fun `returns null when the region misses every display`() {
+        val bounds =
+            awtDisplayBoundsContaining(
+                region = Rectangle(9000, 0, 100, 100),
+                displays = listOf(Rectangle(0, 0, 1920, 1080)),
+            )
+        assertNull(bounds)
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/SmokeWindowPlacement.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/SmokeWindowPlacement.kt
@@ -14,13 +14,17 @@ import javax.swing.JFrame
  */
 internal object SmokeWindowPlacement {
     fun placeOnVisibleScreen(frame: JFrame, preferredSize: Dimension) {
-        val screen = visibleScreenBounds()
+        val placed = placedBounds(visibleScreenBounds(), preferredSize)
+        frame.setSize(placed.width, placed.height)
+        frame.setLocation(placed.x, placed.y)
+    }
+
+    fun placedBounds(screen: Rectangle, preferredSize: Dimension): Rectangle {
         val width = preferredSize.width.coerceAtMost(screen.width).coerceAtLeast(1)
         val height = preferredSize.height.coerceAtMost(screen.height).coerceAtLeast(1)
-        frame.setSize(width, height)
         val x = screen.x + ((screen.width - width) / 2).coerceAtLeast(0)
         val y = screen.y + ((screen.height - height) / 2).coerceAtLeast(0)
-        frame.setLocation(x, y)
+        return Rectangle(x, y, width, height)
     }
 
     fun visibleScreenBounds(

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/SmokeWindowPlacement.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/SmokeWindowPlacement.kt
@@ -1,0 +1,36 @@
+package dev.sebastiano.spectre.recording.portal
+
+import java.awt.Dimension
+import java.awt.GraphicsEnvironment
+import java.awt.Insets
+import java.awt.Rectangle
+import javax.swing.JFrame
+
+/**
+ * Places a smoke [JFrame] fully inside the visible AWT screen, instead of blindly centering it.
+ *
+ * Fractional Wayland scale can make `setLocationRelativeTo(null)` put a 480×240 window so far into
+ * logical coordinates that the portal stream (device pixels) no longer contains it.
+ */
+internal object SmokeWindowPlacement {
+    fun placeOnVisibleScreen(frame: JFrame, preferredSize: Dimension) {
+        val screen = visibleScreenBounds()
+        val width = preferredSize.width.coerceAtMost(screen.width).coerceAtLeast(1)
+        val height = preferredSize.height.coerceAtMost(screen.height).coerceAtLeast(1)
+        frame.setSize(width, height)
+        val x = screen.x + ((screen.width - width) / 2).coerceAtLeast(0)
+        val y = screen.y + ((screen.height - height) / 2).coerceAtLeast(0)
+        frame.setLocation(x, y)
+    }
+
+    fun visibleScreenBounds(
+        screen: Rectangle = GraphicsEnvironment.getLocalGraphicsEnvironment().maximumWindowBounds,
+        insets: Insets = Insets(0, 0, 0, 0),
+    ): Rectangle {
+        val x = screen.x + insets.left
+        val y = screen.y + insets.top
+        val width = (screen.width - insets.left - insets.right).coerceAtLeast(1)
+        val height = (screen.height - insets.top - insets.bottom).coerceAtLeast(1)
+        return Rectangle(x, y, width, height)
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/SmokeWindowPlacementTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/SmokeWindowPlacementTest.kt
@@ -1,0 +1,58 @@
+package dev.sebastiano.spectre.recording.portal
+
+import java.awt.Dimension
+import java.awt.GraphicsEnvironment
+import java.awt.Insets
+import java.awt.Rectangle
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SmokeWindowPlacementTest {
+    @Test
+    fun `visible screen shrinks by insets`() {
+        val visible =
+            SmokeWindowPlacement.visibleScreenBounds(
+                screen = Rectangle(0, 0, 1536, 864),
+                insets = Insets(32, 0, 0, 0),
+            )
+        assertEquals(Rectangle(0, 32, 1536, 832), visible)
+    }
+
+    @Test
+    fun `placeOnVisibleScreen keeps a 480x240 window inside the screen`() {
+        assumeDisplay()
+        val frame = JFrame("placement")
+        try {
+            SwingUtilities.invokeAndWait {
+                frame.isUndecorated = true
+                SmokeWindowPlacement.placeOnVisibleScreen(frame, Dimension(480, 240))
+                frame.pack()
+            }
+            val screen = GraphicsEnvironment.getLocalGraphicsEnvironment().maximumWindowBounds
+            val bounds = frame.bounds
+            assertTrue(bounds.width <= 480, "width=${bounds.width}")
+            assertTrue(bounds.height <= 240, "height=${bounds.height}")
+            assertTrue(
+                screen.contains(bounds) || intersectsFullyInside(screen, bounds),
+                "placed=$bounds screen=$screen",
+            )
+        } finally {
+            SwingUtilities.invokeAndWait { frame.dispose() }
+        }
+    }
+
+    private fun assumeDisplay() {
+        org.junit.jupiter.api.Assumptions.assumeFalse(
+            GraphicsEnvironment.isHeadless(),
+            "Needs a display to place a JFrame",
+        )
+    }
+
+    private fun intersectsFullyInside(screen: Rectangle, bounds: Rectangle): Boolean {
+        val intersection = screen.intersection(bounds)
+        return intersection == bounds && !intersection.isEmpty
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/SmokeWindowPlacementTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/SmokeWindowPlacementTest.kt
@@ -1,11 +1,8 @@
 package dev.sebastiano.spectre.recording.portal
 
 import java.awt.Dimension
-import java.awt.GraphicsEnvironment
 import java.awt.Insets
 import java.awt.Rectangle
-import javax.swing.JFrame
-import javax.swing.SwingUtilities
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -22,37 +19,17 @@ class SmokeWindowPlacementTest {
     }
 
     @Test
-    fun `placeOnVisibleScreen keeps a 480x240 window inside the screen`() {
-        assumeDisplay()
-        val frame = JFrame("placement")
-        try {
-            SwingUtilities.invokeAndWait {
-                frame.isUndecorated = true
-                SmokeWindowPlacement.placeOnVisibleScreen(frame, Dimension(480, 240))
-                frame.pack()
-            }
-            val screen = GraphicsEnvironment.getLocalGraphicsEnvironment().maximumWindowBounds
-            val bounds = frame.bounds
-            assertTrue(bounds.width <= 480, "width=${bounds.width}")
-            assertTrue(bounds.height <= 240, "height=${bounds.height}")
-            assertTrue(
-                screen.contains(bounds) || intersectsFullyInside(screen, bounds),
-                "placed=$bounds screen=$screen",
-            )
-        } finally {
-            SwingUtilities.invokeAndWait { frame.dispose() }
-        }
+    fun `centered 480x240 window stays inside a 1536-wide screen`() {
+        val screen = Rectangle(0, 0, 1536, 864)
+        val placed = SmokeWindowPlacement.placedBounds(screen, Dimension(480, 240))
+        assertEquals(Rectangle(528, 312, 480, 240), placed)
+        assertTrue(screen.contains(placed), "placed=$placed screen=$screen")
     }
 
-    private fun assumeDisplay() {
-        org.junit.jupiter.api.Assumptions.assumeFalse(
-            GraphicsEnvironment.isHeadless(),
-            "Needs a display to place a JFrame",
-        )
-    }
-
-    private fun intersectsFullyInside(screen: Rectangle, bounds: Rectangle): Boolean {
-        val intersection = screen.intersection(bounds)
-        return intersection == bounds && !intersection.isEmpty
+    @Test
+    fun `window larger than the screen is clamped to the visible area`() {
+        val screen = Rectangle(0, 0, 800, 600)
+        val placed = SmokeWindowPlacement.placedBounds(screen, Dimension(2000, 1800))
+        assertEquals(screen, placed)
     }
 }

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalCursorSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalCursorSmoke.kt
@@ -183,7 +183,10 @@ private fun openSmokeWindow(): Pair<JFrame, JLabel> {
                 contentPane = panel
                 preferredSize = Dimension(WINDOW_WIDTH, WINDOW_HEIGHT)
                 pack()
-                setLocationRelativeTo(null)
+                SmokeWindowPlacement.placeOnVisibleScreen(
+                    this,
+                    Dimension(WINDOW_WIDTH, WINDOW_HEIGHT),
+                )
                 isVisible = true
                 toFront()
                 requestFocus()

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalSmoke.kt
@@ -58,7 +58,7 @@ private fun runSmoke() {
     Thread.sleep(WINDOW_SETTLE_MS)
 
     val recorder = WaylandPortalRecorder()
-    val frameBoundsAtStart = frame.bounds
+    val frameBoundsAtStart = java.awt.Rectangle(frame.locationOnScreen, frame.size)
     println(
         "(NOTE: a compositor permission dialog will pop on first run today; pick the monitor " +
             "with the JFrame and click \"Share.\" Subsequent runs reuse the grant silently.)"
@@ -138,7 +138,10 @@ private fun openSmokeWindow(): Pair<JFrame, JLabel> {
                 contentPane = panel
                 preferredSize = Dimension(WINDOW_WIDTH, WINDOW_HEIGHT)
                 pack()
-                setLocationRelativeTo(null)
+                SmokeWindowPlacement.placeOnVisibleScreen(
+                    this,
+                    Dimension(WINDOW_WIDTH, WINDOW_HEIGHT),
+                )
                 isVisible = true
                 toFront()
                 requestFocus()

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalStartCommandFactoryTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalStartCommandFactoryTest.kt
@@ -11,16 +11,16 @@ import org.junit.jupiter.api.Assumptions.assumeFalse
 
 class WaylandPortalStartCommandFactoryTest {
     @Test
-    fun `monitor start includes AWT virtual desktop size`() {
+    fun `monitor start includes the AWT display that contains the region`() {
         assumeFalse(GraphicsEnvironment.isHeadless())
+        val region = Rectangle(10, 20, 480, 240)
         val command =
             WaylandPortalRecorder.defaultStartCommandFactory(listOf(SourceType.MONITOR))(
-                Rectangle(10, 20, 480, 240),
+                region,
                 Path.of("/tmp/out.mp4"),
                 RecordingOptions(),
             )
-        val screen = awtVirtualDesktopSize()
-        assertEquals(screen, command.screenSize)
+        assertEquals(awtDisplayBoundsContaining(region)?.toWire(), command.screenSize)
         assertEquals(Region(10, 20, 480, 240), command.region)
     }
 

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalStartCommandFactoryTest.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalStartCommandFactoryTest.kt
@@ -1,0 +1,37 @@
+package dev.sebastiano.spectre.recording.portal
+
+import dev.sebastiano.spectre.recording.RecordingOptions
+import java.awt.GraphicsEnvironment
+import java.awt.Rectangle
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import org.junit.jupiter.api.Assumptions.assumeFalse
+
+class WaylandPortalStartCommandFactoryTest {
+    @Test
+    fun `monitor start includes AWT virtual desktop size`() {
+        assumeFalse(GraphicsEnvironment.isHeadless())
+        val command =
+            WaylandPortalRecorder.defaultStartCommandFactory(listOf(SourceType.MONITOR))(
+                Rectangle(10, 20, 480, 240),
+                Path.of("/tmp/out.mp4"),
+                RecordingOptions(),
+            )
+        val screen = awtVirtualDesktopSize()
+        assertEquals(screen, command.screenSize)
+        assertEquals(Region(10, 20, 480, 240), command.region)
+    }
+
+    @Test
+    fun `window start does not send AWT screen size`() {
+        val command =
+            WaylandPortalRecorder.defaultStartCommandFactory(listOf(SourceType.WINDOW))(
+                Rectangle(25, 25, 480, 240),
+                Path.of("/tmp/out.mp4"),
+                RecordingOptions(),
+            )
+        assertNull(command.screenSize)
+    }
+}

--- a/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowSmoke.kt
+++ b/recording/src/test/kotlin/dev/sebastiano/spectre/recording/portal/WaylandPortalWindowSmoke.kt
@@ -132,7 +132,10 @@ private fun openSmokeWindow(): Pair<JFrame, JLabel> {
                 contentPane = panel
                 preferredSize = Dimension(WINDOW_WIDTH, WINDOW_HEIGHT)
                 pack()
-                setLocationRelativeTo(null)
+                SmokeWindowPlacement.placeOnVisibleScreen(
+                    this,
+                    Dimension(WINDOW_WIDTH, WINDOW_HEIGHT),
+                )
                 isVisible = true
                 toFront()
                 requestFocus()


### PR DESCRIPTION
## Summary
- Convert matching-aspect AWT/XWayland region bounds onto the ScreenCast stream before crop, so fractional-scale HiDPI (2560×1440 vs 1536×864) records the full window instead of failing at `region right edge 1842 exceeds stream width 1536`.
- Clamp leftover overflow / genuinely oversized windows; reject empty intersections. Window-source crops stay stream-relative.
- Place portal smoke windows inside the visible AWT screen instead of blindly centering them.

## Test plan
- [x] `cargo test` on Linux helper (28/28)
- [x] `./gradlew check` in the worktree
- [ ] Linux Wayland portal smoke on jbr-bench after merge (warn before portal)