### PR TITLE
docs: stop claiming agent attach requires preinstalled spectre-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ npx skills add rock3r/spectre --skill spectre
   window/region recording and still screenshots. Runtime machines need Windows 10 version
   1903+, .NET 8 Desktop Runtime, and Windows App Runtime 1.8; contributors building the
   helper need the .NET 8 SDK.
-- `agent` — experimental local attach transport for driving a Spectre-instrumented JVM from a
-  separate process.
+- `agent` — experimental local attach transport for driving a running Compose JVM from a
+  separate process (preinstalled `spectre-core` preferred; inject when the target has no core).
 - `agent-runtime` — loadable Java-agent runtime jar used by `agent` when attaching to a target JVM.
 - `testing` — JUnit 5 extension and JUnit 4 rule.
 - `sample-desktop` — Compose Desktop app for manual smokes.

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/Exceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/Exceptions.kt
@@ -11,11 +11,13 @@ internal sealed class SpectreAgentBootstrapException(message: String) : RuntimeE
 
 /**
  * Thrown by [AgentBootstrap] when no class with the fully-qualified name
- * `dev.sebastiano.spectre.core.ComposeAutomator` is found among the target JVM's loaded classes.
+ * `dev.sebastiano.spectre.core.ComposeAutomator` is found among the target JVM's loaded classes
+ * **and** nested inject-runtime bootstrap cannot supply one.
  *
- * The thin-agent design (UC-1 in the issue #153 workshop plan) requires the target application to
- * already have Spectre on its classpath. This exception is the agent's way of saying "you attached
- * to a JVM that doesn't have Spectre — add the dependency and try again".
+ * Prefer a preinstalled `spectre-core` dependency on the target. When core is absent, bootstrap
+ * tries `META-INF/spectre/inject-runtime.jar` from the agent runtime jar. This exception means both
+ * paths failed — typically a runtime jar built without the inject payload, or a target with neither
+ * Spectre nor a usable inject jar.
  */
 internal class SpectreNotOnClasspathException :
     SpectreAgentBootstrapException(

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/AgentAttachDocsContractTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/AgentAttachDocsContractTest.kt
@@ -1,0 +1,85 @@
+package dev.sebastiano.spectre.core
+
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Pins user-facing agent-attach guidance against the two-path bootstrap that actually ships:
+ * preinstalled `spectre-core` is preferred, but attach still works via nested inject-runtime when
+ * the target only has Compose.
+ */
+class AgentAttachDocsContractTest {
+
+    @Test
+    fun `agent skill does not require preinstalled spectre-core`() {
+        val skill = read("skills/spectre/references/agent.md")
+        assertFalse(
+            skill.contains("must already have"),
+            "Agent skill still claims the target must already have spectre-core on its classpath",
+        )
+        assertContains(skill, "inject-runtime.jar")
+        assertContains(skill, "preinstalled")
+        assertContains(skill, "ComposeAutomator")
+    }
+
+    @Test
+    fun `user guide and install docs describe inject as the no-core path`() {
+        val installation = read("docs/guide/installation.md")
+        val troubleshooting = read("docs/guide/troubleshooting.md")
+        val readme = read("README.md")
+
+        assertContains(installation, "inject-runtime.jar")
+        assertContains(troubleshooting, "inject")
+        assertFalse(
+            troubleshooting.contains("Ensure the app depends on\n`spectre-core`"),
+            "Troubleshooting still treats missing spectre-core as the only AGENT_BOOTSTRAP cause",
+        )
+        assertFalse(
+            readme.contains("Spectre-instrumented JVM"),
+            "README still implies attach only works against a pre-instrumented target",
+        )
+        assertContains(readme, "inject")
+    }
+
+    @Test
+    fun `published spectre-ui-automation skill matches current typing and wait APIs`() {
+        val packaged = read("skill/SKILL.md")
+        assertFalse(
+            packaged.contains("clipboard-based"),
+            "Packaged skill still describes typeText as clipboard-based",
+        )
+        assertContains(packaged, "pasteText")
+        assertFalse(
+            packaged.contains("EDT-safe"),
+            "Packaged skill still calls waitForNode EDT-safe; all wait helpers reject the EDT",
+        )
+        assertContains(packaged, "runSpectreTest")
+    }
+
+    @Test
+    fun `spectre skill evals require runSpectreTest not runBlocking`() {
+        val evals = read("skills/spectre/evals/evals.json")
+        assertContains(evals, "runSpectreTest")
+        assertFalse(
+            evals.contains("runBlocking { ... }"),
+            "Skill evals still require runBlocking instead of runSpectreTest",
+        )
+        assertFalse(
+            evals.contains("dev.sebastiano.spectre.core.synthetic"),
+            "Skill evals still claim a non-existent synthetic extension import",
+        )
+    }
+
+    private fun read(relative: String): String = root.resolve(relative).readText()
+
+    private fun assertContains(haystack: String, needle: String) {
+        assertTrue(haystack.contains(needle), "Expected '$needle' in guidance, but it was missing")
+    }
+
+    private companion object {
+        val root: Path = Path.of("..").toAbsolutePath().normalize()
+    }
+}

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -563,8 +563,9 @@ Not additive-safe without a version bump:
   # PowerShell: quote -P… so the shell does not split on the property name
   ./gradlew :agent:test "-Pspectre.agent.attachE2e.allowWindows=true" --tests '*AgentAttachIntegration*'
   ```
-- **Wait ops.** `waitForNode` / `waitForVisualIdle` are supported over agent IPC (#201) with
-  shared deadline budgets and cancel. Idling-resource `waitForIdle` stays in-process only.
+- **Wait ops.** `waitForNode`, `waitForVisualIdle`, and fingerprint `waitForIdle` are
+  supported over agent IPC with shared deadline budgets and cancel. Idling-resource
+  registration stays in-process only.
 - **IntelliJ-hosted Compose**: the classloader-disambiguation rule (D-14 in the plan) was
   designed to handle `PluginClassLoader` chains but isn't automatically tested yet. If
   you hit issues attaching to an IntelliJ-hosted target, file a Spectre issue with the

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -93,8 +93,14 @@ If you depend on `agent`, keep the artifact roles separate:
   `AgentAttach`, `AttachedAutomator`, and `AttachOptions`.
 - Add `spectre-agent-runtime` to the attacher's runtime/test-runtime classpath. `AgentAttach`
   locates that physical jar and passes it to `VirtualMachine.loadAgent(...)`.
-- Add `spectre-core` to the target app. The target does not need `spectre-agent` or
-  `spectre-agent-runtime` declared as dependencies.
+- Prefer adding `spectre-core` to the **target** app (instrumented attach). The target does
+  not need `spectre-agent` or `spectre-agent-runtime` declared as dependencies.
+- If the target cannot take that dependency (stock IDE, third-party binary) but already
+  loads Compose, attach still works: `spectre-agent-runtime` carries a nested
+  `META-INF/spectre/inject-runtime.jar` and bootstrap loads Spectre core from that payload.
+  Same `AgentAttach.attach(pid)` call — no separate inject flag. This is an experimental
+  inspect path; prefer preinstalled core when you control the target build. See
+  [Agent attach](agent.md).
 
 Custom launchers that do not expose the runtime jar on `java.class.path` can pass an explicit
 `AttachOptions.agentJarPath` or set `-Ddev.sebastiano.spectre.agent.runtimeJar=<path>`. See

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -290,7 +290,7 @@ A few things to know about IDE-hosted Compose surfaces:
     1. **Region-capture the tool window's screen bounds.** Compute the tool window
        component's `boundsOnScreen` and pass it to `AutoRecorder.startRegion(...)`.
        `AutoRecorder` routes that through platform region capture (Windows Graphics
-       Capture on Windows, `ffmpeg` on macOS, the Linux helper on Xorg/Xvfb, or the Wayland portal on
+       Capture on Windows, the ScreenCaptureKit helper on macOS, the Linux helper on Xorg/Xvfb, or the Wayland portal on
        Linux Wayland). Works everywhere; the trade-off is
        that anything overlapping the captured rectangle — the IDE's chrome,
        notifications, popups that escape the tool window's bounds — appears in the
@@ -317,9 +317,9 @@ A few things to know about IDE-hosted Compose surfaces:
 - **Popups inside the IDE** are still tracked. Compose creates separate roots for them,
   and Spectre's window tracking enumerates each one — your selectors find nodes regardless
   of whether they live in the main tool window or a dropdown.
-- **The IDE owns its own EDT**. Spectre's `waitForIdle` and `waitForVisualIdle` still
-  refuse to run on it, so any code path triggered from a UI handler needs to bounce
-  off to a pooled background thread before calling them.
+- **The IDE owns its own EDT**. Spectre's `waitForNode`, `waitForIdle`, and
+  `waitForVisualIdle` still refuse to run on it, so any code path triggered from a
+  UI handler needs to bounce off to a pooled background thread before calling them.
 
 ## Where to look
 

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -88,7 +88,10 @@ When the UI under test is a **separate JVM** (prod-like `java -jar`, installDist
 `./gradlew :app:run` with warnings), use `LaunchAndAttachExtension` (JUnit 5) or
 `LaunchAndAttachRule` (JUnit 4) from `:testing`. They call the shared agent launch core
 before each test and tear the process tree down after — the same lifecycle window
-`ComposeAutomatorExtension` / `ComposeAutomatorRule` use. Failure-artifact capture is
+`ComposeAutomatorExtension` / `ComposeAutomatorRule` use. The launched app does **not**
+need a preinstalled `spectre-core` dependency: attach uses the same two-path bootstrap as
+[agent attach](agent.md) (inject when Compose is present and core is not). Prefer
+preinstalled core when you control the app build. Failure-artifact capture is
 wired into those automator wrappers (see [Failure artifacts](#failure-artifacts)); keep
 the automator rule/extension innermost if you also use launch-and-attach so capture still
 sees open windows.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -36,10 +36,14 @@ caveats. Prefer a prod-like launch (`java -jar`, installDist) when you control t
 
 ### "Agent bootstrap failed (AGENT_BOOTSTRAP)"
 
-The target JVM was found but the agent did not bind its UDS in time, or
-`ComposeAutomator` was not on the target classpath. Ensure the app depends on
-`spectre-core`, and for direct launches that Spectre injects
-`-XX:+EnableDynamicAgentLoading` (Gradle launches must set that flag in the build).
+The target JVM was found but the agent did not bind its UDS in time, bootstrap
+could not find or inject `ComposeAutomator`, or the target has no Compose host.
+Prefer a `spectre-core` dependency on the app (instrumented attach). If the target
+is Compose-only, current `spectre-agent-runtime` jars inject nested
+`META-INF/spectre/inject-runtime.jar` automatically — a missing core dependency is
+no longer a hard requirement. Direct launches that Spectre starts get
+`-XX:+EnableDynamicAgentLoading`; Gradle launches must set that flag in the build.
+See [Agent attach](agent.md#injection-without-preinstalled-core).
 
 ### "Attached but no window (FIRST_WINDOW)"
 
@@ -61,7 +65,7 @@ bounded worker that enforces the timeout, so the helpers raise
 `IllegalStateException` instead. The exact wait name in the message tells you which
 call to wrap.
 
-JUnit test methods don't run on the EDT, so a a `runSpectreTest { … }` body is fine (or plain `runBlocking` as a fallback)
+JUnit test methods don't run on the EDT, so a `runSpectreTest { … }` body is fine (or plain `runBlocking` as a fallback)
 there — no `withContext` needed. The error appears when the call originates from a
 coroutine on `Dispatchers.Main` or any Swing-backed dispatcher, e.g.:
 

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -15,10 +15,13 @@ compatibility: Requires a Compose Desktop or Compose Multiplatform (desktop targ
 
 Spectre automates live Compose Desktop UIs by reading the semantics tree and dispatching real OS input. Full docs and API reference: **[spectre.sebastiano.dev](https://spectre.sebastiano.dev)**
 
+For the longer agent skill (selectors, recording, agent attach, IntelliJ), use **`spectre`** /
+`skills/spectre/SKILL.md`. For atomic `capture.json` workflows, use **`spectre-capture`**.
+
 ## Spectre vs `ComposeTestRule`
 
 - **`ComposeTestRule`** (`compose-ui-test`) — tests a composable in isolation, without launching a real app. Right for unit and component tests.
-- **Spectre** — automates a fully running app end-to-end: the local process, a separate JVM via HTTP, or an IntelliJ plugin hosting Compose UI. Right when you need the whole app stack in motion, for UI automation and user-journey level validation.
+- **Spectre** — automates a fully running app end-to-end: the local process, a separate JVM via HTTP or Java-agent attach, or an IntelliJ plugin hosting Compose UI. Right when you need the whole app stack in motion, for UI automation and user-journey level validation.
 
 If you're testing an individual composable in isolation → use `ComposeTestRule`. If you're automating a full app → use Spectre.
 
@@ -26,7 +29,8 @@ If you're testing an individual composable in isolation → use `ComposeTestRule
 
 - **Use `runSpectreTest`, not `runTest`.** `runTest` collapses `delay()` to zero, which silently breaks `longClick` hold durations, `swipe` step pacing, and clipboard-settle polling. Prefer `runSpectreTest` from the testing module (real wall time + leak detection); plain `runBlocking` is a fallback.
 - **Selectors are non-waiting.** Every `findBy...` / `findOneBy...` call reads the semantics tree once. Call `waitForNode` before querying any node that might not exist yet.
-- **EDT rule.** `waitForIdle` and `waitForVisualIdle` throw `IllegalStateException` when called from the AWT event dispatch thread. Standard JUnit test methods run off the EDT so this isn't normally an issue; if you call them from the EDT, wrap with `withContext(Dispatchers.Default)`.
+- **EDT rule.** All three wait helpers (`waitForNode`, `waitForIdle`, and `waitForVisualIdle`) throw `IllegalStateException` when called from the AWT event dispatch thread. Standard JUnit test methods run off the EDT so this isn't normally an issue; if you call them from the EDT, wrap with `withContext(Dispatchers.Default)`.
+- **Expression-body tests.** Write `@Test fun mySpec(): Unit = runSpectreTest { ... }`. JUnit 5.14+ rejects non-void test methods, and Kotlin infers the return type from the last expression in the `runSpectreTest` body.
 
 ## Setup
 
@@ -44,6 +48,8 @@ dependencies {
 
     // optional:
     testImplementation("dev.sebastiano.spectre:spectre-server:$spectreVersion") // cross-JVM HTTP transport
+    testImplementation("dev.sebastiano.spectre:spectre-agent:$spectreVersion") // agent attach API
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-agent-runtime:$spectreVersion") // loadable Java agent
 }
 ```
 
@@ -64,7 +70,7 @@ class MyTest {
     val automatorExt = ComposeAutomatorExtension()
 
     @Test
-    fun myTest() = runSpectreTest {
+    fun myTest(): Unit = runSpectreTest {
         launchMyApp()  // your responsibility — Spectre manages the automator, not the window
         val automator = automatorExt.automator
         automator.waitForNode(tag = "root-content")
@@ -87,7 +93,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 @ExtendWith(ComposeAutomatorExtension::class)
 class MyTest {
     @Test
-    fun myTest(automator: ComposeAutomator) = runSpectreTest {
+    fun myTest(automator: ComposeAutomator): Unit = runSpectreTest {
         launchMyApp()
         automator.waitForNode(tag = "root-content")
         // interact and assert
@@ -123,8 +129,9 @@ automator.longClick(node, holdFor = 600.milliseconds)
 automator.swipe(from = firstNode, to = lastNode)
 automator.swipe(startX = 100, startY = 400, endX = 100, endY = 100, steps = 16, duration = 200.milliseconds)
 automator.scrollWheel(listNode, wheelClicks = 5)   // negative = scroll up
-automator.typeText("hello")                        // clipboard-based; works for non-ASCII
-automator.clearAndTypeText(node, "replacement")    // click + clear + type in one call
+automator.typeText("hello")                        // key events; supported ASCII only
+automator.pasteText("こんにちは")                   // clipboard paste for large or Unicode text
+automator.clearAndTypeText(node, "replacement")    // click + clear + typeText
 automator.pressKey(KeyEvent.VK_TAB)
 automator.pressKey(KeyEvent.VK_S, modifiers = InputEvent.CTRL_DOWN_MASK)
 automator.pressEnter()
@@ -134,10 +141,12 @@ val img = automator.screenshot(windowIndex = 0)         // native single-window 
 val img = automator.screenshot(node)                    // native window capture; needs recording + platform helper
 ```
 
+`typeText` dispatches key press/release pairs and does not touch the clipboard. Use `pasteText` for large strings or arbitrary Unicode.
+
 ## Synchronization
 
 ```kotlin
-// After launching — poll until a node appears (EDT-safe)
+// After launching — poll until a node appears
 automator.waitForNode(tag = "root-content")
 
 // After an interaction — wait for semantics tree + idling resources to settle
@@ -156,15 +165,16 @@ automator.waitForVisualIdle()  // pixels settled
 val result = automator.findOneByTestTag("Result")
 ```
 
-All three wait helpers are `suspend`. Default timeout is 5 s; all parameters are tunable.
+All three wait helpers are `suspend` and **must not** be called from the AWT EDT. Default timeout is 5 s; all parameters are tunable.
 
 ## Input drivers
 
 Use `ComposeAutomator.inProcess()` (the default) for most tests — it uses a real `java.awt.Robot` and moves the actual cursor. Switch drivers only when needed:
 
-- `RobotDriver.synthetic(window)` — synthetic AWT events posted directly into the window's event queue; no real cursor motion, safe for parallel test runs.
+- `RobotDriver.synthetic(rootWindow = window)` — synthetic AWT events posted directly into the window's event queue; no real cursor motion, safe for parallel test runs.
 - `RobotDriver.headless()` — read-only; every input or screenshot call throws `UnsupportedOperationException`. Semantics-tree reads still work.
 - `ComposeAutomator.http("localhost", 7654)` — cross-JVM via HTTP; requires the `:server` module running in the target process.
+- `AgentAttach.attach(pid)` — attach to a **running** Compose JVM. The target does **not** need `spectre-core` preinstalled: when core is absent, the agent runtime injects nested `META-INF/spectre/inject-runtime.jar`. Prefer a `spectre-core` dependency when you control the target build. The attacher needs `spectre-agent` plus `spectre-agent-runtime`.
 
 ---
 

--- a/skill/package.json
+++ b/skill/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spectre-ui-automation",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Claude skill for automating Compose Desktop UIs with Spectre",
   "keywords": ["claude-skill", "spectre", "compose-desktop", "ui-automation", "kotlin"],
   "author": "Sebastiano Poggi <poggos@gmail.com>",

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -312,8 +312,9 @@ touches that area*; they are not needed for the common case.
   the repo-local `jewel-swing-interop` skill applies as well.
 - **Java-agent attach** → `references/agent.md` — `AgentAttach`,
   `AttachedAutomator`, `AttachOptions`, the `spectre-agent` /
-  `spectre-agent-runtime` split, runtime jar auto-discovery, and custom
-  attach paths.
+  `spectre-agent-runtime` split, runtime jar auto-discovery, custom
+  attach paths, and **inject** when the target has Compose but no
+  preinstalled `spectre-core`.
 
 ## Common pitfalls (memorise these)
 

--- a/skills/spectre/evals/evals.json
+++ b/skills/spectre/evals/evals.json
@@ -9,7 +9,7 @@
         "Uses ComposeAutomatorExtension (the JUnit 5 wrapper) — not ComposeAutomatorRule",
         "Registers the extension with @RegisterExtension",
         "Uses @JvmField on the extension field",
-        "Wraps the test body in runBlocking { ... } and NOT in runTest",
+        "Wraps the test body in runSpectreTest { ... } and NOT in runTest or runBlocking",
         "Calls a wait (waitForNode or waitForVisualIdle or waitForIdle) before reading post-click state",
         "Uses click() — not performSemanticsClick — on the Increment node",
         "Locates nodes via findOneByTestTag",
@@ -35,7 +35,7 @@
         "Recommends switching to RobotDriver.synthetic(...) as the primary fix",
         "Identifies that RobotDriver.synthetic takes a rootWindow (the top-level java.awt.Window)",
         "Wires the driver via the factory-form trailing lambda on ComposeAutomatorExtension/Rule (e.g. ComposeAutomatorExtension { ComposeAutomator.inProcess(robotDriver = ...) }) — NOT via a non-existent robotDriver = named arg on the extension/rule itself",
-        "Imports dev.sebastiano.spectre.core.synthetic (since synthetic is an extension on RobotDriver.Companion)",
+        "Uses RobotDriver.synthetic(rootWindow = ...) from RobotDriver's companion (import RobotDriver; there is no separate synthetic extension import)",
         "Does NOT recommend disabling parallelism / lowering maxParallelForks as the fix",
         "Does NOT recommend performSemanticsClick as the primary fix"
       ]
