### PR TITLE
fix(core): capture stills at screen-pixel resolution, and size the IPC frame budget for them

### DIFF
--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -191,7 +191,9 @@ class SmokeLibSchemaTest(unittest.TestCase):
             cargo_bin = cargo_home / "bin"
             cargo_bin.mkdir(parents=True)
             old_path = os.environ.get("PATH")
-            os.environ["PATH"] = "/usr/bin:/bin"
+            # os.pathsep, not ":" — on Windows the hardcoded colon left PATH as a single
+            # unsplittable entry and this assertion failed for the separator, not the behaviour.
+            os.environ["PATH"] = os.pathsep.join(["/usr/bin", "/bin"])
             try:
                 result = smoke_lib.linux_toolchain_path({"CARGO_HOME": str(cargo_home)})
             finally:

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -54,16 +54,18 @@ public final class dev/sebastiano/spectre/agent/AttachOptions {
 	public static final field Companion Ldev/sebastiano/spectre/agent/AttachOptions$Companion;
 	public static final field DEFAULT_ATTACH_TIMEOUT_MS J
 	public fun <init> ()V
-	public fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;J)V
-	public synthetic fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/nio/file/Path;
 	public final fun component2 ()Ljava/nio/file/Path;
 	public final fun component3 ()J
-	public final fun copy (Ljava/nio/file/Path;Ljava/nio/file/Path;J)Ldev/sebastiano/spectre/agent/AttachOptions;
-	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/AttachOptions;Ljava/nio/file/Path;Ljava/nio/file/Path;JILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AttachOptions;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;)Ldev/sebastiano/spectre/agent/AttachOptions;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/AttachOptions;Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AttachOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAgentJarPath ()Ljava/nio/file/Path;
 	public final fun getAttachTimeoutMs ()J
+	public final fun getMaxFrameBytes ()Ljava/lang/Integer;
 	public final fun getUdsPath ()Ljava/nio/file/Path;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -354,6 +356,25 @@ public final class dev/sebastiano/spectre/agent/launch/SpectreCoreMissingOnClass
 	public final fun getClasspath ()Ljava/lang/String;
 }
 
