### PR TITLE
fix(smoke): keep JBR Robot cells off the Wayland seat

### DIFF
--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -601,9 +601,51 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
         self.assertEqual("/tmp/tokens", env["SPECTRE_WAYLAND_RESTORE_TOKEN_DIR"])
         self.assertEqual("", env["SPECTRE_WAYLAND_HELPER"])
 
-    def test_wayland_portal_ui_prefix_is_empty(self):
+    def test_wayland_portal_ui_prefix_is_empty_only_for_seat_bound_cells(self):
         self.assertEqual([], self.rs._ui_prefix("Linux", wayland_portal=True))
         self.assertIsInstance(self.rs._ui_prefix("Linux", wayland_portal=False), list)
+
+    def test_robot_cells_keep_xvfb_after_wayland_portal_warmup(self):
+        # Helper restore tokens do not cover JBR Robot / Remote Desktop. After
+        # portal warmup, check/attach/corpus must still use xvfb-run or each JVM
+        # pops a new compositor dialog on the seat. Ignore an inherited DISPLAY.
+        with tempfile.TemporaryDirectory() as tmp:
+            fake = Path(tmp) / "xvfb-run"
+            fake.write_text("#!/bin/sh\n", encoding="utf-8")
+            fake.chmod(0o755)
+            previous_path = os.environ.get("PATH", "")
+            previous_display = os.environ.get("DISPLAY")
+            os.environ["PATH"] = f"{tmp}{os.pathsep}{previous_path}"
+            os.environ["DISPLAY"] = ":0"
+            try:
+                self.assertEqual(
+                    ["xvfb-run", "-a"],
+                    self.rs._robot_ui_prefix("Linux", wayland_portal=True),
+                )
+                self.assertEqual(
+                    ["xvfb-run", "-a"],
+                    self.rs._robot_ui_prefix("Linux", wayland_portal=False),
+                )
+                self.assertEqual([], smoke_lib.xvfb_prefix("Linux"))
+                robot_env = self.rs._robot_env(
+                    {
+                        "SPECTRE_WAYLAND_RESTORE_TOKEN_DIR": "/tmp/tokens",
+                        "WAYLAND_DISPLAY": "wayland-0",
+                        "XDG_SESSION_TYPE": "wayland",
+                    }
+                )
+                self.assertEqual("x11", robot_env["SPECTRE_CAPTURE_BACKEND"])
+                self.assertEqual("", robot_env["WAYLAND_DISPLAY"])
+                self.assertEqual("x11", robot_env["XDG_SESSION_TYPE"])
+                self.assertEqual(
+                    "/tmp/tokens", robot_env["SPECTRE_WAYLAND_RESTORE_TOKEN_DIR"]
+                )
+            finally:
+                os.environ["PATH"] = previous_path
+                if previous_display is None:
+                    os.environ.pop("DISPLAY", None)
+                else:
+                    os.environ["DISPLAY"] = previous_display
 
     def test_assert_linux_portal_tokens_captured_requires_restore_file(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -605,6 +605,18 @@ class ReleaseSmokeHelperLogicTest(unittest.TestCase):
         self.assertEqual([], self.rs._ui_prefix("Linux", wayland_portal=True))
         self.assertIsInstance(self.rs._ui_prefix("Linux", wayland_portal=False), list)
 
+    def test_missing_xvfb_run_fails_robot_cells_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            previous_path = os.environ.get("PATH", "")
+            os.environ["PATH"] = tmp
+            try:
+                self.assertEqual([], smoke_lib.robot_xvfb_prefix("Linux"))
+                reason = smoke_lib.robot_xvfb_unavailable_reason("Linux")
+                self.assertIsNotNone(reason)
+                self.assertIn("xvfb-run", reason or "")
+            finally:
+                os.environ["PATH"] = previous_path
+
     def test_robot_cells_keep_xvfb_after_wayland_portal_warmup(self):
         # Helper restore tokens do not cover JBR Robot / Remote Desktop. After
         # portal warmup, check/attach/corpus must still use xvfb-run or each JVM

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -70,8 +70,10 @@ interactive and not automatable. Spectre's `spectre-wayland-helper` uses portal
 - **First run** (no token, or compositor rejects a stale token): the portal dialog is
   shown. A human must accept once. Release smoke does this up front as `portal-token-warmup`
   for the **monitor-embedded** grant and pins `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` +
-  `SPECTRE_WAYLAND_HELPER` so later monitor ScreenCast cells reuse that token. Window-source
-  tokens are bound to the picked window and are not pre-warmed against an unrelated window.
+  `SPECTRE_WAYLAND_HELPER` so later helper monitor ScreenCast cells reuse that token.
+  Release smoke keeps JBR Robot / attach / `check` under `xvfb-run` even on a seated
+  Wayland display. Window-source tokens are bound to the picked window and are not
+  pre-warmed against an unrelated window.
 - **Later CLI/agent sessions**: the helper reuses the stored token so no dialog appears
   (validated on GNOME/mutter; other compositors are best-effort). Tokens are single-use at
   the portal: each successful `Start` writes a replacement file. A cancelled dialog never

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -283,7 +283,7 @@ The cross-platform runner covers the stable baseline that should not be reinvent
   pass) + strict stdio (version / tools/list including `detach` / unknown-session detach `isError`)
 - host native recording smoke (macOS SCK region / Linux X11; Windows WGC via interactive PS script)
 - Maven Local `verifyMavenLocalPublication` + fresh consumer jar resolve
