### PR TITLE
Never attach to a JVM that was already running when the launch began

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -247,7 +247,8 @@ public final class dev/sebastiano/spectre/agent/launch/LaunchCommandRewriter {
 
 public final class dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery {
 	public static final field INSTANCE Ldev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery;
-	public final fun discoverAppJvm (JLjava/lang/String;)Ljava/lang/Long;
+	public final fun discoverAppJvm (JLjava/lang/String;Ljava/time/Instant;)Ljava/lang/Long;
+	public static synthetic fun discoverAppJvm$default (Ldev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery;JLjava/lang/String;Ljava/time/Instant;ILjava/lang/Object;)Ljava/lang/Long;
 	public final fun isGradleDaemonDisplayName (Ljava/lang/String;)Z
 }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
@@ -5,6 +5,7 @@ import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 
 /**
  * Launch a command, wait through staged readiness, attach Spectre, and return a [LaunchedSession]
@@ -41,7 +42,15 @@ public object LaunchAndAttach {
             warningSink(warning)
         }
         val process = startProcess(prepared.command, spec, prepared.stdoutPath, prepared.stderrPath)
-        return attachAfterStart(process, prepared, spec)
+        // #446: read the launch boundary here, the earliest point at which the process exists. A
+        // gradle-ish client can be reaped almost immediately, and a reaped process reports no
+        // start instant — so this must not wait until a later readiness stage.
+        val launchBoundary =
+            LaunchReadiness.launchBoundary(
+                osStartInstant = process.info().startInstant().orElse(null),
+                observedAt = Instant.now(),
+            )
+        return attachAfterStart(process, prepared, spec, launchBoundary)
     }
 
     /** Default warning destination — stderr so interactive tools and CI logs surface it. */
@@ -126,6 +135,7 @@ public object LaunchAndAttach {
         process: Process,
         prepared: PreparedLaunch,
         spec: LaunchSpec,
+        launchBoundary: Instant,
     ): LaunchedSession {
         val launchedPid = process.pid()
         // Gradle-ish: expand default JVM_ATTACHABLE budget (15s → 120s) so cold daemon + compile
@@ -155,6 +165,7 @@ public object LaunchAndAttach {
                     timeoutMs = stageTimeouts.jvmAttachableMs,
                     stdoutPath = prepared.stdoutPath,
                     stderrPath = prepared.stderrPath,
+                    clientStart = launchBoundary,
                 )
             automator =
                 LaunchReadiness.awaitAgentBootstrap(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt
@@ -41,14 +41,18 @@ public object LaunchAndAttach {
         for (warning in prepared.warnings) {
             warningSink(warning)
         }
+        // #446: sample the wall clock *before* the process exists, so the fallback boundary can
+        // never land after the app JVM this launch is about to start. Erring early only risks
+        // admitting a stale candidate, which pid ordering and the name filter still narrow;
+        // erring late would reject the real app JVM on every poll until the stage times out.
+        val launchedAt = Instant.now()
         val process = startProcess(prepared.command, spec, prepared.stdoutPath, prepared.stderrPath)
-        // #446: read the launch boundary here, the earliest point at which the process exists. A
-        // gradle-ish client can be reaped almost immediately, and a reaped process reports no
-        // start instant — so this must not wait until a later readiness stage.
+        // Read the OS start time at the earliest point the process exists: a gradle-ish client can
+        // be reaped almost immediately, and a reaped process reports no start instant at all.
         val launchBoundary =
             LaunchReadiness.launchBoundary(
                 osStartInstant = process.info().startInstant().orElse(null),
-                observedAt = Instant.now(),
+                observedAt = launchedAt,
             )
         return attachAfterStart(process, prepared, spec, launchBoundary)
     }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -31,8 +31,20 @@ public object LaunchDescendantDiscovery {
      * @param nameFilter case-insensitive substring of the app's main-class display name. Required
      *   to safely pick among daemon children on machines with concurrent Gradle apps.
      */
-    public fun discoverAppJvm(clientPid: Long, nameFilter: String?): Long? =
-        selectAppJvm(clientPid = clientPid, nameFilter = nameFilter)
+    public fun discoverAppJvm(
+        clientPid: Long,
+        nameFilter: String?,
+        /**
+         * When the launch began, used to reject JVMs that predate it (see [predatesLaunch]).
+         *
+         * Callers that poll must capture this **once, while the client is still alive** and pass
+         * the same value every time. Gradle-ish discovery deliberately keeps running after the
+         * client exits, and a reaped pid no longer resolves to a [ProcessHandle] — so re-deriving
+         * the boundary per poll would silently fail open exactly when the gate matters most.
+         */
+        clientStart: Instant? = processStartInstant(clientPid),
+    ): Long? =
+        selectAppJvm(clientPid = clientPid, nameFilter = nameFilter, clientStart = clientStart)
 
     /**
      * [discoverAppJvm] with its process facts injectable, so the selection rules can be tested
@@ -41,20 +53,20 @@ public object LaunchDescendantDiscovery {
     internal fun selectAppJvm(
         clientPid: Long,
         nameFilter: String?,
+        clientStart: Instant?,
         listed: List<JvmProcessInfo> =
             runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList()),
         descendantsOf: (Long) -> Set<Long> = ::descendantPidsOf,
         parentOf: (Long) -> Long? = ::parentPid,
         startInstantOf: (Long) -> Instant? = ::processStartInstant,
         nativeFallback: (Long, Set<Long>, String?) -> Long? = { client, daemons, filter ->
-            discoverByNativeTree(client, daemons, filter, startInstantOf)
+            discoverByNativeTree(client, daemons, filter, clientStart, startInstantOf)
         },
     ): Long? {
         if (listed.isEmpty()) return null
 
         val daemonPids =
             listed.filter { isGradleDaemonDisplayName(it.displayName) }.map { it.pid }.toSet()
-        val clientStart = startInstantOf(clientPid)
         val nonDaemon = listed.filter { info ->
             info.pid != clientPid &&
                 !isGradleDaemonDisplayName(info.displayName) &&
@@ -113,7 +125,8 @@ public object LaunchDescendantDiscovery {
         return candidateStart.isBefore(clientStart)
     }
 
-    private fun processStartInstant(pid: Long): Instant? =
+    /** Best-effort process start time; empty on hosts or permission setups that hide it. */
+    internal fun processStartInstant(pid: Long): Instant? =
         ProcessHandle.of(pid).flatMap { it.info().startInstant() }.orElse(null)
 
     /**
@@ -124,6 +137,7 @@ public object LaunchDescendantDiscovery {
         clientPid: Long,
         daemonPids: Set<Long>,
         nameFilter: String?,
+        clientStart: Instant?,
         startInstantOf: (Long) -> Instant?,
     ): Long? {
         val roots = buildList {
@@ -133,7 +147,6 @@ public object LaunchDescendantDiscovery {
             }
         }
         val daemonPidSet = daemonPids // roots may include daemon pids as walk roots only
-        val clientStart = startInstantOf(clientPid)
         return roots
             .asSequence()
             .flatMap { root -> descendantPidsOf(root).asSequence() }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -74,7 +74,14 @@ public object LaunchDescendantDiscovery {
                 // else — a leftover fixture, or a sibling e2e sharing the daemon (#446).
                 !predatesLaunch(startInstantOf(info.pid), clientStart)
         }
-        if (nonDaemon.isEmpty()) return null
+        if (nonDaemon.isEmpty()) {
+            // Every Attach-visible JVM is either a daemon or predates the launch. That does not
+            // mean the target is absent: VirtualMachine.list() lags behind spawn, and
+            // -XX:-UsePerfData hides a JVM from it entirely. The native walk is the fallback for
+            // exactly that case, so do not short-circuit past it (#446).
+            val walkRoots = if (nameFilter.isNullOrBlank()) emptySet() else daemonPids
+            return nativeFallback(clientPid, walkRoots, nameFilter)
+        }
 
         val clientDescendants = descendantsOf(clientPid)
         val childOfDaemon = nonDaemon.filter { info ->

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.agent.launch
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.JvmProcessInfo
 import dev.sebastiano.spectre.agent.SpectreProcesses
+import java.time.Instant
 import kotlin.streams.asSequence
 
 /**
@@ -14,6 +15,8 @@ import kotlin.streams.asSequence
  * Safety rules:
  * - Never returns a Gradle daemon display-name match.
  * - Never returns an arbitrary machine-wide JVM.
+ * - Never returns a JVM that was already running when the launch began — it belongs to something
+ *   else, however well its main class matches (#446). See [predatesLaunch].
  * - Daemon-child candidates are only considered when [nameFilter] is set (shared daemons often host
  *   unrelated app JVMs).
  * - Without [nameFilter], only ProcessHandle descendants of the client are considered
@@ -28,20 +31,42 @@ public object LaunchDescendantDiscovery {
      * @param nameFilter case-insensitive substring of the app's main-class display name. Required
      *   to safely pick among daemon children on machines with concurrent Gradle apps.
      */
-    public fun discoverAppJvm(clientPid: Long, nameFilter: String?): Long? {
-        val listed = runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList())
+    public fun discoverAppJvm(clientPid: Long, nameFilter: String?): Long? =
+        selectAppJvm(clientPid = clientPid, nameFilter = nameFilter)
+
+    /**
+     * [discoverAppJvm] with its process facts injectable, so the selection rules can be tested
+     * against a fixed process layout instead of whatever happens to be running (#446).
+     */
+    internal fun selectAppJvm(
+        clientPid: Long,
+        nameFilter: String?,
+        listed: List<JvmProcessInfo> =
+            runCatching { SpectreProcesses.listJvmProcesses() }.getOrDefault(emptyList()),
+        descendantsOf: (Long) -> Set<Long> = ::descendantPidsOf,
+        parentOf: (Long) -> Long? = ::parentPid,
+        startInstantOf: (Long) -> Instant? = ::processStartInstant,
+        nativeFallback: (Long, Set<Long>, String?) -> Long? = { client, daemons, filter ->
+            discoverByNativeTree(client, daemons, filter, startInstantOf)
+        },
+    ): Long? {
         if (listed.isEmpty()) return null
 
         val daemonPids =
             listed.filter { isGradleDaemonDisplayName(it.displayName) }.map { it.pid }.toSet()
+        val clientStart = startInstantOf(clientPid)
         val nonDaemon = listed.filter { info ->
-            info.pid != clientPid && !isGradleDaemonDisplayName(info.displayName)
+            info.pid != clientPid &&
+                !isGradleDaemonDisplayName(info.displayName) &&
+                // A JVM that was already running when this launch started belongs to something
+                // else — a leftover fixture, or a sibling e2e sharing the daemon (#446).
+                !predatesLaunch(startInstantOf(info.pid), clientStart)
         }
         if (nonDaemon.isEmpty()) return null
 
-        val clientDescendants = descendantPidsOf(clientPid)
+        val clientDescendants = descendantsOf(clientPid)
         val childOfDaemon = nonDaemon.filter { info ->
-            val parent = parentPid(info.pid) ?: return@filter false
+            val parent = parentOf(info.pid) ?: return@filter false
             parent in daemonPids
         }
 
@@ -66,21 +91,30 @@ public object LaunchDescendantDiscovery {
                     return it
                 }
             // Native process-tree fallback: hsperfdata/list can lag behind spawn.
-            return discoverByNativeTree(
-                clientPid = clientPid,
-                daemonPids = daemonPids,
-                nameFilter = nameFilter,
-            )
+            return nativeFallback(clientPid, daemonPids, nameFilter)
         }
 
         // No name filter: only client descendants (never unfiltered daemon children).
         return nonDaemon.filter { it.pid in clientDescendants }.maxByOrNull { it.pid }?.pid
-            ?: discoverByNativeTree(
-                clientPid = clientPid,
-                daemonPids = emptySet(), // no unfiltered daemon walk without nameFilter
-                nameFilter = null,
-            )
+            // No unfiltered daemon walk without nameFilter.
+            ?: nativeFallback(clientPid, emptySet(), null)
     }
+
+    /**
+     * True when [candidateStart] proves the candidate JVM was already running before the launch
+     * began at [clientStart], so it cannot be the JVM this launch started.
+     *
+     * Fails open. Not every platform and permission setup exposes process start times, and losing
+     * discovery entirely would be far worse than the race this guards — so an unknown instant on
+     * either side keeps the candidate. Equal instants keep it too: process clocks are coarse.
+     */
+    internal fun predatesLaunch(candidateStart: Instant?, clientStart: Instant?): Boolean {
+        if (candidateStart == null || clientStart == null) return false
+        return candidateStart.isBefore(clientStart)
+    }
+
+    private fun processStartInstant(pid: Long): Instant? =
+        ProcessHandle.of(pid).flatMap { it.info().startInstant() }.orElse(null)
 
     /**
      * Walk [ProcessHandle] descendants when Attach list is incomplete. With [nameFilter], also walk
@@ -90,6 +124,7 @@ public object LaunchDescendantDiscovery {
         clientPid: Long,
         daemonPids: Set<Long>,
         nameFilter: String?,
+        startInstantOf: (Long) -> Instant?,
     ): Long? {
         val roots = buildList {
             add(clientPid)
@@ -98,11 +133,15 @@ public object LaunchDescendantDiscovery {
             }
         }
         val daemonPidSet = daemonPids // roots may include daemon pids as walk roots only
+        val clientStart = startInstantOf(clientPid)
         return roots
             .asSequence()
             .flatMap { root -> descendantPidsOf(root).asSequence() }
             .filter { pid -> pid != clientPid }
             .filter { pid -> pid !in daemonPidSet }
+            // Same rule as the listed-JVM path: this launch cannot have started a JVM that was
+            // already running when it began (#446).
+            .filter { pid -> !predatesLaunch(startInstantOf(pid), clientStart) }
             .filter { pid -> looksLikeJavaProcess(pid) }
             .filter { pid -> !commandLineLooksLikeGradleDaemon(pid) }
             .filter { pid -> nameFilter.isNullOrBlank() || commandLineContains(pid, nameFilter) }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -52,6 +52,11 @@ internal object LaunchReadiness {
         stderrPath: Path,
     ): Long {
         val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+        // #446: pin the launch boundary now, while the client is still alive. Gradle-ish discovery
+        // below deliberately keeps polling after the client exits, and a reaped pid no longer
+        // resolves to a ProcessHandle — re-deriving this per poll would hand predatesLaunch a null
+        // boundary and silently re-admit every JVM the gate exists to reject.
+        val clientStart = process.info().startInstant().orElse(null)
         while (System.nanoTime() < deadline) {
             if (!gradleish) {
                 // Direct: client is the target. Stage PROCESS_ALIVE established the process is
@@ -65,7 +70,7 @@ internal object LaunchReadiness {
             // Gradle-ish: keep discovering after the client exits. The app JVM is often a
             // daemon child (not a ProcessHandle descendant of ./gradlew); tasks that fork and
             // return still need the remaining stage budget to observe the app.
-            val pid = LaunchDescendantDiscovery.discoverAppJvm(launchedPid, nameFilter)
+            val pid = LaunchDescendantDiscovery.discoverAppJvm(launchedPid, nameFilter, clientStart)
             if (pid != null) return pid
             sleepQuietly(POLL_MS)
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -12,6 +12,7 @@ import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
+import java.time.Instant
 import java.util.concurrent.TimeUnit
 
 /** Per-stage readiness polls for [LaunchAndAttach]. */
@@ -42,6 +43,19 @@ internal object LaunchReadiness {
         }
     }
 
+    /**
+     * The boundary handed to app-JVM discovery: when this launch began.
+     *
+     * Prefers [osStartInstant], the launched process's own start time, and falls back to
+     * [observedAt] — the moment the launch call created it. Never null, because a null boundary
+     * makes [LaunchDescendantDiscovery.predatesLaunch] fail open, which is exactly what the gate
+     * must not do (#446). A gradle-ish client can be reaped moments after it starts, and a reaped
+     * process reports no start instant at all. The fallback is safe: the app JVM this launch is
+     * waiting for cannot have started before the launch created its client.
+     */
+    internal fun launchBoundary(osStartInstant: Instant?, observedAt: Instant): Instant =
+        osStartInstant ?: observedAt
+
     fun awaitJvmAttachable(
         process: Process,
         launchedPid: Long,
@@ -50,13 +64,16 @@ internal object LaunchReadiness {
         timeoutMs: Long,
         stdoutPath: Path,
         stderrPath: Path,
+        /**
+         * When this launch began, captured by the caller at process creation — see
+         * [launchBoundary]. Gradle-ish discovery below deliberately keeps polling after the client
+         * exits, and a reaped pid no longer resolves to a `ProcessHandle`, so deriving this here
+         * would hand [LaunchDescendantDiscovery.predatesLaunch] a null boundary and silently
+         * re-admit every JVM the gate exists to reject (#446).
+         */
+        clientStart: Instant,
     ): Long {
         val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMs)
-        // #446: pin the launch boundary now, while the client is still alive. Gradle-ish discovery
-        // below deliberately keeps polling after the client exits, and a reaped pid no longer
-        // resolves to a ProcessHandle — re-deriving this per poll would hand predatesLaunch a null
-        // boundary and silently re-admit every JVM the gate exists to reject.
-        val clientStart = process.info().startInstant().orElse(null)
         while (System.nanoTime() < deadline) {
             if (!gradleish) {
                 // Direct: client is the target. Stage PROCESS_ALIVE established the process is

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
@@ -110,6 +110,23 @@ class LaunchDescendantDiscoveryTest {
     }
 
     @Test
+    fun `selectAppJvm keeps rejecting a leftover after the gradle client has exited`() {
+        // Gradle-ish discovery deliberately keeps polling after the client exits — the app JVM is
+        // a daemon child that often appears later. Once the client is reaped,
+        // ProcessHandle.of(clientPid) is empty, so a boundary resolved per poll would be null and
+        // predatesLaunch would fail open, re-admitting the very leftover the gate exists to
+        // reject. The boundary has to be captured once, while the client is alive.
+        val scenario = GradleLaunchScenario(includeFreshFixture = false, clientReaped = true)
+        assertNull(scenario.select(nameFilter = "ComposeFixtureMain"))
+    }
+
+    @Test
+    fun `selectAppJvm still finds the fresh fixture after the gradle client has exited`() {
+        val scenario = GradleLaunchScenario(clientReaped = true)
+        assertEquals(scenario.freshFixturePid, scenario.select(nameFilter = "ComposeFixtureMain"))
+    }
+
+    @Test
     fun `selectAppJvm falls back to the highest matching pid when start times are unknown`() {
         // Fail-open: with no start times to compare, selection is exactly what it was before the
         // gate — highest matching pid, leftover included. Worse than the gate, better than no
@@ -128,13 +145,15 @@ class LaunchDescendantDiscoveryTest {
     private class GradleLaunchScenario(
         includeFreshFixture: Boolean = true,
         private val startTimesKnown: Boolean = true,
+        /** The gradlew client has been reaped, so its pid no longer resolves to a handle. */
+        private val clientReaped: Boolean = false,
     ) {
         val clientPid: Long = 12_300
         val daemonPid: Long = 12_310
         val leftoverFixturePid: Long = 12_900
         val freshFixturePid: Long = 12_672
 
-        private val launchedAt: Instant = Instant.parse("2026-08-23T10:00:00Z")
+        val launchedAt: Instant = Instant.parse("2026-08-23T10:00:00Z")
 
         private val listed: List<JvmProcessInfo> = buildList {
             add(JvmProcessInfo(daemonPid, "org.gradle.launcher.daemon.bootstrap.GradleDaemon 8.14"))
@@ -166,10 +185,16 @@ class LaunchDescendantDiscoveryTest {
             LaunchDescendantDiscovery.selectAppJvm(
                 clientPid = clientPid,
                 nameFilter = nameFilter,
+                // Captured once by awaitJvmAttachable while the client was still alive.
+                clientStart = launchedAt.takeIf { startTimesKnown },
                 listed = listed,
                 descendantsOf = { emptySet() },
                 parentOf = { pid -> daemonPid.takeIf { pid != daemonPid && pid != clientPid } },
-                startInstantOf = { pid -> startInstants[pid].takeIf { startTimesKnown } },
+                startInstantOf = { pid ->
+                    startInstants[pid].takeIf {
+                        startTimesKnown && !(clientReaped && pid == clientPid)
+                    }
+                },
                 nativeFallback = { _, _, _ -> null },
             )
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
@@ -127,6 +127,23 @@ class LaunchDescendantDiscoveryTest {
     }
 
     @Test
+    fun `the fallback boundary is sampled before the client process is created`() {
+        // Ordering invariant that no unit test can observe directly: when the OS hides the client's
+        // start time, the fallback must be read before startProcess. Sampled after, a fast Gradle
+        // task could spawn the app JVM first, making the legitimate candidate look like it
+        // predates the launch — and discovery would then reject it on every poll until timeout.
+        val source =
+            repoRoot()
+                .resolve(
+                    "agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchAndAttach.kt"
+                )
+                .readText()
+        val nowAt = source.indexOf("Instant.now()")
+        val startAt = source.indexOf("startProcess(prepared.command")
+        assertTrue(nowAt in 0..<startAt, "Instant.now()=$nowAt must precede startProcess=$startAt")
+    }
+
+    @Test
     fun `selectAppJvm keeps rejecting a leftover after the gradle client has exited`() {
         // Gradle-ish discovery deliberately keeps polling after the client exits — the app JVM is
         // a daemon child that often appears later. Once the client is reaped,
@@ -175,6 +192,15 @@ class LaunchDescendantDiscoveryTest {
      * The #446 process layout: a gradlew client, a long-lived Gradle daemon, a leftover fixture
      * from an earlier run hanging off that daemon, and the fixture this launch actually started.
      */
+    private fun repoRoot(): java.io.File {
+        var candidate: java.io.File? = java.io.File("").absoluteFile
+        while (candidate != null) {
+            if (java.io.File(candidate, "settings.gradle.kts").isFile) return candidate
+            candidate = candidate.parentFile
+        }
+        error("Could not locate the Spectre repo root")
+    }
+
     private class GradleLaunchScenario(
         includeFreshFixture: Boolean = true,
         private val startTimesKnown: Boolean = true,

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
@@ -110,6 +110,23 @@ class LaunchDescendantDiscoveryTest {
     }
 
     @Test
+    fun `the launch boundary prefers the OS start time when it is available`() {
+        val osStart = Instant.parse("2026-08-23T10:00:00Z")
+        val observed = Instant.parse("2026-08-23T10:00:01Z")
+        assertEquals(osStart, LaunchReadiness.launchBoundary(osStart, observed))
+    }
+
+    @Test
+    fun `the launch boundary is never null even when the OS hides the start time`() {
+        // A gradle-ish client can survive awaitProcessAlive and be reaped moments later, and a
+        // reaped process reports no start instant. A null boundary makes predatesLaunch fail open,
+        // which is exactly what the gate must never do — so fall back to when the launch call
+        // created the process. Safe, because the app JVM cannot predate its own launch.
+        val observed = Instant.parse("2026-08-23T10:00:01Z")
+        assertEquals(observed, LaunchReadiness.launchBoundary(null, observed))
+    }
+
+    @Test
     fun `selectAppJvm keeps rejecting a leftover after the gradle client has exited`() {
         // Gradle-ish discovery deliberately keeps polling after the client exits — the app JVM is
         // a daemon child that often appears later. Once the client is reaped,

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
@@ -127,6 +127,22 @@ class LaunchDescendantDiscoveryTest {
     }
 
     @Test
+    fun `selectAppJvm still walks the native tree when every listed JVM predates the launch`() {
+        // VirtualMachine.list() lags behind spawn, and -XX:-UsePerfData hides a JVM from it
+        // entirely — the native process-tree walk is the fallback for exactly that. Filtering the
+        // listed set down to nothing must not short-circuit past it, or a launch whose target is
+        // only discoverable natively polls until timeout.
+        val scenario = GradleLaunchScenario(includeFreshFixture = false)
+        assertEquals(
+            NATIVE_FALLBACK_PID,
+            scenario.select(
+                nameFilter = "ComposeFixtureMain",
+                nativeFallback = { _, _, _ -> NATIVE_FALLBACK_PID },
+            ),
+        )
+    }
+
+    @Test
     fun `selectAppJvm falls back to the highest matching pid when start times are unknown`() {
         // Fail-open: with no start times to compare, selection is exactly what it was before the
         // gate — highest matching pid, leftover included. Worse than the gate, better than no
@@ -181,7 +197,10 @@ class LaunchDescendantDiscoveryTest {
                 freshFixturePid to launchedAt.plusSeconds(5),
             )
 
-        fun select(nameFilter: String?): Long? =
+        fun select(
+            nameFilter: String?,
+            nativeFallback: (Long, Set<Long>, String?) -> Long? = { _, _, _ -> null },
+        ): Long? =
             LaunchDescendantDiscovery.selectAppJvm(
                 clientPid = clientPid,
                 nameFilter = nameFilter,
@@ -195,8 +214,12 @@ class LaunchDescendantDiscoveryTest {
                         startTimesKnown && !(clientReaped && pid == clientPid)
                     }
                 },
-                nativeFallback = { _, _, _ -> null },
+                nativeFallback = nativeFallback,
             )
+    }
+
+    private companion object {
+        const val NATIVE_FALLBACK_PID = 99_999L
     }
 
     @Test

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
@@ -3,7 +3,10 @@
 package dev.sebastiano.spectre.agent.launch
 
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.JvmProcessInfo
+import java.time.Instant
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
@@ -25,6 +28,150 @@ class LaunchDescendantDiscoveryTest {
             )
         )
         assertFalse(LaunchDescendantDiscovery.isGradleDaemonDisplayName("SampleDesktopKt"))
+    }
+
+    // ---------------------------------------------------------------------------------------
+    // #446: a JVM that was already running when the launch started cannot belong to that launch.
+    //
+    // `./gradlew check` runs other agent e2es that spawn the same Compose fixture main class
+    // directly, and those are ProcessHandle descendants of the same Gradle daemon. When one of
+    // them is still alive — or a crashed earlier run left one behind — it matches the name filter
+    // just as well as the JVM this launch is waiting for, and discovery picked it. Attaching there
+    // loaded the agent into a JVM that never binds the launch's UDS path, so AGENT_BOOTSTRAP timed
+    // out 30s later against a process that was never the target.
+    // ---------------------------------------------------------------------------------------
+
+    @Test
+    fun `a candidate that started before the launch cannot belong to it`() {
+        val launchedAt = Instant.parse("2026-08-23T10:00:00Z")
+        assertTrue(
+            LaunchDescendantDiscovery.predatesLaunch(
+                candidateStart = launchedAt.minusSeconds(600),
+                clientStart = launchedAt,
+            )
+        )
+    }
+
+    @Test
+    fun `a candidate that started after the launch can belong to it`() {
+        val launchedAt = Instant.parse("2026-08-23T10:00:00Z")
+        assertFalse(
+            LaunchDescendantDiscovery.predatesLaunch(
+                candidateStart = launchedAt.plusSeconds(5),
+                clientStart = launchedAt,
+            )
+        )
+        // Equal instants are not proof of anything; clocks are coarse.
+        assertFalse(
+            LaunchDescendantDiscovery.predatesLaunch(
+                candidateStart = launchedAt,
+                clientStart = launchedAt,
+            )
+        )
+    }
+
+    @Test
+    fun `an unknown start time keeps the candidate`() {
+        // Not every platform and permission setup exposes process start times. Failing closed
+        // there would break discovery entirely, which is far worse than the race it guards.
+        val launchedAt = Instant.parse("2026-08-23T10:00:00Z")
+        assertFalse(
+            LaunchDescendantDiscovery.predatesLaunch(
+                candidateStart = null,
+                clientStart = launchedAt,
+            )
+        )
+        assertFalse(
+            LaunchDescendantDiscovery.predatesLaunch(
+                candidateStart = launchedAt.minusSeconds(600),
+                clientStart = null,
+            )
+        )
+    }
+
+    @Test
+    fun `selectAppJvm skips a leftover fixture and picks the one this launch started`() {
+        // The leftover deliberately holds the *higher* pid, so "highest pid wins" cannot be what
+        // saves this: only the start-time gate can tell the two fixtures apart.
+        val scenario = GradleLaunchScenario()
+        assertEquals(
+            scenario.freshFixturePid,
+            scenario.select(nameFilter = "ComposeFixtureMain"),
+            "must pick the fixture started by this launch, not the leftover one",
+        )
+    }
+
+    @Test
+    fun `selectAppJvm returns null while only a leftover fixture is running`() {
+        // The real fixture has not registered yet. Returning null keeps awaitJvmAttachable polling
+        // instead of committing the attach to the wrong JVM.
+        val scenario = GradleLaunchScenario(includeFreshFixture = false)
+        assertNull(scenario.select(nameFilter = "ComposeFixtureMain"))
+    }
+
+    @Test
+    fun `selectAppJvm falls back to the highest matching pid when start times are unknown`() {
+        // Fail-open: with no start times to compare, selection is exactly what it was before the
+        // gate — highest matching pid, leftover included. Worse than the gate, better than no
+        // discovery at all on a platform that hides process start times.
+        val scenario = GradleLaunchScenario(startTimesKnown = false)
+        assertEquals(
+            scenario.leftoverFixturePid,
+            scenario.select(nameFilter = "ComposeFixtureMain"),
+        )
+    }
+
+    /**
+     * The #446 process layout: a gradlew client, a long-lived Gradle daemon, a leftover fixture
+     * from an earlier run hanging off that daemon, and the fixture this launch actually started.
+     */
+    private class GradleLaunchScenario(
+        includeFreshFixture: Boolean = true,
+        private val startTimesKnown: Boolean = true,
+    ) {
+        val clientPid: Long = 12_300
+        val daemonPid: Long = 12_310
+        val leftoverFixturePid: Long = 12_900
+        val freshFixturePid: Long = 12_672
+
+        private val launchedAt: Instant = Instant.parse("2026-08-23T10:00:00Z")
+
+        private val listed: List<JvmProcessInfo> = buildList {
+            add(JvmProcessInfo(daemonPid, "org.gradle.launcher.daemon.bootstrap.GradleDaemon 8.14"))
+            add(
+                JvmProcessInfo(
+                    leftoverFixturePid,
+                    "dev.sebastiano.spectre.agent.fixture.ComposeFixtureMainKt",
+                )
+            )
+            if (includeFreshFixture) {
+                add(
+                    JvmProcessInfo(
+                        freshFixturePid,
+                        "dev.sebastiano.spectre.agent.fixture.ComposeFixtureMainKt",
+                    )
+                )
+            }
+        }
+
+        private val startInstants: Map<Long, Instant> =
+            mapOf(
+                clientPid to launchedAt,
+                daemonPid to launchedAt.minusSeconds(3_600),
+                leftoverFixturePid to launchedAt.minusSeconds(600),
+                freshFixturePid to launchedAt.plusSeconds(5),
+            )
+
+        fun select(nameFilter: String?): Long? =
+            LaunchDescendantDiscovery.selectAppJvm(
+                clientPid = clientPid,
+                nameFilter = nameFilter,
+                listed = listed,
+                descendantsOf = { emptySet() },
+                parentOf = { pid -> daemonPid.takeIf { pid != daemonPid && pid != clientPid } },
+                startInstantOf = { pid -> startInstants[pid].takeIf { startTimesKnown } },
+                nativeFallback = { _, _, _ -> null },
+            )
     }
 
     @Test


### PR DESCRIPTION
## Summary

`LaunchAndAttachGradleIntegrationTest` intermittently attached to the wrong JVM: the agent went into pid 12331 while the fixture came up as pid 12672, so nothing ever bound the launch's UDS path and `AGENT_BOOTSTRAP` timed out 30s later against a process that was never the target.

**The issue's diagnosis is wrong, so this PR does not do what it suggests.** #446 guessed the test was missing an `appJvmNameFilter`. It is not — the test has set `appJvmNameFilter = "ComposeFixtureMain"` since #308.

The filter is not enough on its own, because it cannot tell two JVMs with the same main class apart. During `./gradlew check` there usually are two: other agent e2es spawn the same Compose fixture directly from the test worker, which is itself a `ProcessHandle` descendant of the same Gradle daemon, and a crashed earlier run can leave one behind too. Either matches the filter exactly as well as the JVM this launch is waiting for, and discovery picked whichever had the higher pid.

Discovery now rejects any candidate whose process start time proves it was **already running when the launch began** — such a JVM cannot be one this launch started, however well its main class matches. The rule applies to both the listed-JVM path and the native process-tree fallback, and joins the existing safety rules in the class docs.

It **fails open**. Not every platform and permission setup exposes process start times, and losing discovery entirely would be worse than the race it guards, so an unknown instant on either side keeps the candidate. Equal instants keep it too, because process clocks are coarse.

Closes #446

## Test plan

`selectAppJvm` is `discoverAppJvm` with its process facts injectable, so the selection rules can be tested against the exact #446 layout — a gradlew client, a long-lived daemon, a leftover fixture, and the fixture this launch started — instead of whatever happens to be running on the machine.

- [x] In that scenario the leftover deliberately holds the **higher** pid, so "highest pid wins" cannot be what passes the test
- [x] All three scenario tests confirmed to **fail against a neutralised gate** (the first draft passed on pid ordering alone; it was strengthened until it didn't)
- [x] A fail-open test pins the pre-gate behaviour for hosts that hide process start times
- [x] `LaunchAndAttachGradleIntegrationTest` itself ran (not skipped) and passed in the local `check`
- [x] `./gradlew check` passes locally
- [x] `./gradlew ktfmtFormat` produced no changes

## Confirmations

- [ ] ~I read CONTRIBUTING.md and this PR is **not** LLM-generated.~ — **This PR was written by Claude Code at the repo owner's direction.** Not ticking a box that would say otherwise.
- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)