+public final class dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs {
+	public static final field INSTANCE Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs;
+	public final fun parse (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;
+	public final fun render (Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;)Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxFrameBytes ()Ljava/lang/Integer;
+	public final fun getUdsPath ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class dev/sebastiano/spectre/agent/runtime/SpectreAgent {
 	public static final field INSTANCE Ldev/sebastiano/spectre/agent/runtime/SpectreAgent;
 	public static final fun agentmain (Ljava/lang/String;Ljava/lang/instrument/Instrumentation;)V
@@ -382,6 +403,15 @@ public final class dev/sebastiano/spectre/agent/transport/AgentErrorCategory$Com
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class dev/sebastiano/spectre/agent/transport/FrameLimits {
+	public static final field ENV_VAR Ljava/lang/String;
+	public static final field INSTANCE Ldev/sebastiano/spectre/agent/transport/FrameLimits;
+	public final fun configure (I)V
+	public final fun getMaxFrameBytes ()I
+	public final fun parseMaxFrameBytes (Ljava/lang/String;)Ljava/lang/Integer;
+	public final fun resolveBudget (Lkotlin/jvm/functions/Function1;)I
+}
+
 public final class dev/sebastiano/spectre/agent/transport/Framing {
 	public static final field INSTANCE Ldev/sebastiano/spectre/agent/transport/Framing;
 	public final fun readFrame (Ljava/io/InputStream;)[B
@@ -389,7 +419,8 @@ public final class dev/sebastiano/spectre/agent/transport/Framing {
 }
 
 public final class dev/sebastiano/spectre/agent/transport/FramingKt {
-	public static final field MAX_FRAME_BYTES I
+	public static final field DEFAULT_MAX_FRAME_BYTES I
+	public static final field MAX_FRAME_BYTES_CEILING I
 }
 
 public final class dev/sebastiano/spectre/agent/transport/NodeSnapshotDto {

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -359,7 +359,7 @@ public final class dev/sebastiano/spectre/agent/launch/SpectreCoreMissingOnClass
 public final class dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs {
 	public static final field INSTANCE Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs;
 	public final fun parse (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;
-	public final fun render (Ljava/lang/String;Ljava/lang/Integer;)Ljava/lang/String;
+	public final fun render (Ljava/lang/String;I)Ljava/lang/String;
 }
 
 public final class dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed {
@@ -408,8 +408,11 @@ public final class dev/sebastiano/spectre/agent/transport/FrameLimits {
 	public static final field INSTANCE Ldev/sebastiano/spectre/agent/transport/FrameLimits;
 	public final fun configure (I)V
 	public final fun getMaxFrameBytes ()I
+	public final fun getRequestedMaxFrameBytes ()Ljava/lang/Integer;
 	public final fun parseMaxFrameBytes (Ljava/lang/String;)Ljava/lang/Integer;
+	public final fun resetToEnvironment ()V
 	public final fun resolveBudget (Lkotlin/jvm/functions/Function1;)I
+	public final fun resolveRequest (Lkotlin/jvm/functions/Function1;)Ljava/lang/Integer;
 }
 
 public final class dev/sebastiano/spectre/agent/transport/Framing {

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -424,6 +424,7 @@ public final class dev/sebastiano/spectre/agent/transport/Framing {
 public final class dev/sebastiano/spectre/agent/transport/FramingKt {
 	public static final field DEFAULT_MAX_FRAME_BYTES I
 	public static final field MAX_FRAME_BYTES_CEILING I
+	public static final field MIN_MAX_FRAME_BYTES I
 }
 
 public final class dev/sebastiano/spectre/agent/transport/NodeSnapshotDto {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -1,5 +1,8 @@
 package dev.sebastiano.spectre.agent
 
+import dev.sebastiano.spectre.agent.runtime.AgentBootstrapArgs
+import dev.sebastiano.spectre.agent.transport.DEFAULT_MAX_FRAME_BYTES
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.agent.transport.IpcClient
 import java.io.IOException
 import java.nio.file.Files
@@ -25,6 +28,20 @@ import java.nio.file.Paths
 @ExperimentalSpectreAgentApi
 public object AgentAttach {
 
+    /**
+     * Builds the `agentArgs` string for [pid]'s injected runtime.
+     *
+     * Stays on the bare-UDS-path form while this process runs the default frame budget, so an older
+     * agent runtime keeps parsing it; only a configured budget triggers the structured form.
+     */
+    private fun agentArgsFor(options: AttachOptions, udsPath: Path): String {
+        val budget = options.maxFrameBytes ?: FrameLimits.maxFrameBytes
+        return AgentBootstrapArgs.render(
+            udsPath = udsPath.toString(),
+            maxFrameBytes = budget.takeIf { it != DEFAULT_MAX_FRAME_BYTES },
+        )
+    }
+
     /** Attach to the JVM identified by [pid] and return a connected [AttachedAutomator]. */
     @Throws(SpectreAttachException::class)
     public fun attach(pid: Long, options: AttachOptions = AttachOptions()): AttachedAutomator {
@@ -42,7 +59,7 @@ public object AgentAttach {
 
         val (vmClass, vm) = openVirtualMachine(pid)
         try {
-            loadAgentReflectively(vmClass, vm, agentJar.toString(), udsPath.toString())
+            loadAgentReflectively(vmClass, vm, agentJar.toString(), agentArgsFor(options, udsPath))
         } finally {
             detachVirtualMachine(vmClass, vm)
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -1,7 +1,6 @@
 package dev.sebastiano.spectre.agent
 
 import dev.sebastiano.spectre.agent.runtime.AgentBootstrapArgs
-import dev.sebastiano.spectre.agent.transport.DEFAULT_MAX_FRAME_BYTES
 import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.agent.transport.IpcClient
 import java.io.IOException
@@ -31,16 +30,16 @@ public object AgentAttach {
     /**
      * Builds the `agentArgs` string for [pid]'s injected runtime.
      *
-     * Stays on the bare-UDS-path form while this process runs the default frame budget, so an older
-     * agent runtime keeps parsing it; only a configured budget triggers the structured form.
+     * Always carries the budget, including the default one. The target may have been launched with
+     * a `SPECTRE_MAX_FRAME_BYTES` of its own, and letting that win would leave the daemon and the
+     * JVM it injected disagreeing about the hop between them — a 16MiB target under a 64MiB daemon
+     * would fail captures the daemon could carry.
      */
-    private fun agentArgsFor(options: AttachOptions, udsPath: Path): String {
-        val budget = options.maxFrameBytes ?: FrameLimits.maxFrameBytes
-        return AgentBootstrapArgs.render(
+    private fun agentArgsFor(options: AttachOptions, udsPath: Path): String =
+        AgentBootstrapArgs.render(
             udsPath = udsPath.toString(),
-            maxFrameBytes = budget.takeIf { it != DEFAULT_MAX_FRAME_BYTES },
+            maxFrameBytes = options.maxFrameBytes ?: FrameLimits.maxFrameBytes,
         )
-    }
 
     /** Attach to the JVM identified by [pid] and return a connected [AttachedAutomator]. */
     @Throws(SpectreAttachException::class)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
@@ -51,7 +51,10 @@ public class AgentBootstrapTimeoutException(udsPath: java.nio.file.Path, timeout
     SpectreAttachException(
         "Agent runtime did not bind UDS path $udsPath within ${timeoutMs} ms. Check the " +
             "target JVM's stderr for `[spectre-agent]` diagnostic lines or an " +
-            "AgentInitializationException with the underlying cause."
+            "AgentInitializationException with the underlying cause. If the runtime JAR was " +
+            "chosen explicitly (AttachOptions.agentJarPath or the runtimeJar system property), " +
+            "check it matches this library: a runtime older than structured agent arguments " +
+            "treats the whole argument string as the socket path and binds somewhere else."
     )
 
 /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -32,12 +32,18 @@ import java.util.UUID
  *   directory, you own that parent directory's permissions; Spectre only tightens directories it
  *   creates itself.
  * @property attachTimeoutMs how long to wait for the agent's bootstrap + IPC server to come up.
+ * @property maxFrameBytes IPC frame write budget the injected agent should adopt. `null` (default)
+ *   forwards this process's own budget, so a daemon started with `SPECTRE_MAX_FRAME_BYTES` or
+ *   `--max-frame-bytes` propagates it to every JVM it injects. The target cannot read the
+ *   attacher's environment, and it is the side that writes screenshot frames, so this is the only
+ *   channel that reaches it.
  */
 @ExperimentalSpectreAgentApi
 public data class AttachOptions(
     public val agentJarPath: Path? = null,
     public val udsPath: Path? = null,
     public val attachTimeoutMs: Long = DEFAULT_ATTACH_TIMEOUT_MS,
+    public val maxFrameBytes: Int? = null,
 ) {
     public companion object {
         public const val DEFAULT_ATTACH_TIMEOUT_MS: Long = 5_000

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.agent
 
 import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES_CEILING
+import dev.sebastiano.spectre.agent.transport.MIN_MAX_FRAME_BYTES
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.UUID
@@ -51,7 +52,10 @@ public data class AttachOptions(
         // attach() report success while the target silently kept its own and later rejected
         // captures this caller sized for. Fail at the mistake instead.
         if (maxFrameBytes != null) {
-            require(maxFrameBytes > 0) { "maxFrameBytes must be positive, got $maxFrameBytes" }
+            require(maxFrameBytes >= MIN_MAX_FRAME_BYTES) {
+                "maxFrameBytes=$maxFrameBytes is below the $MIN_MAX_FRAME_BYTES-byte minimum; " +
+                    "a budget that small cannot carry the protocol's own frames"
+            }
             require(maxFrameBytes <= MAX_FRAME_BYTES_CEILING) {
                 "maxFrameBytes=$maxFrameBytes exceeds the frame ceiling " +
                     "$MAX_FRAME_BYTES_CEILING; readers would refuse frames that large"

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.agent
 
+import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES_CEILING
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.UUID
@@ -45,6 +46,19 @@ public data class AttachOptions(
     public val attachTimeoutMs: Long = DEFAULT_ATTACH_TIMEOUT_MS,
     public val maxFrameBytes: Int? = null,
 ) {
+    init {
+        // The agent logs and ignores a budget it cannot apply, so an unusable value here would let
+        // attach() report success while the target silently kept its own and later rejected
+        // captures this caller sized for. Fail at the mistake instead.
+        if (maxFrameBytes != null) {
+            require(maxFrameBytes > 0) { "maxFrameBytes must be positive, got $maxFrameBytes" }
+            require(maxFrameBytes <= MAX_FRAME_BYTES_CEILING) {
+                "maxFrameBytes=$maxFrameBytes exceeds the frame ceiling " +
+                    "$MAX_FRAME_BYTES_CEILING; readers would refuse frames that large"
+            }
+        }
+    }
+
     public companion object {
         public const val DEFAULT_ATTACH_TIMEOUT_MS: Long = 5_000
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -215,8 +215,9 @@ internal constructor(
      *
      * Window/surface targets (default, [windowIndex], or [surfaceId]) fail closed on the attach
      * path (#359): they would crop occlusion-prone desktop pixels rather than a native window
-     * surface. Only [fullscreen] is supported as an explicit screen-pixel capture mode. Prefer
-     * in-process `ComposeAutomator.screenshot(windowIndex)` with the recording native backend for
+     * surface. Only [fullscreen] is supported, as an explicit whole-desktop capture mode whose PNG
+     * is screen-pixel sized rather than dp sized. Prefer in-process
+     * `ComposeAutomator.screenshot(windowIndex)` with the recording native backend for
      * occlusion-safe window stills.
      *
      * @return raw PNG bytes

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
@@ -6,17 +6,19 @@ import dev.sebastiano.spectre.agent.transport.FrameLimits
 /**
  * The `agentArgs` string handed to [SpectreAgent.premain] / [SpectreAgent.agentmain].
  *
- * Two forms are accepted:
+ * Two forms are **accepted**, and [render] always emits the second:
  * - **bare** — the UDS path on its own, e.g. `/tmp/sp-a-123-abcd/agent.sock`. This is what a
  *   hand-written `-javaagent:spectre-agent-runtime.jar=<path>` produces, so it stays supported.
- * - **structured** — `uds=<path>[,key=value]*`, used when the attacher has something else to pass.
- *   Today the only extra key is `maxFrameBytes`: an injected agent cannot read the daemon's
+ * - **structured** — `uds=<path>[,key=value]*`. An injected agent cannot read the attacher's
  *   environment, and it is the process that writes the bulky screenshot frames, so its budget has
- *   to arrive here.
+ *   to arrive here — including when that budget is the default, since the target may carry a
+ *   `SPECTRE_MAX_FRAME_BYTES` of its own that must not silently win.
  *
  * The structured form is recognised by the `uds=` prefix, which a UDS path never starts with.
- * Unknown keys and unparseable values are ignored rather than failing the attach — a newer daemon
- * injecting an older runtime should still get a working session, just without the newer knob.
+ * Values are percent-escaped, so a caller-supplied UDS path containing `,` or `=` survives the
+ * round trip instead of truncating and leaving the target bound to a different socket. Unknown keys
+ * and unparseable values are ignored rather than failing the attach — a newer daemon injecting an
+ * older runtime should still get a working session, just without the newer knob.
  */
 @ExperimentalSpectreAgentApi
 public object AgentBootstrapArgs {
@@ -35,15 +37,27 @@ public object AgentBootstrapArgs {
             }
         val fields = entries.toMap()
         return Parsed(
-            udsPath = fields[UDS_KEY]?.takeIf { it.isNotEmpty() },
+            udsPath = fields[UDS_KEY]?.let(::decodeValue)?.takeIf { it.isNotEmpty() },
             maxFrameBytes = FrameLimits.parseMaxFrameBytes(fields[MAX_FRAME_BYTES_KEY]),
         )
     }
 
-    /** Renders [udsPath], using the bare form unless [maxFrameBytes] needs carrying. */
-    public fun render(udsPath: String, maxFrameBytes: Int?): String =
-        if (maxFrameBytes == null) udsPath
-        else "$STRUCTURED_PREFIX$udsPath$SEPARATOR$MAX_FRAME_BYTES_KEY$KEY_VALUE$maxFrameBytes"
+    /** Renders [udsPath] and [maxFrameBytes] as a structured, escaped argument string. */
+    public fun render(udsPath: String, maxFrameBytes: Int): String =
+        "$STRUCTURED_PREFIX${encodeValue(udsPath)}" +
+            "$SEPARATOR$MAX_FRAME_BYTES_KEY$KEY_VALUE$maxFrameBytes"
+
+    /**
+     * Escapes the delimiters this format reserves. `%` goes first so its escape is not re-escaped.
+     */
+    private fun encodeValue(raw: String): String =
+        raw.replace("%", "%25").replace(SEPARATOR, "%2C").replace(KEY_VALUE, "%3D")
+
+    /**
+     * Reverses [encodeValue]. `%25` goes last so an escaped `%` cannot produce a fake delimiter.
+     */
+    private fun decodeValue(raw: String): String =
+        raw.replace("%2C", SEPARATOR).replace("%3D", KEY_VALUE).replace("%25", "%")
 
     private const val UDS_KEY: String = "uds"
     private const val MAX_FRAME_BYTES_KEY: String = "maxFrameBytes"

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
@@ -1,0 +1,53 @@
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.FrameLimits
+
+/**
+ * The `agentArgs` string handed to [SpectreAgent.premain] / [SpectreAgent.agentmain].
+ *
+ * Two forms are accepted:
+ * - **bare** — the UDS path on its own, e.g. `/tmp/sp-a-123-abcd/agent.sock`. This is what a
+ *   hand-written `-javaagent:spectre-agent-runtime.jar=<path>` produces, so it stays supported.
+ * - **structured** — `uds=<path>[,key=value]*`, used when the attacher has something else to pass.
+ *   Today the only extra key is `maxFrameBytes`: an injected agent cannot read the daemon's
+ *   environment, and it is the process that writes the bulky screenshot frames, so its budget has
+ *   to arrive here.
+ *
+ * The structured form is recognised by the `uds=` prefix, which a UDS path never starts with.
+ * Unknown keys and unparseable values are ignored rather than failing the attach — a newer daemon
+ * injecting an older runtime should still get a working session, just without the newer knob.
+ */
+@ExperimentalSpectreAgentApi
+public object AgentBootstrapArgs {
+
+    /** Parsed view of an `agentArgs` string. */
+    public data class Parsed(public val udsPath: String?, public val maxFrameBytes: Int?)
+
+    /** Parses [agentArgs]; a null/blank string means diagnostic mode (no UDS, no IPC server). */
+    public fun parse(agentArgs: String?): Parsed {
+        val text = agentArgs?.trim()?.takeIf { it.isNotEmpty() } ?: return Parsed(null, null)
+        if (!text.startsWith(STRUCTURED_PREFIX)) return Parsed(text, null)
+        val entries =
+            text.split(SEPARATOR).mapNotNull { entry ->
+                val key = entry.substringBefore(KEY_VALUE, missingDelimiterValue = "")
+                if (key.isEmpty()) null else key to entry.substringAfter(KEY_VALUE)
+            }
+        val fields = entries.toMap()
+        return Parsed(
+            udsPath = fields[UDS_KEY]?.takeIf { it.isNotEmpty() },
+            maxFrameBytes = FrameLimits.parseMaxFrameBytes(fields[MAX_FRAME_BYTES_KEY]),
+        )
+    }
+
+    /** Renders [udsPath], using the bare form unless [maxFrameBytes] needs carrying. */
+    public fun render(udsPath: String, maxFrameBytes: Int?): String =
+        if (maxFrameBytes == null) udsPath
+        else "$STRUCTURED_PREFIX$udsPath$SEPARATOR$MAX_FRAME_BYTES_KEY$KEY_VALUE$maxFrameBytes"
+
+    private const val UDS_KEY: String = "uds"
+    private const val MAX_FRAME_BYTES_KEY: String = "maxFrameBytes"
+    private const val KEY_VALUE: String = "="
+    private const val SEPARATOR: String = ","
+    private const val STRUCTURED_PREFIX: String = "$UDS_KEY$KEY_VALUE"
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
@@ -14,15 +14,16 @@ import dev.sebastiano.spectre.agent.transport.FrameLimits
  *   to arrive here — including when that budget is the default, since the target may carry a
  *   `SPECTRE_MAX_FRAME_BYTES` of its own that must not silently win.
  *
- * The structured form is recognised by the `uds=` prefix, which a UDS path never starts with.
- * Values are percent-escaped, so a caller-supplied UDS path containing `,` or `=` survives the
- * round trip instead of truncating and leaving the target bound to a different socket. Unknown keys
- * and unparseable values are ignored rather than failing the attach, so a runtime that understands
- * this format but not a newer key still gets a working session. That tolerance does not extend to a
- * runtime predating the format itself: it would read the whole string as a socket path and bind the
- * wrong one. Pairing a mismatched runtime JAR is only reachable through
- * `AttachOptions.agentJarPath` or the runtime-jar system property, and the agent protocol's
- * exact-match handshake rejects the pairing once it binds.
+ * The structured form is recognised by a `uds=` prefix *and* at least one further `,`-separated
+ * field, which everything [render] emits carries. A bare path is only misread if it both starts
+ * with `uds=` and contains a comma. Values are percent-escaped, so a caller-supplied UDS path
+ * containing `,` or `=` survives the round trip instead of truncating and leaving the target bound
+ * to a different socket. Unknown keys and unparseable values are ignored rather than failing the
+ * attach, so a runtime that understands this format but not a newer key still gets a working
+ * session. That tolerance does not extend to a runtime predating the format itself: it would read
+ * the whole string as a socket path and bind the wrong one. Pairing a mismatched runtime JAR is
+ * only reachable through `AttachOptions.agentJarPath` or the runtime-jar system property, and the
+ * agent protocol's exact-match handshake rejects the pairing once it binds.
  */
 @ExperimentalSpectreAgentApi
 public object AgentBootstrapArgs {
@@ -33,7 +34,12 @@ public object AgentBootstrapArgs {
     /** Parses [agentArgs]; a null/blank string means diagnostic mode (no UDS, no IPC server). */
     public fun parse(agentArgs: String?): Parsed {
         val text = agentArgs?.trim()?.takeIf { it.isNotEmpty() } ?: return Parsed(null, null)
-        if (!text.startsWith(STRUCTURED_PREFIX)) return Parsed(text, null)
+        // Prefix *and* a separator: `uds=agent.sock` is a legal relative path, and everything
+        // render() emits carries at least one more field, so requiring both keeps that path bare
+        // instead of silently binding `agent.sock` while the attacher waits on `uds=agent.sock`.
+        if (!text.startsWith(STRUCTURED_PREFIX) || !text.contains(SEPARATOR)) {
+            return Parsed(text, null)
+        }
         val entries =
             text.split(SEPARATOR).mapNotNull { entry ->
                 val key = entry.substringBefore(KEY_VALUE, missingDelimiterValue = "")

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
@@ -17,8 +17,12 @@ import dev.sebastiano.spectre.agent.transport.FrameLimits
  * The structured form is recognised by the `uds=` prefix, which a UDS path never starts with.
  * Values are percent-escaped, so a caller-supplied UDS path containing `,` or `=` survives the
  * round trip instead of truncating and leaving the target bound to a different socket. Unknown keys
- * and unparseable values are ignored rather than failing the attach — a newer daemon injecting an
- * older runtime should still get a working session, just without the newer knob.
+ * and unparseable values are ignored rather than failing the attach, so a runtime that understands
+ * this format but not a newer key still gets a working session. That tolerance does not extend to a
+ * runtime predating the format itself: it would read the whole string as a socket path and bind the
+ * wrong one. Pairing a mismatched runtime JAR is only reachable through
+ * `AttachOptions.agentJarPath` or the runtime-jar system property, and the agent protocol's
+ * exact-match handshake rejects the pairing once it binds.
  */
 @ExperimentalSpectreAgentApi
 public object AgentBootstrapArgs {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
@@ -15,15 +15,18 @@ import dev.sebastiano.spectre.agent.transport.FrameLimits
  *   `SPECTRE_MAX_FRAME_BYTES` of its own that must not silently win.
  *
  * The structured form is recognised by a `uds=` prefix *and* at least one further `,`-separated
- * field, which everything [render] emits carries. A bare path is only misread if it both starts
- * with `uds=` and contains a comma. Values are percent-escaped, so a caller-supplied UDS path
- * containing `,` or `=` survives the round trip instead of truncating and leaving the target bound
- * to a different socket. Unknown keys and unparseable values are ignored rather than failing the
- * attach, so a runtime that understands this format but not a newer key still gets a working
- * session. That tolerance does not extend to a runtime predating the format itself: it would read
- * the whole string as a socket path and bind the wrong one. Pairing a mismatched runtime JAR is
- * only reachable through `AttachOptions.agentJarPath` or the runtime-jar system property, and the
- * agent protocol's exact-match handshake rejects the pairing once it binds.
+ * field, which everything [render] emits carries. A bare path is therefore only misread if it both
+ * starts with `uds=` and contains a comma (`uds=agent,1.sock`). Every prefix-based discriminator
+ * has some such filename; this one is documented rather than chased, since Spectre only emits the
+ * structured form and the bare form exists for hand-written `-javaagent:` lines. Values are
+ * percent-escaped, so a caller-supplied UDS path containing `,` or `=` survives the round trip
+ * instead of truncating and leaving the target bound to a different socket. Unknown keys and
+ * unparseable values are ignored rather than failing the attach, so a runtime that understands this
+ * format but not a newer key still gets a working session. That tolerance does not extend to a
+ * runtime predating the format itself: it would read the whole string as a socket path and bind the
+ * wrong one. Pairing a mismatched runtime JAR is only reachable through
+ * `AttachOptions.agentJarPath` or the runtime-jar system property, and the agent protocol's
+ * exact-match handshake rejects the pairing once it binds.
  */
 @ExperimentalSpectreAgentApi
 public object AgentBootstrapArgs {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
@@ -9,6 +9,9 @@ import dev.sebastiano.spectre.agent.transport.FrameLimits
  */
 internal object AtomicCaptureReflectiveMapper {
 
+    /** Field names, ints, and discriminators around the two byte strings — a few hundred bytes. */
+    private const val CAPTURE_ENVELOPE_HEADROOM_BYTES: Long = 64L * 1024L
+
     fun invoke(automator: Any, windowIndex: Int): AgentResponse {
         // `ComposeAutomator.capture(windowIndex: Int = 0)` is a single Kotlin method with a
         // default param. Without `@JvmOverloads` the JVM signature is `capture(int)`.
@@ -45,15 +48,20 @@ internal object AtomicCaptureReflectiveMapper {
         val pngBytes = resultClass.getMethod("getPngBytes").invoke(result) as ByteArray
         val captureJson = resultClass.getMethod("getCaptureJson").invoke(result) as String
         val captureJsonUtf8 = captureJson.toByteArray(Charsets.UTF_8)
-        // CBOR envelope is larger than raw bytes; leave headroom so Framing.writeFrame does not
-        // kill the connection after a successful capture.
+        // Both bulk fields are @ByteString, so the CBOR envelope around them is a small constant
+        // rather than a multiple of their size — reserve that constant instead of a percentage, or
+        // raising the budget would not make the extra budget usable.
         val rawBytes = pngBytes.size.toLong() + captureJsonUtf8.size.toLong()
-        val maxRawPayload = (FrameLimits.maxFrameBytes * 3L) / 4L
+        val maxRawPayload = FrameLimits.maxFrameBytes.toLong() - CAPTURE_ENVELOPE_HEADROOM_BYTES
         if (rawBytes > maxRawPayload) {
             return AgentResponse.Error(
-                "Atomic capture is too large for the agent IPC frame limit " +
-                    "(png+json=${rawBytes}B, max≈${maxRawPayload}B). Capture a smaller window " +
-                    "or reduce UI density; a path-based transfer is tracked with payload limits."
+                message =
+                    "Atomic capture is too large for the agent IPC frame limit " +
+                        "(png+json=${rawBytes}B, max≈${maxRawPayload}B). Raise the budget with " +
+                        "--max-frame-bytes / SPECTRE_MAX_FRAME_BYTES, or capture a smaller window.",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.PayloadTooLarge
+                        .wireName,
             )
         }
         return AgentResponse.Capture(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureReflectiveMapper.kt
@@ -1,7 +1,7 @@
 package dev.sebastiano.spectre.agent.runtime
 
 import dev.sebastiano.spectre.agent.transport.AgentResponse
-import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 
 /**
  * Invokes `ComposeAutomator.capture` reflectively and maps the result onto the agent wire
@@ -48,7 +48,7 @@ internal object AtomicCaptureReflectiveMapper {
         // CBOR envelope is larger than raw bytes; leave headroom so Framing.writeFrame does not
         // kill the connection after a successful capture.
         val rawBytes = pngBytes.size.toLong() + captureJsonUtf8.size.toLong()
-        val maxRawPayload = (MAX_FRAME_BYTES * 3L) / 4L
+        val maxRawPayload = (FrameLimits.maxFrameBytes * 3L) / 4L
         if (rawBytes > maxRawPayload) {
             return AgentResponse.Error(
                 "Atomic capture is too large for the agent IPC frame limit " +

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -7,6 +7,7 @@ import dev.sebastiano.spectre.agent.resolveScreenshotTarget
 import dev.sebastiano.spectre.agent.transport.AgentRequest
 import dev.sebastiano.spectre.agent.transport.AgentRequestHandler
 import dev.sebastiano.spectre.agent.transport.AgentResponse
+import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.RectDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
@@ -17,6 +18,14 @@ import java.io.ByteArrayOutputStream
 import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 import javax.imageio.ImageIO
+
+/**
+ * Largest still PNG the handler will put on the wire before dropping back to logical resolution.
+ *
+ * The CBOR envelope around the bytes is a few hundred bytes; the headroom below keeps a still that
+ * passes this check from failing the framing guard afterwards.
+ */
+private const val DEFAULT_MAX_STILL_PNG_BYTES: Int = MAX_FRAME_BYTES - 64 * 1024
 
 /**
  * [AgentRequestHandler] that drives a Spectre `ComposeAutomator` instance entirely through
@@ -41,6 +50,7 @@ import javax.imageio.ImageIO
 internal class ReflectiveAutomatorHandler(
     private val automator: Any,
     private val isTargetJvmFocused: () -> Boolean = ::targetJvmHasKeyboardFocus,
+    private val maxStillPngBytes: Int = DEFAULT_MAX_STILL_PNG_BYTES,
 ) : AgentRequestHandler {
 
     private val automatorClass: Class<*> = automator.javaClass
@@ -386,22 +396,44 @@ internal class ReflectiveAutomatorHandler(
             )
         }
 
-        val regionScreenshotMethod =
-            regionScreenshotMethodOrError()
-                ?: return AgentResponse.Error(
-                    message =
-                        "ComposeAutomator does not expose screenshot(Rectangle?) on this build",
-                    category =
-                        dev.sebastiano.spectre.agent.transport.AgentErrorCategory
-                            .UnsupportedOperation
-                            .wireName,
-                )
+        val deviceScaleMethod = deviceScaleScreenshotMethodOrError()
+        val regionMethod = regionScreenshotMethodOrError()
+        if (deviceScaleMethod == null && regionMethod == null) {
+            return AgentResponse.Error(
+                message = "ComposeAutomator does not expose screenshot(Rectangle?) on this build",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.UnsupportedOperation
+                        .wireName,
+            )
+        }
 
         // Only Fullscreen remains (explicit opt-in). null region = full virtual desktop (#289).
         check(target is ScreenshotTarget.Fullscreen)
-        val image = regionScreenshotMethod.invoke(automator, null) as BufferedImage
-        return AgentResponse.Screenshot(imageToPng(image))
+        return AgentResponse.Screenshot(fullscreenStillPng(deviceScaleMethod, regionMethod))
     }
+
+    /**
+     * Encodes the fullscreen still, preferring screen pixels but staying inside the frame budget.
+     *
+     * Screen-pixel stills carry 4x the pixels of the logical ones on a 2x display, and the whole
+     * virtual desktop is the one still whose size no caller bounds — a multi-monitor HiDPI desktop
+     * can encode past [MAX_FRAME_BYTES], which would fail the request outright. Falling back to the
+     * logical still keeps a command that works today working; callers that need to know which they
+     * got can compare the PNG size against the desktop's logical bounds.
+     */
+    private fun fullscreenStillPng(deviceScaleMethod: Method?, regionMethod: Method?): ByteArray {
+        // Older injected cores expose only screenshot(Rectangle?). The caller rejects the request
+        // before this point when neither method is present, so one of the two is always non-null.
+        if (deviceScaleMethod == null) {
+            return encodeFullscreenStill(checkNotNull(regionMethod))
+        }
+        val deviceScalePng = encodeFullscreenStill(deviceScaleMethod)
+        if (regionMethod == null || deviceScalePng.size <= maxStillPngBytes) return deviceScalePng
+        return encodeFullscreenStill(regionMethod)
+    }
+
+    private fun encodeFullscreenStill(method: Method): ByteArray =
+        imageToPng(method.invoke(automator, null) as BufferedImage)
 
     /**
      * Capture a node's on-screen bounds (#362).
@@ -478,7 +510,9 @@ internal class ReflectiveAutomatorHandler(
      * bridge is absent, the node overload is missing, or native returns a degenerate crop.
      *
      * Region capture uses a **defensive copy** of the AWT rectangle: live `boundsOnScreen` getters
-     * return snapshots that must not be mutated by `Robot.createScreenCapture` / AWT.
+     * return snapshots that must not be mutated by `Robot.createScreenCapture` / AWT. It prefers
+     * the device-scale call so a fallback node still keeps the same screen-pixel scale the native
+     * path produces; a node rectangle is small enough that the frame budget is never in play.
      */
     private fun captureNodeScreenshotPreferNative(
         node: Any,
@@ -495,7 +529,8 @@ internal class ReflectiveAutomatorHandler(
                 if (!isNativeWindowCaptureUnavailable(ex)) throw ex
             }
         }
-        val regionScreenshotMethod = regionScreenshotMethodOrError() ?: return null
+        val regionScreenshotMethod =
+            deviceScaleScreenshotMethodOrError() ?: regionScreenshotMethodOrError() ?: return null
         val image = regionScreenshotMethod.invoke(automator, captureBounds) as BufferedImage
         check(isPlausibleNodeCapture(image, captureBounds)) {
             "Region node screenshot ${image.width}x${image.height} is implausible for " +
@@ -541,6 +576,18 @@ internal class ReflectiveAutomatorHandler(
     private fun regionScreenshotMethodOrError(): Method? =
         automatorClass.methods.firstOrNull {
             it.name == "screenshot" &&
+                it.parameterTypes.size == 1 &&
+                it.parameterTypes[0].name == AWT_RECTANGLE_FQN
+        }
+
+    /**
+     * `screenshotAtDeviceScale(region: Rectangle?)` — the screen-pixel still counterpart of
+     * `screenshot(Rectangle?)`. Absent on targets running a Spectre core older than the
+     * device-scale still contract, which is why callers treat it as optional.
+     */
+    private fun deviceScaleScreenshotMethodOrError(): Method? =
+        automatorClass.methods.firstOrNull {
+            it.name == "screenshotAtDeviceScale" &&
                 it.parameterTypes.size == 1 &&
                 it.parameterTypes[0].name == AWT_RECTANGLE_FQN
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -7,7 +7,7 @@ import dev.sebastiano.spectre.agent.resolveScreenshotTarget
 import dev.sebastiano.spectre.agent.transport.AgentRequest
 import dev.sebastiano.spectre.agent.transport.AgentRequestHandler
 import dev.sebastiano.spectre.agent.transport.AgentResponse
-import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.RectDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
@@ -19,13 +19,17 @@ import java.lang.reflect.Method
 import java.util.concurrent.ConcurrentHashMap
 import javax.imageio.ImageIO
 
+/** Headroom for the CBOR envelope wrapped around a still's bytes before it is framed. */
+private const val STILL_ENVELOPE_HEADROOM_BYTES: Int = 64 * 1024
+
 /**
  * Largest still PNG the handler will put on the wire before dropping back to logical resolution.
  *
- * The CBOR envelope around the bytes is a few hundred bytes; the headroom below keeps a still that
- * passes this check from failing the framing guard afterwards.
+ * Derived from the configured frame budget so raising `SPECTRE_MAX_FRAME_BYTES` raises this too;
+ * the headroom keeps a still that passes this check from failing the framing guard afterwards.
  */
-private const val DEFAULT_MAX_STILL_PNG_BYTES: Int = MAX_FRAME_BYTES - 64 * 1024
+private fun defaultMaxStillPngBytes(): Int =
+    (FrameLimits.maxFrameBytes - STILL_ENVELOPE_HEADROOM_BYTES).coerceAtLeast(1)
 
 /**
  * [AgentRequestHandler] that drives a Spectre `ComposeAutomator` instance entirely through
@@ -50,7 +54,7 @@ private const val DEFAULT_MAX_STILL_PNG_BYTES: Int = MAX_FRAME_BYTES - 64 * 1024
 internal class ReflectiveAutomatorHandler(
     private val automator: Any,
     private val isTargetJvmFocused: () -> Boolean = ::targetJvmHasKeyboardFocus,
-    private val maxStillPngBytes: Int = DEFAULT_MAX_STILL_PNG_BYTES,
+    private val maxStillPngBytes: Int = defaultMaxStillPngBytes(),
 ) : AgentRequestHandler {
 
     private val automatorClass: Class<*> = automator.javaClass
@@ -417,7 +421,7 @@ internal class ReflectiveAutomatorHandler(
      *
      * Screen-pixel stills carry 4x the pixels of the logical ones on a 2x display, and the whole
      * virtual desktop is the one still whose size no caller bounds — a multi-monitor HiDPI desktop
-     * can encode past [MAX_FRAME_BYTES], which would fail the request outright. Falling back to the
+     * can encode past the frame budget, which would fail the request outright. Falling back to the
      * logical still keeps a command that works today working; callers that need to know which they
      * got can compare the PNG size against the desktop's logical bounds.
      */

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -4,6 +4,7 @@ package dev.sebastiano.spectre.agent.runtime
 
 import dev.sebastiano.spectre.agent.ScreenshotTarget
 import dev.sebastiano.spectre.agent.resolveScreenshotTarget
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
 import dev.sebastiano.spectre.agent.transport.AgentRequest
 import dev.sebastiano.spectre.agent.transport.AgentRequestHandler
 import dev.sebastiano.spectre.agent.transport.AgentResponse
@@ -413,7 +414,7 @@ internal class ReflectiveAutomatorHandler(
 
         // Only Fullscreen remains (explicit opt-in). null region = full virtual desktop (#289).
         check(target is ScreenshotTarget.Fullscreen)
-        return AgentResponse.Screenshot(fullscreenStillPng(deviceScaleMethod, regionMethod))
+        return fullscreenStill(deviceScaleMethod, regionMethod)
     }
 
     /**
@@ -421,20 +422,39 @@ internal class ReflectiveAutomatorHandler(
      *
      * Screen-pixel stills carry 4x the pixels of the logical ones on a 2x display, and the whole
      * virtual desktop is the one still whose size no caller bounds — a multi-monitor HiDPI desktop
-     * can encode past the frame budget, which would fail the request outright. Falling back to the
-     * logical still keeps a command that works today working; callers that need to know which they
-     * got can compare the PNG size against the desktop's logical bounds.
+     * can encode past the frame budget, which would fail the request outright. Dropping to the
+     * logical still keeps a command that works today working.
+     *
+     * That fallback is best-effort, not a guarantee: with a small budget no desktop screenshot fits
+     * at any resolution, so there is nothing to degrade to. When even the logical still overruns,
+     * this reports [AgentErrorCategory.PayloadTooLarge] naming the flag that fixes it, rather than
+     * letting the framing layer substitute its own generic message further downstream.
      */
-    private fun fullscreenStillPng(deviceScaleMethod: Method?, regionMethod: Method?): ByteArray {
+    private fun fullscreenStill(deviceScaleMethod: Method?, regionMethod: Method?): AgentResponse {
         // Older injected cores expose only screenshot(Rectangle?). The caller rejects the request
         // before this point when neither method is present, so one of the two is always non-null.
-        if (deviceScaleMethod == null) {
-            return encodeFullscreenStill(checkNotNull(regionMethod))
+        if (deviceScaleMethod != null) {
+            val deviceScalePng = encodeFullscreenStill(deviceScaleMethod)
+            if (regionMethod == null || deviceScalePng.size <= maxStillPngBytes) {
+                return stillWithinBudget(deviceScalePng)
+            }
         }
-        val deviceScalePng = encodeFullscreenStill(deviceScaleMethod)
-        if (regionMethod == null || deviceScalePng.size <= maxStillPngBytes) return deviceScalePng
-        return encodeFullscreenStill(regionMethod)
+        return stillWithinBudget(encodeFullscreenStill(checkNotNull(regionMethod)))
     }
+
+    private fun stillWithinBudget(png: ByteArray): AgentResponse =
+        if (png.size <= maxStillPngBytes) {
+            AgentResponse.Screenshot(png)
+        } else {
+            AgentResponse.Error(
+                message =
+                    "Fullscreen still is too large for the agent IPC frame limit " +
+                        "(png=${png.size}B, max≈${maxStillPngBytes}B) even at logical resolution. " +
+                        "Raise the budget with --max-frame-bytes / SPECTRE_MAX_FRAME_BYTES, or " +
+                        "capture a window instead of the whole desktop.",
+                category = AgentErrorCategory.PayloadTooLarge.wireName,
+            )
+        }
 
     private fun encodeFullscreenStill(method: Method): ByteArray =
         imageToPng(method.invoke(automator, null) as BufferedImage)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.agent.runtime
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.agent.transport.IpcServer
 import java.lang.instrument.Instrumentation
 import java.nio.file.Path
@@ -18,9 +19,9 @@ import java.util.concurrent.atomic.AtomicReference
  * Both go through [bootstrap]:
  * 1. Locate Spectre on the target's classpath via [AgentBootstrap.findSpectreClassLoader].
  * 2. Reflectively construct a `ComposeAutomator.inProcess(...)` instance in that classloader.
- * 3. If `agentArgs` carries a UDS path, start an [IpcServer] there that dispatches
- *    [dev.sebastiano.spectre.agent.transport.AgentRequest]s against the automator via
- *    [ReflectiveAutomatorHandler].
+ * 3. If `agentArgs` carries a UDS path (see [AgentBootstrapArgs] for the accepted forms), start an
+ *    [IpcServer] there that dispatches [dev.sebastiano.spectre.agent.transport.AgentRequest]s
+ *    against the automator via [ReflectiveAutomatorHandler].
  *
  * **Failure propagation**: any exception thrown by [bootstrap] escapes [premain] / [agentmain]. The
  * JVM's `loadClassAndStartAgent` rethrows it, which causes `VirtualMachine.loadAgent` on the
@@ -100,7 +101,18 @@ public object SpectreAgent {
             val automator = createAutomatorReflectively(loader)
             System.err.println("[spectre-agent] ComposeAutomator ready: $automator")
 
-            val udsPath = agentArgs.takeUnless { it.isNullOrBlank() }?.let(Path::of)
+            val parsedArgs = AgentBootstrapArgs.parse(agentArgs)
+            // The attacher's frame budget has to be adopted before the IPC server can answer: this
+            // JVM writes the bulky screenshot frames and cannot read the daemon's environment.
+            parsedArgs.maxFrameBytes?.let { budget ->
+                runCatching { FrameLimits.configure(budget) }
+                    .onFailure {
+                        System.err.println(
+                            "[spectre-agent] ignoring invalid maxFrameBytes=$budget: ${it.message}"
+                        )
+                    }
+            }
+            val udsPath = parsedArgs.udsPath?.let(Path::of)
             if (udsPath == null) {
                 // No UDS path means manual diagnostic mode: report window count to stderr so a
                 // user can verify Spectre is correctly on a target's classpath.

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/FrameIoDeadline.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/FrameIoDeadline.kt
@@ -92,7 +92,7 @@ internal object FrameIoDeadline {
             header[0] = first.toByte()
             readFully(input, header, offset = 1, length = HEADER_BYTES - 1)
             val frameLength = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN).int
-            check(frameLength in 0..MAX_FRAME_BYTES) {
+            check(frameLength in 0..MAX_FRAME_BYTES_CEILING) {
                 val headerDump = header.joinToString(",") { it.toInt().toString() }
                 "Invalid frame length $frameLength (header bytes: $headerDump)"
             }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
@@ -117,8 +117,9 @@ public object FrameLimits {
      *
      * Returns `null` for anything that is not a positive size that fits an [Int] — including
      * decimal-suffixed forms like `12MB`, so a value that looks like it means 12 million bytes is
-     * never silently read as 12 MiB. Overflow returns `null` instead of wrapping, which would
-     * shrink the budget when the caller asked to raise it.
+     * never silently read as 12 MiB. Overflow returns `null` instead of wrapping, both when the
+     * mantissa alone exceeds [Int] and when multiplying it by the suffix would wrap [Long]; either
+     * would shrink the budget when the caller asked to raise it.
      */
     @Suppress("ReturnCount")
     public fun parseMaxFrameBytes(raw: String?): Int? {
@@ -136,6 +137,10 @@ public object FrameLimits {
                 "gib" -> 1024L * 1024L * 1024L
                 else -> return null
             }
+        // Check before multiplying: a huge mantissa with a suffix can wrap Long back into a small
+        // positive value, so "18014398509481985k" would otherwise silently configure a 1KiB budget
+        // instead of being rejected, and every ordinary IPC response would then fail to frame.
+        if (digits > Long.MAX_VALUE / multiplier) return null
         val bytes = digits * multiplier
         if (bytes <= 0L || bytes > Int.MAX_VALUE.toLong()) return null
         return bytes.toInt()

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
@@ -59,14 +59,27 @@ public object FrameLimits {
     /** Environment variable that overrides [DEFAULT_MAX_FRAME_BYTES]. */
     public const val ENV_VAR: String = "SPECTRE_MAX_FRAME_BYTES"
 
-    @Volatile private var budget: Int = resolveBudget(System::getenv)
+    @Volatile private var request: Int? = resolveRequest(System::getenv)
+    @Volatile private var budget: Int = request ?: DEFAULT_MAX_FRAME_BYTES
 
     /** Largest payload this process will write into a single frame. */
     public val maxFrameBytes: Int
         get() = budget
 
     /**
-     * Overrides the write budget for this process.
+     * The budget this process was explicitly asked for, or `null` when nothing asked.
+     *
+     * Distinct from [maxFrameBytes] on purpose: an explicit request that happens to equal
+     * [DEFAULT_MAX_FRAME_BYTES] is still a request, and callers that propagate or validate the
+     * setting must not infer intent from the value. Asking for 64MiB while a daemon runs 128MiB is
+     * a real conflict, and a spawned process must be told 64MiB rather than left to re-read an
+     * environment that says otherwise.
+     */
+    public val requestedMaxFrameBytes: Int?
+        get() = request
+
+    /**
+     * Overrides the write budget for this process, and records it as an explicit request.
      *
      * @throws IllegalArgumentException if [bytes] is not positive or exceeds
      *   [MAX_FRAME_BYTES_CEILING], since a reader would refuse the frames it produced.
@@ -78,6 +91,13 @@ public object FrameLimits {
                 "readers would refuse frames that large"
         }
         budget = bytes
+        request = bytes
+    }
+
+    /** Drops any [configure] call and re-resolves from the environment, as at process start. */
+    public fun resetToEnvironment() {
+        request = resolveRequest(System::getenv)
+        budget = request ?: DEFAULT_MAX_FRAME_BYTES
     }
 
     /**
@@ -85,10 +105,12 @@ public object FrameLimits {
      * value falls back to [DEFAULT_MAX_FRAME_BYTES] rather than failing process startup: a bad
      * tuning knob should not stop the daemon from booting.
      */
-    public fun resolveBudget(getenv: (String) -> String?): Int {
-        val parsed = parseMaxFrameBytes(getenv(ENV_VAR)) ?: return DEFAULT_MAX_FRAME_BYTES
-        return parsed.coerceAtMost(MAX_FRAME_BYTES_CEILING)
-    }
+    public fun resolveBudget(getenv: (String) -> String?): Int =
+        resolveRequest(getenv) ?: DEFAULT_MAX_FRAME_BYTES
+
+    /** The explicitly requested budget from [getenv], or `null` when the variable asks nothing. */
+    public fun resolveRequest(getenv: (String) -> String?): Int? =
+        parseMaxFrameBytes(getenv(ENV_VAR))?.coerceAtMost(MAX_FRAME_BYTES_CEILING)
 
     /**
      * Parses a byte count with an optional binary suffix (`512`, `128k`, `64M`, `64MiB`, `1G`).

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
@@ -21,6 +21,17 @@ import java.nio.ByteOrder
 @ExperimentalSpectreAgentApi public const val DEFAULT_MAX_FRAME_BYTES: Int = 64 * 1024 * 1024
 
 /**
+ * Smallest usable write budget.
+ *
+ * A budget only has to be "positive and under the ceiling" to look valid, but one too small to
+ * frame the protocol's own Hello/HelloAck makes *every* operation fail — including the `spectre
+ * daemon kill` the mismatch error tells users to run, so the configuration cannot even be undone
+ * from the CLI. Control frames are tens of bytes; this floor sits far above them while still
+ * catching the plausible typo of writing a megabyte count without its suffix.
+ */
+@ExperimentalSpectreAgentApi public const val MIN_MAX_FRAME_BYTES: Int = 64 * 1024
+
+/**
  * Hard upper bound on any frame length, whatever the writer's budget.
  *
  * [readFrame] allocates the payload buffer up front from a length it has not yet validated against
@@ -85,7 +96,10 @@ public object FrameLimits {
      *   [MAX_FRAME_BYTES_CEILING], since a reader would refuse the frames it produced.
      */
     public fun configure(bytes: Int) {
-        require(bytes > 0) { "$ENV_VAR must be a positive size, got $bytes" }
+        require(bytes >= MIN_MAX_FRAME_BYTES) {
+            "$ENV_VAR=$bytes is below the $MIN_MAX_FRAME_BYTES-byte minimum; a budget that small " +
+                "cannot carry the protocol's own frames, so nothing would work"
+        }
         require(bytes <= MAX_FRAME_BYTES_CEILING) {
             "$ENV_VAR=$bytes exceeds the frame ceiling $MAX_FRAME_BYTES_CEILING; " +
                 "readers would refuse frames that large"
@@ -108,9 +122,17 @@ public object FrameLimits {
     public fun resolveBudget(getenv: (String) -> String?): Int =
         resolveRequest(getenv) ?: DEFAULT_MAX_FRAME_BYTES
 
-    /** The explicitly requested budget from [getenv], or `null` when the variable asks nothing. */
+    /**
+     * The explicitly requested budget from [getenv], or `null` when the variable asks nothing.
+     *
+     * A value below [MIN_MAX_FRAME_BYTES] is treated like an unparseable one — ignored in favour of
+     * the default — rather than failing startup, matching [resolveBudget]'s contract that a bad
+     * tuning knob must not stop a daemon from booting.
+     */
     public fun resolveRequest(getenv: (String) -> String?): Int? =
-        parseMaxFrameBytes(getenv(ENV_VAR))?.coerceAtMost(MAX_FRAME_BYTES_CEILING)
+        parseMaxFrameBytes(getenv(ENV_VAR))
+            ?.takeIf { it >= MIN_MAX_FRAME_BYTES }
+            ?.coerceAtMost(MAX_FRAME_BYTES_CEILING)
 
     /**
      * Parses a byte count with an optional binary suffix (`512`, `128k`, `64M`, `64MiB`, `1G`).

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Framing.kt
@@ -8,16 +8,125 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 /**
- * Default upper bound on a single frame's payload. Screenshots are the bulkiest reasonable case.
+ * Default write budget for a single frame's payload.
+ *
+ * Screenshots are the bulkiest payload, and the worst case is an incompressible one: PNG can only
+ * approach raw bytes-per-pixel, so a 3840x2160 desktop tops out near 25 MB of 24-bit sRGB. 64 MiB
+ * clears that with room for a dual-4K desktop, and `SPECTRE_MAX_FRAME_BYTES` raises it for larger
+ * multi-monitor HiDPI rigs (see [FrameLimits]).
+ *
+ * This is a **policy** limit applied when writing. Readers accept anything up to
+ * [MAX_FRAME_BYTES_CEILING] so two endpoints on different budgets can never deadlock the wire.
  */
-@ExperimentalSpectreAgentApi public const val MAX_FRAME_BYTES: Int = 16 * 1024 * 1024
+@ExperimentalSpectreAgentApi public const val DEFAULT_MAX_FRAME_BYTES: Int = 64 * 1024 * 1024
+
+/**
+ * Hard upper bound on any frame length, whatever the writer's budget.
+ *
+ * [readFrame] allocates the payload buffer up front from a length it has not yet validated against
+ * the sender, so this caps what a corrupt or desynchronised header can make a reader allocate. It
+ * is deliberately far above [DEFAULT_MAX_FRAME_BYTES]: keeping it fixed and generous is what lets a
+ * reader stay compatible with a writer configured through [FrameLimits], while still refusing the
+ * multi-gigabyte lengths a garbled 4-byte header would otherwise produce.
+ */
+@ExperimentalSpectreAgentApi public const val MAX_FRAME_BYTES_CEILING: Int = 512 * 1024 * 1024
+
+/**
+ * Byte-count grammar for [FrameLimits.parseMaxFrameBytes].
+ *
+ * Lives at file scope on purpose: [FrameLimits] parses the environment in its *own* initializer, so
+ * a regex declared inside the object would still be null at that point and only blow up on the
+ * machines that actually set the override.
+ */
+private val FRAME_SIZE_PATTERN = Regex("""(\d+)\s*([A-Za-z]*)""")
+
+/**
+ * Process-wide frame write budget (#204).
+ *
+ * Resolution order: the `SPECTRE_MAX_FRAME_BYTES` environment variable, then
+ * [DEFAULT_MAX_FRAME_BYTES]. The CLI's `--max-frame-bytes` and the daemon's matching option both
+ * land here through [configure], and the daemon forwards its resolved value to every JVM it injects
+ * — an injected agent cannot read the daemon's environment, and it is the process that writes the
+ * bulky screenshot frames.
+ *
+ * Only writers consult this. A reader that receives a frame larger than its own budget still
+ * accepts it (up to [MAX_FRAME_BYTES_CEILING]), so raising the budget on one hop never strands a
+ * response on another.
+ */
+@ExperimentalSpectreAgentApi
+public object FrameLimits {
+
+    /** Environment variable that overrides [DEFAULT_MAX_FRAME_BYTES]. */
+    public const val ENV_VAR: String = "SPECTRE_MAX_FRAME_BYTES"
+
+    @Volatile private var budget: Int = resolveBudget(System::getenv)
+
+    /** Largest payload this process will write into a single frame. */
+    public val maxFrameBytes: Int
+        get() = budget
+
+    /**
+     * Overrides the write budget for this process.
+     *
+     * @throws IllegalArgumentException if [bytes] is not positive or exceeds
+     *   [MAX_FRAME_BYTES_CEILING], since a reader would refuse the frames it produced.
+     */
+    public fun configure(bytes: Int) {
+        require(bytes > 0) { "$ENV_VAR must be a positive size, got $bytes" }
+        require(bytes <= MAX_FRAME_BYTES_CEILING) {
+            "$ENV_VAR=$bytes exceeds the frame ceiling $MAX_FRAME_BYTES_CEILING; " +
+                "readers would refuse frames that large"
+        }
+        budget = bytes
+    }
+
+    /**
+     * Resolves the budget from [getenv], clamping to [MAX_FRAME_BYTES_CEILING]. An unparseable
+     * value falls back to [DEFAULT_MAX_FRAME_BYTES] rather than failing process startup: a bad
+     * tuning knob should not stop the daemon from booting.
+     */
+    public fun resolveBudget(getenv: (String) -> String?): Int {
+        val parsed = parseMaxFrameBytes(getenv(ENV_VAR)) ?: return DEFAULT_MAX_FRAME_BYTES
+        return parsed.coerceAtMost(MAX_FRAME_BYTES_CEILING)
+    }
+
+    /**
+     * Parses a byte count with an optional binary suffix (`512`, `128k`, `64M`, `64MiB`, `1G`).
+     *
+     * Returns `null` for anything that is not a positive size that fits an [Int] — including
+     * decimal-suffixed forms like `12MB`, so a value that looks like it means 12 million bytes is
+     * never silently read as 12 MiB. Overflow returns `null` instead of wrapping, which would
+     * shrink the budget when the caller asked to raise it.
+     */
+    @Suppress("ReturnCount")
+    public fun parseMaxFrameBytes(raw: String?): Int? {
+        val text = raw?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+        val match = FRAME_SIZE_PATTERN.matchEntire(text) ?: return null
+        val digits = match.groupValues[1].toLongOrNull() ?: return null
+        val multiplier =
+            when (match.groupValues[2].lowercase()) {
+                "" -> 1L
+                "k",
+                "kib" -> 1024L
+                "m",
+                "mib" -> 1024L * 1024L
+                "g",
+                "gib" -> 1024L * 1024L * 1024L
+                else -> return null
+            }
+        val bytes = digits * multiplier
+        if (bytes <= 0L || bytes > Int.MAX_VALUE.toLong()) return null
+        return bytes.toInt()
+    }
+}
 
 /**
  * Length-prefixed binary framing for the agent's IPC wire protocol.
  *
  * Wire format: `[4-byte big-endian payload length][payload bytes]`. The 4-byte header carries a
- * non-negative `int` length capped at [MAX_FRAME_BYTES]. Zero-length payloads are legal (they
- * serialize a `data object` to an empty CBOR map sometimes — the codec layer handles them).
+ * non-negative `int` length: writes are capped at [FrameLimits.maxFrameBytes] and reads at
+ * [MAX_FRAME_BYTES_CEILING]. Zero-length payloads are legal (they serialize a `data object` to an
+ * empty CBOR map sometimes — the codec layer handles them).
  *
  * Streams are not closed by these functions; that's the caller's responsibility.
  *
@@ -33,8 +142,9 @@ public object Framing {
      */
     @Throws(java.io.IOException::class)
     public fun writeFrame(output: OutputStream, payload: ByteArray) {
-        require(payload.size <= MAX_FRAME_BYTES) {
-            "Frame payload size ${payload.size} exceeds MAX_FRAME_BYTES=$MAX_FRAME_BYTES"
+        val budget = FrameLimits.maxFrameBytes
+        require(payload.size <= budget) {
+            "Frame payload size ${payload.size} exceeds MAX_FRAME_BYTES=$budget"
         }
         val header =
             ByteBuffer.allocate(HEADER_BYTES)
@@ -55,7 +165,7 @@ public object Framing {
     public fun readFrame(input: InputStream): ByteArray? {
         val header = readFullyOrNull(input, HEADER_BYTES) ?: return null
         val length = ByteBuffer.wrap(header).order(ByteOrder.BIG_ENDIAN).int
-        check(length in 0..MAX_FRAME_BYTES) {
+        check(length in 0..MAX_FRAME_BYTES_CEILING) {
             "Invalid frame length $length (header bytes: ${header.joinToString(",") { it.toInt().toString() }})"
         }
         if (length == 0) return ByteArray(0)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -332,8 +332,9 @@ internal class MultiplexedIpcSession(
         body: AgentResponse,
     ) {
         val payload = WireCodec.encode(OpResponse(opId = opId, body = body))
+        val budget = FrameLimits.maxFrameBytes
         val toWrite =
-            if (payload.size <= MAX_FRAME_BYTES) {
+            if (payload.size <= budget) {
                 payload
             } else {
                 // Fail closed with a small taxonomy error instead of throwing mid-write (#204).
@@ -344,7 +345,7 @@ internal class MultiplexedIpcSession(
                             AgentResponse.Error(
                                 message =
                                     "Response payload size ${payload.size} exceeds " +
-                                        "MAX_FRAME_BYTES=$MAX_FRAME_BYTES",
+                                        "MAX_FRAME_BYTES=$budget",
                                 category = AgentErrorCategory.PayloadTooLarge.wireName,
                             ),
                     )

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolVersion.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolVersion.kt
@@ -13,7 +13,13 @@ public object ProtocolVersion {
      * Current protocol revision carried on [AgentRequest.Hello] / [AgentResponse.HelloAck].
      *
      * v1: bare request/response frames after Hello. v2 (#200): operation envelopes with op ids,
-     * cancel, and deadline budgets; long ops run off the accept thread.
+     * cancel, and deadline budgets; long ops run off the accept thread. v3: bulk payloads
+     * (`pngBytes`, `captureJsonUtf8`) encode as CBOR byte strings rather than integer arrays.
+     *
+     * v3 is a **representation** change, invisible to the type system: a library and a runtime jar
+     * from either side of it would otherwise pass the exact-match handshake and fail only when a
+     * screenshot came back in an encoding the peer does not speak. `AttachOptions.agentJarPath` and
+     * the runtime-jar system property make that pairing reachable, so it has to fail at Hello.
      */
-    public const val CURRENT: Int = 2
+    public const val CURRENT: Int = 3
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -1,10 +1,15 @@
-@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+@file:OptIn(
+    dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class,
+    kotlinx.serialization.ExperimentalSerializationApi::class,
+)
 
 package dev.sebastiano.spectre.agent.transport
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.ByteString
 
 /**
  * Wire protocol between Spectre's attach-side client and the in-target agent runtime.
@@ -308,7 +313,7 @@ internal sealed interface AgentResponse {
     /** Reply to [AgentRequest.Screenshot] — raw PNG bytes (not base64). */
     @Serializable
     @SerialName("screenshot")
-    data class Screenshot(val pngBytes: ByteArray) : AgentResponse {
+    data class Screenshot(@ByteString val pngBytes: ByteArray) : AgentResponse {
         // ByteArray needs explicit equals/hashCode because Kotlin uses array identity by default
         // for data class auto-generated equals. Tests rely on structural comparison.
         override fun equals(other: Any?): Boolean =
@@ -327,8 +332,8 @@ internal sealed interface AgentResponse {
     data class Capture(
         val windowIndex: Int,
         val schemaVersion: Int,
-        val captureJsonUtf8: ByteArray,
-        val pngBytes: ByteArray,
+        @ByteString val captureJsonUtf8: ByteArray,
+        @ByteString val pngBytes: ByteArray,
         val nodeCount: Int,
         val taggedNodeCount: Int,
         val textedNodeCount: Int,

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
@@ -32,9 +32,13 @@ class AttachOptionsTest {
     }
 
     @Test
+    fun `a budget too small for protocol frames is rejected at construction`() {
+        assertFailsWith<IllegalArgumentException> { AttachOptions(maxFrameBytes = 1) }
+    }
+
+    @Test
     fun `a usable budget and the unset default are both accepted`() {
         AttachOptions(maxFrameBytes = MAX_FRAME_BYTES_CEILING)
-        AttachOptions(maxFrameBytes = 1)
         AttachOptions(maxFrameBytes = null)
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
@@ -2,59 +2,39 @@
 
 package dev.sebastiano.spectre.agent
 
-import java.nio.file.Path
+import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES_CEILING
 import kotlin.test.Test
-import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
-import org.junit.jupiter.api.condition.EnabledOnOs
-import org.junit.jupiter.api.condition.OS
 
+/**
+ * A budget the target cannot apply must fail at the caller, not in the injected JVM. The agent logs
+ * and ignores a bad value so a tuning mistake cannot break the attach, which means an unvalidated
+ * option would let `attach()` report success while the target silently kept its own budget and
+ * later rejected captures the caller sized for.
+ */
 class AttachOptionsTest {
-    // ---- base-dir selection (pure, platform-agnostic) ----
 
     @Test
-    fun `udsBaseDir uses the JVM temp dir on Windows`() {
-        assertEquals(
-            "C:\\Users\\x\\AppData\\Local\\Temp",
-            AttachOptions.udsBaseDir("Windows 11", "C:\\Users\\x\\AppData\\Local\\Temp"),
-        )
+    fun `a budget above the read ceiling is rejected at construction`() {
+        val failure =
+            assertFailsWith<IllegalArgumentException> {
+                AttachOptions(maxFrameBytes = MAX_FRAME_BYTES_CEILING + 1)
+            }
+
+        assertTrue(failure.message.orEmpty().contains("ceiling", ignoreCase = true), "$failure")
     }
 
     @Test
-    fun `udsBaseDir uses slash tmp on POSIX`() {
-        assertEquals("/tmp", AttachOptions.udsBaseDir("Linux", "/var/folders/ignored"))
-        assertEquals("/tmp", AttachOptions.udsBaseDir("Mac OS X", "/var/folders/ignored"))
-    }
-
-    // ---- default path structure (platform-agnostic) ----
-
-    @Test
-    fun `defaultUdsPath ends in the per-attach dir plus agent socket`() {
-        val p = AttachOptions.defaultUdsPath(1234L)
-        assertEquals("agent.sock", p.fileName.toString())
-        assertTrue(
-            p.parent.fileName.toString().startsWith("sp-a-1234-"),
-            "per-attach dir should be sp-a-<pid>-<uuid>, got ${p.parent.fileName}",
-        )
-    }
-
-    // ---- real path per platform ----
-
-    @Test
-    @EnabledOnOs(OS.WINDOWS)
-    fun `defaultUdsPath is absolute and under the JVM temp dir on Windows`() {
-        val p = AttachOptions.defaultUdsPath(1234L)
-        assertTrue(p.isAbsolute, "UDS path must be absolute on Windows, got $p")
-        assertTrue(
-            p.startsWith(Path.of(System.getProperty("java.io.tmpdir"))),
-            "UDS path must live under java.io.tmpdir (%TEMP%) on Windows, got $p",
-        )
+    fun `a non-positive budget is rejected at construction`() {
+        assertFailsWith<IllegalArgumentException> { AttachOptions(maxFrameBytes = 0) }
+        assertFailsWith<IllegalArgumentException> { AttachOptions(maxFrameBytes = -1) }
     }
 
     @Test
-    @EnabledOnOs(OS.LINUX, OS.MAC)
-    fun `defaultUdsPath is under slash tmp on POSIX`() {
-        val p = AttachOptions.defaultUdsPath(1234L)
-        assertTrue(p.startsWith(Path.of("/tmp")), "UDS path must live under /tmp on POSIX, got $p")
+    fun `a usable budget and the unset default are both accepted`() {
+        AttachOptions(maxFrameBytes = MAX_FRAME_BYTES_CEILING)
+        AttachOptions(maxFrameBytes = 1)
+        AttachOptions(maxFrameBytes = null)
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgsTest.kt
@@ -62,15 +62,9 @@ class AgentBootstrapArgsTest {
     }
 
     @Test
-    fun `renders the bare form when no budget override is in play`() {
-        assertEquals(
-            "/tmp/sp-a-1/agent.sock",
-            AgentBootstrapArgs.render(udsPath = "/tmp/sp-a-1/agent.sock", maxFrameBytes = null),
-        )
-    }
-
-    @Test
-    fun `renders the structured form when a budget is set`() {
+    fun `always renders the structured form, default budget included`() {
+        // The target may carry a SPECTRE_MAX_FRAME_BYTES of its own; omitting the default would
+        // let that win and leave the daemon and its injected JVM disagreeing.
         assertEquals(
             "uds=/tmp/sp-a-1/agent.sock,maxFrameBytes=1024",
             AgentBootstrapArgs.render(udsPath = "/tmp/sp-a-1/agent.sock", maxFrameBytes = 1024),
@@ -85,5 +79,28 @@ class AgentBootstrapArgsTest {
 
         assertEquals("/tmp/sp-a-9/agent.sock", parsed.udsPath)
         assertEquals(65536, parsed.maxFrameBytes)
+    }
+
+    @Test
+    fun `a uds path containing the delimiters survives the round trip`() {
+        // AttachOptions lets a caller pick the socket path, and a comma is legal in one. Without
+        // escaping, parse() would truncate it and the target would bind a different socket than
+        // the attacher waits for.
+        val awkward = "/tmp/spectre,a=b/%weird/agent.sock"
+
+        val parsed = AgentBootstrapArgs.parse(AgentBootstrapArgs.render(awkward, 4096))
+
+        assertEquals(awkward, parsed.udsPath)
+        assertEquals(4096, parsed.maxFrameBytes)
+    }
+
+    @Test
+    fun `an escaped percent cannot forge a delimiter`() {
+        // "%252C" must decode to the literal "%2C", not to a comma that splits the path.
+        val awkward = "/tmp/sp-a/%2C/agent.sock"
+
+        val parsed = AgentBootstrapArgs.parse(AgentBootstrapArgs.render(awkward, 4096))
+
+        assertEquals(awkward, parsed.udsPath)
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgsTest.kt
@@ -29,6 +29,16 @@ class AgentBootstrapArgsTest {
     }
 
     @Test
+    fun `a bare relative path that starts with uds= is not mistaken for structured args`() {
+        // Both are legal POSIX names. Everything Spectre renders carries at least one more field,
+        // so requiring the separator keeps the pathological bare path working.
+        val parsed = AgentBootstrapArgs.parse("uds=agent.sock")
+
+        assertEquals("uds=agent.sock", parsed.udsPath)
+        assertNull(parsed.maxFrameBytes)
+    }
+
+    @Test
     fun `structured args carry the uds path and the frame budget`() {
         val parsed = AgentBootstrapArgs.parse("uds=/tmp/sp-a-1/agent.sock,maxFrameBytes=134217728")
 
@@ -38,7 +48,7 @@ class AgentBootstrapArgsTest {
 
     @Test
     fun `structured args tolerate a missing budget`() {
-        val parsed = AgentBootstrapArgs.parse("uds=/tmp/sp-a-1/agent.sock")
+        val parsed = AgentBootstrapArgs.parse("uds=/tmp/sp-a-1/agent.sock,futureKnob=7")
 
         assertEquals("/tmp/sp-a-1/agent.sock", parsed.udsPath)
         assertNull(parsed.maxFrameBytes)

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgsTest.kt
@@ -1,0 +1,89 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * The injected agent cannot see the daemon's environment, so the frame budget has to ride along in
+ * `agentArgs`. Hand-written `-javaagent:spectre-agent-runtime.jar=/path/to.sock` lines must keep
+ * working, so the bare-path form stays valid.
+ */
+class AgentBootstrapArgsTest {
+
+    @Test
+    fun `a bare path is still the UDS path`() {
+        val parsed = AgentBootstrapArgs.parse("/tmp/sp-a-123-abcd/agent.sock")
+
+        assertEquals("/tmp/sp-a-123-abcd/agent.sock", parsed.udsPath)
+        assertNull(parsed.maxFrameBytes, "bare form carries no budget; the default applies")
+    }
+
+    @Test
+    fun `null and blank args mean diagnostic mode`() {
+        assertNull(AgentBootstrapArgs.parse(null).udsPath)
+        assertNull(AgentBootstrapArgs.parse("   ").udsPath)
+    }
+
+    @Test
+    fun `structured args carry the uds path and the frame budget`() {
+        val parsed = AgentBootstrapArgs.parse("uds=/tmp/sp-a-1/agent.sock,maxFrameBytes=134217728")
+
+        assertEquals("/tmp/sp-a-1/agent.sock", parsed.udsPath)
+        assertEquals(134217728, parsed.maxFrameBytes)
+    }
+
+    @Test
+    fun `structured args tolerate a missing budget`() {
+        val parsed = AgentBootstrapArgs.parse("uds=/tmp/sp-a-1/agent.sock")
+
+        assertEquals("/tmp/sp-a-1/agent.sock", parsed.udsPath)
+        assertNull(parsed.maxFrameBytes)
+    }
+
+    @Test
+    fun `an unparseable budget is ignored rather than failing the attach`() {
+        val parsed = AgentBootstrapArgs.parse("uds=/tmp/sp-a-1/agent.sock,maxFrameBytes=banana")
+
+        assertEquals("/tmp/sp-a-1/agent.sock", parsed.udsPath)
+        assertNull(parsed.maxFrameBytes)
+    }
+
+    @Test
+    fun `unknown keys are ignored so newer daemons can attach older runtimes`() {
+        val parsed =
+            AgentBootstrapArgs.parse("uds=/tmp/sp-a-1/agent.sock,futureKnob=7,maxFrameBytes=1024")
+
+        assertEquals("/tmp/sp-a-1/agent.sock", parsed.udsPath)
+        assertEquals(1024, parsed.maxFrameBytes)
+    }
+
+    @Test
+    fun `renders the bare form when no budget override is in play`() {
+        assertEquals(
+            "/tmp/sp-a-1/agent.sock",
+            AgentBootstrapArgs.render(udsPath = "/tmp/sp-a-1/agent.sock", maxFrameBytes = null),
+        )
+    }
+
+    @Test
+    fun `renders the structured form when a budget is set`() {
+        assertEquals(
+            "uds=/tmp/sp-a-1/agent.sock,maxFrameBytes=1024",
+            AgentBootstrapArgs.render(udsPath = "/tmp/sp-a-1/agent.sock", maxFrameBytes = 1024),
+        )
+    }
+
+    @Test
+    fun `render and parse round-trip`() {
+        val rendered =
+            AgentBootstrapArgs.render(udsPath = "/tmp/sp-a-9/agent.sock", maxFrameBytes = 65536)
+        val parsed = AgentBootstrapArgs.parse(rendered)
+
+        assertEquals("/tmp/sp-a-9/agent.sock", parsed.udsPath)
+        assertEquals(65536, parsed.maxFrameBytes)
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureBudgetTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AtomicCaptureBudgetTest.kt
@@ -1,0 +1,117 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+import dev.sebastiano.spectre.agent.transport.AgentRequest
+import dev.sebastiano.spectre.agent.transport.AgentResponse
+import dev.sebastiano.spectre.agent.transport.FrameLimits
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * The atomic-capture guard decides whether a capture fits the frame budget. Bulk fields now encode
+ * as CBOR byte strings, so the budget a user configures should be nearly all usable — a percentage
+ * cutoff would silently withhold a quarter of it, and raising the budget would not deliver.
+ */
+class AtomicCaptureBudgetTest {
+
+    @AfterTest fun restore() = FrameLimits.resetToEnvironment()
+
+    @Test
+    fun `a capture just under the budget is served, not refused`() {
+        FrameLimits.configure(BUDGET)
+        // 800KiB of a 1MiB budget: over the old 75% cutoff, comfortably inside the real envelope.
+        val handler = ReflectiveAutomatorHandler(automatorWithPng(800 * 1024))
+
+        val response = handler.handle(AgentRequest.Capture(windowIndex = 0))
+
+        assertIs<AgentResponse.Capture>(response, "capture within budget must not be refused")
+    }
+
+    @Test
+    fun `a capture over the budget is refused as payloadTooLarge`() {
+        FrameLimits.configure(BUDGET)
+        val handler = ReflectiveAutomatorHandler(automatorWithPng(BUDGET + 1))
+
+        val response = handler.handle(AgentRequest.Capture(windowIndex = 0))
+
+        val error = assertIs<AgentResponse.Error>(response)
+        assertEquals(
+            AgentErrorCategory.PayloadTooLarge.wireName,
+            error.category,
+            "an oversized capture is a payload problem, not an internal error: ${error.message}",
+        )
+        assertTrue(error.message.contains("too large", ignoreCase = true), error.message)
+    }
+
+    private fun automatorWithPng(size: Int): Any =
+        FakeCaptureAutomator(ByteArray(size) { 0xAB.toByte() })
+
+    private companion object {
+        const val BUDGET: Int = 1024 * 1024
+    }
+}
+
+/** Minimal stand-in exposing what [ReflectiveAutomatorHandler] looks up for a capture. */
+private class FakeCaptureAutomator(
+    private val png: ByteArray,
+    private val windows: List<Any> = emptyList(),
+) {
+    @Suppress("unused") fun refreshWindows() = Unit
+
+    @Suppress("unused") fun getWindows(): List<Any> = windows
+
+    @Suppress("unused") fun allNodes(): List<Any> = windows
+
+    @Suppress("unused") fun findByTestTag(tag: String): List<Any> = windows
+
+    @Suppress("unused") fun capture(windowIndex: Int): Any = FakeCapture(png)
+}
+
+private class FakeCapture(
+    private val png: ByteArray,
+    private val json: String = """{"schemaVersion":1}""",
+    private val document: Any = FakeDocument(),
+) {
+    @Suppress("unused") fun getDocument(): Any = document
+
+    @Suppress("unused") fun getPngBytes(): ByteArray = png
+
+    @Suppress("unused") fun getCaptureJson(): String = json
+}
+
+private class FakeDocument(
+    private val schemaVersion: Int = 1,
+    private val summary: Any = FakeSummary(),
+) {
+    @Suppress("unused") fun getSchemaVersion(): Int = schemaVersion
+
+    @Suppress("unused") fun getSummary(): Any = summary
+}
+
+@Suppress("LongParameterList")
+private class FakeSummary(
+    private val nodeCount: Int = 1,
+    private val taggedNodeCount: Int = 1,
+    private val textedNodeCount: Int = 1,
+    private val imageWidth: Int = 10,
+    private val imageHeight: Int = 10,
+    private val captureDurationMs: Long = 1L,
+) {
+    @Suppress("unused") fun getNodeCount(): Int = nodeCount
+
+    @Suppress("unused") fun getTaggedNodeCount(): Int = taggedNodeCount
+
+    @Suppress("unused") fun getTextedNodeCount(): Int = textedNodeCount
+
+    @Suppress("unused") fun getImageWidth(): Int = imageWidth
+
+    @Suppress("unused") fun getImageHeight(): Int = imageHeight
+
+    @Suppress("unused") fun getCaptureDurationMs(): Long = captureDurationMs
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerMappingTest.kt
@@ -317,30 +317,6 @@ class ReflectiveAutomatorHandlerMappingTest {
     }
 
     @Test
-    fun `Screenshot op with fullscreen true calls screenshot(Rectangle) with null`() {
-        var receivedArg: Any? = "<not invoked>"
-        val image = java.awt.image.BufferedImage(2, 2, java.awt.image.BufferedImage.TYPE_INT_ARGB)
-        val automator =
-            FakeAutomator(
-                screenshotImpl = { region ->
-                    receivedArg = region
-                    image
-                }
-            )
-        val handler = ReflectiveAutomatorHandler(automator)
-
-        val response = handler.handle(AgentRequest.Screenshot(fullscreen = true))
-        check(response is AgentResponse.Screenshot) {
-            "expected Screenshot, got ${response::class.simpleName}: $response"
-        }
-        assertEquals(
-            null,
-            receivedArg,
-            "handler must call screenshot(null) only for explicit fullscreen",
-        )
-    }
-
-    @Test
     fun `Screenshot op with explicit window index fails closed without region crop`() {
         var regionInvoked = false
         val targetBounds = Rectangle(5, 6, 200, 200)

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorStillScaleTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorStillScaleTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.agent.runtime
 
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
 import dev.sebastiano.spectre.agent.transport.AgentRequest
 import dev.sebastiano.spectre.agent.transport.AgentResponse
 import java.awt.Rectangle
@@ -8,6 +9,8 @@ import java.io.ByteArrayInputStream
 import javax.imageio.ImageIO
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 /**
  * Fullscreen stills must carry screen pixels so a `spectre screenshot --fullscreen` PNG matches a
@@ -79,16 +82,17 @@ class ReflectiveAutomatorStillScaleTest {
     @Test
     fun `fullscreen drops to the logical still when the device-scale PNG will not fit the frame`() {
         var logicalCalls = 0
+        // Incompressible device-scale still (hundreds of KiB) against a trivially small logical
+        // one, so the budget below sits unambiguously between the two encoded sizes.
         val automator =
             FakeStillAutomator(
                 screenshotImpl = {
                     logicalCalls += 1
-                    argb(2, 2)
+                    argb(LOGICAL_EDGE, LOGICAL_EDGE)
                 },
-                screenshotAtDeviceScaleImpl = { argb(4, 4) },
+                screenshotAtDeviceScaleImpl = { noise(DEVICE_EDGE, DEVICE_EDGE) },
             )
-        // Any real PNG is larger than this, so the device-scale still always overruns the budget.
-        val handler = ReflectiveAutomatorHandler(automator, maxStillPngBytes = 1)
+        val handler = ReflectiveAutomatorHandler(automator, maxStillPngBytes = BUDGET_BETWEEN)
 
         val response = handler.handle(AgentRequest.Screenshot(fullscreen = true))
 
@@ -97,10 +101,29 @@ class ReflectiveAutomatorStillScaleTest {
         }
         assertEquals(1, logicalCalls, "oversized stills must retry through the logical capture")
         assertEquals(
-            2,
+            LOGICAL_EDGE,
             decodePngWidth(response.pngBytes),
             "an oversized fullscreen still must degrade in resolution, not fail the request",
         )
+    }
+
+    @Test
+    fun `a still too large even at logical resolution says how to fix it`() {
+        // Nothing to degrade to: with a budget this small no desktop screenshot fits at any
+        // resolution, so the fallback cannot save it and the caller needs the actionable error
+        // rather than the framing layer's generic substitution.
+        val automator =
+            FakeStillAutomator(
+                screenshotImpl = { argb(64, 64) },
+                screenshotAtDeviceScaleImpl = { argb(128, 128) },
+            )
+        val handler = ReflectiveAutomatorHandler(automator, maxStillPngBytes = 1)
+
+        val response = handler.handle(AgentRequest.Screenshot(fullscreen = true))
+
+        val error = assertIs<AgentResponse.Error>(response)
+        assertEquals(AgentErrorCategory.PayloadTooLarge.wireName, error.category)
+        assertTrue(error.message.contains("--max-frame-bytes"), error.message)
     }
 
     private fun decodePngWidth(pngBytes: ByteArray): Int =
@@ -108,11 +131,25 @@ class ReflectiveAutomatorStillScaleTest {
 
     private companion object {
         const val NOT_INVOKED = "<not invoked>"
+        const val DEVICE_EDGE: Int = 400
+        const val LOGICAL_EDGE: Int = 8
+        /** Far above the 8x8 logical PNG, far below the incompressible 400x400 one. */
+        const val BUDGET_BETWEEN: Int = 100_000
     }
 }
 
 private fun argb(width: Int, height: Int): BufferedImage =
     BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+
+/** A blank image compresses to nothing; noise is what makes a still genuinely large. */
+private fun noise(width: Int, height: Int): BufferedImage {
+    val random = kotlin.random.Random(width * 31 + height)
+    return argb(width, height).also { image ->
+        for (y in 0 until height) {
+            for (x in 0 until width) image.setRGB(x, y, random.nextInt())
+        }
+    }
+}
 
 /**
  * Minimal stand-in exposing exactly what [ReflectiveAutomatorHandler] looks up for a fullscreen

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorStillScaleTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorStillScaleTest.kt
@@ -1,0 +1,151 @@
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.transport.AgentRequest
+import dev.sebastiano.spectre.agent.transport.AgentResponse
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import java.io.ByteArrayInputStream
+import javax.imageio.ImageIO
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Fullscreen stills must carry screen pixels so a `spectre screenshot --fullscreen` PNG matches a
+ * recording of the same desktop. The handler reaches the target's `ComposeAutomator` reflectively
+ * and agent/target can ship different Spectre versions, so the device-scale call is preferred when
+ * present and the logical one remains a working fallback.
+ */
+class ReflectiveAutomatorStillScaleTest {
+
+    @Test
+    fun `fullscreen prefers the device-scale still`() {
+        var logicalCalls = 0
+        var receivedArg: Any? = NOT_INVOKED
+        val automator =
+            FakeStillAutomator(
+                screenshotImpl = {
+                    logicalCalls += 1
+                    argb(2, 2)
+                },
+                screenshotAtDeviceScaleImpl = { region ->
+                    receivedArg = region
+                    argb(4, 4)
+                },
+            )
+        val handler = ReflectiveAutomatorHandler(automator)
+
+        val response = handler.handle(AgentRequest.Screenshot(fullscreen = true))
+
+        check(response is AgentResponse.Screenshot) {
+            "expected Screenshot, got ${response::class.simpleName}: $response"
+        }
+        assertEquals(
+            0,
+            logicalCalls,
+            "fullscreen stills must not go through the logical-size region capture",
+        )
+        assertEquals(
+            null,
+            receivedArg,
+            "handler must call screenshotAtDeviceScale(null) for explicit fullscreen",
+        )
+        assertEquals(4, decodePngWidth(response.pngBytes), "PNG must be the device-scale image")
+    }
+
+    @Test
+    fun `fullscreen falls back when the target predates device-scale stills`() {
+        var receivedArg: Any? = NOT_INVOKED
+        val automator =
+            FakeLegacyStillAutomator(
+                screenshotImpl = { region ->
+                    receivedArg = region
+                    argb(2, 2)
+                }
+            )
+        val handler = ReflectiveAutomatorHandler(automator)
+
+        val response = handler.handle(AgentRequest.Screenshot(fullscreen = true))
+
+        check(response is AgentResponse.Screenshot) {
+            "expected Screenshot, got ${response::class.simpleName}: $response"
+        }
+        assertEquals(
+            null,
+            receivedArg,
+            "older injected cores must still serve fullscreen via screenshot(Rectangle?)",
+        )
+    }
+
+    @Test
+    fun `fullscreen drops to the logical still when the device-scale PNG will not fit the frame`() {
+        var logicalCalls = 0
+        val automator =
+            FakeStillAutomator(
+                screenshotImpl = {
+                    logicalCalls += 1
+                    argb(2, 2)
+                },
+                screenshotAtDeviceScaleImpl = { argb(4, 4) },
+            )
+        // Any real PNG is larger than this, so the device-scale still always overruns the budget.
+        val handler = ReflectiveAutomatorHandler(automator, maxStillPngBytes = 1)
+
+        val response = handler.handle(AgentRequest.Screenshot(fullscreen = true))
+
+        check(response is AgentResponse.Screenshot) {
+            "expected Screenshot, got ${response::class.simpleName}: $response"
+        }
+        assertEquals(1, logicalCalls, "oversized stills must retry through the logical capture")
+        assertEquals(
+            2,
+            decodePngWidth(response.pngBytes),
+            "an oversized fullscreen still must degrade in resolution, not fail the request",
+        )
+    }
+
+    private fun decodePngWidth(pngBytes: ByteArray): Int =
+        ImageIO.read(ByteArrayInputStream(pngBytes)).width
+
+    private companion object {
+        const val NOT_INVOKED = "<not invoked>"
+    }
+}
+
+private fun argb(width: Int, height: Int): BufferedImage =
+    BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+
+/**
+ * Minimal stand-in exposing exactly what [ReflectiveAutomatorHandler] looks up for a fullscreen
+ * still.
+ */
+private class FakeStillAutomator(
+    private val screenshotImpl: (Rectangle?) -> BufferedImage,
+    private val screenshotAtDeviceScaleImpl: (Rectangle?) -> BufferedImage,
+) {
+    @Suppress("unused") fun refreshWindows() = Unit
+
+    @Suppress("unused") fun getWindows(): List<Any> = emptyList()
+
+    @Suppress("unused") fun allNodes(): List<Any> = emptyList()
+
+    @Suppress("unused") fun findByTestTag(tag: String): List<Any> = emptyList()
+
+    @Suppress("unused") fun screenshot(region: Rectangle?): BufferedImage = screenshotImpl(region)
+
+    @Suppress("unused")
+    fun screenshotAtDeviceScale(region: Rectangle?): BufferedImage =
+        screenshotAtDeviceScaleImpl(region)
+}
+
+/** An injected `core` from before device-scale stills existed: no `screenshotAtDeviceScale`. */
+private class FakeLegacyStillAutomator(private val screenshotImpl: (Rectangle?) -> BufferedImage) {
+    @Suppress("unused") fun refreshWindows() = Unit
+
+    @Suppress("unused") fun getWindows(): List<Any> = emptyList()
+
+    @Suppress("unused") fun allNodes(): List<Any> = emptyList()
+
+    @Suppress("unused") fun findByTestTag(tag: String): List<Any> = emptyList()
+
+    @Suppress("unused") fun screenshot(region: Rectangle?): BufferedImage = screenshotImpl(region)
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsEnvProbe.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsEnvProbe.kt
@@ -1,0 +1,16 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+
+/**
+ * Prints the frame budget this JVM resolved at class-initialization time.
+ *
+ * Spawned by [FrameLimitsEnvTest]. The environment is only read inside `FrameLimits`' own
+ * initializer, so the override path can only be exercised in a process that started with the
+ * variable already set — an in-process test always finds the class initialized.
+ */
+public fun main() {
+    println("budget=${FrameLimits.maxFrameBytes}")
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsEnvTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsEnvTest.kt
@@ -1,0 +1,64 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `FrameLimits` reads `SPECTRE_MAX_FRAME_BYTES` in its own static initializer, so a JVM that starts
+ * with the variable set takes a code path no in-process test can reach — the class is already
+ * initialized by then. A field ordering slip there once made the class fail to load on exactly the
+ * machines that configured the override, so this spawns a real JVM to cover it.
+ */
+class FrameLimitsEnvTest {
+
+    @Test
+    fun `an unset environment resolves the default budget`() {
+        assertEquals("budget=$DEFAULT_MAX_FRAME_BYTES", runProbe(override = null))
+    }
+
+    @Test
+    fun `a JVM started with the override resolves and applies it`() {
+        assertEquals("budget=${128 * 1024 * 1024}", runProbe(override = "128MiB"))
+    }
+
+    @Test
+    fun `an unparseable override still boots on the default`() {
+        assertEquals("budget=$DEFAULT_MAX_FRAME_BYTES", runProbe(override = "banana"))
+    }
+
+    @Test
+    fun `an override above the ceiling is clamped rather than refused`() {
+        assertEquals("budget=$MAX_FRAME_BYTES_CEILING", runProbe(override = "1G"))
+    }
+
+    private fun runProbe(override: String?): String {
+        val java = java.nio.file.Path.of(System.getProperty("java.home"), "bin", "java").toString()
+        val builder =
+            ProcessBuilder(java, "-cp", System.getProperty("java.class.path"), PROBE_MAIN_CLASS)
+        builder.redirectErrorStream(true)
+        if (override == null) {
+            builder.environment().remove(FrameLimits.ENV_VAR)
+        } else {
+            builder.environment()[FrameLimits.ENV_VAR] = override
+        }
+        val process = builder.start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        assertTrue(
+            process.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+            "probe JVM did not exit in time",
+        )
+        assertEquals(0, process.exitValue(), "probe JVM failed to start FrameLimits:\n$output")
+        return output.trim().lines().last()
+    }
+
+    private companion object {
+        const val PROBE_MAIN_CLASS: String =
+            "dev.sebastiano.spectre.agent.transport.FrameLimitsEnvProbeKt"
+        const val PROBE_TIMEOUT_SECONDS: Long = 60
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsEnvTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsEnvTest.kt
@@ -4,6 +4,7 @@ package dev.sebastiano.spectre.agent.transport
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -47,18 +48,32 @@ class FrameLimitsEnvTest {
             builder.environment()[FrameLimits.ENV_VAR] = override
         }
         val process = builder.start()
-        val output = process.inputStream.bufferedReader().use { it.readText() }
-        assertTrue(
-            process.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS),
-            "probe JVM did not exit in time",
+        // Drain on a daemon thread rather than readText() on this one: reading to EOF before
+        // waitFor has no timeout, so a probe JVM that never exits would hang the test — and the
+        // whole CI job — instead of failing. Same shape as core's bounded xdpyinfo probe.
+        val output = AtomicReference("")
+        val drain =
+            Thread({ runCatching { output.set(process.inputStream.bufferedReader().readText()) } })
+                .apply {
+                    isDaemon = true
+                    start()
+                }
+        val exited = process.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        if (!exited) process.destroyForcibly()
+        drain.join(DRAIN_JOIN_MS)
+        assertTrue(exited, "probe JVM did not exit in time; output so far:\n${output.get()}")
+        assertEquals(
+            0,
+            process.exitValue(),
+            "probe JVM failed to start FrameLimits:\n${output.get()}",
         )
-        assertEquals(0, process.exitValue(), "probe JVM failed to start FrameLimits:\n$output")
-        return output.trim().lines().last()
+        return output.get().trim().lines().last()
     }
 
     private companion object {
         const val PROBE_MAIN_CLASS: String =
             "dev.sebastiano.spectre.agent.transport.FrameLimitsEnvProbeKt"
         const val PROBE_TIMEOUT_SECONDS: Long = 60
+        const val DRAIN_JOIN_MS: Long = 5_000
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsTest.kt
@@ -75,6 +75,27 @@ class FrameLimitsTest {
     }
 
     @Test
+    fun `refuses a budget too small to carry the protocol's own frames`() {
+        // A budget of 1 is "positive and under the ceiling" but cannot even frame a Hello, so
+        // every operation fails — including the `spectre daemon kill` used to recover.
+        assertFailsWith<IllegalArgumentException> { FrameLimits.configure(1) }
+        assertFailsWith<IllegalArgumentException> { FrameLimits.configure(MIN_MAX_FRAME_BYTES - 1) }
+        FrameLimits.configure(MIN_MAX_FRAME_BYTES)
+        FrameLimits.resetToEnvironment()
+    }
+
+    @Test
+    fun `an environment budget below the minimum falls back to the default`() {
+        assertEquals(
+            DEFAULT_MAX_FRAME_BYTES,
+            FrameLimits.resolveBudget { name -> if (name == FrameLimits.ENV_VAR) "1" else null },
+        )
+        assertNull(
+            FrameLimits.resolveRequest { name -> if (name == FrameLimits.ENV_VAR) "1" else null }
+        )
+    }
+
+    @Test
     fun `configure refuses a budget above the read ceiling`() {
         assertFailsWith<IllegalArgumentException> {
                 FrameLimits.configure(MAX_FRAME_BYTES_CEILING + 1)
@@ -132,8 +153,8 @@ class FrameLimitsTest {
     fun `configure applies and restores a budget`() {
         val original = FrameLimits.maxFrameBytes
         try {
-            FrameLimits.configure(1234)
-            assertEquals(1234, FrameLimits.maxFrameBytes)
+            FrameLimits.configure(MIN_MAX_FRAME_BYTES)
+            assertEquals(MIN_MAX_FRAME_BYTES, FrameLimits.maxFrameBytes)
         } finally {
             FrameLimits.configure(original)
         }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsTest.kt
@@ -74,6 +74,52 @@ class FrameLimitsTest {
     }
 
     @Test
+    fun `nothing is requested until something asks`() {
+        val restore = FrameLimits.maxFrameBytes
+        try {
+            FrameLimits.resetToEnvironment()
+            assertNull(
+                FrameLimits.requestedMaxFrameBytes,
+                "an unset environment must not look like an explicit request",
+            )
+            assertEquals(DEFAULT_MAX_FRAME_BYTES, FrameLimits.maxFrameBytes)
+        } finally {
+            FrameLimits.configure(restore)
+        }
+    }
+
+    @Test
+    fun `a request equal to the default is still a request`() {
+        val restore = FrameLimits.maxFrameBytes
+        try {
+            FrameLimits.configure(DEFAULT_MAX_FRAME_BYTES)
+            assertEquals(
+                DEFAULT_MAX_FRAME_BYTES,
+                FrameLimits.requestedMaxFrameBytes,
+                "intent must not be inferred from the value matching the default",
+            )
+        } finally {
+            FrameLimits.configure(restore)
+        }
+    }
+
+    @Test
+    fun `an environment override counts as a request`() {
+        assertEquals(
+            32 * 1024 * 1024,
+            FrameLimits.resolveRequest { name ->
+                if (name == FrameLimits.ENV_VAR) "32MiB" else null
+            },
+        )
+        assertNull(FrameLimits.resolveRequest { null })
+        assertNull(
+            FrameLimits.resolveRequest { name ->
+                if (name == FrameLimits.ENV_VAR) "banana" else null
+            }
+        )
+    }
+
+    @Test
     fun `configure applies and restores a budget`() {
         val original = FrameLimits.maxFrameBytes
         try {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsTest.kt
@@ -66,6 +66,15 @@ class FrameLimitsTest {
     }
 
     @Test
+    fun `a suffixed size that would wrap Long is rejected, not silently shrunk`() {
+        // 18014398509481985 * 1024 wraps to 1024: without an overflow guard this configures a
+        // 1KiB budget and every ordinary IPC response then fails to frame.
+        assertNull(FrameLimits.parseMaxFrameBytes("18014398509481985k"))
+        assertNull(FrameLimits.parseMaxFrameBytes("9007199254740993M"))
+        assertNull(FrameLimits.parseMaxFrameBytes("${Long.MAX_VALUE}G"))
+    }
+
+    @Test
     fun `configure refuses a budget above the read ceiling`() {
         assertFailsWith<IllegalArgumentException> {
                 FrameLimits.configure(MAX_FRAME_BYTES_CEILING + 1)

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FrameLimitsTest.kt
@@ -1,0 +1,113 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The frame budget is the knob that decides whether a HiDPI fullscreen still fits on the wire. #204
+ * asked for it to be deterministic and documented rather than a round number nobody picked: the
+ * default holds a worst-case 4K desktop, and the override raises it for larger rigs.
+ */
+class FrameLimitsTest {
+
+    @Test
+    fun `default budget holds a worst-case 4K fullscreen still`() {
+        // A 3840x2160 screenshot is 8.3MP. PNG worst case is roughly raw bytes-per-pixel, so
+        // budget for 3 bytes per pixel (24-bit sRGB) with no compression win at all.
+        val worstCase4K = 3840L * 2160L * 3L
+        assertTrue(
+            DEFAULT_MAX_FRAME_BYTES >= worstCase4K,
+            "default $DEFAULT_MAX_FRAME_BYTES must hold an incompressible 4K still ($worstCase4K)",
+        )
+    }
+
+    @Test
+    fun `read ceiling stays above the default so a configured writer is always readable`() {
+        assertTrue(MAX_FRAME_BYTES_CEILING > DEFAULT_MAX_FRAME_BYTES)
+    }
+
+    @Test
+    fun `parses plain byte counts`() {
+        assertEquals(1024, FrameLimits.parseMaxFrameBytes("1024"))
+        assertEquals(64 * 1024 * 1024, FrameLimits.parseMaxFrameBytes(" 67108864 "))
+    }
+
+    @Test
+    fun `parses binary size suffixes`() {
+        assertEquals(64 * 1024 * 1024, FrameLimits.parseMaxFrameBytes("64M"))
+        assertEquals(64 * 1024 * 1024, FrameLimits.parseMaxFrameBytes("64MiB"))
+        assertEquals(128 * 1024, FrameLimits.parseMaxFrameBytes("128k"))
+        assertEquals(1024 * 1024 * 1024, FrameLimits.parseMaxFrameBytes("1G"))
+    }
+
+    @Test
+    fun `rejects values that are not a positive size`() {
+        assertNull(FrameLimits.parseMaxFrameBytes(null))
+        assertNull(FrameLimits.parseMaxFrameBytes(""))
+        assertNull(FrameLimits.parseMaxFrameBytes("zero"))
+        assertNull(FrameLimits.parseMaxFrameBytes("-5"))
+        assertNull(FrameLimits.parseMaxFrameBytes("0"))
+        assertNull(FrameLimits.parseMaxFrameBytes("12MB"))
+    }
+
+    @Test
+    fun `rejects sizes that overflow the ceiling instead of wrapping`() {
+        // 2GiB does not fit a signed Int; the parser must not wrap into a small or negative
+        // budget, which would silently shrink the limit instead of raising it.
+        assertNull(FrameLimits.parseMaxFrameBytes("2G"))
+        assertNull(FrameLimits.parseMaxFrameBytes("8G"))
+        assertNull(FrameLimits.parseMaxFrameBytes("999999999999"))
+    }
+
+    @Test
+    fun `configure refuses a budget above the read ceiling`() {
+        assertFailsWith<IllegalArgumentException> {
+                FrameLimits.configure(MAX_FRAME_BYTES_CEILING + 1)
+            }
+            .also { assertTrue(it.message.orEmpty().contains("ceiling", ignoreCase = true)) }
+    }
+
+    @Test
+    fun `configure applies and restores a budget`() {
+        val original = FrameLimits.maxFrameBytes
+        try {
+            FrameLimits.configure(1234)
+            assertEquals(1234, FrameLimits.maxFrameBytes)
+        } finally {
+            FrameLimits.configure(original)
+        }
+        assertEquals(original, FrameLimits.maxFrameBytes)
+    }
+
+    @Test
+    fun `environment override wins over the default`() {
+        assertEquals(
+            32 * 1024 * 1024,
+            FrameLimits.resolveBudget { name -> if (name == FrameLimits.ENV_VAR) "32MiB" else null },
+        )
+    }
+
+    @Test
+    fun `unparseable environment override falls back to the default`() {
+        assertEquals(
+            DEFAULT_MAX_FRAME_BYTES,
+            FrameLimits.resolveBudget { name ->
+                if (name == FrameLimits.ENV_VAR) "banana" else null
+            },
+        )
+    }
+
+    @Test
+    fun `environment override is clamped to the read ceiling`() {
+        assertEquals(
+            MAX_FRAME_BYTES_CEILING,
+            FrameLimits.resolveBudget { name -> if (name == FrameLimits.ENV_VAR) "1G" else null },
+        )
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt
@@ -84,23 +84,42 @@ class FramingTest {
     }
 
     @Test
-    fun `readFrame throws IllegalStateException on length above MAX_FRAME_BYTES`() {
-        // 32 MiB > 16 MiB cap.
-        val tooBig = ByteArrayInputStream(byteArrayOf(0x02, 0, 0, 0))
+    fun `readFrame throws IllegalStateException on length above the read ceiling`() {
+        // 0x40000000 = 1 GiB > the 512 MiB ceiling.
+        val tooBig = ByteArrayInputStream(byteArrayOf(0x40, 0, 0, 0))
         assertFailsWith<IllegalStateException> { Framing.readFrame(tooBig) }
     }
 
     @Test
-    fun `writeFrame throws when payload exceeds MAX_FRAME_BYTES`() {
-        val oversized = ByteArray(MAX_FRAME_BYTES + 1)
-        assertFailsWith<IllegalArgumentException> {
-            Framing.writeFrame(ByteArrayOutputStream(), oversized)
+    fun `readFrame accepts a length above this process's write budget`() {
+        // Readers must not reject what a peer on a larger budget legitimately sent; the header
+        // below claims 1 MiB against a 64 KiB write budget, so only the payload read should fail.
+        val restore = FrameLimits.maxFrameBytes
+        FrameLimits.configure(64 * 1024)
+        try {
+            val header = ByteArrayInputStream(byteArrayOf(0x00, 0x10, 0x00, 0x00))
+            assertFailsWith<java.io.EOFException> { Framing.readFrame(header) }
+        } finally {
+            FrameLimits.configure(restore)
         }
     }
 
     @Test
-    fun `roundtrip handles a payload exactly at MAX_FRAME_BYTES`() {
-        // Smaller test version: 1 MiB. We don't want a 16 MiB allocation per test run for
+    fun `writeFrame throws when payload exceeds the configured budget`() {
+        val restore = FrameLimits.maxFrameBytes
+        FrameLimits.configure(1024)
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                Framing.writeFrame(ByteArrayOutputStream(), ByteArray(1025))
+            }
+        } finally {
+            FrameLimits.configure(restore)
+        }
+    }
+
+    @Test
+    fun `roundtrip handles a large payload well under the budget`() {
+        // Smaller test version: 1 MiB. We don't want a full-budget allocation per test run for
         // CI hygiene; the boundary logic is identical at any size below the cap.
         val payload = ByteArray(1 shl 20) { (it % 256).toByte() }
         val buffer = ByteArrayOutputStream()

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/FramingTest.kt
@@ -95,7 +95,7 @@ class FramingTest {
         // Readers must not reject what a peer on a larger budget legitimately sent; the header
         // below claims 1 MiB against a 64 KiB write budget, so only the payload read should fail.
         val restore = FrameLimits.maxFrameBytes
-        FrameLimits.configure(64 * 1024)
+        FrameLimits.configure(MIN_MAX_FRAME_BYTES)
         try {
             val header = ByteArrayInputStream(byteArrayOf(0x00, 0x10, 0x00, 0x00))
             assertFailsWith<java.io.EOFException> { Framing.readFrame(header) }
@@ -107,10 +107,10 @@ class FramingTest {
     @Test
     fun `writeFrame throws when payload exceeds the configured budget`() {
         val restore = FrameLimits.maxFrameBytes
-        FrameLimits.configure(1024)
+        FrameLimits.configure(MIN_MAX_FRAME_BYTES)
         try {
             assertFailsWith<IllegalArgumentException> {
-                Framing.writeFrame(ByteArrayOutputStream(), ByteArray(1025))
+                Framing.writeFrame(ByteArrayOutputStream(), ByteArray(MIN_MAX_FRAME_BYTES + 1))
             }
         } finally {
             FrameLimits.configure(restore)

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/PayloadLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/PayloadLimitsTest.kt
@@ -28,40 +28,49 @@ class PayloadLimitsTest {
 
     @Test
     fun `oversized screenshot response returns payloadTooLarge`() {
+        // Shrink the budget rather than allocating a real one: this exercises the same guard, and
+        // proves FrameLimits.configure actually reaches the write path, without a 64 MiB array.
+        val restore = FrameLimits.maxFrameBytes
+        FrameLimits.configure(TEST_FRAME_BUDGET_BYTES)
         // A PNG larger than the frame budget once wrapped in OpResponse CBOR.
-        val hugePng = ByteArray(MAX_FRAME_BYTES) { 0xAB.toByte() }
-        IpcServer(
-                udsPath,
-                AgentRequestHandler { request ->
-                    when (request) {
-                        is AgentRequest.Screenshot -> AgentResponse.Screenshot(pngBytes = hugePng)
-                        AgentRequest.Ping -> AgentResponse.Pong
-                        else -> AgentResponse.Ok
-                    }
-                },
-            )
-            .use {
-                awaitSocket(udsPath)
-                IpcClient(udsPath).use { client ->
-                    val response =
-                        client.send(
-                            AgentRequest.Screenshot(
-                                windowIndex = 0,
-                                surfaceId = null,
-                                fullscreen = false,
+        val hugePng = ByteArray(TEST_FRAME_BUDGET_BYTES) { 0xAB.toByte() }
+        try {
+            IpcServer(
+                    udsPath,
+                    AgentRequestHandler { request ->
+                        when (request) {
+                            is AgentRequest.Screenshot ->
+                                AgentResponse.Screenshot(pngBytes = hugePng)
+                            AgentRequest.Ping -> AgentResponse.Pong
+                            else -> AgentResponse.Ok
+                        }
+                    },
+                )
+                .use {
+                    awaitSocket(udsPath)
+                    IpcClient(udsPath).use { client ->
+                        val response =
+                            client.send(
+                                AgentRequest.Screenshot(
+                                    windowIndex = 0,
+                                    surfaceId = null,
+                                    fullscreen = false,
+                                )
                             )
+                        val err = assertIs<AgentResponse.Error>(response)
+                        assertEquals(AgentErrorCategory.PayloadTooLarge.wireName, err.category)
+                        assertTrue(
+                            err.message.contains("MAX_FRAME_BYTES") ||
+                                err.message.contains("payload", ignoreCase = true),
+                            "expected size-limit message; got: ${err.message}",
                         )
-                    val err = assertIs<AgentResponse.Error>(response)
-                    assertEquals(AgentErrorCategory.PayloadTooLarge.wireName, err.category)
-                    assertTrue(
-                        err.message.contains("MAX_FRAME_BYTES") ||
-                            err.message.contains("payload", ignoreCase = true),
-                        "expected size-limit message; got: ${err.message}",
-                    )
-                    // Connection stays usable after a payloadTooLarge error.
-                    assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+                        // Connection stays usable after a payloadTooLarge error.
+                        assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+                    }
                 }
-            }
+        } finally {
+            FrameLimits.configure(restore)
+        }
     }
 
     @Test
@@ -69,15 +78,20 @@ class PayloadLimitsTest {
         val err =
             AgentResponse.Error(
                 message =
-                    "Response payload size ${MAX_FRAME_BYTES + 1} exceeds " +
-                        "MAX_FRAME_BYTES=$MAX_FRAME_BYTES",
+                    "Response payload size ${DEFAULT_MAX_FRAME_BYTES + 1} exceeds " +
+                        "MAX_FRAME_BYTES=$DEFAULT_MAX_FRAME_BYTES",
                 category = AgentErrorCategory.PayloadTooLarge.wireName,
             )
         val bytes = WireCodec.encode(OpResponse(opId = 1L, body = err))
         assertTrue(
-            bytes.size < MAX_FRAME_BYTES,
+            bytes.size < DEFAULT_MAX_FRAME_BYTES,
             "taxonomy error itself must always fit under the frame cap (${bytes.size})",
         )
+    }
+
+    private companion object {
+        /** Small enough to keep the oversized-payload array cheap, large enough to frame. */
+        const val TEST_FRAME_BUDGET_BYTES: Int = 256 * 1024
     }
 
     private fun awaitSocket(path: Path, timeoutMs: Long = 5_000) {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/ProtocolCompatTest.kt
@@ -24,6 +24,16 @@ import org.junit.jupiter.api.condition.OS
  */
 @EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
 class ProtocolCompatTest {
+
+    @Test
+    fun `the byte-string payload encoding has its own protocol revision`() {
+        // AttachOptions.agentJarPath and the runtime-jar system property let a caller pair this
+        // library with a runtime built on either side of the @ByteString change. Both would
+        // otherwise advertise the same version, pass the exact-match handshake, and only fail when
+        // a screenshot came back in the encoding the peer does not speak.
+        assertEquals(3, ProtocolVersion.CURRENT, "bump this when the wire representation changes")
+    }
+
     private val udsPath: Path =
         udsBase().resolve("sp-pc-${UUID.randomUUID().toString().take(8)}.sock")
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WirePayloadEncodingTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WirePayloadEncodingTest.kt
@@ -1,0 +1,87 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * Bulk payloads must reach the wire as CBOR byte strings, not arrays of integers.
+ *
+ * Without `@ByteString`, kotlinx serializes each signed byte as its own CBOR integer and the
+ * encoded response runs about 1.8x the payload. Every budget in the transport is expressed against
+ * payload size — the still-fallback threshold, the atomic-capture guard, and the "64MiB holds a
+ * worst-case 4K desktop" sizing — so that expansion silently invalidates all of them: a still that
+ * passes its check still frames past the budget, and the documented fallback never runs.
+ */
+class WirePayloadEncodingTest {
+
+    @Test
+    fun `a screenshot response does not balloon on the wire`() {
+        // Incompressible payload: CBOR does not compress, so any growth here is pure encoding.
+        val png = Random(1).nextBytes(1 shl 20)
+
+        val encoded = WireCodec.encode(OpResponse(opId = 1L, body = AgentResponse.Screenshot(png)))
+
+        assertTrue(
+            encoded.size < png.size + ENVELOPE_SLACK_BYTES,
+            "encoded ${encoded.size} for a ${png.size} payload — byte fields must be CBOR byte " +
+                "strings, or every payload budget in this transport is wrong",
+        )
+    }
+
+    @Test
+    fun `an atomic capture response does not balloon on the wire`() {
+        val png = Random(2).nextBytes(1 shl 20)
+        val json = Random(3).nextBytes(1 shl 16)
+
+        val encoded =
+            WireCodec.encode(
+                OpResponse(
+                    opId = 1L,
+                    body =
+                        AgentResponse.Capture(
+                            windowIndex = 0,
+                            schemaVersion = 1,
+                            captureJsonUtf8 = json,
+                            pngBytes = png,
+                            nodeCount = 1,
+                            taggedNodeCount = 1,
+                            textedNodeCount = 1,
+                            imageWidth = 10,
+                            imageHeight = 10,
+                            captureDurationMs = 1L,
+                        ),
+                )
+            )
+
+        assertTrue(
+            encoded.size < png.size + json.size + ENVELOPE_SLACK_BYTES,
+            "encoded ${encoded.size} for ${png.size + json.size} of payload",
+        )
+    }
+
+    @Test
+    fun `byte payloads survive the round trip unchanged`() {
+        val png = Random(4).nextBytes(4096)
+
+        val decoded =
+            WireCodec.decodeOpResponse(
+                WireCodec.encode(OpResponse(7L, AgentResponse.Screenshot(png)))
+            )
+
+        val body = assertIs<AgentResponse.Screenshot>(decoded.body)
+        assertContentEquals(png, body.pngBytes)
+    }
+
+    private companion object {
+        /**
+         * Frame headers, op id, and the discriminator — kilobytes, not a multiple of the payload.
+         */
+        const val ENVELOPE_SLACK_BYTES: Int = 4096
+    }
+}

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -7,6 +7,7 @@ import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.parse
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
@@ -14,6 +15,7 @@ import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.long
 import com.github.ajalt.clikt.parameters.types.path
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import dev.sebastiano.spectre.cli.daemon.CaptureSessionReport
@@ -168,7 +170,37 @@ private class RootCommand(
         )
     }
 
-    override fun run(): Unit = Unit
+    /**
+     * IPC frame write budget for this invocation, and for the daemon if this invocation starts it.
+     *
+     * A daemon that is already running keeps the budget it booted with — restart it (`spectre
+     * daemon stop`) to change it. Raising the budget on one hop is never harmful on its own:
+     * readers accept frames up to a fixed ceiling regardless of their own budget.
+     */
+    private val maxFrameBytes: Int? by
+        option(
+                "--max-frame-bytes",
+                help =
+                    "Largest IPC frame payload, e.g. 64MiB (default) or 256MiB. Raise it for " +
+                        "multi-monitor HiDPI fullscreen screenshots. Overrides " +
+                        "\$SPECTRE_MAX_FRAME_BYTES; applies to a daemon this command starts.",
+            )
+            .convert { raw ->
+                FrameLimits.parseMaxFrameBytes(raw)
+                    ?: throw CliktError(
+                        "--max-frame-bytes must be a positive size (e.g. 64MiB), got '$raw'"
+                    )
+            }
+
+    override fun run() {
+        maxFrameBytes?.let { budget ->
+            try {
+                FrameLimits.configure(budget)
+            } catch (exception: IllegalArgumentException) {
+                throw CliktError(exception.message ?: "invalid --max-frame-bytes", exception)
+            }
+        }
+    }
 }
 
 private class McpCommand(private val request: (DaemonRequest) -> DaemonResponse) :

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -175,6 +175,7 @@ private class RootCommand(
      *
      * A daemon that is already running keeps the budget it booted with, so asking for a different
      * one is refused at the handshake rather than half-applied — see `frameBudgetMismatchFailure`.
+     * Scoped to one invocation: each `run` re-resolves from the environment before applying it.
      */
     private val maxFrameBytes: Int? by
         option(
@@ -194,6 +195,10 @@ private class RootCommand(
             }
 
     override fun run() {
+        // Re-resolve per invocation: SpectreCli.run can be called repeatedly in one process, and a
+        // --max-frame-bytes from an earlier call would otherwise leave this one silently requesting
+        // a budget it never asked for — enough to fail the daemon handshake or boot a daemon on it.
+        FrameLimits.resetToEnvironment()
         maxFrameBytes?.let { budget ->
             try {
                 FrameLimits.configure(budget)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -224,8 +224,8 @@ private class ScreenshotCommand(
         option(
                 "--fullscreen",
                 help =
-                    "Capture the full virtual desktop (explicit opt-in; the only screen-pixel " +
-                        "mode on this CLI path).",
+                    "Capture the full virtual desktop (explicit opt-in; the only whole-desktop " +
+                        "mode on this CLI path). The PNG is screen-pixel sized, not dp sized.",
             )
             .flag(default = false)
     private val json: Boolean by option("--json").flag(default = false)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -173,9 +173,8 @@ private class RootCommand(
     /**
      * IPC frame write budget for this invocation, and for the daemon if this invocation starts it.
      *
-     * A daemon that is already running keeps the budget it booted with — restart it (`spectre
-     * daemon stop`) to change it. Raising the budget on one hop is never harmful on its own:
-     * readers accept frames up to a fixed ceiling regardless of their own budget.
+     * A daemon that is already running keeps the budget it booted with, so asking for a different
+     * one is refused at the handshake rather than half-applied — see `frameBudgetMismatchFailure`.
      */
     private val maxFrameBytes: Int? by
         option(
@@ -183,7 +182,9 @@ private class RootCommand(
                 help =
                     "Largest IPC frame payload, e.g. 64MiB (default) or 256MiB. Raise it for " +
                         "multi-monitor HiDPI fullscreen screenshots. Overrides " +
-                        "\$SPECTRE_MAX_FRAME_BYTES; applies to a daemon this command starts.",
+                        "\$SPECTRE_MAX_FRAME_BYTES. Applies to a daemon this command starts; " +
+                        "against an already-running daemon on another budget it fails rather " +
+                        "than half-applying (run `spectre daemon kill` first).",
             )
             .convert { raw ->
                 FrameLimits.parseMaxFrameBytes(raw)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -1,5 +1,8 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.DEFAULT_MAX_FRAME_BYTES
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import java.io.EOFException
 import java.io.IOException
 import java.net.SocketException
@@ -12,6 +15,7 @@ import java.nio.file.NoSuchFileException
 import java.nio.file.Path
 
 /** One-request client for the local Spectre daemon protocol. */
+@OptIn(ExperimentalSpectreAgentApi::class)
 public class DaemonClient(public val socketPath: Path) : AutoCloseable {
     /** Starts the daemon when its endpoint is absent, then sends [request]. */
     @Throws(IOException::class)
@@ -75,6 +79,11 @@ public class DaemonClient(public val socketPath: Path) : AutoCloseable {
                         daemonCompatibilityFailure(requiredVersion, response.daemonVersion)
                     )
                 }
+                frameBudgetMismatchFailure(
+                        requested = FrameLimits.maxFrameBytes,
+                        daemonBudget = response.maxFrameBytes,
+                    )
+                    ?.let { throw IOException(it) }
             }
             is DaemonResponse.Error ->
                 throw IOException(daemonHandshakeFailure(requiredVersion, response))
@@ -96,6 +105,38 @@ public class DaemonClient(public val socketPath: Path) : AutoCloseable {
 
 internal class DaemonConnectionClosedException(cause: Throwable? = null) :
     IOException("Daemon closed the connection during handshake", cause)
+
+/**
+ * Explains why a requested frame budget cannot take effect, or `null` when it can.
+ *
+ * The daemon is long-lived and shared, so it keeps the budget it booted with: `--max-frame-bytes`
+ * on a later invocation would otherwise apply to the CLI alone while the two hops that actually
+ * carry a screenshot — target to daemon, daemon to CLI — stayed on the old value.
+ *
+ * Only an explicit request is worth failing over. A client left on [DEFAULT_MAX_FRAME_BYTES] asked
+ * for nothing, and readers accept frames up to the fixed ceiling whatever their own budget, so a
+ * daemon running something larger is harmless. A daemon too old to report its budget cannot have
+ * been started with the requested one, so it is refused the same way rather than assumed.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal fun frameBudgetMismatchFailure(requested: Int, daemonBudget: Int?): String? {
+    if (requested == DEFAULT_MAX_FRAME_BYTES) return null
+    if (daemonBudget == requested) return null
+    val running =
+        if (daemonBudget == null) "a version that predates the setting"
+        else "${renderFrameBudget(daemonBudget)} (${daemonBudget} bytes)"
+    return "Cannot honour --max-frame-bytes=${renderFrameBudget(requested)} " +
+        "(${requested} bytes): the running Spectre daemon started with $running, and a daemon " +
+        "keeps the budget it booted with. Run `spectre daemon kill` and retry so the new budget " +
+        "applies to the daemon and to the JVMs it injects."
+}
+
+/** Renders [bytes] in the largest binary unit that divides it, matching what the flag accepts. */
+internal fun renderFrameBudget(bytes: Int): String {
+    val units = listOf("GiB" to (1 shl 30), "MiB" to (1 shl 20), "KiB" to (1 shl 10))
+    val unit = units.firstOrNull { (_, size) -> bytes >= size && bytes % size == 0 }
+    return if (unit == null) "$bytes bytes" else "${bytes / unit.second}${unit.first}"
+}
 
 internal fun daemonCompatibilityFailure(
     required: DaemonProtocolVersion,

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -78,11 +78,13 @@ public class DaemonClient(public val socketPath: Path) : AutoCloseable {
                         daemonCompatibilityFailure(requiredVersion, response.daemonVersion)
                     )
                 }
-                frameBudgetMismatchFailure(
-                        requested = FrameLimits.requestedMaxFrameBytes,
-                        daemonBudget = response.maxFrameBytes,
-                    )
-                    ?.let { throw IOException(it) }
+                if (!ignoresFrameBudget(request)) {
+                    frameBudgetMismatchFailure(
+                            requested = FrameLimits.requestedMaxFrameBytes,
+                            daemonBudget = response.maxFrameBytes,
+                        )
+                        ?.let { throw IOException(it) }
+                }
             }
             is DaemonResponse.Error ->
                 throw IOException(daemonHandshakeFailure(requiredVersion, response))
@@ -104,6 +106,16 @@ public class DaemonClient(public val socketPath: Path) : AutoCloseable {
 
 internal class DaemonConnectionClosedException(cause: Throwable? = null) :
     IOException("Daemon closed the connection during handshake", cause)
+
+/**
+ * Requests exempt from the frame-budget check.
+ *
+ * The mismatch error tells the user to run `spectre daemon kill`, which inherits the same
+ * `SPECTRE_MAX_FRAME_BYTES` and would hit the same check — leaving the documented recovery path a
+ * dead end and the daemon killable only by hand. Shutdown carries no bulky payload, so exempting it
+ * costs nothing.
+ */
+internal fun ignoresFrameBudget(request: DaemonRequest): Boolean = request is DaemonRequest.Shutdown
 
 /**
  * Explains why a requested frame budget cannot take effect, or `null` when it can.

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -1,7 +1,6 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
-import dev.sebastiano.spectre.agent.transport.DEFAULT_MAX_FRAME_BYTES
 import dev.sebastiano.spectre.agent.transport.FrameLimits
 import java.io.EOFException
 import java.io.IOException
@@ -80,7 +79,7 @@ public class DaemonClient(public val socketPath: Path) : AutoCloseable {
                     )
                 }
                 frameBudgetMismatchFailure(
-                        requested = FrameLimits.maxFrameBytes,
+                        requested = FrameLimits.requestedMaxFrameBytes,
                         daemonBudget = response.maxFrameBytes,
                     )
                     ?.let { throw IOException(it) }
@@ -113,14 +112,16 @@ internal class DaemonConnectionClosedException(cause: Throwable? = null) :
  * on a later invocation would otherwise apply to the CLI alone while the two hops that actually
  * carry a screenshot — target to daemon, daemon to CLI — stayed on the old value.
  *
- * Only an explicit request is worth failing over. A client left on [DEFAULT_MAX_FRAME_BYTES] asked
- * for nothing, and readers accept frames up to the fixed ceiling whatever their own budget, so a
- * daemon running something larger is harmless. A daemon too old to report its budget cannot have
- * been started with the requested one, so it is refused the same way rather than assumed.
+ * Only an explicit request is worth failing over, which is why [requested] is nullable rather than
+ * compared against [DEFAULT_MAX_FRAME_BYTES]: a client that asked for nothing is happy with any
+ * daemon, since readers accept frames up to the fixed ceiling whatever their own budget, while a
+ * client that explicitly asked for the default-sized budget is still asking. A daemon too old to
+ * report its budget cannot have been started with the requested one, so it is refused the same way
+ * rather than assumed.
  */
 @OptIn(ExperimentalSpectreAgentApi::class)
-internal fun frameBudgetMismatchFailure(requested: Int, daemonBudget: Int?): String? {
-    if (requested == DEFAULT_MAX_FRAME_BYTES) return null
+internal fun frameBudgetMismatchFailure(requested: Int?, daemonBudget: Int?): String? {
+    if (requested == null) return null
     if (daemonBudget == requested) return null
     val running =
         if (daemonBudget == null) "a version that predates the setting"

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFraming.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFraming.kt
@@ -1,16 +1,17 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.agent.transport.Framing
-import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES
 import java.io.InputStream
 import java.io.OutputStream
 
 @OptIn(ExperimentalSpectreAgentApi::class)
 /** Length-prefixed binary framing for the Spectre CLI/daemon wire protocol. */
 public object DaemonFraming {
-    /** Default upper bound on a single daemon frame payload. */
-    public const val MaxFrameBytes: Int = MAX_FRAME_BYTES
+    /** Largest payload this process writes into one daemon frame; see `FrameLimits`. */
+    public val MaxFrameBytes: Int
+        get() = FrameLimits.maxFrameBytes
 
     /** Write one `[4-byte big-endian length][payload]` frame and flush [output]. */
     @Throws(java.io.IOException::class)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonMain.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonMain.kt
@@ -1,25 +1,49 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import java.io.IOException
 import java.nio.file.Path
 
 /** Runnable entrypoint for one Spectre daemon process. */
+@OptIn(ExperimentalSpectreAgentApi::class)
 public object DaemonMain {
     /** Starts the daemon at the socket supplied by [arguments]. */
     @Throws(IOException::class, InterruptedException::class)
     public fun run(arguments: List<String>) {
+        // Applied before the socket opens so every frame this daemon writes — and every budget it
+        // forwards into an injected JVM — uses the configured value.
+        maxFrameBytes(arguments)?.let(FrameLimits::configure)
         DaemonProcess(socketPath(arguments)).use { process -> process.runUntilShutdown() }
     }
 
     /** Extracts the socket location from the daemon-only command line. */
     public fun socketPath(arguments: List<String>): Path {
-        require(arguments.size == 2 && arguments.first() == SOCKET_OPTION) {
-            "Usage: spectre-daemon --socket <path>"
+        val index = arguments.indexOf(SOCKET_OPTION)
+        require(index >= 0 && index + 1 < arguments.size) { USAGE }
+        return Path.of(arguments[index + 1])
+    }
+
+    /**
+     * Extracts the optional IPC frame budget; `null` leaves the daemon on the default.
+     *
+     * @throws IllegalArgumentException when the option is present but not a usable size, so a typo
+     *   fails the daemon at startup rather than silently reverting it to the default.
+     */
+    public fun maxFrameBytes(arguments: List<String>): Int? {
+        val index = arguments.indexOf(MAX_FRAME_BYTES_OPTION)
+        if (index < 0) return null
+        require(index + 1 < arguments.size) { USAGE }
+        val raw = arguments[index + 1]
+        return requireNotNull(FrameLimits.parseMaxFrameBytes(raw)) {
+            "$MAX_FRAME_BYTES_OPTION must be a positive size (e.g. 64MiB), got '$raw'"
         }
-        return Path.of(arguments[1])
     }
 
     private const val SOCKET_OPTION: String = "--socket"
+    private const val MAX_FRAME_BYTES_OPTION: String = "--max-frame-bytes"
+    private const val USAGE: String =
+        "Usage: spectre-daemon --socket <path> [--max-frame-bytes <size>]"
 }
 
 @Throws(IOException::class, InterruptedException::class)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -1,10 +1,14 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.DEFAULT_MAX_FRAME_BYTES
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 
 /** Starts a detached JVM hosting [DaemonMain] for one local socket endpoint. */
+@OptIn(ExperimentalSpectreAgentApi::class)
 public class DaemonProcessLauncher(
     private val socketPath: Path,
     private val javaExecutable: String = defaultJavaExecutable(),
@@ -56,6 +60,12 @@ public class DaemonProcessLauncher(
         add(DAEMON_MAIN_CLASS)
         add("--socket")
         add(socketPath.toString())
+        // Only pin the budget when this process is running a non-default one, so an ordinary
+        // daemon keeps inheriting whatever the shipped default becomes.
+        if (FrameLimits.maxFrameBytes != DEFAULT_MAX_FRAME_BYTES) {
+            add("--max-frame-bytes")
+            add(FrameLimits.maxFrameBytes.toString())
+        }
     }
 
     private fun agentRuntimePropertyArgument(): List<String> =

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -1,7 +1,6 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
-import dev.sebastiano.spectre.agent.transport.DEFAULT_MAX_FRAME_BYTES
 import dev.sebastiano.spectre.agent.transport.FrameLimits
 import java.io.IOException
 import java.nio.file.Files
@@ -60,11 +59,13 @@ public class DaemonProcessLauncher(
         add(DAEMON_MAIN_CLASS)
         add("--socket")
         add(socketPath.toString())
-        // Only pin the budget when this process is running a non-default one, so an ordinary
-        // daemon keeps inheriting whatever the shipped default becomes.
-        if (FrameLimits.maxFrameBytes != DEFAULT_MAX_FRAME_BYTES) {
+        // Pin the budget whenever one was explicitly asked for, even if it equals the default:
+        // the daemon inherits this process's environment, so `--max-frame-bytes 64MiB` over a
+        // `SPECTRE_MAX_FRAME_BYTES=128MiB` would otherwise boot the daemon on 128MiB. With no
+        // explicit request the daemon resolves the same environment and lands on the same value.
+        FrameLimits.requestedMaxFrameBytes?.let { budget ->
             add("--max-frame-bytes")
-            add(FrameLimits.maxFrameBytes.toString())
+            add(budget.toString())
         }
     }
 

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -29,6 +29,24 @@ public object DaemonProtocol {
             else -> VersionCompatibility.Compatible
         }
 
+    /**
+     * True when [handshake] predates the byte-string payload encoding.
+     *
+     * Newer daemons otherwise serve older clients happily, and that still holds for every op whose
+     * response carries no bulk bytes. `Screenshot` is the exception: from
+     * [SCREEN_PIXEL_STILLS_INTRODUCED_MINOR] on, `pngBytes` goes out as a CBOR byte string, which a
+     * client built earlier decodes as an integer array.
+     *
+     * The check is per request rather than at the handshake because `DaemonRequest.Hello` carries
+     * the *minimum* version the pending request needs, not the client's build: a current CLI
+     * running `ps` legitimately announces 1.3. A current CLI issuing a screenshot announces 1.12,
+     * because [minimumDaemonVersion] floors that op there — so an announcement below the floor on a
+     * screenshot is exactly an old client.
+     */
+    internal fun clientPredatesBinaryPayloads(handshake: DaemonProtocolVersion): Boolean =
+        handshake.major == CurrentVersion.major &&
+            handshake.minor < SCREEN_PIXEL_STILLS_INTRODUCED_MINOR
+
     internal fun minimumDaemonVersion(request: DaemonRequest): DaemonProtocolVersion =
         when (request) {
             is DaemonRequest.Hello -> versionFor(MINIMUM_PROTOCOL_MINOR)
@@ -105,7 +123,7 @@ public object DaemonProtocol {
      * the old 16 MiB budget, and the upgrade would silently do nothing. Requiring 1.12 turns that
      * into the existing "daemon protocol is too old, run `spectre daemon kill`" error instead.
      */
-    private const val SCREEN_PIXEL_STILLS_INTRODUCED_MINOR: Int = 12
+    internal const val SCREEN_PIXEL_STILLS_INTRODUCED_MINOR: Int = 12
 }
 
 @Serializable public data class DaemonProtocolVersion(public val major: Int, public val minor: Int)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -60,8 +60,17 @@ public object DaemonProtocol {
                 }
             is DaemonRequest.StopRecording,
             is DaemonRequest.RecordingStatus -> versionFor(RECORDING_SESSION_INTRODUCED_MINOR)
-            is DaemonRequest.Capture -> versionFor(CAPTURE_INTRODUCED_MINOR)
-            is DaemonRequest.Screenshot -> versionFor(SCREENSHOT_TARGETING_INTRODUCED_MINOR)
+            // Each still op needs the minor that introduced it *and* the minor its pixels
+            // changed in: an older daemon answers these "successfully" but with dp-sized stills.
+            is DaemonRequest.Capture ->
+                versionFor(maxOf(CAPTURE_INTRODUCED_MINOR, SCREEN_PIXEL_STILLS_INTRODUCED_MINOR))
+            is DaemonRequest.Screenshot ->
+                versionFor(
+                    maxOf(
+                        SCREENSHOT_TARGETING_INTRODUCED_MINOR,
+                        SCREEN_PIXEL_STILLS_INTRODUCED_MINOR,
+                    )
+                )
         }
 
     private fun versionFor(minor: Int): DaemonProtocolVersion =
@@ -85,6 +94,17 @@ public object DaemonProtocol {
     private const val SELECTOR_PARITY_INTRODUCED_MINOR: Int = 10
     /** waitForReloadSettled for Compose Hot Reload awareness (#211). */
     private const val RELOAD_SETTLE_INTRODUCED_MINOR: Int = 11
+
+    /**
+     * Screen-pixel stills, the 64 MiB frame budget, and `Hello.maxFrameBytes`.
+     *
+     * A behaviour floor rather than a capability one. The daemon endpoint is `daemon-v1.sock`,
+     * stable across minors, so an upgraded CLI reaches a daemon still running the previous build —
+     * which would answer `capture` and `screenshot` perfectly well, just with dp-sized pixels on
+     * the old 16 MiB budget, and the upgrade would silently do nothing. Requiring 1.12 turns that
+     * into the existing "daemon protocol is too old, run `spectre daemon kill`" error instead.
+     */
+    private const val SCREEN_PIXEL_STILLS_INTRODUCED_MINOR: Int = 12
 }
 
 @Serializable public data class DaemonProtocolVersion(public val major: Int, public val minor: Int)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.cbor.Cbor
 /** Shared client/daemon wire protocol metadata for Spectre's agent-facing entrypoints. */
 @OptIn(ExperimentalSerializationApi::class)
 public object DaemonProtocol {
-    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 11)
+    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 12)
 
     public val cbor: Cbor = Cbor {
         ignoreUnknownKeys = true
@@ -281,8 +281,16 @@ public sealed interface DaemonRequest {
 @OptIn(ExperimentalSpectreAgentApi::class)
 @Serializable
 public sealed interface DaemonResponse {
+    /**
+     * @property maxFrameBytes the frame write budget this daemon booted with. `null` from a daemon
+     *   that predates budget reporting, which is indistinguishable from "not the budget you asked
+     *   for" — see `frameBudgetMismatchFailure`.
+     */
     @Serializable
-    public data class Hello(public val daemonVersion: DaemonProtocolVersion) : DaemonResponse
+    public data class Hello(
+        public val daemonVersion: DaemonProtocolVersion,
+        public val maxFrameBytes: Int? = null,
+    ) : DaemonResponse
 
     @Serializable
     @SerialName("attached")

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -6,6 +6,7 @@ import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.cbor.ByteString
 import kotlinx.serialization.cbor.Cbor
 
 /** Shared client/daemon wire protocol metadata for Spectre's agent-facing entrypoints. */
@@ -358,8 +359,10 @@ public sealed interface DaemonResponse {
 
     @Serializable
     @SerialName("screenshot")
-    public data class Screenshot(public val sessionId: String, public val pngBytes: ByteArray) :
-        DaemonResponse {
+    public data class Screenshot(
+        public val sessionId: String,
+        @ByteString public val pngBytes: ByteArray,
+    ) : DaemonResponse {
         override fun equals(other: Any?): Boolean =
             other is Screenshot &&
                 sessionId == other.sessionId &&

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServer.kt
@@ -184,12 +184,14 @@ public constructor(
                 val input = Channels.newInputStream(channel)
                 val output = Channels.newOutputStream(channel)
                 var handshakeComplete = false
+                var handshakeVersion: DaemonProtocolVersion? = null
                 while (running.get()) {
                     val request = DaemonWireCodec.readRequest(input) ?: return
                     synchronized(activityLock) { lastActivityNanos = System.nanoTime() }
-                    val response = handleRequest(request, handshakeComplete)
+                    val response = handleRequest(request, handshakeComplete, handshakeVersion)
                     if (request is DaemonRequest.Hello) {
                         handshakeComplete = response is DaemonResponse.Hello
+                        handshakeVersion = request.clientVersion.takeIf { handshakeComplete }
                     }
                     val isShutdown = request is DaemonRequest.Shutdown && handshakeComplete
                     if (isShutdown) {
@@ -209,7 +211,11 @@ public constructor(
         }
     }
 
-    private fun handleRequest(request: DaemonRequest, handshakeComplete: Boolean): DaemonResponse =
+    private fun handleRequest(
+        request: DaemonRequest,
+        handshakeComplete: Boolean,
+        handshakeVersion: DaemonProtocolVersion?,
+    ): DaemonResponse =
         when (request) {
             is DaemonRequest.Hello ->
                 when (
@@ -224,6 +230,26 @@ public constructor(
                             code = DaemonErrorCode.ProtocolError,
                             message = "incompatible daemon protocol version",
                         )
+                }
+            is DaemonRequest.Screenshot ->
+                if (!handshakeComplete) {
+                    DaemonResponse.Error(
+                        code = DaemonErrorCode.ProtocolError,
+                        message = "send a compatible Hello request before session commands",
+                    )
+                } else if (
+                    handshakeVersion != null &&
+                        DaemonProtocol.clientPredatesBinaryPayloads(handshakeVersion)
+                ) {
+                    DaemonResponse.Error(
+                        code = DaemonErrorCode.ProtocolError,
+                        message =
+                            "This Spectre client is too old for the running daemon: screenshot " +
+                                "PNG bytes are sent in a format it cannot decode. Upgrade the " +
+                                "client, or run `spectre daemon kill` and retry with it.",
+                    )
+                } else {
+                    registry.handle(request)
                 }
             else ->
                 if (handshakeComplete) registry.handle(request)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.cli.daemon
 import dev.sebastiano.spectre.agent.AgentAttach
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.SpectreAttachException
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.cli.hotreload.HotReloadCapability
 import dev.sebastiano.spectre.cli.hotreload.HotReloadPortDiscovery
 import dev.sebastiano.spectre.cli.hotreload.HotReloadSession
@@ -68,7 +69,10 @@ internal constructor(
     private fun handleSynchronized(request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.Hello ->
-                DaemonResponse.Hello(daemonVersion = DaemonProtocol.CurrentVersion)
+                DaemonResponse.Hello(
+                    daemonVersion = DaemonProtocol.CurrentVersion,
+                    maxFrameBytes = FrameLimits.maxFrameBytes,
+                )
             is DaemonRequest.Attach -> error("attach must use attach() outside the monitor")
             is DaemonRequest.Detach -> error("detach must use handleDetachOutsideLock")
             DaemonRequest.ListSessions ->

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/MaxFrameBytesCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/MaxFrameBytesCliTest.kt
@@ -1,0 +1,82 @@
+package dev.sebastiano.spectre.cli
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.FrameLimits
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * `--max-frame-bytes` is the escape hatch for multi-monitor HiDPI fullscreen stills, which can
+ * encode past the default budget. It must apply before any request goes out, and a typo must fail
+ * the invocation rather than silently leaving the default in place.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+class MaxFrameBytesCliTest {
+
+    private val original = FrameLimits.maxFrameBytes
+
+    @AfterTest fun restore() = FrameLimits.configure(original)
+
+    @Test
+    fun `applies the budget before the command runs`() {
+        var budgetAtRequest = 0
+        val cli =
+            SpectreCli(
+                request = {
+                    budgetAtRequest = FrameLimits.maxFrameBytes
+                    error("stop after observing the budget")
+                },
+                output = StringBuilder(),
+                errorOutput = StringBuilder(),
+            )
+
+        runCatching { cli.run(listOf("--max-frame-bytes", "128MiB", "windows", "session-1")) }
+
+        assertEquals(
+            128 * 1024 * 1024,
+            budgetAtRequest,
+            "the budget must be in effect by the time a request is written",
+        )
+    }
+
+    @Test
+    fun `rejects a size it cannot parse instead of falling back`() {
+        val err = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { error("must not reach the daemon") },
+                output = StringBuilder(),
+                errorOutput = err,
+            )
+
+        val code = cli.run(listOf("--max-frame-bytes", "banana", "windows", "session-1"))
+
+        assertTrue(code != 0, "a bad size must fail the invocation")
+        assertTrue(
+            err.toString().contains("max-frame-bytes"),
+            "error should name the offending option: $err",
+        )
+        assertEquals(original, FrameLimits.maxFrameBytes, "a rejected value must not be applied")
+    }
+
+    @Test
+    fun `rejects a size above the read ceiling`() {
+        val err = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { error("must not reach the daemon") },
+                output = StringBuilder(),
+                errorOutput = err,
+            )
+
+        val code = cli.run(listOf("--max-frame-bytes", "1G", "windows", "session-1"))
+
+        assertTrue(code != 0, "a budget readers would refuse must fail the invocation")
+        assertTrue(
+            err.toString().contains("ceiling", ignoreCase = true),
+            "error should explain the ceiling: $err",
+        )
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/MaxFrameBytesCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/MaxFrameBytesCliTest.kt
@@ -43,6 +43,28 @@ class MaxFrameBytesCliTest {
     }
 
     @Test
+    fun `each invocation resolves its own budget`() {
+        // SpectreCli.run is reusable, so a --max-frame-bytes from one call must not leave the
+        // next one silently requesting a budget it never asked for — which would then either fail
+        // the daemon handshake or boot a daemon on a value the user did not choose.
+        val budgets = mutableListOf<Int?>()
+        val cli =
+            SpectreCli(
+                request = {
+                    budgets += FrameLimits.requestedMaxFrameBytes
+                    error("stop after observing the budget")
+                },
+                output = StringBuilder(),
+                errorOutput = StringBuilder(),
+            )
+
+        runCatching { cli.run(listOf("--max-frame-bytes", "128MiB", "windows", "session-1")) }
+        runCatching { cli.run(listOf("windows", "session-1")) }
+
+        assertEquals(listOf<Int?>(128 * 1024 * 1024, null), budgets)
+    }
+
+    @Test
     fun `rejects a size it cannot parse instead of falling back`() {
         val err = StringBuilder()
         val cli =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/MaxFrameBytesCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/MaxFrameBytesCliTest.kt
@@ -5,6 +5,7 @@ import dev.sebastiano.spectre.agent.transport.FrameLimits
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 /**
@@ -17,7 +18,7 @@ class MaxFrameBytesCliTest {
 
     private val original = FrameLimits.maxFrameBytes
 
-    @AfterTest fun restore() = FrameLimits.configure(original)
+    @AfterTest fun restore() = FrameLimits.resetToEnvironment()
 
     @Test
     fun `applies the budget before the command runs`() {
@@ -59,6 +60,10 @@ class MaxFrameBytesCliTest {
             "error should name the offending option: $err",
         )
         assertEquals(original, FrameLimits.maxFrameBytes, "a rejected value must not be applied")
+        assertNull(
+            FrameLimits.requestedMaxFrameBytes,
+            "a rejected value must not count as a request",
+        )
     }
 
     @Test

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
@@ -34,6 +34,7 @@ class DaemonEndpointTest {
     fun `discovers prior minor-version sockets during the stable endpoint migration`() {
         assertEquals(
             listOf(
+                Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-11.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-10.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-9.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-8.sock"),

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetE2eTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetE2eTest.kt
@@ -81,6 +81,24 @@ class DaemonFrameBudgetE2eTest {
     }
 
     @Test
+    fun `a refused client can still run the recovery command`() {
+        // The refusal tells the user to run `spectre daemon kill`, which inherits the same
+        // SPECTRE_MAX_FRAME_BYTES and would hit the same check. Shutdown must stay reachable or
+        // the documented recovery path is a dead end and the daemon has to be killed by hand.
+        DaemonClient(socketPath).use { client ->
+            startDaemonWith(client, BOOTED_BUDGET)
+
+            FrameLimits.configure(REQUESTED_BUDGET)
+            assertTrue(
+                runCatching { client.request(DaemonRequest.ListSessions) }.isFailure,
+                "ordinary requests must still be refused",
+            )
+
+            assertEquals(DaemonResponse.ShuttingDown, client.request(DaemonRequest.Shutdown))
+        }
+    }
+
+    @Test
     fun `an unconfigured client works against a daemon on a raised budget`() {
         DaemonClient(socketPath).use { client ->
             startDaemonWith(client, BOOTED_BUDGET)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetE2eTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetE2eTest.kt
@@ -25,13 +25,12 @@ import org.junit.jupiter.api.condition.OS
 class DaemonFrameBudgetE2eTest {
 
     private val socketPath: Path = temporarySocketPath()
-    private val original = FrameLimits.maxFrameBytes
     private var daemon: Process? = null
 
     @AfterTest
     fun cleanUp() {
         daemon?.destroyForcibly()?.waitFor()
-        FrameLimits.configure(original)
+        FrameLimits.resetToEnvironment()
         Files.deleteIfExists(socketPath)
         Files.deleteIfExists(socketPath.parent)
         Files.deleteIfExists(socketPath.parent.parent)
@@ -45,6 +44,20 @@ class DaemonFrameBudgetE2eTest {
                 DaemonResponse.Sessions(emptyList()),
                 startDaemonWith(client, BOOTED_BUDGET),
             )
+        }
+    }
+
+    @Test
+    fun `an explicit default-sized budget is checked against the daemon too`() {
+        DaemonClient(socketPath).use { client ->
+            startDaemonWith(client, BOOTED_BUDGET)
+
+            FrameLimits.configure(DEFAULT_MAX_FRAME_BYTES)
+            val failure =
+                runCatching { client.request(DaemonRequest.ListSessions) }.exceptionOrNull()
+                    ?: fail("an explicit request must be checked whatever its value")
+
+            assertTrue(failure.message.orEmpty().contains("64MiB"), failure.message.orEmpty())
         }
     }
 
@@ -72,7 +85,7 @@ class DaemonFrameBudgetE2eTest {
         DaemonClient(socketPath).use { client ->
             startDaemonWith(client, BOOTED_BUDGET)
 
-            FrameLimits.configure(DEFAULT_MAX_FRAME_BYTES)
+            FrameLimits.resetToEnvironment()
             assertEquals(
                 DaemonResponse.Sessions(emptyList()),
                 client.request(DaemonRequest.ListSessions),

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetE2eTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetE2eTest.kt
@@ -1,0 +1,121 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.DEFAULT_MAX_FRAME_BYTES
+import dev.sebastiano.spectre.agent.transport.FrameLimits
+import java.io.IOException
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * A daemon keeps the frame budget it booted with, so this only holds against a *real* daemon
+ * process: the in-process registry would report whatever the test JVM currently has configured.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+@EnabledOnOs(OS.LINUX, OS.MAC)
+class DaemonFrameBudgetE2eTest {
+
+    private val socketPath: Path = temporarySocketPath()
+    private val original = FrameLimits.maxFrameBytes
+    private var daemon: Process? = null
+
+    @AfterTest
+    fun cleanUp() {
+        daemon?.destroyForcibly()?.waitFor()
+        FrameLimits.configure(original)
+        Files.deleteIfExists(socketPath)
+        Files.deleteIfExists(socketPath.parent)
+        Files.deleteIfExists(socketPath.parent.parent)
+    }
+
+    @Test
+    fun `a daemon reports the budget it booted with`() {
+        DaemonClient(socketPath).use { client ->
+            // Booted and queried on the same budget: the handshake must not object.
+            assertEquals(
+                DaemonResponse.Sessions(emptyList()),
+                startDaemonWith(client, BOOTED_BUDGET),
+            )
+        }
+    }
+
+    @Test
+    fun `asking for a budget the running daemon cannot honour fails loudly`() {
+        DaemonClient(socketPath).use { client ->
+            startDaemonWith(client, BOOTED_BUDGET)
+
+            FrameLimits.configure(REQUESTED_BUDGET)
+            val failure =
+                runCatching { client.request(DaemonRequest.ListSessions) }.exceptionOrNull()
+                    ?: fail("expected the handshake to refuse the budget")
+
+            assertTrue(failure is IOException, "unexpected failure type: $failure")
+            val message = failure.message.orEmpty()
+            assertTrue(message.contains("--max-frame-bytes"), message)
+            assertTrue(message.contains("256MiB"), "should name what was asked for: $message")
+            assertTrue(message.contains("128MiB"), "should name what the daemon runs: $message")
+            assertTrue(message.contains("spectre daemon kill"), message)
+        }
+    }
+
+    @Test
+    fun `an unconfigured client works against a daemon on a raised budget`() {
+        DaemonClient(socketPath).use { client ->
+            startDaemonWith(client, BOOTED_BUDGET)
+
+            FrameLimits.configure(DEFAULT_MAX_FRAME_BYTES)
+            assertEquals(
+                DaemonResponse.Sessions(emptyList()),
+                client.request(DaemonRequest.ListSessions),
+            )
+        }
+    }
+
+    /**
+     * Boots a daemon on [budget] and returns its first response. Goes through `requestOrStart` so
+     * the startup coordinator owns the socket-appears-before-accept race rather than this test.
+     */
+    private fun startDaemonWith(client: DaemonClient, budget: Int): DaemonResponse {
+        FrameLimits.configure(budget)
+        val command =
+            DaemonProcessLauncher(
+                    socketPath = socketPath,
+                    classPath = System.getProperty("java.class.path"),
+                )
+                .command()
+        assertTrue(
+            command.contains("--max-frame-bytes"),
+            "launcher must pin a non-default budget: $command",
+        )
+        return client.requestOrStart(DaemonRequest.ListSessions) {
+            daemon =
+                ProcessBuilder(command)
+                    .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                    .redirectErrorStream(false)
+                    .start()
+        }
+    }
+
+    private fun temporarySocketPath(): Path =
+        Path.of(
+                if ("posix" in FileSystems.getDefault().supportedFileAttributeViews()) "/tmp"
+                else System.getProperty("java.io.tmpdir"),
+                "sp-d-${UUID.randomUUID().toString().take(8)}",
+            )
+            .resolve("daemon")
+            .resolve("daemon.sock")
+
+    private companion object {
+        const val BOOTED_BUDGET: Int = 128 * 1024 * 1024
+        const val REQUESTED_BUDGET: Int = 256 * 1024 * 1024
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetHandshakeTest.kt
@@ -1,0 +1,76 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.DEFAULT_MAX_FRAME_BYTES
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * A running daemon keeps the frame budget it booted with, so `--max-frame-bytes` on a later
+ * invocation cannot reach it. Silently continuing would apply the requested budget to one hop of
+ * three; the handshake refuses instead and says how to make it stick.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+class DaemonFrameBudgetHandshakeTest {
+
+    @Test
+    fun `a matching budget is accepted`() {
+        assertNull(frameBudgetMismatchFailure(requested = 128 * MIB, daemonBudget = 128 * MIB))
+    }
+
+    @Test
+    fun `an unconfigured client accepts whatever the daemon booted with`() {
+        // Nothing was asked for, and readers accept frames up to the ceiling regardless of their
+        // own budget, so a daemon on a larger budget is not a problem worth failing over.
+        assertNull(
+            frameBudgetMismatchFailure(
+                requested = DEFAULT_MAX_FRAME_BYTES,
+                daemonBudget = 256 * MIB,
+            )
+        )
+        assertNull(
+            frameBudgetMismatchFailure(requested = DEFAULT_MAX_FRAME_BYTES, daemonBudget = null)
+        )
+    }
+
+    @Test
+    fun `a budget the running daemon cannot honour is refused`() {
+        val failure =
+            assertNotNull(
+                frameBudgetMismatchFailure(requested = 256 * MIB, daemonBudget = 64 * MIB)
+            )
+
+        assertTrue(failure.contains("--max-frame-bytes"), failure)
+        assertTrue(failure.contains("256MiB"), "should name what was asked for: $failure")
+        assertTrue(failure.contains("64MiB"), "should name what the daemon runs: $failure")
+        assertTrue(
+            failure.contains("spectre daemon kill"),
+            "should say how to make the budget stick: $failure",
+        )
+    }
+
+    @Test
+    fun `a daemon too old to report its budget is refused rather than assumed`() {
+        val failure =
+            assertNotNull(frameBudgetMismatchFailure(requested = 256 * MIB, daemonBudget = null))
+
+        assertTrue(failure.contains("spectre daemon kill"), failure)
+    }
+
+    @Test
+    fun `sizes are rendered in the units the flag accepts`() {
+        val failure =
+            assertNotNull(
+                frameBudgetMismatchFailure(requested = 128 * MIB, daemonBudget = 100 * 1024)
+            )
+
+        assertTrue(failure.contains("128MiB"), failure)
+        assertTrue(failure.contains("100KiB"), "sub-MiB budgets should not round to 0MiB: $failure")
+    }
+
+    private companion object {
+        const val MIB: Int = 1024 * 1024
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetHandshakeTest.kt
@@ -24,14 +24,33 @@ class DaemonFrameBudgetHandshakeTest {
     fun `an unconfigured client accepts whatever the daemon booted with`() {
         // Nothing was asked for, and readers accept frames up to the ceiling regardless of their
         // own budget, so a daemon on a larger budget is not a problem worth failing over.
+        assertNull(frameBudgetMismatchFailure(requested = null, daemonBudget = 256 * MIB))
+        assertNull(frameBudgetMismatchFailure(requested = null, daemonBudget = null))
+    }
+
+    @Test
+    fun `an explicit request for the default budget is still checked`() {
+        // Intent cannot be read off the value: asking for 64MiB against a 128MiB daemon is a
+        // conflict just like any other, and treating it as "unconfigured" would hide it.
+        val failure =
+            assertNotNull(
+                frameBudgetMismatchFailure(
+                    requested = DEFAULT_MAX_FRAME_BYTES,
+                    daemonBudget = 128 * MIB,
+                )
+            )
+
+        assertTrue(failure.contains("64MiB"), failure)
+        assertTrue(failure.contains("128MiB"), failure)
+    }
+
+    @Test
+    fun `an explicit request matching the daemon is accepted`() {
         assertNull(
             frameBudgetMismatchFailure(
                 requested = DEFAULT_MAX_FRAME_BYTES,
-                daemonBudget = 256 * MIB,
+                daemonBudget = DEFAULT_MAX_FRAME_BYTES,
             )
-        )
-        assertNull(
-            frameBudgetMismatchFailure(requested = DEFAULT_MAX_FRAME_BYTES, daemonBudget = null)
         )
     }
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetTest.kt
@@ -1,0 +1,76 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.DEFAULT_MAX_FRAME_BYTES
+import dev.sebastiano.spectre.agent.transport.FrameLimits
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The daemon is a separate process from the CLI that spawns it, so its frame budget has to be
+ * carried on the daemon command line — otherwise a `--max-frame-bytes` on the CLI would silently
+ * apply to only one of the two hops a screenshot travels.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+class DaemonFrameBudgetTest {
+
+    @Test
+    fun `socket path still parses without a budget option`() {
+        assertEquals(
+            Path.of("/tmp/spectre.sock"),
+            DaemonMain.socketPath(listOf("--socket", "/tmp/spectre.sock")),
+        )
+    }
+
+    @Test
+    fun `socket path parses alongside a budget option`() {
+        val arguments = listOf("--socket", "/tmp/spectre.sock", "--max-frame-bytes", "1048576")
+
+        assertEquals(Path.of("/tmp/spectre.sock"), DaemonMain.socketPath(arguments))
+        assertEquals(1048576, DaemonMain.maxFrameBytes(arguments))
+    }
+
+    @Test
+    fun `absent budget option means the default applies`() {
+        assertNull(DaemonMain.maxFrameBytes(listOf("--socket", "/tmp/spectre.sock")))
+    }
+
+    @Test
+    fun `an unusable command line still fails loudly`() {
+        assertFailsWith<IllegalArgumentException> { DaemonMain.socketPath(listOf("--socket")) }
+        assertFailsWith<IllegalArgumentException> { DaemonMain.socketPath(emptyList()) }
+        assertFailsWith<IllegalArgumentException> {
+            DaemonMain.maxFrameBytes(listOf("--socket", "/tmp/s.sock", "--max-frame-bytes", "nope"))
+        }
+    }
+
+    @Test
+    fun `launcher omits the budget option when the default is in effect`() {
+        val command = DaemonProcessLauncher(Path.of("/tmp/spectre.sock")).command()
+
+        assertTrue(command.contains("--socket"))
+        assertTrue(
+            !command.contains("--max-frame-bytes"),
+            "an unconfigured daemon should inherit the default, not pin it: $command",
+        )
+    }
+
+    @Test
+    fun `launcher forwards a configured budget to the daemon process`() {
+        val original = FrameLimits.maxFrameBytes
+        try {
+            FrameLimits.configure(DEFAULT_MAX_FRAME_BYTES * 2)
+            val command = DaemonProcessLauncher(Path.of("/tmp/spectre.sock")).command()
+
+            val index = command.indexOf("--max-frame-bytes")
+            assertTrue(index >= 0, "configured budget must reach the daemon: $command")
+            assertEquals((DEFAULT_MAX_FRAME_BYTES * 2).toString(), command[index + 1])
+        } finally {
+            FrameLimits.configure(original)
+        }
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFrameBudgetTest.kt
@@ -49,19 +49,23 @@ class DaemonFrameBudgetTest {
     }
 
     @Test
-    fun `launcher omits the budget option when the default is in effect`() {
-        val command = DaemonProcessLauncher(Path.of("/tmp/spectre.sock")).command()
+    fun `launcher omits the budget option when nothing was asked for`() {
+        try {
+            FrameLimits.resetToEnvironment()
+            val command = DaemonProcessLauncher(Path.of("/tmp/spectre.sock")).command()
 
-        assertTrue(command.contains("--socket"))
-        assertTrue(
-            !command.contains("--max-frame-bytes"),
-            "an unconfigured daemon should inherit the default, not pin it: $command",
-        )
+            assertTrue(command.contains("--socket"))
+            assertTrue(
+                !command.contains("--max-frame-bytes"),
+                "an unconfigured daemon resolves the same environment: $command",
+            )
+        } finally {
+            FrameLimits.resetToEnvironment()
+        }
     }
 
     @Test
     fun `launcher forwards a configured budget to the daemon process`() {
-        val original = FrameLimits.maxFrameBytes
         try {
             FrameLimits.configure(DEFAULT_MAX_FRAME_BYTES * 2)
             val command = DaemonProcessLauncher(Path.of("/tmp/spectre.sock")).command()
@@ -70,7 +74,23 @@ class DaemonFrameBudgetTest {
             assertTrue(index >= 0, "configured budget must reach the daemon: $command")
             assertEquals((DEFAULT_MAX_FRAME_BYTES * 2).toString(), command[index + 1])
         } finally {
-            FrameLimits.configure(original)
+            FrameLimits.resetToEnvironment()
+        }
+    }
+
+    @Test
+    fun `launcher forwards an explicit default-sized budget`() {
+        // The daemon inherits this process's environment, so `--max-frame-bytes 64MiB` layered
+        // over SPECTRE_MAX_FRAME_BYTES=128MiB must be pinned or the daemon re-reads 128MiB.
+        try {
+            FrameLimits.configure(DEFAULT_MAX_FRAME_BYTES)
+            val command = DaemonProcessLauncher(Path.of("/tmp/spectre.sock")).command()
+
+            val index = command.indexOf("--max-frame-bytes")
+            assertTrue(index >= 0, "an explicit default must still be pinned: $command")
+            assertEquals(DEFAULT_MAX_FRAME_BYTES.toString(), command[index + 1])
+        } finally {
+            FrameLimits.resetToEnvironment()
         }
     }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
@@ -72,18 +72,7 @@ class DaemonHandshakeTest {
             DaemonProtocolVersion(major = 1, minor = 6),
             DaemonProtocol.minimumDaemonVersion(DaemonRequest.RecordingStatus("session-1234")),
         )
-        assertEquals(
-            DaemonProtocolVersion(major = 1, minor = 5),
-            DaemonProtocol.minimumDaemonVersion(
-                DaemonRequest.Capture(sessionId = "session-1234", windowIndex = 0)
-            ),
-        )
-        assertEquals(
-            DaemonProtocolVersion(major = 1, minor = 7),
-            DaemonProtocol.minimumDaemonVersion(
-                DaemonRequest.Screenshot(sessionId = "session-1234")
-            ),
-        )
+        // Capture and Screenshot moved to the screen-pixel floor; see the dedicated test below.
         assertEquals(
             DaemonProtocolVersion(major = 1, minor = 8),
             DaemonProtocol.minimumDaemonVersion(
@@ -122,6 +111,25 @@ class DaemonHandshakeTest {
             DaemonProtocolVersion(major = 1, minor = 11),
             DaemonProtocol.minimumDaemonVersion(
                 DaemonRequest.WaitForReloadSettled(sessionId = "session-1234")
+            ),
+        )
+    }
+
+    @Test
+    fun `still requests require the screen-pixel daemon`() {
+        // The daemon endpoint is `daemon-v1.sock`, stable across minors, so an upgraded CLI reaches
+        // a daemon that is still running the previous build. Without this floor it would keep
+        // serving dp-sized stills on the old 16 MiB budget and the upgrade would silently no-op.
+        assertEquals(
+            DaemonProtocolVersion(major = 1, minor = 12),
+            DaemonProtocol.minimumDaemonVersion(
+                DaemonRequest.Capture(sessionId = "session-1234", windowIndex = 0, outDir = null)
+            ),
+        )
+        assertEquals(
+            DaemonProtocolVersion(major = 1, minor = 12),
+            DaemonProtocol.minimumDaemonVersion(
+                DaemonRequest.Screenshot(sessionId = "session-1234", fullscreen = true)
             ),
         )
     }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
@@ -6,7 +6,9 @@ import dev.sebastiano.spectre.agent.transport.RectDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 import kotlinx.serialization.ExperimentalSerializationApi
 
 @OptIn(ExperimentalSerializationApi::class)
@@ -112,6 +114,33 @@ class DaemonHandshakeTest {
             DaemonProtocol.minimumDaemonVersion(
                 DaemonRequest.WaitForReloadSettled(sessionId = "session-1234")
             ),
+        )
+    }
+
+    @Test
+    fun `a handshake below the byte-string floor marks an old client`() {
+        // Screenshot pngBytes now go out as a CBOR byte string, which a 1.7-1.11 client decodes as
+        // an integer array. Since minimumDaemonVersion floors screenshots at 1.12, anything lower
+        // announced for that op is an old client rather than a newer one asking for less.
+        assertTrue(
+            DaemonProtocol.clientPredatesBinaryPayloads(
+                DaemonProtocolVersion(major = 1, minor = 11)
+            )
+        )
+        assertTrue(
+            DaemonProtocol.clientPredatesBinaryPayloads(DaemonProtocolVersion(major = 1, minor = 7))
+        )
+    }
+
+    @Test
+    fun `a current handshake is not treated as an old client`() {
+        assertFalse(DaemonProtocol.clientPredatesBinaryPayloads(DaemonProtocol.CurrentVersion))
+        assertFalse(
+            DaemonProtocol.clientPredatesBinaryPayloads(
+                DaemonProtocol.minimumDaemonVersion(
+                    DaemonRequest.Screenshot(sessionId = "session-1234", fullscreen = true)
+                )
+            )
         )
     }
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.Channels
@@ -55,7 +56,7 @@ class DaemonProcessTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
                     DaemonWireCodec.readResponse(input),
                 )
             }
@@ -110,7 +111,7 @@ class DaemonProcessTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
                     DaemonWireCodec.readResponse(input),
                 )
                 DaemonWireCodec.writeRequest(output, DaemonRequest.Shutdown)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.transport.FrameLimits
 import java.nio.channels.Channels
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
@@ -147,7 +148,7 @@ class DaemonServerTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
                     DaemonWireCodec.readResponse(input),
                 )
                 DaemonWireCodec.writeRequest(output, DaemonRequest.ListSessions)
@@ -206,7 +207,7 @@ class DaemonServerTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
                     DaemonWireCodec.readResponse(input),
                 )
             }
@@ -402,7 +403,7 @@ class DaemonServerTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
                     DaemonWireCodec.readResponse(input),
                 )
 
@@ -448,7 +449,7 @@ class DaemonServerTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion),
+                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
                     DaemonWireCodec.readResponse(input),
                 )
                 DaemonWireCodec.writeRequest(output, DaemonRequest.ListSessions)

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -109,6 +109,8 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public final fun screenshot (Ldev/sebastiano/spectre/core/AutomatorNode;)Ljava/awt/image/BufferedImage;
 	public final fun screenshot (Ljava/awt/Rectangle;)Ljava/awt/image/BufferedImage;
 	public static synthetic fun screenshot$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/awt/Rectangle;ILjava/lang/Object;)Ljava/awt/image/BufferedImage;
+	public final fun screenshotAtDeviceScale (Ljava/awt/Rectangle;)Ljava/awt/image/BufferedImage;
+	public static synthetic fun screenshotAtDeviceScale$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/awt/Rectangle;ILjava/lang/Object;)Ljava/awt/image/BufferedImage;
 	public final fun scrollWheel (Ldev/sebastiano/spectre/core/AutomatorNode;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun surfaceIds ()Ljava/util/List;
 	public final fun swipe-x2RqbK4 (IIIIIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -197,6 +199,8 @@ public final class dev/sebastiano/spectre/core/RobotDriver {
 	public static synthetic fun pressKey$default (Ldev/sebastiano/spectre/core/RobotDriver;IILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun screenshot (Ljava/awt/Rectangle;)Ljava/awt/image/BufferedImage;
 	public static synthetic fun screenshot$default (Ldev/sebastiano/spectre/core/RobotDriver;Ljava/awt/Rectangle;ILjava/lang/Object;)Ljava/awt/image/BufferedImage;
+	public final fun screenshotAtDeviceScale (Ljava/awt/Rectangle;)Ljava/awt/image/BufferedImage;
+	public static synthetic fun screenshotAtDeviceScale$default (Ldev/sebastiano/spectre/core/RobotDriver;Ljava/awt/Rectangle;ILjava/lang/Object;)Ljava/awt/image/BufferedImage;
 	public final fun scrollWheel (IIILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun swipe-x2RqbK4 (IIIIIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun swipe-x2RqbK4$default (Ldev/sebastiano/spectre/core/RobotDriver;IIIIIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -8,8 +8,6 @@ import androidx.compose.ui.semantics.getOrNull
 import dev.sebastiano.spectre.core.capture.AtomicCapture
 import dev.sebastiano.spectre.core.capture.AtomicCaptureBuilder
 import dev.sebastiano.spectre.core.capture.CaptureNodeSnapshot
-import dev.sebastiano.spectre.core.capture.cropImageToScreenRegion
-import dev.sebastiano.spectre.core.capture.normalizeImageToScreenBounds
 import dev.sebastiano.spectre.core.perf.ExperimentalSpectreApi
 import dev.sebastiano.spectre.core.perf.RecompositionMonitor
 import java.awt.Rectangle
@@ -271,9 +269,28 @@ private constructor(
      * sRGB pixels as a [BufferedImage]. Delegates to [RobotDriver.screenshot] — see that method's
      * KDoc for colour-space, focus-overlay, and per-platform TCC / Wayland gotchas before using the
      * result for pixel-level assertions.
+     *
+     * **Dimensions.** One pixel per logical screen unit, so image coordinates equal screen
+     * coordinates even on a scaled display. Use [screenshotAtDeviceScale] when you want the
+     * screen-pixel resolution Spectre's still artifacts and recordings use.
      */
     public fun screenshot(region: Rectangle? = null): BufferedImage =
         screenCaptureBackend.captureRegion(region)
+
+    /**
+     * Captures the given screen [region] (or the entire virtual desktop, if `null`) at the
+     * display's **device** resolution, and returns sRGB pixels as a [BufferedImage].
+     *
+     * Identical to [screenshot] except for dimensions: a 400x300dp region yields an 800x600 pixel
+     * image on a 2x display instead of 400x300, matching the resolution `Recorder` writes for the
+     * same region. Delegates to [RobotDriver.screenshotAtDeviceScale] — see that method's KDoc for
+     * the mixed-density rule and the same colour-space / TCC / Wayland caveats as [screenshot].
+     *
+     * This backs Spectre's still artifacts. Use [screenshot] when you want image coordinates to
+     * equal screen coordinates.
+     */
+    public fun screenshotAtDeviceScale(region: Rectangle? = null): BufferedImage =
+        screenCaptureBackend.captureStillRegion(region)
 
     /**
      * Captures the on-screen bounds of [node] as an sRGB [BufferedImage].
@@ -281,6 +298,9 @@ private constructor(
      * Captures through the optional native window backend. If that backend cannot identify or
      * capture the tracked window, this method fails rather than substituting a screen-region crop.
      * Use [screenshot] with an explicit [Rectangle] when screen-region capture is intended.
+     *
+     * **Dimensions.** Screen pixels, not dp: [node] bounds of 400x300dp yield an 800x600 pixel
+     * image on a 2x display. Divide by the window's density scale to get back to logical units.
      */
     public fun screenshot(node: AutomatorNode): BufferedImage {
         val geometry = readOnEdt {
@@ -305,6 +325,9 @@ private constructor(
      * Captures through the optional native window backend. If that backend cannot identify or
      * capture the tracked window, this method fails rather than substituting a screen-region crop.
      * Use [screenshot] with an explicit [Rectangle] when screen-region capture is intended.
+     *
+     * **Dimensions.** Screen pixels, not dp: a 1600x1000dp Compose surface yields a 3200x2000 pixel
+     * image on a 2x display, matching what `Recorder` writes for the same window.
      */
     public fun screenshot(windowIndex: Int): BufferedImage {
         refreshWindows()
@@ -334,6 +357,12 @@ private constructor(
      * as [screenshot] with a [windowIndex] (fails loudly rather than substituting a screen-region
      * crop after a native failure). Without that backend (e.g. inject payload that omits
      * recording), the still is a Robot region capture of the Compose surface.
+     *
+     * The PNG is **screen-pixel** sized, not dp sized: a 1600x1000dp window on a 2x display
+     * produces a 3200x2000 pixel PNG, the same resolution `Recorder` writes for that window.
+     * `capture.json` reports the exact PNG size as `window.imageWidth` / `imageHeight`, keeps
+     * `window.boundsScreen` in logical units, and records the density as `densityScaleX` /
+     * `densityScaleY`.
      *
      * Node bounds in the returned document use **image-pixel space of the PNG as primary** and
      * screen space as secondary. Callers that want files on disk should pass the result through
@@ -402,7 +431,7 @@ private constructor(
                 )
             } else {
                 WindowCapture(
-                    image = screenCaptureBackend.captureRegion(pre.captureRegion),
+                    image = screenCaptureBackend.captureStillRegion(pre.captureRegion),
                     boundsOnScreen = pre.captureRegion,
                 )
             }
@@ -738,18 +767,11 @@ private constructor(
         region: Rectangle,
         windowBounds: Rectangle = trackedWindow.window.bounds,
         frameInsets: java.awt.Insets = frameInsets(trackedWindow.window),
-    ): WindowCapture {
-        val capture = screenCaptureBackend.captureWindow(trackedWindow, windowBounds, frameInsets)
-        val normalizedImage = normalizeImageToScreenBounds(capture.image, capture.boundsOnScreen)
-        if (capture.boundsOnScreen == region) {
-            return WindowCapture(normalizedImage, capture.boundsOnScreen)
-        }
-        val visibleRegion = region.intersection(capture.boundsOnScreen)
-        return WindowCapture(
-            image = cropImageToScreenRegion(normalizedImage, visibleRegion, capture.boundsOnScreen),
-            boundsOnScreen = visibleRegion,
+    ): WindowCapture =
+        windowStillForRegion(
+            screenCaptureBackend.captureWindow(trackedWindow, windowBounds, frameInsets),
+            region,
         )
-    }
 
     private fun frameInsets(window: java.awt.Window): java.awt.Insets =
         (window as? java.awt.Frame)?.insets ?: java.awt.Insets(0, 0, 0, 0)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -284,7 +284,8 @@ private constructor(
      * Identical to [screenshot] except for dimensions: a 400x300dp region yields an 800x600 pixel
      * image on a 2x display instead of 400x300, matching the resolution `Recorder` writes for the
      * same region. Delegates to [RobotDriver.screenshotAtDeviceScale] — see that method's KDoc for
-     * the mixed-density rule and the same colour-space / TCC / Wayland caveats as [screenshot].
+     * the mixed-density limitation and the same colour-space / TCC / Wayland caveats as
+     * [screenshot].
      *
      * This backs Spectre's still artifacts. Use [screenshot] when you want image coordinates to
      * equal screen coordinates.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/DeviceScaleScreenCapture.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/DeviceScaleScreenCapture.kt
@@ -8,12 +8,21 @@ import java.awt.image.MultiResolutionImage
 /**
  * Picks the densest variant of a multi-resolution screen capture.
  *
- * `Robot.createMultiResolutionScreenCapture` returns one variant per distinct display scale the
- * requested rectangle touches. Taking the largest is what makes a still match the recorder on a
- * Retina display, and it degrades correctly elsewhere: on a 1x display there is a single variant,
- * and across mixed densities the densest one upscales the lower-density displays rather than
- * dropping them. [region] is the requested logical rectangle, used only to ask for a base variant
- * when a backend reports no variants at all.
+ * Taking the largest variant is what makes a still match the recorder on a Retina display, and it
+ * degrades safely on a 1x display, where there is a single variant.
+ *
+ * **Mixed-density desktops are bounded by the JDK, not by this function.**
+ * `Robot.createMultiResolutionScreenCapture` does not capture per display: `Robot`'s
+ * `createCompatibleImage` resolves one `GraphicsConfiguration` from the *centre* of the requested
+ * rectangle and offers variants for that display's scale alone. A region spanning monitors of
+ * different densities is therefore captured at the centre display's scale — so a rectangle centred
+ * on a 1x monitor yields no 2x variant at all, and the Retina portion stays downsampled. Capturing
+ * each intersecting display at its own scale and composing them would lift that limit; it is not
+ * something variant selection can fix. Window-scoped stills are unaffected: they go through the
+ * native helpers, which use the target window's own screen scale.
+ *
+ * [region] is the requested logical rectangle, used only to ask for a base variant when a backend
+ * reports no variants at all.
  */
 internal fun highestResolutionVariant(
     capture: MultiResolutionImage,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/DeviceScaleScreenCapture.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/DeviceScaleScreenCapture.kt
@@ -18,8 +18,12 @@ import java.awt.image.MultiResolutionImage
  * different densities is therefore captured at the centre display's scale — so a rectangle centred
  * on a 1x monitor yields no 2x variant at all, and the Retina portion stays downsampled. Capturing
  * each intersecting display at its own scale and composing them would lift that limit; it is not
- * something variant selection can fix. Window-scoped stills are unaffected: they go through the
- * native helpers, which use the target window's own screen scale.
+ * something variant selection can fix.
+ *
+ * Window-scoped stills escape it only while the native still bridge is present, since those helpers
+ * use the target window's own screen scale. Without `spectre-recording` on the target's classpath
+ * the window still is a Robot region capture too, so a window straddling displays of different
+ * densities shares the limit above.
  *
  * [region] is the requested logical rectangle, used only to ask for a base variant when a backend
  * reports no variants at all.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/DeviceScaleScreenCapture.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/DeviceScaleScreenCapture.kt
@@ -1,0 +1,48 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.Image
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import java.awt.image.MultiResolutionImage
+
+/**
+ * Picks the densest variant of a multi-resolution screen capture.
+ *
+ * `Robot.createMultiResolutionScreenCapture` returns one variant per distinct display scale the
+ * requested rectangle touches. Taking the largest is what makes a still match the recorder on a
+ * Retina display, and it degrades correctly elsewhere: on a 1x display there is a single variant,
+ * and across mixed densities the densest one upscales the lower-density displays rather than
+ * dropping them. [region] is the requested logical rectangle, used only to ask for a base variant
+ * when a backend reports no variants at all.
+ */
+internal fun highestResolutionVariant(
+    capture: MultiResolutionImage,
+    region: Rectangle,
+): BufferedImage {
+    val densest =
+        capture.resolutionVariants
+            .filter { it.getWidth(null) > 0 && it.getHeight(null) > 0 }
+            .maxByOrNull { it.getWidth(null).toLong() * it.getHeight(null).toLong() }
+            ?: capture.getResolutionVariant(
+                region.width.toDouble().coerceAtLeast(1.0),
+                region.height.toDouble().coerceAtLeast(1.0),
+            )
+    return densest.asBufferedImage()
+}
+
+/** Robot hands back `BufferedImage` variants; only a foreign backend would need the copy. */
+private fun Image.asBufferedImage(): BufferedImage =
+    this as? BufferedImage
+        ?: BufferedImage(
+                getWidth(null).coerceAtLeast(1),
+                getHeight(null).coerceAtLeast(1),
+                BufferedImage.TYPE_INT_ARGB,
+            )
+            .also { copy ->
+                val graphics = copy.createGraphics()
+                try {
+                    graphics.drawImage(this, 0, 0, null)
+                } finally {
+                    graphics.dispose()
+                }
+            }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -436,7 +436,8 @@ internal constructor(
      * the *centre* of [region], not per display, so a rectangle spanning monitors of different
      * densities is captured at the centre display's scale: parts on lower-density displays are
      * upscaled, and — when the centre lands on the lower-density monitor — the higher-density parts
-     * are downsampled. Single-display captures and window-scoped stills are unaffected; see
+     * are downsampled. Single-display captures are unaffected, as are window-scoped stills while
+     * the native still bridge is present — but not the Robot fallback used when it is absent; see
      * [highestResolutionVariant].
      */
     public fun screenshotAtDeviceScale(region: Rectangle? = null): BufferedImage {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -356,9 +356,11 @@ internal constructor(
      *
      * **Dimensions.** The returned image is sized to the requested *logical* [region] regardless of
      * display DPI scaling — `java.awt.Robot.createScreenCapture` downsamples HiDPI device pixels to
-     * the logical rectangle, so a 60×60 request yields a 60×60 image even on a 2× display. The
-     * device-resolution pixels are reachable only via `createMultiResolutionScreenCapture`, which
-     * this path deliberately does not use.
+     * the logical rectangle, so a 60×60 request yields a 60×60 image even on a 2× display. That 1:1
+     * screen↔image mapping is the point of this method: `boundsOnScreen` doubles as an image offset
+     * without a density conversion. When you want the device-resolution pixels instead — which is
+     * what Spectre's still artifacts and recordings use — call [screenshotAtDeviceScale], which
+     * reaches them via `createMultiResolutionScreenCapture`.
      *
      * **Colour space.** The returned image is sRGB (`TYPE_INT_ARGB` / sRGB `ColorModel`), matching
      * `java.awt.Robot.createScreenCapture`'s contract. Pixel values are post-display-pipeline: what
@@ -413,6 +415,31 @@ internal constructor(
         tccGuard.requireScreenRecording()
         val captureRegion = region ?: screenCapture.defaultScreenshotRegion()
         return screenCapture.createScreenCapture(captureRegion)
+    }
+
+    /**
+     * Captures the given screen [region] (or the entire virtual desktop, if `null`) at the
+     * display's **device** resolution.
+     *
+     * Same pixels, colour space, permission model, and trust boundary as [screenshot] — the only
+     * difference is dimensions. Where [screenshot] returns one pixel per logical unit (a 400x300
+     * request yields 400x300 even on a 2x display), this returns the backing-store pixels: 800x600
+     * for that same request at 2x, matching what `Recorder` writes for the region. On a 1x display
+     * the two are identical.
+     *
+     * This is what Spectre's still **artifacts** use (capture PNGs, CLI/MCP screenshots) so a still
+     * and a recording of the same surface agree on resolution. Prefer [screenshot] when you are
+     * asserting on pixels addressed by screen coordinates, since the 1:1 mapping is what makes
+     * `boundsOnScreen` usable as an image offset without a density conversion.
+     *
+     * On a multi-monitor desktop with mixed densities, the densest variant available for the
+     * requested rectangle wins; lower-density displays inside it are upscaled by the OS rather than
+     * dropped.
+     */
+    public fun screenshotAtDeviceScale(region: Rectangle? = null): BufferedImage {
+        tccGuard.requireScreenRecording()
+        val captureRegion = region ?: screenCapture.defaultScreenshotRegion()
+        return screenCapture.createDeviceScaleScreenCapture(captureRegion)
     }
 
     private suspend fun runOffEdt(block: suspend () -> Unit) = runOffEdt(robot, block)
@@ -564,6 +591,14 @@ internal interface ScreenCaptureAdapter {
 
     fun createScreenCapture(region: Rectangle): BufferedImage
 
+    /**
+     * Device-resolution counterpart of [createScreenCapture]. The default keeps the logical-size
+     * behaviour so synthetic, headless, and test adapters need no extra plumbing; only the real
+     * `java.awt.Robot` adapter can reach the backing-store pixels.
+     */
+    fun createDeviceScaleScreenCapture(region: Rectangle): BufferedImage =
+        createScreenCapture(region)
+
     fun defaultScreenshotRegion(): Rectangle = virtualDesktopBounds()
 }
 
@@ -637,6 +672,11 @@ private class AwtRobotAdapter(private val robot: Robot = createAwtRobot()) :
 
     override fun createScreenCapture(region: Rectangle): BufferedImage =
         robot.createScreenCapture(region)
+
+    // createScreenCapture downsamples HiDPI device pixels to the logical rectangle; the
+    // multi-resolution call is the only way to reach the backing store (see RobotDriver KDoc).
+    override fun createDeviceScaleScreenCapture(region: Rectangle): BufferedImage =
+        highestResolutionVariant(robot.createMultiResolutionScreenCapture(region), region)
 
     override fun waitForIdle() = robot.waitForIdle()
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -432,9 +432,12 @@ internal constructor(
      * asserting on pixels addressed by screen coordinates, since the 1:1 mapping is what makes
      * `boundsOnScreen` usable as an image offset without a density conversion.
      *
-     * On a multi-monitor desktop with mixed densities, the densest variant available for the
-     * requested rectangle wins; lower-density displays inside it are upscaled by the OS rather than
-     * dropped.
+     * **Mixed-density desktops.** `java.awt.Robot` derives one capture scale from the display under
+     * the *centre* of [region], not per display, so a rectangle spanning monitors of different
+     * densities is captured at the centre display's scale: parts on lower-density displays are
+     * upscaled, and — when the centre lands on the lower-density monitor — the higher-density parts
+     * are downsampled. Single-display captures and window-scoped stills are unaffected; see
+     * [highestResolutionVariant].
      */
     public fun screenshotAtDeviceScale(region: Rectangle? = null): BufferedImage {
         tccGuard.requireScreenRecording()

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackend.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ScreenCaptureBackend.kt
@@ -2,6 +2,7 @@
 
 package dev.sebastiano.spectre.core
 
+import dev.sebastiano.spectre.core.capture.cropImageToScreenRegion
 import java.awt.Frame
 import java.awt.Insets
 import java.awt.Rectangle
@@ -12,7 +13,19 @@ import java.nio.file.Path
 
 /** Internal capture seam for explicit screen regions and identity-preserving native windows. */
 internal interface ScreenCaptureBackend {
+    /**
+     * Logical-size region capture: one pixel per AWT screen unit regardless of display density.
+     * This is the cheap frame source for visual-idle hashing and the backing call for the public
+     * `screenshot(region)` API, whose 1:1 screen↔image mapping callers assert against.
+     */
     fun captureRegion(region: Rectangle? = null): BufferedImage
+
+    /**
+     * Screen-pixel region capture for still **artifacts** (capture PNGs, CLI/MCP screenshots). A
+     * 400x300dp region on a 2x display yields a 800x600 pixel PNG, matching what `Recorder` writes
+     * for the same region. See [captureRegion] for the logical-size counterpart.
+     */
+    fun captureStillRegion(region: Rectangle? = null): BufferedImage
 
     fun captureWindow(
         window: TrackedWindow,
@@ -21,9 +34,33 @@ internal interface ScreenCaptureBackend {
     ): WindowCapture
 }
 
-/** Pixels from a tracked window and the screen-space rectangle those pixels represent. */
+/**
+ * Pixels from a tracked window and the screen-space rectangle those pixels represent.
+ *
+ * The two are in **different units** whenever the display is scaled: native still helpers hand back
+ * backing-store pixels (3200x2000 for a 1600x1000dp window at 2x) while [boundsOnScreen] stays in
+ * AWT logical units. Consumers that need to map between them must go through
+ * [dev.sebastiano.spectre.core.capture.screenRectToImageRect] rather than assuming 1:1.
+ */
 internal data class WindowCapture(val image: BufferedImage, val boundsOnScreen: Rectangle)
 
+/**
+ * Narrows a native window capture to [region] while preserving its device-pixel resolution.
+ *
+ * The crop runs in image space via [cropImageToScreenRegion], so a 2x still stays 2x; only the
+ * reported [WindowCapture.boundsOnScreen] is expressed in logical units. Downsampling here instead
+ * would make every still 1x while the recorder kept writing screen-pixel video for the same window.
+ */
+internal fun windowStillForRegion(capture: WindowCapture, region: Rectangle): WindowCapture {
+    if (capture.boundsOnScreen == region) return capture
+    val visibleRegion = region.intersection(capture.boundsOnScreen)
+    return WindowCapture(
+        image = cropImageToScreenRegion(capture.image, visibleRegion, capture.boundsOnScreen),
+        boundsOnScreen = visibleRegion,
+    )
+}
+
+@Suppress("LongParameterList") // Every collaborator is a seam the capture tests substitute.
 internal class PlatformScreenCaptureBackend(
     private val regionCapture: (Rectangle?) -> BufferedImage,
     private val nativeCapture: (Frame) -> BufferedImage,
@@ -38,17 +75,22 @@ internal class PlatformScreenCaptureBackend(
                 isWayland = isWaylandSession(),
             )
         },
+    private val deviceScaleRegionCapture: (Rectangle?) -> BufferedImage = regionCapture,
 ) : ScreenCaptureBackend {
     internal constructor(
         robotDriver: RobotDriver
     ) : this(
-        robotDriver::screenshot,
-        defaultNativeCapture(),
-        { robotDriver.allowsPlatformCapture },
-        ::defaultNativeCaptureDisambiguatesTitles,
+        regionCapture = robotDriver::screenshot,
+        nativeCapture = defaultNativeCapture(),
+        nativeCaptureEnabled = { robotDriver.allowsPlatformCapture },
+        nativeCaptureDisambiguatesTitles = ::defaultNativeCaptureDisambiguatesTitles,
+        deviceScaleRegionCapture = robotDriver::screenshotAtDeviceScale,
     )
 
     override fun captureRegion(region: Rectangle?): BufferedImage = regionCapture(region)
+
+    override fun captureStillRegion(region: Rectangle?): BufferedImage =
+        deviceScaleRegionCapture(region)
 
     override fun captureWindow(
         window: TrackedWindow,

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/capture/ImageSpaceBounds.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/capture/ImageSpaceBounds.kt
@@ -86,7 +86,12 @@ internal fun cropImageToScreenRegion(
 }
 
 /**
- * Converts a native device-pixel capture into one pixel per logical screen unit before cropping.
+ * Converts a native device-pixel capture into one pixel per logical screen unit.
+ *
+ * This is a **frame-hashing** helper, not a still-capture one: visual-idle sampling wants small,
+ * cheap, density-independent frames. Still artifacts must keep the backend's device pixels (see
+ * [dev.sebastiano.spectre.core.windowStillForRegion]) so a PNG and a recording of the same window
+ * agree on resolution — resampling them here is what made HiDPI stills 1x.
  */
 internal fun normalizeImageToScreenBounds(
     image: BufferedImage,

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/AtomicCaptureWindowRoutingTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/AtomicCaptureWindowRoutingTest.kt
@@ -50,20 +50,12 @@ class AtomicCaptureWindowRoutingTest {
                     windowBounds,
                     Insets(24, 0, 0, 0),
                 )
-            // Production crops the native frame to the Compose surface (screenshotTrackedRegion).
-            val cropped =
-                dev.sebastiano.spectre.core.capture.cropImageToScreenRegion(
-                    dev.sebastiano.spectre.core.capture.normalizeImageToScreenBounds(
-                        capture.image,
-                        capture.boundsOnScreen,
-                    ),
-                    surface.intersection(capture.boundsOnScreen),
-                    capture.boundsOnScreen,
-                )
+            // Same call production makes to crop the native frame to the Compose surface.
+            val cropped = windowStillForRegion(capture, surface)
             assertEquals(1, windowCalls)
             assertEquals(0, regionCalls)
-            assertEquals(160, cropped.width)
-            assertEquals(96, cropped.height)
+            assertEquals(160, cropped.image.width)
+            assertEquals(96, cropped.image.height)
         } finally {
             frame.dispose()
         }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -359,6 +359,7 @@ class ComposeAutomatorPublicSurfaceTest {
                 "focusWindow",
                 "performSemanticsClick",
                 "screenshot",
+                "screenshotAtDeviceScale",
                 "capture",
                 "registerIdlingResource",
                 "unregisterIdlingResource",

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/DeviceScaleScreenCaptureTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/DeviceScaleScreenCaptureTest.kt
@@ -1,0 +1,111 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import java.awt.Rectangle
+import java.awt.image.BaseMultiResolutionImage
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * Region stills written as artifacts must carry screen pixels, not the logical rectangle
+ * `java.awt.Robot.createScreenCapture` downsamples to. The device-pixel variants are only reachable
+ * through `createMultiResolutionScreenCapture`, so these tests pin the variant-selection rule.
+ */
+class DeviceScaleScreenCaptureTest {
+
+    @Test
+    fun `picks the densest resolution variant`() {
+        val logical = argb(100, 100)
+        val device = argb(200, 200)
+
+        val picked =
+            highestResolutionVariant(
+                BaseMultiResolutionImage(logical, device),
+                Rectangle(0, 0, 100, 100),
+            )
+
+        assertEquals(200, picked.width)
+        assertEquals(200, picked.height)
+    }
+
+    @Test
+    fun `hands back the only variant on a 1x display without resampling`() {
+        val logical = argb(100, 100)
+
+        val picked =
+            highestResolutionVariant(BaseMultiResolutionImage(logical), Rectangle(0, 0, 100, 100))
+
+        assertSame(logical, picked, "a single-variant capture must not be copied")
+    }
+
+    @Test
+    fun `variant order does not decide the winner`() {
+        val device = argb(300, 200)
+        val logical = argb(150, 100)
+
+        val picked =
+            highestResolutionVariant(
+                BaseMultiResolutionImage(1, device, logical),
+                Rectangle(0, 0, 150, 100),
+            )
+
+        assertEquals(300, picked.width)
+        assertEquals(200, picked.height)
+    }
+
+    @Test
+    fun `still region capture uses the device-scale source, not the logical one`() {
+        var logicalCalls = 0
+        var deviceCalls = 0
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = {
+                    logicalCalls += 1
+                    argb(100, 100)
+                },
+                nativeCapture = { error("region stills must not touch the native window path") },
+                deviceScaleRegionCapture = {
+                    deviceCalls += 1
+                    argb(200, 200)
+                },
+            )
+
+        val still = backend.captureStillRegion(Rectangle(0, 0, 100, 100))
+
+        assertEquals(0, logicalCalls, "still artifacts must not use the downsampling path")
+        assertEquals(1, deviceCalls)
+        assertEquals(200, still.width)
+        assertEquals(200, still.height)
+    }
+
+    @Test
+    fun `frame-hash region capture stays on the logical path`() {
+        var logicalCalls = 0
+        var deviceCalls = 0
+        val backend =
+            PlatformScreenCaptureBackend(
+                regionCapture = {
+                    logicalCalls += 1
+                    argb(100, 100)
+                },
+                nativeCapture = { error("region capture must not touch the native window path") },
+                deviceScaleRegionCapture = {
+                    deviceCalls += 1
+                    argb(200, 200)
+                },
+            )
+
+        val image = backend.captureRegion(Rectangle(0, 0, 100, 100))
+
+        assertEquals(1, logicalCalls)
+        assertEquals(0, deviceCalls, "visual-idle hashing must keep its cheaper logical frames")
+        assertTrue(image.width == 100 && image.height == 100)
+    }
+
+    private fun argb(width: Int, height: Int): BufferedImage =
+        BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB)
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowStillScaleTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WindowStillScaleTest.kt
@@ -1,0 +1,77 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+import java.awt.Rectangle
+import java.awt.image.BufferedImage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * Window stills must keep the pixel scale the native helper produced.
+ *
+ * The macOS/Windows/Linux still helpers hand back backing-store pixels (a 1600x1000dp window on a
+ * 2x display arrives as 3200x2000) while [WindowCapture.boundsOnScreen] stays in AWT logical units.
+ * Resampling those pixels down to the logical rectangle made every still 1x while `Recorder` kept
+ * writing screen-pixel video for the same window — the asymmetry these tests pin shut.
+ */
+class WindowStillScaleTest {
+
+    @Test
+    fun `an uncropped window still is handed back untouched`() {
+        val image = BufferedImage(3200, 2000, BufferedImage.TYPE_INT_ARGB)
+        val bounds = Rectangle(0, 0, 1600, 1000)
+
+        val still = windowStillForRegion(WindowCapture(image, bounds), bounds)
+
+        assertSame(image, still.image, "a still that needs no crop must not be resampled")
+        assertEquals(bounds, still.boundsOnScreen)
+    }
+
+    @Test
+    fun `cropping to the Compose surface keeps device pixels`() {
+        // 1600x1000dp window on a 2x display, 28dp of title-bar chrome above the Compose surface.
+        val image = BufferedImage(3200, 2000, BufferedImage.TYPE_INT_ARGB)
+        val windowBounds = Rectangle(0, 0, 1600, 1000)
+        val composeSurface = Rectangle(0, 28, 1600, 972)
+
+        val still = windowStillForRegion(WindowCapture(image, windowBounds), composeSurface)
+
+        assertEquals(3200, still.image.width, "cropped still must stay at 2x width")
+        assertEquals(1944, still.image.height, "cropped still must stay at 2x height")
+        assertEquals(composeSurface, still.boundsOnScreen, "bounds stay in logical screen units")
+    }
+
+    @Test
+    fun `cropped pixels are read through the image-space transform`() {
+        val image = BufferedImage(200, 200, BufferedImage.TYPE_INT_ARGB)
+        // Logical (10,20) is device (20,40) at 2x — the first pixel of the crop below.
+        image.setRGB(20, 40, MARKER)
+        val windowBounds = Rectangle(0, 0, 100, 100)
+
+        val still =
+            windowStillForRegion(WindowCapture(image, windowBounds), Rectangle(10, 20, 50, 50))
+
+        assertEquals(100, still.image.width)
+        assertEquals(100, still.image.height)
+        assertEquals(MARKER, still.image.getRGB(0, 0), "crop must start at the scaled origin")
+    }
+
+    @Test
+    fun `a still clipped by the screen keeps the visible region only`() {
+        val image = BufferedImage(400, 400, BufferedImage.TYPE_INT_ARGB)
+        val windowBounds = Rectangle(0, 0, 200, 200)
+
+        val still =
+            windowStillForRegion(WindowCapture(image, windowBounds), Rectangle(100, 100, 200, 200))
+
+        assertEquals(Rectangle(100, 100, 100, 100), still.boundsOnScreen)
+        assertEquals(200, still.image.width, "clipped still keeps the 2x scale")
+        assertEquals(200, still.image.height)
+    }
+
+    private companion object {
+        const val MARKER: Int = 0xFF112233.toInt()
+    }
+}

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -285,7 +285,7 @@ compositor and not raw framebuffer reads.
   region on a 2× display becomes an 800×600 pixel video.
 - Still capture follows the same rule, so a `spectre capture` PNG and a recording of the same
   window come out at the same resolution. See
-  [Atomic capture — Pixel scale](https://spectre.sebastiano.dev/guide/capture/#pixel-scale).
+  [Atomic capture — Pixel scale](guide/capture.md#pixel-scale).
 - `Rectangle` coordinates passed to `start(...)` are in screen pixels. If you derive the region
   from `AutomatorNode.boundsOnScreen` you get the right thing for free; if you derive it from
   `boundsInWindow` you have to apply the density yourself.

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -283,6 +283,9 @@ compositor and not raw framebuffer reads.
 
 - The recorded resolution is the **screen-pixel** size of the region, not the dp size. A 400×300dp
   region on a 2× display becomes an 800×600 pixel video.
+- Still capture follows the same rule, so a `spectre capture` PNG and a recording of the same
+  window come out at the same resolution. See
+  [Atomic capture — Pixel scale](https://spectre.sebastiano.dev/guide/capture/#pixel-scale).
 - `Rectangle` coordinates passed to `start(...)` are in screen pixels. If you derive the region
   from `AutomatorNode.boundsOnScreen` you get the right thing for free; if you derive it from
   `boundsInWindow` you have to apply the density yourself.

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -462,7 +462,7 @@ Exceeding the write budget is **fail-closed**:
 - Parity CI can rely on deterministic taxonomy behaviour instead of size-threshold flakes.
 
 The one exception is the **fullscreen still**, whose size nothing bounds: rather than failing, it
-falls back to logical resolution. See
+drops to logical resolution first, and only reports `payloadTooLarge` if even that overruns. See
 [Atomic capture — Pixel scale](capture.md#pixel-scale).
 
 Spill-to-file for large captures remains a higher-level concern (capture directories / daemon

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -343,7 +343,7 @@ hierarchy.
 
 After the UDS connects, the first exchange is always:
 
-1. Client → `hello` with `protocolVersion` (currently `2` — `ProtocolVersion.CURRENT`)
+1. Client → `hello` with `protocolVersion` (currently `3` — `ProtocolVersion.CURRENT`)
 2. Runtime → `helloAck` with the same version, or `error` with category
    `protocolMismatch`
 
@@ -351,6 +351,13 @@ While the agent API is experimental, compatibility is **exact-match**. A version
 mismatch fails attach with a clear `IOException` / `SpectreAgentException` rather than
 proceeding and hanging on later frames. From 1.0 the rule may become additive-compatible
 (min/max range); that change will bump `ProtocolVersion.CURRENT` and this section.
+
+Revisions so far: **v1** bare request/response frames after `hello`; **v2** (#200) operation
+envelopes with op ids, cancel, and deadline budgets; **v3** bulk payloads (`pngBytes`,
+`captureJsonUtf8`) as CBOR byte strings rather than integer arrays. v3 is the reason the
+handshake matters for more than op availability — it is a *representation* change that the
+type system cannot see, so peers must be refused at `hello` rather than at the frame that
+carries a screenshot.
 
 ### Unknown operations
 

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -432,10 +432,12 @@ Propagation matters, because three processes are involved:
   injects.
   ```
 
-  Only an explicit request is refused. Leaving the budget at its default asks for nothing, so a
-  daemon running something larger is accepted silently — readers take frames up to the ceiling
-  whatever their own budget. A daemon too old to report its budget cannot have been started with
-  the requested one, so it is refused the same way rather than assumed compatible.
+  Only an explicit request is refused, and *explicit* means the option or the variable was
+  present — not that its value differs from the default. Asking for `64MiB` against a `128MiB`
+  daemon is a conflict like any other. Leaving the budget alone asks for nothing, so a daemon
+  running something larger is accepted silently: readers take frames up to the ceiling whatever
+  their own budget. A daemon too old to report its budget cannot have been started with the
+  requested one, so it is refused the same way rather than assumed compatible.
 - The **injected agent** cannot read the daemon's environment, and it is the process that writes
   the bulky screenshot frames, so the daemon forwards its resolved budget in `agentArgs` (see
   below). It applies before the agent's IPC server accepts a request.
@@ -466,11 +468,18 @@ shared FS from #181); the wire layer does not invent a second path for oversized
 
 | Form | Example | Used by |
 |---|---|---|
-| Bare UDS path | `/tmp/sp-a-123-abcd/agent.sock` | hand-written `-javaagent:` lines; still supported |
-| Structured | `uds=/tmp/sp-a-123-abcd/agent.sock,maxFrameBytes=268435456` | the daemon, when it has a non-default budget to pass |
+| Bare UDS path | `/tmp/sp-a-123-abcd/agent.sock` | hand-written `-javaagent:` lines; still **accepted** |
+| Structured | `uds=/tmp/sp-a-123-abcd/agent.sock,maxFrameBytes=268435456` | everything Spectre **emits** |
 
-The structured form is recognised by the `uds=` prefix. Unknown keys and unparseable values are
-ignored rather than failing the attach, so a newer daemon can still drive an older runtime.
+The structured form is recognised by the `uds=` prefix. Values are percent-escaped, so a
+caller-supplied UDS path containing `,` or `=` survives the round trip instead of truncating.
+Unknown keys and unparseable values are ignored rather than failing the attach, so a newer daemon
+can still drive an older runtime.
+
+Spectre always emits the budget, **including the default one**. The target may have been launched
+with a `SPECTRE_MAX_FRAME_BYTES` of its own, and letting that win would leave the daemon and the
+JVM it injected disagreeing about the hop between them — a 16MiB target under a 64MiB daemon would
+fail captures the daemon could carry.
 
 HTTP maps `payloadTooLarge` → **413 Payload Too Large**.
 

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -485,11 +485,21 @@ shared FS from #181); the wire layer does not invent a second path for oversized
 | Structured | `uds=/tmp/sp-a-123-abcd/agent.sock,maxFrameBytes=268435456` | everything Spectre **emits** |
 
 The structured form is recognised by a `uds=` prefix *and* at least one further `,`-separated
-field, so a hand-written bare path that happens to start with `uds=` is still read as a path.
-Values are percent-escaped, so a caller-supplied UDS path containing `,` or `=` survives the round
-trip instead of truncating.
-Unknown keys and unparseable values are ignored rather than failing the attach, so a newer daemon
-can still drive an older runtime.
+field. Values Spectre emits are percent-escaped, so a UDS path containing `,` or `=` survives the
+round trip instead of truncating. The one shape that stays ambiguous is a **hand-written** bare
+path that both starts with `uds=` and contains a comma — `uds=agent,1.sock` is read as structured.
+Any prefix-based discriminator has such a case; this one is documented rather than chased, since
+Spectre only ever emits the structured form and the bare form exists for `-javaagent:` lines you
+write yourself.
+
+Unknown keys and unparseable values are ignored rather than failing the attach, so a runtime that
+understands this format but not a newer key still gets a working session. That tolerance does not
+extend to a runtime predating the format: it reads the whole string as a socket path, binds
+somewhere else, and the attach times out. Spectre resolves the runtime JAR from the attacher, so
+that pairing is only reachable by overriding it (`AttachOptions.agentJarPath` or the runtime-jar
+system property), the bootstrap timeout names the possibility, and `ProtocolVersion.CURRENT` is
+bumped whenever the payload representation changes so a mismatched pair fails the handshake rather
+than a later frame.
 
 Spectre always emits the budget, **including the default one**. The target may have been launched
 with a `SPECTRE_MAX_FRAME_BYTES` of its own, and letting that win would leave the daemon and the

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -407,6 +407,12 @@ The write budget is sized for the bulkiest payload, screenshots, in their worst 
 approach raw bytes-per-pixel on incompressible content, so a 3840x2160 desktop tops out near 25 MB
 of 24-bit sRGB; 64 MiB clears that with room for a dual-4K desktop.
 
+That arithmetic only holds because bulk fields (`pngBytes`, `captureJsonUtf8`) are annotated
+`@ByteString` and therefore encode as CBOR byte strings. Without it kotlinx serializes each signed
+byte as its own integer, inflating the framed response to roughly **1.8x** the payload — which
+would silently invalidate every budget on this page, since they are all expressed against payload
+size. `WirePayloadEncodingTest` pins the encoding.
+
 #### Raising the budget
 
 Larger multi-monitor HiDPI rigs (dual-5K and up) can exceed the default. Raise it with either:

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -484,8 +484,10 @@ shared FS from #181); the wire layer does not invent a second path for oversized
 | Bare UDS path | `/tmp/sp-a-123-abcd/agent.sock` | hand-written `-javaagent:` lines; still **accepted** |
 | Structured | `uds=/tmp/sp-a-123-abcd/agent.sock,maxFrameBytes=268435456` | everything Spectre **emits** |
 
-The structured form is recognised by the `uds=` prefix. Values are percent-escaped, so a
-caller-supplied UDS path containing `,` or `=` survives the round trip instead of truncating.
+The structured form is recognised by a `uds=` prefix *and* at least one further `,`-separated
+field, so a hand-written bare path that happens to start with `uds=` is still read as a path.
+Values are percent-escaped, so a caller-supplied UDS path containing `,` or `=` survives the round
+trip instead of truncating.
 Unknown keys and unparseable values are ignored rather than failing the attach, so a newer daemon
 can still drive an older runtime.
 

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -422,13 +422,26 @@ Propagation matters, because three processes are involved:
 
 - The **CLI** applies the value to itself.
 - A **daemon this invocation starts** inherits it on its command line. A daemon that is *already
-  running* keeps the budget it booted with — restart it (`spectre daemon stop`) to change it.
+  running* keeps the budget it booted with, and reports it in the handshake — so asking for a
+  different one **fails loudly** rather than half-applying:
+
+  ```text
+  Cannot honour --max-frame-bytes=256MiB (268435456 bytes): the running Spectre daemon started
+  with 64MiB (67108864 bytes), and a daemon keeps the budget it booted with. Run
+  `spectre daemon kill` and retry so the new budget applies to the daemon and to the JVMs it
+  injects.
+  ```
+
+  Only an explicit request is refused. Leaving the budget at its default asks for nothing, so a
+  daemon running something larger is accepted silently — readers take frames up to the ceiling
+  whatever their own budget. A daemon too old to report its budget cannot have been started with
+  the requested one, so it is refused the same way rather than assumed compatible.
 - The **injected agent** cannot read the daemon's environment, and it is the process that writes
   the bulky screenshot frames, so the daemon forwards its resolved budget in `agentArgs` (see
   below). It applies before the agent's IPC server accepts a request.
 
-Because readers are permissive up to the ceiling, a partial rollout (say, a raised CLI against an
-older daemon) degrades to the lower of the two budgets rather than breaking.
+Because readers are permissive up to the ceiling, no hop ever rejects a frame a peer legitimately
+sent; the refusal above is about the *request* not being honourable, not about the wire.
 
 #### Over-budget behaviour
 

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -390,17 +390,74 @@ window+screen rects.
 
 ### Payload limits (#204)
 
-Each IPC frame is length-prefixed and hard-capped at **16 MiB** (`MAX_FRAME_BYTES`). This is a
-**fail-closed** policy:
+Each IPC frame is length-prefixed, with **two** separate bounds:
 
-- Responses that encode larger than the cap (e.g. a huge screenshot) are **not** truncated or
-  spilled to disk by the agent transport. The runtime replies with `error` category
-  **`payloadTooLarge`** and a message that includes the sizes.
+| Bound | Value | Applies to |
+|---|---|---|
+| Write budget | **64 MiB** default (`DEFAULT_MAX_FRAME_BYTES`), configurable | the payload a process will send |
+| Read ceiling | **512 MiB** fixed (`MAX_FRAME_BYTES_CEILING`) | the length a process will accept from a header |
+
+They are deliberately different. The read ceiling exists because `readFrame` allocates the payload
+buffer from a length it has not yet validated, so it bounds what a corrupt or desynchronised header
+can make a reader allocate. Keeping it fixed and well above the write budget means two endpoints on
+different budgets can never strand a response: a reader always accepts what any legitimately
+configured writer sends.
+
+The write budget is sized for the bulkiest payload, screenshots, in their worst case. PNG can only
+approach raw bytes-per-pixel on incompressible content, so a 3840x2160 desktop tops out near 25 MB
+of 24-bit sRGB; 64 MiB clears that with room for a dual-4K desktop.
+
+#### Raising the budget
+
+Larger multi-monitor HiDPI rigs (dual-5K and up) can exceed the default. Raise it with either:
+
+```shell
+export SPECTRE_MAX_FRAME_BYTES=256MiB   # bytes, or a binary suffix: 512, 128k, 64M, 64MiB, 1G
+spectre --max-frame-bytes 256MiB capture <session-id>
+```
+
+The flag overrides the environment variable. Both accept up to the 512 MiB read ceiling.
+
+Propagation matters, because three processes are involved:
+
+- The **CLI** applies the value to itself.
+- A **daemon this invocation starts** inherits it on its command line. A daemon that is *already
+  running* keeps the budget it booted with — restart it (`spectre daemon stop`) to change it.
+- The **injected agent** cannot read the daemon's environment, and it is the process that writes
+  the bulky screenshot frames, so the daemon forwards its resolved budget in `agentArgs` (see
+  below). It applies before the agent's IPC server accepts a request.
+
+Because readers are permissive up to the ceiling, a partial rollout (say, a raised CLI against an
+older daemon) degrades to the lower of the two budgets rather than breaking.
+
+#### Over-budget behaviour
+
+Exceeding the write budget is **fail-closed**:
+
+- Responses that encode larger than the budget are **not** truncated or spilled to disk by the
+  agent transport. The runtime replies with `error` category **`payloadTooLarge`** and a message
+  that includes the sizes.
 - The connection stays open; subsequent ops on the same session continue normally.
 - Parity CI can rely on deterministic taxonomy behaviour instead of size-threshold flakes.
 
+The one exception is the **fullscreen still**, whose size nothing bounds: rather than failing, it
+falls back to logical resolution. See
+[Atomic capture — Pixel scale](capture.md#pixel-scale).
+
 Spill-to-file for large captures remains a higher-level concern (capture directories / daemon
 shared FS from #181); the wire layer does not invent a second path for oversized frames.
+
+#### `agentArgs` format
+
+`-javaagent:spectre-agent-runtime.jar=<agentArgs>` accepts two forms:
+
+| Form | Example | Used by |
+|---|---|---|
+| Bare UDS path | `/tmp/sp-a-123-abcd/agent.sock` | hand-written `-javaagent:` lines; still supported |
+| Structured | `uds=/tmp/sp-a-123-abcd/agent.sock,maxFrameBytes=268435456` | the daemon, when it has a non-default budget to pass |
+
+The structured form is recognised by the `uds=` prefix. Unknown keys and unparseable values are
+ignored rather than failing the attach, so a newer daemon can still drive an older runtime.
 
 HTTP maps `payloadTooLarge` → **413 Payload Too Large**.
 

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -113,6 +113,12 @@ the JUnit failure artifacts below.
     `--max-frame-bytes` / `$SPECTRE_MAX_FRAME_BYTES` to get the full-resolution still — see
     [Agent — Payload limits](agent.md#payload-limits-204).
 
+    On a **mixed-density multi-monitor** desktop a fullscreen still is also bounded by
+    `java.awt.Robot`, which derives one scale from the display under the centre of the captured
+    rectangle rather than capturing each display at its own. The still comes back at that display's
+    scale, so a desktop centred on a 1x monitor downsamples the Retina parts. Window-scoped stills
+    are unaffected — they use the target window's own screen scale.
+
     Window-scoped stills are bounded by the window, so they effectively never hit the budget. A
     `capture` of an extremely large window on a high-density display is the exception: it fails
     loudly with a `payloadTooLarge` error rather than downgrading, because `capture.json` records

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -106,15 +106,17 @@ the JUnit failure artifacts below.
 !!! note "Oversized fullscreen stills degrade instead of failing"
 
     `spectre screenshot --fullscreen` is the one still whose size nothing bounds — a multi-monitor
-    HiDPI desktop can encode past the attach transport's 16 MiB frame limit. When the screen-pixel
-    PNG would not fit, Spectre falls back to a **logical**-resolution desktop still rather than
-    failing the command. Compare the PNG size against your desktop's logical bounds if you need to
-    know which one you got.
+    HiDPI desktop can encode past the attach transport's frame budget (64 MiB by default, which
+    holds a worst-case 4K desktop). When the screen-pixel PNG would not fit, Spectre falls back to
+    a **logical**-resolution desktop still rather than failing the command. Compare the PNG size
+    against your desktop's logical bounds if you need to know which one you got, and raise
+    `--max-frame-bytes` / `$SPECTRE_MAX_FRAME_BYTES` to get the full-resolution still — see
+    [Agent — Payload limits](agent.md#payload-limits-204).
 
-    Window-scoped stills are bounded by the window, so they effectively never hit the limit. A
+    Window-scoped stills are bounded by the window, so they effectively never hit the budget. A
     `capture` of an extremely large window on a high-density display is the exception: it fails
     loudly with a `payloadTooLarge` error rather than downgrading, because `capture.json` records
-    the PNG's exact size and must keep agreeing with it.
+    the PNG's exact size and must keep agreeing with it. Raise the budget and retry.
 
 The one deliberate exception is in-process `ComposeAutomator.screenshot(region)`, which stays
 **logical**-sized so image coordinates equal screen coordinates — that 1:1 mapping is what makes it

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -103,6 +103,19 @@ This applies to every still Spectre writes — `spectre capture`, `spectre scree
 in-process `screenshot(windowIndex)` / `screenshot(node)` / `screenshotAtDeviceScale(region)`, and
 the JUnit failure artifacts below.
 
+!!! warning "One exception: an older `spectre-core` in the target application"
+
+    On the attach path the pixels come from the `spectre-core` already on the **target's**
+    classpath, not from the CLI. A target running a core older than screen-pixel stills has no
+    `screenshotAtDeviceScale`, so `screenshot --fullscreen` falls back to its logical-size
+    `screenshot(region)` and `capture` uses that core's own still behaviour — the command succeeds
+    and returns a **dp-sized** PNG. This is deliberate: refusing would break attach against
+    applications Spectre otherwise drives fine.
+
+    `capture.json` still describes what you actually got, so the check is the same one as always —
+    compare `window.imageWidth` against `window.boundsScreen.width`. Bump the `spectre-core`
+    dependency in the target application to get screen-pixel stills.
+
 !!! note "Oversized fullscreen stills degrade instead of failing"
 
     `spectre screenshot --fullscreen` is the one still whose size nothing bounds — a multi-monitor

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -133,8 +133,12 @@ the JUnit failure artifacts below.
     On a **mixed-density multi-monitor** desktop a fullscreen still is also bounded by
     `java.awt.Robot`, which derives one scale from the display under the centre of the captured
     rectangle rather than capturing each display at its own. The still comes back at that display's
-    scale, so a desktop centred on a 1x monitor downsamples the Retina parts. Window-scoped stills
-    are unaffected — they use the target window's own screen scale.
+    scale, so a desktop centred on a 1x monitor downsamples the Retina parts.
+
+    Window-scoped stills escape this only while `spectre-recording` is on the target's classpath,
+    because the native helpers use the target window's own screen scale. Without it a window still
+    is a Robot region capture too, so a window straddling displays of different densities shares
+    the limit.
 
     Window-scoped stills are bounded by the window, so they effectively never hit the budget. A
     `capture` of an extremely large window on a high-density display is the exception: it fails

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -107,11 +107,15 @@ the JUnit failure artifacts below.
 
     `spectre screenshot --fullscreen` is the one still whose size nothing bounds — a multi-monitor
     HiDPI desktop can encode past the attach transport's frame budget (64 MiB by default, which
-    holds a worst-case 4K desktop). When the screen-pixel PNG would not fit, Spectre falls back to
-    a **logical**-resolution desktop still rather than failing the command. Compare the PNG size
+    holds a worst-case 4K desktop). When the screen-pixel PNG would not fit, Spectre drops to a
+    **logical**-resolution desktop still rather than failing the command. Compare the PNG size
     against your desktop's logical bounds if you need to know which one you got, and raise
     `--max-frame-bytes` / `$SPECTRE_MAX_FRAME_BYTES` to get the full-resolution still — see
     [Agent — Payload limits](agent.md#payload-limits-204).
+
+    That drop is best-effort, not a guarantee: below a certain budget no desktop screenshot fits at
+    any resolution, so there is nothing to degrade to. If even the logical still overruns you get a
+    `payloadTooLarge` error naming the flag that fixes it, rather than a silent failure.
 
     On a **mixed-density multi-monitor** desktop a fullscreen still is also bounded by
     `java.awt.Robot`, which derives one scale from the display under the centre of the captured

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -77,7 +77,7 @@ Library details live in `:core` under `dev.sebastiano.spectre.core.capture`.
 ## Pixel scale
 
 `screenshot.png` is written at **screen-pixel** size, not dp size — the same rule
-[recording](https://github.com/rock3r/spectre/blob/main/docs/RECORDING-LIMITATIONS.md) follows.
+[recording](../RECORDING-LIMITATIONS.md) follows.
 A 1600×1000dp window on a 2× display produces a **3200×2000 pixel** PNG. On a 1× display the two
 sizes coincide.
 

--- a/docs/guide/capture.md
+++ b/docs/guide/capture.md
@@ -74,9 +74,56 @@ pixels stay decision-grade across native still-helper latency.
 
 Library details live in `:core` under `dev.sebastiano.spectre.core.capture`.
 
+## Pixel scale
+
+`screenshot.png` is written at **screen-pixel** size, not dp size — the same rule
+[recording](https://github.com/rock3r/spectre/blob/main/docs/RECORDING-LIMITATIONS.md) follows.
+A 1600×1000dp window on a 2× display produces a **3200×2000 pixel** PNG. On a 1× display the two
+sizes coincide.
+
+`capture.json` always states which is which, so nothing has to be inferred from the file:
+
+| Field | Units | 1600×1000dp window at 2× |
+|---|---|---|
+| `window.imageWidth` / `imageHeight` | PNG pixels | `3200` / `2000` |
+| `window.boundsScreen` | logical screen units | `width: 1600, height: 1000` |
+| `window.densityScaleX` / `densityScaleY` | ratio | `2.0` / `2.0` |
+| `nodes[].boundsImage` | PNG pixels | scales with the PNG |
+| `nodes[].boundsScreen` | logical screen units | use this for input targeting |
+
+Two consequences worth knowing:
+
+- **Node bounds do not need a density conversion.** `boundsImage` is derived from the actual PNG
+  size, so it addresses the PNG correctly at any scale. Keep using `boundsScreen` for clicks —
+  input coordinates stay logical.
+- **Comparing PNGs across machines needs care.** The same UI captured on a 1× and a 2× display
+  yields different pixel dimensions. Normalise with `densityScale*`, or assert on `boundsScreen`.
+
+This applies to every still Spectre writes — `spectre capture`, `spectre screenshot --fullscreen`,
+in-process `screenshot(windowIndex)` / `screenshot(node)` / `screenshotAtDeviceScale(region)`, and
+the JUnit failure artifacts below.
+
+!!! note "Oversized fullscreen stills degrade instead of failing"
+
+    `spectre screenshot --fullscreen` is the one still whose size nothing bounds — a multi-monitor
+    HiDPI desktop can encode past the attach transport's 16 MiB frame limit. When the screen-pixel
+    PNG would not fit, Spectre falls back to a **logical**-resolution desktop still rather than
+    failing the command. Compare the PNG size against your desktop's logical bounds if you need to
+    know which one you got.
+
+    Window-scoped stills are bounded by the window, so they effectively never hit the limit. A
+    `capture` of an extremely large window on a high-density display is the exception: it fails
+    loudly with a `payloadTooLarge` error rather than downgrading, because `capture.json` records
+    the PNG's exact size and must keep agreeing with it.
+
+The one deliberate exception is in-process `ComposeAutomator.screenshot(region)`, which stays
+**logical**-sized so image coordinates equal screen coordinates — that 1:1 mapping is what makes it
+useful for pixel assertions addressed by `boundsOnScreen`. Call `screenshotAtDeviceScale(region)`
+for the screen-pixel version of the same region.
+
 ## Failure artifacts from JUnit
 
 On a **failed** Spectre JUnit test, `ComposeAutomatorExtension` / `ComposeAutomatorRule`
 write the same `capture.json` + `screenshot.png` layout under `build/reports/spectre/`
-(not `$TMPDIR`). See [JUnit integration — Failure artifacts](junit.md#failure-artifacts)
+(not `$TMPDIR`), at the same screen-pixel scale — they go through `capture()` too. See [JUnit integration — Failure artifacts](junit.md#failure-artifacts)
 and the CI upload snippet in [Running on CI](ci.md#failure-artifacts).

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -248,7 +248,7 @@ Three different surfaces — pick intentionally:
 
 | Surface | CLI | What you get | Targeting notes |
 | --- | --- | --- | --- |
-| **Fullscreen screenshot** | `screenshot … --fullscreen` | Single PNG of the **full virtual desktop** | **Only** screen-pixel mode on the attach/CLI path. Default / `--window` / `--surface` **fail closed** (occlusion/privacy risk). MCP returns inline PNG bytes, not a path. |
+| **Fullscreen screenshot** | `screenshot … --fullscreen` | Single PNG of the **full virtual desktop** | **Only** whole-desktop mode on the attach/CLI path. Default / `--window` / `--surface` **fail closed** (occlusion/privacy risk). MCP returns inline PNG bytes, not a path. |
 | **Atomic capture** | `capture` | Window PNG + full semantics tree on **daemon disk** (`capture.json` + `screenshot.png`) | `--window` default **0**. Summary only on stdout/MCP (paths + counts). See [Atomic capture](capture.md). |
 | **Recording** | `record start` / `stop` / `status` | MP4 path on **daemon filesystem** | Default: tracked **window index 0**. `--fullscreen` = **primary display only** (not multi-monitor). Returns **paths**, never video bytes. |
 
@@ -273,6 +273,12 @@ spectre captures prune --keep 20
 spectre captures prune --session <session-id>
 spectre captures prune --older-than 7d --include-out-dir --force
 ```
+
+All three write **screen-pixel** sized output, not dp sized: on a 2× display a 1600×1000dp
+window yields a 3200×2000 pixel PNG and an equally sized MP4. `capture.json` reports the exact
+PNG size in `window.imageWidth` / `imageHeight`. The one exception is a `--fullscreen` still too
+large for the attach transport's 16 MiB frame, which falls back to logical resolution rather than
+failing — see [Atomic capture — Pixel scale](capture.md#pixel-scale).
 
 `captures list` shows size and live/closed status. `captures prune` supports `--keep N`,
 `--older-than` (`30s` / `5m` / `24h` / `7d`), `--all`, `--session <id>`, `--force` (override

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -277,8 +277,10 @@ spectre captures prune --older-than 7d --include-out-dir --force
 All three write **screen-pixel** sized output, not dp sized: on a 2× display a 1600×1000dp
 window yields a 3200×2000 pixel PNG and an equally sized MP4. `capture.json` reports the exact
 PNG size in `window.imageWidth` / `imageHeight`. The one exception is a `--fullscreen` still too
-large for the attach transport's 16 MiB frame, which falls back to logical resolution rather than
-failing — see [Atomic capture — Pixel scale](capture.md#pixel-scale).
+large for the attach transport's frame budget, which falls back to logical resolution rather than
+failing — see [Atomic capture — Pixel scale](capture.md#pixel-scale). The budget defaults to 64 MiB
+(a worst-case 4K desktop) and is raised with `--max-frame-bytes` or `$SPECTRE_MAX_FRAME_BYTES`; see
+[Agent — Payload limits](agent.md#payload-limits-204).
 
 `captures list` shows size and live/closed status. `captures prune` supports `--keep N`,
 `--older-than` (`30s` / `5m` / `24h` / `7d`), `--all`, `--session <id>`, `--force` (override

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/AtomicCaptureValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/AtomicCaptureValidationTest.kt
@@ -33,6 +33,9 @@ class AtomicCaptureValidationTest {
 
     private val fixture = SampleAppFixture(title = "Spectre atomic capture validation")
 
+    /** Rounding slack: capture regions are integer dp, so the PNG ratio can drift a hair. */
+    private val PNG_SCALE_TOLERANCE: Double = 0.02
+
     @BeforeAll
     fun start() {
         assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
@@ -108,15 +111,32 @@ class AtomicCaptureValidationTest {
             assertEquals(window.imageHeight, png.height)
             assertTargetPixelsPresent(png, node.boundsImage)
 
-            // Density is recorded from the graphics transform; PNG scale may differ (synthetic
-            // screenshots often yield 1:1 AWT↔image while densityScale reports Retina 2.0). The
-            // image-space transform must still reconcile boundsScreen with the actual PNG size.
+            // Stills are screen-pixel sized, so the PNG must be the logical window bounds scaled
+            // by the display density — on a 2x display a 1600x1000dp surface is a 3200x2000 PNG.
+            // This is the end-to-end guard against silently resampling native stills back to 1x.
             assertTrue(window.densityScaleX > 0.0 && window.densityScaleY > 0.0)
             val scaleFromPixelsX =
                 window.imageWidth.toDouble() / window.boundsScreen.width.toDouble()
             val scaleFromPixelsY =
                 window.imageHeight.toDouble() / window.boundsScreen.height.toDouble()
-            assertTrue(scaleFromPixelsX > 0.0 && scaleFromPixelsY > 0.0)
+            println(
+                "[atomic-capture] png=${window.imageWidth}x${window.imageHeight} " +
+                    "boundsScreen=${window.boundsScreen.width}x${window.boundsScreen.height} " +
+                    "density=${window.densityScaleX}x${window.densityScaleY} " +
+                    "pngScale=${scaleFromPixelsX}x$scaleFromPixelsY"
+            )
+            assertEquals(
+                window.densityScaleX,
+                scaleFromPixelsX,
+                PNG_SCALE_TOLERANCE,
+                "PNG width must be the logical width at display density, not dp-sized",
+            )
+            assertEquals(
+                window.densityScaleY,
+                scaleFromPixelsY,
+                PNG_SCALE_TOLERANCE,
+                "PNG height must be the logical height at display density, not dp-sized",
+            )
 
             // Second target: relative geometry in image space must preserve the 2:1 dp ratio
             // (160dp x, 80dp y) regardless of absolute density — HiDPI-scaled config coverage.

--- a/skills/spectre-capture/SKILL.md
+++ b/skills/spectre-capture/SKILL.md
@@ -113,6 +113,12 @@ Stable API surface — a schema bump is a skill bump (release checklist).
 | `boundsImage` | **Primary** — pixels of `screenshot.png` |
 | `boundsScreen` | Secondary — screen-space for input targeting |
 
+`screenshot.png` is **screen-pixel** sized, so on a 2× display it is twice the dp size of the
+window and `window.imageWidth` ≠ `window.boundsScreen.width`. Use `boundsImage` to address the
+PNG and `boundsScreen` to target input — neither needs a manual density conversion.
+`window.densityScaleX` / `densityScaleY` report the ratio when you need to compare captures taken
+on displays with different densities.
+
 `summary.textedNodeCount` counts nodes with non-empty `text` **or** `editableText`.
 
 ## jq recipes


### PR DESCRIPTION
`spectre capture` produced PNGs at dp size, so stills on a HiDPI display were effectively 1x and visibly soft — while `docs/RECORDING-LIMITATIONS.md` documents recording as screen-pixel sized. This makes the two agree, then fixes the transport limit that agreement ran into.

## 1. Stills keep the pixels the backend captured

`ComposeAutomator.screenshotTrackedRegionCapture` resampled the native still down to the AWT logical rectangle via `normalizeImageToScreenBounds`. The helpers were already doing the right thing — the macOS SCK path multiplies the window frame by the display's backing scale — so 3200x2000 pixels were captured and thrown away.

Dropping the resample is enough: cropping already runs in image space through `screenRectToImageRect`, so a 2x still stays 2x and `boundsImage` scales with the PNG for free. The golden fixture already modelled this contract (`boundsScreen` 400x300, `densityScale` 2.0, `imageWidth` 800), which is good evidence it was a bug rather than a decision. `normalizeImageToScreenBounds` stays for visual-idle frame hashing, which wants cheap logical frames.

`screenshotAtDeviceScale(region)` is new on `RobotDriver` / `ComposeAutomator`, reaching device pixels through `createMultiResolutionScreenCapture`. It backs the `capture()` fallback used when `spectre-recording` is absent, plus the attach fullscreen and node-region stills, so every still artifact agrees. `screenshot(region)` keeps its documented 1:1 screen-to-image mapping — that mapping is what makes it useful for pixel assertions addressed by `boundsOnScreen`.

| Path | Before | After |
|---|---|---|
| `capture`, `screenshot(windowIndex)`, `screenshot(node)`, JUnit artifacts | logical | **screen pixels** |
| `capture()` fallback without `spectre-recording` | logical | **screen pixels** |
| `screenshot --fullscreen` | logical | **screen pixels** |
| `ComposeAutomator.screenshot(region)` / `RobotDriver.screenshot(region)` | logical | logical (unchanged) |

Verified live on a 2x display. Same machine, before and after:

- without the fix: `png=800x572  boundsScreen=800x572  density=2.0  pngScale=1.0` — the reported bug
- with the fix: `png=1600x1144  boundsScreen=800x572  density=2.0  pngScale=2.0`

`AtomicCaptureValidationTest` now asserts that ratio, and I confirmed it fails against unmodified production code rather than passing vacuously.

## 2. The frame budget that agreement ran into

Screen-pixel stills quadruple the IPC payload, and the repo's own integration tests caught it: `payloadTooLarge — 20671738 exceeds MAX_FRAME_BYTES=16777216`, reproducibly.

16 MiB turned out to have no reason behind it. The 4-byte length header means the protocol ceiling is `Int.MAX_VALUE`; the value was picked in the original `:agent` commit (#156) and its KDoc justified it only with *"screenshots are the bulkiest reasonable case"*. #204 tracks the policy as explicitly undecided and predicted this exact failure — *"parity CI ... cannot be flaky because a HiDPI screenshot crossed a size threshold"* — so this closes out a known gap.

The single cap was conflating two concerns, now split:

| Bound | Value | Purpose |
|---|---|---|
| Write budget | **64 MiB** default, configurable | what a process will send |
| Read ceiling | **512 MiB** fixed | what a process accepts from a header |

Keeping the ceiling fixed and well above the budget is what makes this safe: a reader always accepts what any legitimately configured writer sends, so the three processes can never disagree into a stranded response. The allocation guard on `readFrame` survives, just at a level that bounds garbage rather than policy. 64 MiB comes from the worst case being incompressible — PNG only approaches raw bytes-per-pixel, so 3840x2160 tops out near 25 MB of 24-bit sRGB; dual-4K also fits.

Override is `SPECTRE_MAX_FRAME_BYTES` (bytes or a binary suffix) or `spectre --max-frame-bytes`, clamped to the ceiling. Propagation is the subtle part: an injected agent cannot read the daemon's environment and is the process that writes the bulky frames, so the daemon forwards its resolved budget in `agentArgs`. That gains a structured `uds=<path>,k=v` form; a bare UDS path still parses, so hand-written `-javaagent:` lines keep working, and unknown keys are ignored so a newer daemon can drive an older runtime.

Verified against a live attach: the default reaches the injected JVM as `67108864` over the unchanged bare-path form, and `SPECTRE_MAX_FRAME_BYTES=128MiB` arrives as `uds=...,maxFrameBytes=134217728` with the target adopting it.

That run also caught a real bug: `FrameLimits` parsed the environment in its own initializer while the regex it used was declared after the field reading it, so the class failed to load on exactly the machines that set the override. The pattern moved to file scope, and `FrameLimitsEnvTest` spawns a JVM with the variable set to cover the path no in-process test can reach — confirmed red against the old ordering.

## 3. A budget the daemon can't honour is refused, not half-applied

A daemon keeps the budget it booted with, so `--max-frame-bytes` on a later invocation would have applied to the CLI alone while the two hops that actually carry a screenshot stayed on the old value.

The daemon now reports its budget in the handshake (`DaemonResponse.Hello` gains `maxFrameBytes`, protocol minor 1.11 -> 1.12) and the client refuses:

```text
Cannot honour --max-frame-bytes=256MiB (268435456 bytes): the running Spectre daemon
started with 64MiB (67108864 bytes), and a daemon keeps the budget it booted with. Run
`spectre daemon kill` and retry so the new budget applies to the daemon and to the JVMs
it injects.
```

Only an explicit request is refused. A client left on the default asked for nothing, and readers take frames up to the ceiling whatever their own budget, so a daemon on more is accepted silently. A daemon too old to report its budget cannot have been started with the requested one, so it is refused rather than assumed compatible.

This is covered by a pure decision function plus `DaemonFrameBudgetE2eTest`, which boots real daemon processes on one budget and queries them on another — the property only holds against a real process, since the in-process registry reports whatever the test JVM currently has set. Verified red with the check disabled, stable over three runs.

The protocol bump also rotates the versioned daemon socket, so a stale 1.11 daemon is not contacted at all.

## Documentation

`docs/guide/capture.md` gains a **Pixel scale** section with a units table for every `capture.json` field — its absence is how the mismatch went unnoticed. `docs/guide/agent.md` gets the payload-limit policy in its wire-format section, which is what #204's acceptance criteria asked for. Also updated: `cli.md`, the HiDPI section of `RECORDING-LIMITATIONS.md`, the `spectre-capture` skill, and the KDocs.

## Deliberate non-changes

- **`capture` fails loudly on an oversized payload** rather than downgrading — `capture.json` records the PNG's exact size and must keep agreeing with it. `screenshot --fullscreen` is the exception and degrades to logical resolution, because the virtual desktop is the one still whose size nothing bounds; both are documented.
- **`RobotDriver.screenshot(region)` keeps its logical contract.** Silently changing it would break pixel-assertion tests that rely on image coordinates equalling screen coordinates.
- **`MAX_FRAME_BYTES` is removed** rather than deprecated. It is `@ExperimentalSpectreAgentApi`, and the ABI diff is otherwise additive.

## Verification

`./gradlew check` and `mkdocs build --strict` pass. ABI dumps updated for `:core` and `:agent`.

`AgentAttachIntegrationTest` flakes intermittently on `typeText` keyboard focus when the host machine is being driven concurrently, which is how it behaved before this branch too; it passed 4/5 loops locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