-- Linux Wayland `portal-token-warmup`: one `:recording:runWaylandPortalSmoke` with a pinned `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` under `build/smoke/wayland-restore-tokens/`. Approve **Share** + **Remember** for the **whole screen**; later monitor ScreenCast cells reuse that token. Window-source prompts are per-window and may still appear. Xvfb / macOS / Windows record hard `n/a`.
+- Linux Wayland `portal-token-warmup`: one `:recording:runWaylandPortalSmoke` with a pinned `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` under `build/smoke/wayland-restore-tokens/`. Approve **Share** + **Remember** for the **whole screen**; only later helper monitor ScreenCast cells (`host-native-recording`) reuse that token. Robot-backed cells stay under `xvfb-run`. Window-source prompts are per-window and may still appear. Xvfb / macOS / Windows record hard `n/a`.
 
 Each release still needs delta cells based on `git log <previous-tag>..HEAD`. Add reusable delta
 coverage to the runner rather than leaving a one-release command only in chat.
@@ -358,12 +358,13 @@ These cannot currently be made portable and fail-closed by the baseline runner:
 - **macOS TCC and release seal:** grant Screen Recording to the actual helper identity, exercise one
   live SCK still/record, then verify the signed release app with `codesign --verify --deep --strict`,
   `spctl`, and `xcrun stapler validate`. A local ad-hoc app is not notarization evidence.
-- **Wayland portal:** Xvfb proves X11 only. On a real Wayland desktop the Unix harness now runs
+- **Wayland portal:** Xvfb proves X11 only. On a real Wayland desktop the Unix harness runs
   `portal-token-warmup` first (`:recording:runWaylandPortalSmoke`) and pins
-  `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR` for the rest of the run. Approve
-  **Share** + **Remember** for the whole screen; later monitor ScreenCast cells reuse that token.
-  Window-source, JBR `java.awt.Robot`, and Remote Desktop prompts are separate identities and may
-  still appear.
+  `SPECTRE_WAYLAND_HELPER` + `SPECTRE_WAYLAND_RESTORE_TOKEN_DIR`. Approve **Share** + **Remember**
+  for the whole screen once. Only helper monitor ScreenCast cells stay on the seat
+  (`host-native-recording`). `check`, attach, corpus, inject, CLI, and MCP stay under
+  `xvfb-run` even when `DISPLAY=:0`, because JBR `java.awt.Robot` and Remote Desktop are a
+  different app identity and would otherwise pop a new compositor dialog per JVM.
 - **Homebrew/Scoop/public archives:** after the draft artifacts exist, install through the real
   package manager and rerun launcher/MCP smoke. Local packaging does not prove channel metadata.
 - **Input focus/lock keys:** real Robot input uses global desktop state. Record focus failures and

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -364,7 +364,8 @@ These cannot currently be made portable and fail-closed by the baseline runner:
   for the whole screen once. Only helper monitor ScreenCast cells stay on the seat
   (`host-native-recording`). `check`, attach, corpus, inject, CLI, and MCP stay under
   `xvfb-run` even when `DISPLAY=:0`, because JBR `java.awt.Robot` and Remote Desktop are a
