### PR TITLE
feat(core): add moveTo/moveBy pointer-move verbs

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -94,6 +94,9 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public static synthetic fun longClick-8Mi8wO0$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun monitorRecompositions-LRDsOJo (J)Ldev/sebastiano/spectre/core/perf/RecompositionMonitor;
 	public static synthetic fun monitorRecompositions-LRDsOJo$default (Ldev/sebastiano/spectre/core/ComposeAutomator;JILjava/lang/Object;)Ldev/sebastiano/spectre/core/perf/RecompositionMonitor;
+	public final fun moveBy (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun moveTo (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun moveTo (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun pasteText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun performSemanticsClick (Ldev/sebastiano/spectre/core/AutomatorNode;)V
 	public final fun pressEnter (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -187,6 +190,8 @@ public final class dev/sebastiano/spectre/core/RobotDriver {
 	public final fun doubleClick (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun longClick-exY8QGI (IIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun longClick-exY8QGI$default (Ldev/sebastiano/spectre/core/RobotDriver;IIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun moveBy (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun moveTo (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun pasteText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun pressKey (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun pressKey$default (Ldev/sebastiano/spectre/core/RobotDriver;IILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -144,6 +144,28 @@ private constructor(
         robotDriver.longClick(center.x, center.y, holdFor)
     }
 
+    /** Moves the pointer to [node]'s centre without pressing a button. */
+    public suspend fun moveTo(node: AutomatorNode) {
+        val center = node.centerOnScreen
+        robotDriver.moveTo(center.x, center.y)
+    }
+
+    /**
+     * Moves the pointer to screen coordinates (same space as [swipe]) without pressing a button.
+     */
+    public suspend fun moveTo(x: Int, y: Int) {
+        robotDriver.moveTo(x, y)
+    }
+
+    /**
+     * Moves the pointer by [deltaX], [deltaY] relative to the last Spectre-issued pointer position
+     * on this automator's [RobotDriver]. Throws [IllegalStateException] if no Spectre pointer move
+     * has happened yet.
+     */
+    public suspend fun moveBy(deltaX: Int, deltaY: Int) {
+        robotDriver.moveBy(deltaX, deltaY)
+    }
+
     public suspend fun swipe(
         startX: Int,
         startY: Int,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -40,6 +40,10 @@ internal constructor(
 
     public constructor(robot: Robot) : this(AwtRobotAdapter(robot))
 
+    @Volatile private var lastPointerX: Int = 0
+    @Volatile private var lastPointerY: Int = 0
+    @Volatile private var hasLastPointer: Boolean = false
+
     /**
      * Dispatches a single left-button click at the given screen coordinates: move, press, release.
      *
@@ -50,7 +54,7 @@ internal constructor(
     public suspend fun click(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            robot.mouseMove(screenX, screenY)
+            movePointer(screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
         }
@@ -67,7 +71,7 @@ internal constructor(
     public suspend fun doubleClick(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            robot.mouseMove(screenX, screenY)
+            movePointer(screenX, screenY)
             repeat(DOUBLE_CLICK_COUNT) {
                 robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
                 robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
@@ -93,7 +97,7 @@ internal constructor(
     ) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            robot.mouseMove(screenX, screenY)
+            movePointer(screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             try {
                 delay(holdFor)
@@ -130,11 +134,11 @@ internal constructor(
             val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
             val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = robot.autoDelayMs)
             val firstPoint = points.first()
-            robot.mouseMove(firstPoint.x, firstPoint.y)
+            movePointer(firstPoint.x, firstPoint.y)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             try {
                 for (point in points.drop(1)) {
-                    robot.mouseMove(point.x, point.y)
+                    movePointer(point.x, point.y)
                     if (pausePerStepMs > 0) {
                         delay(pausePerStepMs.milliseconds)
                     }
@@ -294,9 +298,46 @@ internal constructor(
     public suspend fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            robot.mouseMove(screenX, screenY)
+            movePointer(screenX, screenY)
             robot.mouseWheel(wheelClicks)
         }
+    }
+
+    /**
+     * Moves the pointer to ([screenX], [screenY]) without pressing or releasing any button. Use
+     * this for hover, tooltip, and "park the pointer" cases that `click` / `swipe` cannot express
+     * because they always press.
+     *
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
+    public suspend fun moveTo(screenX: Int, screenY: Int) {
+        tccGuard.requireAccessibility()
+        runOffEdt { movePointer(screenX, screenY) }
+    }
+
+    /**
+     * Moves the pointer by ([deltaX], [deltaY]) relative to the last Spectre-issued pointer
+     * position (`click`, `doubleClick`, `longClick`, `swipe`, `scrollWheel`, [moveTo], or a
+     * previous [moveBy]). Does not read the OS cursor — synthetic and headless backends have no
+     * real cursor, and `java.awt.MouseInfo` is a different coordinate story.
+     *
+     * Throws [IllegalStateException] if no Spectre pointer move has happened yet on this driver.
+     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
+     */
+    public suspend fun moveBy(deltaX: Int, deltaY: Int) {
+        check(hasLastPointer) {
+            "moveBy requires a prior Spectre pointer move; call moveTo(...) first"
+        }
+        moveTo(screenX = lastPointerX + deltaX, screenY = lastPointerY + deltaY)
+    }
+
+    private fun movePointer(x: Int, y: Int) {
+        robot.mouseMove(x, y)
+        lastPointerX = x
+        lastPointerY = y
+        hasLastPointer = true
     }
 
     /**

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -19,6 +19,8 @@ import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 public class RobotDriver
@@ -40,9 +42,7 @@ internal constructor(
 
     public constructor(robot: Robot) : this(AwtRobotAdapter(robot))
 
-    @Volatile private var lastPointerX: Int = 0
-    @Volatile private var lastPointerY: Int = 0
-    @Volatile private var hasLastPointer: Boolean = false
+    private val pointer = PointerPositionTracker()
 
     /**
      * Dispatches a single left-button click at the given screen coordinates: move, press, release.
@@ -54,7 +54,7 @@ internal constructor(
     public suspend fun click(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            movePointer(screenX, screenY)
+            pointer.moveTo(robot, screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
         }
@@ -71,7 +71,7 @@ internal constructor(
     public suspend fun doubleClick(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            movePointer(screenX, screenY)
+            pointer.moveTo(robot, screenX, screenY)
             repeat(DOUBLE_CLICK_COUNT) {
                 robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
                 robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
@@ -97,7 +97,7 @@ internal constructor(
     ) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            movePointer(screenX, screenY)
+            pointer.moveTo(robot, screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             try {
                 delay(holdFor)
@@ -134,11 +134,11 @@ internal constructor(
             val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
             val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = robot.autoDelayMs)
             val firstPoint = points.first()
-            movePointer(firstPoint.x, firstPoint.y)
+            pointer.moveTo(robot, firstPoint.x, firstPoint.y)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             try {
                 for (point in points.drop(1)) {
-                    movePointer(point.x, point.y)
+                    pointer.moveTo(robot, point.x, point.y)
                     if (pausePerStepMs > 0) {
                         delay(pausePerStepMs.milliseconds)
                     }
@@ -298,7 +298,7 @@ internal constructor(
     public suspend fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            movePointer(screenX, screenY)
+            pointer.moveTo(robot, screenX, screenY)
             robot.mouseWheel(wheelClicks)
         }
     }
@@ -313,7 +313,7 @@ internal constructor(
      */
     public suspend fun moveTo(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
-        runOffEdt { movePointer(screenX, screenY) }
+        runOffEdt { pointer.moveTo(robot, screenX, screenY) }
     }
 
     /**
@@ -327,17 +327,8 @@ internal constructor(
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun moveBy(deltaX: Int, deltaY: Int) {
-        check(hasLastPointer) {
-            "moveBy requires a prior Spectre pointer move; call moveTo(...) first"
-        }
-        moveTo(screenX = lastPointerX + deltaX, screenY = lastPointerY + deltaY)
-    }
-
-    private fun movePointer(x: Int, y: Int) {
-        robot.mouseMove(x, y)
-        lastPointerX = x
-        lastPointerY = y
-        hasLastPointer = true
+        tccGuard.requireAccessibility()
+        runOffEdt { pointer.moveBy(robot, deltaX, deltaY) }
     }
 
     /**
@@ -856,6 +847,35 @@ internal fun interpolateSwipePoints(
             val progress = step.toFloat() / steps
             add(Point(lerp(startX, endX, progress), lerp(startY, endY, progress)))
         }
+    }
+}
+
+/**
+ * Last Spectre-issued pointer position for one [RobotDriver]. Absolute and relative moves share one
+ * mutex so concurrent `moveBy` / `moveTo` / click calls cannot tear the stored `(x, y)` or apply
+ * two deltas from the same base.
+ */
+private class PointerPositionTracker {
+    private val mutex = Mutex()
+    private var last: Point? = null
+
+    suspend fun moveTo(robot: RobotAdapter, x: Int, y: Int) {
+        mutex.withLock { moveToUnlocked(robot, x, y) }
+    }
+
+    suspend fun moveBy(robot: RobotAdapter, deltaX: Int, deltaY: Int) {
+        mutex.withLock {
+            val origin =
+                checkNotNull(last) {
+                    "moveBy requires a prior Spectre pointer move; call moveTo(...) first"
+                }
+            moveToUnlocked(robot, origin.x + deltaX, origin.y + deltaY)
+        }
+    }
+
+    private fun moveToUnlocked(robot: RobotAdapter, x: Int, y: Int) {
+        robot.mouseMove(x, y)
+        last = Point(x, y)
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -341,6 +341,11 @@ internal constructor(
         runOffEdt { pointer.moveBy(robot, deltaX, deltaY) }
     }
 
+    /** Test-only hook so concurrent pointer races can park after lock acquisition. */
+    internal fun installPointerLockHook(hook: (() -> Unit)?) {
+        pointer.onLockAcquired = hook
+    }
+
     /**
      * Presses [keyCode] (a `java.awt.event.KeyEvent.VK_*` constant) with any AWT modifier-mask bits
      * set in [modifiers] (`InputEvent.SHIFT_DOWN_MASK`, `CTRL_DOWN_MASK`, etc.). Modifier keys are
@@ -524,6 +529,13 @@ internal interface RobotAdapter : ScreenCaptureAdapter {
 
     fun mouseMove(x: Int, y: Int)
 
+    /**
+     * Throws when this adapter cannot dispatch input (the headless backend). Default is a no-op so
+     * real and synthetic adapters stay silent. Used by [RobotDriver.moveBy] so the headless
+     * [UnsupportedOperationException] contract is evaluated before the relative-position check.
+     */
+    fun requireInputSupported() = Unit
+
     fun mousePress(buttons: Int)
 
     fun mouseRelease(buttons: Int)
@@ -657,6 +669,8 @@ private object HeadlessThrowingRobotAdapter : RobotAdapter {
     override val requiresOffEdt: Boolean = false
 
     override fun mouseMove(x: Int, y: Int): Unit = throwHeadless("mouseMove")
+
+    override fun requireInputSupported(): Unit = throwHeadless("moveBy")
 
     override fun mousePress(buttons: Int): Unit = throwHeadless("mousePress")
 
@@ -870,7 +884,10 @@ private class PointerPositionTracker {
     private val mutex = Mutex()
     private var last: Point? = null
 
+    internal var onLockAcquired: (() -> Unit)? = null
+
     suspend fun <T> withLock(block: suspend PointerSession.() -> T): T = mutex.withLock {
+        onLockAcquired?.invoke()
         PointerSession().block()
     }
 
@@ -879,6 +896,10 @@ private class PointerPositionTracker {
     }
 
     suspend fun moveBy(robot: RobotAdapter, deltaX: Int, deltaY: Int) {
+        // Headless must reject before the relative-position check: no successful headless
+        // move can ever initialize [last], so evaluating it first would turn every
+        // headless moveBy into IllegalStateException instead of UnsupportedOperationException.
+        robot.requireInputSupported()
         withLock {
             val origin =
                 checkNotNull(last) {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -13,14 +13,13 @@ import java.awt.datatransfer.UnsupportedFlavorException
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.awt.image.BufferedImage
+import java.util.concurrent.atomic.AtomicReference
 import javax.swing.SwingUtilities
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 public class RobotDriver
@@ -860,36 +859,31 @@ internal fun interpolateSwipePoints(
 }
 
 /**
- * Last Spectre-issued pointer position for one [RobotDriver]. Read-modify-write of that position is
- * mutex-protected so concurrent `moveBy` calls cannot apply two deltas from the same base. Gestures
- * themselves are *not* held under the mutex: a synthetic longClick/swipe that delays while holding
- * it would deadlock an EDT `moveTo` (`invokeAndWait` cannot run until the lock is released, and the
- * lock holder cannot release until `invokeAndWait` returns).
+ * Last Spectre-issued pointer position for one [RobotDriver]. Stored as one atomic [Point] so a
+ * concurrent reader cannot observe a torn `(x, y)`. No mutex: holding a lock across
+ * `robot.mouseMove` deadlocks an EDT `moveTo`/`moveBy` against a synthetic adapter's
+ * `invokeAndWait`. Concurrent pointer ops on one driver are not a supported contract.
  */
 private class PointerPositionTracker {
-    private val mutex = Mutex()
-    private var last: Point? = null
+    private val last = AtomicReference<Point?>(null)
 
-    suspend fun moveTo(robot: RobotAdapter, x: Int, y: Int) {
-        mutex.withLock {
-            robot.mouseMove(x, y)
-            last = Point(x, y)
-        }
+    fun moveTo(robot: RobotAdapter, x: Int, y: Int) {
+        robot.mouseMove(x, y)
+        last.set(Point(x, y))
     }
 
-    suspend fun moveBy(robot: RobotAdapter, deltaX: Int, deltaY: Int) {
+    fun moveBy(robot: RobotAdapter, deltaX: Int, deltaY: Int) {
         // Headless must reject before the relative-position check: no successful headless
         // move can ever initialize [last], so evaluating it first would turn every
         // headless moveBy into IllegalStateException instead of UnsupportedOperationException.
         robot.requireInputSupported()
-        mutex.withLock {
-            val origin =
-                checkNotNull(last) {
-                    "moveBy requires a prior Spectre pointer move; call moveTo(...) first"
-                }
-            robot.mouseMove(origin.x + deltaX, origin.y + deltaY)
-            last = Point(origin.x + deltaX, origin.y + deltaY)
-        }
+        val origin =
+            checkNotNull(last.get()) {
+                "moveBy requires a prior Spectre pointer move; call moveTo(...) first"
+            }
+        val next = Point(origin.x + deltaX, origin.y + deltaY)
+        robot.mouseMove(next.x, next.y)
+        last.set(next)
     }
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -54,11 +54,9 @@ internal constructor(
     public suspend fun click(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            pointer.withLock {
-                moveTo(robot, screenX, screenY)
-                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
-            }
+            pointer.moveTo(robot, screenX, screenY)
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
         }
     }
 
@@ -73,12 +71,10 @@ internal constructor(
     public suspend fun doubleClick(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            pointer.withLock {
-                moveTo(robot, screenX, screenY)
-                repeat(DOUBLE_CLICK_COUNT) {
-                    robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
-                }
+            pointer.moveTo(robot, screenX, screenY)
+            repeat(DOUBLE_CLICK_COUNT) {
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
             }
         }
     }
@@ -101,14 +97,12 @@ internal constructor(
     ) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            pointer.withLock {
-                moveTo(robot, screenX, screenY)
-                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-                try {
-                    delay(holdFor)
-                } finally {
-                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
-                }
+            pointer.moveTo(robot, screenX, screenY)
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+            try {
+                delay(holdFor)
+            } finally {
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
             }
         }
     }
@@ -140,19 +134,17 @@ internal constructor(
             val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
             val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = robot.autoDelayMs)
             val firstPoint = points.first()
-            pointer.withLock {
-                moveTo(robot, firstPoint.x, firstPoint.y)
-                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-                try {
-                    for (point in points.drop(1)) {
-                        moveTo(robot, point.x, point.y)
-                        if (pausePerStepMs > 0) {
-                            delay(pausePerStepMs.milliseconds)
-                        }
+            pointer.moveTo(robot, firstPoint.x, firstPoint.y)
+            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+            try {
+                for (point in points.drop(1)) {
+                    pointer.moveTo(robot, point.x, point.y)
+                    if (pausePerStepMs > 0) {
+                        delay(pausePerStepMs.milliseconds)
                     }
-                } finally {
-                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
                 }
+            } finally {
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
             }
         }
     }
@@ -306,10 +298,8 @@ internal constructor(
     public suspend fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            pointer.withLock {
-                moveTo(robot, screenX, screenY)
-                robot.mouseWheel(wheelClicks)
-            }
+            pointer.moveTo(robot, screenX, screenY)
+            robot.mouseWheel(wheelClicks)
         }
     }
 
@@ -339,12 +329,6 @@ internal constructor(
     public suspend fun moveBy(deltaX: Int, deltaY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt { pointer.moveBy(robot, deltaX, deltaY) }
-    }
-
-    /** Test-only hooks so concurrent pointer races can park the holder until a waiter contends. */
-    internal fun installPointerLockHooks(onAcquired: (() -> Unit)?, onContended: (() -> Unit)?) {
-        pointer.onLockAcquired = onAcquired
-        pointer.onLockContended = onContended
     }
 
     /**
@@ -876,28 +860,21 @@ internal fun interpolateSwipePoints(
 }
 
 /**
- * Last Spectre-issued pointer position for one [RobotDriver]. Absolute and relative moves, plus the
- * rest of each pointer gesture (press / drag / wheel), share one mutex so concurrent `moveBy` /
- * `moveTo` / click calls cannot tear the stored `(x, y)`, apply two deltas from the same base, or
- * press at a coordinate another coroutine just moved to.
+ * Last Spectre-issued pointer position for one [RobotDriver]. Read-modify-write of that position is
+ * mutex-protected so concurrent `moveBy` calls cannot apply two deltas from the same base. Gestures
+ * themselves are *not* held under the mutex: a synthetic longClick/swipe that delays while holding
+ * it would deadlock an EDT `moveTo` (`invokeAndWait` cannot run until the lock is released, and the
+ * lock holder cannot release until `invokeAndWait` returns).
  */
 private class PointerPositionTracker {
     private val mutex = Mutex()
     private var last: Point? = null
 
-    internal var onLockAcquired: (() -> Unit)? = null
-    internal var onLockContended: (() -> Unit)? = null
-
-    suspend fun <T> withLock(block: suspend PointerSession.() -> T): T {
-        if (mutex.isLocked) onLockContended?.invoke()
-        return mutex.withLock {
-            onLockAcquired?.invoke()
-            PointerSession().block()
-        }
-    }
-
     suspend fun moveTo(robot: RobotAdapter, x: Int, y: Int) {
-        withLock { moveTo(robot, x, y) }
+        mutex.withLock {
+            robot.mouseMove(x, y)
+            last = Point(x, y)
+        }
     }
 
     suspend fun moveBy(robot: RobotAdapter, deltaX: Int, deltaY: Int) {
@@ -905,19 +882,13 @@ private class PointerPositionTracker {
         // move can ever initialize [last], so evaluating it first would turn every
         // headless moveBy into IllegalStateException instead of UnsupportedOperationException.
         robot.requireInputSupported()
-        withLock {
+        mutex.withLock {
             val origin =
                 checkNotNull(last) {
                     "moveBy requires a prior Spectre pointer move; call moveTo(...) first"
                 }
-            moveTo(robot, origin.x + deltaX, origin.y + deltaY)
-        }
-    }
-
-    inner class PointerSession {
-        fun moveTo(robot: RobotAdapter, x: Int, y: Int) {
-            robot.mouseMove(x, y)
-            last = Point(x, y)
+            robot.mouseMove(origin.x + deltaX, origin.y + deltaY)
+            last = Point(origin.x + deltaX, origin.y + deltaY)
         }
     }
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -341,9 +341,10 @@ internal constructor(
         runOffEdt { pointer.moveBy(robot, deltaX, deltaY) }
     }
 
-    /** Test-only hook so concurrent pointer races can park after lock acquisition. */
-    internal fun installPointerLockHook(hook: (() -> Unit)?) {
-        pointer.onLockAcquired = hook
+    /** Test-only hooks so concurrent pointer races can park the holder until a waiter contends. */
+    internal fun installPointerLockHooks(onAcquired: (() -> Unit)?, onContended: (() -> Unit)?) {
+        pointer.onLockAcquired = onAcquired
+        pointer.onLockContended = onContended
     }
 
     /**
@@ -885,10 +886,14 @@ private class PointerPositionTracker {
     private var last: Point? = null
 
     internal var onLockAcquired: (() -> Unit)? = null
+    internal var onLockContended: (() -> Unit)? = null
 
-    suspend fun <T> withLock(block: suspend PointerSession.() -> T): T = mutex.withLock {
-        onLockAcquired?.invoke()
-        PointerSession().block()
+    suspend fun <T> withLock(block: suspend PointerSession.() -> T): T {
+        if (mutex.isLocked) onLockContended?.invoke()
+        return mutex.withLock {
+            onLockAcquired?.invoke()
+            PointerSession().block()
+        }
     }
 
     suspend fun moveTo(robot: RobotAdapter, x: Int, y: Int) {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -54,9 +54,11 @@ internal constructor(
     public suspend fun click(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            pointer.moveTo(robot, screenX, screenY)
-            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-            robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+            pointer.withLock {
+                moveTo(robot, screenX, screenY)
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+            }
         }
     }
 
@@ -71,10 +73,12 @@ internal constructor(
     public suspend fun doubleClick(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            pointer.moveTo(robot, screenX, screenY)
-            repeat(DOUBLE_CLICK_COUNT) {
-                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+            pointer.withLock {
+                moveTo(robot, screenX, screenY)
+                repeat(DOUBLE_CLICK_COUNT) {
+                    robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+                }
             }
         }
     }
@@ -97,12 +101,14 @@ internal constructor(
     ) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            pointer.moveTo(robot, screenX, screenY)
-            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-            try {
-                delay(holdFor)
-            } finally {
-                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+            pointer.withLock {
+                moveTo(robot, screenX, screenY)
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+                try {
+                    delay(holdFor)
+                } finally {
+                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
+                }
             }
         }
     }
@@ -134,17 +140,19 @@ internal constructor(
             val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
             val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = robot.autoDelayMs)
             val firstPoint = points.first()
-            pointer.moveTo(robot, firstPoint.x, firstPoint.y)
-            robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
-            try {
-                for (point in points.drop(1)) {
-                    pointer.moveTo(robot, point.x, point.y)
-                    if (pausePerStepMs > 0) {
-                        delay(pausePerStepMs.milliseconds)
+            pointer.withLock {
+                moveTo(robot, firstPoint.x, firstPoint.y)
+                robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
+                try {
+                    for (point in points.drop(1)) {
+                        moveTo(robot, point.x, point.y)
+                        if (pausePerStepMs > 0) {
+                            delay(pausePerStepMs.milliseconds)
+                        }
                     }
+                } finally {
+                    robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
                 }
-            } finally {
-                robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
             }
         }
     }
@@ -298,8 +306,10 @@ internal constructor(
     public suspend fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
         tccGuard.requireAccessibility()
         runOffEdt {
-            pointer.moveTo(robot, screenX, screenY)
-            robot.mouseWheel(wheelClicks)
+            pointer.withLock {
+                moveTo(robot, screenX, screenY)
+                robot.mouseWheel(wheelClicks)
+            }
         }
     }
 
@@ -851,31 +861,38 @@ internal fun interpolateSwipePoints(
 }
 
 /**
- * Last Spectre-issued pointer position for one [RobotDriver]. Absolute and relative moves share one
- * mutex so concurrent `moveBy` / `moveTo` / click calls cannot tear the stored `(x, y)` or apply
- * two deltas from the same base.
+ * Last Spectre-issued pointer position for one [RobotDriver]. Absolute and relative moves, plus the
+ * rest of each pointer gesture (press / drag / wheel), share one mutex so concurrent `moveBy` /
+ * `moveTo` / click calls cannot tear the stored `(x, y)`, apply two deltas from the same base, or
+ * press at a coordinate another coroutine just moved to.
  */
 private class PointerPositionTracker {
     private val mutex = Mutex()
     private var last: Point? = null
 
+    suspend fun <T> withLock(block: suspend PointerSession.() -> T): T = mutex.withLock {
+        PointerSession().block()
+    }
+
     suspend fun moveTo(robot: RobotAdapter, x: Int, y: Int) {
-        mutex.withLock { moveToUnlocked(robot, x, y) }
+        withLock { moveTo(robot, x, y) }
     }
 
     suspend fun moveBy(robot: RobotAdapter, deltaX: Int, deltaY: Int) {
-        mutex.withLock {
+        withLock {
             val origin =
                 checkNotNull(last) {
                     "moveBy requires a prior Spectre pointer move; call moveTo(...) first"
                 }
-            moveToUnlocked(robot, origin.x + deltaX, origin.y + deltaY)
+            moveTo(robot, origin.x + deltaX, origin.y + deltaY)
         }
     }
 
-    private fun moveToUnlocked(robot: RobotAdapter, x: Int, y: Int) {
-        robot.mouseMove(x, y)
-        last = Point(x, y)
+    inner class PointerSession {
+        fun moveTo(robot: RobotAdapter, x: Int, y: Int) {
+            robot.mouseMove(x, y)
+            last = Point(x, y)
+        }
     }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -347,6 +347,8 @@ class ComposeAutomatorPublicSurfaceTest {
                 "click",
                 "doubleClick",
                 "longClick",
+                "moveTo",
+                "moveBy",
                 "swipe",
                 "scrollWheel",
                 "typeText",

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InjectionApiAuditContractTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InjectionApiAuditContractTest.kt
@@ -39,7 +39,16 @@ class InjectionApiAuditContractTest {
 
         // Geometry-only Robot verbs that must remain listed for inject/read-only design.
         for (verb in
-            listOf("click", "doubleClick", "longClick", "swipe", "scrollWheel", "typeText")) {
+            listOf(
+                "click",
+                "doubleClick",
+                "longClick",
+                "swipe",
+                "scrollWheel",
+                "moveTo",
+                "moveBy",
+                "typeText",
+            )) {
             assertContains(text, verb)
         }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -329,18 +329,23 @@ class RobotDriverTest {
     @Test
     fun `concurrent moveBy applies each delta against the previous completed move`() {
         val firstHold = CountDownLatch(1)
-        val secondInFlight = CountDownLatch(1)
+        val secondContended = CountDownLatch(1)
         val robot = RecordingRobotAdapter()
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
         runBlocking { driver.moveTo(screenX = 0, screenY = 0) }
         var firstLock = true
-        driver.installPointerLockHook {
-            if (firstLock) {
-                firstLock = false
-                firstHold.countDown()
-                check(secondInFlight.await(2, TimeUnit.SECONDS)) { "second moveBy never started" }
-            }
-        }
+        driver.installPointerLockHooks(
+            onAcquired = {
+                if (firstLock) {
+                    firstLock = false
+                    firstHold.countDown()
+                    check(secondContended.await(2, TimeUnit.SECONDS)) {
+                        "second moveBy never contended the pointer lock"
+                    }
+                }
+            },
+            onContended = { secondContended.countDown() },
+        )
 
         val first = Thread({ runBlocking { driver.moveBy(deltaX = 1, deltaY = 0) } }, "moveBy-x")
         val second =
@@ -349,7 +354,6 @@ class RobotDriverTest {
                     check(firstHold.await(2, TimeUnit.SECONDS)) {
                         "first moveBy never acquired the pointer lock"
                     }
-                    secondInFlight.countDown()
                     runBlocking { driver.moveBy(deltaX = 0, deltaY = 1) }
                 },
                 "moveBy-y",
@@ -373,19 +377,22 @@ class RobotDriverTest {
     @Test
     fun `concurrent moveTo cannot sneak between click press and release`() {
         val clickHold = CountDownLatch(1)
-        val moveToInFlight = CountDownLatch(1)
+        val moveToContended = CountDownLatch(1)
         val robot = RecordingRobotAdapter()
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
         var firstLock = true
-        driver.installPointerLockHook {
-            if (firstLock) {
-                firstLock = false
-                clickHold.countDown()
-                check(moveToInFlight.await(2, TimeUnit.SECONDS)) {
-                    "concurrent moveTo never started"
+        driver.installPointerLockHooks(
+            onAcquired = {
+                if (firstLock) {
+                    firstLock = false
+                    clickHold.countDown()
+                    check(moveToContended.await(2, TimeUnit.SECONDS)) {
+                        "concurrent moveTo never contended the pointer lock"
+                    }
                 }
-            }
-        }
+            },
+            onContended = { moveToContended.countDown() },
+        )
         val clicker = Thread({ runBlocking { driver.click(10, 20) } }, "clicker")
         val mover =
             Thread(
@@ -393,7 +400,6 @@ class RobotDriverTest {
                     check(clickHold.await(2, TimeUnit.SECONDS)) {
                         "click never acquired the pointer lock"
                     }
-                    moveToInFlight.countDown()
                     runBlocking { driver.moveTo(screenX = 99, screenY = 99) }
                 },
                 "mover",

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -240,6 +240,90 @@ class RobotDriverTest {
     }
 
     @Test
+    fun `moveTo moves without pressing or releasing`() = runTest {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.moveTo(screenX = 10, screenY = 20)
+
+        assertEquals(listOf("move(10,20)"), robot.events)
+    }
+
+    @Test
+    fun `moveBy offsets from the last Spectre-issued pointer position`() = runTest {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.moveTo(screenX = 10, screenY = 20)
+        driver.moveBy(deltaX = 5, deltaY = -3)
+
+        assertEquals(listOf("move(10,20)", "move(15,17)"), robot.events)
+    }
+
+    @Test
+    fun `moveBy after click offsets from the click target`() = runTest {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.click(10, 20)
+        driver.moveBy(deltaX = 4, deltaY = 6)
+
+        assertEquals(
+            listOf(
+                "move(10,20)",
+                "press(${InputEvent.BUTTON1_DOWN_MASK})",
+                "release(${InputEvent.BUTTON1_DOWN_MASK})",
+                "move(14,26)",
+            ),
+            robot.events,
+        )
+    }
+
+    @Test
+    fun `moveBy after swipe offsets from the swipe end`() = runTest {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.swipe(startX = 10, startY = 20, endX = 40, endY = 50, steps = 3, duration = ZERO)
+        driver.moveBy(deltaX = 1, deltaY = 2)
+
+        assertEquals(
+            listOf(
+                "move(10,20)",
+                "press(${InputEvent.BUTTON1_DOWN_MASK})",
+                "move(20,30)",
+                "move(30,40)",
+                "move(40,50)",
+                "release(${InputEvent.BUTTON1_DOWN_MASK})",
+                "move(41,52)",
+            ),
+            robot.events,
+        )
+    }
+
+    @Test
+    fun `moveBy after scrollWheel offsets from the wheel position`() = runTest {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.scrollWheel(screenX = 8, screenY = 12, wheelClicks = 1)
+        driver.moveBy(deltaX = -2, deltaY = 3)
+
+        assertEquals(listOf("move(8,12)", "mouseWheel(1)", "move(6,15)"), robot.events)
+    }
+
+    @Test
+    fun `moveBy without a prior Spectre pointer move fails loudly`() = runTest {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        val error = assertFailsWith<IllegalStateException> { driver.moveBy(deltaX = 1, deltaY = 1) }
+
+        assertTrue(error.message?.contains("moveBy") == true)
+        assertEquals(emptyList(), robot.events)
+    }
+
+    @Test
     fun `pasteText waits for the clipboard to reflect the new text before dispatching paste`() =
         runTest {
             // Simulate a slow OS pasteboard: the first N reads after setContents still return the
@@ -346,6 +430,30 @@ class RobotDriverTest {
     }
 
     @Test
+    fun `moveTo consults the TCC guard before invoking the robot`() = runTest {
+        val guard = RecordingTccGuard()
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
+
+        driver.moveTo(screenX = 10, screenY = 20)
+
+        assertEquals(1, guard.accessibilityCalls)
+        assertEquals(0, guard.screenRecordingCalls)
+        assertEquals(listOf("move(10,20)"), robot.events)
+    }
+
+    @Test
+    fun `moveTo that fails the accessibility check does not dispatch any input`() = runTest {
+        val guard = RecordingTccGuard(accessibilityThrows = true)
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter(), guard)
+
+        assertFailsWith<IllegalStateException> { driver.moveTo(screenX = 10, screenY = 20) }
+
+        assertEquals(emptyList(), robot.events)
+    }
+
+    @Test
     fun `screenshot consults the screen-recording guard before capturing`() {
         val guard = RecordingTccGuard()
         val robot = RecordingRobotAdapter()
@@ -444,6 +552,19 @@ class RobotDriverTest {
         assertFailsWith<UnsupportedOperationException> {
             driver.swipe(startX = 0, startY = 0, endX = 1, endY = 1, steps = 1, duration = ZERO)
         }
+    }
+
+    @Test
+    fun `headless moveTo throws UnsupportedOperationException`() = runTest {
+        val driver = RobotDriver.headless()
+        assertFailsWith<UnsupportedOperationException> { driver.moveTo(screenX = 0, screenY = 0) }
+    }
+
+    @Test
+    fun `headless moveBy without a prior Spectre pointer move fails loudly`() = runTest {
+        val driver = RobotDriver.headless()
+        val error = assertFailsWith<IllegalStateException> { driver.moveBy(deltaX = 1, deltaY = 1) }
+        assertTrue(error.message?.contains("moveBy") == true)
     }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -347,6 +347,28 @@ class RobotDriverTest {
     }
 
     @Test
+    fun `concurrent moveTo cannot sneak between click press and release`() = runTest {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        awaitAll(
+            async { driver.click(10, 20) },
+            async { driver.moveTo(screenX = 99, screenY = 99) },
+        )
+
+        val clickStart = robot.events.indexOf("move(10,20)")
+        check(clickStart >= 0) { "expected click move in ${robot.events}" }
+        assertEquals(
+            listOf(
+                "move(10,20)",
+                "press(${InputEvent.BUTTON1_DOWN_MASK})",
+                "release(${InputEvent.BUTTON1_DOWN_MASK})",
+            ),
+            robot.events.subList(clickStart, clickStart + 3),
+        )
+    }
+
+    @Test
     fun `pasteText waits for the clipboard to reflect the new text before dispatching paste`() =
         runTest {
             // Simulate a slow OS pasteboard: the first N reads after setContents still return the

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -14,6 +14,8 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
 
 class RobotDriverTest {
@@ -321,6 +323,27 @@ class RobotDriverTest {
 
         assertTrue(error.message?.contains("moveBy") == true)
         assertEquals(emptyList(), robot.events)
+    }
+
+    @Test
+    fun `concurrent moveBy applies each delta against the previous completed move`() = runTest {
+        val robot = RecordingRobotAdapter()
+        val driver = RobotDriver(robot, RecordingClipboardAdapter())
+
+        driver.moveTo(screenX = 0, screenY = 0)
+        awaitAll(
+            async { driver.moveBy(deltaX = 1, deltaY = 0) },
+            async { driver.moveBy(deltaX = 0, deltaY = 1) },
+        )
+
+        // Either interleaving is valid; both deltas must compose rather than overwrite.
+        assertEquals(listOf("move(0,0)") + robot.events.drop(1), robot.events)
+        assertEquals("move(1,1)", robot.events.last())
+        assertEquals(3, robot.events.size)
+        assertTrue(
+            robot.events[1] == "move(1,0)" || robot.events[1] == "move(0,1)",
+            "expected one single-axis hop first, got ${robot.events}",
+        )
     }
 
     @Test

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -8,7 +8,7 @@ import java.awt.datatransfer.Transferable
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.awt.image.BufferedImage
-import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -328,28 +328,28 @@ class RobotDriverTest {
 
     @Test
     fun `concurrent moveBy applies each delta against the previous completed move`() {
-        var delayMoves = false
-        val start = CyclicBarrier(2)
-        val robot =
-            RecordingRobotAdapter(
-                beforeMove = { if (delayMoves) Thread.sleep(POINTER_RACE_WINDOW_MS) }
-            )
+        val firstHold = CountDownLatch(1)
+        val secondInFlight = CountDownLatch(1)
+        val robot = RecordingRobotAdapter()
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
         runBlocking { driver.moveTo(screenX = 0, screenY = 0) }
-        delayMoves = true
+        var firstLock = true
+        driver.installPointerLockHook {
+            if (firstLock) {
+                firstLock = false
+                firstHold.countDown()
+                check(secondInFlight.await(2, TimeUnit.SECONDS)) { "second moveBy never started" }
+            }
+        }
 
-        val first =
-            Thread(
-                {
-                    start.await(2, TimeUnit.SECONDS)
-                    runBlocking { driver.moveBy(deltaX = 1, deltaY = 0) }
-                },
-                "moveBy-x",
-            )
+        val first = Thread({ runBlocking { driver.moveBy(deltaX = 1, deltaY = 0) } }, "moveBy-x")
         val second =
             Thread(
                 {
-                    start.await(2, TimeUnit.SECONDS)
+                    check(firstHold.await(2, TimeUnit.SECONDS)) {
+                        "first moveBy never acquired the pointer lock"
+                    }
+                    secondInFlight.countDown()
                     runBlocking { driver.moveBy(deltaX = 0, deltaY = 1) }
                 },
                 "moveBy-y",
@@ -360,8 +360,8 @@ class RobotDriverTest {
         second.join(JOIN_TIMEOUT_MS)
         assertTrue(!first.isAlive && !second.isAlive, "moveBy threads did not finish")
 
-        // Without the pointer mutex both threads would read the same origin during the sleep
-        // and the last position would be (1,0) or (0,1), not the composed (1,1).
+        // Without the pointer mutex both threads would read the same origin while the first
+        // move is parked, and the last position would be (1,0) or (0,1), not composed (1,1).
         assertEquals("move(1,1)", robot.events.last())
         assertEquals(3, robot.events.size)
         assertTrue(
@@ -372,24 +372,28 @@ class RobotDriverTest {
 
     @Test
     fun `concurrent moveTo cannot sneak between click press and release`() {
-        val start = CyclicBarrier(2)
-        val robot =
-            RecordingRobotAdapter(
-                afterMove = { x, y -> if (x == 10 && y == 20) Thread.sleep(POINTER_RACE_WINDOW_MS) }
-            )
+        val clickHold = CountDownLatch(1)
+        val moveToInFlight = CountDownLatch(1)
+        val robot = RecordingRobotAdapter()
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
-        val clicker =
-            Thread(
-                {
-                    start.await(2, TimeUnit.SECONDS)
-                    runBlocking { driver.click(10, 20) }
-                },
-                "clicker",
-            )
+        var firstLock = true
+        driver.installPointerLockHook {
+            if (firstLock) {
+                firstLock = false
+                clickHold.countDown()
+                check(moveToInFlight.await(2, TimeUnit.SECONDS)) {
+                    "concurrent moveTo never started"
+                }
+            }
+        }
+        val clicker = Thread({ runBlocking { driver.click(10, 20) } }, "clicker")
         val mover =
             Thread(
                 {
-                    start.await(2, TimeUnit.SECONDS)
+                    check(clickHold.await(2, TimeUnit.SECONDS)) {
+                        "click never acquired the pointer lock"
+                    }
+                    moveToInFlight.countDown()
                     runBlocking { driver.moveTo(screenX = 99, screenY = 99) }
                 },
                 "mover",
@@ -650,10 +654,9 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `headless moveBy without a prior Spectre pointer move fails loudly`() = runTest {
+    fun `headless moveBy throws UnsupportedOperationException`() = runTest {
         val driver = RobotDriver.headless()
-        val error = assertFailsWith<IllegalStateException> { driver.moveBy(deltaX = 1, deltaY = 1) }
-        assertTrue(error.message?.contains("moveBy") == true)
+        assertFailsWith<UnsupportedOperationException> { driver.moveBy(deltaX = 1, deltaY = 1) }
     }
 }
 
@@ -690,8 +693,6 @@ private class RecordingRobotAdapter(
     private val drainAfterPaste: Boolean = false,
     initialCapsLockOn: Boolean = false,
     private val allowCapsLockWrite: Boolean = true,
-    private val beforeMove: (() -> Unit)? = null,
-    private val afterMove: ((Int, Int) -> Unit)? = null,
 ) : RobotAdapter {
     override val requiresOffEdt: Boolean = false
     val events = mutableListOf<String>()
@@ -705,11 +706,7 @@ private class RecordingRobotAdapter(
         sharedLog?.add("robot:$event")
     }
 
-    override fun mouseMove(x: Int, y: Int) {
-        beforeMove?.invoke()
-        log("move($x,$y)")
-        afterMove?.invoke(x, y)
-    }
+    override fun mouseMove(x: Int, y: Int) = log("move($x,$y)")
 
     override fun mousePress(buttons: Int) = log("press($buttons)")
 
@@ -826,5 +823,4 @@ private class LatentClipboardAdapter(
     }
 }
 
-private const val POINTER_RACE_WINDOW_MS: Long = 50L
 private const val JOIN_TIMEOUT_MS: Long = 2_000L

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -8,15 +8,12 @@ import java.awt.datatransfer.Transferable
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.awt.image.BufferedImage
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 
 class RobotDriverTest {
@@ -324,102 +321,6 @@ class RobotDriverTest {
 
         assertTrue(error.message?.contains("moveBy") == true)
         assertEquals(emptyList(), robot.events)
-    }
-
-    @Test
-    fun `concurrent moveBy applies each delta against the previous completed move`() {
-        val firstHold = CountDownLatch(1)
-        val secondContended = CountDownLatch(1)
-        val robot = RecordingRobotAdapter()
-        val driver = RobotDriver(robot, RecordingClipboardAdapter())
-        runBlocking { driver.moveTo(screenX = 0, screenY = 0) }
-        var firstLock = true
-        driver.installPointerLockHooks(
-            onAcquired = {
-                if (firstLock) {
-                    firstLock = false
-                    firstHold.countDown()
-                    check(secondContended.await(2, TimeUnit.SECONDS)) {
-                        "second moveBy never contended the pointer lock"
-                    }
-                }
-            },
-            onContended = { secondContended.countDown() },
-        )
-
-        val first = Thread({ runBlocking { driver.moveBy(deltaX = 1, deltaY = 0) } }, "moveBy-x")
-        val second =
-            Thread(
-                {
-                    check(firstHold.await(2, TimeUnit.SECONDS)) {
-                        "first moveBy never acquired the pointer lock"
-                    }
-                    runBlocking { driver.moveBy(deltaX = 0, deltaY = 1) }
-                },
-                "moveBy-y",
-            )
-        first.start()
-        second.start()
-        first.join(JOIN_TIMEOUT_MS)
-        second.join(JOIN_TIMEOUT_MS)
-        assertTrue(!first.isAlive && !second.isAlive, "moveBy threads did not finish")
-
-        // Without the pointer mutex both threads would read the same origin while the first
-        // move is parked, and the last position would be (1,0) or (0,1), not composed (1,1).
-        assertEquals("move(1,1)", robot.events.last())
-        assertEquals(3, robot.events.size)
-        assertTrue(
-            robot.events[1] == "move(1,0)" || robot.events[1] == "move(0,1)",
-            "expected one single-axis hop first, got ${robot.events}",
-        )
-    }
-
-    @Test
-    fun `concurrent moveTo cannot sneak between click press and release`() {
-        val clickHold = CountDownLatch(1)
-        val moveToContended = CountDownLatch(1)
-        val robot = RecordingRobotAdapter()
-        val driver = RobotDriver(robot, RecordingClipboardAdapter())
-        var firstLock = true
-        driver.installPointerLockHooks(
-            onAcquired = {
-                if (firstLock) {
-                    firstLock = false
-                    clickHold.countDown()
-                    check(moveToContended.await(2, TimeUnit.SECONDS)) {
-                        "concurrent moveTo never contended the pointer lock"
-                    }
-                }
-            },
-            onContended = { moveToContended.countDown() },
-        )
-        val clicker = Thread({ runBlocking { driver.click(10, 20) } }, "clicker")
-        val mover =
-            Thread(
-                {
-                    check(clickHold.await(2, TimeUnit.SECONDS)) {
-                        "click never acquired the pointer lock"
-                    }
-                    runBlocking { driver.moveTo(screenX = 99, screenY = 99) }
-                },
-                "mover",
-            )
-        clicker.start()
-        mover.start()
-        clicker.join(JOIN_TIMEOUT_MS)
-        mover.join(JOIN_TIMEOUT_MS)
-        assertTrue(!clicker.isAlive && !mover.isAlive, "pointer threads did not finish")
-
-        val clickStart = robot.events.indexOf("move(10,20)")
-        check(clickStart >= 0) { "expected click move in ${robot.events}" }
-        assertEquals(
-            listOf(
-                "move(10,20)",
-                "press(${InputEvent.BUTTON1_DOWN_MASK})",
-                "release(${InputEvent.BUTTON1_DOWN_MASK})",
-            ),
-            robot.events.subList(clickStart, clickStart + 3),
-        )
     }
 
     @Test
@@ -828,5 +729,3 @@ private class LatentClipboardAdapter(
         }
     }
 }
-
-private const val JOIN_TIMEOUT_MS: Long = 2_000L

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -8,14 +8,15 @@ import java.awt.datatransfer.Transferable
 import java.awt.event.InputEvent
 import java.awt.event.KeyEvent
 import java.awt.image.BufferedImage
+import java.util.concurrent.CyclicBarrier
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.milliseconds
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 
 class RobotDriverTest {
@@ -326,18 +327,41 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `concurrent moveBy applies each delta against the previous completed move`() = runTest {
-        val robot = RecordingRobotAdapter()
+    fun `concurrent moveBy applies each delta against the previous completed move`() {
+        var delayMoves = false
+        val start = CyclicBarrier(2)
+        val robot =
+            RecordingRobotAdapter(
+                beforeMove = { if (delayMoves) Thread.sleep(POINTER_RACE_WINDOW_MS) }
+            )
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
+        runBlocking { driver.moveTo(screenX = 0, screenY = 0) }
+        delayMoves = true
 
-        driver.moveTo(screenX = 0, screenY = 0)
-        awaitAll(
-            async { driver.moveBy(deltaX = 1, deltaY = 0) },
-            async { driver.moveBy(deltaX = 0, deltaY = 1) },
-        )
+        val first =
+            Thread(
+                {
+                    start.await(2, TimeUnit.SECONDS)
+                    runBlocking { driver.moveBy(deltaX = 1, deltaY = 0) }
+                },
+                "moveBy-x",
+            )
+        val second =
+            Thread(
+                {
+                    start.await(2, TimeUnit.SECONDS)
+                    runBlocking { driver.moveBy(deltaX = 0, deltaY = 1) }
+                },
+                "moveBy-y",
+            )
+        first.start()
+        second.start()
+        first.join(JOIN_TIMEOUT_MS)
+        second.join(JOIN_TIMEOUT_MS)
+        assertTrue(!first.isAlive && !second.isAlive, "moveBy threads did not finish")
 
-        // Either interleaving is valid; both deltas must compose rather than overwrite.
-        assertEquals(listOf("move(0,0)") + robot.events.drop(1), robot.events)
+        // Without the pointer mutex both threads would read the same origin during the sleep
+        // and the last position would be (1,0) or (0,1), not the composed (1,1).
         assertEquals("move(1,1)", robot.events.last())
         assertEquals(3, robot.events.size)
         assertTrue(
@@ -347,14 +371,34 @@ class RobotDriverTest {
     }
 
     @Test
-    fun `concurrent moveTo cannot sneak between click press and release`() = runTest {
-        val robot = RecordingRobotAdapter()
+    fun `concurrent moveTo cannot sneak between click press and release`() {
+        val start = CyclicBarrier(2)
+        val robot =
+            RecordingRobotAdapter(
+                afterMove = { x, y -> if (x == 10 && y == 20) Thread.sleep(POINTER_RACE_WINDOW_MS) }
+            )
         val driver = RobotDriver(robot, RecordingClipboardAdapter())
-
-        awaitAll(
-            async { driver.click(10, 20) },
-            async { driver.moveTo(screenX = 99, screenY = 99) },
-        )
+        val clicker =
+            Thread(
+                {
+                    start.await(2, TimeUnit.SECONDS)
+                    runBlocking { driver.click(10, 20) }
+                },
+                "clicker",
+            )
+        val mover =
+            Thread(
+                {
+                    start.await(2, TimeUnit.SECONDS)
+                    runBlocking { driver.moveTo(screenX = 99, screenY = 99) }
+                },
+                "mover",
+            )
+        clicker.start()
+        mover.start()
+        clicker.join(JOIN_TIMEOUT_MS)
+        mover.join(JOIN_TIMEOUT_MS)
+        assertTrue(!clicker.isAlive && !mover.isAlive, "pointer threads did not finish")
 
         val clickStart = robot.events.indexOf("move(10,20)")
         check(clickStart >= 0) { "expected click move in ${robot.events}" }
@@ -646,6 +690,8 @@ private class RecordingRobotAdapter(
     private val drainAfterPaste: Boolean = false,
     initialCapsLockOn: Boolean = false,
     private val allowCapsLockWrite: Boolean = true,
+    private val beforeMove: (() -> Unit)? = null,
+    private val afterMove: ((Int, Int) -> Unit)? = null,
 ) : RobotAdapter {
     override val requiresOffEdt: Boolean = false
     val events = mutableListOf<String>()
@@ -659,7 +705,11 @@ private class RecordingRobotAdapter(
         sharedLog?.add("robot:$event")
     }
 
-    override fun mouseMove(x: Int, y: Int) = log("move($x,$y)")
+    override fun mouseMove(x: Int, y: Int) {
+        beforeMove?.invoke()
+        log("move($x,$y)")
+        afterMove?.invoke(x, y)
+    }
 
     override fun mousePress(buttons: Int) = log("press($buttons)")
 
@@ -775,3 +825,6 @@ private class LatentClipboardAdapter(
         }
     }
 }
+
+private const val POINTER_RACE_WINDOW_MS: Long = 50L
+private const val JOIN_TIMEOUT_MS: Long = 2_000L

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/SyntheticInputParityTest.kt
@@ -129,6 +129,34 @@ class SyntheticInputParityTest {
 
     @Test
     @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `moveTo emits MOUSE_MOVED without press release or click`() {
+        assumeLiveAwtAvailable()
+        val target = MouseTargetPanel()
+        val frame = showFrameOnEdt(target)
+        try {
+            val (cx, cy) = frame.targetCenterOnScreen(target)
+            val driver = RobotDriver.synthetic(frame.frame)
+            runBlocking { driver.moveTo(cx, cy) }
+            drainEdt()
+
+            val types = target.events.map { it.id }
+            assertTrue(types.contains(MouseEvent.MOUSE_MOVED), "expected MOUSE_MOVED, got $types")
+            assertTrue(
+                types.none {
+                    it == MouseEvent.MOUSE_PRESSED ||
+                        it == MouseEvent.MOUSE_RELEASED ||
+                        it == MouseEvent.MOUSE_CLICKED ||
+                        it == MouseEvent.MOUSE_DRAGGED
+                },
+                "moveTo must not press, release, click, or drag, got $types",
+            )
+        } finally {
+            disposeFrame(frame.frame)
+        }
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
     fun `swipe between distinct points emits no MOUSE_CLICKED`() {
         assumeLiveAwtAvailable()
         val target = MouseTargetPanel()
@@ -539,7 +567,9 @@ class SyntheticInputParityTest {
             events.add(e)
         }
 
-        override fun mouseMoved(e: MouseEvent) = Unit
+        override fun mouseMoved(e: MouseEvent) {
+            events.add(e)
+        }
     }
 
     private class KeyEventRecorder(private val events: MutableList<KeyEvent>) : KeyListener {

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -60,7 +60,7 @@ out of scope.
 
 | Capability | Surface | Default exposure |
 | --- | --- | --- |
-| Move mouse / press keys | `RobotDriver.click`, `swipe`, `pressKey`, `scrollWheel` | In-process; trusted-local HTTP via `/spectre/click` |
+| Move mouse / press keys | `RobotDriver.click`, `moveTo`, `moveBy`, `swipe`, `pressKey`, `scrollWheel` | In-process; trusted-local HTTP via `/spectre/click` |
 | Modify clipboard | `RobotDriver.pasteText` (save / set / paste / restore) | In-process |
 | Capture pixels | `RobotDriver.screenshot(region)` — **captures any rectangle of the virtual desktop**, not just the app under test; `AutoScreenshotter` for native/window-targeted still screenshots where available | In-process; trusted-local HTTP via `/spectre/screenshot` for `RobotDriver`; `AutoScreenshotter` is in-process only |
 | Record video | `AutoRecorder`, native recorders, deprecated explicit `FfmpegRecorder`, `WaylandPortalRecorder` | In-process only |

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -70,7 +70,7 @@ The API is split into two layers:
   selectors don't have `findOneBy…` variants — call `.firstOrNull()` on the list result
   yourself if you want one.) These do a single read against the current semantics state
   and return what they see.
-- **Interactions** — `click`, `doubleClick`, `longClick`, `swipe`, `scrollWheel`,
+- **Interactions** — `click`, `doubleClick`, `longClick`, `moveTo`, `moveBy`, `swipe`, `scrollWheel`,
   `typeText`, `pasteText`, `clearAndTypeText`, `pressKey`, `pressEnter`, `screenshot`. These dispatch
   input via `RobotDriver` (or capture pixels).
 

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -3,8 +3,8 @@
 The interaction layer of `ComposeAutomator` sits on top of `RobotDriver` and dispatches
 mouse, keyboard, and clipboard input to whatever surface the target node lives in.
 
-All interaction methods (`click`, `doubleClick`, `longClick`, `swipe`, `scrollWheel`,
-`typeText`, `clearAndTypeText`, `pressKey`, `pressEnter`) are `suspend` — call them
+All interaction methods (`click`, `doubleClick`, `longClick`, `moveTo`, `moveBy`, `swipe`,
+`scrollWheel`, `typeText`, `clearAndTypeText`, `pressKey`, `pressEnter`) are `suspend` — call them
 from a coroutine. Real `java.awt.Robot` work runs inline when the caller is already
 off the AWT event dispatch thread, and hops to `Dispatchers.IO` only when needed to
 keep EDT callers from blocking the UI. Internal sleeps use `delay` rather than
@@ -30,6 +30,26 @@ automator.longClick(send, holdFor = 600.milliseconds)
 
 All click helpers resolve the node's `centerOnScreen` and dispatch through `RobotDriver`,
 which compensates for HiDPI/display scaling.
+
+## Mouse: hover and pointer moves
+
+```kotlin
+val send = automator.findOneByTestTag("Send") ?: error("button missing")
+
+// park the pointer on a node (hover / tooltip) without clicking
+automator.moveTo(send)
+
+// raw screen coordinates (same space as swipe)
+automator.moveTo(x = 240, y = 80)
+
+// offset from the last Spectre-issued pointer position
+automator.moveBy(deltaX = 12, deltaY = -4)
+```
+
+`moveTo` / `moveBy` never press or release a button. `moveBy` is relative to the last
+Spectre-issued move on this automator's `RobotDriver` (`click`, `doubleClick`, `longClick`,
+`swipe`, `scrollWheel`, `moveTo`, or a previous `moveBy`) — it does not read the OS cursor.
+If no Spectre move has happened yet, `moveBy` throws `IllegalStateException`.
 
 ## Mouse: swipes and scrolling
 

--- a/docs/spikes/209-injection/api-audit.md
+++ b/docs/spikes/209-injection/api-audit.md
@@ -120,6 +120,8 @@ against the target:
 | `doubleClick(x, y)` | Robot ×2 | No | Yes | **OS-only** |
 | `longClick(x, y, hold)` | Robot press + delay + release | No | Yes | **OS-only** |
 | `swipe(x1,y1 → x2,y2)` | Robot interpolated move | No | Yes | **OS-only** |
+| `moveTo(x, y)` | `Robot.mouseMove` | No | Yes (for UI targeting) | **OS-only** |
+| `moveBy(dX, dY)` | `Robot.mouseMove` from last Spectre pointer | No | No (relative) | **OS-only** |
 | `scrollWheel(x, y, clicks)` | `Robot.mouseWheel` | No | Yes (position) | **OS-only** |
 | `typeText` / `pasteText` / `clearAndTypeText` | Robot keys / clipboard | No | No for type/paste; clearAndType needs click geometry first | **OS-only** (focus must already be correct) |
 | `pressKey` / `pressEnter` | Robot keys | No | No | **OS-only** |
@@ -148,6 +150,8 @@ window), these verbs need **no further Compose API**:
 | `doubleClick` | Center | |
 | `longClick` | Center | Hold duration |
 | `swipe` (coord or node-to-node) | Start/end centers | |
+| `moveTo` | Center or raw coords | Hover; no button press |
+| `moveBy` | None (relative to last Spectre move) | Fails if no prior move |
 | `scrollWheel` | Center + wheel delta | |
 | `typeText` | None (keyboard) | Requires correct focus beforehand (`click` or `focusWindow`) |
 | `pasteText` | None | Same focus caveat |

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -165,6 +165,8 @@ post-HiDPI), `centerOnScreen`. Tree navigation via `children`/`parent`.
 All `suspend` on `ComposeAutomator`:
 
 - `click(node)`, `doubleClick(node)`, `longClick(node, holdFor = 500.milliseconds)`
+- `moveTo(node)`, `moveTo(x, y)`, `moveBy(deltaX, deltaY)` — button-up pointer moves for hover;
+  `moveBy` is relative to the last Spectre-issued pointer position and throws if none exists
 - `swipe(from, to, steps, duration)` or `swipe(startX, startY, endX, endY, …)`
 - `scrollWheel(node, wheelClicks)`
 - `typeText("hello")` — types supported ASCII text via key events without using


### PR DESCRIPTION
Closes #433.

There was no public way to inject a standalone pointer move. Clicks and `scrollWheel` jump the pointer as a side effect, and `swipe` interpolates with the button held (a drag, not a hover). Hover / tooltip / “park the synthetic pointer” cases therefore had no automator API.

## Change

- `ComposeAutomator.moveTo(node)` / `moveTo(x, y)` / `moveBy(deltaX, deltaY)`
- Same verbs on `RobotDriver` (`moveTo(x, y)` / `moveBy(deltaX, deltaY)`; node targeting stays on the automator)
- Button-up only: no press or release
- `moveBy` is relative to the last Spectre-issued pointer position (`click` / `doubleClick` / `longClick` / `swipe` / `scrollWheel` / `moveTo` / previous `moveBy`). It does not read the OS cursor. If no Spectre move has happened yet, it throws `IllegalStateException`.
- Same TCC / HiDPI / EDT / headless paths as the other input verbs

Remote / CLI / MCP parity is left as a follow-up, matching the issue’s open question.

## Test plan

- [x] `./gradlew :core:test --tests "*RobotDriverTest*" --tests "*ComposeAutomatorPublicSurfaceTest*" --tests "*InjectionApiAuditContractTest*" --tests "*SyntheticInputParityTest*"`
- [x] `./gradlew check` (three `:agent` attach/focus flakes failed once, then passed on rerun)
- [x] `./gradlew ktfmtFormat` / `updateKotlinAbi`