@@ -47,7 +47,7 @@
       "assertions": [
         "Uses ComposeAutomatorRule (the JUnit 4 wrapper) — not ComposeAutomatorExtension",
         "Annotates the rule with @get:Rule (Kotlin-correct form)",
-        "Wraps test body in runBlocking { ... } and NOT in runTest",
+        "Wraps the test body in runSpectreTest { ... } and NOT in runTest or runBlocking",
         "Types the email into EmailField via typeText or clearAndTypeText",
         "Calls click on the LoginButton node",
         "Uses waitForNode(tag = \"Dashboard\") (or equivalent) to wait for the dashboard"

--- a/skills/spectre/references/agent.md
+++ b/skills/spectre/references/agent.md
@@ -15,27 +15,44 @@ Prefer the user guide for detailed setup. Keep answers aligned with it.
 
 ## Mental model
 
-Agent attach involves two JVMs:
+Agent attach involves two JVMs and **two target shapes, one API**:
 
-- **Target JVM**: the Compose app being inspected or driven. It must already have
-  `spectre-core` on its classpath.
-- **Attacher JVM**: the test, inspector, or tool process that calls `AgentAttach.attach(pid)`.
-  It compiles against `spectre-agent` and normally has `spectre-agent-runtime` on its runtime
-  classpath.
+- **Target JVM**: the Compose app being inspected or driven.
+  1. **Preferred — preinstalled `spectre-core`** (instrumented attach). Bootstrap
+     finds `ComposeAutomator` on the app classpath. Use this whenever you control
+     the target build.
+  2. **Inject — no preinstalled core** (experimental inspect). The loadable
+     `spectre-agent-runtime` jar carries a nested `META-INF/spectre/inject-runtime.jar`.
+     Bootstrap loads Spectre core from that payload when the target only has
+     Compose/Skiko. Same `AgentAttach.attach(pid)` call — no separate inject flag.
+     Fine for attach → dump → detach (e.g. stock IntelliJ); prefer preinstalled
+     core for sustained or high-frequency use.
+- **Attacher JVM**: the test, inspector, or tool process that calls
+  `AgentAttach.attach(pid)`. It compiles against `spectre-agent` and normally has
+  `spectre-agent-runtime` on its runtime classpath.
 
-Do not tell users to add `spectre-agent` or `spectre-agent-runtime` to the target app unless they
-are also writing the attacher in that same process. The runtime jar is supplied by the attacher and
-loaded into the target through the JDK Attach API.
+Do not tell users to add `spectre-agent` or `spectre-agent-runtime` to the target app
+unless they are also writing the attacher in that same process. The runtime jar is
+supplied by the attacher and loaded into the target through the JDK Attach API.
+
+Do **not** tell users the target JVM requires a preinstalled `spectre-core`
+dependency. That was true of the original thin-agent design; current bootstrap
+falls back to inject when core is absent.
 
 ## Dependencies
 
-For the target app:
+For the target app, **when you control the build** (preferred):
 
 ```kotlin
 dependencies {
     implementation("dev.sebastiano.spectre:spectre-core:<version>")
 }
 ```
+
+If the target cannot take that dependency (stock IDE, third-party binary), attach
+still works when Compose is present and the attacher's `spectre-agent-runtime` jar
+carries the nested inject payload. No extra target-side Spectre coordinate is
+required.
 
 For the attacher/test process:
 
@@ -46,10 +63,11 @@ dependencies {
 }
 ```
 
-Use `testImplementation` / `testRuntimeOnly` instead when the attacher is a test source set.
+Use `testImplementation` / `testRuntimeOnly` instead when the attacher is a test
+source set.
 
-Do not recommend an `-all` classifier. `spectre-agent-runtime` is a separate artifactId because it
-is the loadable Java-agent runtime, not the normal API jar.
+Do not recommend an `-all` classifier. `spectre-agent-runtime` is a separate
+artifactId because it is the loadable Java-agent runtime, not the normal API jar.
 
 ## What happens during attach
 
@@ -63,21 +81,28 @@ is the loadable Java-agent runtime, not the normal API jar.
    Windows 10 1803+ / Server 2019+) and same-OS-user checks.
 4. Calls `VirtualMachine.attach(pid).loadAgent(runtimeJarPath, udsPath)`.
 5. Lets the target JVM invoke `SpectreAgent.agentmain(...)`.
-6. In the target JVM, finds `ComposeAutomator` from the target's existing `spectre-core`
-   dependency, creates an in-process automator, and starts a UDS IPC server.
+6. In the target JVM, bootstrap **prefers** a preinstalled `ComposeAutomator` on
+   the app classpath. If that class is absent, it extracts
+   `META-INF/spectre/inject-runtime.jar`, opens a child classloader parented at a
+   Compose host loader, and loads Spectre core from that payload. Then it creates
+   an in-process automator and starts a UDS IPC server.
 7. Connects the attach-side `IpcClient` and returns `AttachedAutomator`.
 
 After that, `AttachedAutomator` methods send small IPC requests to the target JVM.
 
+Inject is an **experimental inspect** path: class unload after detach is
+GC-dependent, so do not treat it as a leak-free production mode.
+
 ## Runtime jar discovery and custom attach
 
-Classpath auto-discovery means `AgentAttach` scans the attacher's `java.class.path` for a physical
-`spectre-agent-runtime-*.jar`, then passes that jar path to `VirtualMachine.loadAgent(...)`.
-It does not mean the target app declared `spectre-agent-runtime`, and it does not mean user code
-should call runtime classes directly.
+Classpath auto-discovery means `AgentAttach` scans the attacher's `java.class.path`
+for a physical `spectre-agent-runtime-*.jar`, then passes that jar path to
+`VirtualMachine.loadAgent(...)`. It does not mean the target app declared
+`spectre-agent-runtime`, and it does not mean user code should call runtime classes
+directly.
 
-If a custom launcher, shaded distribution, module-path launch, or script hides the physical runtime
-jar from `java.class.path`, use one of these explicit forms:
+If a custom launcher, shaded distribution, module-path launch, or script hides the
+physical runtime jar from `java.class.path`, use one of these explicit forms:
 
 ```kotlin
 AgentAttach.attach(
@@ -101,5 +126,12 @@ Or set this on the attacher JVM:
   1803 / Server 2019 or newer). No named-pipe transport.
 - The attacher and target must run as the same OS user.
 - The target should start with `-XX:+EnableDynamicAgentLoading`.
-- Communication is local UDS IPC, unauthenticated, and intended for trusted dev/test machines.
-  Trust is filesystem ownership (POSIX 0700/0600 or Windows owner-only ACL).
+- Communication is local UDS IPC, unauthenticated, and intended for trusted
+  dev/test machines. Trust is filesystem ownership (POSIX 0700/0600 or Windows
+  owner-only ACL).
+- Window/surface attach screenshots fail closed; fullscreen is the only
+  screen-pixel capture mode on this path.
+- `waitForIdle` over attach is a fingerprint-only wait. Idling-resource
+  registration stays in-process.
+- JUnit launch-and-attach (`LaunchAndAttachExtension` / `LaunchAndAttachRule`) uses
+  this same attach path; see `references/junit.md` and the user-guide JUnit page.

--- a/skills/spectre/references/intellij.md
+++ b/skills/spectre/references/intellij.md
@@ -65,9 +65,21 @@ Two facts worth knowing up front:
 - An embedded `ComposePanel` has no top-level title. Window-targeted
   recording can't follow it; use region capture or pass the host IDE frame.
 
+## External attach without `spectre-core`
+
+When you need to inspect Jewel-hosted Compose from a **sister process** and
+the IDE (or plugin) does **not** ship `spectre-core`, use agent attach. The
+same `AgentAttach.attach(pid)` call injects nested
+`META-INF/spectre/inject-runtime.jar` when core is absent. Add
+`-XX:+EnableDynamicAgentLoading` to the IDE VM options and restart. Prefer
+in-process `ComposeAutomator` (sections above) when your code already runs
+inside the IDE. Details: `references/agent.md` and the user guide
+[IntelliJ-hosted Compose](https://spectre.sebastiano.dev/guide/intellij/).
+
 ## What about HTTP / cross-JVM?
 
 The `:server` module that lets another JVM drive the IDE's Compose UI is
 **experimental** and has security caveats (see `docs/SECURITY.md` in the
 repo). Don't recommend it for general use without flagging that — prefer
-running tests in-process via `executeOnPooledThread`.
+running tests in-process via `executeOnPooledThread`, or agent attach
+(inject when the IDE build does not ship Spectre).

--- a/skills/spectre/references/junit.md
+++ b/skills/spectre/references/junit.md
@@ -111,6 +111,37 @@ ComposeAutomatorExtension(
 )
 ```
 
+## Launch-and-attach (separate UI JVM)
+
+When the UI under test is a **separate JVM** (prod-like `java -jar`,
+`installDist`, or `./gradlew :app:run` with warnings), use
+`LaunchAndAttachExtension` (JUnit 5) or `LaunchAndAttachRule` (JUnit 4)
+instead of only `ComposeAutomatorExtension` / `ComposeAutomatorRule`. They
+call the shared agent launch core, attach, and tear the process tree down
+after each test. The launched app does **not** have to preinstall
+`spectre-core` — attach injects it when Compose is present — but
+preinstalled core is still the preferred target shape.
+
+```kotlin
+@JvmField
+@RegisterExtension
+val launchExt =
+    LaunchAndAttachExtension(
+        LaunchSpec(
+            command =
+                listOf(
+                    "${System.getProperty("java.home")}/bin/java",
+                    "-jar",
+                    "app/build/libs/app.jar",
+                )
+        )
+    )
+```
+
+Keep a `ComposeAutomatorExtension` / `Rule` innermost if you also want
+in-process failure artifacts. Full recipe: user guide
+[JUnit — Launch-and-attach](https://spectre.sebastiano.dev/guide/junit/).
+
 ## Lifecycle notes
 
 - The extension/rule does **not** open a Compose window for you. Launch your


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Agent attach no longer requires `spectre-core` on the target classpath. Bootstrap prefers a preinstalled core, then falls back to nested `META-INF/spectre/inject-runtime.jar`. The spectre skill still said the target **must already have** core; several user-guide pages implied the same.

This PR aligns the skill, packaged `spectre-ui-automation` skill, and user-facing docs with that two-path model, and pins it with a contract test.

Also caught while scanning:

- Packaged skill still called `typeText` clipboard-based and `waitForNode` EDT-safe
- Skill evals still required `runBlocking` and a non-existent `synthetic` extension import
- IntelliJ guide still said region capture used `ffmpeg` on macOS
- Launch-and-attach JUnit docs/skill omitted inject
- `SpectreNotOnClasspathException` KDoc still described the old thin-agent-only design

## Test plan

- [x] Wrote `AgentAttachDocsContractTest` first; it failed on current wording
- [x] `./gradlew :core:test --tests "*AgentAttachDocsContractTest*" --tests "*DocsGuidanceContractTest*"`
- [x] `./gradlew check`
- [x] `mkdocs build --strict`

## Confirmations

- Docs-only plus one KDoc and a contract test. No attach runtime behaviour change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f46452bc-1814-422f-8031-290b9d86b1dc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f46452bc-1814-422f-8031-290b9d86b1dc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