-  different app identity and would otherwise pop a new compositor dialog per JVM.
+  different app identity and would otherwise pop a new compositor dialog per JVM. Missing
+  `xvfb-run` is a hard fail for those cells, not a fallback onto the seat.
 - **Homebrew/Scoop/public archives:** after the draft artifacts exist, install through the real
   package manager and rerun launcher/MCP smoke. Local packaging does not prove channel metadata.
 - **Input focus/lock keys:** real Robot input uses global desktop state. Record focus failures and

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -42,6 +42,7 @@ from smoke_lib import (  # noqa: E402
     packaged_cli_executable,
     portal_token_warmup_skip_reason,
     prepare_linux_portal_token_env,
+    robot_xvfb_prefix,
     run_callable_scenario,
     run_scenario,
     scenario_result,
@@ -165,6 +166,31 @@ def _ui_prefix(system: str, *, wayland_portal: bool = False) -> list[str]:
     if wayland_portal:
         return []
     return xvfb_prefix(system)
+
+
+def _robot_ui_prefix(system: str, *, wayland_portal: bool = False) -> list[str]:
+    """Prefix for JBR/AWT Robot cells.
+
+    Helper ScreenCast restore tokens do not cover Robot / Remote Desktop. Even
+    after a successful Wayland portal warmup, these cells must stay off the
+    seated compositor or each JVM pops a new Share dialog.
+    """
+    del wayland_portal
+    return robot_xvfb_prefix(system)
+
+
+def _robot_env(env: dict[str, str] | None) -> dict[str, str]:
+    """Force Robot cells onto X11/Xvfb even when the login session is Wayland.
+
+    Nested xvfb-run inherits WAYLAND_DISPLAY from the seat. Empty values are
+    stripped by run_command, so clearing that variable plus SPECTRE_CAPTURE_BACKEND=x11
+    keeps JBR Robot off xdg-desktop-portal.
+    """
+    robot = dict(env or {})
+    robot["SPECTRE_CAPTURE_BACKEND"] = "x11"
+    robot["WAYLAND_DISPLAY"] = ""
+    robot["XDG_SESSION_TYPE"] = "x11"
+    return robot
 
 
 def _packaged_cli_portal_env(env: dict[str, str] | None) -> dict[str, str] | None:
@@ -356,8 +382,8 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(
             "portal-token-warmup: approve Share + Remember for the whole screen; "
-            "later monitor ScreenCast cells reuse that token. Window-source prompts "
-            "are per-window and may still appear.",
+            "only helper monitor ScreenCast cells reuse that token. Robot-backed "
+            "cells stay under xvfb-run. Window-source prompts are per-window.",
             flush=True,
         )
         scenario_env = prepare_linux_portal_token_env(ROOT, out_dir)
@@ -415,7 +441,8 @@ def main(argv: list[str] | None = None) -> int:
                 scenario_env = None
             add(warmup)
 
-    prefix = _ui_prefix(system, wayland_portal=scenario_env is not None)
+    seat_prefix = _ui_prefix(system, wayland_portal=scenario_env is not None)
+    robot_prefix = _robot_ui_prefix(system, wayland_portal=scenario_env is not None)
 
     # --- check ---
     if args.skip_check:
@@ -433,11 +460,11 @@ def main(argv: list[str] | None = None) -> int:
             run_scenario(
                 "check",
                 name="./gradlew check",
-                command=[gradle, "check", "--console=plain"],
+                command=[*robot_prefix, gradle, "check", "--console=plain"],
                 cwd=ROOT,
                 timeout=1200,
                 out_dir=out_dir,
-                env=scenario_env,
+                env=_robot_env(scenario_env),
                 overall_deadline=overall_deadline,
             )
         )
@@ -447,11 +474,11 @@ def main(argv: list[str] | None = None) -> int:
         run_scenario(
             "junit-live",
             name="Live JUnit failure artifacts/video and atomic capture",
-            command=[*prefix, gradle, ":sample-desktop:validationTest", *force],
+            command=[*robot_prefix, gradle, ":sample-desktop:validationTest", *force],
             cwd=ROOT,
             timeout=900,
             out_dir=out_dir,
-            env=scenario_env,
+            env=_robot_env(scenario_env),
             overall_deadline=overall_deadline,
         )
     )
