### PR TITLE
Read the formula with an explicit encoding so check survives an unset locale

### DIFF
--- a/.github/scripts/test-homebrew-formula-install-semantics.rb
+++ b/.github/scripts/test-homebrew-formula-install-semantics.rb
@@ -156,7 +156,7 @@ end
 
 formula_paths.each do |path|
   assert!(File.file?(path), "missing formula file #{path}")
-  formula_text = File.read(path)
+  formula_text = File.read(path, encoding: "UTF-8")
   label = File.basename(path) == "spectre.rb" ? path : path
 
   record_failure(failures, "formula text contract (#{label})") do
@@ -234,7 +234,7 @@ formula_paths.each do |path|
         !File.symlink?(result[:wrapper]),
         "bin/spectre must not be a symlink of the Roast binary"
       )
-      wrapper_body = File.read(result[:wrapper])
+      wrapper_body = File.read(result[:wrapper], encoding: "UTF-8")
       assert!(wrapper_body.include?("#!/bin/sh"), "wrapper must be a shell script")
       assert!(
         wrapper_body.include?(%(exec "#{result[:real]}")),
@@ -269,6 +269,19 @@ formula_paths.each do |path|
 end
 
 # Symlink entry point breaks argv[0]-sensitive launcher (documents #284 invariant).
+record_failure(failures, "suite reads files with an explicit encoding") do
+  # Ruby derives File.read's encoding from the locale. With LANG/LC_ALL unset it defaults to
+  # US-ASCII, and Formula/spectre.rb contains non-ASCII bytes (an em dash in a comment), so every
+  # bare read raises "invalid byte sequence in US-ASCII" and the whole suite fails. That made
+  # `./gradlew check` unrunnable in a shell with no locale set. Keep the reads explicit.
+  source = File.read(__FILE__, encoding: "UTF-8")
+  bare = source.scan(/File\.read\([^)]*\)/).reject { |call| call.include?("encoding:") }
+  assert!(
+    bare.empty?,
+    "File.read without an explicit encoding breaks when LANG/LC_ALL are unset: #{bare.join(", ")}"
+  )
+end
+
 record_failure(failures, "raw bin symlink fails argv0-sensitive binary") do
   Dir.mktmpdir do |tmp|
     stage = File.join(tmp, "stage")


### PR DESCRIPTION
## Summary

`./gradlew check` failed on `:verifyHomebrewFormulaInstallSemantics` in any shell with `LANG` and `LC_ALL` unset:

```
formula text contract (Formula/spectre.rb): invalid byte sequence in US-ASCII
```

Ruby derives `File.read`'s encoding from the locale, defaulting to US-ASCII when there is none. `Formula/spectre.rb` contains an em dash in a comment, so every bare read raised and six of the seven contract tests failed for a reason that had nothing to do with the formula.

Both reads in the suite now name UTF-8 explicitly. A new contract test scans the suite's own source and fails on any `File.read` without an explicit encoding, so this cannot quietly come back.

## Test plan

- [x] Suite run with `env -u LANG -u LC_ALL -u LC_CTYPE` — all seven tests pass (previously six failed)
- [x] Suite run under `en_US.UTF-8` — still passes
- [x] The new contract test confirmed red before the fix (it named both offending call sites)
- [x] Full `./gradlew check` with the locale stripped — `:verifyHomebrewFormulaInstallSemantics` is green
- [x] `./gradlew ktfmtFormat` produced no changes

## Note for the reviewer

`generate-cli-package-manifests.py` uses `write_text` without an explicit encoding — same class of bug, in the same `check` path. It is harmless today because Python enables UTF-8 mode when the locale is C/POSIX, so I left it alone rather than widen this PR. Worth a follow-up if you want it belt-and-braces.

## Confirmations

- [ ] ~I read CONTRIBUTING.md and this PR is **not** LLM-generated.~ — **This PR was written by Claude Code at the repo owner's direction.** Not ticking a box that would say otherwise.
- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)