### PR TITLE
Make the attach integration test survive the handshake race and a busy desktop

### DIFF
--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -106,6 +106,17 @@ tasks.withType<Test>().configureEach {
             .orElse("")
     inputs.property("spectre.agent.attachE2e.allowWindows", allowWindowsAttachE2e)
 
+    // Real-keyboard (Robot typeText) subpath opt-in (#444). CI enables it from the `CI` env var;
+    // developer machines keep `./gradlew check` runnable while another window holds OS keyboard
+    // focus, and opt in with -Pspectre.agent.realKeyboard=true on an idle desktop. Same
+    // forwarding and task-input reasoning as the Windows gate above.
+    val realKeyboardE2e =
+        providers
+            .gradleProperty("spectre.agent.realKeyboard")
+            .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.realKeyboard"))
+            .orElse("")
+    inputs.property("spectre.agent.realKeyboard", realKeyboardE2e)
+
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {
             buildList {
@@ -120,6 +131,10 @@ tasks.withType<Test>().configureEach {
                 val allowWin = allowWindowsAttachE2e.get().takeIf { it.isNotBlank() }
                 if (allowWin != null) {
                     add("-Ddev.sebastiano.spectre.agent.attachE2e.allowWindows=$allowWin")
+                }
+                val realKeyboard = realKeyboardE2e.get().takeIf { it.isNotBlank() }
+                if (realKeyboard != null) {
+                    add("-Ddev.sebastiano.spectre.agent.realKeyboard=$realKeyboard")
                 }
             }
         }

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -116,6 +116,12 @@ tasks.withType<Test>().configureEach {
             .orElse(providers.systemProperty("dev.sebastiano.spectre.agent.realKeyboard"))
             .orElse("")
     inputs.property("spectre.agent.realKeyboard", realKeyboardE2e)
+    // `CI` is the other half of the gate: with no property set, RealKeyboardE2eGate flips from
+    // disabled to enabled purely because the env var changed. Without it as an input, a CI run
+    // could stay UP-TO-DATE on (or restore from cache) a developer-mode result where the Robot
+    // keyboard path was skipped, silently dropping the coverage CI is supposed to provide.
+    val realKeyboardCi = providers.environmentVariable("CI").orElse("")
+    inputs.property("spectre.agent.realKeyboard.ci", realKeyboardCi)
 
     jvmArgumentProviders.add(
         CommandLineArgumentProvider {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -197,7 +197,10 @@ internal object LaunchReadiness {
             } catch (ex: SpectreAttachException) {
                 rethrowIfProcessDied(process, gradleish, stdoutPath, stderrPath)
                 lastAttachFailure = ex
-                if (!isPreLoadAttachRetryable(ex) || System.nanoTime() >= deadline) {
+                if (
+                    !isPreLoadAttachRetryable(ex.message, ex.cause?.message) ||
+                        System.nanoTime() >= deadline
+                ) {
                     throw LaunchAgentBootstrapException(
                         attachedPid = attachedPid,
                         stdoutPath = stdoutPath,
@@ -231,16 +234,19 @@ internal object LaunchReadiness {
     }
 
     /**
-     * True when [ex] is a **short** pre-`loadAgent` HotSpot race (safe to retry with the same UDS
-     * path).
+     * True when an attach failure with [message] (and optional [causeMessage]) is a **short**
+     * pre-`loadAgent` HotSpot race, and so safe to retry with the same UDS path.
      *
      * Deliberately does **not** treat every `AttachNotSupportedException` as retryable: HotSpot
      * also uses that type for its independent attach-socket wait timeout (~10s). Retrying after
      * that terminal timeout would start another full JDK handshake and blow the stage budget. Only
      * the documented "state is not ready…" race (and "no such process" pid churn) retries.
+     *
+     * Internal rather than private so tests that drive [AgentAttach.attach] directly — instead of
+     * going through [awaitAgentBootstrap] — retry the same race against the same definition (#443).
      */
-    private fun isPreLoadAttachRetryable(ex: SpectreAttachException): Boolean {
-        val msg = (ex.message.orEmpty() + " " + (ex.cause?.message.orEmpty())).lowercase()
+    internal fun isPreLoadAttachRetryable(message: String?, causeMessage: String?): Boolean {
+        val msg = (message.orEmpty() + " " + causeMessage.orEmpty()).lowercase()
         return "not ready to participate in attach handshake" in msg || "no such process" in msg
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentAttachIntegrationTest.kt
@@ -7,6 +7,7 @@ import dev.sebastiano.spectre.agent.fixture.SPECTRE_FIXTURE_WINDOW_TITLE
 import dev.sebastiano.spectre.agent.fixture.TAG_BUTTON
 import dev.sebastiano.spectre.agent.fixture.TAG_LABEL
 import dev.sebastiano.spectre.agent.fixture.TAG_TEXT_FIELD
+import dev.sebastiano.spectre.agent.launch.LaunchReadiness
 import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import dev.sebastiano.spectre.agent.transport.WindowSummaryDto
 import java.awt.GraphicsEnvironment
@@ -49,7 +50,8 @@ import org.junit.jupiter.api.condition.OS
  * - `findByTestTag(TAG_LABEL / TAG_BUTTON / TAG_TEXT_FIELD)` each return at least one match.
  * - `click(buttonKey)` bare-throws on any wire-level error. Focused-field `typeText("x")` also
  *   bare-throws except for CI-only macOS focus handoff loss, where the already-covered
- *   real-keyboard subpath is skipped after the attach/click/focus contract has been proven.
+ *   real-keyboard subpath is skipped after the attach/click/focus contract has been proven. The
+ *   real-keyboard subpath itself only runs when [RealKeyboardE2eGate] allows it (#444).
  *
  * The pure-mapping correctness (getter names, `Rectangle → RectDto`, screenshot's `Rectangle?`
  * lookup, refresh-before-read contract) is *also* covered at the unit level in
@@ -59,8 +61,8 @@ import org.junit.jupiter.api.condition.OS
  * **Do not loosen these assertions.** Earlier drafts wrapped `click`/`typeText` in `runCatching`
  * and let empty `windows()` pass — that hid a real `windows()`-cache-staleness bug (the handler
  * needed `refreshWindows()`) and a `BufferedReader` deadlock in `FixtureProcess.close()`. The only
- * exception is CI macOS OS-focus loss after Compose focus has been proven; local runs still fail so
- * developers can diagnose real keyboard regressions.
+ * exception is CI macOS OS-focus loss after Compose focus has been proven; a local opt-in run still
+ * fails so developers can diagnose real keyboard regressions.
  *
  * Gating:
  * - **Runs on Linux, macOS, and Windows** via `@EnabledOnOs`. Hosted GitHub `windows-latest` lacks
@@ -73,8 +75,15 @@ import org.junit.jupiter.api.condition.OS
  *   to create a `JFrame + ComposePanel` without a display.
  * - Skipped when `dev.sebastiano.spectre.agent.runtimeJar` isn't set. Gradle's `:agent:test` task
  *   sets it from the `:agent-runtime:jar` output.
- * - Real-keyboard `typeText` tolerates a CI-only loss of OS keyboard focus on any platform (see
- *   `typeTextOrSkipCiFocusLoss`); the attach/click/focus contract is still asserted.
+ * - The real-keyboard subpath (click-to-focus + `typeText`) is **opt-in off CI** via
+ *   [RealKeyboardE2eGate]: it needs the fixture window to own OS keyboard focus for the whole run,
+ *   which a developer machine in use cannot guarantee, and `./gradlew check` is the documented
+ *   pre-push gate (#444). Everything else — attach, `windows()`, `findByTestTag`, `click()`, window
+ *   identity, screenshot — runs on every host. When the subpath does run, real-keyboard `typeText`
+ *   still tolerates a CI-only loss of OS keyboard focus on any platform (see
+ *   `typeTextOrSkipCiFocusLoss`).
+ * - Attach itself retries the pre-`loadAgent` HotSpot handshake race via
+ *   `attachRetryingHandshakeRace` (#443); no other attach failure is retried.
  */
 @EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
 class AgentAttachIntegrationTest {
@@ -116,10 +125,12 @@ class AgentAttachIntegrationTest {
 
             val exception =
                 assertFailsWith<SpectreAttachException> {
-                    AgentAttach.attach(
-                        fixture.pid,
-                        AttachOptions(agentJarPath = agentJar, udsPath = udsPath),
-                    )
+                    // `.use` so an unexpected success closes the automator instead of leaking it.
+                    attachRetryingHandshakeRace(
+                            fixture.pid,
+                            AttachOptions(agentJarPath = agentJar, udsPath = udsPath),
+                        )
+                        .use {}
                 }
 
             assertEquals(
@@ -140,7 +151,7 @@ class AgentAttachIntegrationTest {
                 attachTimeoutMs = ATTACH_TIMEOUT_MS,
             )
 
-        AgentAttach.attach(fixture.pid, options).use { automator ->
+        attachRetryingHandshakeRace(fixture.pid, options).use { automator ->
             assertEquals(fixture.pid, automator.pid)
 
             // Strict contract: the fixture put up exactly one tagged Compose UI before
@@ -206,21 +217,18 @@ class AgentAttachIntegrationTest {
                 textFieldKey.isNotBlank(),
                 "iteration $iteration: text field node key should be non-blank; got '$textFieldKey'",
             )
-            val focusedTextField =
-                automator.waitForFocusedTextField(textFieldKey, iteration = iteration)
-            if (focusedTextField != null) {
-                val editableTextBefore = focusedTextField.editableText.orEmpty()
-                // This is a real keyboard event path. Do not call typeText until a refreshed
-                // semantics snapshot proves the fixture text field owns Compose focus; the
-                // in-target handler also checks that this JVM owns OS keyboard focus before
-                // dispatching Robot key events.
-                if (automator.typeTextOrSkipCiFocusLoss(iteration = iteration)) {
-                    automator.waitForTextFieldToReceiveTypedCharacterOrSkipCi(
-                        textFieldKey = textFieldKey,
-                        previousEditableText = editableTextBefore,
-                        iteration = iteration,
-                    )
-                }
+            if (RealKeyboardE2eGate.isEnabled()) {
+                automator.exerciseRealKeyboard(textFieldKey, iteration = iteration)
+            } else {
+                System.err.println(
+                    "iteration $iteration: skipped the real-keyboard subpath — click-to-focus on " +
+                        "$textFieldKey, typeText('$TYPED_CHARACTER'), and the typed-character " +
+                        "assertion. It needs the fixture window to own OS keyboard focus for the " +
+                        "whole run, which a machine in use cannot guarantee (#444). CI runs it by " +
+                        "default; on an idle desktop pass " +
+                        "\"-Pspectre.agent.realKeyboard=true\" (or " +
+                        "-D${RealKeyboardE2eGate.ENABLE_PROP}=true on the test JVM)."
+                )
             }
         }
 
@@ -422,6 +430,60 @@ class AgentAttachIntegrationTest {
         )
     }
 
+    /**
+     * Attaches to [pid], retrying **only** the pre-`loadAgent` HotSpot handshake race (#443).
+     *
+     * HotSpot opens the attach handshake a few hundred milliseconds after the JVM becomes visible,
+     * so an attach that arrives too early fails with `AttachNotSupportedException: state is not
+     * ready to participate in attach handshake`. [LaunchReadiness.awaitAgentBootstrap] already
+     * retries exactly this failure for the launch path; this suite calls [AgentAttach.attach]
+     * directly, so it retries against the same [LaunchReadiness.isPreLoadAttachRetryable]
+     * definition rather than a second copy of the rule.
+     *
+     * Every other failure — including the dynamic-agent-loading refusal that `attach explains when
+     * the target JVM disables dynamic agent loading` asserts on — propagates from the first
+     * attempt, unchanged. The UDS path stays pinned across retries, which is safe because the
+     * retried failures all happen before `loadAgent` binds a socket.
+     */
+    private fun attachRetryingHandshakeRace(pid: Long, options: AttachOptions): AttachedAutomator {
+        val deadline =
+            System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(ATTACH_HANDSHAKE_RETRY_BUDGET_MS)
+        while (true) {
+            try {
+                return AgentAttach.attach(pid, options)
+            } catch (ex: SpectreAttachException) {
+                val retryable =
+                    LaunchReadiness.isPreLoadAttachRetryable(ex.message, ex.cause?.message)
+                if (!retryable || System.nanoTime() >= deadline) throw ex
+                System.err.println(
+                    "pid $pid was not ready for the attach handshake yet; retrying. ${ex.message}"
+                )
+                sleepQuietly(ATTACH_HANDSHAKE_RETRY_INTERVAL_MS)
+            }
+        }
+    }
+
+    /**
+     * The Robot-backed keyboard subpath: click the field until Compose reports it focused, type one
+     * character, then assert the field received it. Gated by [RealKeyboardE2eGate] because it needs
+     * the fixture window to own OS keyboard focus throughout (#444).
+     */
+    private fun AttachedAutomator.exerciseRealKeyboard(textFieldKey: String, iteration: Int) {
+        val focusedTextField =
+            waitForFocusedTextField(textFieldKey, iteration = iteration) ?: return
+        val editableTextBefore = focusedTextField.editableText.orEmpty()
+        // This is a real keyboard event path. Do not call typeText until a refreshed semantics
+        // snapshot proves the fixture text field owns Compose focus; the in-target handler also
+        // checks that this JVM owns OS keyboard focus before dispatching Robot key events.
+        if (typeTextOrSkipCiFocusLoss(iteration = iteration)) {
+            waitForTextFieldToReceiveTypedCharacterOrSkipCi(
+                textFieldKey = textFieldKey,
+                previousEditableText = editableTextBefore,
+                iteration = iteration,
+            )
+        }
+    }
+
     private fun spawnComposeFixture(dynamicAgentLoadingEnabled: Boolean = true): FixtureProcess {
         // ProcessBuilder does not append `.exe` for an absolute path on Windows, so pick the
         // launcher name explicitly via FixtureJavaHome (also honours mixed-runtime overrides).
@@ -611,9 +673,11 @@ class AgentAttachIntegrationTest {
         error(message)
     }
 
-    private fun sleepBetweenFocusPolls() {
+    private fun sleepBetweenFocusPolls() = sleepQuietly(FOCUS_POLL_INTERVAL_MS)
+
+    private fun sleepQuietly(millis: Long) {
         try {
-            Thread.sleep(FOCUS_POLL_INTERVAL_MS)
+            Thread.sleep(millis)
         } catch (ex: InterruptedException) {
             Thread.currentThread().interrupt()
             throw ex
@@ -662,6 +726,11 @@ class AgentAttachIntegrationTest {
     private companion object {
         const val REPEAT_CYCLES: Int = 3
         const val ATTACH_TIMEOUT_MS: Long = 15_000
+        // #443: budget for the pre-loadAgent HotSpot handshake race only. The fixture is already
+        // settled for FIXTURE_ATTACH_SETTLE_MS after READY, so this rarely spends more than one
+        // retry.
+        const val ATTACH_HANDSHAKE_RETRY_BUDGET_MS: Long = 10_000
+        const val ATTACH_HANDSHAKE_RETRY_INTERVAL_MS: Long = 250
         const val FIXTURE_READY_TIMEOUT_MS: Long = 30_000
         const val FIXTURE_ATTACH_SETTLE_MS: Long = 750
         const val FOCUS_TIMEOUT_MS: Long = 2_000

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/RealKeyboardE2eGate.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/RealKeyboardE2eGate.kt
@@ -1,0 +1,50 @@
+package dev.sebastiano.spectre.agent
+
+/**
+ * Opt-in gate for the Robot-backed real-keyboard subpath of [AgentAttachIntegrationTest] (#444).
+ *
+ * The subpath clicks the fixture's text field and types into it with a real `java.awt.Robot`. That
+ * only works while the fixture window owns OS keyboard focus, so anything else taking focus — a
+ * terminal, an editor, a notification — fails the test. `./gradlew check` is the documented
+ * pre-push gate, and it must stay runnable on a machine someone is using.
+ *
+ * Defaults:
+ * - **CI** (`CI=true` in the environment): enabled, so the keyboard path keeps its coverage.
+ * - **Developer machines**: disabled. The attach, `windows()`, `findByTestTag`, `click()`,
+ *   window-identity and screenshot assertions all still run; only the click-to-focus and `typeText`
+ *   assertions are skipped, and the test prints to stderr exactly what it skipped.
+ *
+ * Opt in on an idle desktop with:
+ * ```
+ * ./gradlew :agent:test --tests '*AgentAttachIntegrationTest*' -Pspectre.agent.realKeyboard=true
+ * ```
+ *
+ * **PowerShell:** quote the property so the shell does not treat `.agent…` as a separate task:
+ * `./gradlew :agent:test "-Pspectre.agent.realKeyboard=true" --tests '*…*'`
+ *
+ * or `-D[ENABLE_PROP]=true` on the test JVM (Gradle forwards the `-P` form via
+ * [agent/build.gradle.kts]). Passing `false` turns the subpath off on CI too.
+ *
+ * When the subpath *does* run, its assertions are unchanged: CI still tolerates a lost OS focus
+ * handoff (that flakiness is not what this gate is about), and a local opt-in run still fails
+ * loudly so a real keyboard regression is visible.
+ */
+internal object RealKeyboardE2eGate {
+    const val ENABLE_PROP: String = "dev.sebastiano.spectre.agent.realKeyboard"
+
+    /**
+     * Returns true when the real-keyboard subpath may run on this host.
+     *
+     * [property] wins in both directions when it parses as a boolean. Anything else (unset, blank,
+     * or a typo such as `yes`) falls back to [ci], so a mistyped property cannot silently drop the
+     * CI-side keyboard coverage.
+     */
+    fun isEnabled(
+        property: String? = System.getProperty(ENABLE_PROP),
+        ci: String? = System.getenv("CI"),
+    ): Boolean {
+        val explicit = property?.trim()?.lowercase()?.toBooleanStrictOrNull()
+        if (explicit != null) return explicit
+        return ci.equals("true", ignoreCase = true)
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/RealKeyboardE2eGateTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/RealKeyboardE2eGateTest.kt
@@ -1,0 +1,45 @@
+package dev.sebastiano.spectre.agent
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for the real-keyboard opt-in that keeps `./gradlew check` runnable on a machine
+ * someone is using, while CI still exercises the Robot-backed `typeText` subpath of
+ * [AgentAttachIntegrationTest] (#444).
+ */
+class RealKeyboardE2eGateTest {
+    @Test
+    fun `CI enables the subpath when no property is set`() {
+        assertTrue(RealKeyboardE2eGate.isEnabled(property = null, ci = "true"))
+        assertTrue(RealKeyboardE2eGate.isEnabled(property = null, ci = "TRUE"))
+    }
+
+    @Test
+    fun `a developer machine disables the subpath by default`() {
+        assertFalse(RealKeyboardE2eGate.isEnabled(property = null, ci = null))
+        assertFalse(RealKeyboardE2eGate.isEnabled(property = null, ci = ""))
+        assertFalse(RealKeyboardE2eGate.isEnabled(property = null, ci = "false"))
+    }
+
+    @Test
+    fun `the property wins over the CI environment in both directions`() {
+        assertTrue(RealKeyboardE2eGate.isEnabled(property = "true", ci = null))
+        assertTrue(RealKeyboardE2eGate.isEnabled(property = "TRUE", ci = "false"))
+        assertFalse(RealKeyboardE2eGate.isEnabled(property = "false", ci = "true"))
+    }
+
+    @Test
+    fun `a blank property falls back to the CI environment`() {
+        assertTrue(RealKeyboardE2eGate.isEnabled(property = "  ", ci = "true"))
+        assertFalse(RealKeyboardE2eGate.isEnabled(property = "", ci = null))
+    }
+
+    @Test
+    fun `an unparseable property falls back to the CI environment`() {
+        // A typo must not silently drop the CI-side keyboard coverage.
+        assertTrue(RealKeyboardE2eGate.isEnabled(property = "yes", ci = "true"))
+        assertFalse(RealKeyboardE2eGate.isEnabled(property = "yes", ci = null))
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessAttachRetryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessAttachRetryTest.kt
@@ -1,0 +1,69 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Unit coverage for the pre-`loadAgent` attach race predicate shared by
+ * [LaunchReadiness.awaitAgentBootstrap] and the direct-attach integration tests (#443).
+ *
+ * The predicate must stay narrow. HotSpot reuses `AttachNotSupportedException` for its own attach
+ * socket timeout (~10s), and retrying after that terminal timeout would start another full
+ * handshake and blow the caller's budget.
+ */
+class LaunchReadinessAttachRetryTest {
+    @Test
+    fun `the HotSpot handshake race is retryable`() {
+        assertTrue(
+            LaunchReadiness.isPreLoadAttachRetryable(
+                message =
+                    "VirtualMachine.attach(22962) failed: AttachNotSupportedException: " +
+                        "pid: 22962, state is not ready to participate in attach handshake!",
+                causeMessage = null,
+            )
+        )
+    }
+
+    @Test
+    fun `pid churn is retryable`() {
+        assertTrue(
+            LaunchReadiness.isPreLoadAttachRetryable(
+                message = "attach failed: No such process",
+                causeMessage = null,
+            )
+        )
+    }
+
+    @Test
+    fun `the race is recognised when it only appears on the cause`() {
+        assertTrue(
+            LaunchReadiness.isPreLoadAttachRetryable(
+                message = "VirtualMachine.attach(22962) failed",
+                causeMessage = "pid: 22962, state is not ready to participate in attach handshake!",
+            )
+        )
+    }
+
+    @Test
+    fun `terminal attach failures are not retryable`() {
+        assertFalse(
+            LaunchReadiness.isPreLoadAttachRetryable(
+                message =
+                    "The target JVM does not allow dynamic agent loading. Restart it with " +
+                        "`-XX:+EnableDynamicAgentLoading` and retry the attach.",
+                causeMessage = "Dynamic agent loading is not enabled",
+            )
+        )
+        assertFalse(
+            LaunchReadiness.isPreLoadAttachRetryable(
+                message = "Unable to open socket file: target process not responding",
+                causeMessage = null,
+            )
+        )
+        assertFalse(LaunchReadiness.isPreLoadAttachRetryable(message = null, causeMessage = null))
+    }
+}

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -70,6 +70,7 @@ These are structural, not one-release accidents:
 | CLI package-channel (Homebrew/Scoop) contracts | Structural on every Unix `check` (`python3`); install-semantics when Ruby present or under `CI` (issue #400) | Optional: install Ruby on a clean Linux box and run `./gradlew verifyHomebrewFormulaInstallSemantics` if claiming formula behaviour beyond CI |
 | Agent attach + contract corpus (live UI) | Linux Xvfb + macOS desktop; Windows **transport/ACL** unit tests | **Windows headed desktop** (not SSH-only for capture) |
 | Agent Windows UI e2e | Opt-in only: `-Pspectre.agent.attachE2e.allowWindows=true` | Run that property on Mattone-class boxes |
+| Agent real-keyboard `typeText` | Runs on CI (`CI=true`); **skipped** on developer machines | Add `-Pspectre.agent.realKeyboard=true` on an idle desktop |
 | Agent **inject** attach | Linux + macOS e2e | **Windows** inject fixture (no preinstalled core) |
 | Launch-and-attach e2e | Linux + macOS | **Windows** direct `java` (and Gradle if claimed) |
 | CLI daemon + live fixture | Linux + macOS | **Windows** release-shaped CLI binary |
@@ -466,7 +467,8 @@ What it does (no second terminal), using the **same stable scenario IDs** as
 1. `preflight` + optional `check`
 2. `pointer-move` — live `moveTo`/`moveBy` hover (`*PointerMoveLive*`)
 3. Agent UI e2e: `agent-attach-core`, `agent-inject`, `agent-launch-and-attach`
-   (`-Pspectre.agent.attachE2e.allowWindows=true`, properly quoted for PowerShell)
+   (`-Pspectre.agent.attachE2e.allowWindows=true`, properly quoted for PowerShell;
+   `agent-attach-core` also passes `-Pspectre.agent.realKeyboard=true`)
 4. `host-native-recording` — WGC region smoke only when `displayMode` is interactive
    (SSH → hard `n/a` with reason, never fake PASS)
 5. `cli-packaged` / `cli-native-helper-layout` / packaged `spectre launch --once` as `cli-user-flow`
@@ -508,15 +510,20 @@ Optional **full UI e2e** on a physical Windows desktop (not hosted CI default):
 # bash / zsh / cmd
 ./gradlew :agent:test \
   -Pspectre.agent.attachE2e.allowWindows=true \
+  -Pspectre.agent.realKeyboard=true \
   --tests '*AgentAttachIntegration*'
 ```
 
 ```powershell
-# PowerShell: quote the -P argument (otherwise PS splits on dots after -Pspectre)
+# PowerShell: quote the -P arguments (otherwise PS splits on dots after -Pspectre)
 ./gradlew :agent:test `
   "-Pspectre.agent.attachE2e.allowWindows=true" `
+  "-Pspectre.agent.realKeyboard=true" `
   --tests '*AgentAttachIntegration*'
 ```
+
+`-Pspectre.agent.realKeyboard=true` keeps the Robot `typeText` subpath, which is opt-in off CI so
+`./gradlew check` stays runnable on a machine in use. Leave the smoke desktop idle while it runs.
 
 See [Agent attach](guide/agent.md). Do not enable this property on headless
 `windows-latest` as a fail-closed gate without a headed runner story.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -85,6 +85,35 @@ Examples for Spectre:
 These tests should use the real payload or coordinate format rather than a hand-crafted idealized
 version. Unit tests for internal math are necessary, but boundary tests catch drift between layers.
 
+## Running `./gradlew check` Locally
+
+`./gradlew check` is the pre-push gate, so it must stay runnable on a machine you are also using.
+
+One suite needs the whole desktop to itself: `AgentAttachIntegrationTest` types into a spawned
+Compose window with a real `java.awt.Robot`, which only works while that window owns OS keyboard
+focus. A terminal, an editor, or a notification taking focus mid-run used to fail the suite.
+
+That real-keyboard subpath is therefore **opt-in off CI**. By default it runs on CI (`CI=true` in
+the environment) and is skipped on developer machines, where the test prints to stderr exactly
+which assertions it skipped. Everything else in the suite — attach, `windows()`, `findByTestTag`,
+`click()`, window identity, screenshot — runs on every host.
+
+Run the keyboard path yourself on an idle desktop:
+
+```shell
+# bash / zsh / cmd
+./gradlew :agent:test --tests '*AgentAttachIntegrationTest*' -Pspectre.agent.realKeyboard=true
+```
+
+```powershell
+# PowerShell: quote -P… so the shell does not split on the property name
+./gradlew :agent:test --tests '*AgentAttachIntegrationTest*' "-Pspectre.agent.realKeyboard=true"
+```
+
+Pass `-Pspectre.agent.realKeyboard=false` to turn it off on CI. When the subpath does run its
+assertions are unchanged: a local run fails loudly on focus loss so a real keyboard regression is
+visible.
+
 ## Manual Spike Validation
 
 Some concerns still need live manual verification even with good automated tests:

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -605,6 +605,14 @@ def main(argv: list[str] | None = None) -> int:
                     *robot_prefix,
                     gradle,
                     ":agent:test",
+                    # AgentAttachIntegrationTest's Robot typeText subpath is opt-in off CI so
+                    # `./gradlew check` stays runnable on a machine in use (#444). The smoke
+                    # desktop is dedicated, so keep the coverage.
+                    *(
+                        ["-Pspectre.agent.realKeyboard=true"]
+                        if scenario_id == "agent-attach-core"
+                        else []
+                    ),
                     "--tests",
                     test_filter,
                     *force,

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -608,6 +608,9 @@ try {
                 Invoke-Gradle -RepoRoot $repoRoot -TimeoutSeconds $AgentE2eTimeoutSeconds -LogName "agent-attach" -GradleArgs @(
                     ":agent:test",
                     "-Pspectre.agent.attachE2e.allowWindows=true",
+                    # Interactive smoke desktop: keep the Robot typeText subpath, which is
+                    # opt-in off CI so `./gradlew check` stays runnable on a machine in use (#444).
+                    "-Pspectre.agent.realKeyboard=true",
                     "--tests", "*AgentAttachIntegration*",
                     "--rerun-tasks",
                     "--no-build-cache"


### PR DESCRIPTION
Fixes #443 and #444. Both are flakes in `AgentAttachIntegrationTest` that made `./gradlew check` — the documented pre-push gate — unreliable on a developer machine.

## #443 — retry the pre-`loadAgent` attach handshake race

HotSpot opens the attach handshake a few hundred milliseconds after the JVM becomes visible, so an attach sent too early fails with `AttachNotSupportedException: state is not ready to participate in attach handshake`.

`LaunchReadiness.awaitAgentBootstrap` already retried exactly this failure for the launch path. The test calls `AgentAttach.attach` directly, so it got no retry.

The test now retries against **the same rule** rather than a third copy of the string match (`DaemonFixtureIntegrationTest` and `HotReloadDaemonFixtureE2eTest` already carry their own copies). `LaunchReadiness.isPreLoadAttachRetryable` becomes `internal` and takes the message and cause message instead of the exception, which also makes it unit-testable:

```kotlin
internal fun isPreLoadAttachRetryable(message: String?, causeMessage: String?): Boolean
```

The predicate stays deliberately narrow — HotSpot reuses `AttachNotSupportedException` for its own ~10s attach-socket timeout, and retrying after that terminal timeout would start another full handshake. Every other attach failure, **including the dynamic-agent-loading refusal the negative test asserts on**, still propagates from the first attempt. That assertion is unchanged.

## #444 — make the real-keyboard subpath opt-in off CI

Option 3 from the issue. The subpath clicks to focus and types with a real `Robot`, which only works while the fixture window owns OS keyboard focus, so a terminal, an editor, or a notification taking focus failed the suite.

New `RealKeyboardE2eGate` (test-source, modelled on the existing `WindowsAttachE2eGate`):

| Host | Default | Override |
|---|---|---|
| CI (`CI=true`) | subpath runs | `-Pspectre.agent.realKeyboard=false` |
| Developer machine | subpath skipped, stderr says what was skipped | `-Pspectre.agent.realKeyboard=true` |

An unparseable property value falls back to `CI` rather than to `false`, so a typo cannot silently drop the CI-side keyboard coverage.

Everything else — attach, `windows()`, `findByTestTag`, `click()`, window identity, screenshot — still runs on every host. **When the subpath does run, its assertions are unchanged**: CI still tolerates a lost OS focus handoff, and a local opt-in run still fails loudly.

The Windows release smoke runs on a dedicated desktop, so `scripts/windows-release-smoke.ps1` and the `RELEASE-SMOKE.md` recipes pass `-Pspectre.agent.realKeyboard=true` explicitly and keep the coverage they had before this change.

I used the repo's `spectre.agent.*` / `dev.sebastiano.spectre.agent.*` naming rather than the `spectre.test.realKeyboard` the issue floated as an example, to match `spectre.agent.attachE2e.allowWindows`.

## Verification

`./gradlew check` passes on an idle macOS desktop. `AgentAttachIntegrationTest` verified in all three modes:

| Mode | Result |
|---|---|
| default, while actively using the machine | passes; 3 skip messages (one per `REPEAT_CYCLES` iteration) |
| `-Pspectre.agent.realKeyboard=true`, idle | passes; 0 skips — keyboard path ran |
| `CI=true` env, no property | passes; 0 skips — CI keeps its coverage |

Both new unit tests were written first and confirmed failing (compile error against the missing symbols) before the production change.

The `inputs.property` wiring was checked too: toggling the flag re-runs `:agent:test` instead of leaving it `UP-TO-DATE`.

## Known residual (not this PR)

While validating I hit a *third*, pre-existing instance of the same class of problem, in a different suite and module: `AgentContractCorpusTest` → `press-key-tab-after-focus` fails locally when focus is stolen, because `PressKeyAfterFocus.run` (in `:testing`) hard-fails off macOS-CI by design. It is unaffected by this change and fails on `main` the same way. Filed separately — fixing it properly means touching `:testing`'s published API, its ABI dump, and the `CapabilityMatrix` rationale strings, which does not belong in this PR.

So `./gradlew check` is now robust against the two `AgentAttachIntegrationTest` flakes, but is not yet fully clean on a busy desktop until that residual is addressed.

I also hit #446 once during validation (`LaunchAndAttachGradleIntegrationTest` attaching to the Gradle client instead of the fixture, so nothing bound the socket and `AGENT_BOOTSTRAP` timed out after 30s). It passes in isolation and is unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