@@ -462,7 +489,7 @@ def main(argv: list[str] | None = None) -> int:
             "agent-attach-core",
             name="Agent attach with preinstalled core",
             command=[
-                *prefix,
+                *robot_prefix,
                 gradle,
                 ":agent:test",
                 "--tests",
@@ -472,7 +499,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
-            env=scenario_env,
+            env=_robot_env(scenario_env),
             overall_deadline=overall_deadline,
         )
     )
@@ -481,7 +508,7 @@ def main(argv: list[str] | None = None) -> int:
             "agent-contract-corpus",
             name="Agent contract corpus",
             command=[
-                *prefix,
+                *robot_prefix,
                 gradle,
                 ":agent:test",
                 "--tests",
@@ -491,7 +518,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
-            env=scenario_env,
+            env=_robot_env(scenario_env),
             overall_deadline=overall_deadline,
         )
     )
@@ -500,7 +527,7 @@ def main(argv: list[str] | None = None) -> int:
             "agent-inject",
             name="Injected attach without preinstalled core",
             command=[
-                *prefix,
+                *robot_prefix,
                 gradle,
                 ":agent:test",
                 "--tests",
@@ -510,7 +537,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
-            env=scenario_env,
+            env=_robot_env(scenario_env),
             overall_deadline=overall_deadline,
         )
     )
@@ -519,7 +546,7 @@ def main(argv: list[str] | None = None) -> int:
             "agent-launch-and-attach",
             name="Launch-and-attach",
             command=[
-                *prefix,
+                *robot_prefix,
                 gradle,
                 ":agent:test",
                 "--tests",
@@ -529,7 +556,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
-            env=scenario_env,
+            env=_robot_env(scenario_env),
             overall_deadline=overall_deadline,
         )
     )
@@ -599,7 +626,7 @@ def main(argv: list[str] | None = None) -> int:
                 "cli-user-flow",
                 name="Packaged CLI user flow (ps/attach/tree/input/capture/detach)",
                 command=[
-                    *prefix,
+                    *robot_prefix,
                     gradle,
                     ":cli:test",
                     "--tests",
@@ -610,7 +637,7 @@ def main(argv: list[str] | None = None) -> int:
                 cwd=ROOT,
                 timeout=600,
                 out_dir=out_dir,
-                env=_packaged_cli_portal_env(scenario_env),
+                env=_robot_env(_packaged_cli_portal_env(scenario_env)),
                 overall_deadline=overall_deadline,
             )
         )
@@ -621,7 +648,7 @@ def main(argv: list[str] | None = None) -> int:
             "mcp-sdk-flow",
             name=mcp_name,
             command=[
-                *prefix,
+                *robot_prefix,
                 gradle,
                 ":cli:test",
                 # Same VERSION_NAME as package so SpectreMcpStdioIntegrationTest
@@ -637,7 +664,7 @@ def main(argv: list[str] | None = None) -> int:
             cwd=ROOT,
             timeout=600,
             out_dir=out_dir,
-            env=_packaged_cli_portal_env(scenario_env),
+            env=_robot_env(_packaged_cli_portal_env(scenario_env)),
             overall_deadline=overall_deadline,
         )
         if mcp_sdk.result == RESULT_PASS:
