### PR TITLE
Give the MCP stdio connect and protocol phases separate budgets

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -29,6 +29,10 @@ on:
       - "agent/**"
       - "agent-runtime/**"
       - "agent-test-fixture/**"
+      # `:cli` runs SpectreMcpStdioIntegrationTest, which has only ever failed on Windows
+      # (#455). Without this path, a Windows-only fix in `:cli` cannot be verified before
+      # merge and `:cli` regressions reach main before CI sees them.
+      - "cli/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"
@@ -48,6 +52,10 @@ on:
       - "agent/**"
       - "agent-runtime/**"
       - "agent-test-fixture/**"
+      # `:cli` runs SpectreMcpStdioIntegrationTest, which has only ever failed on Windows
+      # (#455). Without this path, a Windows-only fix in `:cli` cannot be verified before
+      # merge and `:cli` regressions reach main before CI sees them.
+      - "cli/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -14,6 +14,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withTimeout
 import kotlinx.io.asSink
@@ -95,8 +96,11 @@ class SpectreMcpStdioIntegrationTest {
             )
         try {
             val client = Client(clientInfo = Implementation(name = "spectre-test", version = "1"))
-            withTimeout(CONNECTION_TIMEOUT_MILLIS) {
-                client.connect(transport)
+            // Two budgets, each sized for what it actually covers (#455). Folding a cold JVM
+            // start into the protocol budget made this the only one of the three tests in this
+            // class that could fail on a slow host, and it did so repeatedly on windows-latest.
+            phase("connect", CONNECT_TIMEOUT_MILLIS) { client.connect(transport) }
+            phase("protocol exchange", PROTOCOL_TIMEOUT_MILLIS) {
                 assertEquals(
                     expectedMcpVersion(),
                     client.serverVersion?.version,
@@ -142,6 +146,25 @@ class SpectreMcpStdioIntegrationTest {
         }
     }
 
+    /**
+     * Run [block] under [millis], reporting *which* phase timed out.
+     *
+     * A bare `TimeoutCancellationException` says nothing about whether the server failed to start
+     * or failed to answer, which is what made #455 hard to read from CI logs alone.
+     */
+    private suspend fun <T> phase(name: String, millis: Long, block: suspend () -> T): T =
+        try {
+            withTimeout(millis) { block() }
+        } catch (ex: TimeoutCancellationException) {
+            throw AssertionError(
+                "MCP stdio $name did not complete within ${millis}ms. If this is the connect " +
+                    "phase on a loaded runner, suspect cold JVM startup rather than the " +
+                    "protocol; the other tests in this class prove the server answers " +
+                    "initialize (#455).",
+                ex,
+            )
+        }
+
     private fun mcpCommand(): List<String> =
         System.getProperty("spectre.cli.distributionExecutable")?.let { executable ->
             listOf(executable, "mcp")
@@ -168,7 +191,26 @@ class SpectreMcpStdioIntegrationTest {
     }
 
     private companion object {
-        private const val CONNECTION_TIMEOUT_MILLIS: Long = 10_000
+        /**
+         * Hang guard for `connect`, not a performance assertion.
+         *
+         * This phase spawns `java -cp <full CLI classpath>` and completes the MCP handshake, so the
+         * budget has to clear a cold JVM start on the slowest supported runner — on
+         * `windows-latest` that happens while Gradle compiles other modules on the same two cores.
+         * Locally the whole test takes well under a second; on hosted Windows the old shared 10s
+         * budget was exceeded repeatedly (#455). The sibling [PROCESS_EXIT_TIMEOUT_SECONDS] was
+         * already raised to 15s for the same startup reason, and this phase does strictly more than
+         * that one, so it gets more headroom. A genuine hang still fails the build; the value only
+         * decides how long that takes to notice.
+         */
+        private const val CONNECT_TIMEOUT_MILLIS: Long = 60_000
+
+        /**
+         * Budget for the protocol exchange once the server is already up and has answered
+         * `initialize`. No process startup in here, so this stays tight enough to catch a real
+         * protocol stall.
+         */
+        private const val PROTOCOL_TIMEOUT_MILLIS: Long = 15_000
         // Windows hosted runners can take longer than the usual process startup window to
         // initialize the JVM before observing closed stdin.
         private const val PROCESS_EXIT_TIMEOUT_SECONDS: Long = 15


### PR DESCRIPTION
## Summary

`SpectreMcpStdioIntegrationTest > spectre mcp serves tools through official stdio client` fails intermittently on `windows-latest` — on `main` (run 32633604051) as well as on PR branches. Now that #451 has stopped `:agent:test` failing first, this is the thing keeping `check-windows` red for everyone.

## Why it was the only one of the three that could fail

All three tests in the class spawn the same process via `mcpCommand()`. Their budgets are not the same:

| Test | Budget |
|---|---|
| `exits when its stdio input closes` | `waitFor(15s)` |
| `stdout stays protocol-clean through initialize` | blocking `readLine()` — no timeout |
| `serves tools through official stdio client` | `withTimeout(10_000)` |

That second one passing is what rules out a protocol hang: with no timeout it would hang forever rather than fail, so the server does answer `initialize` on Windows. Only the failing test capped anything, and its 10s covered a cold `java -cp <full CLI classpath>` start **plus** the handshake **plus** the assertions. Locally the whole test runs in **0.392s**; on a hosted Windows runner that spawn happens while Gradle compiles other modules on the same two cores.

## What changed

The budget is split to match what each phase actually does:

- **`connect`** — a generous hang guard sized to clear a cold JVM start on the slowest supported runner. Explicitly not a performance assertion. The sibling `PROCESS_EXIT_TIMEOUT_SECONDS` was already raised to 15s for this same reason, and this phase does strictly more than that one.
- **protocol exchange** — runs against an already-initialized server, so it keeps a tight budget that can still catch a real stall.

Timeouts now report *which* phase blew its budget rather than surfacing a bare `TimeoutCancellationException`, which is what made this hard to read from CI logs.

Closes #455

## Test plan

- [x] `./gradlew check` passes locally
- [x] `./gradlew ktfmtFormat` produced no changes
- [x] Forced the connect budget to 1ms and confirmed the recorded failure names the phase: `MCP stdio connect did not complete within 1ms. If this is the connect phase on a loaded runner, suspect cold JVM startup rather than the protocol…`

The real verdict is `check-windows` on this PR.

## Confirmations

- [ ] ~I read CONTRIBUTING.md and this PR is **not** LLM-generated.~ — **This PR was written by Claude Code at the repo owner's direction.** Not ticking a box that would say otherwise.
- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)