### PR TITLE
Stop the default Windows UDS path from overflowing sun_path

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -193,6 +193,11 @@ public final class dev/sebastiano/spectre/agent/SpectreProcesses {
 	public final fun listJvmProcesses ()Ljava/util/List;
 }
 
+public final class dev/sebastiano/spectre/agent/UdsPathTooLongException : dev/sebastiano/spectre/agent/SpectreAttachException {
+	public fun <init> (Ljava/util/List;)V
+	public final fun getCandidates ()Ljava/util/List;
+}
+
 public final class dev/sebastiano/spectre/agent/launch/FirstWindowTimeoutException : dev/sebastiano/spectre/agent/launch/LaunchException {
 	public fun <init> (JJLjava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;)V
 	public synthetic fun <init> (JJLjava/nio/file/Path;Ljava/nio/file/Path;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.agent
 import dev.sebastiano.spectre.agent.runtime.AgentBootstrapArgs
 import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.agent.transport.IpcClient
+import dev.sebastiano.spectre.agent.transport.UdsPathLimits
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
@@ -46,8 +47,13 @@ public object AgentAttach {
     public fun attach(pid: Long, options: AttachOptions = AttachOptions()): AttachedAutomator {
         AttachRuntimePreflight.requireSupported()
         AgentPlatformPreflight.requireSupported()
-        val agentJar = resolveAgentJar(options)
+        // Resolve and length-check the UDS path before anything expensive: the agent binds it
+        // inside the *target* JVM, so an overlong path surfaces there as an opaque
+        // "agent failed to initialize" with the real cause in the target's stderr (#442).
+        // `defaultUdsPath` already picks a base that fits; this catches a caller-supplied one.
         val udsPath = options.udsPath ?: AttachOptions.defaultUdsPath(pid)
+        if (UdsPathLimits.exceedsLimit(udsPath)) throw UdsPathTooLongException(listOf(udsPath))
+        val agentJar = resolveAgentJar(options)
         // Pre-flight: ensure the path doesn't already exist (collisions would confuse the bind).
         Files.deleteIfExists(udsPath)
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -51,7 +51,7 @@ public object AgentAttach {
         // inside the *target* JVM, so an overlong path surfaces there as an opaque
         // "agent failed to initialize" with the real cause in the target's stderr (#442).
         // `defaultUdsPath` already picks a base that fits; this catches a caller-supplied one.
-        val udsPath = options.udsPath ?: AttachOptions.defaultUdsPath(pid)
+        val udsPath = effectiveUdsPath(options.udsPath, pid)
         if (UdsPathLimits.exceedsLimit(udsPath)) throw UdsPathTooLongException(listOf(udsPath))
         val agentJar = resolveAgentJar(options)
         // Pre-flight: ensure the path doesn't already exist (collisions would confuse the bind).
@@ -201,6 +201,20 @@ public object AgentAttach {
 @OptIn(ExperimentalSpectreAgentApi::class)
 private class SpectreAttachExceptionImpl(message: String, cause: Throwable?) :
     SpectreAttachException(message, cause)
+
+/**
+ * The UDS path [AgentAttach.attach] will actually use: [explicit] when the caller supplied one,
+ * otherwise [AttachOptions.defaultUdsPath], resolved to an absolute path either way.
+ *
+ * Resolving matters because the two ends of the attach do not share a working directory. The
+ * attacher polls `Files.exists(udsPath)` in its own; the target JVM binds in its own, which differs
+ * for every launch mode. A relative path would name two different files and the attach could only
+ * time out. Resolving here also makes the `sun_path` length check measure the path the target
+ * really binds.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal fun effectiveUdsPath(explicit: Path?, targetPid: Long): Path =
+    (explicit ?: AttachOptions.defaultUdsPath(targetPid)).toAbsolutePath()
 
 internal fun dynamicAgentLoadingGuidance(message: String?): String? =
     if (

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
@@ -1,5 +1,8 @@
 package dev.sebastiano.spectre.agent
 
+import dev.sebastiano.spectre.agent.transport.UdsPathLimits
+import java.nio.file.Path
+
 /** Base for all attach-side failures surfaced by [AgentAttach.attach]. */
 @ExperimentalSpectreAgentApi
 public sealed class SpectreAttachException(message: String, cause: Throwable? = null) :
@@ -152,4 +155,27 @@ public class AttachInterruptedException(udsPath: java.nio.file.Path, cause: Inte
         "Attach was interrupted while waiting for the agent's UDS at $udsPath. The thread's " +
             "interrupt status has been preserved.",
         cause,
+    )
+
+/**
+ * Thrown when a Unix Domain Socket path is longer than the platform's `sockaddr_un.sun_path` can
+ * hold (103 usable bytes on macOS, 107 on Linux and Windows).
+ *
+ * The kernel rejects such a path at `bind` time, and because the agent binds inside the *target*
+ * JVM the caller would otherwise see only "agent failed to initialize", with `SocketException: Unix
+ * domain path too long` buried in the target's stderr (#442). Raising this on the attaching side,
+ * before the agent JAR is loaded, names the offending path and the limit.
+ *
+ * @property candidates the path(s) that were too long — one when the caller passed
+ *   [AttachOptions.udsPath] explicitly, one per base directory Spectre tried when it was picking
+ *   the default.
+ */
+@ExperimentalSpectreAgentApi
+public class UdsPathTooLongException(public val candidates: List<Path>) :
+    SpectreAttachException(
+        "No usable Unix domain socket path: this platform's sockaddr_un.sun_path holds at most " +
+            "${UdsPathLimits.maxPathBytes} bytes. Tried:\n" +
+            candidates.joinToString("\n") { "  - $it (${UdsPathLimits.byteLength(it)} bytes)" } +
+            "\n\nPass AttachOptions(udsPath = ...) pointing at a shorter path — a directory close " +
+            "to the filesystem root keeps the most room for the socket name."
     )

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachExceptions.kt
@@ -159,7 +159,8 @@ public class AttachInterruptedException(udsPath: java.nio.file.Path, cause: Inte
 
 /**
  * Thrown when a Unix Domain Socket path is longer than the platform's `sockaddr_un.sun_path` can
- * hold (103 usable bytes on macOS, 107 on Linux and Windows).
+ * hold (102 usable bytes on macOS, 106 on Linux and Windows — the JDK reserves two bytes of the
+ * 104/108-byte field, not one; see `UdsPathLimits`).
  *
  * The kernel rejects such a path at `bind` time, and because the agent binds inside the *target*
  * JVM the caller would otherwise see only "agent failed to initialize", with `SocketException: Unix

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -34,7 +34,7 @@ import java.util.UUID
  *   so concurrent attaches don't collide — see [defaultUdsPath] for how `<base>` is picked). If you
  *   override this with a path under an existing directory, you own that parent directory's
  *   permissions; Spectre only tightens directories it creates itself. The path must fit the
- *   platform's `sockaddr_un.sun_path` budget (103 bytes on macOS, 107 elsewhere); `attach` rejects
+ *   platform's `sockaddr_un.sun_path` budget (102 bytes on macOS, 106 elsewhere); `attach` rejects
  *   longer paths up front with [UdsPathTooLongException].
  * @property attachTimeoutMs how long to wait for the agent's bootstrap + IPC server to come up.
  * @property maxFrameBytes IPC frame write budget the injected agent should adopt. `null` (default)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -133,10 +133,17 @@ public data class AttachOptions(
          * Builds `<base>/[perAttachDir]/agent.sock` for each of [baseCandidates] in order and
          * returns the first one that fits the platform's `sun_path` budget.
          *
+         * Each candidate is resolved to an absolute path *before* it is measured. A relative
+         * `java.io.tmpdir` (`-Djava.io.tmpdir=tmp`) is legal and the JVM does not normalise it, so
+         * measuring the short relative spelling would accept a candidate the target then binds as
+         * `<cwd>/<base>/…` — over the limit, with the good fallback already passed over.
+         *
          * @throws UdsPathTooLongException when every candidate overflows the budget.
          */
         internal fun selectUdsPath(baseCandidates: List<String>, perAttachDir: String): Path {
-            val paths = baseCandidates.map { Paths.get(it, perAttachDir, SOCKET_FILE_NAME) }
+            val paths = baseCandidates.map {
+                Paths.get(it, perAttachDir, SOCKET_FILE_NAME).toAbsolutePath()
+            }
             return paths.firstOrNull { !UdsPathLimits.exceedsLimit(it) }
                 ?: throw UdsPathTooLongException(paths)
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -2,6 +2,7 @@ package dev.sebastiano.spectre.agent
 
 import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES_CEILING
 import dev.sebastiano.spectre.agent.transport.MIN_MAX_FRAME_BYTES
+import dev.sebastiano.spectre.agent.transport.UdsPathLimits
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.UUID
@@ -29,10 +30,12 @@ import java.util.UUID
  *
  * @property agentJarPath loadable agent runtime JAR to pass to `VirtualMachine.loadAgent`.
  * @property udsPath Unix Domain Socket path the agent should bind on (must NOT exist already;
- *   defaults to `/tmp/sp-a-<pid>-<8char-uuid>/agent.sock` with a fresh UUID per `attach()` call so
- *   concurrent attaches don't collide). If you override this with a path under an existing
- *   directory, you own that parent directory's permissions; Spectre only tightens directories it
- *   creates itself.
+ *   defaults to `<base>/sp-a-<pid>-<8char-uuid>/agent.sock` with a fresh UUID per `attach()` call
+ *   so concurrent attaches don't collide — see [defaultUdsPath] for how `<base>` is picked). If you
+ *   override this with a path under an existing directory, you own that parent directory's
+ *   permissions; Spectre only tightens directories it creates itself. The path must fit the
+ *   platform's `sockaddr_un.sun_path` budget (103 bytes on macOS, 107 elsewhere); `attach` rejects
+ *   longer paths up front with [UdsPathTooLongException].
  * @property attachTimeoutMs how long to wait for the agent's bootstrap + IPC server to come up.
  * @property maxFrameBytes IPC frame write budget the injected agent should adopt. `null` (default)
  *   forwards this process's own budget, so a daemon started with `SPECTRE_MAX_FRAME_BYTES` or
@@ -69,32 +72,78 @@ public data class AttachOptions(
         /**
          * Default UDS path: `<base>/sp-a-<pid>-<8char-uuid>/agent.sock`.
          *
-         * The base directory is platform-aware and deliberately short to stay inside the `sun_path`
-         * limit (~104 chars on macOS, ~108 on Linux and Windows):
-         * - **Linux/macOS**: hard-coded `/tmp` (symlinked to `/private/tmp` on macOS).
-         *   `java.io.tmpdir` resolves to a much longer `/var/folders/...` on macOS and can blow
-         *   past the limit.
-         * - **Windows**: `java.io.tmpdir` (i.e. `%TEMP%`, per-user ACL'd). `/tmp` is meaningless on
-         *   Windows — `Paths.get("/tmp", …)` yields the drive-relative `\tmp\…`, outside the
-         *   protected per-user temp area.
+         * `<base>` is the first entry of [udsBaseDirCandidates] whose resulting path fits the
+         * platform's `sockaddr_un.sun_path` budget (~104 bytes on macOS, ~108 on Linux and
+         * Windows). Overflowing that budget makes the agent's `bind` fail inside the target JVM,
+         * which the attacher only sees as "agent failed to initialize" (#442) — so the choice is
+         * made here, where a bad outcome can still be reported clearly.
+         *
+         * @throws UdsPathTooLongException when no candidate base directory yields a short enough
+         *   path. Pass [AttachOptions.udsPath] explicitly to recover.
          */
         public fun defaultUdsPath(targetPid: Long): Path {
             val shortUuid = UUID.randomUUID().toString().take(SHORT_UUID_LENGTH)
-            val base = udsBaseDir(System.getProperty("os.name").orEmpty(), TMP_DIR)
-            return Paths.get(base, "sp-a-${targetPid}-${shortUuid}", "agent.sock")
+            val candidates =
+                udsBaseDirCandidates(
+                    osName = System.getProperty("os.name").orEmpty(),
+                    tmpDir = System.getProperty("java.io.tmpdir").orEmpty(),
+                    localAppData = System.getenv(LOCAL_APP_DATA_ENV),
+                    userHome = System.getProperty("user.home").orEmpty(),
+                )
+            return selectUdsPath(candidates, "sp-a-${targetPid}-${shortUuid}")
         }
 
         /**
-         * Base directory for the default UDS path: `java.io.tmpdir` (`%TEMP%`) on Windows, `/tmp`
-         * elsewhere. Extracted for testing — `java.nio.file.Path` construction is
-         * filesystem-specific so the selection logic is validated as strings here.
+         * Ordered base-directory candidates for the default UDS path, most preferred first.
+         * Extracted for testing — `java.nio.file.Path` construction is filesystem-specific, so the
+         * selection logic is validated as strings here.
+         * - **Linux/macOS**: hard-coded `/tmp` (symlinked to `/private/tmp` on macOS), and nothing
+         *   else. `java.io.tmpdir` resolves to a much longer `/var/folders/...` on macOS and can
+         *   blow past the `sun_path` limit.
+         * - **Windows**: [tmpDir] (`%TEMP%`, per-user ACL'd) first, so a harness that points the
+         *   JVM at its own scratch directory keeps it. `/tmp` is meaningless on Windows —
+         *   `Paths.get("/tmp", …)` yields the drive-relative `\tmp\…`, outside the protected
+         *   per-user temp area. Nothing constrains how deep `%TEMP%` is, though: Bazel points it at
+         *   a per-test execroot directory deep enough that appending the per-attach directory and
+         *   socket name overflows `sun_path` (#442). The fallbacks reach the per-user temp
+         *   directory without going through `java.io.tmpdir`, which is what harnesses rewrite.
+         *
+         * The Windows fallbacks join with a literal `\` rather than the host's separator: the
+         * branch only ever runs on Windows, and hard-coding it keeps this function testable
+         * everywhere.
          */
-        internal fun udsBaseDir(osName: String, tmpDir: String): String =
-            if (osName.startsWith("Windows", ignoreCase = true)) tmpDir else "/tmp"
+        internal fun udsBaseDirCandidates(
+            osName: String,
+            tmpDir: String,
+            localAppData: String?,
+            userHome: String,
+        ): List<String> {
+            if (!osName.startsWith("Windows", ignoreCase = true)) {
+                return listOf(POSIX_UDS_BASE_DIR)
+            }
+            return listOfNotNull(
+                    tmpDir.takeIf { it.isNotBlank() },
+                    localAppData?.takeIf { it.isNotBlank() }?.let { "$it\\Temp" },
+                    userHome.takeIf { it.isNotBlank() }?.let { "$it\\AppData\\Local\\Temp" },
+                )
+                .distinct()
+        }
 
-        private val TMP_DIR: String
-            get() = System.getProperty("java.io.tmpdir").orEmpty()
+        /**
+         * Builds `<base>/[perAttachDir]/agent.sock` for each of [baseCandidates] in order and
+         * returns the first one that fits the platform's `sun_path` budget.
+         *
+         * @throws UdsPathTooLongException when every candidate overflows the budget.
+         */
+        internal fun selectUdsPath(baseCandidates: List<String>, perAttachDir: String): Path {
+            val paths = baseCandidates.map { Paths.get(it, perAttachDir, SOCKET_FILE_NAME) }
+            return paths.firstOrNull { !UdsPathLimits.exceedsLimit(it) }
+                ?: throw UdsPathTooLongException(paths)
+        }
 
+        private const val POSIX_UDS_BASE_DIR: String = "/tmp"
+        private const val LOCAL_APP_DATA_ENV: String = "LOCALAPPDATA"
+        private const val SOCKET_FILE_NAME: String = "agent.sock"
         private const val SHORT_UUID_LENGTH = 8
     }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -7,6 +7,7 @@ import dev.sebastiano.spectre.agent.AttachedAutomator
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.SpectreAgentException
 import dev.sebastiano.spectre.agent.SpectreAttachException
+import dev.sebastiano.spectre.agent.effectiveUdsPath
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -133,12 +134,28 @@ internal object LaunchReadiness {
         bootstrapTimeoutMs: Long,
         stdoutPath: Path,
         stderrPath: Path,
+        /** Seam for tests; production always resolves through [effectiveUdsPath]. */
+        resolveUdsPath: (Path?, Long) -> Path = ::effectiveUdsPath,
     ): AttachedAutomator {
         if (!process.isAlive && !gradleish) {
             throw processExited(process, stdoutPath, stderrPath)
         }
-        // Pin UDS path for the whole stage (including pre-load retries).
-        val udsPath = attachOptions.udsPath ?: AttachOptions.defaultUdsPath(attachedPid)
+        // Pin UDS path for the whole stage (including pre-load retries). Resolving it can fail
+        // when no default candidate fits sun_path (#442), and that failure has to arrive as an
+        // AGENT_BOOTSTRAP LaunchAgentBootstrapException carrying the capture paths, like every
+        // other bootstrap failure — not as a bare SpectreAttachException that skips the stage
+        // taxonomy. The retry loop's own catch blocks are below and do not cover this statement.
+        val udsPath =
+            try {
+                resolveUdsPath(attachOptions.udsPath, attachedPid)
+            } catch (ex: SpectreAttachException) {
+                throw LaunchAgentBootstrapException(
+                    attachedPid = attachedPid,
+                    stdoutPath = stdoutPath,
+                    stderrPath = stderrPath,
+                    cause = ex,
+                )
+            }
         val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(bootstrapTimeoutMs)
         var lastAttachFailure: SpectreAttachException? = null
         while (true) {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -55,6 +55,14 @@ constructor(
             // the contract by observing `openFileDescriptorCount`.
             var success = false
             try {
+                // Check the sun_path budget before bind: the JDK's own
+                // `SocketException: Unix domain path too long` names neither the path nor the
+                // cap, and this code runs inside the target JVM where that message is all the
+                // user gets (#442). Deliberately inside the try so the outer `finally` still
+                // releases the channel opened just above.
+                if (UdsPathLimits.exceedsLimit(udsPath)) {
+                    throw IOException(UdsPathLimits.tooLongMessage(udsPath))
+                }
                 createdParentDir = protection.createMissingParentDirectory(udsPath)
                 // Clean up any orphaned socket file from a previous crash; the OS refuses to
                 // bind if the path already exists, even when stale.

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimits.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimits.kt
@@ -1,0 +1,59 @@
+package dev.sebastiano.spectre.agent.transport
+
+import java.nio.charset.Charset
+import java.nio.file.Path
+
+/**
+ * The `sockaddr_un.sun_path` budget for Unix Domain Socket paths, and a readable diagnostic for
+ * paths that blow past it.
+ *
+ * The kernel copies a UDS path into a fixed-size `sun_path` array, so `bind` fails outright once
+ * the path no longer fits. The JDK surfaces that as `SocketException: Unix domain path too long`,
+ * which names neither the path nor the cap — and in Spectre's case the bind happens inside the
+ * *target* JVM, so the attaching process sees only "agent failed to initialize" (#442). Everything
+ * here exists to turn that into a message a user can act on.
+ */
+internal object UdsPathLimits {
+    /** `sun_path` size on macOS/BSD. */
+    private const val MAC_SUN_PATH_SIZE: Int = 104
+
+    /** `sun_path` size on Linux and Windows. */
+    private const val DEFAULT_SUN_PATH_SIZE: Int = 108
+
+    /** Usable path bytes on this host — `sun_path` minus one byte for the NUL terminator. */
+    val maxPathBytes: Int = maxPathBytesFor(System.getProperty("os.name").orEmpty())
+
+    /**
+     * Usable path bytes on [osName]. Extracted from [maxPathBytes] so the per-OS arithmetic is
+     * testable on any host.
+     */
+    fun maxPathBytesFor(osName: String): Int =
+        if (
+            osName.startsWith("Mac", ignoreCase = true) ||
+                osName.startsWith("Darwin", ignoreCase = true)
+        ) {
+            MAC_SUN_PATH_SIZE - 1
+        } else {
+            DEFAULT_SUN_PATH_SIZE - 1
+        }
+
+    /**
+     * Length of [path] in bytes, using the same encoding the JDK uses to hand paths to the OS
+     * (`sun.jnu.encoding`). Counting characters would under-report for non-ASCII paths — a home
+     * directory with accented characters costs more bytes than it looks.
+     */
+    fun byteLength(path: Path): Int = path.toString().toByteArray(NATIVE_CHARSET).size
+
+    /** True when binding a UDS at [path] would fail because the path does not fit `sun_path`. */
+    fun exceedsLimit(path: Path): Boolean = byteLength(path) > maxPathBytes
+
+    /** Diagnostic for a [path] that [exceedsLimit]: names the path, its size, and the cap. */
+    fun tooLongMessage(path: Path): String =
+        "Unix domain socket path is ${byteLength(path)} bytes, but this platform's " +
+            "sockaddr_un.sun_path holds at most $maxPathBytes. Path: $path"
+
+    private val NATIVE_CHARSET: Charset =
+        System.getProperty("sun.jnu.encoding")?.let { name ->
+            runCatching { Charset.forName(name) }.getOrNull()
+        } ?: Charset.defaultCharset()
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimits.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimits.kt
@@ -38,22 +38,48 @@ internal object UdsPathLimits {
         }
 
     /**
-     * Length of [path] in bytes, using the same encoding the JDK uses to hand paths to the OS
-     * (`sun.jnu.encoding`). Counting characters would under-report for non-ASCII paths — a home
-     * directory with accented characters costs more bytes than it looks.
+     * Charset the JDK encodes a UDS path with before handing it to the OS. It is **not** the same
+     * on every platform, and the difference is load-bearing:
+     * - **Windows**: `sun.nio.fs.WindowsFileSystemProvider.getSunPathForSocketFile` ends in
+     *   `s.getBytes(StandardCharsets.UTF_8)` — always UTF-8, whatever the JVM's other encodings
+     *   say.
+     * - **Linux/macOS**: `sun.nio.fs.UnixPath.encode` goes through `Util.jnuEncoding()`, which is
+     *   the `sun.jnu.encoding` property.
+     *
+     * A Windows JVM commonly reports `sun.jnu.encoding=Cp1252`, where an accented letter costs one
+     * byte and UTF-8 costs two. Measuring a `C:\Users\<accented name>\…` path with the code page
+     * would under-count it, keep a candidate that does not actually fit, and reproduce #442 by
+     * another route.
      */
-    fun byteLength(path: Path): Int = path.toString().toByteArray(NATIVE_CHARSET).size
+    fun nativeCharsetFor(osName: String): Charset =
+        if (osName.startsWith("Windows", ignoreCase = true)) Charsets.UTF_8 else jnuCharset()
+
+    /**
+     * Length of [path] in bytes as the OS will receive it. Counting characters would under-report
+     * for non-ASCII paths — a home directory with accented characters costs more bytes than it
+     * looks.
+     */
+    fun byteLength(path: Path): Int = byteLength(path, NATIVE_CHARSET)
+
+    /** [byteLength] against an explicit [charset]; the per-platform choice is testable that way. */
+    fun byteLength(path: Path, charset: Charset): Int = path.toString().toByteArray(charset).size
 
     /** True when binding a UDS at [path] would fail because the path does not fit `sun_path`. */
     fun exceedsLimit(path: Path): Boolean = byteLength(path) > maxPathBytes
+
+    /** [exceedsLimit] against an explicit [charset] and [limit], for the per-platform tests. */
+    fun exceedsLimit(path: Path, charset: Charset, limit: Int): Boolean =
+        byteLength(path, charset) > limit
 
     /** Diagnostic for a [path] that [exceedsLimit]: names the path, its size, and the cap. */
     fun tooLongMessage(path: Path): String =
         "Unix domain socket path is ${byteLength(path)} bytes, but this platform's " +
             "sockaddr_un.sun_path holds at most $maxPathBytes. Path: $path"
 
-    private val NATIVE_CHARSET: Charset =
+    private fun jnuCharset(): Charset =
         System.getProperty("sun.jnu.encoding")?.let { name ->
             runCatching { Charset.forName(name) }.getOrNull()
         } ?: Charset.defaultCharset()
+
+    private val NATIVE_CHARSET: Charset = nativeCharsetFor(System.getProperty("os.name").orEmpty())
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimits.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimits.kt
@@ -20,7 +20,22 @@ internal object UdsPathLimits {
     /** `sun_path` size on Linux and Windows. */
     private const val DEFAULT_SUN_PATH_SIZE: Int = 108
 
-    /** Usable path bytes on this host — `sun_path` minus one byte for the NUL terminator. */
+    /**
+     * Bytes of `sun_path` the JDK will not let a path occupy. It is **two**, not the one byte a NUL
+     * terminator would suggest, and getting this wrong defeats the whole guard: a path one byte
+     * over would pass here and then be refused by `bind` with the opaque error this object exists
+     * to replace.
+     *
+     * Measured, not derived. `ServerSocketChannel.bind` on an `AF_UNIX` channel:
+     * - macOS 15, JDK 21.0.12 — 102 bytes binds, 103 throws `SocketException`. `sun_path` is 104.
+     * - Windows 11, JBR 21.0.10 — 106 bytes binds, 107 throws. `sun_path` is 108.
+     *
+     * `UdsPathLimitsTest` re-measures the boundary with a real bind on whatever host it runs on, so
+     * a platform that disagrees fails there rather than in the field.
+     */
+    private const val SUN_PATH_RESERVED_BYTES: Int = 2
+
+    /** Usable path bytes on this host. */
     val maxPathBytes: Int = maxPathBytesFor(System.getProperty("os.name").orEmpty())
 
     /**
@@ -32,9 +47,9 @@ internal object UdsPathLimits {
             osName.startsWith("Mac", ignoreCase = true) ||
                 osName.startsWith("Darwin", ignoreCase = true)
         ) {
-            MAC_SUN_PATH_SIZE - 1
+            MAC_SUN_PATH_SIZE - SUN_PATH_RESERVED_BYTES
         } else {
-            DEFAULT_SUN_PATH_SIZE - 1
+            DEFAULT_SUN_PATH_SIZE - SUN_PATH_RESERVED_BYTES
         }
 
     /**

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
@@ -3,17 +3,22 @@
 package dev.sebastiano.spectre.agent
 
 import dev.sebastiano.spectre.agent.transport.MAX_FRAME_BYTES_CEILING
+import dev.sebastiano.spectre.agent.transport.UdsPathLimits
+import java.nio.file.Path
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-/**
- * A budget the target cannot apply must fail at the caller, not in the injected JVM. The agent logs
- * and ignores a bad value so a tuning mistake cannot break the attach, which means an unvalidated
- * option would let `attach()` report success while the target silently kept its own budget and
- * later rejected captures the caller sized for.
- */
 class AttachOptionsTest {
+
+    // ---- frame budget validation ----
+    //
+    // A budget the target cannot apply must fail at the caller, not in the injected JVM. The agent
+    // logs and ignores a bad value so a tuning mistake cannot break the attach, which means an
+    // unvalidated option would let `attach()` report success while the target silently kept its own
+    // budget and later rejected captures the caller sized for.
 
     @Test
     fun `a budget above the read ceiling is rejected at construction`() {
@@ -40,5 +45,144 @@ class AttachOptionsTest {
     fun `a usable budget and the unset default are both accepted`() {
         AttachOptions(maxFrameBytes = MAX_FRAME_BYTES_CEILING)
         AttachOptions(maxFrameBytes = null)
+    }
+
+    // ---- base-dir candidates (pure, platform-agnostic) ----
+
+    @Test
+    fun `udsBaseDirCandidates offers only slash tmp on POSIX`() {
+        assertEquals(
+            listOf("/tmp"),
+            AttachOptions.udsBaseDirCandidates(
+                osName = "Linux",
+                tmpDir = "/var/folders/ignored",
+                localAppData = null,
+                userHome = "/home/x",
+            ),
+        )
+        assertEquals(
+            listOf("/tmp"),
+            AttachOptions.udsBaseDirCandidates(
+                osName = "Mac OS X",
+                tmpDir = "/var/folders/ignored",
+                localAppData = null,
+                userHome = "/Users/x",
+            ),
+        )
+    }
+
+    @Test
+    fun `udsBaseDirCandidates prefers the JVM temp dir on Windows, then per-user fallbacks`() {
+        // %LOCALAPPDATA%\Temp and <user.home>\AppData\Local\Temp resolve to the same directory
+        // on a normal profile, so the duplicate is dropped.
+        assertEquals(
+            listOf("C:\\bazel\\_tmp\\5c46559f", "C:\\Users\\x\\AppData\\Local\\Temp"),
+            AttachOptions.udsBaseDirCandidates(
+                osName = "Windows 11",
+                tmpDir = "C:\\bazel\\_tmp\\5c46559f",
+                localAppData = "C:\\Users\\x\\AppData\\Local",
+                userHome = "C:\\Users\\x",
+            ),
+        )
+    }
+
+    @Test
+    fun `udsBaseDirCandidates skips blank or missing Windows candidates`() {
+        assertEquals(
+            listOf("C:\\Users\\x\\AppData\\Local\\Temp"),
+            AttachOptions.udsBaseDirCandidates(
+                osName = "Windows 10",
+                tmpDir = "  ",
+                localAppData = null,
+                userHome = "C:\\Users\\x",
+            ),
+        )
+    }
+
+    // ---- budget-aware selection (issue #442) ----
+
+    @Test
+    fun `selectUdsPath skips a base whose resulting path would overflow sun_path`() {
+        // Mirrors the Bazel-on-Windows report in #442: java.io.tmpdir is deep enough that
+        // <tmp>/sp-a-<pid>-<uuid>/agent.sock passes the sun_path cap, so the next candidate wins.
+        val deepBase = "/deep/" + "d".repeat(100)
+        val perAttachDir = "sp-a-103560-a1b2c3d4"
+
+        val selected = AttachOptions.selectUdsPath(listOf(deepBase, "/tmp"), perAttachDir)
+
+        assertEquals(Path.of("/tmp", perAttachDir, "agent.sock"), selected)
+    }
+
+    @Test
+    fun `selectUdsPath keeps the first candidate when it fits`() {
+        val perAttachDir = "sp-a-1234-a1b2c3d4"
+
+        val selected = AttachOptions.selectUdsPath(listOf("/tmp", "/other"), perAttachDir)
+
+        assertEquals(Path.of("/tmp", perAttachDir, "agent.sock"), selected)
+    }
+
+    @Test
+    fun `selectUdsPath fails with an actionable message when no candidate fits`() {
+        val deepBase = "/deep/" + "d".repeat(120)
+
+        val ex =
+            assertFailsWith<UdsPathTooLongException> {
+                AttachOptions.selectUdsPath(listOf(deepBase), "sp-a-1234-a1b2c3d4")
+            }
+
+        val message = ex.message.orEmpty()
+        assertTrue(deepBase in message, "message should name the candidate, got: $message")
+        assertTrue(
+            "${UdsPathLimits.maxPathBytes}" in message,
+            "message should name the sun_path limit, got: $message",
+        )
+        assertTrue(
+            "udsPath" in message,
+            "message should point at the AttachOptions.udsPath escape hatch, got: $message",
+        )
+    }
+
+    // ---- default path structure (platform-agnostic) ----
+
+    @Test
+    fun `defaultUdsPath ends in the per-attach dir plus agent socket`() {
+        val p = AttachOptions.defaultUdsPath(1234L)
+        assertEquals("agent.sock", p.fileName.toString())
+        assertTrue(
+            p.parent.fileName.toString().startsWith("sp-a-1234-"),
+            "per-attach dir should be sp-a-<pid>-<uuid>, got ${p.parent.fileName}",
+        )
+    }
+
+    @Test
+    fun `defaultUdsPath always fits the sun_path budget`() {
+        // Regression for #442: the default must never hand the agent a path the OS will reject,
+        // whatever the harness set java.io.tmpdir to.
+        val p = AttachOptions.defaultUdsPath(Long.MAX_VALUE)
+        assertFalse(
+            UdsPathLimits.exceedsLimit(p),
+            "default UDS path is ${UdsPathLimits.byteLength(p)} bytes, over the " +
+                "${UdsPathLimits.maxPathBytes}-byte limit: $p",
+        )
+    }
+
+    // ---- real path per platform ----
+
+    @Test
+    fun `defaultUdsPath is under one of this platform's base candidates`() {
+        val candidates =
+            AttachOptions.udsBaseDirCandidates(
+                osName = System.getProperty("os.name").orEmpty(),
+                tmpDir = System.getProperty("java.io.tmpdir").orEmpty(),
+                localAppData = System.getenv("LOCALAPPDATA"),
+                userHome = System.getProperty("user.home").orEmpty(),
+            )
+        val p = AttachOptions.defaultUdsPath(1234L)
+
+        assertTrue(
+            candidates.any { p.startsWith(Path.of(it)) },
+            "UDS path $p should live under one of $candidates",
+        )
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
@@ -123,6 +123,32 @@ class AttachOptionsTest {
     }
 
     @Test
+    fun `selectUdsPath measures a relative base after resolving it`() {
+        // A relative java.io.tmpdir (`-Djava.io.tmpdir=tmp`) is legal and the JVM does not
+        // normalise it. Measuring the short relative spelling would accept a candidate that the
+        // target then binds as <cwd>/<base>/... — over the limit, with the good fallback already
+        // skipped. Raised as P2 by Codex review on PR #445.
+        val perAttachDir = "sp-a-1234-a1b2c3d4"
+        val tailBytes = UdsPathLimits.byteLength(Path.of(perAttachDir, "agent.sock"))
+        // Sized so the relative spelling lands exactly on the limit; resolving it against any
+        // working directory at all must push it over.
+        val relativeBase = "r".repeat(UdsPathLimits.maxPathBytes - tailBytes - 1)
+        val relativePath = Path.of(relativeBase, perAttachDir, "agent.sock")
+        assertEquals(UdsPathLimits.maxPathBytes, UdsPathLimits.byteLength(relativePath))
+
+        val selected = AttachOptions.selectUdsPath(listOf(relativeBase, "/tmp"), perAttachDir)
+
+        assertEquals(Path.of("/tmp", perAttachDir, "agent.sock").toAbsolutePath(), selected)
+    }
+
+    @Test
+    fun `selectUdsPath always returns an absolute path`() {
+        val selected = AttachOptions.selectUdsPath(listOf("/tmp"), "sp-a-1234-a1b2c3d4")
+
+        assertTrue(selected.isAbsolute, "selected UDS path should be absolute, got $selected")
+    }
+
+    @Test
     fun `selectUdsPath fails with an actionable message when no candidate fits`() {
         val deepBase = "/deep/" + "d".repeat(120)
         val perAttachDir = "sp-a-1234-a1b2c3d4"

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
@@ -125,14 +125,18 @@ class AttachOptionsTest {
     @Test
     fun `selectUdsPath fails with an actionable message when no candidate fits`() {
         val deepBase = "/deep/" + "d".repeat(120)
+        val perAttachDir = "sp-a-1234-a1b2c3d4"
 
         val ex =
             assertFailsWith<UdsPathTooLongException> {
-                AttachOptions.selectUdsPath(listOf(deepBase), "sp-a-1234-a1b2c3d4")
+                AttachOptions.selectUdsPath(listOf(deepBase), perAttachDir)
             }
 
+        // Compare against the path as the platform renders it: on Windows `Paths.get` normalises
+        // the separators, so the raw `/deep/...` string is not a substring of the message.
+        val rejected = Path.of(deepBase, perAttachDir, "agent.sock").toString()
         val message = ex.message.orEmpty()
-        assertTrue(deepBase in message, "message should name the candidate, got: $message")
+        assertTrue(rejected in message, "message should name the rejected path, got: $message")
         assertTrue(
             "${UdsPathLimits.maxPathBytes}" in message,
             "message should name the sun_path limit, got: $message",

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
@@ -110,7 +110,9 @@ class AttachOptionsTest {
 
         val selected = AttachOptions.selectUdsPath(listOf(deepBase, "/tmp"), perAttachDir)
 
-        assertEquals(Path.of("/tmp", perAttachDir, "agent.sock"), selected)
+        // `.toAbsolutePath()` on the expected value too: `/tmp` is drive-relative on Windows, so
+        // selection resolves it to `C:\tmp\…` there and leaves it untouched on POSIX.
+        assertEquals(Path.of("/tmp", perAttachDir, "agent.sock").toAbsolutePath(), selected)
     }
 
     @Test
@@ -119,7 +121,7 @@ class AttachOptionsTest {
 
         val selected = AttachOptions.selectUdsPath(listOf("/tmp", "/other"), perAttachDir)
 
-        assertEquals(Path.of("/tmp", perAttachDir, "agent.sock"), selected)
+        assertEquals(Path.of("/tmp", perAttachDir, "agent.sock").toAbsolutePath(), selected)
     }
 
     @Test

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUdsPathLengthTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUdsPathLengthTest.kt
@@ -5,6 +5,7 @@ package dev.sebastiano.spectre.agent
 import dev.sebastiano.spectre.agent.transport.UdsPathLimits
 import java.nio.file.Path
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
@@ -15,6 +16,35 @@ import kotlin.test.assertTrue
  * agent failed to initialize", with the real cause buried in the target's stderr.
  */
 class AttachUdsPathLengthTest {
+
+    @Test
+    fun `a relative UDS path is resolved against the attacher before it is used`() {
+        // The attacher polls `Files.exists(udsPath)` in its own working directory while the target
+        // JVM binds in *its* working directory, which is a different one for every launch mode. A
+        // relative path therefore means two different files and the attach can only time out.
+        // Resolving here makes both sides agree, and makes the length guard above measure the path
+        // the target will really bind. Raised as P2 by Codex review on PR #445 — its stated
+        // mechanism (the Windows provider resolving before encoding) does not hold, since
+        // `WindowsPath.toString()` returns the path as spelled, but the ambiguity is real.
+        val relative = Path.of("sp-a-relative", "agent.sock")
+
+        val resolved = effectiveUdsPath(relative, targetPid = 1L)
+
+        assertTrue(resolved.isAbsolute, "relative UDS path should be resolved, got $resolved")
+        assertEquals(relative.toAbsolutePath(), resolved)
+    }
+
+    @Test
+    fun `an absolute UDS path is left alone`() {
+        val absolute = Path.of("/tmp", "sp-a-absolute", "agent.sock").toAbsolutePath()
+
+        assertEquals(absolute, effectiveUdsPath(absolute, targetPid = 1L))
+    }
+
+    @Test
+    fun `the default UDS path is already absolute`() {
+        assertTrue(effectiveUdsPath(explicit = null, targetPid = 1L).isAbsolute)
+    }
 
     @Test
     fun `attach rejects an explicit UDS path past the sun_path limit`() {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUdsPathLengthTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachUdsPathLengthTest.kt
@@ -1,0 +1,35 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import dev.sebastiano.spectre.agent.transport.UdsPathLimits
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Attach-side guard for #442: a UDS path past the `sun_path` cap must fail on the attacher with a
+ * message naming the path and the limit, *before* the agent JAR is loaded into the target. Without
+ * it the bind failure happens inside the target JVM and the caller only sees "Agent JAR loaded but
+ * agent failed to initialize", with the real cause buried in the target's stderr.
+ */
+class AttachUdsPathLengthTest {
+
+    @Test
+    fun `attach rejects an explicit UDS path past the sun_path limit`() {
+        val tooLong = Path.of("/tmp", "sp-" + "x".repeat(200), "agent.sock")
+
+        val ex =
+            assertFailsWith<UdsPathTooLongException> {
+                AgentAttach.attach(pid = 1L, options = AttachOptions(udsPath = tooLong))
+            }
+
+        val message = ex.message.orEmpty()
+        assertTrue(tooLong.toString() in message, "message should name the path, got: $message")
+        assertTrue(
+            "${UdsPathLimits.maxPathBytes}" in message,
+            "message should name the sun_path limit, got: $message",
+        )
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchUdsPathFailureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchUdsPathFailureTest.kt
@@ -1,0 +1,83 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.AttachOptions
+import dev.sebastiano.spectre.agent.UdsPathTooLongException
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertIs
+
+/**
+ * `LaunchAndAttach.launch` promises [LaunchAgentBootstrapException] for every AGENT_BOOTSTRAP
+ * failure, carrying the stage and the captured stdout/stderr paths callers use to diagnose it.
+ *
+ * The UDS path is pinned before the retry loop, outside its `try`, so a path that fails the
+ * `sun_path` guard would escape that contract as a bare [UdsPathTooLongException] — no stage, no
+ * capture paths. Raised as P2 by Codex review on PR #445.
+ */
+class LaunchUdsPathFailureTest {
+
+    @Test
+    fun `an unusable default UDS path fails the launch stage rather than escaping it`() {
+        // The default-path branch is the one Codex flagged: on Windows every candidate can
+        // overflow sun_path, and that resolution happens before the retry loop's own try/catch.
+        // It cannot be provoked on POSIX, where the only candidate is the hard-coded /tmp, so the
+        // resolver is injected here.
+        val captureDir = Files.createTempDirectory("spectre-launch-uds-default-")
+        val stdoutPath = Files.createFile(captureDir.resolve("stdout.log"))
+        val stderrPath = Files.createFile(captureDir.resolve("stderr.log"))
+        val tooLong = Path.of("/tmp", "sp-" + "x".repeat(200), "agent.sock")
+
+        val ex =
+            assertFailsWith<LaunchAgentBootstrapException> {
+                LaunchReadiness.awaitAgentBootstrap(
+                    process = ProcessBuilder("sleep", "5").start(),
+                    attachedPid = 1L,
+                    gradleish = true,
+                    attachOptions = AttachOptions(),
+                    bootstrapTimeoutMs = 1_000,
+                    stdoutPath = stdoutPath,
+                    stderrPath = stderrPath,
+                    resolveUdsPath = { _, _ -> throw UdsPathTooLongException(listOf(tooLong)) },
+                )
+            }
+
+        assertIs<UdsPathTooLongException>(ex.cause, "the real cause must survive the wrapping")
+        assertEquals(stdoutPath, ex.stdoutPath)
+        assertEquals(stderrPath, ex.stderrPath)
+        assertEquals(LaunchStage.AGENT_BOOTSTRAP, ex.stage)
+    }
+
+    @Test
+    fun `an unusable UDS path fails the launch stage rather than escaping it`() {
+        val captureDir = Files.createTempDirectory("spectre-launch-uds-")
+        val stdoutPath = captureDir.resolve("stdout.log")
+        val stderrPath = captureDir.resolve("stderr.log")
+        Files.createFile(stdoutPath)
+        Files.createFile(stderrPath)
+        val tooLong = Path.of("/tmp", "sp-" + "x".repeat(200), "agent.sock")
+
+        val ex =
+            assertFailsWith<LaunchAgentBootstrapException> {
+                LaunchReadiness.awaitAgentBootstrap(
+                    process = ProcessBuilder("sleep", "5").start(),
+                    attachedPid = 1L,
+                    // `gradleish` skips the liveness precondition, which is not what this covers.
+                    gradleish = true,
+                    attachOptions = AttachOptions(udsPath = tooLong),
+                    bootstrapTimeoutMs = 1_000,
+                    stdoutPath = stdoutPath,
+                    stderrPath = stderrPath,
+                )
+            }
+
+        assertIs<UdsPathTooLongException>(ex.cause, "the real cause must survive the wrapping")
+        assertEquals(stdoutPath, ex.stdoutPath)
+        assertEquals(stderrPath, ex.stderrPath)
+        assertEquals(LaunchStage.AGENT_BOOTSTRAP, ex.stage)
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchUdsPathFailureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchUdsPathFailureTest.kt
@@ -35,7 +35,7 @@ class LaunchUdsPathFailureTest {
         val ex =
             assertFailsWith<LaunchAgentBootstrapException> {
                 LaunchReadiness.awaitAgentBootstrap(
-                    process = ProcessBuilder("sleep", "5").start(),
+                    process = anyProcess(),
                     attachedPid = 1L,
                     gradleish = true,
                     attachOptions = AttachOptions(),
@@ -64,7 +64,7 @@ class LaunchUdsPathFailureTest {
         val ex =
             assertFailsWith<LaunchAgentBootstrapException> {
                 LaunchReadiness.awaitAgentBootstrap(
-                    process = ProcessBuilder("sleep", "5").start(),
+                    process = anyProcess(),
                     attachedPid = 1L,
                     // `gradleish` skips the liveness precondition, which is not what this covers.
                     gradleish = true,
@@ -80,4 +80,17 @@ class LaunchUdsPathFailureTest {
         assertEquals(stderrPath, ex.stderrPath)
         assertEquals(LaunchStage.AGENT_BOOTSTRAP, ex.stage)
     }
+
+    /**
+     * Any [Process] object will do here: `gradleish = true` makes [LaunchReadiness] skip its
+     * liveness precondition, and the failure under test happens before the retry loop ever looks at
+     * the process again. `sleep` does not exist on Windows, so this branches the same way
+     * `LaunchAndAttachIntegrationTest` does.
+     */
+    private fun anyProcess(): Process =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) {
+            ProcessBuilder("cmd.exe", "/c", "exit /b 0").start()
+        } else {
+            ProcessBuilder("/bin/sh", "-c", "exit 0").start()
+        }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -2,6 +2,7 @@
 
 package dev.sebastiano.spectre.agent.transport
 
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
@@ -245,12 +246,30 @@ class IpcRoundTripTest {
     }
 
     @Test
+    fun `IpcServer names the path and the sun_path limit when the path is too long`() {
+        // #442: the raw JDK failure is `SocketException: Unix domain path too long`, which names
+        // neither the path nor the cap. The agent runs inside the target JVM, so this message is
+        // all a user has to go on in the target's stderr.
+        val tooLong = udsBase().resolve("sp-" + "x".repeat(SUN_PATH_OVERFLOW_LEN) + ".sock")
+
+        val ex = assertFailsWith<IOException> { IpcServer(tooLong, stubHandler()).use {} }
+
+        val message = ex.message.orEmpty()
+        assertTrue(tooLong.toString() in message, "should name the path, got: $message")
+        assertTrue(
+            "${UdsPathLimits.maxPathBytes}" in message,
+            "should name the sun_path limit, got: $message",
+        )
+    }
+
+    @Test
     @EnabledOnOs(OS.LINUX, OS.MAC) // relies on UnixOperatingSystemMXBean.openFileDescriptorCount
     fun `IpcServer constructor releases the ServerSocketChannel when bind fails`() {
         // Regression for Bugbot LOW finding on commit 82be70e: in the `IpcServer` constructor,
         // `ServerSocketChannel.open()` opens a channel, but if `bind()` (or the `deleteIfExists`
-        // before it, or the POSIX permission tightening after it) throws, the channel was
-        // never closed. `ServerSocketChannel` has no finalizer/cleaner, so the native FD would
+        // before it, the `sun_path` length check, or the POSIX permission tightening after it)
+        // throws, the channel was never closed. `ServerSocketChannel` has no finalizer/cleaner, so
+        // the native FD would
         // persist until JVM exit.
         //
         // Direct-evidence approach: observe `UnixOperatingSystemMXBean.openFileDescriptorCount`
@@ -260,10 +279,13 @@ class IpcRoundTripTest {
         val osBean =
             java.lang.management.ManagementFactory.getOperatingSystemMXBean()
                 as com.sun.management.UnixOperatingSystemMXBean
-        // Path is way past the `sun_path` cap (~104 bytes macOS, ~108 Linux) so bind must fail.
+        // Path is way past the `sun_path` cap (~104 bytes macOS, ~108 Linux) so the constructor
+        // must fail. Since #442 it fails at the explicit length check rather than in `bind`; the
+        // check sits *after* `ServerSocketChannel.open` on purpose, so this probe still measures
+        // the constructor's `finally` cleanup.
         val tooLongUdsPath = Path.of("/tmp", "sp-" + "x".repeat(SUN_PATH_OVERFLOW_LEN) + ".sock")
 
-        // Sanity-check the test scaffolding: bind must actually throw for this path.
+        // Sanity-check the test scaffolding: construction must actually throw for this path.
         assertFailsWith<java.io.IOException> { IpcServer(tooLongUdsPath, stubHandler()).use {} }
 
         // Warm-up — the first few attempts can churn extra FDs from JVM/JNI lazy init

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimitsTest.kt
@@ -1,21 +1,52 @@
 package dev.sebastiano.spectre.agent.transport
 
+import java.io.IOException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.ServerSocketChannel
 import java.nio.charset.Charset
+import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
 
 class UdsPathLimitsTest {
 
     @Test
-    fun `macOS reserves 104 bytes of sun_path, everything else 108`() {
-        // The usable budget is one byte less than sun_path: the kernel needs the NUL terminator.
-        assertEquals(103, UdsPathLimits.maxPathBytesFor("Mac OS X"))
-        assertEquals(103, UdsPathLimits.maxPathBytesFor("Darwin"))
-        assertEquals(107, UdsPathLimits.maxPathBytesFor("Linux"))
-        assertEquals(107, UdsPathLimits.maxPathBytesFor("Windows 11"))
+    fun `the usable budget is sun_path minus two bytes`() {
+        // Two, not one. Measured with a real bind: macOS (sun_path 104) takes 102 and refuses
+        // 103; Windows (sun_path 108) takes 106 and refuses 107. The boundary test below
+        // re-measures this on whatever host runs it.
+        assertEquals(102, UdsPathLimits.maxPathBytesFor("Mac OS X"))
+        assertEquals(102, UdsPathLimits.maxPathBytesFor("Darwin"))
+        assertEquals(106, UdsPathLimits.maxPathBytesFor("Linux"))
+        assertEquals(106, UdsPathLimits.maxPathBytesFor("Windows 11"))
+    }
+
+    @Test
+    fun `maxPathBytes is the largest path this host actually binds`() {
+        // The arithmetic helper alone cannot catch an off-by-one — the first version of this
+        // constant reserved one byte instead of two and would have waved through a path that
+        // `bind` rejects, which is precisely the failure #442 is about. Codex review on PR #445
+        // asked for the boundary to be proven against a real socket; this is that proof, and it
+        // runs on every platform CI covers.
+        val base = shortestUsableBaseDir()
+        assumeTrue(
+            fitsUnder(base, UdsPathLimits.maxPathBytes + 1),
+            "base directory $base is too long to build a boundary-length path under",
+        )
+
+        assertTrue(
+            bindSucceeds(pathOfLength(base, UdsPathLimits.maxPathBytes)),
+            "a path of exactly ${UdsPathLimits.maxPathBytes} bytes must bind on this host",
+        )
+        assertFalse(
+            bindSucceeds(pathOfLength(base, UdsPathLimits.maxPathBytes + 1)),
+            "a path of ${UdsPathLimits.maxPathBytes + 1} bytes must be refused on this host",
+        )
     }
 
     @Test
@@ -88,4 +119,37 @@ class UdsPathLimitsTest {
             "message should name the limit, got: $message",
         )
     }
+
+    // ---- helpers for the real-bind boundary probe ----
+
+    /** `/tmp` on POSIX; `%TEMP%` on Windows, where `/tmp` is drive-relative nonsense. */
+    private fun shortestUsableBaseDir(): Path =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) {
+            Path.of(System.getProperty("java.io.tmpdir"))
+        } else {
+            Path.of("/tmp")
+        }
+
+    private fun fitsUnder(base: Path, totalBytes: Int): Boolean =
+        UdsPathLimits.byteLength(base.resolve("x")) < totalBytes
+
+    /** A socket path directly under [base] whose total length is exactly [totalBytes]. */
+    private fun pathOfLength(base: Path, totalBytes: Int): Path {
+        val oneChar = base.resolve("x")
+        val padding = totalBytes - UdsPathLimits.byteLength(oneChar) + 1
+        return base.resolve("x".repeat(padding))
+    }
+
+    private fun bindSucceeds(path: Path): Boolean =
+        try {
+            Files.deleteIfExists(path)
+            ServerSocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                channel.bind(UnixDomainSocketAddress.of(path))
+                true
+            }
+        } catch (_: IOException) {
+            false
+        } finally {
+            runCatching { Files.deleteIfExists(path) }
+        }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimitsTest.kt
@@ -1,0 +1,52 @@
+package dev.sebastiano.spectre.agent.transport
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class UdsPathLimitsTest {
+
+    @Test
+    fun `macOS reserves 104 bytes of sun_path, everything else 108`() {
+        // The usable budget is one byte less than sun_path: the kernel needs the NUL terminator.
+        assertEquals(103, UdsPathLimits.maxPathBytesFor("Mac OS X"))
+        assertEquals(103, UdsPathLimits.maxPathBytesFor("Darwin"))
+        assertEquals(107, UdsPathLimits.maxPathBytesFor("Linux"))
+        assertEquals(107, UdsPathLimits.maxPathBytesFor("Windows 11"))
+    }
+
+    @Test
+    fun `byteLength counts the path as the OS sees it`() {
+        val path = Path.of("/tmp/sp-a-1234-abcdef12/agent.sock")
+        assertEquals(path.toString().length, UdsPathLimits.byteLength(path))
+    }
+
+    @Test
+    fun `a path exactly at the limit fits, one byte more does not`() {
+        val limit = UdsPathLimits.maxPathBytes
+        val atLimit = Path.of("/tmp/" + "x".repeat(limit - "/tmp/".length))
+        val overLimit = Path.of("/tmp/" + "x".repeat(limit - "/tmp/".length + 1))
+
+        assertEquals(limit, UdsPathLimits.byteLength(atLimit))
+        assertFalse(UdsPathLimits.exceedsLimit(atLimit), "$atLimit is exactly at the limit")
+        assertTrue(UdsPathLimits.exceedsLimit(overLimit), "$overLimit is one byte past the limit")
+    }
+
+    @Test
+    fun `tooLongMessage names the path, its length, and the limit`() {
+        val path = Path.of("/tmp/" + "x".repeat(200) + "/agent.sock")
+        val message = UdsPathLimits.tooLongMessage(path)
+
+        assertTrue(path.toString() in message, "message should name the path, got: $message")
+        assertTrue(
+            "${UdsPathLimits.byteLength(path)}" in message,
+            "message should name the path's byte length, got: $message",
+        )
+        assertTrue(
+            "${UdsPathLimits.maxPathBytes}" in message,
+            "message should name the limit, got: $message",
+        )
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimitsTest.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.agent.transport
 
+import java.nio.charset.Charset
 import java.nio.file.Path
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,6 +16,44 @@ class UdsPathLimitsTest {
         assertEquals(103, UdsPathLimits.maxPathBytesFor("Darwin"))
         assertEquals(107, UdsPathLimits.maxPathBytesFor("Linux"))
         assertEquals(107, UdsPathLimits.maxPathBytesFor("Windows 11"))
+    }
+
+    @Test
+    fun `Windows counts sun_path bytes as UTF-8, POSIX as the jnu encoding`() {
+        // Verified against the JDK 21 sources: WindowsFileSystemProvider.getSunPathForSocketFile
+        // ends in `s.getBytes(StandardCharsets.UTF_8)`, while UnixPath.encode goes through
+        // Util.jnuEncoding().
+        assertEquals(Charsets.UTF_8, UdsPathLimits.nativeCharsetFor("Windows 11"))
+
+        val jnu = Charset.forName(System.getProperty("sun.jnu.encoding"))
+        assertEquals(jnu, UdsPathLimits.nativeCharsetFor("Linux"))
+        assertEquals(jnu, UdsPathLimits.nativeCharsetFor("Mac OS X"))
+    }
+
+    @Test
+    fun `an accented Windows path fits a legacy code page but not UTF-8`() {
+        // Cp1252 spends one byte on an accented letter; UTF-8 spends two. A Windows JVM commonly
+        // reports sun.jnu.encoding=Cp1252, so measuring a `C:\Users\<accented name>\...` path
+        // with it would under-count the path, keep a candidate that does not actually fit, and
+        // reproduce #442 by another route. Raised by Codex review on PR #445.
+        val cp1252 = Charset.forName("windows-1252")
+        val windowsLimit = UdsPathLimits.maxPathBytesFor("Windows 11")
+        val accents = 4
+        val head = "C:\\Users\\" + "\u00e9".repeat(accents)
+        val tail = "\\AppData\\Local\\Temp\\sp-a-1-abcdef12\\agent.sock"
+        // Pad the user name so the code-page measurement lands exactly on the limit.
+        val path = Path.of(head + "x".repeat(windowsLimit - head.length - tail.length) + tail)
+
+        assertEquals(windowsLimit, UdsPathLimits.byteLength(path, cp1252))
+        assertEquals(windowsLimit + accents, UdsPathLimits.byteLength(path, Charsets.UTF_8))
+        assertFalse(
+            UdsPathLimits.exceedsLimit(path, cp1252, windowsLimit),
+            "the code-page measurement is what made this path look usable",
+        )
+        assertTrue(
+            UdsPathLimits.exceedsLimit(path, Charsets.UTF_8, windowsLimit),
+            "the UTF-8 measurement is the one the Windows socket provider actually applies",
+        )
     }
 
     @Test

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimitsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/UdsPathLimitsTest.kt
@@ -20,6 +20,11 @@ class UdsPathLimitsTest {
         // Two, not one. Measured with a real bind: macOS (sun_path 104) takes 102 and refuses
         // 103; Windows (sun_path 108) takes 106 and refuses 107. The boundary test below
         // re-measures this on whatever host runs it.
+        //
+        // If these numbers ever change, four places mirror them and the compiler checks none of
+        // them: the `udsPath` KDoc on AttachOptions, the UdsPathTooLongException KDoc,
+        // docs/guide/agent.md, and docs/guide/troubleshooting.md. Codex review on PR #445 caught
+        // exactly that drift after the reservation went from one byte to two.
         assertEquals(102, UdsPathLimits.maxPathBytesFor("Mac OS X"))
         assertEquals(102, UdsPathLimits.maxPathBytesFor("Darwin"))
         assertEquals(106, UdsPathLimits.maxPathBytesFor("Linux"))

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WindowsDeepTempUdsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WindowsDeepTempUdsTest.kt
@@ -1,0 +1,93 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.transport
+
+import dev.sebastiano.spectre.agent.AttachOptions
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * End-to-end regression for #442 on the platform that had the bug.
+ *
+ * `AttachOptionsTest` pins the *selection* logic as pure strings, which runs everywhere. This test
+ * closes the remaining gap: given a `java.io.tmpdir` as deep as the one Bazel hands a Windows test,
+ * the fallback base is a real directory on this machine, and a `ServerSocketChannel` actually binds
+ * there and serves a request. Nothing but a Windows host can prove that.
+ */
+@EnabledOnOs(OS.WINDOWS)
+class WindowsDeepTempUdsTest {
+    private var boundPath: Path? = null
+
+    @AfterTest
+    fun cleanUp() {
+        boundPath?.let { path ->
+            runCatching { path.deleteIfExists() }
+            runCatching { path.parent?.deleteIfExists() }
+        }
+    }
+
+    @Test
+    fun `a Bazel-deep java_io_tmpdir falls back to a base that really binds`() {
+        // The reporter's TEST_TMPDIR, verbatim from #442: 83 characters, which pushed
+        // <tmp>\sp-a-<pid>-<uuid>\agent.sock to 115 bytes against the ~108-byte sun_path cap.
+        val bazelTmpDir =
+            "C:\\programdata\\_bazel\\vn2ifhp6\\execroot\\_main\\_tmp\\5c46559f6d626ed6fb8fd5728fe0401e"
+        val perAttachDir = "sp-a-103560-a1b2c3d4"
+
+        val candidates =
+            AttachOptions.udsBaseDirCandidates(
+                osName = System.getProperty("os.name").orEmpty(),
+                tmpDir = bazelTmpDir,
+                localAppData = System.getenv("LOCALAPPDATA"),
+                userHome = System.getProperty("user.home").orEmpty(),
+            )
+        val udsPath = AttachOptions.selectUdsPath(candidates, perAttachDir)
+        boundPath = udsPath
+
+        assertTrue(
+            candidates.first() == bazelTmpDir,
+            "the harness temp dir should still be tried first, got $candidates",
+        )
+        assertFalse(
+            udsPath.startsWith(Path.of(bazelTmpDir)),
+            "the deep harness temp dir should have been skipped, got $udsPath",
+        )
+        assertFalse(
+            UdsPathLimits.exceedsLimit(udsPath),
+            "selected path is ${UdsPathLimits.byteLength(udsPath)} bytes, over the " +
+                "${UdsPathLimits.maxPathBytes}-byte limit: $udsPath",
+        )
+
+        // The real proof: Windows accepts this path for an AF_UNIX bind and the socket serves.
+        IpcServer(udsPath, pingOnlyHandler()).use {
+            awaitSocket(udsPath)
+            IpcClient(udsPath).use { client ->
+                assertEquals(AgentResponse.Pong, client.send(AgentRequest.Ping))
+            }
+        }
+    }
+
+    private fun pingOnlyHandler(): AgentRequestHandler = AgentRequestHandler { request ->
+        when (request) {
+            AgentRequest.Ping -> AgentResponse.Pong
+            else -> AgentResponse.Error(message = "unsupported in this test")
+        }
+    }
+
+    private fun awaitSocket(path: Path, timeoutMs: Long = 2_000) {
+        val deadline = System.currentTimeMillis() + timeoutMs
+        while (System.currentTimeMillis() < deadline) {
+            if (Files.exists(path)) return
+            Thread.sleep(10)
+        }
+        error("UDS file $path did not appear within ${timeoutMs} ms")
+    }
+}

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -32,7 +32,8 @@ out of scope.
    reach the bound port. Bind to `127.0.0.1`. Anything network-reachable broadens the threat
    model beyond what this release covers.
 4. **The agent transport assumes a same-user peer.** `:agent`'s Unix Domain Socket is created
-   under a short private directory (in `/tmp/` on Linux/macOS, under `%TEMP%` on Windows). On
+   under a short private directory (in `/tmp/` on Linux/macOS; under `%TEMP%` on Windows, or
+   `%LOCALAPPDATA%\Temp` when `%TEMP%` is too deep to leave room for the socket path). On
    Linux/macOS the directory is mode 0700 and the socket is mode 0600. On Windows/NTFS, where
    POSIX modes are meaningless, `IpcServer` instead applies an **owner-only ACL** — a single
    ALLOW full-control ACE for the owning user, with inherited ACEs dropped — to both the private

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -266,7 +266,7 @@ AttachOptions(
 
 The default `<base>` is `/tmp` on Linux and macOS. On Windows it is `%TEMP%`, falling back to
 `%LOCALAPPDATA%\Temp` when `%TEMP%` is deep enough to push the socket path past the platform's
-`sockaddr_un.sun_path` limit (103 usable bytes on macOS, 107 on Linux and Windows). A path you
+`sockaddr_un.sun_path` limit (102 usable bytes on macOS, 106 on Linux and Windows). A path you
 pass yourself must also fit that limit; `attach` rejects longer ones with
 `UdsPathTooLongException` before it loads the agent, so the failure names the path and the limit
 instead of surfacing as a bootstrap error inside the target.

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -136,8 +136,9 @@ explicitly.
 
 `AgentAttach.attach(pid)` performs this sequence:
 
-1. Resolve the loadable `spectre-agent-runtime-<version>.jar`.
-2. Create a fresh Unix Domain Socket path such as `/tmp/sp-a-<pid>-<8char-uuid>/agent.sock`.
+1. Pick a fresh Unix Domain Socket path such as `/tmp/sp-a-<pid>-<8char-uuid>/agent.sock`, and
+   check that it fits the platform's `sun_path` limit.
+2. Resolve the loadable `spectre-agent-runtime-<version>.jar`.
 3. Run attach preflights, including the same-OS-user check.
 4. Call `VirtualMachine.attach(pid).loadAgent(runtimeJarPath, udsPath)`.
 5. The target JVM loads the runtime jar and invokes `SpectreAgent.agentmain(...)`.
@@ -258,10 +259,17 @@ cleanup.
 ```kotlin
 AttachOptions(
     agentJarPath = null,        // null = auto-locate (see "Artifact roles" above)
-    udsPath = null,             // null = <tmp>/sp-a-<pid>-<8char-uuid>/agent.sock (/tmp on POSIX, %TEMP% on Windows)
+    udsPath = null,             // null = <base>/sp-a-<pid>-<8char-uuid>/agent.sock (see below)
     attachTimeoutMs = 5_000,    // how long to wait for the agent's IPC server to come up
 )
 ```
+
+The default `<base>` is `/tmp` on Linux and macOS. On Windows it is `%TEMP%`, falling back to
+`%LOCALAPPDATA%\Temp` when `%TEMP%` is deep enough to push the socket path past the platform's
+`sockaddr_un.sun_path` limit (103 usable bytes on macOS, 107 on Linux and Windows). A path you
+pass yourself must also fit that limit; `attach` rejects longer ones with
+`UdsPathTooLongException` before it loads the agent, so the failure names the path and the limit
+instead of surfacing as a bootstrap error inside the target.
 
 If you override `udsPath` with a path under an existing directory, you own that parent
 directory's permissions. Spectre creates the default per-attach directory and socket owner-only —

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -45,6 +45,21 @@ no longer a hard requirement. Direct launches that Spectre starts get
 `-XX:+EnableDynamicAgentLoading`; Gradle launches must set that flag in the build.
 See [Agent attach](agent.md#injection-without-preinstalled-core).
 
+### "Unix domain path too long" / `UdsPathTooLongException`
+
+The socket path the agent binds must fit the operating system's `sockaddr_un.sun_path`
+field: 103 usable bytes on macOS, 107 on Linux and Windows. Longer paths are refused by
+the kernel.
+
+Spectre picks a default path that fits. It uses `/tmp` on Linux and macOS. On Windows it
+uses `%TEMP%` when the result fits, and falls back to `%LOCALAPPDATA%\Temp` when it does
+not — build harnesses such as Bazel point `java.io.tmpdir` at a deep scratch directory,
+which used to push the path past the limit.
+
+You can still hit the limit if you set `AttachOptions.udsPath` yourself. Attach now
+rejects that up front with `UdsPathTooLongException`, which names the path, its size in
+bytes, and the limit. Pick a shorter directory, closer to the filesystem root.
+
 ### "Attached but no window (FIRST_WINDOW)"
 
 Attach succeeded but `windows()` stayed empty until timeout. The app may still be

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -48,7 +48,7 @@ See [Agent attach](agent.md#injection-without-preinstalled-core).
 ### "Unix domain path too long" / `UdsPathTooLongException`
 
 The socket path the agent binds must fit the operating system's `sockaddr_un.sun_path`
-field: 103 usable bytes on macOS, 107 on Linux and Windows. Longer paths are refused by
+field: 102 usable bytes on macOS, 106 on Linux and Windows. Longer paths are refused by
 the kernel.
 
 Spectre picks a default path that fits. It uses `/tmp` on Linux and macOS. On Windows it


### PR DESCRIPTION
Fixes #442.

## The bug

On Windows the default agent socket path was built under `java.io.tmpdir`. Nothing constrains how deep `%TEMP%` is. Bazel points it at a per-test execroot directory, so `<tmp>\sp-a-<pid>-<uuid>\agent.sock` passed the ~108-byte `sockaddr_un.sun_path` cap and the agent's `bind` failed **inside the target JVM**. The attacher saw only `AgentInitializationException: Agent JAR loaded but agent failed to initialize`, with the real cause — `SocketException: Unix domain path too long` — buried in the target's stderr.

Linux and macOS were never exposed: they hard-code `/tmp`.

## The fix

**1. The base directory is chosen, not assumed.**

`AttachOptions.defaultUdsPath` now picks from an ordered candidate list and takes the first entry whose resulting path fits the platform's `sun_path` budget:

| OS | Candidates, in order |
|---|---|
| Linux, macOS | `/tmp` — unchanged |
| Windows | `%TEMP%`, then `%LOCALAPPDATA%\Temp`, then `<user.home>\AppData\Local\Temp` |

Windows still prefers `%TEMP%`, so a harness that points the JVM at its own scratch directory keeps it. The fallbacks reach the per-user temp directory without going through `java.io.tmpdir`, which is the property harnesses rewrite. Both fallbacks are per-user and get the same owner-only ACL Spectre already applies to the directories it creates.

**2. An overlong path is named.**

New internal `UdsPathLimits` holds the budget (103 usable bytes on macOS, 107 on Linux and Windows) and counts path length in bytes using `sun.jnu.encoding`, not characters.

- `AgentAttach.attach` length-checks the effective path **before** loading the agent JAR and throws the new `UdsPathTooLongException`, which names the path, its size in bytes, and the limit. The check moved ahead of JAR resolution so a caller's bad `udsPath` fails on the cheapest input validation.
- `IpcServer` repeats the check before `bind`, so the same detail reaches the target's stderr when the agent is started some other way. It sits *after* `ServerSocketChannel.open` on purpose, so the existing FD-leak regression test still measures the constructor's `finally` cleanup.

## Tests

Written first, failing, then made to pass.

- `AttachOptionsTest` — candidate ordering per OS, blank and duplicate candidates dropped, budget-aware selection, and a case that replays the reported Bazel depth. Runs on every OS.
- `UdsPathLimitsTest` — per-OS budget arithmetic, byte counting, the exact boundary, and the diagnostic message.
- `AttachUdsPathLengthTest` — `attach` rejects a caller-supplied overlong path with `UdsPathTooLongException` before touching the target.
- `IpcRoundTripTest` — the agent-side message names the path and the limit.
- `WindowsDeepTempUdsTest` — **Windows only.** Builds the candidate list with the reporter's exact `java.io.tmpdir`, asserts the deep directory is skipped, then binds a real `IpcServer` at the selected path and round-trips a `Ping`. This is the end-to-end proof, and the Windows CI job is what runs it.

`./gradlew check` passes on macOS. Behaviour on macOS and Linux is unchanged — same `/tmp` base, same path shape.

## Docs

Troubleshooting entry for "Unix domain path too long", the `AttachOptions` section of the agent guide, and the SECURITY.md note on where the socket lives. `agent/api/agent.api` regenerated for the new exception.

## Verified on Windows

Run on a physical Windows 11 desktop (JBR 21.0.10), not just CI:

- **Full `:agent:test`: 310 tests, 0 failures.** That includes `WindowsDeepTempUdsTest`, `AttachOptionsTest` (13), `UdsPathLimitsTest` (4), `AttachUdsPathLengthTest`, `IpcRoundTripTest` and `IpcServerWindowsAclTest`.
- **Real attach end-to-end**, with the Windows opt-in gate (`-Pspectre.agent.attachE2e.allowWindows=true`): `AgentAttach.attach` bound the new default UDS path against a live Compose fixture and ran `windows()`, `findByTestTag`, `click` and `typeText` over it. `attach explains when the target JVM disables dynamic agent loading` passed too. The run stopped later at `screenshot()` because that machine is missing the .NET 8 Desktop Runtime the Windows capture helper needs — an unrelated prerequisite, well past the code this PR touches.

The Windows run also **caught a real defect in this PR**: `selectUdsPath fails with an actionable message when no candidate fits` compared a raw `/deep/...` string against the message, but `Paths.get` normalises separators, so the message names `\deep\...` on Windows. Fixed in `Compare the rejected UDS path the way the platform renders it`, which now asserts on the full rejected path via `Path.of(...).toString()`. The production code was correct throughout.

## Review fixes

Codex raised two points on `UdsPathLimits`; both are answered in `b333bb2`, with the mechanism checked against the JDK 21 sources first.

**P1 — Windows encodes `sun_path` as UTF-8, not `sun.jnu.encoding`. Correct.** `WindowsFileSystemProvider.getSunPathForSocketFile` ends in `s.getBytes(StandardCharsets.UTF_8)` unconditionally, while `UnixPath.encode` goes through `Util.jnuEncoding()`. A Windows JVM commonly reports `Cp1252`, where an accented letter costs one byte and UTF-8 costs two — so a path under an accented user name was measured short, kept as a candidate, and then rejected by `bind`: this PR's own bug by another route. `nativeCharsetFor(osName)` now picks per platform, with a boundary test where Cp1252 measures 107 bytes and UTF-8 measures 111.

**P2 — relative `udsPath`. The stated mechanism does not hold, but it found a real problem.** `WindowsPath.toString()` returns the path as spelled, so a relative path reaches `bind0` as relative bytes and that is exactly what `sun_path` holds; working-directory depth cannot overflow it. What *is* broken is that a relative path means two different files: the attacher polls `Files.exists` in its working directory, the target binds in its own. `attach()` now resolves the path up front (`effectiveUdsPath`), which also makes the length guard measure what the target really binds.

## The limit was wrong, on every platform

Codex's third round found the most important defect in this PR, so it gets its own section.

The original constant reserved **one** byte of `sun_path` — the NUL terminator. The JDK reserves **two**. A path of exactly the old limit passed the new guard and was then refused by `bind`: the opaque failure this PR exists to remove, reintroduced by the fix for it.

Measured by binding a real `AF_UNIX` `ServerSocketChannel` at each length, not derived from headers:

| Platform | JDK | `sun_path` | Largest that binds | First that throws |
|---|---|---|---|---|
| macOS 15 | Temurin 21.0.12 | 104 | **102** | 103 |
| Windows 11 | JBR 21.0.10 | 108 | **106** | 107 |

Codex reported 106 for Linux, which fits the same rule. The constant is now `sun_path - 2`.

The arithmetic helper could never have caught this — it was only ever checking its own arithmetic. `UdsPathLimitsTest` now binds a socket at exactly `maxPathBytes` and at `maxPathBytes + 1` and asserts the first succeeds and the second fails, on every platform CI covers. Linux CI verifies the 106 directly, and a future JDK that changes the reservation fails there rather than in the field.

## Unrelated flakes seen while running the full check

Filed separately, not touched here — all three predate this change and all three passed on re-run:

- #443 — `AgentAttachIntegrationTest` attaches before HotSpot opens the attach handshake.
- #444 — the real-keyboard `typeText` subpath only tolerates focus loss when `CI=true`, so `./gradlew check` cannot be run on a machine in use.
- #446 — `LaunchAndAttachGradleIntegrationTest` can attach to the Gradle client instead of the launched app JVM.
- #447 — `LaunchAndAttachIntegrationTest`'s two `PROCESS_ALIVE` stage tests race on loaded CI runners. Ran them 5x on `main` and 5x on this branch on a physical Windows desktop: 5/5 pass both ways, so not a regression here.

One more failure on macOS, `:verifyMacosCliBundleReleaseContract`, is a local-environment flake in the release-bundle script: it also fails on a pristine `origin/main` checkout, and passes on re-run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