@@ -724,7 +751,7 @@ def main(argv: list[str] | None = None) -> int:
             run_scenario(
                 "host-native-recording",
                 name=f"Host native recording ({recording_task})",
-                command=[*prefix, gradle, recording_task, "--console=plain"],
+                command=[*seat_prefix, gradle, recording_task, "--console=plain"],
                 cwd=ROOT,
                 timeout=300,
                 out_dir=out_dir,

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -43,6 +43,7 @@ from smoke_lib import (  # noqa: E402
     portal_token_warmup_skip_reason,
     prepare_linux_portal_token_env,
     robot_xvfb_prefix,
+    robot_xvfb_unavailable_reason,
     run_callable_scenario,
     run_scenario,
     scenario_result,
@@ -177,6 +178,21 @@ def _robot_ui_prefix(system: str, *, wayland_portal: bool = False) -> list[str]:
     """
     del wayland_portal
     return robot_xvfb_prefix(system)
+
+
+def _robot_cell_blocked_result(
+    scenario_id: str, name: str, system: str
+) -> ScenarioResult | None:
+    reason = robot_xvfb_unavailable_reason(system)
+    if reason is None:
+        return None
+    return scenario_result(
+        scenario_id,
+        name=name,
+        result=RESULT_FAIL,
+        detail=reason,
+        hard=True,
+    )
 
 
 def _robot_env(env: dict[str, str] | None) -> dict[str, str]:
@@ -456,8 +472,10 @@ def main(argv: list[str] | None = None) -> int:
             )
         )
     else:
+        blocked = _robot_cell_blocked_result("check", "./gradlew check", system)
         add(
-            run_scenario(
+            blocked
+            or run_scenario(
                 "check",
                 name="./gradlew check",
                 command=[*robot_prefix, gradle, "check", "--console=plain"],
@@ -470,8 +488,14 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     # --- live JUnit failure artifacts/video + atomic capture ---
+    blocked = _robot_cell_blocked_result(
+        "junit-live",
+        "Live JUnit failure artifacts/video and atomic capture",
+        system,
+    )
     add(
-        run_scenario(
+        blocked
+        or run_scenario(
             "junit-live",
             name="Live JUnit failure artifacts/video and atomic capture",
             command=[*robot_prefix, gradle, ":sample-desktop:validationTest", *force],
@@ -484,82 +508,41 @@ def main(argv: list[str] | None = None) -> int:
     )
 
     # --- agent attach / corpus / inject / launch-and-attach ---
-    add(
-        run_scenario(
+    for scenario_id, name, test_filter in (
+        (
             "agent-attach-core",
-            name="Agent attach with preinstalled core",
-            command=[
-                *robot_prefix,
-                gradle,
-                ":agent:test",
-                "--tests",
-                "*AgentAttachIntegration*",
-                *force,
-            ],
-            cwd=ROOT,
-            timeout=600,
-            out_dir=out_dir,
-            env=_robot_env(scenario_env),
-            overall_deadline=overall_deadline,
-        )
-    )
-    add(
-        run_scenario(
-            "agent-contract-corpus",
-            name="Agent contract corpus",
-            command=[
-                *robot_prefix,
-                gradle,
-                ":agent:test",
-                "--tests",
-                "*AgentContractCorpus*",
-                *force,
-            ],
-            cwd=ROOT,
-            timeout=600,
-            out_dir=out_dir,
-            env=_robot_env(scenario_env),
-            overall_deadline=overall_deadline,
-        )
-    )
-    add(
-        run_scenario(
+            "Agent attach with preinstalled core",
+            "*AgentAttachIntegration*",
+        ),
+        ("agent-contract-corpus", "Agent contract corpus", "*AgentContractCorpus*"),
+        (
             "agent-inject",
-            name="Injected attach without preinstalled core",
-            command=[
-                *robot_prefix,
-                gradle,
-                ":agent:test",
-                "--tests",
-                "*AgentInjectAttachIntegration*",
-                *force,
-            ],
-            cwd=ROOT,
-            timeout=600,
-            out_dir=out_dir,
-            env=_robot_env(scenario_env),
-            overall_deadline=overall_deadline,
+            "Injected attach without preinstalled core",
+            "*AgentInjectAttachIntegration*",
+        ),
+        ("agent-launch-and-attach", "Launch-and-attach", "*LaunchAndAttachIntegration*"),
+    ):
+        blocked = _robot_cell_blocked_result(scenario_id, name, system)
+        add(
+            blocked
+            or run_scenario(
+                scenario_id,
+                name=name,
+                command=[
+                    *robot_prefix,
+                    gradle,
+                    ":agent:test",
+                    "--tests",
+                    test_filter,
+                    *force,
+                ],
+                cwd=ROOT,
+                timeout=600,
+                out_dir=out_dir,
+                env=_robot_env(scenario_env),
+                overall_deadline=overall_deadline,
+            )
         )
-    )
-    add(
-        run_scenario(
-            "agent-launch-and-attach",
-            name="Launch-and-attach",
-            command=[
-                *robot_prefix,
-                gradle,
-                ":agent:test",
-                "--tests",
-                "*LaunchAndAttachIntegration*",
-                *force,
-            ],
-            cwd=ROOT,
-            timeout=600,
-            out_dir=out_dir,
-            env=_robot_env(scenario_env),
-            overall_deadline=overall_deadline,
-        )
-    )
 
     # --- CLI package + native helper layout ---
     # Bake --version into the package so MCP serverInfo.version matches strict stdio
@@ -621,8 +604,14 @@ def main(argv: list[str] | None = None) -> int:
         )
     else:
         # CLI path: ps, attach, find/click, fail-closed window screenshot, fullscreen, cleanup.
+        blocked = _robot_cell_blocked_result(
+            "cli-user-flow",
+            "Packaged CLI user flow (ps/attach/tree/input/capture/detach)",
+            system,
+        )
         add(
-            run_scenario(
+            blocked
+            or run_scenario(
                 "cli-user-flow",
                 name="Packaged CLI user flow (ps/attach/tree/input/capture/detach)",
                 command=[
@@ -644,7 +633,8 @@ def main(argv: list[str] | None = None) -> int:
         # MCP via official Kotlin SDK: fixture attach → op → detach session-gone is required
         # for hard pass after #399/#414 (tools/list + unknown-detach alone is insufficient).
         mcp_name = "Packaged MCP attach/op/detach lifecycle + strict stdio"
-        mcp_sdk = run_scenario(
+        blocked = _robot_cell_blocked_result("mcp-sdk-flow", mcp_name, system)
+        mcp_sdk = blocked or run_scenario(
             "mcp-sdk-flow",
             name=mcp_name,
             command=[

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -837,6 +837,19 @@ def robot_xvfb_prefix(system: str | None = None) -> list[str]:
     return []
 
 
+def robot_xvfb_unavailable_reason(system: str | None = None) -> str | None:
+    """Hard-fail reason when Linux Robot cells cannot leave the compositor seat."""
+    system = system or platform.system()
+    if system != "Linux":
+        return None
+    if _which("xvfb-run"):
+        return None
+    return (
+        "xvfb-run is required for JBR Robot cells on Linux; running them on a "
+        "seated Wayland display pops a new ScreenCast/Remote Desktop dialog per JVM"
+    )
+
+
 def host_cli_package_target(system: str | None = None, machine: str | None = None) -> str:
     system = system or platform.system()
     machine = machine or platform.machine()

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -824,6 +824,19 @@ def xvfb_prefix(system: str | None = None) -> list[str]:
     return []
 
 
+def robot_xvfb_prefix(system: str | None = None) -> list[str]:
+    """Always wrap JBR/AWT Robot cells in Xvfb on Linux.
+
+    Unlike [xvfb_prefix], this ignores an inherited seated DISPLAY. Helper
+    ScreenCast restore tokens do not cover Robot / Remote Desktop, so Robot
+    cells must not reuse the compositor seat after portal warmup.
+    """
+    system = system or platform.system()
+    if system == "Linux" and _which("xvfb-run"):
+        return ["xvfb-run", "-a"]
+    return []
+
+
 def host_cli_package_target(system: str | None = None, machine: str | None = None) -> str:
     system = system or platform.system()
     machine = machine or platform.machine()


### PR DESCRIPTION
## Summary
- Helper ScreenCast restore tokens do not cover JBR `Robot` / Remote Desktop. After `portal-token-warmup` the Unix harness dropped `xvfb-run` for every later cell, so `check` / attach / corpus each popped a new compositor dialog on the GNOME seat.
- Keep only helper monitor ScreenCast (`portal-token-warmup`, `host-native-recording`) on the seated display.
- Wrap Robot-backed cells in `xvfb-run` even when `DISPLAY=:0`, and force `SPECTRE_CAPTURE_BACKEND=x11` plus a cleared `WAYLAND_DISPLAY` so nested Xvfb does not inherit the seated portal.

## Test plan
- [x] `python3 .github/scripts/test-release-smoke-scripts.py` (41/41)
- [x] `./gradlew check` — one flaky MCP attach timeout retried green
- [ ] Do **not** rerun the full seated Linux harness until this lands