### PR TITLE
feat(input): coordinate desktop input across processes

### DIFF
--- a/.agents/skills/spectre-release/SKILL.md
+++ b/.agents/skills/spectre-release/SKILL.md
@@ -35,6 +35,27 @@ Windows agent inject). Do not skip smoke because `main` CI is green. To add a re
 scenario ID, follow **Adding a scenario ID** in [docs/RELEASE-SMOKE.md](../../../docs/RELEASE-SMOKE.md)
 (`REQUIRED_SCENARIO_IDS` + both entrypoints + contract tests) — do not leave commands only in chat.
 
+### Experimental desktop input coordination
+
+When a release contains `ExperimentalSpectreInputCoordinationApi` or changes its runtime:
+
+- Confirm the low-level coordinator/client/server, core policy/scope, and JUnit isolation entry
+  points still carry the warning-level marker. ABI baselines alone do not prove annotations.
+- Keep no-argument `RobotDriver()` uncoordinated unless the release explicitly graduates the
+  feature after a separate stability decision.
+- Treat headed two-JVM contention, cancellation, holder crash/quarantine, exact revoke, forced
+  recovery (`unsafeTakeover=true`), and parallel JUnit `PerTest` as **delta hard cells** on macOS,
+  Windows, and Linux Xorg/Xvfb. Experimental API status does not make these soft.
+- If an OS cannot be exercised, narrow the release notes/platform claim instead of claiming
+  cross-platform coordination.
+- Verify the consumer skill (`skills/spectre/SKILL.md` plus
+  `references/input-coordination.md`) and published guide
+  (`docs/guide/input-coordination.md`) still describe the same opt-in, runtime dependency,
+  cooperative boundary, and unsafe-force semantics.
+
+Do not tag while the release-scoped independent review or any input-coordination hard cell is
+missing. See the dedicated gate in [docs/RELEASE-SMOKE.md](../../../docs/RELEASE-SMOKE.md).
+
 ## Central Portal Check
 
 Use the release checker before publishing a validated Central Portal deployment:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,6 +366,8 @@ jobs:
           test -n "$ORG_GRADLE_PROJECT_signingInMemoryKeyPassword"
           ./gradlew \
             :core:publishToMavenCentral \
+            :input-coordinator:publishToMavenCentral \
+            :input-coordinator-server:publishToMavenCentral \
             :server:publishToMavenCentral \
             :recording:publishToMavenCentral \
             :recording-macos:publishToMavenCentral \

--- a/agent-inject-runtime/build.gradle.kts
+++ b/agent-inject-runtime/build.gradle.kts
@@ -42,6 +42,10 @@ tasks.named<ShadowJar>("shadowJar") {
     relocate("kotlinx.coroutines", "dev.sebastiano.spectre.inject.relocated.kotlinx.coroutines")
     // atomicfu is pulled transitively; relocate to keep inject payload self-contained.
     relocate("kotlinx.atomicfu", "dev.sebastiano.spectre.inject.relocated.kotlinx.atomicfu")
+    relocate(
+        "dev.sebastiano.spectre.input",
+        "dev.sebastiano.spectre.inject.relocated.dev.sebastiano.spectre.input",
+    )
 
     dependencies {
         // Compose / Skiko must come from the target — never shade.
@@ -91,6 +95,9 @@ val verifyInjectRuntimeJarContents by tasks.registering {
                 "Inject jar missing relocated kotlinx.coroutines " +
                     "(got entries sample: ${names.filter { "coroutines" in it }.take(10)})"
             }
+            require(has("dev/sebastiano/spectre/inject/relocated/dev/sebastiano/spectre/input/")) {
+                "Inject jar missing relocated input-coordinator client classes"
+            }
             val forbidden =
                 listOf(
                     "androidx/compose/",
@@ -98,6 +105,8 @@ val verifyInjectRuntimeJarContents by tasks.registering {
                     "org/jetbrains/skiko/",
                     "kotlinx/coroutines/", // must be relocated, not original package
                     "dev/sebastiano/spectre/recording/",
+                    "dev/sebastiano/spectre/input/", // must be relocated
+                    "dev/sebastiano/spectre/inject/relocated/dev/sebastiano/spectre/input/server/",
                 )
             val leaks = names.filter { entry -> forbidden.any { entry.startsWith(it) } }
             require(leaks.isEmpty()) {

--- a/agent-inject-runtime/build.gradle.kts
+++ b/agent-inject-runtime/build.gradle.kts
@@ -40,6 +40,10 @@ tasks.named<ShadowJar>("shadowJar") {
 
     // Relocate kotlinx so IDE-shipped coroutines cannot collide with injected core.
     relocate("kotlinx.coroutines", "dev.sebastiano.spectre.inject.relocated.kotlinx.coroutines")
+    relocate(
+        "kotlinx.serialization",
+        "dev.sebastiano.spectre.inject.relocated.kotlinx.serialization",
+    )
     // atomicfu is pulled transitively; relocate to keep inject payload self-contained.
     relocate("kotlinx.atomicfu", "dev.sebastiano.spectre.inject.relocated.kotlinx.atomicfu")
     relocate(
@@ -95,6 +99,10 @@ val verifyInjectRuntimeJarContents by tasks.registering {
                 "Inject jar missing relocated kotlinx.coroutines " +
                     "(got entries sample: ${names.filter { "coroutines" in it }.take(10)})"
             }
+            require(has("dev/sebastiano/spectre/inject/relocated/kotlinx/serialization/")) {
+                "Inject jar missing relocated kotlinx.serialization " +
+                    "(got entries sample: ${names.filter { "serialization" in it }.take(10)})"
+            }
             require(has("dev/sebastiano/spectre/inject/relocated/dev/sebastiano/spectre/input/")) {
                 "Inject jar missing relocated input-coordinator client classes"
             }
@@ -104,6 +112,7 @@ val verifyInjectRuntimeJarContents by tasks.registering {
                     "org/jetbrains/compose/",
                     "org/jetbrains/skiko/",
                     "kotlinx/coroutines/", // must be relocated, not original package
+                    "kotlinx/serialization/", // must be relocated, not original package
                     "dev/sebastiano/spectre/recording/",
                     "dev/sebastiano/spectre/input/", // must be relocated
                     "dev/sebastiano/spectre/inject/relocated/dev/sebastiano/spectre/input/server/",

--- a/agent-runtime/build.gradle.kts
+++ b/agent-runtime/build.gradle.kts
@@ -102,6 +102,7 @@ val verifyAgentRuntimeJarContents by tasks.registering {
                     "org/jetbrains/compose/",
                     "org/jetbrains/skiko/",
                     "dev/sebastiano/spectre/core/",
+                    "dev/sebastiano/spectre/input/",
                     "kotlin/Pair.class",
                     "kotlinx/coroutines/",
                 )
@@ -131,6 +132,8 @@ private fun includeInAgentRuntimeJar(file: File): Boolean {
         // Never explode the inject payload into the agent-runtime root.
         name.startsWith("spectre-agent-inject-runtime") -> false
         name.startsWith("agent-inject-runtime") -> false
+        name.startsWith("input-coordinator") -> false
+        name.startsWith("spectre-input-coordinator") -> false
         else -> true
     }
 }

--- a/agent/build.gradle.kts
+++ b/agent/build.gradle.kts
@@ -19,6 +19,9 @@ kotlin {
 }
 
 dependencies {
+    // Attaching-side runtime owns availability of the external desktop input coordinator.
+    implementation(projects.inputCoordinatorServer)
+
     // Wire-protocol serialization. CBOR is the only kotlinx-serialization format used by
     // the agent transport; JSON is intentionally not on the agent runtime classpath.
     implementation(libs.kotlinx.serialization.cbor)

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -1,9 +1,12 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
 package dev.sebastiano.spectre.agent
 
 import dev.sebastiano.spectre.agent.runtime.AgentBootstrapArgs
 import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.agent.transport.IpcClient
 import dev.sebastiano.spectre.agent.transport.UdsPathLimits
+import dev.sebastiano.spectre.input.InputCoordinatorClientFactory
 import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
@@ -61,35 +64,53 @@ public object AgentAttach {
         // generic ("Operation not permitted") and hard to diagnose; this gives a clear message
         // before we even open the VM connection.
         checkSameUser(pid)
-
-        val (vmClass, vm) = openVirtualMachine(pid)
+        val coordinatorClient = runCatching(::ensureInputCoordinator).getOrNull()
+        var coordinatorOwnedByResult = false
         try {
-            loadAgentReflectively(vmClass, vm, agentJar.toString(), agentArgsFor(options, udsPath))
-        } finally {
-            detachVirtualMachine(vmClass, vm)
-        }
 
-        waitForUdsPath(udsPath, options.attachTimeoutMs)
-
-        val client =
+            val (vmClass, vm) = openVirtualMachine(pid)
             try {
-                IpcClient(udsPath)
-            } catch (ex: SpectreAgentException) {
-                // Preserve taxonomy from handshake (e.g. protocolMismatch) — do not wrap.
-                throw ex
-            } catch (ex: IOException) {
-                throw SpectreAttachExceptionImpl(
-                    "Failed to connect to agent's UDS at $udsPath: ${ex.message}",
-                    ex,
+                loadAgentReflectively(
+                    vmClass,
+                    vm,
+                    agentJar.toString(),
+                    agentArgsFor(options, udsPath),
                 )
+            } finally {
+                detachVirtualMachine(vmClass, vm)
             }
 
-        return AttachedAutomator(pid = pid, client = client) {
-            // Detacher: best-effort UDS cleanup after the AttachedAutomator closes. The agent's
-            // own shutdown hook handles crash cleanup.
-            runCatching { Files.deleteIfExists(udsPath) }
+            waitForUdsPath(udsPath, options.attachTimeoutMs)
+
+            val client =
+                try {
+                    IpcClient(udsPath)
+                } catch (ex: SpectreAgentException) {
+                    // Preserve taxonomy from handshake (e.g. protocolMismatch) — do not wrap.
+                    throw ex
+                } catch (ex: IOException) {
+                    throw SpectreAttachExceptionImpl(
+                        "Failed to connect to agent's UDS at $udsPath: ${ex.message}",
+                        ex,
+                    )
+                }
+
+            val attached =
+                AttachedAutomator(pid = pid, client = client) {
+                    coordinatorClient?.close()
+                    // Detacher: best-effort UDS cleanup after the AttachedAutomator closes. The
+                    // agent's own shutdown hook handles crash cleanup.
+                    runCatching { Files.deleteIfExists(udsPath) }
+                }
+            coordinatorOwnedByResult = true
+            return attached
+        } finally {
+            if (!coordinatorOwnedByResult) coordinatorClient?.close()
         }
     }
+
+    private fun ensureInputCoordinator() =
+        InputCoordinatorClientFactory.connectOrStart(ownerLabel = "spectre-agent-attacher")
 
     /**
      * Resolve the agent runtime JAR by trying in order:

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
@@ -72,9 +72,25 @@ internal class BlockingSuspendInvoker(private val timeoutMs: Long = DEFAULT_TIME
 
         fun await(timeoutMs: Long): Any? {
             if (!awaitCompletion(timeoutMs)) {
+                awaitCompletion()
                 throw TimeoutException("Suspend call did not complete within ${timeoutMs} ms")
             }
             return outcome?.getOrThrow()
+        }
+
+        private fun awaitCompletion() {
+            var interrupted = false
+            try {
+                while (latch.count > 0L) {
+                    try {
+                        latch.await()
+                    } catch (_: InterruptedException) {
+                        interrupted = true
+                    }
+                }
+            } finally {
+                if (interrupted) Thread.currentThread().interrupt()
+            }
         }
 
         private fun awaitCompletion(timeoutMs: Long): Boolean {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvoker.kt
@@ -71,10 +71,30 @@ internal class BlockingSuspendInvoker(private val timeoutMs: Long = DEFAULT_TIME
         }
 
         fun await(timeoutMs: Long): Any? {
-            if (!latch.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+            if (!awaitCompletion(timeoutMs)) {
                 throw TimeoutException("Suspend call did not complete within ${timeoutMs} ms")
             }
             return outcome?.getOrThrow()
+        }
+
+        private fun awaitCompletion(timeoutMs: Long): Boolean {
+            val timeoutNanos = TimeUnit.MILLISECONDS.toNanos(timeoutMs)
+            val startedAt = System.nanoTime()
+            var remainingNanos = timeoutNanos
+            var interrupted = false
+            try {
+                while (remainingNanos > 0L) {
+                    try {
+                        return latch.await(remainingNanos, TimeUnit.NANOSECONDS)
+                    } catch (_: InterruptedException) {
+                        interrupted = true
+                        remainingNanos = timeoutNanos - (System.nanoTime() - startedAt)
+                    }
+                }
+                return latch.count == 0L
+            } finally {
+                if (interrupted) Thread.currentThread().interrupt()
+            }
         }
     }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
@@ -34,8 +34,9 @@ import java.util.concurrent.atomic.AtomicReference
  * so this matters in practice.
  *
  * **Detach contract** (plan D-7): [onClientDetach] performs the full Path A cleanup — closes the
- * [IpcServer] (releases ServerSocketChannel + unlinks UDS), removes the shutdown hook, and clears
- * the global state slot. A registered shutdown hook (Path B) is the backstop for crashes.
+ * [IpcServer] (releases ServerSocketChannel + unlinks UDS), closes target-side input coordination,
+ * removes the shutdown hook, and clears the global state slot. A registered shutdown hook (Path B)
+ * is the backstop for crashes.
  */
 @ExperimentalSpectreAgentApi
 public object SpectreAgent {
@@ -86,9 +87,10 @@ public object SpectreAgent {
         // JVM agent layer which surfaces them at the attaching `VirtualMachine.loadAgent` call
         // site.
         val bootstrap = AgentBootstrap.findSpectre(instrumentation)
-        // When AgentState is published successfully, detach/shutdown owns inject cleanup.
-        // Until then (or on any failure path), we release in the finally below.
-        var injectOwnedByAgentState = false
+        // When AgentState is published successfully, detach/shutdown owns target-input and inject
+        // cleanup. Until then (or on any failure path), we release both in the finally below.
+        var resourcesOwnedByAgentState = false
+        var targetInputResource: AutoCloseable? = null
         try {
             val loader = bootstrap.classLoader
             System.err.println("[spectre-agent] found Spectre via $loader")
@@ -98,7 +100,9 @@ public object SpectreAgent {
             // failures are logged and identity falls back to null handles.
             AwtPeerModuleOpener.openFor(loader, instrumentation)
 
-            val automator = createAutomatorReflectively(loader)
+            val agentAutomator = createAutomatorReflectively(loader)
+            val automator = agentAutomator.instance
+            targetInputResource = agentAutomator.targetInputResource
             System.err.println("[spectre-agent] ComposeAutomator ready: $automator")
 
             val parsedArgs = AgentBootstrapArgs.parse(agentArgs)
@@ -138,6 +142,7 @@ public object SpectreAgent {
                     {
                         // Path B — crash safety. close() handles its own idempotency.
                         runCatching { server.close() }
+                        runCatching { targetInputResource?.close() }
                         bootstrap.releaseInjectResources()
                     },
                     SHUTDOWN_HOOK_NAME,
@@ -150,6 +155,7 @@ public object SpectreAgent {
                     udsPath = udsPath,
                     shutdownHook = shutdownHook,
                     bootstrap = bootstrap,
+                    targetInputResource = targetInputResource,
                 )
             if (!agentState.compareAndSet(null, newState)) {
                 // Idempotency race: someone bootstrapped between our earlier `get()` check and now.
@@ -163,12 +169,13 @@ public object SpectreAgent {
                 return
             }
 
-            injectOwnedByAgentState = true
+            resourcesOwnedByAgentState = true
             System.err.println(
                 "[spectre-agent] IPC server listening on $udsPath — ready for client connections"
             )
         } finally {
-            if (!injectOwnedByAgentState) {
+            if (!resourcesOwnedByAgentState) {
+                runCatching { targetInputResource?.close() }
                 bootstrap.releaseInjectResources()
             }
         }
@@ -176,8 +183,9 @@ public object SpectreAgent {
 
     /**
      * Called by [IpcServer] when it processes an `AgentRequest.Detach`. Performs the full D-7 Path
-     * A cleanup: clears the global slot, closes the server (idempotent), removes the shutdown hook,
-     * and releases inject payload resources when the attach used injection (#209).
+     * A cleanup: clears the global slot, closes the server and target-side input coordination (both
+     * idempotent), removes the shutdown hook, and releases inject payload resources when the attach
+     * used injection (#209).
      *
      * The server has *already* set its `running` flag to false before invoking this; the `close()`
      * here ensures the ServerSocketChannel native fd is released and the UDS path unlinked. Without
@@ -186,12 +194,13 @@ public object SpectreAgent {
     private fun onClientDetach() {
         val state = agentState.getAndSet(null) ?: return
         runCatching { state.server.close() }
+        runCatching { state.targetInputResource?.close() }
         runCatching { Runtime.getRuntime().removeShutdownHook(state.shutdownHook) }
         state.bootstrap.releaseInjectResources()
         System.err.println("[spectre-agent] detached cleanly; resources released")
     }
 
-    private fun createAutomatorReflectively(classLoader: ClassLoader): Any {
+    private fun createAutomatorReflectively(classLoader: ClassLoader): AgentAutomator {
         val automatorClass = classLoader.loadClass(COMPOSE_AUTOMATOR_FQN)
         val companion = automatorClass.getField("Companion").get(null)
 
@@ -207,7 +216,10 @@ public object SpectreAgent {
                     "Could not find ComposeAutomator.Companion.inProcess(robotDriver, " +
                         "discoverWindows) on ${companion.javaClass}"
                 )
-        return inProcessMethod.invoke(companion, robotDriver, true)
+        return AgentAutomator(
+            instance = inProcessMethod.invoke(companion, robotDriver, true),
+            targetInputResource = robotDriver as? AutoCloseable,
+        )
     }
 
     internal fun createCoordinatedRobotDriverOrLegacyFallback(
@@ -243,11 +255,14 @@ public object SpectreAgent {
     private const val INPUT_LEASE_POLICY_FQN = "dev.sebastiano.spectre.core.InputLeasePolicy"
     private const val SHUTDOWN_HOOK_NAME = "spectre-agent-shutdown"
 
+    private data class AgentAutomator(val instance: Any, val targetInputResource: AutoCloseable?)
+
     /** Single live agent state, swapped under [agentState] atomically. */
     private data class AgentState(
         val server: IpcServer,
         val udsPath: Path,
         val shutdownHook: Thread,
         val bootstrap: SpectreBootstrapResult,
+        val targetInputResource: AutoCloseable?,
     )
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
@@ -196,7 +196,8 @@ public object SpectreAgent {
         val companion = automatorClass.getField("Companion").get(null)
 
         val robotDriverClass = classLoader.loadClass(ROBOT_DRIVER_FQN)
-        val robotDriver = robotDriverClass.getDeclaredConstructor().newInstance()
+        val robotDriver =
+            createCoordinatedRobotDriverOrLegacyFallback(classLoader, robotDriverClass)
 
         val inProcessMethod =
             companion.javaClass.methods.firstOrNull {
@@ -208,6 +209,22 @@ public object SpectreAgent {
                 )
         return inProcessMethod.invoke(companion, robotDriver, true)
     }
+
+    internal fun createCoordinatedRobotDriverOrLegacyFallback(
+        classLoader: ClassLoader,
+        robotDriverClass: Class<*>,
+    ): Any =
+        try {
+            val policyClass = classLoader.loadClass(INPUT_LEASE_POLICY_FQN)
+            val requiredPolicy =
+                policyClass.enumConstants.firstOrNull { (it as Enum<*>).name == "Required" }
+                    ?: error("Could not resolve InputLeasePolicy.Required from $policyClass")
+            robotDriverClass.getDeclaredConstructor(policyClass).newInstance(requiredPolicy)
+        } catch (_: ClassNotFoundException) {
+            robotDriverClass.getDeclaredConstructor().newInstance()
+        } catch (_: NoSuchMethodException) {
+            robotDriverClass.getDeclaredConstructor().newInstance()
+        }
 
     private fun invokeWindowsCountReflectively(automator: Any): Int {
         // `ComposeAutomator.windows` is a stale `@Volatile` cache populated by
@@ -223,6 +240,7 @@ public object SpectreAgent {
     }
 
     private const val ROBOT_DRIVER_FQN = "dev.sebastiano.spectre.core.RobotDriver"
+    private const val INPUT_LEASE_POLICY_FQN = "dev.sebastiano.spectre.core.InputLeasePolicy"
     private const val SHUTDOWN_HOOK_NAME = "spectre-agent-shutdown"
 
     /** Single live agent state, swapped under [agentState] atomically. */

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreInjectClassLoader.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreInjectClassLoader.kt
@@ -6,9 +6,10 @@ import java.net.URLClassLoader
 /**
  * Child-first classloader for the #209 inject payload.
  *
- * Loads Spectre core, inject marker, relocated kotlinx, and other bundled non-Compose deps from the
- * inject jar first so they never collide with IDE-shipped kotlinx. Everything else (Compose, Kotlin
- * stdlib, JDK) delegates to [parent] — the target's Compose-capable loader.
+ * Loads Spectre core, inject marker, relocated coroutines/serialization, and other bundled
+ * non-Compose deps from the inject jar first so they never collide with IDE-shipped kotlinx.
+ * Everything else (Compose, Kotlin stdlib, JDK) delegates to [parent] — the target's
+ * Compose-capable loader.
  */
 internal class SpectreInjectClassLoader(urls: Array<URL>, parent: ClassLoader) :
     URLClassLoader(urls, parent) {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -83,6 +83,7 @@ constructor(
         }
 
     private val running = AtomicBoolean(true)
+    private val inputWorkers = CrossSessionInputWorkers()
 
     private val acceptThread =
         Thread(::acceptLoop, "spectre-agent-accept").apply {
@@ -154,6 +155,7 @@ constructor(
                     onDetach = onDetach,
                     channel = socket,
                     frameIoTimeoutMs = frameIoTimeoutMs,
+                    inputWorkers = inputWorkers,
                 )
                 .run(input, output)
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -175,8 +175,7 @@ constructor(
                         Framing.readFrame(input)
                     } ?: return false
                 } catch (ex: IllegalStateException) {
-                    running.set(false)
-                    onDetach()
+                    detachAfterInputTermination()
                     throw ex
                 }
             val request =
@@ -228,8 +227,7 @@ constructor(
             }
         } finally {
             if (tearDown) {
-                running.set(false)
-                onDetach()
+                detachAfterInputTermination()
             }
         }
         return !tearDown
@@ -271,8 +269,7 @@ constructor(
                 )
             }
         } finally {
-            running.set(false)
-            onDetach()
+            detachAfterInputTermination()
         }
         return false
     }
@@ -297,10 +294,19 @@ constructor(
                 )
             }
         } finally {
-            running.set(false)
-            onDetach()
+            detachAfterInputTermination()
         }
         return false
+    }
+
+    private fun detachAfterInputTermination() {
+        running.set(false)
+        val interrupted = inputWorkers.awaitAllTerminated()
+        try {
+            onDetach()
+        } finally {
+            if (interrupted) Thread.currentThread().interrupt()
+        }
     }
 
     /**

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -28,6 +28,7 @@ internal class MultiplexedIpcSession(
     private val onDetach: () -> Unit,
     private val channel: java.nio.channels.Channel,
     private val frameIoTimeoutMs: Long = FrameIoDeadline.DEFAULT_TIMEOUT_MS,
+    private val inputWorkers: CrossSessionInputWorkers,
 ) {
     fun run(input: InputStream, output: OutputStream) {
         // Bound threads *and* queue so a buggy client cannot OOM the agent with enqueued ops.
@@ -58,6 +59,7 @@ internal class MultiplexedIpcSession(
         val inFlight = ConcurrentHashMap<Long, OpSlot>()
         val writeLock = Any()
         val detachRequested = AtomicBoolean(false)
+        inputWorkers.register(inputWorker)
         try {
             serveOps(
                 input,
@@ -78,8 +80,9 @@ internal class MultiplexedIpcSession(
             runCatching { workers.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
             val inputWaitInterrupted =
                 if (detachRequested.get()) {
-                    awaitInputWorkerTermination(inputWorker)
+                    inputWorkers.awaitAllTerminated()
                 } else {
+                    inputWorkers.releaseAfterTermination(inputWorker)
                     false
                 }
             try {
@@ -211,18 +214,6 @@ internal class MultiplexedIpcSession(
             running.set(false)
             detachRequested.set(true)
         }
-    }
-
-    private fun awaitInputWorkerTermination(inputWorker: ExecutorService): Boolean {
-        var interrupted = false
-        while (!inputWorker.isTerminated) {
-            try {
-                inputWorker.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS)
-            } catch (_: InterruptedException) {
-                interrupted = true
-            }
-        }
-        return interrupted
     }
 
     private fun dispatchOp(
@@ -476,5 +467,44 @@ internal class MultiplexedIpcSession(
         const val MAX_OP_QUEUE: Int = 32
         /** Input requests wait here without consuming any general operation workers. */
         const val MAX_INPUT_QUEUE: Int = 32
+    }
+}
+
+internal class CrossSessionInputWorkers {
+    private val workers = ConcurrentHashMap.newKeySet<ExecutorService>()
+
+    fun register(worker: ExecutorService) {
+        check(workers.add(worker)) { "Input worker is already registered" }
+    }
+
+    fun releaseAfterTermination(worker: ExecutorService) {
+        Thread.ofVirtual().name("spectre-agent-input-reaper").start {
+            awaitTermination(worker)
+            workers.remove(worker)
+        }
+    }
+
+    fun awaitAllTerminated(): Boolean {
+        var interrupted = false
+        while (true) {
+            val activeWorkers = workers.toList()
+            if (activeWorkers.isEmpty()) return interrupted
+            activeWorkers.forEach { worker ->
+                if (awaitTermination(worker)) interrupted = true
+                workers.remove(worker)
+            }
+        }
+    }
+
+    private fun awaitTermination(worker: ExecutorService): Boolean {
+        var interrupted = false
+        while (!worker.isTerminated) {
+            try {
+                worker.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS)
+            } catch (_: InterruptedException) {
+                interrupted = true
+            }
+        }
+        return interrupted
     }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -41,6 +41,16 @@ internal class MultiplexedIpcSession(
                 { r -> Thread(r, "spectre-agent-op-worker").apply { isDaemon = true } },
                 ThreadPoolExecutor.AbortPolicy(),
             )
+        val inputWorker: ExecutorService =
+            ThreadPoolExecutor(
+                /* corePoolSize= */ 1,
+                /* maximumPoolSize= */ 1,
+                /* keepAliveTime= */ 0L,
+                TimeUnit.MILLISECONDS,
+                LinkedBlockingQueue(MAX_INPUT_QUEUE),
+                { r -> Thread(r, "spectre-agent-input-worker").apply { isDaemon = true } },
+                ThreadPoolExecutor.AbortPolicy(),
+            )
         val deadlineScheduler: ScheduledExecutorService =
             Executors.newSingleThreadScheduledExecutor { r ->
                 Thread(r, "spectre-agent-deadline").apply { isDaemon = true }
@@ -48,13 +58,15 @@ internal class MultiplexedIpcSession(
         val inFlight = ConcurrentHashMap<Long, OpSlot>()
         val writeLock = Any()
         try {
-            serveOps(input, output, workers, deadlineScheduler, inFlight, writeLock)
+            serveOps(input, output, workers, inputWorker, deadlineScheduler, inFlight, writeLock)
         } finally {
             inFlight.values.forEach { it.abortRunningWork() }
             inFlight.clear()
             deadlineScheduler.shutdownNow()
             workers.shutdownNow()
+            inputWorker.shutdownNow()
             runCatching { workers.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
+            runCatching { inputWorker.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
         }
     }
 
@@ -62,6 +74,7 @@ internal class MultiplexedIpcSession(
         input: InputStream,
         output: OutputStream,
         workers: ExecutorService,
+        inputWorker: ExecutorService,
         deadlineScheduler: ScheduledExecutorService,
         inFlight: ConcurrentHashMap<Long, OpSlot>,
         writeLock: Any,
@@ -93,7 +106,15 @@ internal class MultiplexedIpcSession(
                     return
                 }
                 else ->
-                    dispatchOp(op, body, workers, deadlineScheduler, inFlight, output, writeLock)
+                    dispatchOp(
+                        op,
+                        body,
+                        if (body.requiresInputLane) inputWorker else workers,
+                        deadlineScheduler,
+                        inFlight,
+                        output,
+                        writeLock,
+                    )
             }
         }
     }
@@ -173,7 +194,7 @@ internal class MultiplexedIpcSession(
     private fun dispatchOp(
         op: OpRequest,
         body: AgentRequest,
-        workers: ExecutorService,
+        executor: ExecutorService,
         deadlineScheduler: ScheduledExecutorService,
         inFlight: ConcurrentHashMap<Long, OpSlot>,
         output: OutputStream,
@@ -183,7 +204,7 @@ internal class MultiplexedIpcSession(
         inFlight[op.opId] = slot
         val future =
             try {
-                workers.submit {
+                executor.submit {
                     if (slot.isAborted || Thread.currentThread().isInterrupted) {
                         inFlight.remove(op.opId, slot)
                         return@submit
@@ -419,5 +440,7 @@ internal class MultiplexedIpcSession(
         const val MAX_OP_WORKERS: Int = 8
         /** Max queued ops beyond the worker pool (reject when full). */
         const val MAX_OP_QUEUE: Int = 32
+        /** Input requests wait here without consuming any general operation workers. */
+        const val MAX_INPUT_QUEUE: Int = 32
     }
 }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -76,7 +76,12 @@ internal class MultiplexedIpcSession(
             workers.shutdownNow()
             inputWorker.shutdownNow()
             runCatching { workers.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
-            val inputWaitInterrupted = awaitInputWorkerTermination(inputWorker)
+            val inputWaitInterrupted =
+                if (detachRequested.get()) {
+                    awaitInputWorkerTermination(inputWorker)
+                } else {
+                    false
+                }
             try {
                 if (detachRequested.get()) onDetach()
             } finally {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -57,8 +57,18 @@ internal class MultiplexedIpcSession(
             }
         val inFlight = ConcurrentHashMap<Long, OpSlot>()
         val writeLock = Any()
+        val detachRequested = AtomicBoolean(false)
         try {
-            serveOps(input, output, workers, inputWorker, deadlineScheduler, inFlight, writeLock)
+            serveOps(
+                input,
+                output,
+                workers,
+                inputWorker,
+                deadlineScheduler,
+                inFlight,
+                writeLock,
+                detachRequested,
+            )
         } finally {
             inFlight.values.forEach { it.abortRunningWork() }
             inFlight.clear()
@@ -66,7 +76,12 @@ internal class MultiplexedIpcSession(
             workers.shutdownNow()
             inputWorker.shutdownNow()
             runCatching { workers.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
-            runCatching { inputWorker.awaitTermination(WORKER_SHUTDOWN_SEC, TimeUnit.SECONDS) }
+            val inputWaitInterrupted = awaitInputWorkerTermination(inputWorker)
+            try {
+                if (detachRequested.get()) onDetach()
+            } finally {
+                if (inputWaitInterrupted) Thread.currentThread().interrupt()
+            }
         }
     }
 
@@ -78,6 +93,7 @@ internal class MultiplexedIpcSession(
         deadlineScheduler: ScheduledExecutorService,
         inFlight: ConcurrentHashMap<Long, OpSlot>,
         writeLock: Any,
+        detachRequested: AtomicBoolean,
     ) {
         while (running.get()) {
             // Channel-close deadlines may surface as SocketTimeoutException or as a
@@ -102,7 +118,7 @@ internal class MultiplexedIpcSession(
             when (val body = op.body) {
                 is AgentRequest.Cancel -> handleCancel(body, op.opId, output, writeLock, inFlight)
                 AgentRequest.Detach -> {
-                    handleDetach(op.opId, output, writeLock, inFlight)
+                    handleDetach(op.opId, output, writeLock, inFlight, detachRequested)
                     return
                 }
                 else ->
@@ -180,6 +196,7 @@ internal class MultiplexedIpcSession(
         output: OutputStream,
         writeLock: Any,
         inFlight: ConcurrentHashMap<Long, OpSlot>,
+        detachRequested: AtomicBoolean,
     ) {
         inFlight.values.forEach { it.abortRunningWork() }
         inFlight.clear()
@@ -187,8 +204,20 @@ internal class MultiplexedIpcSession(
             writeOpResponse(output, writeLock, opId, AgentResponse.Detached)
         } finally {
             running.set(false)
-            onDetach()
+            detachRequested.set(true)
         }
+    }
+
+    private fun awaitInputWorkerTermination(inputWorker: ExecutorService): Boolean {
+        var interrupted = false
+        while (!inputWorker.isTerminated) {
+            try {
+                inputWorker.awaitTermination(Long.MAX_VALUE, TimeUnit.NANOSECONDS)
+            } catch (_: InterruptedException) {
+                interrupted = true
+            }
+        }
+        return interrupted
     }
 
     private fun dispatchOp(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/MultiplexedIpcSession.kt
@@ -59,6 +59,7 @@ internal class MultiplexedIpcSession(
         val inFlight = ConcurrentHashMap<Long, OpSlot>()
         val writeLock = Any()
         val detachRequested = AtomicBoolean(false)
+        val detachOpId = AtomicReference<Long?>()
         inputWorkers.register(inputWorker)
         try {
             serveOps(
@@ -70,6 +71,7 @@ internal class MultiplexedIpcSession(
                 inFlight,
                 writeLock,
                 detachRequested,
+                detachOpId,
             )
         } finally {
             inFlight.values.forEach { it.abortRunningWork() }
@@ -86,7 +88,15 @@ internal class MultiplexedIpcSession(
                     false
                 }
             try {
-                if (detachRequested.get()) onDetach()
+                if (detachRequested.get()) {
+                    onDetach()
+                    writeOpResponse(
+                        output,
+                        writeLock,
+                        requireNotNull(detachOpId.get()),
+                        AgentResponse.Detached,
+                    )
+                }
             } finally {
                 if (inputWaitInterrupted) Thread.currentThread().interrupt()
             }
@@ -102,6 +112,7 @@ internal class MultiplexedIpcSession(
         inFlight: ConcurrentHashMap<Long, OpSlot>,
         writeLock: Any,
         detachRequested: AtomicBoolean,
+        detachOpId: AtomicReference<Long?>,
     ) {
         while (running.get()) {
             // Channel-close deadlines may surface as SocketTimeoutException or as a
@@ -126,7 +137,7 @@ internal class MultiplexedIpcSession(
             when (val body = op.body) {
                 is AgentRequest.Cancel -> handleCancel(body, op.opId, output, writeLock, inFlight)
                 AgentRequest.Detach -> {
-                    handleDetach(op.opId, output, writeLock, inFlight, detachRequested)
+                    handleDetach(op.opId, inFlight, detachRequested, detachOpId)
                     return
                 }
                 else ->
@@ -201,19 +212,15 @@ internal class MultiplexedIpcSession(
 
     private fun handleDetach(
         opId: Long,
-        output: OutputStream,
-        writeLock: Any,
         inFlight: ConcurrentHashMap<Long, OpSlot>,
         detachRequested: AtomicBoolean,
+        detachOpId: AtomicReference<Long?>,
     ) {
         inFlight.values.forEach { it.abortRunningWork() }
         inFlight.clear()
-        try {
-            writeOpResponse(output, writeLock, opId, AgentResponse.Detached)
-        } finally {
-            running.set(false)
-            detachRequested.set(true)
-        }
+        detachOpId.set(opId)
+        running.set(false)
+        detachRequested.set(true)
     }
 
     private fun dispatchOp(

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -288,6 +288,37 @@ internal val AgentRequest.logLabel: String
             AgentRequest.PrintTree -> "printTree"
         }
 
+/** True when this request can mutate shared desktop input, focus, or clipboard state. */
+internal val AgentRequest.requiresInputLane: Boolean
+    get() =
+        when (this) {
+            is AgentRequest.Click,
+            is AgentRequest.DoubleClick,
+            is AgentRequest.LongClick,
+            is AgentRequest.Swipe,
+            is AgentRequest.ScrollWheel,
+            is AgentRequest.PressKey,
+            is AgentRequest.FocusWindow,
+            is AgentRequest.TypeText -> true
+            AgentRequest.Ping,
+            AgentRequest.Windows,
+            AgentRequest.AllNodes,
+            is AgentRequest.FindByTestTag,
+            is AgentRequest.FindByText,
+            is AgentRequest.FindByContentDescription,
+            is AgentRequest.FindByRole,
+            is AgentRequest.Screenshot,
+            is AgentRequest.Capture,
+            is AgentRequest.WindowIdentity,
+            AgentRequest.Detach,
+            is AgentRequest.Hello,
+            is AgentRequest.Cancel,
+            is AgentRequest.WaitForNode,
+            is AgentRequest.WaitForVisualIdle,
+            is AgentRequest.WaitForIdle,
+            AgentRequest.PrintTree -> false
+        }
+
 /** Server-to-client response envelope. */
 @Serializable
 internal sealed interface AgentResponse {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvokerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvokerTest.kt
@@ -1,0 +1,57 @@
+package dev.sebastiano.spectre.agent.runtime
+
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class BlockingSuspendInvokerTest {
+
+    @Test
+    fun `interrupted caller remains attached until the continuation completes`() {
+        val target = InterruptibleSuspendTarget()
+        val method =
+            InterruptibleSuspendTarget::class
+                .java
+                .getMethod("suspendUntilReleased", Continuation::class.java)
+        val result = AtomicReference<Any?>()
+        val invocationFinished = CountDownLatch(1)
+        val thread =
+            Thread {
+                    try {
+                        result.set(BlockingSuspendInvoker().invoke(method, target))
+                    } finally {
+                        invocationFinished.countDown()
+                    }
+                }
+                .apply { start() }
+        val continuation = target.continuation.get(3, TimeUnit.SECONDS)
+
+        thread.interrupt()
+
+        assertFalse(
+            invocationFinished.await(200, TimeUnit.MILLISECONDS),
+            "interruption must not orphan the still-running suspend continuation",
+        )
+        continuation.resumeWith(Result.success("finished"))
+        assertTrue(invocationFinished.await(3, TimeUnit.SECONDS))
+        assertEquals("finished", result.get())
+        assertTrue(thread.isInterrupted)
+    }
+}
+
+internal class InterruptibleSuspendTarget {
+    val continuation = CompletableFuture<Continuation<Any?>>()
+
+    @Suppress("unused")
+    fun suspendUntilReleased(continuation: Continuation<Any?>): Any? {
+        this.continuation.complete(continuation)
+        return COROUTINE_SUSPENDED
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvokerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/BlockingSuspendInvokerTest.kt
@@ -3,6 +3,7 @@ package dev.sebastiano.spectre.agent.runtime
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
@@ -43,6 +44,38 @@ class BlockingSuspendInvokerTest {
         assertTrue(invocationFinished.await(3, TimeUnit.SECONDS))
         assertEquals("finished", result.get())
         assertTrue(thread.isInterrupted)
+    }
+
+    @Test
+    fun `timed out caller remains attached until the continuation completes`() {
+        val target = InterruptibleSuspendTarget()
+        val method =
+            InterruptibleSuspendTarget::class
+                .java
+                .getMethod("suspendUntilReleased", Continuation::class.java)
+        val failure = AtomicReference<Throwable?>()
+        val invocationFinished = CountDownLatch(1)
+        val thread =
+            Thread {
+                    try {
+                        BlockingSuspendInvoker(timeoutMs = 20).invoke(method, target)
+                    } catch (caught: Throwable) {
+                        failure.set(caught)
+                    } finally {
+                        invocationFinished.countDown()
+                    }
+                }
+                .apply { start() }
+        val continuation = target.continuation.get(3, TimeUnit.SECONDS)
+
+        assertFalse(
+            invocationFinished.await(200, TimeUnit.MILLISECONDS),
+            "timeout must not orphan the still-running suspend continuation",
+        )
+        assertTrue(thread.isAlive)
+        continuation.resumeWith(Result.success("finished"))
+        assertTrue(invocationFinished.await(3, TimeUnit.SECONDS))
+        assertTrue(failure.get() is TimeoutException)
     }
 }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgentInputCoordinationCompatibilityTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgentInputCoordinationCompatibilityTest.kt
@@ -1,0 +1,32 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.runtime
+
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class SpectreAgentInputCoordinationCompatibilityTest {
+
+    @Test
+    fun `legacy target without InputLeasePolicy falls back to no-argument driver`() {
+        val legacyLoader =
+            object : ClassLoader(javaClass.classLoader) {
+                override fun loadClass(name: String): Class<*> {
+                    if (name == "dev.sebastiano.spectre.core.InputLeasePolicy") {
+                        throw ClassNotFoundException(name)
+                    }
+                    return super.loadClass(name)
+                }
+            }
+
+        val driver =
+            SpectreAgent.createCoordinatedRobotDriverOrLegacyFallback(
+                legacyLoader,
+                LegacyRobotDriver::class.java,
+            )
+
+        assertIs<LegacyRobotDriver>(driver)
+    }
+
+    private class LegacyRobotDriver
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreInjectClassLoaderTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreInjectClassLoaderTest.kt
@@ -23,6 +23,11 @@ class SpectreInjectClassLoaderTest {
                 "dev.sebastiano.spectre.inject.relocated.kotlinx.coroutines.Dispatchers"
             )
         )
+        assertTrue(
+            SpectreInjectClassLoader.loadFromInjectJar(
+                "dev.sebastiano.spectre.inject.relocated.kotlinx.serialization.json.Json"
+            )
+        )
         assertTrue(SpectreInjectClassLoader.loadFromInjectJar("androidx.tracing.Trace"))
         assertEquals(
             false,

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/InputLaneClassificationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/InputLaneClassificationTest.kt
@@ -1,0 +1,28 @@
+package dev.sebastiano.spectre.agent.transport
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InputLaneClassificationTest {
+    @Test
+    fun `only desktop input and focus requests use the bounded input lane`() {
+        assertTrue(AgentRequest.Click("node").requiresInputLane)
+        assertTrue(AgentRequest.DoubleClick("node").requiresInputLane)
+        assertTrue(AgentRequest.LongClick("node").requiresInputLane)
+        assertTrue(
+            AgentRequest.Swipe("node", endX = 10, endY = 20, durationMs = 100).requiresInputLane
+        )
+        assertTrue(AgentRequest.ScrollWheel("node", 1).requiresInputLane)
+        assertTrue(AgentRequest.PressKey(10).requiresInputLane)
+        assertTrue(AgentRequest.FocusWindow("node").requiresInputLane)
+        assertTrue(AgentRequest.TypeText("secret").requiresInputLane)
+
+        assertFalse(AgentRequest.Windows.requiresInputLane)
+        assertFalse(AgentRequest.AllNodes.requiresInputLane)
+        assertFalse(AgentRequest.Screenshot().requiresInputLane)
+        assertFalse(AgentRequest.WaitForIdle().requiresInputLane)
+        assertFalse(AgentRequest.Cancel(1).requiresInputLane)
+        assertFalse(AgentRequest.Detach.requiresInputLane)
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
@@ -5,6 +5,7 @@ package dev.sebastiano.spectre.agent.transport
 import java.nio.file.Path
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.deleteIfExists
 import kotlin.test.AfterTest
@@ -28,6 +29,79 @@ class LongOpInfrastructureTest {
     @AfterTest
     fun cleanUp() {
         runCatching { udsPath.deleteIfExists() }
+    }
+
+    @Test
+    fun `ordinary EOF accepts a replacement client while input finishes`() {
+        val inputStarted = CountDownLatch(1)
+        val allowInputToFinish = CountDownLatch(1)
+        val inputFinished = CountDownLatch(1)
+        val server =
+            IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    when (request) {
+                        is AgentRequest.Click -> {
+                            inputStarted.countDown()
+                            try {
+                                var finished = false
+                                while (!finished) {
+                                    try {
+                                        allowInputToFinish.await()
+                                        finished = true
+                                    } catch (_: InterruptedException) {
+                                        // Model an input call that cannot stop at interruption.
+                                    }
+                                }
+                                AgentResponse.Ok
+                            } finally {
+                                inputFinished.countDown()
+                            }
+                        }
+                        AgentRequest.Ping -> AgentResponse.Pong
+                        else -> AgentResponse.Ok
+                    }
+                },
+            )
+        val replacementExecutor = Executors.newSingleThreadExecutor()
+        server.use {
+            awaitSocket(udsPath)
+            val firstClient = IpcClient(udsPath)
+            try {
+                val inputThread =
+                    Thread {
+                            runCatching {
+                                firstClient.send(AgentRequest.Click(nodeKey = "target-node"))
+                            }
+                        }
+                        .apply {
+                            isDaemon = true
+                            start()
+                        }
+                assertTrue(inputStarted.await(3, TimeUnit.SECONDS), "input op never started")
+
+                firstClient.close()
+                val replacement =
+                    replacementExecutor.submit<AgentResponse> {
+                        IpcClient(udsPath).use { it.send(AgentRequest.Ping) }
+                    }
+
+                assertEquals(AgentResponse.Pong, replacement.get(3, TimeUnit.SECONDS))
+                assertFalse(
+                    inputFinished.await(200, TimeUnit.MILLISECONDS),
+                    "ordinary EOF should not abandon the still-running input operation",
+                )
+                inputThread.join(3_000)
+            } finally {
+                allowInputToFinish.countDown()
+                assertTrue(
+                    inputFinished.await(3, TimeUnit.SECONDS),
+                    "input operation did not finish during cleanup",
+                )
+                firstClient.close()
+                replacementExecutor.shutdownNow()
+            }
+        }
     }
 
     @Test

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
@@ -11,10 +11,12 @@ import java.util.UUID
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
 import kotlin.io.path.deleteIfExists
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -95,15 +97,14 @@ class LongOpInfrastructureTest {
                         }
                     }
 
-                assertEquals(AgentResponse.Detached, replacement.get(3, TimeUnit.SECONDS))
                 assertFalse(
                     inputFinished.await(200, TimeUnit.MILLISECONDS),
                     "ordinary EOF should not abandon the still-running input operation",
                 )
-                assertFalse(
-                    detached.await(200, TimeUnit.MILLISECONDS),
-                    "a later detach must wait for input orphaned by ordinary EOF",
-                )
+                assertFailsWith<TimeoutException> { replacement.get(200, TimeUnit.MILLISECONDS) }
+                allowInputToFinish.countDown()
+                assertEquals(AgentResponse.Detached, replacement.get(3, TimeUnit.SECONDS))
+                assertTrue(detached.await(3, TimeUnit.SECONDS))
                 inputThread.join(3_000)
             } finally {
                 allowInputToFinish.countDown()
@@ -214,35 +215,41 @@ class LongOpInfrastructureTest {
                 },
                 onDetach = { detached.countDown() },
             )
-        server.use {
-            awaitSocket(udsPath)
-            IpcClient(udsPath).use { client ->
-                val inputThread =
-                    Thread {
-                            runCatching { client.send(AgentRequest.Click(nodeKey = "target-node")) }
-                        }
-                        .apply {
-                            isDaemon = true
-                            start()
-                        }
+        val detachExecutor = Executors.newSingleThreadExecutor()
+        try {
+            server.use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { client ->
+                    val inputThread =
+                        Thread {
+                                runCatching {
+                                    client.send(AgentRequest.Click(nodeKey = "target-node"))
+                                }
+                            }
+                            .apply {
+                                isDaemon = true
+                                start()
+                            }
 
-                assertTrue(inputStarted.await(3, TimeUnit.SECONDS), "input op never started")
-                assertEquals(AgentResponse.Detached, client.send(AgentRequest.Detach))
-                try {
-                    assertFalse(
-                        detached.await(200, TimeUnit.MILLISECONDS),
-                        "detach released target resources while input was still active",
+                    assertTrue(inputStarted.await(3, TimeUnit.SECONDS), "input op never started")
+                    val detach =
+                        detachExecutor.submit<AgentResponse> { client.send(AgentRequest.Detach) }
+                    try {
+                        assertFailsWith<TimeoutException> { detach.get(200, TimeUnit.MILLISECONDS) }
+                    } finally {
+                        allowInputToFinish.countDown()
+                    }
+
+                    assertEquals(AgentResponse.Detached, detach.get(3, TimeUnit.SECONDS))
+                    assertTrue(
+                        detached.await(3, TimeUnit.SECONDS),
+                        "detach did not release target resources after input finished",
                     )
-                } finally {
-                    allowInputToFinish.countDown()
+                    inputThread.join(3_000)
                 }
-
-                assertTrue(
-                    detached.await(3, TimeUnit.SECONDS),
-                    "detach did not release target resources after input finished",
-                )
-                inputThread.join(3_000)
             }
+        } finally {
+            detachExecutor.shutdownNow()
         }
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
@@ -2,6 +2,10 @@
 
 package dev.sebastiano.spectre.agent.transport
 
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
 import java.nio.file.Path
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
@@ -113,6 +117,70 @@ class LongOpInfrastructureTest {
                 )
                 firstClient.close()
                 replacementExecutor.shutdownNow()
+            }
+        }
+    }
+
+    @Test
+    fun `pre-handshake rejection waits for input orphaned by ordinary EOF`() {
+        val inputStarted = CountDownLatch(1)
+        val allowInputToFinish = CountDownLatch(1)
+        val detached = CountDownLatch(1)
+        val server =
+            IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    if (request is AgentRequest.Click) {
+                        inputStarted.countDown()
+                        while (true) {
+                            try {
+                                allowInputToFinish.await()
+                                break
+                            } catch (_: InterruptedException) {
+                                // Model native input that outlives interruption.
+                            }
+                        }
+                    }
+                    AgentResponse.Ok
+                },
+                onDetach = { detached.countDown() },
+            )
+        server.use {
+            awaitSocket(udsPath)
+            val firstClient = IpcClient(udsPath)
+            val inputThread =
+                Thread {
+                        runCatching {
+                            firstClient.send(AgentRequest.Click(nodeKey = "target-node"))
+                        }
+                    }
+                    .apply {
+                        isDaemon = true
+                        start()
+                    }
+            try {
+                assertTrue(inputStarted.await(3, TimeUnit.SECONDS), "input op never started")
+                firstClient.close()
+
+                SocketChannel.open(StandardProtocolFamily.UNIX).use { replacement ->
+                    replacement.connect(UnixDomainSocketAddress.of(udsPath))
+                    val input = Channels.newInputStream(replacement)
+                    val output = Channels.newOutputStream(replacement)
+                    Framing.writeFrame(output, WireCodec.encode(AgentRequest.Ping))
+                    assertIs<AgentResponse.Error>(
+                        WireCodec.decodeResponse(Framing.readFrame(input) ?: error("no response"))
+                    )
+                }
+
+                assertFalse(
+                    detached.await(200, TimeUnit.MILLISECONDS),
+                    "handshake rejection released resources while orphaned input was active",
+                )
+            } finally {
+                allowInputToFinish.countDown()
+                assertTrue(detached.await(3, TimeUnit.SECONDS))
+                inputThread.join(3_000)
+                firstClient.close()
             }
         }
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
@@ -36,6 +36,7 @@ class LongOpInfrastructureTest {
         val inputStarted = CountDownLatch(1)
         val allowInputToFinish = CountDownLatch(1)
         val inputFinished = CountDownLatch(1)
+        val detached = CountDownLatch(1)
         val server =
             IpcServer(
                 udsPath,
@@ -62,6 +63,7 @@ class LongOpInfrastructureTest {
                         else -> AgentResponse.Ok
                     }
                 },
+                onDetach = { detached.countDown() },
             )
         val replacementExecutor = Executors.newSingleThreadExecutor()
         server.use {
@@ -83,13 +85,20 @@ class LongOpInfrastructureTest {
                 firstClient.close()
                 val replacement =
                     replacementExecutor.submit<AgentResponse> {
-                        IpcClient(udsPath).use { it.send(AgentRequest.Ping) }
+                        IpcClient(udsPath).use {
+                            assertEquals(AgentResponse.Pong, it.send(AgentRequest.Ping))
+                            it.send(AgentRequest.Detach)
+                        }
                     }
 
-                assertEquals(AgentResponse.Pong, replacement.get(3, TimeUnit.SECONDS))
+                assertEquals(AgentResponse.Detached, replacement.get(3, TimeUnit.SECONDS))
                 assertFalse(
                     inputFinished.await(200, TimeUnit.MILLISECONDS),
                     "ordinary EOF should not abandon the still-running input operation",
+                )
+                assertFalse(
+                    detached.await(200, TimeUnit.MILLISECONDS),
+                    "a later detach must wait for input orphaned by ordinary EOF",
                 )
                 inputThread.join(3_000)
             } finally {
@@ -97,6 +106,10 @@ class LongOpInfrastructureTest {
                 assertTrue(
                     inputFinished.await(3, TimeUnit.SECONDS),
                     "input operation did not finish during cleanup",
+                )
+                assertTrue(
+                    detached.await(3, TimeUnit.SECONDS),
+                    "detach did not finish after the orphaned input operation",
                 )
                 firstClient.close()
                 replacementExecutor.shutdownNow()

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
@@ -10,6 +10,7 @@ import kotlin.io.path.deleteIfExists
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
 import org.junit.jupiter.api.condition.EnabledOnOs
@@ -27,6 +28,67 @@ class LongOpInfrastructureTest {
     @AfterTest
     fun cleanUp() {
         runCatching { udsPath.deleteIfExists() }
+    }
+
+    @Test
+    fun `detach retains target input resources until active input finishes`() {
+        val inputStarted = CountDownLatch(1)
+        val allowInputToFinish = CountDownLatch(1)
+        val detached = CountDownLatch(1)
+        val server =
+            IpcServer(
+                udsPath,
+                AgentRequestHandler { request ->
+                    when (request) {
+                        is AgentRequest.Click -> {
+                            inputStarted.countDown()
+                            var finished = false
+                            while (!finished) {
+                                try {
+                                    allowInputToFinish.await()
+                                    finished = true
+                                } catch (_: InterruptedException) {
+                                    // A native input call can outlive interruption. Model that
+                                    // contract so detach must retain coordination until return.
+                                }
+                            }
+                            AgentResponse.Ok
+                        }
+                        else -> AgentResponse.Ok
+                    }
+                },
+                onDetach = { detached.countDown() },
+            )
+        server.use {
+            awaitSocket(udsPath)
+            IpcClient(udsPath).use { client ->
+                val inputThread =
+                    Thread {
+                            runCatching { client.send(AgentRequest.Click(nodeKey = "target-node")) }
+                        }
+                        .apply {
+                            isDaemon = true
+                            start()
+                        }
+
+                assertTrue(inputStarted.await(3, TimeUnit.SECONDS), "input op never started")
+                assertEquals(AgentResponse.Detached, client.send(AgentRequest.Detach))
+                try {
+                    assertFalse(
+                        detached.await(200, TimeUnit.MILLISECONDS),
+                        "detach released target resources while input was still active",
+                    )
+                } finally {
+                    allowInputToFinish.countDown()
+                }
+
+                assertTrue(
+                    detached.await(3, TimeUnit.SECONDS),
+                    "detach did not release target resources after input finished",
+                )
+                inputThread.join(3_000)
+            }
+        }
     }
 
     @Test

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -447,6 +447,8 @@ subprojects {
 val publishedLibraryProjects =
     listOf(
         ":core",
+        ":input-coordinator",
+        ":input-coordinator-server",
         ":server",
         ":recording",
         ":recording-macos",
@@ -738,6 +740,7 @@ val verifyMavenLocalPublication by tasks.registering {
                                 "org/jetbrains/compose/",
                                 "org/jetbrains/skiko/",
                                 "dev/sebastiano/spectre/core/",
+                                "dev/sebastiano/spectre/input/",
                                 "kotlin/Pair.class",
                                 "kotlinx/coroutines/",
                             )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -269,6 +269,10 @@ val buildSrcUnitTests by
         outputs.upToDateWhen { false }
     }
 
+// Both tasks launch nested Gradle builds that write buildSrc/build. Running them concurrently can
+// corrupt a cache restore or expose a partially compiled buildSrc classpath on clean CI workers.
+verifyMacosCliBundleReleaseContract.configure { mustRunAfter(buildSrcUnitTests) }
+
 tasks.named("check") {
     dependsOn(
         "detekt",

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -442,6 +442,7 @@ kotlin {
 
 dependencies {
     implementation(projects.agent)
+    implementation(projects.inputCoordinatorServer)
     implementation(projects.recording)
     runtimeOnly(projects.agentRuntime)
     runtimeOnly(projects.recordingLinux)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/InputLockCommand.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/InputLockCommand.kt
@@ -1,0 +1,226 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import dev.sebastiano.spectre.input.CoordinatorControlResult
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.CoordinatorHolderStatus
+import dev.sebastiano.spectre.input.CoordinatorStatus
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.InputCoordinatorException
+import dev.sebastiano.spectre.input.LocalCoordinatorEnvironment
+import dev.sebastiano.spectre.input.LocalInputCoordinatorControl
+import java.io.IOException
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+internal class InputLockCommand
+internal constructor(
+    output: Appendable,
+    endpoint: () -> CoordinatorEndpoint,
+    resourceKey: () -> DesktopResourceKey,
+) : CliktCommand(name = "input-lock") {
+    constructor(
+        output: Appendable,
+        endpoint: CoordinatorEndpoint,
+        resourceKey: DesktopResourceKey,
+    ) : this(output, { endpoint }, { resourceKey })
+
+    init {
+        subcommands(
+            InputLockStatusCommand(output, endpoint, resourceKey),
+            InputLockRevokeCommand(output, endpoint, resourceKey),
+        )
+    }
+
+    override fun run(): Unit = Unit
+
+    companion object {
+        fun default(output: Appendable): InputLockCommand =
+            InputLockCommand(
+                output,
+                LocalCoordinatorEnvironment::defaultEndpoint,
+                LocalCoordinatorEnvironment::defaultDesktopResourceKey,
+            )
+    }
+}
+
+private class InputLockStatusCommand(
+    private val output: Appendable,
+    private val endpoint: () -> CoordinatorEndpoint,
+    private val resourceKey: () -> DesktopResourceKey,
+) : CliktCommand(name = "status") {
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        try {
+            when (val result = LocalInputCoordinatorControl(endpoint()).status(resourceKey())) {
+                CoordinatorControlResult.NoActiveCoordinator ->
+                    if (json) {
+                        output.appendLine(INPUT_LOCK_JSON.encodeToString(InputLockStatusJson()))
+                    } else {
+                        output.appendLine("No active input coordinator.")
+                    }
+                is CoordinatorControlResult.Active -> renderActive(result.status)
+            }
+        } catch (failure: InputCoordinatorException) {
+            failInputLock(output, failure)
+        } catch (failure: IOException) {
+            failInputLockIo(output, failure)
+        }
+    }
+
+    private fun renderActive(status: CoordinatorStatus) {
+        if (json) {
+            output.appendLine(
+                INPUT_LOCK_JSON.encodeToString(
+                    InputLockStatusJson(
+                        noActiveCoordinator = false,
+                        resourceKey = status.resourceKey.value,
+                        holder = status.holder?.let(::InputLockHolderJson),
+                        waiterCount = status.waiters.size,
+                        quarantineLeaseId = status.quarantine?.predecessorLeaseId,
+                        quarantine = status.quarantine?.let(::InputLockQuarantineJson),
+                    )
+                )
+            )
+            return
+        }
+        status.holder?.let { holder ->
+            output.appendLine(
+                "Input lock ${holder.leaseId}: ${holder.state}, owner=${holder.owner.label}, " +
+                    "pid=${holder.owner.processId}, age=${holder.acquisitionAgeMillis}ms, " +
+                    "heartbeatAge=${holder.heartbeatAgeMillis}ms, " +
+                    "operation=${holder.currentOperation}, waiters=${status.waiters.size}"
+            )
+        } ?: output.appendLine("Input lock is free; waiters=${status.waiters.size}.")
+        status.quarantine?.let { quarantine ->
+            output.appendLine(
+                "Recovery quarantine for predecessor ${quarantine.predecessorLeaseId}; " +
+                    "owner=${quarantine.owner.label}, pid=${quarantine.owner.processId}, " +
+                    "releaseEligibleAt=${quarantine.releaseEligibleAtMillis}; an " +
+                    "unacknowledged live owner requires exact-ID --force."
+            )
+        }
+    }
+}
+
+private class InputLockRevokeCommand(
+    private val output: Appendable,
+    private val endpoint: () -> CoordinatorEndpoint,
+    private val resourceKey: () -> DesktopResourceKey,
+) : CliktCommand(name = "revoke") {
+    private val leaseId: String by option("--lease").required()
+    private val reason: String by option("--reason").required()
+    private val force: Boolean by option("--force").flag(default = false)
+
+    override fun run() {
+        try {
+            val resource = resourceKey()
+            val control = LocalInputCoordinatorControl(endpoint())
+            if (control.status(resource) == CoordinatorControlResult.NoActiveCoordinator) {
+                output.appendLine("No active input coordinator.")
+                return
+            }
+            val result =
+                control.revoke(
+                    resourceKey = resource,
+                    observedLeaseId = leaseId,
+                    requesterLabel = "spectre-cli:${ProcessHandle.current().pid()}",
+                    reason = reason,
+                    force = force,
+                )
+            if (result.unsafeTakeover) {
+                output.appendLine(
+                    "warning: lease was fenced without owner acknowledgement; unsafeTakeover=true"
+                )
+            } else {
+                output.appendLine("Lease $leaseId is revoking; unsafeTakeover=false")
+            }
+        } catch (failure: InputCoordinatorException) {
+            if (failure.errorCode == "REVOKE_GRACE_ACTIVE") {
+                output.appendLine(
+                    "The lease is fenced; inspect status, wait for the grace period, then " +
+                        "retry the exact lease ID with --force if recovery is still required."
+                )
+            }
+            failInputLock(output, failure)
+        } catch (failure: IOException) {
+            failInputLockIo(output, failure)
+        }
+    }
+}
+
+private fun failInputLock(output: Appendable, failure: InputCoordinatorException): Nothing {
+    output.appendLine("Input lock error (${failure.errorCode}): ${failure.message}")
+    throw ProgramResult(1)
+}
+
+private fun failInputLockIo(output: Appendable, failure: IOException): Nothing {
+    output.appendLine("Input lock I/O error: ${failure.message}")
+    throw ProgramResult(1)
+}
+
+@Serializable
+private data class InputLockStatusJson(
+    val version: Int = 1,
+    val noActiveCoordinator: Boolean = true,
+    val resourceKey: String? = null,
+    val holder: InputLockHolderJson? = null,
+    val waiterCount: Int = 0,
+    val quarantineLeaseId: String? = null,
+    val quarantine: InputLockQuarantineJson? = null,
+)
+
+@Serializable
+private data class InputLockQuarantineJson(
+    val predecessorLeaseId: String,
+    val predecessorEpoch: String,
+    val owner: String?,
+    val processId: Long,
+    val releaseEligibleAtMillis: Long,
+) {
+    constructor(
+        quarantine: dev.sebastiano.spectre.input.CoordinatorQuarantineStatus
+    ) : this(
+        predecessorLeaseId = quarantine.predecessorLeaseId,
+        predecessorEpoch = quarantine.predecessorEpoch,
+        owner = quarantine.owner.label,
+        processId = quarantine.owner.processId,
+        releaseEligibleAtMillis = quarantine.releaseEligibleAtMillis,
+    )
+}
+
+@Serializable
+private data class InputLockHolderJson(
+    val leaseId: String,
+    val owner: String?,
+    val processId: Long,
+    val state: String,
+    val fence: Long,
+    val acquisitionAgeMillis: Long,
+    val heartbeatAgeMillis: Long,
+    val currentOperation: String?,
+) {
+    constructor(
+        holder: CoordinatorHolderStatus
+    ) : this(
+        leaseId = holder.leaseId,
+        owner = holder.owner.label,
+        processId = holder.owner.processId,
+        state = holder.state,
+        fence = holder.fence,
+        acquisitionAgeMillis = holder.acquisitionAgeMillis,
+        heartbeatAgeMillis = holder.heartbeatAgeMillis,
+        currentOperation = holder.currentOperation,
+    )
+}
+
+private val INPUT_LOCK_JSON: Json = Json { encodeDefaults = true }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -166,6 +166,7 @@ private class RootCommand(
             PermissionsCommand(output),
             PsCommand(request, output),
             DaemonCommand(request, shutdownRequest, output),
+            InputLockCommand.default(output),
             McpCommand(request),
         )
     }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/InputLockCommandTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/InputLockCommandTest.kt
@@ -1,0 +1,146 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.cli
+
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.core.parse
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LocalInputCoordinatorClient
+import dev.sebastiano.spectre.input.server.LocalCoordinatorServer
+import java.io.IOException
+import java.nio.file.Files
+import java.time.Duration
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.boolean
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class InputLockCommandTest {
+
+    private val temporaryDirectory = Files.createTempDirectory("spc-cli-")
+    private val endpoint =
+        CoordinatorEndpoint(temporaryDirectory, temporaryDirectory.resolve("coordinator.sock"))
+    private val resource = DesktopResourceKey("user:501/macos-console")
+    private val resources = mutableListOf<AutoCloseable>()
+
+    @AfterTest
+    fun cleanUp() {
+        resources.asReversed().forEach { runCatching { it.close() } }
+        Files.deleteIfExists(endpoint.socketPath)
+        Files.deleteIfExists(temporaryDirectory.resolve("coordinator.lock"))
+        Files.deleteIfExists(temporaryDirectory.resolve("recovery.properties.tmp"))
+        Files.deleteIfExists(temporaryDirectory.resolve("recovery.properties"))
+        Files.deleteIfExists(temporaryDirectory)
+    }
+
+    @Test
+    fun `status json reports no active coordinator without launching one`() {
+        val output = StringBuilder()
+
+        InputLockCommand(output, endpoint, resource).parse(listOf("status", "--json"))
+
+        val json = Json.parseToJsonElement(output.toString()).jsonObject
+        assertTrue(json.getValue("noActiveCoordinator").jsonPrimitive.boolean)
+        assertFalse(Files.exists(endpoint.socketPath))
+    }
+
+    @Test
+    fun `status json identifies holder and force revoke is visibly unsafe`() {
+        val server =
+            LocalCoordinatorServer(endpoint, revokeGrace = Duration.ZERO).also {
+                it.start()
+                resources += it
+            }
+        val client =
+            LocalInputCoordinatorClient.connect(endpoint, resource, "LoginTest#submits").also {
+                resources += it
+            }
+        val lease = client.acquire(Duration.ofSeconds(1), "typeText").also { resources += it }
+        val statusOutput = StringBuilder()
+
+        InputLockCommand(statusOutput, endpoint, resource).parse(listOf("status", "--json"))
+
+        val status = Json.parseToJsonElement(statusOutput.toString()).jsonObject
+        assertEquals(
+            lease.token.leaseId,
+            status.getValue("holder").jsonObject.getValue("leaseId").jsonPrimitive.content,
+        )
+        val revokeOutput = StringBuilder()
+        InputLockCommand(revokeOutput, endpoint, resource)
+            .parse(
+                listOf(
+                    "revoke",
+                    "--lease",
+                    lease.token.leaseId,
+                    "--reason",
+                    "test JVM is unresponsive",
+                    "--force",
+                )
+            )
+        assertTrue(revokeOutput.toString().contains("unsafeTakeover=true"))
+        assertFalse(lease.isValid() && runCatching { lease.checkpoint() }.isSuccess)
+
+        server.close()
+        server.awaitTermination()
+    }
+
+    @Test
+    fun `stale revoke reports a stable CLI error without a stack trace`() {
+        LocalCoordinatorServer(endpoint).also {
+            it.start()
+            resources += it
+        }
+        val output = StringBuilder()
+
+        val failure =
+            kotlin.test.assertFailsWith<ProgramResult> {
+                InputLockCommand(output, endpoint, resource)
+                    .parse(
+                        listOf(
+                            "revoke",
+                            "--lease",
+                            "stale-id",
+                            "--reason",
+                            "operator inspected the holder",
+                        )
+                    )
+            }
+
+        assertEquals(1, failure.statusCode)
+        assertTrue(output.contains("STALE_LEASE"))
+        assertFalse(output.contains("Exception"))
+    }
+
+    @Test
+    fun `revoke endpoint IO failure reports a stable CLI error`() {
+        val output = StringBuilder()
+
+        val failure =
+            kotlin.test.assertFailsWith<ProgramResult> {
+                InputLockCommand(
+                        output,
+                        endpoint = { throw IOException("socket path is unavailable") },
+                        resourceKey = { resource },
+                    )
+                    .parse(
+                        listOf(
+                            "revoke",
+                            "--lease",
+                            "observed-id",
+                            "--reason",
+                            "operator inspected the holder",
+                        )
+                    )
+            }
+
+        assertEquals(1, failure.statusCode)
+        assertTrue(output.contains("Input lock I/O error: socket path is unavailable"))
+        assertFalse(output.contains("Exception"))
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonFixtureIntegrationTest.kt
@@ -189,7 +189,7 @@ class DaemonFixtureIntegrationTest {
                 )
 
                 val attached = runCliBinary(daemonUser, "attach", fixture.pid.toString(), "--json")
-                assertEquals(0, attached.exitCode)
+                assertEquals(0, attached.exitCode, attached.output + attached.errorOutput)
                 val sessionId =
                     Json.parseToJsonElement(attached.output)
                         .jsonObject

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -9,6 +9,11 @@ public final class dev/sebastiano/spectre/core/AutomatorIdlingResource$DefaultIm
 
 public abstract interface class dev/sebastiano/spectre/core/AutomatorInputLease : java/lang/AutoCloseable {
 	public abstract fun bind (Ldev/sebastiano/spectre/core/ComposeAutomator;)Ljava/lang/AutoCloseable;
+	public fun withLease (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class dev/sebastiano/spectre/core/AutomatorInputLease$DefaultImpls {
+	public static fun withLease (Ldev/sebastiano/spectre/core/AutomatorInputLease;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class dev/sebastiano/spectre/core/AutomatorNode {

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -260,7 +260,7 @@ public final class dev/sebastiano/spectre/core/PerfettoTracer : dev/sebastiano/s
 public final class dev/sebastiano/spectre/core/PerfettoTracer$Companion {
 }
 
-public final class dev/sebastiano/spectre/core/RobotDriver {
+public final class dev/sebastiano/spectre/core/RobotDriver : java/lang/AutoCloseable {
 	public static final field Companion Ldev/sebastiano/spectre/core/RobotDriver$Companion;
 	public fun <init> ()V
 	public fun <init> (Ldev/sebastiano/spectre/core/InputLeasePolicy;)V
@@ -268,6 +268,7 @@ public final class dev/sebastiano/spectre/core/RobotDriver {
 	public fun <init> (Ljava/awt/Robot;Ldev/sebastiano/spectre/core/InputLeasePolicy;)V
 	public final fun clearAndTypeText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun click (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun close ()V
 	public final fun doubleClick (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getInputCapabilities ()Ldev/sebastiano/spectre/core/InputCapabilities;
 	public final fun longClick-exY8QGI (IIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -7,6 +7,10 @@ public final class dev/sebastiano/spectre/core/AutomatorIdlingResource$DefaultIm
 	public static fun diagnosticMessage (Ldev/sebastiano/spectre/core/AutomatorIdlingResource;)Ljava/lang/String;
 }
 
+public abstract interface class dev/sebastiano/spectre/core/AutomatorInputLease : java/lang/AutoCloseable {
+	public abstract fun bind (Ldev/sebastiano/spectre/core/ComposeAutomator;)Ljava/lang/AutoCloseable;
+}
+
 public final class dev/sebastiano/spectre/core/AutomatorNode {
 	public final fun bothBounds ()Ldev/sebastiano/spectre/core/BothBounds;
 	public final fun getBoundsInWindow ()Landroidx/compose/ui/geometry/Rect;
@@ -89,6 +93,7 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public final fun findOneByText (Ljava/lang/String;Z)Ldev/sebastiano/spectre/core/AutomatorNode;
 	public static synthetic fun findOneByText$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;ZILjava/lang/Object;)Ldev/sebastiano/spectre/core/AutomatorNode;
 	public final fun focusWindow (Ldev/sebastiano/spectre/core/AutomatorNode;)V
+	public final fun getInputCapabilities ()Ldev/sebastiano/spectre/core/InputCapabilities;
 	public final fun getWindows ()Ljava/util/List;
 	public final fun longClick-8Mi8wO0 (Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun longClick-8Mi8wO0$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
@@ -129,6 +134,8 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public static synthetic fun waitForVisualIdle-t_idYME$default (Ldev/sebastiano/spectre/core/ComposeAutomator;JIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun windowIdentities ()Ljava/util/List;
 	public final fun windowIdentity (I)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
+	public final fun withExclusiveInput (Ldev/sebastiano/spectre/core/InputLeaseOptions;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun withExclusiveInput$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ldev/sebastiano/spectre/core/InputLeaseOptions;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun withTracing (Ljava/nio/file/Path;Ldev/sebastiano/spectre/core/Tracer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun withTracing$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/nio/file/Path;Ldev/sebastiano/spectre/core/Tracer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
@@ -138,6 +145,39 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator$Companion {
 	public static synthetic fun inProcess$default (Ldev/sebastiano/spectre/core/ComposeAutomator$Companion;Ldev/sebastiano/spectre/core/RobotDriver;ZILjava/lang/Object;)Ldev/sebastiano/spectre/core/ComposeAutomator;
 }
 
+public final class dev/sebastiano/spectre/core/ContendedEdtInputLeaseException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class dev/sebastiano/spectre/core/DesktopInputIsolation {
+	public static final field INSTANCE Ldev/sebastiano/spectre/core/DesktopInputIsolation;
+	public final fun acquire (Ldev/sebastiano/spectre/core/InputLeaseOptions;)Ldev/sebastiano/spectre/core/AutomatorInputLease;
+	public static synthetic fun acquire$default (Ldev/sebastiano/spectre/core/DesktopInputIsolation;Ldev/sebastiano/spectre/core/InputLeaseOptions;ILjava/lang/Object;)Ldev/sebastiano/spectre/core/AutomatorInputLease;
+}
+
+public final class dev/sebastiano/spectre/core/ExclusiveInputScope {
+	public final fun clearAndTypeText (Ldev/sebastiano/spectre/core/AutomatorNode;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun click (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun doubleClick (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun focusWindow (Ldev/sebastiano/spectre/core/AutomatorNode;)V
+	public final fun longClick-8Mi8wO0 (Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun longClick-8Mi8wO0$default (Ldev/sebastiano/spectre/core/ExclusiveInputScope;Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun moveBy (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun moveTo (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun moveTo (Ldev/sebastiano/spectre/core/AutomatorNode;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun pasteText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun pressEnter (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun pressKey (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun pressKey$default (Ldev/sebastiano/spectre/core/ExclusiveInputScope;IILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun scrollWheel (Ldev/sebastiano/spectre/core/AutomatorNode;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun swipe-x2RqbK4 (IIIIIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun swipe-x2RqbK4$default (Ldev/sebastiano/spectre/core/ExclusiveInputScope;IIIIIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun swipe-zkXUZaI (Ldev/sebastiano/spectre/core/AutomatorNode;Ldev/sebastiano/spectre/core/AutomatorNode;IJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun swipe-zkXUZaI$default (Ldev/sebastiano/spectre/core/ExclusiveInputScope;Ldev/sebastiano/spectre/core/AutomatorNode;Ldev/sebastiano/spectre/core/AutomatorNode;IJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun typeText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class dev/sebastiano/spectre/core/HiDpiMapperKt {
 	public static final fun composeBoundsToAwtCenter (FFFFFFII)Ljava/awt/Point;
 	public static final fun composeBoundsToAwtRectangle (FFFFFFII)Ljava/awt/Rectangle;
@@ -145,6 +185,43 @@ public final class dev/sebastiano/spectre/core/HiDpiMapperKt {
 
 public final class dev/sebastiano/spectre/core/IdleTimeoutException : java/lang/RuntimeException {
 	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class dev/sebastiano/spectre/core/InputCapabilities {
+	public fun <init> (ZZ)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun copy (ZZ)Ldev/sebastiano/spectre/core/InputCapabilities;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/core/InputCapabilities;ZZILjava/lang/Object;)Ldev/sebastiano/spectre/core/InputCapabilities;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getRealOsInput ()Z
+	public final fun getRequiresDesktopCoordination ()Z
+	public final fun getSharedSystemClipboard ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/InputLeaseOptions {
+	public synthetic fun <init> (JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-UwyO8pc ()J
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy-VtjQ1oo (JLjava/lang/String;)Ldev/sebastiano/spectre/core/InputLeaseOptions;
+	public static synthetic fun copy-VtjQ1oo$default (Ldev/sebastiano/spectre/core/InputLeaseOptions;JLjava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/core/InputLeaseOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAcquireTimeout-UwyO8pc ()J
+	public final fun getOwnerLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/core/InputLeasePolicy : java/lang/Enum {
+	public static final field Auto Ldev/sebastiano/spectre/core/InputLeasePolicy;
+	public static final field Off Ldev/sebastiano/spectre/core/InputLeasePolicy;
+	public static final field Required Ldev/sebastiano/spectre/core/InputLeasePolicy;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/core/InputLeasePolicy;
+	public static fun values ()[Ldev/sebastiano/spectre/core/InputLeasePolicy;
 }
 
 public abstract interface annotation class dev/sebastiano/spectre/core/InternalSpectreApi : java/lang/annotation/Annotation {
@@ -186,10 +263,13 @@ public final class dev/sebastiano/spectre/core/PerfettoTracer$Companion {
 public final class dev/sebastiano/spectre/core/RobotDriver {
 	public static final field Companion Ldev/sebastiano/spectre/core/RobotDriver$Companion;
 	public fun <init> ()V
+	public fun <init> (Ldev/sebastiano/spectre/core/InputLeasePolicy;)V
 	public fun <init> (Ljava/awt/Robot;)V
+	public fun <init> (Ljava/awt/Robot;Ldev/sebastiano/spectre/core/InputLeasePolicy;)V
 	public final fun clearAndTypeText (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun click (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun doubleClick (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getInputCapabilities ()Ldev/sebastiano/spectre/core/InputCapabilities;
 	public final fun longClick-exY8QGI (IIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun longClick-exY8QGI$default (Ldev/sebastiano/spectre/core/RobotDriver;IIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun moveBy (IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -210,6 +290,7 @@ public final class dev/sebastiano/spectre/core/RobotDriver {
 public final class dev/sebastiano/spectre/core/RobotDriver$Companion {
 	public final fun headless ()Ldev/sebastiano/spectre/core/RobotDriver;
 	public final fun synthetic (Ljava/awt/Window;)Ldev/sebastiano/spectre/core/RobotDriver;
+	public final fun synthetic (Ljava/awt/Window;Ldev/sebastiano/spectre/core/InputLeasePolicy;)Ldev/sebastiano/spectre/core/RobotDriver;
 }
 
 public final class dev/sebastiano/spectre/core/SurfaceIdAssigner {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
 }
 
 dependencies {
+    api(projects.inputCoordinator)
     implementation(libs.compose.runtime)
     implementation(libs.compose.foundation)
     // compose-ui is `api` because the public AutomatorNode surface exposes its types
@@ -32,6 +33,7 @@ dependencies {
 
     testImplementation(libs.kotlin.testJunit5)
     testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(projects.inputCoordinatorServer)
     testRuntimeOnly(projects.recording)
 }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -1,4 +1,7 @@
-@file:OptIn(InternalSpectreApi::class)
+@file:OptIn(
+    InternalSpectreApi::class,
+    dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class,
+)
 
 package dev.sebastiano.spectre.core
 
@@ -10,6 +13,7 @@ import dev.sebastiano.spectre.core.capture.AtomicCaptureBuilder
 import dev.sebastiano.spectre.core.capture.CaptureNodeSnapshot
 import dev.sebastiano.spectre.core.perf.ExperimentalSpectreApi
 import dev.sebastiano.spectre.core.perf.RecompositionMonitor
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
 import java.awt.Rectangle
 import java.awt.event.KeyEvent
 import java.awt.image.BufferedImage
@@ -43,6 +47,25 @@ private constructor(
 
     private val screenCaptureBackend: ScreenCaptureBackend =
         PlatformScreenCaptureBackend(robotDriver)
+
+    /** Shared-OS-resource capabilities of this automator's input driver. */
+    @ExperimentalSpectreInputCoordinationApi
+    public val inputCapabilities: InputCapabilities
+        get() = robotDriver.inputCapabilities
+
+    /** Holds one reentrant desktop lease across the complete [block]. */
+    @ExperimentalSpectreInputCoordinationApi
+    public suspend fun <T> withExclusiveInput(
+        options: InputLeaseOptions = InputLeaseOptions(),
+        block: suspend ExclusiveInputScope.() -> T,
+    ): T =
+        robotDriver.withExclusiveInput(options) {
+            ExclusiveInputScope(this@ComposeAutomator).block()
+        }
+
+    internal fun bindInputLease(
+        lease: dev.sebastiano.spectre.input.CoordinatedInputLease
+    ): AutoCloseable = robotDriver.bindInputLease(lease)
 
     /**
      * Snapshot of the currently tracked windows. Returns the live `TrackedWindow` collaborator
@@ -205,8 +228,10 @@ private constructor(
     }
 
     public suspend fun clearAndTypeText(node: AutomatorNode, text: String) {
-        click(node)
-        robotDriver.clearAndTypeText(text)
+        robotDriver.withExclusiveInput(InputLeaseOptions()) {
+            click(node)
+            robotDriver.clearAndTypeText(text)
+        }
     }
 
     public suspend fun pressKey(keyCode: Int, modifiers: Int = 0) {
@@ -220,9 +245,14 @@ private constructor(
     /**
      * Raises and requests focus on the AWT window that hosts [node]. Useful before a sequence of
      * Robot-driven inputs on a non-focused window. The actual focus change is dispatched on the
-     * EDT.
+     * EDT. A coordinated EDT caller must already hold the lease or acquire it immediately;
+     * contention fails without blocking.
      */
     public fun focusWindow(node: AutomatorNode) {
+        robotDriver.withBlockingInput("focusWindow") { focusWindowUncoordinated(node) }
+    }
+
+    internal fun focusWindowUncoordinated(node: AutomatorNode) {
         val window = node.trackedWindow.window
         if (SwingUtilities.isEventDispatchThread()) {
             window.toFront()
@@ -233,6 +263,10 @@ private constructor(
                 window.requestFocus()
             }
         }
+    }
+
+    internal fun checkpointInputLease() {
+        robotDriver.withBlockingInput("exclusiveFocusCheckpoint") {}
     }
 
     /**

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ExclusiveInputScope.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ExclusiveInputScope.kt
@@ -1,0 +1,60 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.core
+
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+
+/** Coordinated input verbs available while [ComposeAutomator.withExclusiveInput] owns a lease. */
+@ExperimentalSpectreInputCoordinationApi
+public class ExclusiveInputScope internal constructor(private val automator: ComposeAutomator) {
+    public suspend fun click(node: AutomatorNode): Unit = automator.click(node)
+
+    public suspend fun doubleClick(node: AutomatorNode): Unit = automator.doubleClick(node)
+
+    public suspend fun longClick(node: AutomatorNode, holdFor: Duration = 500.milliseconds): Unit =
+        automator.longClick(node, holdFor)
+
+    public suspend fun moveTo(node: AutomatorNode): Unit = automator.moveTo(node)
+
+    public suspend fun moveTo(x: Int, y: Int): Unit = automator.moveTo(x, y)
+
+    public suspend fun moveBy(deltaX: Int, deltaY: Int): Unit = automator.moveBy(deltaX, deltaY)
+
+    public suspend fun swipe(
+        startX: Int,
+        startY: Int,
+        endX: Int,
+        endY: Int,
+        steps: Int = 12,
+        duration: Duration = 200.milliseconds,
+    ): Unit = automator.swipe(startX, startY, endX, endY, steps, duration)
+
+    public suspend fun swipe(
+        from: AutomatorNode,
+        to: AutomatorNode,
+        steps: Int = 12,
+        duration: Duration = 200.milliseconds,
+    ): Unit = automator.swipe(from, to, steps, duration)
+
+    public suspend fun scrollWheel(node: AutomatorNode, wheelClicks: Int): Unit =
+        automator.scrollWheel(node, wheelClicks)
+
+    public suspend fun typeText(text: String): Unit = automator.typeText(text)
+
+    public suspend fun pasteText(text: String): Unit = automator.pasteText(text)
+
+    public suspend fun clearAndTypeText(node: AutomatorNode, text: String): Unit =
+        automator.clearAndTypeText(node, text)
+
+    public suspend fun pressKey(keyCode: Int, modifiers: Int = 0): Unit =
+        automator.pressKey(keyCode, modifiers)
+
+    public suspend fun pressEnter(): Unit = automator.pressEnter()
+
+    public fun focusWindow(node: AutomatorNode) {
+        automator.checkpointInputLease()
+        automator.focusWindowUncoordinated(node)
+    }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -73,6 +73,9 @@ public class ContendedEdtInputLeaseException(message: String, cause: Throwable? 
 public interface AutomatorInputLease : AutoCloseable {
     /** Binds this lease to [automator] until the returned handle is closed. */
     public fun bind(automator: ComposeAutomator): AutoCloseable
+
+    /** Makes this lease ambient while synchronous factory/setup code creates its automator. */
+    public fun <T> withLease(block: () -> T): T = block()
 }
 
 /** Internal integration entry point for acquiring whole-test desktop input leases. */
@@ -101,6 +104,8 @@ private class ProductionAutomatorInputLease(
 
     override fun bind(automator: ComposeAutomator): AutoCloseable = automator.bindInputLease(lease)
 
+    override fun <T> withLease(block: () -> T): T = AmbientInputLease.withLease(lease, block)
+
     override fun close() {
         if (!closed.compareAndSet(false, true)) return
         try {
@@ -128,6 +133,23 @@ internal enum class CoordinatedResource {
     FOCUS,
 }
 
+internal object AmbientInputLease {
+    private val current = ThreadLocal<CoordinatedInputLease?>()
+
+    fun current(): CoordinatedInputLease? = current.get()
+
+    fun <T> withLease(lease: CoordinatedInputLease, block: () -> T): T {
+        val previous = current.get()
+        current.set(lease)
+        return try {
+            lease.checkpoint()
+            block()
+        } finally {
+            if (previous == null) current.remove() else current.set(previous)
+        }
+    }
+}
+
 internal class InputLeaseGuard(
     private val policy: InputLeasePolicy,
     private val capabilities: InputCapabilities,
@@ -142,6 +164,10 @@ internal class InputLeaseGuard(
         block: suspend () -> T,
     ): T {
         boundLease.get()?.let { lease ->
+            lease.checkpoint()
+            return block()
+        }
+        AmbientInputLease.current()?.let { lease ->
             lease.checkpoint()
             return block()
         }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -111,12 +111,14 @@ private class ProductionAutomatorInputLease(
     }
 }
 
-internal fun interface InputLeaseCoordinator {
+internal fun interface InputLeaseCoordinator : AutoCloseable {
     suspend fun acquire(
         options: InputLeaseOptions,
         currentOperation: String,
         immediate: Boolean,
     ): CoordinatedInputLease
+
+    override fun close(): Unit = Unit
 }
 
 internal enum class CoordinatedResource {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -1,0 +1,347 @@
+@file:OptIn(
+    InternalSpectreApi::class,
+    dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class,
+)
+
+package dev.sebastiano.spectre.core
+
+import dev.sebastiano.spectre.input.CoordinatedInputLease
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import dev.sebastiano.spectre.input.InputCoordinatorClientFactory
+import dev.sebastiano.spectre.input.InputCoordinatorException
+import dev.sebastiano.spectre.input.LeaseErrorCode
+import dev.sebastiano.spectre.input.LocalCoordinatorEnvironment
+import dev.sebastiano.spectre.input.LocalInputCoordinatorClient
+import java.io.IOException
+import java.time.Duration as JavaDuration
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.SwingUtilities
+import kotlin.coroutines.AbstractCoroutineContextElement
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.coroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.withContext
+
+/** Controls whether this driver participates in cooperative desktop input coordination. */
+@ExperimentalSpectreInputCoordinationApi
+public enum class InputLeasePolicy {
+    /**
+     * Coordinates shared OS resources when the process artifact is available; a missing provider
+     * degrades to uncoordinated operation while all other coordinator failures remain loud.
+     */
+    Auto,
+
+    /** Requires coordination for every capability that touches shared OS state. */
+    Required,
+
+    /** Explicitly opts out because coordination is provided externally or is not wanted. */
+    Off,
+}
+
+/** Read-only capabilities used by JUnit and advanced integrations to choose isolation. */
+@ExperimentalSpectreInputCoordinationApi
+public data class InputCapabilities(
+    public val realOsInput: Boolean,
+    public val sharedSystemClipboard: Boolean,
+) {
+    public val requiresDesktopCoordination: Boolean
+        get() = realOsInput || sharedSystemClipboard
+}
+
+/** Acquisition options for an explicit input transaction or whole-test lease. */
+@ExperimentalSpectreInputCoordinationApi
+public data class InputLeaseOptions(
+    public val acquireTimeout: Duration = 30.seconds,
+    public val ownerLabel: String? = null,
+)
+
+/** Raised instead of waiting for a contended lease on the AUT's AWT event-dispatch thread. */
+@ExperimentalSpectreInputCoordinationApi
+public class ContendedEdtInputLeaseException(message: String, cause: Throwable? = null) :
+    IllegalStateException(message, cause)
+
+/**
+ * Internal integration handle used by Spectre's in-process test wrappers to bind one lease to an
+ * automator for a complete test lifecycle.
+ */
+@InternalSpectreApi
+public interface AutomatorInputLease : AutoCloseable {
+    /** Binds this lease to [automator] until the returned handle is closed. */
+    public fun bind(automator: ComposeAutomator): AutoCloseable
+}
+
+/** Internal integration entry point for acquiring whole-test desktop input leases. */
+@InternalSpectreApi
+public object DesktopInputIsolation {
+    /** Acquires a lease synchronously for a JUnit lifecycle running off the AWT EDT. */
+    public fun acquire(options: InputLeaseOptions = InputLeaseOptions()): AutomatorInputLease {
+        val coordinator = ProductionInputLeaseCoordinator()
+        val lease =
+            runCatching {
+                    runBlocking { coordinator.acquire(options, "junitPerTest", immediate = false) }
+                }
+                .getOrElse { failure ->
+                    coordinator.close()
+                    throw failure
+                }
+        return ProductionAutomatorInputLease(lease, coordinator)
+    }
+}
+
+private class ProductionAutomatorInputLease(
+    private val lease: CoordinatedInputLease,
+    private val coordinator: ProductionInputLeaseCoordinator,
+) : AutomatorInputLease {
+    private val closed = java.util.concurrent.atomic.AtomicBoolean()
+
+    override fun bind(automator: ComposeAutomator): AutoCloseable = automator.bindInputLease(lease)
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        try {
+            lease.close()
+        } finally {
+            coordinator.close()
+        }
+    }
+}
+
+internal fun interface InputLeaseCoordinator {
+    suspend fun acquire(
+        options: InputLeaseOptions,
+        currentOperation: String,
+        immediate: Boolean,
+    ): CoordinatedInputLease
+}
+
+internal enum class CoordinatedResource {
+    DESKTOP_ANY,
+    REAL_INPUT,
+    SYSTEM_CLIPBOARD,
+    FOCUS,
+}
+
+internal class InputLeaseGuard(
+    private val policy: InputLeasePolicy,
+    private val capabilities: InputCapabilities,
+    private val coordinator: InputLeaseCoordinator,
+) {
+    private val boundLease = AtomicReference<CoordinatedInputLease?>()
+
+    suspend fun <T> withOperation(
+        currentOperation: String,
+        resource: CoordinatedResource,
+        options: InputLeaseOptions = InputLeaseOptions(),
+        block: suspend () -> T,
+    ): T {
+        boundLease.get()?.let { lease ->
+            lease.checkpoint()
+            return block()
+        }
+        if (!coordinates(resource)) return block()
+        val ambient = coroutineContext[LeaseContext]
+        if (ambient?.guard === this) {
+            ambient.lease.checkpoint()
+            return block()
+        }
+        val immediate = SwingUtilities.isEventDispatchThread()
+        val lease =
+            try {
+                coordinator.acquire(options, currentOperation, immediate)
+            } catch (failure: InputCoordinatorException) {
+                if (
+                    policy == InputLeasePolicy.Auto && failure.errorCode in AUTO_DEGRADE_ERROR_CODES
+                ) {
+                    return block()
+                }
+                if (immediate) {
+                    throw ContendedEdtInputLeaseException(
+                        "Desktop input is contended on the EDT (${failure.message}). " +
+                            "Acquire with withExclusiveInput from a non-EDT test thread or use " +
+                            "JUnit per-test input isolation.",
+                        failure,
+                    )
+                }
+                throw failure
+            }
+        return try {
+            lease.checkpoint()
+            withContext(LeaseContext(this, lease)) { block() }
+        } finally {
+            lease.close()
+        }
+    }
+
+    suspend fun checkpoint() {
+        boundLease.get()?.checkpoint()
+            ?: coroutineContext[LeaseContext]?.takeIf { it.guard === this }?.lease?.checkpoint()
+    }
+
+    fun bind(lease: CoordinatedInputLease): AutoCloseable {
+        check(boundLease.compareAndSet(null, lease)) {
+            "This RobotDriver is already bound to a live per-test input lease"
+        }
+        return AutoCloseable { boundLease.compareAndSet(lease, null) }
+    }
+
+    private fun coordinates(resource: CoordinatedResource): Boolean {
+        if (policy == InputLeasePolicy.Off) return false
+        return when (resource) {
+            CoordinatedResource.DESKTOP_ANY -> capabilities.requiresDesktopCoordination
+            CoordinatedResource.REAL_INPUT,
+            CoordinatedResource.FOCUS -> capabilities.realOsInput
+            CoordinatedResource.SYSTEM_CLIPBOARD -> capabilities.sharedSystemClipboard
+        }
+    }
+
+    private class LeaseContext(val guard: InputLeaseGuard, val lease: CoordinatedInputLease) :
+        AbstractCoroutineContextElement(LeaseContext) {
+        companion object Key : CoroutineContext.Key<LeaseContext>
+    }
+
+    private companion object {
+        val AUTO_DEGRADE_ERROR_CODES: Set<String> =
+            setOf("COORDINATOR_PROVIDER_MISSING", "COORDINATOR_SESSION_UNAVAILABLE")
+    }
+}
+
+internal class DriverInputCoordination(private val guard: InputLeaseGuard) {
+    suspend fun checkpoint() {
+        guard.checkpoint()
+    }
+
+    suspend fun <T> withOperation(
+        operation: String,
+        resource: CoordinatedResource,
+        block: suspend () -> T,
+    ): T = guard.withOperation(operation, resource, block = block)
+
+    suspend fun <T> withExclusiveInput(options: InputLeaseOptions, block: suspend () -> T): T =
+        guard.withOperation(
+            currentOperation = "exclusiveInput",
+            resource = CoordinatedResource.DESKTOP_ANY,
+            options = options,
+            block = block,
+        )
+
+    fun bind(lease: CoordinatedInputLease): AutoCloseable = guard.bind(lease)
+
+    fun <T> withBlockingInput(operation: String, block: () -> T): T = runBlocking {
+        guard.withOperation(operation, CoordinatedResource.FOCUS) { block() }
+    }
+}
+
+internal suspend fun <T> RobotDriver.withExclusiveInput(
+    options: InputLeaseOptions,
+    block: suspend () -> T,
+): T = inputCoordination.withExclusiveInput(options, block)
+
+internal fun RobotDriver.bindInputLease(lease: CoordinatedInputLease): AutoCloseable =
+    inputCoordination.bind(lease)
+
+internal fun <T> RobotDriver.withBlockingInput(operation: String, block: () -> T): T =
+    inputCoordination.withBlockingInput(operation, block)
+
+internal class ProductionInputLeaseCoordinator(
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val connectClient: ((String?) -> LocalInputCoordinatorClient)? = null,
+) : InputLeaseCoordinator, AutoCloseable {
+    private val client = AtomicReference<LocalInputCoordinatorClient?>()
+
+    override suspend fun acquire(
+        options: InputLeaseOptions,
+        currentOperation: String,
+        immediate: Boolean,
+    ): CoordinatedInputLease {
+        if (immediate && client.get() == null) {
+            throw InputCoordinatorException(
+                errorCode = "COORDINATOR_SESSION_UNAVAILABLE",
+                message =
+                    "The coordinator session is not connected; establish an exclusive lease " +
+                        "off the EDT",
+            )
+        }
+        if (immediate) {
+            return requireNotNull(client.get()).tryAcquire(currentOperation)
+        }
+        return runInterruptible(ioDispatcher) { acquireBlocking(options, currentOperation) }
+    }
+
+    override fun close() {
+        client.getAndSet(null)?.close()
+    }
+
+    private fun acquireBlocking(
+        options: InputLeaseOptions,
+        currentOperation: String,
+    ): CoordinatedInputLease {
+        repeat(MAX_CONNECT_ATTEMPTS) { attempt ->
+            var activeClient: LocalInputCoordinatorClient? = null
+            try {
+                activeClient = currentClient(options.ownerLabel)
+                return activeClient.acquire(
+                    JavaDuration.ofMillis(options.acquireTimeout.inWholeMilliseconds),
+                    currentOperation,
+                )
+            } catch (failure: IOException) {
+                if (Thread.currentThread().isInterrupted) {
+                    throw InterruptedException("Input lease acquisition was cancelled").apply {
+                        initCause(failure)
+                    }
+                }
+                activeClient?.let(::discard)
+                if (attempt == MAX_CONNECT_ATTEMPTS - 1) {
+                    throw InputCoordinatorException(
+                            errorCode = "COORDINATOR_IO",
+                            message = "Input coordinator connection failed: ${failure.message}",
+                        )
+                        .apply { initCause(failure) }
+                }
+            } catch (failure: InputCoordinatorException) {
+                if (failure.errorCode != LeaseErrorCode.STALE_EPOCH.name) throw failure
+                activeClient?.let(::discard)
+                if (attempt == MAX_CONNECT_ATTEMPTS - 1) throw failure
+            }
+        }
+        error("Input coordinator acquisition retry loop exhausted")
+    }
+
+    private fun currentClient(ownerLabel: String?): LocalInputCoordinatorClient =
+        client.get()
+            ?: openClient(ownerLabel)
+                .also { opened -> if (!client.compareAndSet(null, opened)) opened.close() }
+                .let { client.get() ?: it }
+
+    private fun discard(staleClient: LocalInputCoordinatorClient) {
+        if (client.compareAndSet(staleClient, null)) staleClient.close()
+    }
+
+    private fun openClient(ownerLabel: String?): LocalInputCoordinatorClient =
+        connectClient?.invoke(ownerLabel) ?: connectCoordinator(ownerLabel)
+
+    private fun connectCoordinator(ownerLabel: String?): LocalInputCoordinatorClient =
+        try {
+            InputCoordinatorClientFactory.connectOrStart(ownerLabel = ownerLabel)
+        } catch (failure: InputCoordinatorException) {
+            if (failure.errorCode != "COORDINATOR_PROVIDER_MISSING") throw failure
+            try {
+                LocalInputCoordinatorClient.connect(
+                    LocalCoordinatorEnvironment.defaultEndpoint(),
+                    LocalCoordinatorEnvironment.defaultDesktopResourceKey(),
+                    ownerLabel,
+                )
+            } catch (connectionFailure: IOException) {
+                failure.addSuppressed(connectionFailure)
+                throw failure
+            }
+        }
+
+    private companion object {
+        const val MAX_CONNECT_ATTEMPTS: Int = 2
+    }
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -241,7 +241,7 @@ internal class InputLeaseGuard(
     private fun coordinates(resource: CoordinatedResource): Boolean {
         if (policy == InputLeasePolicy.Off) return false
         return when (resource) {
-            CoordinatedResource.DESKTOP_ANY -> capabilities.requiresDesktopCoordination
+            CoordinatedResource.DESKTOP_ANY -> true
             CoordinatedResource.REAL_INPUT -> capabilities.realOsInput
             CoordinatedResource.FOCUS -> true
             CoordinatedResource.SYSTEM_CLIPBOARD -> capabilities.sharedSystemClipboard

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -23,6 +23,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
@@ -171,7 +172,12 @@ internal class InputLeaseGuard(
         val operationContext = coroutineContext[LeaseContext]
         if (operationContext?.guard === this) {
             operationContext.lease?.checkpoint()
-            return block()
+            // Child coroutines inherit LeaseContext but have distinct Jobs. Serialize those
+            // siblings while keeping same-coroutine composite operations reentrant.
+            if (operationContext.ownerJob === coroutineContext[Job]) return block()
+            return operationContext.childOperationMutex.withLock {
+                withLeaseContext(operationContext.lease, block)
+            }
         }
         val bound = boundLease.get()
         val ambient = AmbientInputLease.current()
@@ -252,12 +258,17 @@ internal class InputLeaseGuard(
         lease: CoordinatedInputLease?,
         block: suspend () -> T,
     ): T {
-        val context = LeaseContext(this, lease)
+        val context = LeaseContext(this, lease, coroutineContext[Job])
         return withContext(context + blockingContext.asContextElement(context)) { block() }
     }
 
-    private class LeaseContext(val guard: InputLeaseGuard, val lease: CoordinatedInputLease?) :
-        AbstractCoroutineContextElement(LeaseContext) {
+    private class LeaseContext(
+        val guard: InputLeaseGuard,
+        val lease: CoordinatedInputLease?,
+        val ownerJob: Job?,
+    ) : AbstractCoroutineContextElement(LeaseContext) {
+        val childOperationMutex: Mutex = Mutex()
+
         companion object Key : CoroutineContext.Key<LeaseContext>
     }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -221,8 +221,8 @@ internal class InputLeaseGuard(
         if (policy == InputLeasePolicy.Off) return false
         return when (resource) {
             CoordinatedResource.DESKTOP_ANY -> capabilities.requiresDesktopCoordination
-            CoordinatedResource.REAL_INPUT,
-            CoordinatedResource.FOCUS -> capabilities.realOsInput
+            CoordinatedResource.REAL_INPUT -> capabilities.realOsInput
+            CoordinatedResource.FOCUS -> true
             CoordinatedResource.SYSTEM_CLIPBOARD -> capabilities.sharedSystemClipboard
         }
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -207,6 +207,7 @@ internal class InputLeaseGuard(
 
     suspend fun checkpoint() {
         boundLease.get()?.checkpoint()
+            ?: AmbientInputLease.current()?.checkpoint()
             ?: coroutineContext[LeaseContext]?.takeIf { it.guard === this }?.lease?.checkpoint()
     }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -25,6 +25,8 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 
 /** Controls whether this driver participates in cooperative desktop input coordination. */
@@ -156,6 +158,7 @@ internal class InputLeaseGuard(
     private val coordinator: InputLeaseCoordinator,
 ) {
     private val boundLease = AtomicReference<CoordinatedInputLease?>()
+    private val operationMutex = Mutex()
 
     suspend fun <T> withOperation(
         currentOperation: String,
@@ -163,45 +166,47 @@ internal class InputLeaseGuard(
         options: InputLeaseOptions = InputLeaseOptions(),
         block: suspend () -> T,
     ): T {
-        boundLease.get()?.let { lease ->
-            lease.checkpoint()
+        val operationContext = coroutineContext[LeaseContext]
+        if (operationContext?.guard === this) {
+            operationContext.lease?.checkpoint()
             return block()
         }
-        AmbientInputLease.current()?.let { lease ->
-            lease.checkpoint()
-            return block()
-        }
-        if (!coordinates(resource)) return block()
-        val ambient = coroutineContext[LeaseContext]
-        if (ambient?.guard === this) {
-            ambient.lease.checkpoint()
-            return block()
-        }
-        val immediate = SwingUtilities.isEventDispatchThread()
-        val lease =
-            try {
-                coordinator.acquire(options, currentOperation, immediate)
-            } catch (failure: InputCoordinatorException) {
-                if (
-                    policy == InputLeasePolicy.Auto && failure.errorCode in AUTO_DEGRADE_ERROR_CODES
-                ) {
-                    return block()
-                }
-                if (immediate) {
-                    throw ContendedEdtInputLeaseException(
-                        "Desktop input is contended on the EDT (${failure.message}). " +
-                            "Acquire with withExclusiveInput from a non-EDT test thread or use " +
-                            "JUnit per-test input isolation.",
-                        failure,
-                    )
-                }
-                throw failure
+        val bound = boundLease.get()
+        val ambient = AmbientInputLease.current()
+        if (bound == null && ambient == null && !coordinates(resource)) return block()
+        return operationMutex.withLock {
+            val existingLease = bound ?: ambient
+            if (existingLease != null) {
+                existingLease.checkpoint()
+                return@withLock withContext(LeaseContext(this, existingLease)) { block() }
             }
-        return try {
-            lease.checkpoint()
-            withContext(LeaseContext(this, lease)) { block() }
-        } finally {
-            lease.close()
+            val immediate = SwingUtilities.isEventDispatchThread()
+            val lease =
+                try {
+                    coordinator.acquire(options, currentOperation, immediate)
+                } catch (failure: InputCoordinatorException) {
+                    if (
+                        policy == InputLeasePolicy.Auto &&
+                            failure.errorCode in AUTO_DEGRADE_ERROR_CODES
+                    ) {
+                        return@withLock withContext(LeaseContext(this, null)) { block() }
+                    }
+                    if (immediate) {
+                        throw ContendedEdtInputLeaseException(
+                            "Desktop input is contended on the EDT (${failure.message}). " +
+                                "Acquire with withExclusiveInput from a non-EDT test thread or " +
+                                "use JUnit per-test input isolation.",
+                            failure,
+                        )
+                    }
+                    throw failure
+                }
+            try {
+                lease.checkpoint()
+                withContext(LeaseContext(this, lease)) { block() }
+            } finally {
+                lease.close()
+            }
         }
     }
 
@@ -228,7 +233,7 @@ internal class InputLeaseGuard(
         }
     }
 
-    private class LeaseContext(val guard: InputLeaseGuard, val lease: CoordinatedInputLease) :
+    private class LeaseContext(val guard: InputLeaseGuard, val lease: CoordinatedInputLease?) :
         AbstractCoroutineContextElement(LeaseContext) {
         companion object Key : CoroutineContext.Key<LeaseContext>
     }
@@ -280,23 +285,26 @@ internal class ProductionInputLeaseCoordinator(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     private val connectClient: ((String?) -> LocalInputCoordinatorClient)? = null,
 ) : InputLeaseCoordinator, AutoCloseable {
-    private val client = AtomicReference<LocalInputCoordinatorClient?>()
+    private val client = AtomicReference<ClientSession?>()
 
     override suspend fun acquire(
         options: InputLeaseOptions,
         currentOperation: String,
         immediate: Boolean,
     ): CoordinatedInputLease {
-        if (immediate && client.get() == null) {
+        val currentSession = client.get()
+        if (
+            immediate && (currentSession == null || currentSession.ownerLabel != options.ownerLabel)
+        ) {
             throw InputCoordinatorException(
                 errorCode = "COORDINATOR_SESSION_UNAVAILABLE",
                 message =
-                    "The coordinator session is not connected; establish an exclusive lease " +
-                        "off the EDT",
+                    "A coordinator session with the requested owner label is not connected; " +
+                        "establish an exclusive lease off the EDT",
             )
         }
         if (immediate) {
-            return requireNotNull(client.get()).tryAcquire(currentOperation)
+            return requireNotNull(currentSession).client.tryAcquire(currentOperation)
         }
         val acquired = AtomicReference<CoordinatedInputLease?>()
         return try {
@@ -310,7 +318,7 @@ internal class ProductionInputLeaseCoordinator(
     }
 
     override fun close() {
-        client.getAndSet(null)?.close()
+        client.getAndSet(null)?.client?.close()
     }
 
     private fun acquireBlocking(
@@ -348,14 +356,28 @@ internal class ProductionInputLeaseCoordinator(
         error("Input coordinator acquisition retry loop exhausted")
     }
 
-    private fun currentClient(ownerLabel: String?): LocalInputCoordinatorClient =
-        client.get()
-            ?: openClient(ownerLabel)
-                .also { opened -> if (!client.compareAndSet(null, opened)) opened.close() }
-                .let { client.get() ?: it }
+    private fun currentClient(ownerLabel: String?): LocalInputCoordinatorClient {
+        while (true) {
+            val current = client.get()
+            if (current != null && current.ownerLabel == ownerLabel) return current.client
+            val opened = ClientSession(ownerLabel, openClient(ownerLabel))
+            if (client.compareAndSet(current, opened)) {
+                current?.client?.close()
+                return opened.client
+            }
+            opened.client.close()
+        }
+    }
 
     private fun discard(staleClient: LocalInputCoordinatorClient) {
-        if (client.compareAndSet(staleClient, null)) staleClient.close()
+        while (true) {
+            val current = client.get() ?: return
+            if (current.client !== staleClient) return
+            if (client.compareAndSet(current, null)) {
+                staleClient.close()
+                return
+            }
+        }
     }
 
     private fun openClient(ownerLabel: String?): LocalInputCoordinatorClient =
@@ -377,6 +399,11 @@ internal class ProductionInputLeaseCoordinator(
                 throw failure
             }
         }
+
+    private data class ClientSession(
+        val ownerLabel: String?,
+        val client: LocalInputCoordinatorClient,
+    )
 
     private companion object {
         const val MAX_CONNECT_ATTEMPTS: Int = 2

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -23,6 +23,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.asContextElement
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
@@ -158,6 +159,7 @@ internal class InputLeaseGuard(
     private val coordinator: InputLeaseCoordinator,
 ) {
     private val boundLease = AtomicReference<CoordinatedInputLease?>()
+    private val blockingContext = ThreadLocal<LeaseContext?>()
     private val operationMutex = Mutex()
 
     suspend fun <T> withOperation(
@@ -178,7 +180,7 @@ internal class InputLeaseGuard(
             val existingLease = bound ?: ambient
             if (existingLease != null) {
                 existingLease.checkpoint()
-                return@withLock withContext(LeaseContext(this, existingLease)) { block() }
+                return@withLock withLeaseContext(existingLease, block)
             }
             val immediate = SwingUtilities.isEventDispatchThread()
             val lease =
@@ -189,7 +191,7 @@ internal class InputLeaseGuard(
                         policy == InputLeasePolicy.Auto &&
                             failure.errorCode in AUTO_DEGRADE_ERROR_CODES
                     ) {
-                        return@withLock withContext(LeaseContext(this, null)) { block() }
+                        return@withLock withLeaseContext(null, block)
                     }
                     if (immediate) {
                         throw ContendedEdtInputLeaseException(
@@ -203,11 +205,24 @@ internal class InputLeaseGuard(
                 }
             try {
                 lease.checkpoint()
-                withContext(LeaseContext(this, lease)) { block() }
+                withLeaseContext(lease, block)
             } finally {
                 lease.close()
             }
         }
+    }
+
+    fun <T> withBlockingOperation(
+        currentOperation: String,
+        resource: CoordinatedResource,
+        block: () -> T,
+    ): T {
+        val activeContext = blockingContext.get()
+        if (activeContext?.guard === this) {
+            activeContext.lease?.checkpoint()
+            return block()
+        }
+        return runBlocking { withOperation(currentOperation, resource) { block() } }
     }
 
     suspend fun checkpoint() {
@@ -231,6 +246,14 @@ internal class InputLeaseGuard(
             CoordinatedResource.FOCUS -> true
             CoordinatedResource.SYSTEM_CLIPBOARD -> capabilities.sharedSystemClipboard
         }
+    }
+
+    private suspend fun <T> withLeaseContext(
+        lease: CoordinatedInputLease?,
+        block: suspend () -> T,
+    ): T {
+        val context = LeaseContext(this, lease)
+        return withContext(context + blockingContext.asContextElement(context)) { block() }
     }
 
     private class LeaseContext(val guard: InputLeaseGuard, val lease: CoordinatedInputLease?) :
@@ -265,9 +288,8 @@ internal class DriverInputCoordination(private val guard: InputLeaseGuard) {
 
     fun bind(lease: CoordinatedInputLease): AutoCloseable = guard.bind(lease)
 
-    fun <T> withBlockingInput(operation: String, block: () -> T): T = runBlocking {
-        guard.withOperation(operation, CoordinatedResource.FOCUS) { block() }
-    }
+    fun <T> withBlockingInput(operation: String, block: () -> T): T =
+        guard.withBlockingOperation(operation, CoordinatedResource.FOCUS, block)
 }
 
 internal suspend fun <T> RobotDriver.withExclusiveInput(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -297,7 +297,15 @@ internal class ProductionInputLeaseCoordinator(
         if (immediate) {
             return requireNotNull(client.get()).tryAcquire(currentOperation)
         }
-        return runInterruptible(ioDispatcher) { acquireBlocking(options, currentOperation) }
+        val acquired = AtomicReference<CoordinatedInputLease?>()
+        return try {
+            runInterruptible(ioDispatcher) {
+                    acquireBlocking(options, currentOperation).also(acquired::set)
+                }
+                .also { acquired.set(null) }
+        } finally {
+            acquired.getAndSet(null)?.close()
+        }
     }
 
     override fun close() {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -24,7 +24,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.asContextElement
+import kotlinx.coroutines.ThreadContextElement
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.sync.Mutex
@@ -160,7 +160,7 @@ internal class InputLeaseGuard(
     private val coordinator: InputLeaseCoordinator,
 ) {
     private val boundLease = AtomicReference<CoordinatedInputLease?>()
-    private val blockingContext = ThreadLocal<LeaseContext?>()
+    private val blockingContext = ThreadLocal<BlockingLeaseContext?>()
     private val operationMutex = Mutex()
 
     suspend fun <T> withOperation(
@@ -224,9 +224,20 @@ internal class InputLeaseGuard(
         block: () -> T,
     ): T {
         val activeContext = blockingContext.get()
-        if (activeContext?.guard === this) {
-            activeContext.lease?.checkpoint()
-            return block()
+        val leaseContext = activeContext?.leaseContext
+        if (leaseContext?.guard === this) {
+            leaseContext.lease?.checkpoint()
+            if (
+                leaseContext.ownerJob === activeContext.currentJob ||
+                    activeContext.ownsChildOperationMutex
+            ) {
+                return block()
+            }
+            return runBlocking {
+                leaseContext.childOperationMutex.withLock {
+                    withBlockingContext(activeContext.copy(ownsChildOperationMutex = true), block)
+                }
+            }
         }
         return runBlocking { withOperation(currentOperation, resource) { block() } }
     }
@@ -259,7 +270,47 @@ internal class InputLeaseGuard(
         block: suspend () -> T,
     ): T {
         val context = LeaseContext(this, lease, coroutineContext[Job])
-        return withContext(context + blockingContext.asContextElement(context)) { block() }
+        return withContext(context + BlockingLeaseContextElement(context, blockingContext)) {
+            block()
+        }
+    }
+
+    private fun <T> withBlockingContext(context: BlockingLeaseContext, block: () -> T): T {
+        val previous = blockingContext.get()
+        blockingContext.set(context)
+        return try {
+            block()
+        } finally {
+            if (previous == null) blockingContext.remove() else blockingContext.set(previous)
+        }
+    }
+
+    private data class BlockingLeaseContext(
+        val leaseContext: LeaseContext,
+        val currentJob: Job?,
+        val ownsChildOperationMutex: Boolean = false,
+    )
+
+    private class BlockingLeaseContextElement(
+        private val leaseContext: LeaseContext,
+        private val threadLocal: ThreadLocal<BlockingLeaseContext?>,
+    ) :
+        ThreadContextElement<BlockingLeaseContext?>,
+        AbstractCoroutineContextElement(BlockingLeaseContextElement) {
+        override fun updateThreadContext(context: CoroutineContext): BlockingLeaseContext? {
+            val previous = threadLocal.get()
+            threadLocal.set(BlockingLeaseContext(leaseContext, context[Job]))
+            return previous
+        }
+
+        override fun restoreThreadContext(
+            context: CoroutineContext,
+            oldState: BlockingLeaseContext?,
+        ) {
+            if (oldState == null) threadLocal.remove() else threadLocal.set(oldState)
+        }
+
+        companion object Key : CoroutineContext.Key<BlockingLeaseContextElement>
     }
 
     private class LeaseContext(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -34,7 +34,7 @@ internal constructor(
     inputLeasePolicy: InputLeasePolicy = InputLeasePolicy.Off,
     inputLeaseCoordinator: InputLeaseCoordinator = ProductionInputLeaseCoordinator(),
     inputCapabilities: InputCapabilities? = null,
-) {
+) : AutoCloseable by inputLeaseCoordinator {
 
     /** Shared-OS-resource capabilities used by isolation integrations. */
     @ExperimentalSpectreInputCoordinationApi

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -1,5 +1,8 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
 package dev.sebastiano.spectre.core
 
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
 import java.awt.GraphicsEnvironment
 import java.awt.Point
 import java.awt.Rectangle
@@ -28,7 +31,24 @@ internal constructor(
     private val clipboard: ClipboardAdapter = SystemClipboardAdapter(),
     private val tccGuard: MacOsTccGuard = defaultTccGuardFor(robot, robot),
     private val screenCapture: ScreenCaptureAdapter = robot,
+    inputLeasePolicy: InputLeasePolicy = InputLeasePolicy.Off,
+    inputLeaseCoordinator: InputLeaseCoordinator = ProductionInputLeaseCoordinator(),
+    inputCapabilities: InputCapabilities? = null,
 ) {
+
+    /** Shared-OS-resource capabilities used by isolation integrations. */
+    @ExperimentalSpectreInputCoordinationApi
+    public val inputCapabilities: InputCapabilities =
+        inputCapabilities
+            ?: InputCapabilities(
+                realOsInput = robot is AwtRobotAdapter,
+                sharedSystemClipboard = clipboard !== HeadlessThrowingClipboardAdapter,
+            )
+
+    internal val inputCoordination =
+        DriverInputCoordination(
+            InputLeaseGuard(inputLeasePolicy, this.inputCapabilities, inputLeaseCoordinator)
+        )
 
     /** Whether callers may use a platform capture backend instead of this driver's adapter. */
     internal val allowsPlatformCapture: Boolean
@@ -39,20 +59,38 @@ internal constructor(
     // adapter-injecting constructor is reserved for tests within this module.
     public constructor() : this(AwtRobotAdapter(), SystemClipboardAdapter())
 
+    /** Creates a real Robot driver with explicit cooperative input coordination [policy]. */
+    @ExperimentalSpectreInputCoordinationApi
+    public constructor(
+        policy: InputLeasePolicy
+    ) : this(
+        robot = AwtRobotAdapter(),
+        clipboard = SystemClipboardAdapter(),
+        inputLeasePolicy = policy,
+    )
+
     public constructor(robot: Robot) : this(AwtRobotAdapter(robot))
+
+    /** Wraps [robot] with explicit cooperative input coordination [policy]. */
+    @ExperimentalSpectreInputCoordinationApi
+    public constructor(
+        robot: Robot,
+        policy: InputLeasePolicy,
+    ) : this(robot = AwtRobotAdapter(robot), inputLeasePolicy = policy)
 
     private val pointer = PointerPositionTracker()
 
     /**
      * Dispatches a single left-button click at the given screen coordinates: move, press, release.
      *
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it
-     * (real `java.awt.Robot`), and dispatches inline otherwise (synthetic adapter). Throws
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves work off the EDT when the backend
+     * requires it (real `java.awt.Robot`), and dispatches inline otherwise. Throws
      * [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun click(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
-        runOffEdt {
+        runOffEdt("click") {
             pointer.moveTo(robot, screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
@@ -64,12 +102,13 @@ internal constructor(
      * press, release. The second press inherits the OS double-click window from the first release,
      * so Compose's `combinedClickable` and Swing's `MouseEvent.clickCount == 2` fire as expected.
      *
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves backend work off the EDT as needed.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun doubleClick(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
-        runOffEdt {
+        runOffEdt("doubleClick") {
             pointer.moveTo(robot, screenX, screenY)
             repeat(DOUBLE_CLICK_COUNT) {
                 robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
@@ -86,7 +125,8 @@ internal constructor(
      * The release is wrapped in a `finally` so a cancellation during the hold still lifts the mouse
      * button — otherwise subsequent clicks would be interpreted as drags.
      *
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves backend work off the EDT as needed.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun longClick(
@@ -95,11 +135,12 @@ internal constructor(
         holdFor: Duration = DEFAULT_LONG_CLICK_DURATION,
     ) {
         tccGuard.requireAccessibility()
-        runOffEdt {
+        runOffEdt("longClick") {
             pointer.moveTo(robot, screenX, screenY)
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             try {
                 delay(holdFor)
+                inputCoordination.checkpoint()
             } finally {
                 robot.mouseRelease(InputEvent.BUTTON1_DOWN_MASK)
             }
@@ -117,7 +158,8 @@ internal constructor(
      * press/move/release across distinct points as a drag, which is the contract Compose's
      * `Modifier.draggable` and lazy-list scroll expect.
      *
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves backend work off the EDT as needed.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun swipe(
@@ -129,7 +171,7 @@ internal constructor(
         duration: Duration = DEFAULT_SWIPE_DURATION,
     ) {
         tccGuard.requireAccessibility()
-        runOffEdt {
+        runOffEdt("swipe") {
             val points = interpolateSwipePoints(startX, startY, endX, endY, steps)
             val pausePerStepMs = swipePauseMillis(duration, steps, autoDelayMs = robot.autoDelayMs)
             val firstPoint = points.first()
@@ -137,6 +179,7 @@ internal constructor(
             robot.mousePress(InputEvent.BUTTON1_DOWN_MASK)
             try {
                 for (point in points.drop(1)) {
+                    inputCoordination.checkpoint()
                     pointer.moveTo(robot, point.x, point.y)
                     if (pausePerStepMs > 0) {
                         delay(pausePerStepMs.milliseconds)
@@ -162,21 +205,28 @@ internal constructor(
      * false "cleared" read-back still left host key events inverted in physical Windows
      * validation). Non-letter characters are unaffected by Caps Lock on standard keyboards.
      *
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves backend work off the EDT as needed.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun typeText(text: String) {
         tccGuard.requireAccessibility()
-        runOffEdt {
+        runOffEdt("typeText") {
             // Read once per call: ambient Caps Lock is stable for a short typeText burst, and we
             // intentionally do not write locking-key state (see KDoc).
             val capsLockOn = robot.getLockingKeyState(KeyEvent.VK_CAPS_LOCK) == true
             for (char in text) {
+                inputCoordination.checkpoint()
                 val stroke = keyStrokeForChar(char, capsLockOn = capsLockOn)
                 for (modifier in stroke.modifiers) robot.keyPress(modifier)
-                robot.keyPress(stroke.keyCode)
-                robot.keyRelease(stroke.keyCode)
-                for (modifier in stroke.modifiers.asReversed()) robot.keyRelease(modifier)
+                try {
+                    robot.keyPress(stroke.keyCode)
+                    robot.keyRelease(stroke.keyCode)
+                } finally {
+                    for (modifier in stroke.modifiers.asReversed()) {
+                        runCatching { robot.keyRelease(modifier) }
+                    }
+                }
             }
         }
     }
@@ -193,12 +243,13 @@ internal constructor(
      * the restore happens. Adapters that don't support clipboard read-back (synthetic test fakes)
      * skip both settle waits.
      *
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves backend work off the EDT as needed.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun pasteText(text: String) {
         tccGuard.requireAccessibility()
-        runOffEdt {
+        runOffEdt("pasteText", CoordinatedResource.SYSTEM_CLIPBOARD) {
             val previousContents = runCatching { clipboard.getContents() }.getOrNull()
             try {
                 clipboard.setContents(StringSelection(text))
@@ -220,9 +271,12 @@ internal constructor(
                 }
                 val modifier = shortcutModifierKeyCode(detectMacOs())
                 robot.keyPress(modifier)
-                robot.keyPress(KeyEvent.VK_V)
-                robot.keyRelease(KeyEvent.VK_V)
-                robot.keyRelease(modifier)
+                try {
+                    robot.keyPress(KeyEvent.VK_V)
+                    robot.keyRelease(KeyEvent.VK_V)
+                } finally {
+                    robot.keyRelease(modifier)
+                }
                 if (clipboard.supportsRead && robot.shouldDrainAfterClipboardPaste) {
                     // Drain queued AWT events (KEY_PRESSED/RELEASED + Compose's input
                     // pipeline) so the paste handler has a chance to read the clipboard before
@@ -261,6 +315,7 @@ internal constructor(
             if (current == expected) return
             if (System.nanoTime() >= deadline) return
             delay(pollMs.milliseconds)
+            inputCoordination.checkpoint()
         }
     }
 
@@ -271,21 +326,27 @@ internal constructor(
      * Useful for overwriting a `TextField`'s current value without the caller having to compute
      * cursor / selection state. Same caveats as [typeText] for supported characters apply.
      *
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves backend work off the EDT as needed.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun clearAndTypeText(text: String) {
-        tccGuard.requireAccessibility()
-        val selectAllModifier = shortcutModifierKeyCode(detectMacOs())
-        runOffEdt {
-            robot.keyPress(selectAllModifier)
-            robot.keyPress(KeyEvent.VK_A)
-            robot.keyRelease(KeyEvent.VK_A)
-            robot.keyRelease(selectAllModifier)
-            robot.keyPress(KeyEvent.VK_BACK_SPACE)
-            robot.keyRelease(KeyEvent.VK_BACK_SPACE)
+        inputCoordination.withOperation("clearAndTypeText", CoordinatedResource.REAL_INPUT) {
+            tccGuard.requireAccessibility()
+            val selectAllModifier = shortcutModifierKeyCode(detectMacOs())
+            runOffEdt("clearText") {
+                robot.keyPress(selectAllModifier)
+                try {
+                    robot.keyPress(KeyEvent.VK_A)
+                    robot.keyRelease(KeyEvent.VK_A)
+                } finally {
+                    robot.keyRelease(selectAllModifier)
+                }
+                robot.keyPress(KeyEvent.VK_BACK_SPACE)
+                robot.keyRelease(KeyEvent.VK_BACK_SPACE)
+            }
+            typeText(text)
         }
-        typeText(text)
     }
 
     /**
@@ -296,7 +357,7 @@ internal constructor(
      */
     public suspend fun scrollWheel(screenX: Int, screenY: Int, wheelClicks: Int) {
         tccGuard.requireAccessibility()
-        runOffEdt {
+        runOffEdt("scrollWheel") {
             pointer.moveTo(robot, screenX, screenY)
             robot.mouseWheel(wheelClicks)
         }
@@ -307,12 +368,13 @@ internal constructor(
      * this for hover, tooltip, and "park the pointer" cases that `click` / `swipe` cannot express
      * because they always press.
      *
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves backend work off the EDT as needed.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun moveTo(screenX: Int, screenY: Int) {
         tccGuard.requireAccessibility()
-        runOffEdt { pointer.moveTo(robot, screenX, screenY) }
+        runOffEdt("moveTo") { pointer.moveTo(robot, screenX, screenY) }
     }
 
     /**
@@ -322,12 +384,13 @@ internal constructor(
      * real cursor, and `java.awt.MouseInfo` is a different coordinate story.
      *
      * Throws [IllegalStateException] if no Spectre pointer move has happened yet on this driver.
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves backend work off the EDT as needed.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun moveBy(deltaX: Int, deltaY: Int) {
         tccGuard.requireAccessibility()
-        runOffEdt { pointer.moveBy(robot, deltaX, deltaY) }
+        runOffEdt("moveBy") { pointer.moveBy(robot, deltaX, deltaY) }
     }
 
     /**
@@ -336,17 +399,21 @@ internal constructor(
      * pressed before the key, released after — the modifier mask appears on the `keyCode`
      * KEY_PRESSED event and does not leak into subsequent calls.
      *
-     * Safe to call from the EDT; [RobotDriver] moves work off the EDT when the backend requires it.
+     * EDT callers require coordination to be off, already held, or immediately available;
+     * contention fails without blocking. [RobotDriver] moves backend work off the EDT as needed.
      * Throws [IllegalStateException] on macOS if Accessibility TCC permission is denied.
      */
     public suspend fun pressKey(keyCode: Int, modifiers: Int = 0) {
         tccGuard.requireAccessibility()
-        runOffEdt {
+        runOffEdt("pressKey") {
             val modifierKeys = modifierMaskToKeyCodes(modifiers)
             for (mod in modifierKeys) robot.keyPress(mod)
-            robot.keyPress(keyCode)
-            robot.keyRelease(keyCode)
-            for (mod in modifierKeys.reversed()) robot.keyRelease(mod)
+            try {
+                robot.keyPress(keyCode)
+                robot.keyRelease(keyCode)
+            } finally {
+                for (mod in modifierKeys.reversed()) robot.keyRelease(mod)
+            }
         }
     }
 
@@ -446,7 +513,13 @@ internal constructor(
         return screenCapture.createDeviceScaleScreenCapture(captureRegion)
     }
 
-    private suspend fun runOffEdt(block: suspend () -> Unit) = runOffEdt(robot, block)
+    private suspend fun runOffEdt(
+        operation: String,
+        resource: CoordinatedResource = CoordinatedResource.REAL_INPUT,
+        block: suspend () -> Unit,
+    ) {
+        inputCoordination.withOperation(operation, resource) { runOffEdt(robot, block) }
+    }
 
     public companion object {
 
@@ -464,6 +537,20 @@ internal constructor(
                     clipboard = SystemClipboardAdapter(),
                     tccGuard = defaultTccGuardFor(syntheticInput, realCapture),
                     screenCapture = realCapture,
+                )
+            }
+
+        /** Returns a synthetic-input driver with explicit shared-resource coordination [policy]. */
+        @ExperimentalSpectreInputCoordinationApi
+        public fun synthetic(rootWindow: Window, policy: InputLeasePolicy): RobotDriver =
+            SyntheticRobotAdapter(rootWindow).let { syntheticInput ->
+                val realCapture = AwtRobotAdapter()
+                RobotDriver(
+                    robot = syntheticInput,
+                    clipboard = SystemClipboardAdapter(),
+                    tccGuard = defaultTccGuardFor(syntheticInput, realCapture),
+                    screenCapture = realCapture,
+                    inputLeasePolicy = policy,
                 )
             }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
 package dev.sebastiano.spectre.core
 
 import java.lang.reflect.Modifier
@@ -248,12 +250,19 @@ class ComposeAutomatorPublicSurfaceTest {
         val DECLARED_TYPES: List<String> =
             listOf(
                 "dev.sebastiano.spectre.core.AutomatorIdlingResource",
+                "dev.sebastiano.spectre.core.AutomatorInputLease",
                 "dev.sebastiano.spectre.core.AutomatorNode",
                 "dev.sebastiano.spectre.core.AutomatorTree",
                 "dev.sebastiano.spectre.core.AutomatorWindow",
                 "dev.sebastiano.spectre.core.BothBounds",
                 "dev.sebastiano.spectre.core.ComposeAutomator",
+                "dev.sebastiano.spectre.core.ContendedEdtInputLeaseException",
+                "dev.sebastiano.spectre.core.DesktopInputIsolation",
+                "dev.sebastiano.spectre.core.ExclusiveInputScope",
                 "dev.sebastiano.spectre.core.IdleTimeoutException",
+                "dev.sebastiano.spectre.core.InputCapabilities",
+                "dev.sebastiano.spectre.core.InputLeaseOptions",
+                "dev.sebastiano.spectre.core.InputLeasePolicy",
                 "dev.sebastiano.spectre.core.InternalSpectreApi",
                 "dev.sebastiano.spectre.core.NodeKey",
                 "dev.sebastiano.spectre.core.PerfettoTracer",
@@ -295,7 +304,12 @@ class ComposeAutomatorPublicSurfaceTest {
                 "dev.sebastiano.spectre.core.AutomatorWindow",
                 "dev.sebastiano.spectre.core.BothBounds",
                 "dev.sebastiano.spectre.core.ComposeAutomator",
+                "dev.sebastiano.spectre.core.ContendedEdtInputLeaseException",
+                "dev.sebastiano.spectre.core.ExclusiveInputScope",
                 "dev.sebastiano.spectre.core.IdleTimeoutException",
+                "dev.sebastiano.spectre.core.InputCapabilities",
+                "dev.sebastiano.spectre.core.InputLeaseOptions",
+                "dev.sebastiano.spectre.core.InputLeasePolicy",
                 "dev.sebastiano.spectre.core.InternalSpectreApi",
                 "dev.sebastiano.spectre.core.NodeKey",
                 "dev.sebastiano.spectre.core.PerfettoTracer",
@@ -323,6 +337,8 @@ class ComposeAutomatorPublicSurfaceTest {
         // Reachable from Kotlin/JVM, but not part of the stability policy.
         val ESCAPE_HATCH_TYPES: Set<String> =
             setOf(
+                "dev.sebastiano.spectre.core.AutomatorInputLease",
+                "dev.sebastiano.spectre.core.DesktopInputIsolation",
                 "dev.sebastiano.spectre.core.SurfaceIdAssigner",
                 "dev.sebastiano.spectre.core.TrackedWindow",
                 "dev.sebastiano.spectre.core.WindowIdentityResolver",
@@ -335,6 +351,8 @@ class ComposeAutomatorPublicSurfaceTest {
         val COMPOSE_AUTOMATOR_PUBLISHED_METHODS: Set<String> =
             setOf(
                 "surfaceIds",
+                "getInputCapabilities",
+                "withExclusiveInput",
                 "refreshWindows",
                 "tree",
                 "allNodes",

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/DocsGuidanceContractTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/DocsGuidanceContractTest.kt
@@ -16,7 +16,11 @@ class DocsGuidanceContractTest {
                     "docs/guide/troubleshooting.md",
                     "docs/guide/selectors.md",
                     "docs/guide/interactions.md",
+                    "docs/guide/input-coordination.md",
+                    "docs/guide/agent.md",
+                    "docs/SECURITY.md",
                     "skills/spectre/SKILL.md",
+                    "skills/spectre/references/input-coordination.md",
                 )
                 .joinToString(separator = "\n") { root.resolve(it).readText() }
 
@@ -27,6 +31,12 @@ class DocsGuidanceContractTest {
         assertContains(docs, "printTree()` returns an empty string")
         assertContains(docs, "No Component provided")
         assertContains(docs, "RobotDriver.synthetic(rootWindow =")
+        assertContains(docs, "ExperimentalSpectreInputCoordinationApi")
+        assertContains(docs, "spectre-input-coordinator-server")
+        assertContains(docs, "InputIsolationConfig.perTest()")
+        assertContains(docs, "unsafeTakeover=true")
+        assertContains(docs, "best-effort attempt")
+        assertContains(docs, "does not rewrite the Windows ACL")
     }
 
     private fun assertContains(haystack: String, needle: String) {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ExperimentalInputCoordinationApiTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ExperimentalInputCoordinationApiTest.kt
@@ -1,0 +1,69 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.core
+
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import java.awt.Robot
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ExperimentalInputCoordinationApiTest {
+
+    @Test
+    fun `core coordination types and entry points remain experimental`() {
+        listOf(
+                ContendedEdtInputLeaseException::class.java,
+                ExclusiveInputScope::class.java,
+                InputCapabilities::class.java,
+                InputLeaseOptions::class.java,
+                InputLeasePolicy::class.java,
+            )
+            .forEach { type ->
+                assertNotNull(
+                    type.getAnnotation(ExperimentalSpectreInputCoordinationApi::class.java),
+                    "${type.name} must remain experimental until the coordination API graduates",
+                )
+            }
+
+        assertNotNull(
+            ComposeAutomator::class
+                .java
+                .methods
+                .single { it.name == "withExclusiveInput" }
+                .getAnnotation(ExperimentalSpectreInputCoordinationApi::class.java)
+        )
+
+        val composeSource =
+            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt").readText()
+        val robotSource =
+            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt").readText()
+        val scopeSource =
+            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/ExclusiveInputScope.kt").readText()
+        assertTrue(
+            composeSource.contains(
+                "@ExperimentalSpectreInputCoordinationApi\n    public val inputCapabilities"
+            )
+        )
+        assertTrue(
+            robotSource.contains(
+                "@ExperimentalSpectreInputCoordinationApi\n    public val inputCapabilities"
+            )
+        )
+        assertTrue(scopeSource.contains("automator.checkpointInputLease()"))
+
+        listOf(
+                RobotDriver::class.java.getConstructor(InputLeasePolicy::class.java),
+                RobotDriver::class
+                    .java
+                    .getConstructor(Robot::class.java, InputLeasePolicy::class.java),
+            )
+            .forEach { constructor ->
+                assertNotNull(
+                    constructor.getAnnotation(ExperimentalSpectreInputCoordinationApi::class.java)
+                )
+            }
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ExperimentalInputCoordinationApiTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ExperimentalInputCoordinationApiTest.kt
@@ -37,11 +37,14 @@ class ExperimentalInputCoordinationApiTest {
         )
 
         val composeSource =
-            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt").readText()
+            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt")
+                .readNormalizedText()
         val robotSource =
-            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt").readText()
+            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt")
+                .readNormalizedText()
         val scopeSource =
-            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/ExclusiveInputScope.kt").readText()
+            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/ExclusiveInputScope.kt")
+                .readNormalizedText()
         assertTrue(
             composeSource.contains(
                 "@ExperimentalSpectreInputCoordinationApi\n    public val inputCapabilities"
@@ -67,3 +70,5 @@ class ExperimentalInputCoordinationApiTest {
             }
     }
 }
+
+private fun Path.readNormalizedText(): String = readText().replace("\r\n", "\n")

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardBlockingSerializationTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardBlockingSerializationTest.kt
@@ -1,0 +1,105 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.core
+
+import dev.sebastiano.spectre.input.CoordinatedInputLease
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseToken
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
+
+class InputLeaseGuardBlockingSerializationTest {
+
+    @Test
+    fun `sibling blocking operations inside an exclusive scope are serialized`() {
+        val coordinator = SingleLeaseCoordinator()
+        val guard =
+            InputLeaseGuard(
+                policy = InputLeasePolicy.Required,
+                capabilities = InputCapabilities(realOsInput = true, sharedSystemClipboard = true),
+                coordinator = coordinator,
+            )
+        val executor = Executors.newFixedThreadPool(3)
+        executor.asCoroutineDispatcher().use { dispatcher ->
+            runBlocking(dispatcher) {
+                guard.withOperation("exclusiveInput", CoordinatedResource.DESKTOP_ANY) {
+                    coroutineScope {
+                        val firstEntered = CountDownLatch(1)
+                        val releaseFirst = CountDownLatch(1)
+                        val secondReady = CountDownLatch(1)
+                        val secondEntered = CountDownLatch(1)
+                        val first = async {
+                            guard.withBlockingOperation("first", CoordinatedResource.REAL_INPUT) {
+                                guard.withBlockingOperation(
+                                    "firstNested",
+                                    CoordinatedResource.REAL_INPUT,
+                                ) {
+                                    firstEntered.countDown()
+                                    assertTrue(releaseFirst.await(5, TimeUnit.SECONDS))
+                                }
+                            }
+                        }
+                        assertTrue(firstEntered.await(5, TimeUnit.SECONDS))
+                        val second = async {
+                            secondReady.countDown()
+                            guard.withBlockingOperation("second", CoordinatedResource.REAL_INPUT) {
+                                secondEntered.countDown()
+                            }
+                        }
+
+                        assertTrue(secondReady.await(5, TimeUnit.SECONDS))
+                        try {
+                            assertFalse(secondEntered.await(250, TimeUnit.MILLISECONDS))
+                        } finally {
+                            releaseFirst.countDown()
+                        }
+                        first.await()
+                        second.await()
+                    }
+                }
+            }
+        }
+
+        assertEquals(1, coordinator.acquisitions)
+        assertEquals(1, coordinator.releases)
+    }
+
+    private class SingleLeaseCoordinator : InputLeaseCoordinator {
+        var acquisitions: Int = 0
+        var releases: Int = 0
+
+        override suspend fun acquire(
+            options: InputLeaseOptions,
+            currentOperation: String,
+            immediate: Boolean,
+        ): CoordinatedInputLease {
+            acquisitions += 1
+            return object : CoordinatedInputLease {
+                override val token =
+                    LeaseToken(
+                        coordinatorEpoch = "epoch",
+                        leaseId = "lease",
+                        resourceKey = DesktopResourceKey("test/desktop"),
+                        fence = 1,
+                    )
+
+                override fun isValid(): Boolean = true
+
+                override fun checkpoint(): Unit = Unit
+
+                override fun close() {
+                    releases += 1
+                }
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -58,6 +58,18 @@ class InputLeaseGuardTest {
     }
 
     @Test
+    fun `ambient whole-test lease prevents factory driver self-contention`() {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver = realDriver(coordinator)
+        val wholeTestLease = recordingLease()
+
+        AmbientInputLease.withLease(wholeTestLease) { runBlocking { driver.click(10, 20) } }
+
+        assertEquals(2, wholeTestLease.checkpoints)
+        assertTrue(coordinator.operations.isEmpty())
+    }
+
+    @Test
     fun `automator exclusive scope exposes coordinated input verbs and capabilities`() = runTest {
         val coordinator = RecordingInputLeaseCoordinator()
         val driver = realDriver(coordinator)

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -62,6 +62,31 @@ class InputLeaseGuardTest {
     }
 
     @Test
+    fun `blocking focus within an exclusive scope remains reentrant`() {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver = realDriver(coordinator)
+        val executor = Executors.newSingleThreadExecutor()
+
+        try {
+            val completed =
+                executor.submit<Boolean> {
+                    runBlocking {
+                        driver.withExclusiveInput(InputLeaseOptions(ownerLabel = "transaction")) {
+                            driver.withBlockingInput("focusWindow") {}
+                        }
+                    }
+                    true
+                }
+
+            assertTrue(completed.get(5, TimeUnit.SECONDS))
+            assertEquals(listOf("exclusiveInput"), coordinator.operations)
+            assertEquals(1, coordinator.closedLeases)
+        } finally {
+            executor.shutdownNow()
+        }
+    }
+
+    @Test
     fun `concurrent top-level operations on one driver are serialized`() = runTest {
         val coordinator = RecordingInputLeaseCoordinator()
         val guard =

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -71,6 +71,33 @@ class InputLeaseGuardTest {
     }
 
     @Test
+    fun `ambient whole-test lease fences type burst at operation checkpoint`() {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val robot = LeaseTestRobotAdapter()
+        val driver =
+            RobotDriver(
+                robot = robot,
+                clipboard = LeaseTestClipboardAdapter(),
+                inputLeasePolicy = InputLeasePolicy.Required,
+                inputLeaseCoordinator = coordinator,
+                inputCapabilities =
+                    InputCapabilities(realOsInput = true, sharedSystemClipboard = true),
+            )
+        val wholeTestLease = recordingLease(failCheckpointAt = 4)
+
+        val failure =
+            assertFailsWith<InputCoordinatorException> {
+                AmbientInputLease.withLease(wholeTestLease) {
+                    runBlocking { driver.typeText("abc") }
+                }
+            }
+
+        assertEquals("FENCED", failure.errorCode)
+        assertEquals(listOf("press:65", "release:65"), robot.events)
+        assertTrue(coordinator.operations.isEmpty())
+    }
+
+    @Test
     fun `automator exclusive scope exposes coordinated input verbs and capabilities`() = runTest {
         val coordinator = RecordingInputLeaseCoordinator()
         val driver = realDriver(coordinator)
@@ -468,9 +495,11 @@ class InputLeaseGuardTest {
     }
 }
 
-private fun recordingLease(): RecordingCoordinatedInputLease = RecordingCoordinatedInputLease()
+private fun recordingLease(failCheckpointAt: Int? = null): RecordingCoordinatedInputLease =
+    RecordingCoordinatedInputLease(failCheckpointAt)
 
-private class RecordingCoordinatedInputLease : CoordinatedInputLease {
+private class RecordingCoordinatedInputLease(private val failCheckpointAt: Int?) :
+    CoordinatedInputLease {
     var checkpoints: Int = 0
 
     override val token =
@@ -485,6 +514,9 @@ private class RecordingCoordinatedInputLease : CoordinatedInputLease {
 
     override fun checkpoint() {
         checkpoints += 1
+        if (checkpoints == failCheckpointAt) {
+            throw InputCoordinatorException("FENCED", "revoked")
+        }
     }
 
     override fun close(): Unit = Unit

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -23,13 +23,16 @@ import javax.swing.SwingUtilities
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.yield
 
 class InputLeaseGuardTest {
 
@@ -56,6 +59,40 @@ class InputLeaseGuardTest {
 
         assertEquals(listOf("exclusiveInput"), coordinator.operations)
         assertEquals(1, coordinator.closedLeases)
+    }
+
+    @Test
+    fun `concurrent top-level operations on one driver are serialized`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val guard =
+            InputLeaseGuard(
+                policy = InputLeasePolicy.Required,
+                capabilities = InputCapabilities(realOsInput = true, sharedSystemClipboard = true),
+                coordinator = coordinator,
+            )
+        val firstEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        val secondEntered = CompletableDeferred<Unit>()
+
+        val first = async {
+            guard.withOperation("first", CoordinatedResource.REAL_INPUT) {
+                firstEntered.complete(Unit)
+                releaseFirst.await()
+            }
+        }
+        firstEntered.await()
+        val second = async {
+            guard.withOperation("second", CoordinatedResource.REAL_INPUT) {
+                secondEntered.complete(Unit)
+            }
+        }
+        yield()
+
+        assertFalse(secondEntered.isCompleted)
+        releaseFirst.complete(Unit)
+        first.await()
+        second.await()
+        assertEquals(listOf("first", "second"), coordinator.operations)
     }
 
     @Test
@@ -153,6 +190,32 @@ class InputLeaseGuardTest {
     }
 
     @Test
+    fun `auto provider fallback remains reentrant for nested composite operations`() = runTest {
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure =
+                    InputCoordinatorException(
+                        "COORDINATOR_PROVIDER_MISSING",
+                        "runtime artifact unavailable",
+                    )
+            )
+        val guard =
+            InputLeaseGuard(
+                policy = InputLeasePolicy.Auto,
+                capabilities = InputCapabilities(realOsInput = true, sharedSystemClipboard = true),
+                coordinator = coordinator,
+            )
+
+        withTimeout(1_000) {
+            guard.withOperation("outer", CoordinatedResource.REAL_INPUT) {
+                guard.withOperation("inner", CoordinatedResource.REAL_INPUT) {}
+            }
+        }
+
+        assertEquals(listOf("outer"), coordinator.operations)
+    }
+
+    @Test
     fun `auto keeps non-provider coordinator failures loud`() = runTest {
         val coordinator =
             RecordingInputLeaseCoordinator(
@@ -232,6 +295,46 @@ class InputLeaseGuardTest {
                 }
 
             coordinator.acquire(InputLeaseOptions(), "after restart", immediate = false).close()
+        } finally {
+            coordinator.close()
+            server.close()
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory.resolve("coordinator.lock"))
+            Files.deleteIfExists(directory.resolve("recovery.properties.tmp"))
+            Files.deleteIfExists(directory.resolve("recovery.properties"))
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
+    fun `production coordinator reopens an idle session when owner label changes`() = runBlocking {
+        val directory = Files.createTempDirectory("spc-label-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val resource = DesktopResourceKey("test/owner-label")
+        val server =
+            LocalCoordinatorServer(endpoint, idleTimeout = JavaDuration.ofMinutes(1)).also {
+                it.start()
+            }
+        val coordinator =
+            ProductionInputLeaseCoordinator(
+                connectClient = { label ->
+                    LocalInputCoordinatorClient.connect(endpoint, resource, label)
+                }
+            )
+        try {
+            coordinator.acquire(InputLeaseOptions(), "unlabeled", immediate = false).close()
+            val labeled =
+                coordinator.acquire(
+                    InputLeaseOptions(ownerLabel = "submits checkout"),
+                    "labeled",
+                    immediate = false,
+                )
+
+            val status = LocalInputCoordinatorControl(endpoint).status(resource)
+            assertTrue(status is CoordinatorControlResult.Active)
+            assertEquals("submits checkout", status.status.holder?.owner?.label)
+
+            labeled.close()
         } finally {
             coordinator.close()
             server.close()

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -83,6 +83,16 @@ class InputLeaseGuardTest {
     }
 
     @Test
+    fun `closing a driver releases its coordinator session`() {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver = realDriver(coordinator)
+
+        driver.close()
+
+        assertEquals(1, coordinator.closeCount)
+    }
+
+    @Test
     fun `auto degrades only when the coordinator provider is unavailable`() = runTest {
         val coordinator =
             RecordingInputLeaseCoordinator(
@@ -454,6 +464,7 @@ private class RecordingInputLeaseCoordinator(
     val operations = mutableListOf<String>()
     val immediateRequests = mutableListOf<Boolean>()
     var closedLeases: Int = 0
+    var closeCount: Int = 0
 
     override suspend fun acquire(
         options: InputLeaseOptions,
@@ -490,5 +501,9 @@ private class RecordingInputLeaseCoordinator(
                 closedLeases += 1
             }
         }
+    }
+
+    override fun close() {
+        closeCount += 1
     }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -29,6 +29,7 @@ import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
@@ -118,6 +119,47 @@ class InputLeaseGuardTest {
         first.await()
         second.await()
         assertEquals(listOf("first", "second"), coordinator.operations)
+    }
+
+    @Test
+    fun `sibling operations inside an exclusive scope are serialized`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val guard =
+            InputLeaseGuard(
+                policy = InputLeasePolicy.Required,
+                capabilities = InputCapabilities(realOsInput = true, sharedSystemClipboard = true),
+                coordinator = coordinator,
+            )
+        val firstEntered = CompletableDeferred<Unit>()
+        val releaseFirst = CompletableDeferred<Unit>()
+        val secondEntered = CompletableDeferred<Unit>()
+
+        guard.withOperation("exclusiveInput", CoordinatedResource.DESKTOP_ANY) {
+            coroutineScope {
+                val first = async {
+                    guard.withOperation("first", CoordinatedResource.REAL_INPUT) {
+                        guard.withOperation("firstNested", CoordinatedResource.REAL_INPUT) {
+                            firstEntered.complete(Unit)
+                            releaseFirst.await()
+                        }
+                    }
+                }
+                firstEntered.await()
+                val second = async {
+                    guard.withOperation("second", CoordinatedResource.REAL_INPUT) {
+                        secondEntered.complete(Unit)
+                    }
+                }
+                yield()
+
+                assertFalse(secondEntered.isCompleted)
+                releaseFirst.complete(Unit)
+                first.await()
+                second.await()
+            }
+        }
+
+        assertEquals(listOf("exclusiveInput"), coordinator.operations)
     }
 
     @Test

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -24,6 +24,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.async
 import kotlinx.coroutines.runBlocking
@@ -273,6 +274,48 @@ class InputLeaseGuardTest {
         }
 
     @Test
+    fun `cancellation after production acquisition closes the discarded lease`() = runTest {
+        val directory = Files.createTempDirectory("spc-h-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val resource = DesktopResourceKey("test/cancelled-handoff")
+        val server =
+            LocalCoordinatorServer(endpoint, idleTimeout = JavaDuration.ofMinutes(1)).also {
+                it.start()
+            }
+        val acquisitionDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+        val coordinator =
+            ProductionInputLeaseCoordinator(
+                ioDispatcher = acquisitionDispatcher,
+                connectClient = { label ->
+                    LocalInputCoordinatorClient.connect(endpoint, resource, label)
+                },
+            )
+        try {
+            val discarded =
+                async(start = CoroutineStart.UNDISPATCHED) {
+                    coordinator.acquire(InputLeaseOptions(), "discarded", immediate = false)
+                }
+            awaitHolder(endpoint, resource)
+
+            discarded.cancel()
+            discarded.join()
+
+            LocalInputCoordinatorClient.connect(endpoint, resource, "successor").use { successor ->
+                successor.acquire(JavaDuration.ofSeconds(2), "successor").close()
+            }
+        } finally {
+            coordinator.close()
+            acquisitionDispatcher.close()
+            server.close()
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory.resolve("coordinator.lock"))
+            Files.deleteIfExists(directory.resolve("recovery.properties.tmp"))
+            Files.deleteIfExists(directory.resolve("recovery.properties"))
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
     fun `driver-bound lease takes precedence even when operation acquisition is off`() = runTest {
         val coordinator = RecordingInputLeaseCoordinator()
         val driver = realDriver(coordinator, policy = InputLeasePolicy.Off)
@@ -411,6 +454,17 @@ class InputLeaseGuardTest {
             Thread.onSpinWait()
         }
         assertTrue(false, "Timed out waiting for $expected queued lease request")
+    }
+
+    private fun awaitHolder(endpoint: CoordinatorEndpoint, resource: DesktopResourceKey) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+        while (System.nanoTime() < deadline) {
+            val status = LocalInputCoordinatorControl(endpoint).status(resource)
+            val active = status as? CoordinatorControlResult.Active
+            if (active?.status?.holder != null) return
+            Thread.onSpinWait()
+        }
+        assertTrue(false, "Timed out waiting for a granted lease")
     }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -316,6 +316,24 @@ class InputLeaseGuardTest {
     }
 
     @Test
+    fun `synthetic focus participates when coordination is required`() {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver =
+            RobotDriver(
+                robot = LeaseTestRobotAdapter(),
+                clipboard = LeaseTestClipboardAdapter(),
+                inputLeasePolicy = InputLeasePolicy.Required,
+                inputLeaseCoordinator = coordinator,
+                inputCapabilities =
+                    InputCapabilities(realOsInput = false, sharedSystemClipboard = false),
+            )
+
+        driver.withBlockingInput("focusWindow") {}
+
+        assertEquals(listOf("focusWindow"), coordinator.operations)
+    }
+
+    @Test
     fun `headless failure happens without coordinator acquisition`() = runTest {
         val coordinator = RecordingInputLeaseCoordinator()
         val driver =

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -1,0 +1,494 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.core
+
+import dev.sebastiano.spectre.input.CoordinatedInputLease
+import dev.sebastiano.spectre.input.CoordinatorControlResult
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.InputCoordinatorException
+import dev.sebastiano.spectre.input.LeaseToken
+import dev.sebastiano.spectre.input.LocalInputCoordinatorClient
+import dev.sebastiano.spectre.input.LocalInputCoordinatorControl
+import dev.sebastiano.spectre.input.server.LocalCoordinatorServer
+import java.awt.Rectangle
+import java.awt.datatransfer.Transferable
+import java.awt.image.BufferedImage
+import java.io.IOException
+import java.nio.file.Files
+import java.time.Duration as JavaDuration
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlinx.coroutines.asCoroutineDispatcher
+import kotlinx.coroutines.async
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
+
+class InputLeaseGuardTest {
+
+    @Test
+    fun `clear and type acquires once around the whole composite`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver = realDriver(coordinator)
+
+        driver.clearAndTypeText("abc")
+
+        assertEquals(listOf("clearAndTypeText"), coordinator.operations)
+        assertEquals(1, coordinator.closedLeases)
+    }
+
+    @Test
+    fun `explicit exclusive scope is reentrant across operations`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver = realDriver(coordinator)
+
+        driver.withExclusiveInput(InputLeaseOptions(ownerLabel = "transaction")) {
+            driver.click(10, 20)
+            driver.typeText("a")
+        }
+
+        assertEquals(listOf("exclusiveInput"), coordinator.operations)
+        assertEquals(1, coordinator.closedLeases)
+    }
+
+    @Test
+    fun `automator exclusive scope exposes coordinated input verbs and capabilities`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver = realDriver(coordinator)
+        val automator = ComposeAutomator.inProcess(driver, discoverWindows = false)
+
+        automator.withExclusiveInput(InputLeaseOptions(ownerLabel = "form")) {
+            typeText("a")
+            pressKey(java.awt.event.KeyEvent.VK_ENTER)
+        }
+
+        assertTrue(automator.inputCapabilities.realOsInput)
+        assertEquals(listOf("exclusiveInput"), coordinator.operations)
+    }
+
+    @Test
+    fun `off policy never contacts coordinator`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Off)
+
+        driver.click(1, 2)
+
+        assertTrue(coordinator.operations.isEmpty())
+    }
+
+    @Test
+    fun `auto degrades only when the coordinator provider is unavailable`() = runTest {
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure =
+                    InputCoordinatorException(
+                        "COORDINATOR_PROVIDER_MISSING",
+                        "runtime artifact unavailable",
+                    )
+            )
+        val autoDriver = realDriver(coordinator, policy = InputLeasePolicy.Auto)
+        val requiredDriver = realDriver(coordinator, policy = InputLeasePolicy.Required)
+
+        autoDriver.click(1, 2)
+        val requiredFailure =
+            assertFailsWith<InputCoordinatorException> { requiredDriver.click(1, 2) }
+
+        assertEquals("COORDINATOR_PROVIDER_MISSING", requiredFailure.errorCode)
+    }
+
+    @Test
+    fun `auto keeps non-provider coordinator failures loud`() = runTest {
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure = InputCoordinatorException("FENCED", "lease was revoked")
+            )
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Auto)
+
+        val failure = assertFailsWith<InputCoordinatorException> { driver.click(1, 2) }
+
+        assertEquals("FENCED", failure.errorCode)
+    }
+
+    @Test
+    fun `auto on EDT degrades when no coordinator session can be established`() {
+        val coordinator =
+            ProductionInputLeaseCoordinator(
+                connectClient = {
+                    throw InputCoordinatorException(
+                        "COORDINATOR_PROVIDER_MISSING",
+                        "runtime artifact unavailable",
+                    )
+                }
+            )
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Auto)
+        var failure: Throwable? = null
+
+        SwingUtilities.invokeAndWait {
+            failure = runCatching { runBlocking { driver.click(1, 2) } }.exceptionOrNull()
+        }
+
+        coordinator.close()
+        assertEquals(null, failure)
+    }
+
+    @Test
+    fun `production coordinator retries and classifies connection IO failures`() = runBlocking {
+        var attempts = 0
+        val coordinator =
+            ProductionInputLeaseCoordinator(
+                connectClient = {
+                    attempts += 1
+                    throw IOException("coordinator did not become ready")
+                }
+            )
+
+        val failure =
+            assertFailsWith<InputCoordinatorException> {
+                coordinator.acquire(InputLeaseOptions(), "click", immediate = false)
+            }
+
+        assertEquals(2, attempts)
+        assertEquals("COORDINATOR_IO", failure.errorCode)
+    }
+
+    @Test
+    fun `production coordinator reconnects after server epoch changes`() = runBlocking {
+        val directory = Files.createTempDirectory("spc-r-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val resource = DesktopResourceKey("test/reconnect")
+        var server =
+            LocalCoordinatorServer(endpoint, idleTimeout = JavaDuration.ofMinutes(1)).also {
+                it.start()
+            }
+        val coordinator =
+            ProductionInputLeaseCoordinator(
+                connectClient = { label ->
+                    LocalInputCoordinatorClient.connect(endpoint, resource, label)
+                }
+            )
+        try {
+            coordinator.acquire(InputLeaseOptions(), "before restart", immediate = false).close()
+            server.close()
+            Files.deleteIfExists(endpoint.socketPath)
+            server =
+                LocalCoordinatorServer(endpoint, idleTimeout = JavaDuration.ofMinutes(1)).also {
+                    it.start()
+                }
+
+            coordinator.acquire(InputLeaseOptions(), "after restart", immediate = false).close()
+        } finally {
+            coordinator.close()
+            server.close()
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory.resolve("coordinator.lock"))
+            Files.deleteIfExists(directory.resolve("recovery.properties.tmp"))
+            Files.deleteIfExists(directory.resolve("recovery.properties"))
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
+    fun `cancelling queued production acquisition removes waiter and permits successor`() =
+        runBlocking {
+            val directory = Files.createTempDirectory("spc-core-cancel-")
+            val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+            val resource = DesktopResourceKey("test/coroutine-cancellation")
+            val server =
+                LocalCoordinatorServer(
+                        endpoint,
+                        heartbeatTimeout = JavaDuration.ofSeconds(5),
+                        idleTimeout = JavaDuration.ofMinutes(1),
+                    )
+                    .also { it.start() }
+            val holderClient = LocalInputCoordinatorClient.connect(endpoint, resource, "holder")
+            val holder = holderClient.acquire(JavaDuration.ofSeconds(2), "holder")
+            val acquisitionDispatcher = Executors.newSingleThreadExecutor().asCoroutineDispatcher()
+            val coordinator =
+                ProductionInputLeaseCoordinator(
+                    connectClient = { label ->
+                        LocalInputCoordinatorClient.connect(endpoint, resource, label)
+                    }
+                )
+            try {
+                val cancelled =
+                    async(acquisitionDispatcher) {
+                        assertFailsWith<kotlinx.coroutines.TimeoutCancellationException> {
+                            withTimeout(100) {
+                                coordinator.acquire(
+                                    InputLeaseOptions(
+                                        acquireTimeout = kotlin.time.Duration.parse("10s")
+                                    ),
+                                    "cancelled",
+                                    immediate = false,
+                                )
+                            }
+                        }
+                    }
+                awaitWaiterCount(endpoint, resource, 1)
+                cancelled.await()
+                awaitWaiterCount(endpoint, resource, 0)
+                holder.close()
+
+                coordinator.acquire(InputLeaseOptions(), "successor", immediate = false).close()
+            } finally {
+                coordinator.close()
+                acquisitionDispatcher.close()
+                holder.close()
+                holderClient.close()
+                server.close()
+                Files.deleteIfExists(endpoint.socketPath)
+                Files.deleteIfExists(directory.resolve("coordinator.lock"))
+                Files.deleteIfExists(directory.resolve("recovery.properties.tmp"))
+                Files.deleteIfExists(directory.resolve("recovery.properties"))
+                Files.deleteIfExists(directory)
+            }
+        }
+
+    @Test
+    fun `driver-bound lease takes precedence even when operation acquisition is off`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Off)
+        val boundLease = recordingLease()
+
+        driver.bindInputLease(boundLease).use { driver.click(1, 2) }
+
+        assertEquals(1, boundLease.checkpoints)
+        assertTrue(coordinator.operations.isEmpty())
+    }
+
+    @Test
+    fun `binding a second live test lease fails closed`() {
+        val driver = realDriver(RecordingInputLeaseCoordinator(), policy = InputLeasePolicy.Off)
+        val firstBinding = driver.bindInputLease(recordingLease())
+
+        try {
+            assertFailsWith<IllegalStateException> { driver.bindInputLease(recordingLease()) }
+        } finally {
+            firstBinding.close()
+        }
+    }
+
+    @Test
+    fun `synthetic pointer bypasses coordinator while shared clipboard participates`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver =
+            RobotDriver(
+                robot = LeaseTestRobotAdapter(),
+                clipboard = LeaseTestClipboardAdapter(),
+                inputLeasePolicy = InputLeasePolicy.Auto,
+                inputLeaseCoordinator = coordinator,
+                inputCapabilities =
+                    InputCapabilities(realOsInput = false, sharedSystemClipboard = true),
+            )
+
+        driver.click(1, 2)
+        driver.pasteText("hello")
+
+        assertEquals(listOf("pasteText"), coordinator.operations)
+    }
+
+    @Test
+    fun `headless failure happens without coordinator acquisition`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver =
+            RobotDriver(
+                robot = ThrowingLeaseTestRobotAdapter,
+                clipboard = ThrowingLeaseTestClipboardAdapter,
+                tccGuard = MacOsTccGuard.noop(),
+                screenCapture = ThrowingLeaseTestRobotAdapter,
+                inputLeasePolicy = InputLeasePolicy.Required,
+                inputLeaseCoordinator = coordinator,
+                inputCapabilities =
+                    InputCapabilities(realOsInput = false, sharedSystemClipboard = false),
+            )
+
+        assertFailsWith<UnsupportedOperationException> { driver.click(1, 2) }
+        assertTrue(coordinator.operations.isEmpty())
+    }
+
+    @Test
+    fun `contended EDT operation requests immediate acquisition instead of waiting`() {
+        val coordinator = RecordingInputLeaseCoordinator(failImmediate = true)
+        val driver = realDriver(coordinator)
+        var failure: Throwable? = null
+
+        SwingUtilities.invokeAndWait {
+            failure = runCatching { runBlocking { driver.click(1, 2) } }.exceptionOrNull()
+        }
+
+        assertTrue(failure is ContendedEdtInputLeaseException)
+        assertEquals(listOf(true), coordinator.immediateRequests)
+    }
+
+    @Test
+    fun `fenced type burst stops at next character checkpoint`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator(failCheckpointAt = 3)
+        val robot = LeaseTestRobotAdapter()
+        val driver =
+            RobotDriver(
+                robot = robot,
+                clipboard = LeaseTestClipboardAdapter(),
+                inputLeasePolicy = InputLeasePolicy.Required,
+                inputLeaseCoordinator = coordinator,
+                inputCapabilities =
+                    InputCapabilities(realOsInput = true, sharedSystemClipboard = true),
+            )
+
+        val failure = assertFailsWith<InputCoordinatorException> { driver.typeText("abc") }
+
+        assertEquals("FENCED", failure.errorCode)
+        assertEquals(listOf("press:65", "release:65"), robot.events)
+    }
+
+    private fun realDriver(
+        coordinator: InputLeaseCoordinator,
+        policy: InputLeasePolicy = InputLeasePolicy.Required,
+    ): RobotDriver =
+        RobotDriver(
+            robot = LeaseTestRobotAdapter(),
+            clipboard = LeaseTestClipboardAdapter(),
+            inputLeasePolicy = policy,
+            inputLeaseCoordinator = coordinator,
+            inputCapabilities = InputCapabilities(realOsInput = true, sharedSystemClipboard = true),
+        )
+
+    private fun awaitWaiterCount(
+        endpoint: CoordinatorEndpoint,
+        resource: DesktopResourceKey,
+        expected: Int,
+    ) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+        while (System.nanoTime() < deadline) {
+            val status = LocalInputCoordinatorControl(endpoint).status(resource)
+            val active = status as? CoordinatorControlResult.Active
+            if (active?.status?.waiters?.size == expected) return
+            Thread.onSpinWait()
+        }
+        assertTrue(false, "Timed out waiting for $expected queued lease request")
+    }
+}
+
+private fun recordingLease(): RecordingCoordinatedInputLease = RecordingCoordinatedInputLease()
+
+private class RecordingCoordinatedInputLease : CoordinatedInputLease {
+    var checkpoints: Int = 0
+
+    override val token =
+        LeaseToken(
+            coordinatorEpoch = "epoch",
+            leaseId = "bound-lease",
+            resourceKey = DesktopResourceKey("test/desktop"),
+            fence = 1,
+        )
+
+    override fun isValid(): Boolean = true
+
+    override fun checkpoint() {
+        checkpoints += 1
+    }
+
+    override fun close(): Unit = Unit
+}
+
+private open class LeaseTestRobotAdapter : RobotAdapter {
+    val events = mutableListOf<String>()
+    override val autoDelayMs: Int = 0
+    override val requiresOffEdt: Boolean = false
+
+    override fun mouseMove(x: Int, y: Int): Unit = Unit
+
+    override fun mousePress(buttons: Int): Unit = Unit
+
+    override fun mouseRelease(buttons: Int): Unit = Unit
+
+    override fun keyPress(keyCode: Int) {
+        events += "press:$keyCode"
+    }
+
+    override fun keyRelease(keyCode: Int) {
+        events += "release:$keyCode"
+    }
+
+    override fun mouseWheel(wheelClicks: Int): Unit = Unit
+
+    override fun waitForIdle(): Unit = Unit
+
+    override fun createScreenCapture(region: Rectangle): BufferedImage =
+        BufferedImage(region.width, region.height, BufferedImage.TYPE_INT_ARGB)
+}
+
+private class LeaseTestClipboardAdapter : ClipboardAdapter {
+    private var contents: Transferable? = null
+
+    override val supportsRead: Boolean = false
+
+    override fun getContents(): Transferable? = contents
+
+    override fun setContents(contents: Transferable) {
+        this.contents = contents
+    }
+}
+
+private object ThrowingLeaseTestRobotAdapter : LeaseTestRobotAdapter() {
+    override fun mouseMove(x: Int, y: Int): Unit = throw UnsupportedOperationException("headless")
+}
+
+private object ThrowingLeaseTestClipboardAdapter : ClipboardAdapter {
+    override fun getContents(): Transferable? = throw UnsupportedOperationException("headless")
+
+    override fun setContents(contents: Transferable): Unit =
+        throw UnsupportedOperationException("headless")
+}
+
+private class RecordingInputLeaseCoordinator(
+    private val failImmediate: Boolean = false,
+    private val failCheckpointAt: Int? = null,
+    private val acquireFailure: InputCoordinatorException? = null,
+) : InputLeaseCoordinator {
+    val operations = mutableListOf<String>()
+    val immediateRequests = mutableListOf<Boolean>()
+    var closedLeases: Int = 0
+
+    override suspend fun acquire(
+        options: InputLeaseOptions,
+        currentOperation: String,
+        immediate: Boolean,
+    ): CoordinatedInputLease {
+        operations += currentOperation
+        immediateRequests += immediate
+        acquireFailure?.let { throw it }
+        if (immediate && failImmediate) {
+            throw ContendedEdtInputLeaseException("held by another test")
+        }
+        return object : CoordinatedInputLease {
+            private var checkpoints: Int = 0
+
+            override val token =
+                LeaseToken(
+                    coordinatorEpoch = "epoch",
+                    leaseId = "lease-${operations.size}",
+                    resourceKey = DesktopResourceKey("test/desktop"),
+                    fence = 1,
+                )
+
+            override fun isValid(): Boolean = true
+
+            override fun checkpoint() {
+                checkpoints += 1
+                if (checkpoints == failCheckpointAt) {
+                    throw InputCoordinatorException("FENCED", "revoked")
+                }
+            }
+
+            override fun close() {
+                closedLeases += 1
+            }
+        }
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -532,6 +532,27 @@ class InputLeaseGuardTest {
     }
 
     @Test
+    fun `synthetic explicit scope coordinates focus for the whole scope`() = runTest {
+        val coordinator = RecordingInputLeaseCoordinator()
+        val driver =
+            RobotDriver(
+                robot = LeaseTestRobotAdapter(),
+                clipboard = LeaseTestClipboardAdapter(),
+                inputLeasePolicy = InputLeasePolicy.Required,
+                inputLeaseCoordinator = coordinator,
+                inputCapabilities =
+                    InputCapabilities(realOsInput = false, sharedSystemClipboard = false),
+            )
+
+        driver.withExclusiveInput(InputLeaseOptions(ownerLabel = "synthetic scope")) {
+            driver.withBlockingInput("focusWindow") {}
+        }
+
+        assertEquals(listOf("exclusiveInput"), coordinator.operations)
+        assertEquals(1, coordinator.closedLeases)
+    }
+
+    @Test
     fun `headless failure happens without coordinator acquisition`() = runTest {
         val coordinator = RecordingInputLeaseCoordinator()
         val driver =

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ReleasePublicationContractTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ReleasePublicationContractTest.kt
@@ -1,0 +1,21 @@
+package dev.sebastiano.spectre.core
+
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ReleasePublicationContractTest {
+
+    @Test
+    fun `release publishes both input coordinator artifacts`() {
+        val workflow = root.resolve(".github/workflows/release.yml").readText()
+
+        assertTrue(workflow.contains(":input-coordinator:publishToMavenCentral"))
+        assertTrue(workflow.contains(":input-coordinator-server:publishToMavenCentral"))
+    }
+
+    private companion object {
+        val root: Path = Path.of("..").toAbsolutePath().normalize()
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,6 +5,8 @@
 ```text
 spectre
 ├── core/                    — shared automation model and desktop automation primitives
+├── input-coordinator/       — published local protocol, identity, client, and fencing tokens
+├── input-coordinator-server/— published external FIFO coordinator process and recovery state
 ├── server/                  — optional transport layer for cross-JVM access
 ├── cli/                     — agent-facing CLI / daemon / MCP entrypoint
 ├── recording/               — screenshot / recording API and common JVM implementation
@@ -32,6 +34,9 @@ recording-windows  ─┘
 Guidelines:
 
 - `core` owns the reusable automation concepts.
+- `core` implementation-depends only on `input-coordinator`; CLI, testing, and the attaching-side
+  agent bring `input-coordinator-server`. The injected agent relocates only client/protocol classes
+  and must never contain a server main or launcher.
 - `server` should be transport-only glue over `core`, not a second implementation.
 - `sample-desktop` is a harness, not the source of truth for automation logic.
 - `testing` should exercise public seams and reusable fixtures, not reach through private internals
@@ -81,6 +86,16 @@ Expected long-term responsibilities:
 - remote client
 
 Keep server concerns out of the core data model unless they are genuinely transport-independent.
+
+### Desktop input coordinator
+
+One owner-only local process serializes the logical `desktop-interaction` resource per normalized
+OS user/desktop key. Its deterministic state machine owns FIFO acquisition, bounded queues,
+heartbeats, epochs, fencing, restart quarantine, compare-and-revoke, and audited unsafe takeover.
+Core input guards resolve ownership as driver-bound JUnit lease, coroutine-scoped lease, then a
+fresh operation lease. Query, wait, screenshot, and recording paths stay outside the automatic
+critical section; the agent routes input through a dedicated bounded worker so lease waiters cannot
+exhaust its general query pool.
 
 
 ### `cli`

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -135,6 +135,11 @@ corresponding doc page is touched:
   `Window.focusOwner`, so `typeText` works in `apple.awt.UIElement=true` helper JVMs.
   Keep documenting `pasteText` and OS recording as separate macOS-service paths that
   UIElement mode can still break.
+- **Desktop input coordination is experimental and opt-in.** Consumer examples use
+  `ExperimentalSpectreInputCoordinationApi`; no-argument `RobotDriver()` remains uncoordinated.
+  `--force` is documented only as unsafe recovery with possible native-input overlap and
+  `unsafeTakeover=true`. The coordinator serialises participating Spectre clients, not people or
+  other automation tools.
 - **Linux Wayland routes through the portal.** Xorg/Xvfb capture uses the Linux
   helper's GStreamer `ximagesrc` path; native Wayland capture uses the portal helper.
   Do not document a silent X11 fallback on Wayland.
@@ -203,6 +208,7 @@ affected docs:
 | ----------------------------------------------------------------------- | ------------------------------------------- |
 | `ComposeAutomator`, query/interaction methods, wait helpers              | `automator.md`, `selectors.md`, `interactions.md`, `synchronization.md` |
 | `RobotDriver` factories, public constructors                            | `interactions.md`, `automator.md`           |
+| Input coordination policy, scope, runtime, or JUnit isolation           | `input-coordination.md`, `interactions.md`, `junit.md`, `ci.md`, `STABILITY.md`, `SECURITY.md` |
 | `WindowTracker`, `SemanticsReader`, `AutomatorNode`, `AutomatorTree`     | `automator.md`, `selectors.md`              |
 | `AutomatorIdlingResource`                                               | `synchronization.md`                        |
 | `ComposeAutomatorExtension`, `ComposeAutomatorRule`, `AutomatorFactory`  | `junit.md`, `getting-started.md`            |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,7 +1,8 @@
 # Publishing
 
-Spectre's library modules (`:core`, `:server`, `:recording`, `:recording-macos`,
-`:recording-linux`, `:recording-windows`, `:agent`, `:agent-runtime`, `:testing`) publish to Sonatype Central via the
+Spectre's library modules (`:core`, `:server`, `:input-coordinator`,
+`:input-coordinator-server`, `:recording`, `:recording-macos`, `:recording-linux`,
+`:recording-windows`, `:agent`, `:agent-runtime`, `:testing`) publish to Sonatype Central via the
 [`com.vanniktech.maven.publish`][vanniktech] plugin.
 The sample modules (`:sample-desktop`, `:sample-intellij-plugin`) never apply
 the plugin — they're deliverables, not libraries.
@@ -150,7 +151,7 @@ Manual promotion checklist (after the tag workflow is green):
 
 - Confirm the tag points at the intended, already-reviewed `main` SHA that completed
   [release smoke](RELEASE-SMOKE.md) (results table on file).
-- Inspect the Central Portal staging deployment for all nine modules, including
+- Inspect the Central Portal staging deployment for all eleven modules, including
   POM metadata, sources jars, javadoc jars, and Gradle module metadata.
 - Confirm `spectre-recording-<version>.jar` contains no `native/...` entries.
 - Confirm `spectre-recording-macos-<version>.jar` contains
@@ -280,6 +281,8 @@ contract (fixed required set + deps.json closure) for both arches.
 |---|---|
 | `:core` | `dev.sebastiano.spectre:spectre-core:<version>` |
 | `:server` | `dev.sebastiano.spectre:spectre-server:<version>` |
+| `:input-coordinator` | `dev.sebastiano.spectre:spectre-input-coordinator:<version>` |
+| `:input-coordinator-server` | `dev.sebastiano.spectre:spectre-input-coordinator-server:<version>` |
 | `:recording` | `dev.sebastiano.spectre:spectre-recording:<version>` |
 | `:recording-macos` | `dev.sebastiano.spectre:spectre-recording-macos:<version>` |
 | `:recording-linux` | `dev.sebastiano.spectre:spectre-recording-linux:<version>` |

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -93,7 +93,8 @@ following as **delta hard cells** on a headed macOS, Windows, and Linux Xorg/Xvf
 
 - two independent JVMs acquire real-input work in FIFO order without interleaving;
 - a queued waiter is cancelled without stranding the next waiter;
-- holder termination releases or recovers through quarantine without granting stale ownership;
+- holder session loss stays fenced until cleanup acknowledgement or exact-ID forced recovery,
+  without granting stale ownership;
 - exact-ID normal revoke cannot affect a newer lease;
 - explicit forced recovery reports `unsafeTakeover=true` and allows the queue to progress; and
 - parallel JUnit invocations using `InputIsolationConfig.perTest()` serialise factory, body,

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -69,6 +69,7 @@ These are structural, not one-release accidents:
 | --- | --- | --- |
 | CLI package-channel (Homebrew/Scoop) contracts | Structural on every Unix `check` (`python3`); install-semantics when Ruby present or under `CI` (issue #400) | Optional: install Ruby on a clean Linux box and run `./gradlew verifyHomebrewFormulaInstallSemantics` if claiming formula behaviour beyond CI |
 | Agent attach + contract corpus (live UI) | Linux Xvfb + macOS desktop; Windows **transport/ACL** unit tests | **Windows headed desktop** (not SSH-only for capture) |
+| Input coordinator contention/recovery | Deterministic + forked process on every OS | Two real-input JVMs, holder crash, exact revoke, and explicit forced recovery on a headed desktop |
 | Agent Windows UI e2e | Opt-in only: `-Pspectre.agent.attachE2e.allowWindows=true` | Run that property on Mattone-class boxes |
 | Agent real-keyboard `typeText` | Runs on CI (`CI=true`); **skipped** on developer machines | Add `-Pspectre.agent.realKeyboard=true` on an idle desktop |
 | Agent **inject** attach | Linux + macOS e2e | **Windows** inject fixture (no preinstalled core) |
@@ -84,6 +85,24 @@ These are structural, not one-release accidents:
 Capture / WGC under **SSH** (e.g. `0x80070424`, black Skiko pixels). Treat attach (semantics)
 as SSH-safe when proven; treat **pixel capture / WGC** as requiring a local interactive
 desktop session (RDP console or physical).
+
+### Experimental input coordination release gate
+
+Shipping the experimental coordinator is a release claim even though its API may change. Treat the
+following as **delta hard cells** on a headed macOS, Windows, and Linux Xorg/Xvfb desktop:
+
+- two independent JVMs acquire real-input work in FIFO order without interleaving;
+- a queued waiter is cancelled without stranding the next waiter;
+- holder termination releases or recovers through quarantine without granting stale ownership;
+- exact-ID normal revoke cannot affect a newer lease;
+- explicit forced recovery reports `unsafeTakeover=true` and allows the queue to progress; and
+- parallel JUnit invocations using `InputIsolationConfig.perTest()` serialise factory, body,
+  evidence, and teardown.
+
+The Experimental label does not turn these into soft cells. If an OS cannot be exercised, narrow
+the release notes/platform claim rather than calling the coordinator cross-platform. Making
+`Auto` the no-argument driver default is a separate stability decision and requires the full matrix
+again.
 
 ## Environments
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -5,8 +5,8 @@ test environments**. It drives real OS input, captures screenshots, and records 
 by design. This page documents the trust boundaries Spectre relies on, the security-sensitive
 capabilities it exposes, and the risks that are explicitly accepted for the pre-1.0 release.
 
-Spectre is **pre-1.0**. The HTTP transport in the `server` module is **experimental** and is
-expected to change.
+Spectre is **pre-1.0**. The HTTP transport and cooperative desktop input coordinator are
+**experimental** and expected to change.
 
 ## Reporting a vulnerability
 
@@ -47,14 +47,29 @@ out of scope.
    authentication, no encryption, and no origin check. The agent transport is intentionally
    a testing affordance for the same machine and the same user, not a remote-control
    protocol. See [Agent attach](guide/agent.md).
-5. **Bundled native helpers are trusted artifacts.** Spectre extracts and executes Swift
+
+5. **The input coordinator is a same-user cooperative boundary.** Its canonical endpoint lives in
+   a short owner-checked directory and rejects symlink/path substitution. On POSIX filesystems it
+   enforces directory mode 0700 and socket mode 0600. On Windows it uses the current user's
+   `LOCALAPPDATA` and inherits the existing directory ACL; unlike the agent transport, the
+   coordinator layer does not replace that ACL with an owner-only one. Java Unix-domain sockets do
+   not expose portable peer credentials, so requester labels are self-reported attribution, not
+   authentication. The coordinator never records typed text, clipboard contents, selectors,
+   credentials, or prompts.
+
+   Revocation requires the exact observed lease ID. Normal revoke fences the owner and waits for
+   cleanup acknowledgement or confirmed exit. `--force` may advance after grace and is recorded as
+   `unsafeTakeover=true`; it cannot retract an uninterruptible native call and never kills a
+   process. Coordinator restart enters recovery quarantine rather than assuming the desktop is
+   free.
+6. **Bundled native helpers are trusted artifacts.** Spectre extracts and executes Swift
    (`spectre-screencapture`), Rust/Linux (`spectre-wayland-helper`), and Windows
    (`spectre-window-capture.exe`) helpers from the published jar
    resources. The extraction path is process-private; the helpers are launched with `argv`
    lists (never shell strings). Developer-only override env vars exist for local iteration
    and are explicitly documented as such — see the
    [`SPECTRE_WAYLAND_HELPER` note](#developer-only-override-env-vars) below.
-6. **External binaries (ffmpeg, GStreamer, xprop, osascript) come from the host PATH.** Spectre does not
+7. **External binaries (ffmpeg, GStreamer, xprop, osascript) come from the host PATH.** Spectre does not
    pin versions and treats them as prerequisites of the host environment.
 
 ## Capabilities and their exposure

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -58,11 +58,12 @@ out of scope.
    credentials, or prompts.
 
    Revocation requires the exact observed lease ID. Normal revoke fences the owner and waits for
-   cleanup acknowledgement or confirmed exit. `--force` is an explicit unsafe decision recorded
-   as `unsafeTakeover=true`; it cannot retract an uninterruptible native call and never kills a
-   process. Coordinator restart enters recovery quarantine rather than assuming the desktop is
-   free, and that quarantine never expires automatically. An operator must inspect it and force
-   recovery with the exact predecessor lease ID.
+   cleanup acknowledgement. Session EOF also fences a live holder rather than advancing FIFO,
+   because transport loss does not prove that native input has stopped. `--force` is an explicit
+   unsafe decision recorded as `unsafeTakeover=true`; it cannot retract an uninterruptible native
+   call and never kills a process. Coordinator restart enters recovery quarantine rather than
+   assuming the desktop is free, and that quarantine never expires automatically. An operator
+   must inspect it and force recovery with the exact predecessor lease ID.
 6. **Bundled native helpers are trusted artifacts.** Spectre extracts and executes Swift
    (`spectre-screencapture`), Rust/Linux (`spectre-wayland-helper`), and Windows
    (`spectre-window-capture.exe`) helpers from the published jar

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -58,10 +58,11 @@ out of scope.
    credentials, or prompts.
 
    Revocation requires the exact observed lease ID. Normal revoke fences the owner and waits for
-   cleanup acknowledgement or confirmed exit. `--force` may advance after grace and is recorded as
-   `unsafeTakeover=true`; it cannot retract an uninterruptible native call and never kills a
+   cleanup acknowledgement or confirmed exit. `--force` is an explicit unsafe decision recorded
+   as `unsafeTakeover=true`; it cannot retract an uninterruptible native call and never kills a
    process. Coordinator restart enters recovery quarantine rather than assuming the desktop is
-   free.
+   free, and that quarantine never expires automatically. An operator must inspect it and force
+   recovery with the exact predecessor lease ID.
 6. **Bundled native helpers are trusted artifacts.** Spectre extracts and executes Swift
    (`spectre-screencapture`), Rust/Linux (`spectre-wayland-helper`), and Windows
    (`spectre-window-capture.exe`) helpers from the published jar

--- a/docs/STABILITY.md
+++ b/docs/STABILITY.md
@@ -43,7 +43,7 @@ Public declarations annotated with `@ExperimentalSpectreHttpApi` (or any future 
 the API baselines**, but they are explicitly **not covered** by compatibility guarantees and
 may change or be removed in any release, including patch releases.
 
-Three experimental markers exist today:
+Four experimental markers exist today:
 
 - **`@ExperimentalSpectreApi`** covers selected `core` APIs that are useful now but still
   settling, such as the recomposition-monitor surface exposed through
@@ -62,6 +62,11 @@ Three experimental markers exist today:
   inject-runtime packaging (attach when the target has no preinstalled `spectre-core`) is
   **experimental inspect only** for 1.0 — keep the marker; do not treat inject as a stable
   production attach mode.
+- **`@ExperimentalSpectreInputCoordinationApi`** covers the cooperative desktop coordinator,
+  its low-level client/server modules, the explicit core policy/scope entry points, and JUnit
+  whole-test isolation. It remains opt-in while desktop identity, recovery, and lifecycle
+  behaviour receive cross-platform headed smoke and real-world feedback. See
+  [Experimental desktop input coordination](guide/input-coordination.md).
 
 Consumers opt in either at file level or call site:
 
@@ -144,6 +149,13 @@ Spectre is JVM-first and targets desktop OSes.
 | **Linux Xorg** | Full | AWT Robot input + helper/GStreamer Xorg/Xvfb recording and screenshots. Validated against Xvfb in CI. |
 | **Linux Wayland** | Best-effort | Portal-mediated capture via `WaylandPortalRecorder`, `WaylandPortalWindowRecorder`, and `LinuxNativeScreenshotter`. **Validated on GNOME/Mutter only**; KDE / sway / wlroots compositors may behave differently and are not exercised in CI. Real Robot input is unavailable on Wayland — use the synthetic adapter for tests. |
 | **BSD** | Unsupported | Not built or tested. |
+
+Cooperative desktop coordination is an **Experimental** preview for participating Spectre clients
+on macOS, Windows AF_UNIX-capable releases, and Linux Xorg/Xvfb. It deliberately over-serialises
+when a safe session discriminator is unavailable. It is not an OS input grab and makes no claim
+against human or non-Spectre interference. Automatic coordination is opt-in through
+`InputLeasePolicy.Auto`/`Required` and JUnit `PerTest`; changing the no-argument driver default
+requires the full cross-platform input smoke and a separate stability decision.
 
 ## JVM runtime support tiers
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -81,6 +81,14 @@ Examples for Spectre:
 - compound node identity formatting and parsing
 - coordinate conversion behaviour across Compose/AWT/Robot units
 - native helper invocation contracts for recording
+- coordinator frames plus real forked-JVM endpoint/process behavior
+- JUnit extension/rule lease ownership across factory, artifacts, video, and teardown
+
+Desktop coordination tests use a fake clock/state machine for FIFO, fencing, expiry, cancellation,
+and recovery. At least one forked boundary test must use the real local socket and process. Live
+desktop validation records lease ordering and an observable UI result; a skipped assumption is not
+a pass. Platform release smoke covers macOS, Windows, and Linux Xorg/Xvfb independently, while
+Wayland remains synthetic-input-only.
 
 These tests should use the real payload or coordinate format rather than a hand-crafted idealized
 version. Unit tests for internal math are necessary, but boundary tests catch drift between layers.

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -150,6 +150,12 @@ After that, calls such as `windows()`, `findByTestTag(...)`, `click(...)`, and `
 small CBOR requests over the socket. They execute inside the target JVM against the in-process
 automator, then return DTOs or bytes to the attacher.
 
+The attacher also makes a best-effort attempt to start the experimental desktop input coordinator.
+Failure to start it does not block read-only attach operations. A target using the current core
+selects `InputLeasePolicy.Required`, so real input then fails closed if coordination remains
+unavailable. When a target has an older preinstalled core without `InputLeasePolicy`, bootstrap
+falls back to its legacy no-argument `RobotDriver`; that compatibility path is uncoordinated.
+
 ### Injection without preinstalled core
 
 Bootstrap order inside the target:

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -256,9 +256,9 @@ AgentAttach.attach(target.pid).use { automator ->
 ```
 
 `AttachedAutomator` is `AutoCloseable`. Closing it sends an `AgentRequest.Detach` over the
-wire; the agent stops accepting new requests, releases its `ComposeAutomator`, unlinks
-the UDS path, and removes its shutdown hook. A target-side shutdown hook covers crash
-cleanup.
+wire; the agent stops accepting new requests, closes the target-side input coordinator session,
+releases its `ComposeAutomator`, unlinks the UDS path, and removes its shutdown hook. A target-side
+shutdown hook covers crash cleanup.
 
 ### `AttachOptions`
 

--- a/docs/guide/capability-matrix.md
+++ b/docs/guide/capability-matrix.md
@@ -30,6 +30,14 @@ is the human-readable view of that source of truth.
 Platform rows are **prerequisites**, not just OS names: headless JVMs, Linux Xvfb,
 Wayland sessions, and interactive desktops behave differently for Robot and Compose.
 
+Shared desktop input has an additional cooperative boundary. In-process `Required`, in-process
+JUnit `PerTest`, CLI, and injected-agent input participate in the per-user desktop coordinator.
+Synthetic pointer/keyboard and headless query work do not; synthetic clipboard use does. Current
+HTTP callers participate when their supplied automator uses `Auto`/`Required`. Cross-request remote
+lease tokens and launch-and-attach whole-test leases remain a follow-up, so the matrix must not
+claim a multi-request remote transaction today. The entire coordination surface is
+**Experimental** and opt-in; see [Experimental desktop input coordination](input-coordination.md).
+
 ## Contract form decision (#198)
 
 | Option | Outcome |

--- a/docs/guide/ci.md
+++ b/docs/guide/ci.md
@@ -1,5 +1,24 @@
 # Running on CI
 
+## Parallel real-input jobs
+
+Desktop input coordination is an experimental, opt-in preview. Consumer source must opt in with
+`ExperimentalSpectreInputCoordinationApi`; see
+[Experimental desktop input coordination](input-coordination.md). Experimental does not make an
+unproven platform claim release-safe: headed cross-platform smoke remains required.
+
+Separate Gradle forks and separate CI jobs cannot coordinate through JUnit's in-memory resource
+locks. Use `InputIsolationConfig.perTest()` for in-process real-input JUnit tests and install the
+`spectre-input-coordinator-server` runtime (the `spectre-testing`, CLI, and attaching-side agent
+artifacts wire it automatically). Synthetic/headless tests remain parallel unless they use the
+system clipboard.
+
+The coordinator serializes per normalized OS user/desktop identity and uses a short owner-only
+local socket. X11 spellings such as `:0`, `:0.0`, and `unix/:0` converge; Wayland socket paths are
+canonicalized where possible. Over-serialization is intentional when a platform cannot safely
+distinguish sessions. Do not treat Xvfb evidence as Wayland real-input evidence: Robot input is not
+claimed on Wayland.
+
 Spectre can run live Compose Desktop tests on CI as long as the test JVM is a real desktop JVM.
 GitHub Actions Linux runners are validated on Ubuntu 24.04 under `xvfb` for both scripted-RPC
 tests and real-backend Compose Desktop tests.

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -1,5 +1,25 @@
 # CLI
 
+## Inspecting and recovering the desktop input lease
+
+!!! warning "Experimental control surface"
+    Desktop input coordination and these control commands are experimental. The protocol, output,
+    and recovery workflow may change in any release. See
+    [Experimental desktop input coordination](input-coordination.md).
+
+The control commands observe an existing coordinator and never launch one:
+
+```text
+spectre input-lock status
+spectre input-lock status --json
+spectre input-lock revoke --lease <observed-id> --reason <text>
+spectre input-lock revoke --lease <observed-id> --reason <text> --force
+```
+
+Revoke is compare-and-revoke: always copy the current ID from `status`; a stale ID cannot affect a
+new holder. `--force` is an unsafe recovery escape hatch after grace, is audited, and reports
+`unsafeTakeover=true`. It does not prove an in-flight native call stopped.
+
 The `spectre` command is for inspecting and driving a running Compose Desktop application
 without first writing a JUnit test. It is useful for debugging a live UI, exploring its
 semantics tree, capturing evidence while developing, and giving an MCP client access to the

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -9,22 +9,24 @@ The guide walks through using Spectre end-to-end:
    queries vs. interactions, and why there's no auto-wait.
 4. **[Finding nodes](selectors.md)** — selector reference.
 5. **[Driving input](interactions.md)** — clicks, swipes, scrolling, typing, screenshots.
-6. **[Synchronization](synchronization.md)** — wait helpers and the EDT rule.
-7. **[JUnit integration](junit.md)** — `ComposeAutomatorExtension` (JUnit 5) and
+6. **[Experimental input coordination](input-coordination.md)** — serialize real input across
+   participating JVMs, including JUnit and forced recovery.
+7. **[Synchronization](synchronization.md)** — wait helpers and the EDT rule.
+8. **[JUnit integration](junit.md)** — `ComposeAutomatorExtension` (JUnit 5) and
    `ComposeAutomatorRule` (JUnit 4).
-8. **[Running on CI](ci.md)** — JVM flags, `xvfb`, macOS helper JVMs, and recording tags.
-9. **[Recording and screenshots](recording.md)** — region capture, window-targeted video,
-   and native still-window screenshots.
-10. **[Cross-JVM access](cross-jvm.md)** — driving a UI hosted in another JVM.
-11. **[Agent attach](agent.md)** — attach to a running Compose JVM (preinstalled core or inject).
-12. **[Capability matrix](capability-matrix.md)** — ops × transports × platforms, with
+9. **[Running on CI](ci.md)** — JVM flags, `xvfb`, macOS helper JVMs, and recording tags.
+10. **[Recording and screenshots](recording.md)** — region capture, window-targeted video,
+    and native still-window screenshots.
+11. **[Cross-JVM access](cross-jvm.md)** — driving a UI hosted in another JVM.
+12. **[Agent attach](agent.md)** — attach to a running Compose JVM (preinstalled core or inject).
+13. **[Capability matrix](capability-matrix.md)** — ops × transports × platforms, with
     fail-closed CI evidence for every Supported cell.
-13. **[CLI](cli.md)** — interactive `spectre` command and MCP server.
-14. **[Atomic capture](capture.md)** — window PNG + versioned tree for agents.
-15. **[Compose Hot Reload](hot-reload.md)** — optional reload settle wait and key
+14. **[CLI](cli.md)** — interactive `spectre` command and MCP server.
+15. **[Atomic capture](capture.md)** — window PNG + versioned tree for agents.
+16. **[Compose Hot Reload](hot-reload.md)** — optional reload settle wait and key
     invalidation when the target runs under HR (CLI/MCP only).
-16. **[IntelliJ-hosted Compose](intellij.md)** — Jewel-on-IntelliJ tool windows.
-17. **[Troubleshooting](troubleshooting.md)** — platform-specific gotchas.
+17. **[IntelliJ-hosted Compose](intellij.md)** — Jewel-on-IntelliJ tool windows.
+18. **[Troubleshooting](troubleshooting.md)** — platform-specific gotchas.
 
 If you're new to Spectre, start with [Installation](installation.md) and
 [Getting started](getting-started.md), then read [The automator](automator.md) before

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -61,6 +61,11 @@ close the driver (prefer `use { ... }` when its lifetime is block-scoped) to sto
 an idle coordinator exit. JUnit isolation and attached-agent teardown close their owned sessions
 automatically.
 
+Losing the coordinator session while a lease is held does not prove that native input has stopped.
+The coordinator fences that holder and keeps later work queued until the original lease cleanup
+acknowledges release. If the process died or cleanup cannot acknowledge, inspect the `revoking`
+holder and use exact-ID forced recovery only after accepting the overlap risk described below.
+
 ## Choose the narrowest useful mode
 
 | Need | Recommended mode |

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -141,13 +141,15 @@ Revoke is compare-and-revoke. Copy the exact current lease ID from `status`; a s
 revoke a newer holder. Normal revoke fences the owner and allows its cleanup path to finish.
 
 !!! danger "Forced recovery can overlap native input"
-    `--force` is an unsafe recovery escape hatch after grace. It records the reason and returns
+    `--force` is an explicit unsafe recovery escape hatch. It records the reason and returns
     `unsafeTakeover=true`, but it cannot prove an in-flight native call has stopped and never kills
-    the holder process. Use it only after inspecting the exact current lease and deciding that
-    restoring progress is worth possible overlapping input.
+    the holder process. Use it only after inspecting the exact current lease, allowing a reasonable
+    cleanup interval, and deciding that restoring progress is worth possible overlapping input.
 
 Coordinator restart enters recovery quarantine instead of assuming the desktop is free. Corrupt
-or ambiguous recovery state quarantines conservatively until an exact forced recovery decision.
+or ambiguous recovery state quarantines conservatively. Restart quarantine never expires
+automatically because Spectre cannot prove that predecessor native input has stopped; it remains
+closed until an operator makes an exact-ID forced recovery decision.
 
 ## Platform and trust boundaries
 

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -1,0 +1,157 @@
+# Experimental desktop input coordination
+
+!!! warning "Experimental, opt-in API"
+    Cooperative desktop input coordination ships as an experimental preview. Its API and runtime
+    protocol may change in any release. Opt in with
+    `ExperimentalSpectreInputCoordinationApi`; the no-argument `RobotDriver()` remains
+    uncoordinated during this rollout.
+
+Real desktop input is shared state. Two test JVMs can move the same pointer, type into whichever
+window currently owns focus, and overwrite the same system clipboard. JUnit's in-process locks do
+not cover separate Gradle forks, CLI processes, or attached target JVMs.
+
+Spectre's coordinator gives participating local processes a FIFO, fenced lease for one normalised
+user/desktop identity. It is cooperative rather than an OS input grab: it does not block people,
+older Spectre versions, or other automation tools.
+
+## Install and opt in
+
+`spectre-core` contains the client integration. A core-only application that selects `Auto` or
+`Required` must also put the process-launching runtime on its runtime classpath:
+
+```kotlin
+dependencies {
+    testImplementation("dev.sebastiano.spectre:spectre-core:<version>")
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-input-coordinator-server:<version>")
+}
+```
+
+`spectre-testing`, the CLI, and the attaching side of `spectre-agent` already bring the
+coordinator server runtime. Low-level integrations may compile against
+`spectre-input-coordinator`, but most tests should use the core or JUnit entry points.
+
+The experimental launcher starts a dedicated JVM with the client process's
+`java.class.path`. Thin `java -jar` launchers and module-path-only applications must make the
+coordinator server and its dependencies visible on that classpath. Automatic launches discard
+the child process's output; if startup times out, run the command returned by
+`CoordinatorProcessLauncher.command()` directly to retain its diagnostics.
+
+The marker is warning-level: code still compiles without `@OptIn`, but every experimental call
+site produces a compiler warning.
+
+```kotlin
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.InputLeasePolicy
+import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+
+val automator = ComposeAutomator.inProcess(RobotDriver(InputLeasePolicy.Required))
+```
+
+## Choose the narrowest useful mode
+
+| Need | Recommended mode |
+| --- | --- |
+| No real OS input or shared clipboard | `RobotDriver.synthetic(rootWindow)`; no coordinator |
+| Real input, fail if coordination cannot start | `InputLeasePolicy.Required` |
+| Coordinate when the runtime is present | `InputLeasePolicy.Auto` |
+| An external harness already serialises the desktop | `InputLeasePolicy.Off` |
+| One JUnit lease around setup, body, evidence, and teardown | `InputIsolationConfig.perTest()` |
+
+`Auto` and `Required` are explicit choices. The no-argument `RobotDriver()` preserves the existing
+uncoordinated behaviour. Changing that default requires the full cross-platform release-smoke
+evidence and a separate stability decision.
+
+`Auto` never blocks the AWT event-dispatch thread to establish a new coordinator session. If no
+session is already connected, an EDT operation proceeds uncoordinated; use `Required`, acquire an
+exclusive scope off the EDT, or use JUnit per-test isolation when that fallback is unacceptable.
+
+For a multi-step transaction, hold one reentrant lease so another process cannot run between the
+steps:
+
+```kotlin
+import dev.sebastiano.spectre.core.InputLeaseOptions
+
+automator.withExclusiveInput(InputLeaseOptions(ownerLabel = "submits checkout")) {
+    focusWindow(email)
+    click(email)
+    typeText("alice@example.com")
+    click(submit)
+    waitForIdle()
+}
+```
+
+Automatic leases cover real pointer, keyboard, focus, and system-clipboard work. Semantics reads,
+waits, screenshots, and recording do not acquire automatically. Put a visibility-sensitive
+capture inside `withExclusiveInput` when it must not race another client's input.
+
+## JUnit 4 and JUnit 5
+
+Whole-test isolation is available on both in-process wrappers:
+
+```kotlin
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import dev.sebastiano.spectre.testing.ComposeAutomatorExtension
+import dev.sebastiano.spectre.testing.InputIsolationConfig
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@JvmField
+@RegisterExtension
+val automatorExt =
+    ComposeAutomatorExtension(
+        inputIsolation = InputIsolationConfig.perTest(),
+    )
+```
+
+`PerTest` acquires before the default/custom factory and releases after failure evidence, video
+finalisation, and teardown. JUnit 4 wraps the complete `Statement.evaluate()` lifecycle. JUnit 5
+stores the lease per invocation, so parameter-injected automators remain parallel-safe.
+
+`LaunchAndAttachExtension` and `LaunchAndAttachRule` intentionally do not expose a test-JVM
+`PerTest` lease. Input is dispatched and coordinated in the attached target JVM; holding a second
+lease in the test JVM would self-deadlock.
+
+## Inspect and recover a stuck lease
+
+Control commands observe an existing coordinator and never launch one:
+
+```text
+spectre input-lock status
+spectre input-lock status --json
+spectre input-lock revoke --lease <observed-id> --reason <text>
+spectre input-lock revoke --lease <observed-id> --reason <text> --force
+```
+
+Revoke is compare-and-revoke. Copy the exact current lease ID from `status`; a stale ID cannot
+revoke a newer holder. Normal revoke fences the owner and allows its cleanup path to finish.
+
+!!! danger "Forced recovery can overlap native input"
+    `--force` is an unsafe recovery escape hatch after grace. It records the reason and returns
+    `unsafeTakeover=true`, but it cannot prove an in-flight native call has stopped and never kills
+    the holder process. Use it only after inspecting the exact current lease and deciding that
+    restoring progress is worth possible overlapping input.
+
+Coordinator restart enters recovery quarantine instead of assuming the desktop is free. Corrupt
+or ambiguous recovery state quarantines conservatively until an exact forced recovery decision.
+
+## Platform and trust boundaries
+
+- macOS uses one conservative per-user console identity.
+- Windows requires native `AF_UNIX` support and uses the current logon session when available.
+- Linux Xorg/Xvfb normalises equivalent local `DISPLAY` spellings.
+- Linux Wayland real Robot input is not claimed; use synthetic input. Socket-backed identities are
+  canonicalized where possible.
+- POSIX endpoints enforce mode 0700 on the directory and 0600 on the socket. On Windows, the
+  coordinator uses the current user's `LOCALAPPDATA` and inherits that directory's ACL; this layer
+  rejects path substitution but does not rewrite the Windows ACL. Labels are diagnostic
+  attribution, not authentication; typed text, clipboard contents, selectors, credentials, and
+  prompts are never recorded.
+
+Coordination remains **Experimental** until headed two-process smoke records FIFO contention,
+holder crash, exact revoke, forced recovery, and JUnit parallelism on macOS, Windows, and Linux
+Xorg/Xvfb. Graduation or making `Auto` the default requires that evidence plus real-world feedback
+without unresolved recovery or lifecycle defects.

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -90,7 +90,7 @@ automator.withExclusiveInput(InputLeaseOptions(ownerLabel = "submits checkout"))
     click(email)
     typeText("alice@example.com")
     click(submit)
-    waitForIdle()
+    automator.waitForIdle()
 }
 ```
 

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -66,6 +66,12 @@ The coordinator fences that holder and keeps later work queued until the origina
 acknowledges release. If the process died or cleanup cannot acknowledge, inspect the `revoking`
 holder and use exact-ID forced recovery only after accepting the overlap risk described below.
 
+If recovery-state persistence temporarily prevents a lease from being released, `close()` throws
+`InputCoordinatorException` with `RECOVERY_PERSISTENCE_FAILED`. The client keeps the coordinator
+session live and retries that exact release request in the background; closing the client waits for
+that acknowledgement instead of discarding the only safe cleanup path. Repair the persistence
+problem rather than forcing recovery while the owner can still acknowledge cleanup safely.
+
 ## Choose the narrowest useful mode
 
 | Need | Recommended mode |

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -47,8 +47,19 @@ import dev.sebastiano.spectre.core.InputLeasePolicy
 import dev.sebastiano.spectre.core.RobotDriver
 import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
 
-val automator = ComposeAutomator.inProcess(RobotDriver(InputLeasePolicy.Required))
+val driver = RobotDriver(InputLeasePolicy.Required)
+try {
+    val automator = ComposeAutomator.inProcess(driver)
+    // Use automator.
+} finally {
+    driver.close()
+}
 ```
+
+`RobotDriver` is `AutoCloseable`. `Auto` and `Required` open their coordinator session lazily;
+close the driver (prefer `use { ... }` when its lifetime is block-scoped) to stop heartbeats and let
+an idle coordinator exit. JUnit isolation and attached-agent teardown close their owned sessions
+automatically.
 
 ## Choose the narrowest useful mode
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -13,6 +13,8 @@ Spectre publishes these library modules to Maven Central:
 | `server` | `dev.sebastiano.spectre:spectre-server:<version>` |
 | `agent` | `dev.sebastiano.spectre:spectre-agent:<version>` |
 | `agent-runtime` | `dev.sebastiano.spectre:spectre-agent-runtime:<version>` |
+| `input-coordinator` | `dev.sebastiano.spectre:spectre-input-coordinator:<version>` |
+| `input-coordinator-server` | `dev.sebastiano.spectre:spectre-input-coordinator-server:<version>` |
 
 !!! note "Using unreleased changes"
     The `main` branch declares `0.1.0-SNAPSHOT`. Use a published release version from Maven
@@ -76,6 +78,9 @@ dependencies {
     testImplementation("dev.sebastiano.spectre:spectre-server:<version>")
     testImplementation("dev.sebastiano.spectre:spectre-agent:<version>")
     testRuntimeOnly("dev.sebastiano.spectre:spectre-agent-runtime:<version>") // Java-agent runtime
+
+    // Experimental: core-only callers selecting InputLeasePolicy.Auto/Required need this runtime.
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-input-coordinator-server:<version>")
 }
 ```
 
@@ -159,6 +164,10 @@ includeBuild("../spectre") {
             .using(project(":agent"))
         substitute(module("dev.sebastiano.spectre:spectre-agent-runtime"))
             .using(project(":agent-runtime"))
+        substitute(module("dev.sebastiano.spectre:spectre-input-coordinator"))
+            .using(project(":input-coordinator"))
+        substitute(module("dev.sebastiano.spectre:spectre-input-coordinator-server"))
+            .using(project(":input-coordinator-server"))
     }
 }
 ```
@@ -179,6 +188,7 @@ dependencies {
     testImplementation("dev.sebastiano.spectre:spectre-server")
     testImplementation("dev.sebastiano.spectre:spectre-agent")
     testRuntimeOnly("dev.sebastiano.spectre:spectre-agent-runtime")
+    testRuntimeOnly("dev.sebastiano.spectre:spectre-input-coordinator-server")
 }
 ```
 
@@ -206,10 +216,14 @@ Maven Local:
 | `server`    | Embedded HTTP transport (Ktor) and `HttpComposeAutomator` for cross-JVM access. **Experimental**; see [Security notes](../SECURITY.md). |
 | `agent`     | Local attach transport API. **Experimental**; see [Agent attach](agent.md). |
 | `agent-runtime` | Loadable Java-agent runtime for `agent`; add as runtime-only beside the API jar. |
+| `input-coordinator` | Experimental low-level lease/client/protocol API; most users consume it through `core` or `testing`. |
+| `input-coordinator-server` | Experimental process-launching runtime for core-only `Auto`/`Required` callers. |
 
 Most projects only need `core` + `testing`. Add `recording` and the matching platform helper
 artifact(s) when you need video output or native window-scoped screenshots; add `server` or
-`agent` if your test process needs to reach a UI in a different JVM.
+`agent` if your test process needs to reach a UI in a different JVM. See
+[Experimental desktop input coordination](input-coordination.md) before enabling shared-desktop
+leases.
 
 ## Next
 

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -45,7 +45,7 @@ automator.withExclusiveInput(InputLeaseOptions(ownerLabel = "fills login form"))
     click(username)
     typeText("alice")
     click(submit)
-    waitForIdle()
+    automator.waitForIdle()
 }
 ```
 

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -19,6 +19,55 @@ frame; use them from a coroutine-friendly test context when that latency matters
 The snippets below are written as if they sit inside a suspend block (e.g. a JUnit
 test wrapped in `runSpectreTest { … }`).
 
+## Cooperative desktop input leases
+
+!!! warning "Experimental and opt-in"
+    This surface requires `@OptIn(ExperimentalSpectreInputCoordinationApi::class)` and may change
+    in any release. See [Experimental desktop input coordination](input-coordination.md) for
+    dependencies, JUnit setup, recovery controls, platform boundaries, and graduation criteria.
+
+Real mouse, keyboard, focus, and system-clipboard work can be coordinated across participating
+Spectre processes. Opt in on the driver with `InputLeasePolicy.Required`, or hold one reentrant
+lease across a larger sequence:
+
+```kotlin
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import dev.sebastiano.spectre.core.InputLeaseOptions
+import dev.sebastiano.spectre.core.InputLeasePolicy
+import dev.sebastiano.spectre.core.RobotDriver
+
+val automator = ComposeAutomator.inProcess(RobotDriver(InputLeasePolicy.Required))
+
+automator.withExclusiveInput(InputLeaseOptions(ownerLabel = "fills login form")) {
+    focusWindow(username)
+    click(username)
+    typeText("alice")
+    click(submit)
+    waitForIdle()
+}
+```
+
+`Auto` coordinates capabilities that touch shared OS state when the coordinator runtime is
+available; `Required` fails closed if it is unavailable; `Off` is the explicit escape hatch for
+externally coordinated or hermetic callers. The no-argument driver keeps the pre-coordinator
+default while the feature is experimental; select `Auto` or `Required` deliberately.
+
+The lease covers real pointer/keyboard/focus operations and `pasteText`'s system clipboard use.
+Synthetic pointer and keyboard work stays parallel. Synthetic `pasteText` coordinates only when
+the synthetic driver was created with an explicit `Auto` or `Required` policy; the ordinary
+`RobotDriver.synthetic(rootWindow)` factory remains `Off`.
+Screenshots, semantics reads, waits, and recording do not acquire automatically; put a
+visibility-sensitive capture inside `withExclusiveInput` when it must not race input.
+
+Coordination is cooperative: it prevents participating Spectre clients from interleaving. It
+cannot block a human, an older Spectre version, or another automation framework. A contended EDT
+call fails immediately with `ContendedEdtInputLeaseException`; acquire the scope from a non-EDT
+test thread or use JUnit per-test isolation instead of blocking the AUT's event thread.
+`Auto` also avoids opening a new coordinator session from the EDT: without an already-connected
+session it proceeds uncoordinated. Choose `Required` when that fallback is unacceptable.
+
 ## Mouse: clicks and drags
 
 ```kotlin

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -36,7 +36,8 @@ The same `inputIsolation` constructor is available on `ComposeAutomatorRule` for
 - `PerInteraction` relies on core operation/scoped leases. The input-isolation-only constructor
   creates a default driver with `InputLeasePolicy.Required`; custom factories must select
   `InputLeasePolicy.Auto` or `Required` themselves. Legacy no-argument wrappers remain
-  uncoordinated.
+  uncoordinated. The wrappers close their default coordination-enabled driver after test evidence
+  and teardown complete.
 - `Off` declares that coordination is external or intentionally disabled.
 
 During a synchronous custom factory, `PerTest` makes its acquired lease ambient on the invoking

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -36,6 +36,11 @@ The same `inputIsolation` constructor is available on `ComposeAutomatorRule` for
 - `PerInteraction` keeps the compatibility default and relies on core operation/scoped leases.
 - `Off` declares that coordination is external or intentionally disabled.
 
+During a synchronous custom factory, `PerTest` makes its acquired lease ambient on the invoking
+thread. A factory that uses `RobotDriver(InputLeasePolicy.Required)` for setup therefore reuses the
+whole-test lease instead of queueing behind itself. Do not launch factory work that outlives the
+factory call; after the factory returns, the lease is bound to the returned automator normally.
+
 JUnit 5 stores the lease per invocation, so parameter-injected automators remain parallel-safe.
 JUnit 4 wraps the complete `Statement.evaluate()` lifecycle. Owner diagnostics contain class and
 method identity, never parameter values. `LaunchAndAttachExtension` and `LaunchAndAttachRule` do

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -33,7 +33,10 @@ The same `inputIsolation` constructor is available on `ComposeAutomatorRule` for
 - `Auto` acquires for real input or shared clipboard capabilities. With a custom factory it must
   create the automator before it can inspect capabilities, so factory-time focus is not covered;
   use `PerTest` when setup itself needs isolation.
-- `PerInteraction` keeps the compatibility default and relies on core operation/scoped leases.
+- `PerInteraction` relies on core operation/scoped leases. The input-isolation-only constructor
+  creates a default driver with `InputLeasePolicy.Required`; custom factories must select
+  `InputLeasePolicy.Auto` or `Required` themselves. Legacy no-argument wrappers remain
+  uncoordinated.
 - `Off` declares that coordination is external or intentionally disabled.
 
 During a synchronous custom factory, `PerTest` makes its acquired lease ambient on the invoking

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -2,6 +2,46 @@
 
 The `testing` module provides drop-in wrappers that own a per-test `ComposeAutomator`.
 
+## Whole-test input isolation
+
+!!! warning "Experimental and opt-in"
+    JUnit input isolation requires
+    `@OptIn(ExperimentalSpectreInputCoordinationApi::class)`. The constructors and configuration
+    may change in any release. See [Experimental desktop input coordination](input-coordination.md)
+    for runtime dependencies, recovery, and platform status.
+
+In-process JUnit wrappers can hold one lease across factory setup, the test body, failure capture,
+failure-video finalization, and teardown:
+
+```kotlin
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import dev.sebastiano.spectre.testing.InputIsolationConfig
+
+@JvmField
+@RegisterExtension
+val automatorExt =
+    ComposeAutomatorExtension(
+        inputIsolation = InputIsolationConfig.perTest(),
+    )
+```
+
+The same `inputIsolation` constructor is available on `ComposeAutomatorRule` for JUnit 4. Modes:
+
+- `PerTest` acquires before the default/custom factory and releases unconditionally after teardown.
+- `Auto` acquires for real input or shared clipboard capabilities. With a custom factory it must
+  create the automator before it can inspect capabilities, so factory-time focus is not covered;
+  use `PerTest` when setup itself needs isolation.
+- `PerInteraction` keeps the compatibility default and relies on core operation/scoped leases.
+- `Off` declares that coordination is external or intentionally disabled.
+
+JUnit 5 stores the lease per invocation, so parameter-injected automators remain parallel-safe.
+JUnit 4 wraps the complete `Statement.evaluate()` lifecycle. Owner diagnostics contain class and
+method identity, never parameter values. `LaunchAndAttachExtension` and `LaunchAndAttachRule` do
+not expose `PerTest`: input runs in the target JVM and currently uses target-side operation leases;
+holding a separate test-JVM lease would self-deadlock.
+
 ## JUnit 5: `ComposeAutomatorExtension`
 
 The safest pattern is `@RegisterExtension` on a `@JvmField` — one extension instance per

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -117,6 +117,26 @@ In order of likelihood:
 Real `RobotDriver` dispatches OS-level input. Two parallel test JVMs racing for the
 same screen will collide.
 
+For participating Spectre processes, enable cooperative coordination with
+`RobotDriver(InputLeasePolicy.Required)`, wrap a sequence in `withExclusiveInput`, or configure
+the in-process JUnit wrapper with `InputIsolationConfig.perTest()`. Inspect a suspected wedge with
+`spectre input-lock status --json`. Revoke only the exact observed lease ID:
+
+```text
+spectre input-lock revoke --lease <id> --reason "test JVM is unresponsive"
+```
+
+Normal revoke fences new work and waits for owner cleanup. If the owner cannot reach a checkpoint,
+`--force` advances after a bounded grace period and reports `unsafeTakeover=true`. That is an
+audited escape hatch, not proof that an already-running native call stopped. A stale lease ID can
+never revoke a newer holder.
+
+If the coordinator process does not become ready, check that
+`spectre-input-coordinator-server` and its dependencies are present in `java.class.path`. This is
+especially relevant for thin `java -jar` launchers and module-path-only applications. Run the
+command returned by `CoordinatorProcessLauncher.command()` directly when you need to retain the
+child JVM's standard error; automatic launches intentionally discard child output.
+
 Use synthetic input:
 
 ```kotlin
@@ -448,6 +468,11 @@ returns a human-readable diagnostic without throwing.
 target only needs to allow dynamic agent loading. **IntelliJ-hosted Compose** always
 implies the IDE’s bundled JBR — do not ship a second skiko into the plugin classloader
 (see [IntelliJ guide](intellij.md)).
+
+If an attached session can inspect semantics but real input reports that the coordinator provider
+is missing, add `spectre-input-coordinator-server` to the attacher's runtime classpath and retry.
+Read-only attach deliberately remains available when the experimental coordinator cannot start;
+current-core real input uses `Required` and fails closed instead of running uncoordinated.
 
 The sample IntelliJ plugin module configures its sandbox JDK via the IntelliJ Platform
 Gradle plugin; you do not pick Temurin for that path.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,8 @@ familiar — Spectre brings the same "find a node, do a thing, assert" loop to C
 
 !!! warning "Pre-1.0"
     Spectre is pre-1.0. Stable APIs are covered by the project's compatibility policy;
-    experimental APIs, especially the HTTP transport, may change between releases. See
+    experimental APIs, including HTTP, agent attach, and desktop input coordination, may change
+    between releases. See
     [Stability policy](STABILITY.md) and [Security notes](SECURITY.md) before depending on
     cross-JVM control or recording in environments that handle untrusted input.
 
@@ -36,6 +37,9 @@ familiar — Spectre brings the same "find a node, do a thing, assert" loop to C
   defaults to OS-level `java.awt.Robot` events. Swap in `RobotDriver.synthetic(...)` and
   AWT events go directly into the window hierarchy — useful when tests run in parallel
   and can't fight over OS focus.
+- **Experimental cooperative input leases.** Participating real-input test JVMs can serialise
+  focus, pointer, keyboard, and clipboard work without disabling parallel query/synthetic tests.
+  See [desktop input coordination](guide/input-coordination.md).
 - **Recording and screenshots built in.** Region capture, plus window-targeted recording
   and still screenshots where the platform exposes them (ScreenCaptureKit on macOS,
   Windows Graphics Capture on Windows, helper-driven Xorg/Xvfb and portal/PipeWire
@@ -62,6 +66,8 @@ familiar — Spectre brings the same "find a node, do a thing, assert" loop to C
   — `waitForIdle`, `waitForVisualIdle`, `waitForNode`, and the EDT rule.
 - :material-monitor-dashboard: **[Running on CI](guide/ci.md)** — `xvfb`, required test-JVM
   flags, macOS helper mode, and recording test tags.
+- :material-lock-clock: **[Experimental input coordination](guide/input-coordination.md)** —
+  FIFO leases, JUnit isolation, diagnostics, and explicit forced recovery.
 - :material-video: **[Recording and screenshots](guide/recording.md)** — Region,
   window-targeted video, and native still-window screenshots across macOS, Windows,
   and Linux.

--- a/input-coordinator-server/api/input-coordinator-server.api
+++ b/input-coordinator-server/api/input-coordinator-server.api
@@ -1,0 +1,40 @@
+public final class dev/sebastiano/spectre/input/server/CoordinatorProcessLauncher {
+	public static final field COORDINATOR_MAIN_CLASS Ljava/lang/String;
+	public static final field DEFAULT_IDLE_TIMEOUT_SECONDS J
+	public fun <init> (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ljava/lang/String;Ljava/lang/String;Ljava/time/Duration;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ljava/lang/String;Ljava/lang/String;Ljava/time/Duration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun command ()Ljava/util/List;
+	public final fun start ()Ljava/lang/Process;
+}
+
+public final class dev/sebastiano/spectre/input/server/CoordinatorProcessMain {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/server/CoordinatorProcessMain;
+	public final fun run (Ljava/util/List;)V
+}
+
+public final class dev/sebastiano/spectre/input/server/CoordinatorProcessMainKt {
+	public static final fun main ([Ljava/lang/String;)V
+}
+
+public final class dev/sebastiano/spectre/input/server/LaunchingInputCoordinatorClientProvider : dev/sebastiano/spectre/input/InputCoordinatorClientProvider {
+	public fun <init> ()V
+	public fun connect (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;)Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient;
+}
+
+public final class dev/sebastiano/spectre/input/server/LocalCoordinatorServer : java/lang/AutoCloseable {
+	public static final field ACQUIRE_RESPONSE_GRACE_MILLIS J
+	public static final field CLOSE_WAIT_SECONDS J
+	public static final field DEFAULT_HEARTBEAT_TIMEOUT_SECONDS J
+	public static final field DEFAULT_IDLE_TIMEOUT_SECONDS J
+	public static final field DEFAULT_RECOVERY_GRACE_SECONDS J
+	public static final field DEFAULT_REVOKE_GRACE_SECONDS J
+	public static final field IDLE_CHECK_DIVISOR J
+	public static final field MAX_IDLE_CHECK_MILLIS J
+	public static final field MIN_IDLE_CHECK_MILLIS J
+	public fun <init> (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ldev/sebastiano/spectre/input/CoordinatorWireCodec;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ljava/time/Duration;Ldev/sebastiano/spectre/input/CoordinatorWireCodec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun awaitTermination ()V
+	public fun close ()V
+	public final fun start ()V
+}
+

--- a/input-coordinator-server/build.gradle.kts
+++ b/input-coordinator-server/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.ktfmt)
+    alias(libs.plugins.mavenPublish)
+}
+
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation { enabled.set(true) }
+}
+
+dependencies {
+    api(projects.inputCoordinator)
+    testImplementation(libs.kotlin.testJunit5)
+}
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/input-coordinator-server/gradle.properties
+++ b/input-coordinator-server/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=spectre-input-coordinator-server
+POM_NAME=Spectre Input Coordinator Server
+POM_DESCRIPTION=Local process and deterministic lease service for cooperative desktop input coordination.

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -97,9 +97,14 @@ internal class CoordinatorLeaseService(
     }
 
     private fun releaseToken(token: LeaseToken): CoordinatorWireMessage {
-        return when (val result = machine.release(token)) {
+        val result =
+            try {
+                machine.release(token) { recoveryLedger?.clear(token.leaseId) }
+            } catch (_: IOException) {
+                return error("RECOVERY_PERSISTENCE_FAILED", "Could not persist lease release")
+            }
+        return when (result) {
             is ReleaseResult.Released -> {
-                recoveryLedger?.clear(token.leaseId)
                 result.nextGrant?.let(::completeGrant)
                 success()
             }

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -166,7 +166,13 @@ internal class CoordinatorLeaseService(
                 // requests sharing the client session remain live.
                 val release = releaseToken(ambiguousGrant)
                 if (!release.ok) {
-                    abandonUnobservedGrant(machine, requestTracker, ambiguousGrant, ::completeGrant)
+                    abandonUnobservedGrant(
+                        machine,
+                        requestTracker,
+                        ambiguousGrant,
+                        { leaseId -> recoveryLedger?.discardUnobserved(leaseId) },
+                        ::completeGrant,
+                    )
                 }
             }
         }
@@ -430,10 +436,14 @@ private fun abandonUnobservedGrant(
     machine: LeaseStateMachine,
     requestTracker: AcquisitionRequestTracker,
     token: LeaseToken,
+    discardRecovery: (String) -> Unit,
     completeGrant: (LeaseGrant) -> Unit,
 ) {
     when (val released = machine.release(token)) {
-        is ReleaseResult.Released -> released.nextGrant?.let(completeGrant)
+        is ReleaseResult.Released -> {
+            discardRecovery(token.leaseId)
+            released.nextGrant?.let(completeGrant)
+        }
         is ReleaseResult.StillHeld -> Unit
         is ReleaseResult.Rejected -> {
             check(released.code == LeaseErrorCode.FENCED) {
@@ -443,6 +453,7 @@ private fun abandonUnobservedGrant(
                 is RevokeResult.Acknowledged -> {
                     if (acknowledged.remainingDepth == 0) {
                         requestTracker.forgetLease(token.leaseId)
+                        discardRecovery(token.leaseId)
                         acknowledged.nextGrant?.let(completeGrant)
                     }
                 }

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -91,8 +91,13 @@ internal class CoordinatorLeaseService(
     @Synchronized
     fun release(message: CoordinatorWireMessage): CoordinatorWireMessage {
         val token = wireMapper.toToken(message)
+        val clientId = requireNotNull(message.clientId)
+        val requestId = requireNotNull(message.requestId)
+        if (!requestTracker.matchesGrant(clientId, requestId, token)) {
+            return error("STALE_LEASE", "Lease release request does not match an active grant")
+        }
         val response = releaseToken(token)
-        if (response.ok) requestTracker.forgetOneGrant(token, requireNotNull(message.clientId))
+        if (response.ok) requestTracker.forgetGrant(clientId, requestId, token)
         return response
     }
 
@@ -387,14 +392,11 @@ private class AcquisitionRequestTracker {
     fun takeGrant(clientId: String, requestId: String): LeaseToken? =
         grantsByRequest.remove(CancelledAcquire(clientId, requestId))
 
-    fun forgetOneGrant(token: LeaseToken, clientId: String) {
-        val key =
-            grantsByRequest.entries
-                .firstOrNull { (request, grantedToken) ->
-                    request.clientId == clientId && grantedToken == token
-                }
-                ?.key
-        if (key != null) grantsByRequest.remove(key)
+    fun matchesGrant(clientId: String, requestId: String, token: LeaseToken): Boolean =
+        grantsByRequest[CancelledAcquire(clientId, requestId)] == token
+
+    fun forgetGrant(clientId: String, requestId: String, token: LeaseToken) {
+        grantsByRequest.remove(CancelledAcquire(clientId, requestId), token)
     }
 
     fun forgetClient(clientId: String) {
@@ -452,6 +454,7 @@ private class CoordinatorWireMapper {
     fun grant(grant: LeaseGrant): CoordinatorWireMessage =
         CoordinatorWireMessage(
             kind = CoordinatorWireKind.RESPONSE,
+            requestId = grant.requestId,
             coordinatorEpoch = grant.token.coordinatorEpoch,
             leaseId = grant.token.leaseId,
             fence = grant.token.fence,

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -126,7 +126,13 @@ internal class CoordinatorLeaseService(
     @Synchronized
     fun disconnect(clientId: String) {
         recoveryLedger?.clearClient(clientId)
-        machine.disconnect(clientId).forEach(::completeGrant)
+        val result = machine.disconnect(clientId)
+        result.cancelledRequestIds.forEach { requestId ->
+            pendingAcquires
+                .remove(requestId)
+                ?.complete(error("CLIENT_DISCONNECTED", "Client session disconnected"))
+        }
+        result.grants.forEach(::completeGrant)
     }
 
     @Synchronized

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -55,7 +55,7 @@ internal class CoordinatorLeaseService(
     @Synchronized
     fun acquire(message: CoordinatorWireMessage): CompletableFuture<CoordinatorWireMessage> {
         val request = wireMapper.toAcquireRequest(message)
-        if (requestTracker.isDisconnected(request.owner.clientId)) {
+        if (!requestTracker.isConnected(request.owner.clientId)) {
             return CompletableFuture.completedFuture(
                 error("CLIENT_DISCONNECTED", "Client session disconnected")
             )
@@ -307,17 +307,17 @@ internal class CoordinatorLeaseService(
 
 private class AcquisitionRequestTracker {
     private val cancelledBeforeAcquire = LinkedHashSet<CancelledAcquire>()
-    private val disconnectedClients = mutableSetOf<String>()
+    private val connectedClients = mutableSetOf<String>()
     private val grantsByRequest = mutableMapOf<CancelledAcquire, LeaseToken>()
 
-    fun isDisconnected(clientId: String): Boolean = clientId in disconnectedClients
+    fun isConnected(clientId: String): Boolean = clientId in connectedClients
 
     fun markConnected(clientId: String) {
-        disconnectedClients -= clientId
+        connectedClients += clientId
     }
 
     fun markDisconnected(clientId: String) {
-        disconnectedClients += clientId
+        connectedClients -= clientId
     }
 
     fun consumeCancellation(clientId: String, requestId: String): Boolean =

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -9,6 +9,7 @@ import dev.sebastiano.spectre.input.CoordinatorWireQuarantine
 import dev.sebastiano.spectre.input.CoordinatorWireStatus
 import dev.sebastiano.spectre.input.CoordinatorWireWaiter
 import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseErrorCode
 import dev.sebastiano.spectre.input.LeaseOwner
 import dev.sebastiano.spectre.input.LeaseToken
 import java.io.IOException
@@ -164,7 +165,9 @@ internal class CoordinatorLeaseService(
                 // ACQUIRE won but its response was lost. Release only that exact hold; unrelated
                 // requests sharing the client session remain live.
                 val release = releaseToken(ambiguousGrant)
-                if (!release.ok) disconnect(clientId)
+                if (!release.ok) {
+                    abandonUnobservedGrant(machine, requestTracker, ambiguousGrant, ::completeGrant)
+                }
             }
         }
         return success()
@@ -422,6 +425,34 @@ private class AcquisitionRequestTracker {
 }
 
 private data class CancelledAcquire(val clientId: String, val requestId: String)
+
+private fun abandonUnobservedGrant(
+    machine: LeaseStateMachine,
+    requestTracker: AcquisitionRequestTracker,
+    token: LeaseToken,
+    completeGrant: (LeaseGrant) -> Unit,
+) {
+    when (val released = machine.release(token)) {
+        is ReleaseResult.Released -> released.nextGrant?.let(completeGrant)
+        is ReleaseResult.StillHeld -> Unit
+        is ReleaseResult.Rejected -> {
+            check(released.code == LeaseErrorCode.FENCED) {
+                "Could not abandon known-unobserved grant: ${released.code}"
+            }
+            when (val acknowledged = machine.acknowledgeRevocation(token)) {
+                is RevokeResult.Acknowledged -> {
+                    if (acknowledged.remainingDepth == 0) {
+                        requestTracker.forgetLease(token.leaseId)
+                        acknowledged.nextGrant?.let(completeGrant)
+                    }
+                }
+                is RevokeResult.Rejected ->
+                    error("Could not abandon fenced unobserved grant: ${acknowledged.code}")
+                else -> error("Unexpected unobserved-grant abandonment result")
+            }
+        }
+    }
+}
 
 private fun AcquisitionTimeout.diagnosticContext(): String =
     holder?.let { snapshot ->

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -11,6 +11,7 @@ import dev.sebastiano.spectre.input.CoordinatorWireWaiter
 import dev.sebastiano.spectre.input.DesktopResourceKey
 import dev.sebastiano.spectre.input.LeaseOwner
 import dev.sebastiano.spectre.input.LeaseToken
+import java.io.IOException
 import java.time.Duration
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
@@ -65,9 +66,9 @@ internal class CoordinatorLeaseService(
         }
         return when (val result = machine.acquire(request)) {
             is AcquireResult.Granted -> {
-                recoveryLedger?.record(result.grant)
-                requestTracker.rememberGrant(result.grant)
-                CompletableFuture.completedFuture(wireMapper.grant(result.grant))
+                CompletableFuture.completedFuture(
+                    recordGrantOrRollback(result.grant) ?: wireMapper.grant(result.grant)
+                )
             }
             is AcquireResult.Queued ->
                 if (message.waitForLease) {
@@ -269,9 +270,25 @@ internal class CoordinatorLeaseService(
     }
 
     private fun completeGrant(grant: LeaseGrant) {
-        recoveryLedger?.record(grant)
+        val response = recordGrantOrRollback(grant) ?: wireMapper.grant(grant)
+        pendingAcquires.remove(grant.requestId)?.complete(response)
+    }
+
+    private fun recordGrantOrRollback(grant: LeaseGrant): CoordinatorWireMessage? {
+        try {
+            recoveryLedger?.record(grant)
+        } catch (_: IOException) {
+            val rollback = machine.release(grant.token, advanceQueue = false)
+            check(rollback !is ReleaseResult.Rejected) {
+                "Could not roll back an unpersisted input lease grant"
+            }
+            return error(
+                "RECOVERY_PERSISTENCE_FAILED",
+                "Could not persist the input lease recovery record",
+            )
+        }
         requestTracker.rememberGrant(grant)
-        pendingAcquires.remove(grant.requestId)?.complete(wireMapper.grant(grant))
+        return null
     }
 
     private fun success(

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -229,11 +229,11 @@ internal class CoordinatorLeaseService(
 
     @Synchronized
     fun revoke(message: CoordinatorWireMessage): CoordinatorWireMessage {
+        val resourceKey = DesktopResourceKey(requireNotNull(message.resourceKey))
         val leaseId = requireNotNull(message.leaseId)
         val requesterLabel = requireNotNull(message.requesterLabel)
         val reason = requireNotNull(message.reason)
-        val quarantine =
-            machine.status(DesktopResourceKey(requireNotNull(message.resourceKey))).quarantine
+        val quarantine = machine.status(resourceKey).quarantine
         if (quarantine?.predecessorLeaseId == leaseId && message.force) {
             val result =
                 try {
@@ -254,7 +254,7 @@ internal class CoordinatorLeaseService(
         }
         val result =
             try {
-                machine.revoke(leaseId, requesterLabel, reason, message.force) {
+                machine.revoke(resourceKey, leaseId, requesterLabel, reason, message.force) {
                     recoveryLedger?.clear(leaseId)
                 }
             } catch (_: IOException) {

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -91,8 +91,10 @@ internal class CoordinatorLeaseService(
                 if (result.code.name == "FENCED") {
                     when (val acknowledged = machine.acknowledgeRevocation(token)) {
                         is RevokeResult.Acknowledged -> {
-                            recoveryLedger?.clear(token.leaseId)
-                            acknowledged.nextGrant?.let(::completeGrant)
+                            if (acknowledged.remainingDepth == 0) {
+                                recoveryLedger?.clear(token.leaseId)
+                                acknowledged.nextGrant?.let(::completeGrant)
+                            }
                             success()
                         }
                         is RevokeResult.Rejected ->
@@ -176,8 +178,10 @@ internal class CoordinatorLeaseService(
                 success(unsafeTakeover = result.unsafeTakeover)
             }
             is RevokeResult.Acknowledged -> {
-                recoveryLedger?.clear(leaseId)
-                result.nextGrant?.let(::completeGrant)
+                if (result.remainingDepth == 0) {
+                    recoveryLedger?.clear(leaseId)
+                    result.nextGrant?.let(::completeGrant)
+                }
                 success()
             }
             is RevokeResult.Rejected ->

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -22,7 +22,7 @@ internal class CoordinatorLeaseService(
     val epoch: String,
     heartbeatTimeout: Duration,
     private val revokeGrace: Duration,
-    private val recoveryGrace: Duration,
+    recoveryGrace: Duration,
     recoveryRecord: RecoveryRecord? = null,
     private val recoveryLedger: RecoveryLedger? = null,
 ) : AutoCloseable {
@@ -216,9 +216,16 @@ internal class CoordinatorLeaseService(
         val quarantine =
             machine.status(DesktopResourceKey(requireNotNull(message.resourceKey))).quarantine
         if (quarantine?.predecessorLeaseId == leaseId && message.force) {
-            return when (val result = machine.forceRecover(leaseId, requesterLabel, reason)) {
+            val result =
+                try {
+                    machine.forceRecover(leaseId, requesterLabel, reason) {
+                        recoveryLedger?.clear(leaseId)
+                    }
+                } catch (_: IOException) {
+                    return error("RECOVERY_PERSISTENCE_FAILED", "Could not persist forced recovery")
+                }
+            return when (result) {
                 is RecoveryResult.Recovered -> {
-                    recoveryLedger?.clear(leaseId)
                     requestTracker.forgetLease(leaseId)
                     result.nextGrants.forEach(::completeGrant)
                     success(unsafeTakeover = result.unsafeTakeover)
@@ -226,10 +233,17 @@ internal class CoordinatorLeaseService(
                 is RecoveryResult.Rejected -> error(result.code.name, "Recovery was rejected")
             }
         }
-        return when (val result = machine.revoke(leaseId, requesterLabel, reason, message.force)) {
+        val result =
+            try {
+                machine.revoke(leaseId, requesterLabel, reason, message.force) {
+                    recoveryLedger?.clear(leaseId)
+                }
+            } catch (_: IOException) {
+                return error("RECOVERY_PERSISTENCE_FAILED", "Could not persist forced recovery")
+            }
+        return when (result) {
             is RevokeResult.Requested -> success(unsafeTakeover = result.unsafeTakeover)
             is RevokeResult.Forced -> {
-                recoveryLedger?.clear(leaseId)
                 requestTracker.forgetLease(leaseId)
                 result.nextGrant?.let(::completeGrant)
                 success(unsafeTakeover = result.unsafeTakeover)
@@ -266,7 +280,6 @@ internal class CoordinatorLeaseService(
 
     @Synchronized
     private fun expire() {
-        recoveryLedger?.clearExpiredRecovery(recoveryGrace)
         machine.expire().forEach { event ->
             event.grant?.let(::completeGrant)
             event.timeout?.let { timeout ->

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -111,10 +111,20 @@ internal class CoordinatorLeaseService(
             is ReleaseResult.StillHeld -> success()
             is ReleaseResult.Rejected -> {
                 if (result.code.name == "FENCED") {
-                    when (val acknowledged = machine.acknowledgeRevocation(token)) {
+                    val acknowledged =
+                        try {
+                            machine.acknowledgeRevocation(token) {
+                                recoveryLedger?.clear(token.leaseId)
+                            }
+                        } catch (_: IOException) {
+                            return error(
+                                "RECOVERY_PERSISTENCE_FAILED",
+                                "Could not persist lease release",
+                            )
+                        }
+                    when (acknowledged) {
                         is RevokeResult.Acknowledged -> {
                             if (acknowledged.remainingDepth == 0) {
-                                recoveryLedger?.clear(token.leaseId)
                                 requestTracker.forgetLease(token.leaseId)
                                 acknowledged.nextGrant?.let(::completeGrant)
                             }

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -91,6 +91,7 @@ internal class CoordinatorLeaseService(
                 if (result.code.name == "FENCED") {
                     when (val acknowledged = machine.acknowledgeRevocation(token)) {
                         is RevokeResult.Acknowledged -> {
+                            recoveryLedger?.clear(token.leaseId)
                             acknowledged.nextGrant?.let(::completeGrant)
                             success()
                         }

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -55,6 +55,11 @@ internal class CoordinatorLeaseService(
     @Synchronized
     fun acquire(message: CoordinatorWireMessage): CompletableFuture<CoordinatorWireMessage> {
         val request = wireMapper.toAcquireRequest(message)
+        if (requestTracker.isDisconnected(request.owner.clientId)) {
+            return CompletableFuture.completedFuture(
+                error("CLIENT_DISCONNECTED", "Client session disconnected")
+            )
+        }
         if (requestTracker.consumeCancellation(request.owner.clientId, request.requestId)) {
             return CompletableFuture.completedFuture(error("ACQUIRE_CANCELLED", "Cancelled"))
         }
@@ -154,7 +159,13 @@ internal class CoordinatorLeaseService(
         }
 
     @Synchronized
+    fun openSession(clientId: String) {
+        requestTracker.markConnected(clientId)
+    }
+
+    @Synchronized
     fun disconnect(clientId: String) {
+        requestTracker.markDisconnected(clientId)
         recoveryLedger?.clearClient(clientId)
         requestTracker.forgetClient(clientId)
         val result = machine.disconnect(clientId)
@@ -296,7 +307,18 @@ internal class CoordinatorLeaseService(
 
 private class AcquisitionRequestTracker {
     private val cancelledBeforeAcquire = LinkedHashSet<CancelledAcquire>()
+    private val disconnectedClients = mutableSetOf<String>()
     private val grantsByRequest = mutableMapOf<CancelledAcquire, LeaseToken>()
+
+    fun isDisconnected(clientId: String): Boolean = clientId in disconnectedClients
+
+    fun markConnected(clientId: String) {
+        disconnectedClients -= clientId
+    }
+
+    fun markDisconnected(clientId: String) {
+        disconnectedClients += clientId
+    }
 
     fun consumeCancellation(clientId: String, requestId: String): Boolean =
         cancelledBeforeAcquire.remove(CancelledAcquire(clientId, requestId))

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -37,6 +37,7 @@ internal class CoordinatorLeaseService(
             leaseIdGenerator = LeaseIdGenerator { UUID.randomUUID().toString() },
         )
     private val pendingAcquires = mutableMapOf<String, CompletableFuture<CoordinatorWireMessage>>()
+    private val requestTracker = AcquisitionRequestTracker()
     private val wireMapper = CoordinatorWireMapper()
     private val expiryExecutor = Executors.newSingleThreadScheduledExecutor { task ->
         Thread(task, "spectre-input-expiry").apply { isDaemon = true }
@@ -54,9 +55,13 @@ internal class CoordinatorLeaseService(
     @Synchronized
     fun acquire(message: CoordinatorWireMessage): CompletableFuture<CoordinatorWireMessage> {
         val request = wireMapper.toAcquireRequest(message)
+        if (requestTracker.consumeCancellation(request.owner.clientId, request.requestId)) {
+            return CompletableFuture.completedFuture(error("ACQUIRE_CANCELLED", "Cancelled"))
+        }
         return when (val result = machine.acquire(request)) {
             is AcquireResult.Granted -> {
                 recoveryLedger?.record(result.grant)
+                requestTracker.rememberGrant(result.grant)
                 CompletableFuture.completedFuture(wireMapper.grant(result.grant))
             }
             is AcquireResult.Queued ->
@@ -80,6 +85,12 @@ internal class CoordinatorLeaseService(
     @Synchronized
     fun release(message: CoordinatorWireMessage): CoordinatorWireMessage {
         val token = wireMapper.toToken(message)
+        val response = releaseToken(token)
+        if (response.ok) requestTracker.forgetOneGrant(token, requireNotNull(message.clientId))
+        return response
+    }
+
+    private fun releaseToken(token: LeaseToken): CoordinatorWireMessage {
         return when (val result = machine.release(token)) {
             is ReleaseResult.Released -> {
                 recoveryLedger?.clear(token.leaseId)
@@ -93,6 +104,7 @@ internal class CoordinatorLeaseService(
                         is RevokeResult.Acknowledged -> {
                             if (acknowledged.remainingDepth == 0) {
                                 recoveryLedger?.clear(token.leaseId)
+                                requestTracker.forgetLease(token.leaseId)
                                 acknowledged.nextGrant?.let(::completeGrant)
                             }
                             success()
@@ -111,8 +123,23 @@ internal class CoordinatorLeaseService(
     @Synchronized
     fun cancel(message: CoordinatorWireMessage): CoordinatorWireMessage {
         val requestId = requireNotNull(message.requestId)
-        machine.cancelWaiter(requestId)
-        pendingAcquires.remove(requestId)?.complete(error("ACQUIRE_CANCELLED", "Cancelled"))
+        val clientId = requireNotNull(message.clientId)
+        val cancellation = CancelledAcquire(clientId, requestId)
+        val waiterRemoved = machine.cancelWaiter(requestId)
+        val pending = pendingAcquires.remove(requestId)
+        pending?.complete(error("ACQUIRE_CANCELLED", "Cancelled"))
+        if (!waiterRemoved && pending == null) {
+            val ambiguousGrant = requestTracker.takeGrant(clientId, requestId)
+            if (ambiguousGrant == null) {
+                // The operation connections are independent, so CANCEL can beat ACQUIRE. Retain a
+                // bounded tombstone so the delayed request cannot recreate the cancelled grant.
+                requestTracker.rememberCancellation(cancellation)
+            } else {
+                // ACQUIRE won but its response was lost. Release only that exact hold; unrelated
+                // requests sharing the client session remain live.
+                releaseToken(ambiguousGrant)
+            }
+        }
         return success()
     }
 
@@ -129,6 +156,7 @@ internal class CoordinatorLeaseService(
     @Synchronized
     fun disconnect(clientId: String) {
         recoveryLedger?.clearClient(clientId)
+        requestTracker.forgetClient(clientId)
         val result = machine.disconnect(clientId)
         result.cancelledRequestIds.forEach { requestId ->
             pendingAcquires
@@ -164,6 +192,7 @@ internal class CoordinatorLeaseService(
             return when (val result = machine.forceRecover(leaseId, requesterLabel, reason)) {
                 is RecoveryResult.Recovered -> {
                     recoveryLedger?.clear(leaseId)
+                    requestTracker.forgetLease(leaseId)
                     result.nextGrants.forEach(::completeGrant)
                     success(unsafeTakeover = result.unsafeTakeover)
                 }
@@ -174,12 +203,14 @@ internal class CoordinatorLeaseService(
             is RevokeResult.Requested -> success(unsafeTakeover = result.unsafeTakeover)
             is RevokeResult.Forced -> {
                 recoveryLedger?.clear(leaseId)
+                requestTracker.forgetLease(leaseId)
                 result.nextGrant?.let(::completeGrant)
                 success(unsafeTakeover = result.unsafeTakeover)
             }
             is RevokeResult.Acknowledged -> {
                 if (result.remainingDepth == 0) {
                     recoveryLedger?.clear(leaseId)
+                    requestTracker.forgetLease(leaseId)
                     result.nextGrant?.let(::completeGrant)
                 }
                 success()
@@ -228,6 +259,7 @@ internal class CoordinatorLeaseService(
 
     private fun completeGrant(grant: LeaseGrant) {
         recoveryLedger?.record(grant)
+        requestTracker.rememberGrant(grant)
         pendingAcquires.remove(grant.requestId)?.complete(wireMapper.grant(grant))
     }
 
@@ -261,6 +293,56 @@ internal class CoordinatorLeaseService(
         const val EXPIRY_INTERVAL_MILLIS: Long = 10
     }
 }
+
+private class AcquisitionRequestTracker {
+    private val cancelledBeforeAcquire = LinkedHashSet<CancelledAcquire>()
+    private val grantsByRequest = mutableMapOf<CancelledAcquire, LeaseToken>()
+
+    fun consumeCancellation(clientId: String, requestId: String): Boolean =
+        cancelledBeforeAcquire.remove(CancelledAcquire(clientId, requestId))
+
+    fun rememberCancellation(cancellation: CancelledAcquire) {
+        if (cancelledBeforeAcquire.size >= MAX_CANCELLATION_TOMBSTONES) {
+            val oldest = cancelledBeforeAcquire.iterator()
+            if (oldest.hasNext()) {
+                oldest.next()
+                oldest.remove()
+            }
+        }
+        cancelledBeforeAcquire += cancellation
+    }
+
+    fun rememberGrant(grant: LeaseGrant) {
+        grantsByRequest[CancelledAcquire(grant.owner.clientId, grant.requestId)] = grant.token
+    }
+
+    fun takeGrant(clientId: String, requestId: String): LeaseToken? =
+        grantsByRequest.remove(CancelledAcquire(clientId, requestId))
+
+    fun forgetOneGrant(token: LeaseToken, clientId: String) {
+        val key =
+            grantsByRequest.entries
+                .firstOrNull { (request, grantedToken) ->
+                    request.clientId == clientId && grantedToken == token
+                }
+                ?.key
+        if (key != null) grantsByRequest.remove(key)
+    }
+
+    fun forgetClient(clientId: String) {
+        grantsByRequest.keys.removeAll { it.clientId == clientId }
+    }
+
+    fun forgetLease(leaseId: String) {
+        grantsByRequest.entries.removeAll { it.value.leaseId == leaseId }
+    }
+
+    private companion object {
+        const val MAX_CANCELLATION_TOMBSTONES: Int = 1_024
+    }
+}
+
+private data class CancelledAcquire(val clientId: String, val requestId: String)
 
 private fun AcquisitionTimeout.diagnosticContext(): String =
     holder?.let { snapshot ->

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -188,15 +188,18 @@ internal class CoordinatorLeaseService(
     @Synchronized
     fun disconnect(clientId: String) {
         requestTracker.markDisconnected(clientId)
-        recoveryLedger?.clearClient(clientId)
-        requestTracker.forgetClient(clientId)
         val result = machine.disconnect(clientId)
+        if (result.retainedLeaseIds.isEmpty()) {
+            recoveryLedger?.clearClient(clientId)
+            requestTracker.forgetClient(clientId)
+        } else {
+            requestTracker.forgetClientExcept(clientId, result.retainedLeaseIds)
+        }
         result.cancelledRequestIds.forEach { requestId ->
             pendingAcquires
                 .remove(requestId)
                 ?.complete(error("CLIENT_DISCONNECTED", "Client session disconnected"))
         }
-        result.grants.forEach(::completeGrant)
     }
 
     @Synchronized
@@ -401,6 +404,12 @@ private class AcquisitionRequestTracker {
 
     fun forgetClient(clientId: String) {
         grantsByRequest.keys.removeAll { it.clientId == clientId }
+    }
+
+    fun forgetClientExcept(clientId: String, retainedLeaseIds: Set<String>) {
+        grantsByRequest.entries.removeAll { (request, token) ->
+            request.clientId == clientId && token.leaseId !in retainedLeaseIds
+        }
     }
 
     fun forgetLease(leaseId: String) {

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -158,7 +158,8 @@ internal class CoordinatorLeaseService(
             } else {
                 // ACQUIRE won but its response was lost. Release only that exact hold; unrelated
                 // requests sharing the client session remain live.
-                releaseToken(ambiguousGrant)
+                val release = releaseToken(ambiguousGrant)
+                if (!release.ok) disconnect(clientId)
             }
         }
         return success()

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -293,6 +293,7 @@ internal class CoordinatorLeaseService(
                 future.complete(error("COORDINATOR_CLOSED", "Input coordinator stopped"))
             }
             pendingAcquires.clear()
+            runCatching { recoveryLedger?.retryDiscarded() }
         }
     }
 

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -94,11 +94,12 @@ internal class CoordinatorLeaseService(
         val token = wireMapper.toToken(message)
         val clientId = requireNotNull(message.clientId)
         val requestId = requireNotNull(message.requestId)
+        if (requestTracker.matchesCompletedRelease(clientId, requestId, token)) return success()
         if (!requestTracker.matchesGrant(clientId, requestId, token)) {
             return error("STALE_LEASE", "Lease release request does not match an active grant")
         }
         val response = releaseToken(token)
-        if (response.ok) requestTracker.forgetGrant(clientId, requestId, token)
+        if (response.ok) requestTracker.completeRelease(clientId, requestId, token)
         return response
     }
 
@@ -373,6 +374,7 @@ private class AcquisitionRequestTracker {
     private val cancelledBeforeAcquire = LinkedHashSet<CancelledAcquire>()
     private val connectedClients = mutableSetOf<String>()
     private val grantsByRequest = mutableMapOf<CancelledAcquire, LeaseToken>()
+    private val completedReleasesByRequest = LinkedHashMap<CancelledAcquire, LeaseToken>()
 
     fun isConnected(clientId: String): Boolean = clientId in connectedClients
 
@@ -399,7 +401,9 @@ private class AcquisitionRequestTracker {
     }
 
     fun rememberGrant(grant: LeaseGrant) {
-        grantsByRequest[CancelledAcquire(grant.owner.clientId, grant.requestId)] = grant.token
+        val request = CancelledAcquire(grant.owner.clientId, grant.requestId)
+        completedReleasesByRequest.remove(request)
+        grantsByRequest[request] = grant.token
     }
 
     fun takeGrant(clientId: String, requestId: String): LeaseToken? =
@@ -408,26 +412,42 @@ private class AcquisitionRequestTracker {
     fun matchesGrant(clientId: String, requestId: String, token: LeaseToken): Boolean =
         grantsByRequest[CancelledAcquire(clientId, requestId)] == token
 
-    fun forgetGrant(clientId: String, requestId: String, token: LeaseToken) {
-        grantsByRequest.remove(CancelledAcquire(clientId, requestId), token)
+    fun matchesCompletedRelease(clientId: String, requestId: String, token: LeaseToken): Boolean =
+        completedReleasesByRequest[CancelledAcquire(clientId, requestId)] == token
+
+    fun completeRelease(clientId: String, requestId: String, token: LeaseToken) {
+        val request = CancelledAcquire(clientId, requestId)
+        grantsByRequest.remove(request, token)
+        if (completedReleasesByRequest.size >= MAX_COMPLETED_RELEASE_TOMBSTONES) {
+            val oldest = completedReleasesByRequest.iterator()
+            if (oldest.hasNext()) {
+                oldest.next()
+                oldest.remove()
+            }
+        }
+        completedReleasesByRequest[request] = token
     }
 
     fun forgetClient(clientId: String) {
         grantsByRequest.keys.removeAll { it.clientId == clientId }
+        completedReleasesByRequest.keys.removeAll { it.clientId == clientId }
     }
 
     fun forgetClientExcept(clientId: String, retainedLeaseIds: Set<String>) {
         grantsByRequest.entries.removeAll { (request, token) ->
             request.clientId == clientId && token.leaseId !in retainedLeaseIds
         }
+        completedReleasesByRequest.keys.removeAll { it.clientId == clientId }
     }
 
     fun forgetLease(leaseId: String) {
         grantsByRequest.entries.removeAll { it.value.leaseId == leaseId }
+        completedReleasesByRequest.entries.removeAll { it.value.leaseId == leaseId }
     }
 
     private companion object {
         const val MAX_CANCELLATION_TOMBSTONES: Int = 1_024
+        const val MAX_COMPLETED_RELEASE_TOMBSTONES: Int = 1_024
     }
 }
 

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseService.kt
@@ -1,0 +1,330 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorWireHolder
+import dev.sebastiano.spectre.input.CoordinatorWireKind
+import dev.sebastiano.spectre.input.CoordinatorWireMessage
+import dev.sebastiano.spectre.input.CoordinatorWireQuarantine
+import dev.sebastiano.spectre.input.CoordinatorWireStatus
+import dev.sebastiano.spectre.input.CoordinatorWireWaiter
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseOwner
+import dev.sebastiano.spectre.input.LeaseToken
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+internal class CoordinatorLeaseService(
+    val epoch: String,
+    heartbeatTimeout: Duration,
+    private val revokeGrace: Duration,
+    private val recoveryGrace: Duration,
+    recoveryRecord: RecoveryRecord? = null,
+    private val recoveryLedger: RecoveryLedger? = null,
+) : AutoCloseable {
+    private val machine =
+        LeaseStateMachine(
+            clock = MonotonicClock { TimeUnit.NANOSECONDS.toMillis(System.nanoTime()) },
+            epoch = epoch,
+            maxWaitersPerResource = MAX_WAITERS_PER_RESOURCE,
+            heartbeatTimeoutMillis = heartbeatTimeout.toMillis(),
+            revokeGraceMillis = revokeGrace.toMillis(),
+            recoveryGraceMillis = recoveryGrace.toMillis(),
+            recoveryRecord = recoveryRecord,
+            leaseIdGenerator = LeaseIdGenerator { UUID.randomUUID().toString() },
+        )
+    private val pendingAcquires = mutableMapOf<String, CompletableFuture<CoordinatorWireMessage>>()
+    private val wireMapper = CoordinatorWireMapper()
+    private val expiryExecutor = Executors.newSingleThreadScheduledExecutor { task ->
+        Thread(task, "spectre-input-expiry").apply { isDaemon = true }
+    }
+
+    init {
+        expiryExecutor.scheduleWithFixedDelay(
+            ::expire,
+            EXPIRY_INTERVAL_MILLIS,
+            EXPIRY_INTERVAL_MILLIS,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    @Synchronized
+    fun acquire(message: CoordinatorWireMessage): CompletableFuture<CoordinatorWireMessage> {
+        val request = wireMapper.toAcquireRequest(message)
+        return when (val result = machine.acquire(request)) {
+            is AcquireResult.Granted -> {
+                recoveryLedger?.record(result.grant)
+                CompletableFuture.completedFuture(wireMapper.grant(result.grant))
+            }
+            is AcquireResult.Queued ->
+                if (message.waitForLease) {
+                    CompletableFuture<CoordinatorWireMessage>().also { future ->
+                        pendingAcquires[result.requestId] = future
+                    }
+                } else {
+                    machine.cancelWaiter(result.requestId)
+                    CompletableFuture.completedFuture(
+                        error("LEASE_CONTENDED", "Desktop input lease is currently held")
+                    )
+                }
+            is AcquireResult.Rejected ->
+                CompletableFuture.completedFuture(
+                    error(result.code.name, "Lease acquisition rejected")
+                )
+        }
+    }
+
+    @Synchronized
+    fun release(message: CoordinatorWireMessage): CoordinatorWireMessage {
+        val token = wireMapper.toToken(message)
+        return when (val result = machine.release(token)) {
+            is ReleaseResult.Released -> {
+                recoveryLedger?.clear(token.leaseId)
+                result.nextGrant?.let(::completeGrant)
+                success()
+            }
+            is ReleaseResult.StillHeld -> success()
+            is ReleaseResult.Rejected -> {
+                if (result.code.name == "FENCED") {
+                    when (val acknowledged = machine.acknowledgeRevocation(token)) {
+                        is RevokeResult.Acknowledged -> {
+                            acknowledged.nextGrant?.let(::completeGrant)
+                            success()
+                        }
+                        is RevokeResult.Rejected ->
+                            error(acknowledged.code.name, "Lease release was rejected")
+                        else -> error(result.code.name, "Lease release was rejected")
+                    }
+                } else {
+                    error(result.code.name, "Lease release was rejected")
+                }
+            }
+        }
+    }
+
+    @Synchronized
+    fun cancel(message: CoordinatorWireMessage): CoordinatorWireMessage {
+        val requestId = requireNotNull(message.requestId)
+        machine.cancelWaiter(requestId)
+        pendingAcquires.remove(requestId)?.complete(error("ACQUIRE_CANCELLED", "Cancelled"))
+        return success()
+    }
+
+    @Synchronized
+    fun heartbeat(message: CoordinatorWireMessage): CoordinatorWireMessage =
+        when (val result = machine.heartbeat(wireMapper.toToken(message))) {
+            ValidationResult.Valid -> {
+                recoveryLedger?.heartbeat(wireMapper.toToken(message))
+                success()
+            }
+            is ValidationResult.Rejected -> error(result.code.name, "Lease heartbeat was rejected")
+        }
+
+    @Synchronized
+    fun disconnect(clientId: String) {
+        recoveryLedger?.clearClient(clientId)
+        machine.disconnect(clientId).forEach(::completeGrant)
+    }
+
+    @Synchronized
+    fun status(message: CoordinatorWireMessage): CoordinatorWireMessage {
+        val resourceKey = DesktopResourceKey(requireNotNull(message.resourceKey))
+        val snapshot = machine.status(resourceKey)
+        return success(
+            status =
+                CoordinatorWireStatus(
+                    resourceKey = resourceKey.value,
+                    holder = snapshot.holder?.let(wireMapper::holder),
+                    waiters = snapshot.waiters.map(wireMapper::waiter),
+                    quarantine = snapshot.quarantine?.let(wireMapper::quarantine),
+                )
+        )
+    }
+
+    @Synchronized
+    fun revoke(message: CoordinatorWireMessage): CoordinatorWireMessage {
+        val leaseId = requireNotNull(message.leaseId)
+        val requesterLabel = requireNotNull(message.requesterLabel)
+        val reason = requireNotNull(message.reason)
+        val quarantine =
+            machine.status(DesktopResourceKey(requireNotNull(message.resourceKey))).quarantine
+        if (quarantine?.predecessorLeaseId == leaseId && message.force) {
+            return when (val result = machine.forceRecover(leaseId, requesterLabel, reason)) {
+                is RecoveryResult.Recovered -> {
+                    recoveryLedger?.clear(leaseId)
+                    result.nextGrants.forEach(::completeGrant)
+                    success(unsafeTakeover = result.unsafeTakeover)
+                }
+                is RecoveryResult.Rejected -> error(result.code.name, "Recovery was rejected")
+            }
+        }
+        return when (val result = machine.revoke(leaseId, requesterLabel, reason, message.force)) {
+            is RevokeResult.Requested -> success(unsafeTakeover = result.unsafeTakeover)
+            is RevokeResult.Forced -> {
+                recoveryLedger?.clear(leaseId)
+                result.nextGrant?.let(::completeGrant)
+                success(unsafeTakeover = result.unsafeTakeover)
+            }
+            is RevokeResult.Acknowledged -> {
+                recoveryLedger?.clear(leaseId)
+                result.nextGrant?.let(::completeGrant)
+                success()
+            }
+            is RevokeResult.Rejected ->
+                error(
+                    result.code.name,
+                    if (result.code.name == "REVOKE_GRACE_ACTIVE") {
+                        "Revoke grace is still active for ${revokeGrace.toMillis()} ms"
+                    } else {
+                        "Lease revoke was rejected"
+                    },
+                )
+        }
+    }
+
+    override fun close() {
+        expiryExecutor.shutdownNow()
+        synchronized(this) {
+            pendingAcquires.values.forEach { future ->
+                future.complete(error("COORDINATOR_CLOSED", "Input coordinator stopped"))
+            }
+            pendingAcquires.clear()
+        }
+    }
+
+    @Synchronized
+    private fun expire() {
+        recoveryLedger?.clearExpiredRecovery(recoveryGrace)
+        machine.expire().forEach { event ->
+            event.grant?.let(::completeGrant)
+            event.timeout?.let { timeout ->
+                pendingAcquires
+                    .remove(timeout.requestId)
+                    ?.complete(
+                        error(
+                            code = "ACQUIRE_TIMEOUT",
+                            message =
+                                "Timed out for ${timeout.resourceKey.value} at queue position " +
+                                    "${timeout.queuePosition}; ${timeout.diagnosticContext()}",
+                        )
+                    )
+            }
+        }
+    }
+
+    private fun completeGrant(grant: LeaseGrant) {
+        recoveryLedger?.record(grant)
+        pendingAcquires.remove(grant.requestId)?.complete(wireMapper.grant(grant))
+    }
+
+    private fun success(
+        coordinatorEpoch: String? = null,
+        leaseId: String? = null,
+        fence: Long? = null,
+        unsafeTakeover: Boolean = false,
+        status: CoordinatorWireStatus? = null,
+    ): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.RESPONSE,
+            ok = true,
+            coordinatorEpoch = coordinatorEpoch,
+            leaseId = leaseId,
+            fence = fence,
+            unsafeTakeover = unsafeTakeover,
+            status = status,
+        )
+
+    private fun error(code: String, message: String): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.RESPONSE,
+            ok = false,
+            errorCode = code,
+            message = message,
+        )
+
+    private companion object {
+        const val MAX_WAITERS_PER_RESOURCE: Int = 128
+        const val EXPIRY_INTERVAL_MILLIS: Long = 10
+    }
+}
+
+private fun AcquisitionTimeout.diagnosticContext(): String =
+    holder?.let { snapshot ->
+        "holder ${snapshot.token.leaseId} owner=${snapshot.owner.label} " +
+            "pid=${snapshot.owner.processId} age=${snapshot.acquisitionAgeMillis}ms " +
+            "heartbeatAge=${snapshot.heartbeatAgeMillis}ms " +
+            "operation=${snapshot.currentOperation}"
+    }
+        ?: quarantine?.let { snapshot ->
+            "recovery quarantine predecessor=${snapshot.predecessorLeaseId} " +
+                "owner=${snapshot.owner.label} pid=${snapshot.owner.processId} " +
+                "releaseEligibleAt=${snapshot.releaseEligibleAtMillis}"
+        }
+        ?: "holder unavailable"
+
+private class CoordinatorWireMapper {
+    fun toAcquireRequest(message: CoordinatorWireMessage): AcquireRequest =
+        AcquireRequest(
+            requestId = requireNotNull(message.requestId),
+            resourceKey = DesktopResourceKey(requireNotNull(message.resourceKey)),
+            owner =
+                LeaseOwner(
+                    clientId = requireNotNull(message.clientId),
+                    processId = requireNotNull(message.processId),
+                    label = message.ownerLabel,
+                ),
+            timeoutMillis = requireNotNull(message.timeoutMillis),
+            currentOperation = message.currentOperation,
+        )
+
+    fun toToken(message: CoordinatorWireMessage): LeaseToken =
+        LeaseToken(
+            coordinatorEpoch = requireNotNull(message.coordinatorEpoch),
+            leaseId = requireNotNull(message.leaseId),
+            resourceKey = DesktopResourceKey(requireNotNull(message.resourceKey)),
+            fence = requireNotNull(message.fence),
+        )
+
+    fun grant(grant: LeaseGrant): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.RESPONSE,
+            coordinatorEpoch = grant.token.coordinatorEpoch,
+            leaseId = grant.token.leaseId,
+            fence = grant.token.fence,
+        )
+
+    fun holder(snapshot: HolderSnapshot): CoordinatorWireHolder =
+        CoordinatorWireHolder(
+            leaseId = snapshot.token.leaseId,
+            clientId = snapshot.owner.clientId,
+            processId = snapshot.owner.processId,
+            ownerLabel = snapshot.owner.label,
+            state = snapshot.status.name.lowercase(),
+            fence = snapshot.fence,
+            acquisitionAgeMillis = snapshot.acquisitionAgeMillis,
+            heartbeatAgeMillis = snapshot.heartbeatAgeMillis,
+            currentOperation = snapshot.currentOperation,
+        )
+
+    fun waiter(snapshot: WaiterSnapshot): CoordinatorWireWaiter =
+        CoordinatorWireWaiter(
+            requestId = snapshot.requestId,
+            clientId = snapshot.owner.clientId,
+            processId = snapshot.owner.processId,
+            ownerLabel = snapshot.owner.label,
+            position = snapshot.position,
+        )
+
+    fun quarantine(snapshot: QuarantineSnapshot): CoordinatorWireQuarantine =
+        CoordinatorWireQuarantine(
+            predecessorLeaseId = snapshot.predecessorLeaseId,
+            predecessorEpoch = snapshot.predecessorEpoch,
+            clientId = snapshot.owner.clientId,
+            processId = snapshot.owner.processId,
+            ownerLabel = snapshot.owner.label,
+            releaseEligibleAtMillis = snapshot.releaseEligibleAtMillis,
+        )
+}

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorProcessLauncher.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorProcessLauncher.kt
@@ -1,0 +1,59 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import java.io.IOException
+import java.nio.file.Path
+import java.time.Duration
+
+/** Starts a dedicated coordinator JVM from the supplied runtime classpath. */
+@ExperimentalSpectreInputCoordinationApi
+public class CoordinatorProcessLauncher(
+    private val endpoint: CoordinatorEndpoint,
+    private val javaExecutable: String = defaultJavaExecutable(),
+    private val classPath: String = System.getProperty("java.class.path"),
+    private val idleTimeout: Duration = Duration.ofSeconds(DEFAULT_IDLE_TIMEOUT_SECONDS),
+) {
+    init {
+        require(!idleTimeout.isNegative && !idleTimeout.isZero) { "Idle timeout must be positive" }
+    }
+
+    /** Launches the coordinator without inheriting client standard streams. */
+    @Throws(IOException::class)
+    public fun start(): Process =
+        ProcessBuilder(command())
+            .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+            .redirectError(ProcessBuilder.Redirect.DISCARD)
+            .start()
+
+    /** Returns the dedicated coordinator Java command without starting it. */
+    public fun command(): List<String> =
+        listOf(
+            javaExecutable,
+            "-cp",
+            classPath,
+            COORDINATOR_MAIN_CLASS,
+            "--socket",
+            endpoint.socketPath.toString(),
+            "--idle-millis",
+            idleTimeout.toMillis().toString(),
+        )
+
+    private companion object {
+        const val COORDINATOR_MAIN_CLASS: String =
+            "dev.sebastiano.spectre.input.server.CoordinatorProcessMainKt"
+        const val DEFAULT_IDLE_TIMEOUT_SECONDS: Long = 30
+
+        fun defaultJavaExecutable(): String {
+            val executable =
+                if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+                    "java.exe"
+                } else {
+                    "java"
+                }
+            return Path.of(System.getProperty("java.home"), "bin", executable).toString()
+        }
+    }
+}

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorProcessMain.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/CoordinatorProcessMain.kt
@@ -1,0 +1,40 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import java.nio.file.Path
+import java.time.Duration
+
+/** Runnable entrypoint for one local coordinator process. */
+@ExperimentalSpectreInputCoordinationApi
+public object CoordinatorProcessMain {
+    /** Parses [arguments], binds the requested endpoint, and serves until shutdown. */
+    @Throws(InterruptedException::class)
+    public fun run(arguments: List<String>) {
+        val socketPath = option(arguments, SOCKET_OPTION)?.let(Path::of) ?: error(USAGE)
+        val idleMillis = option(arguments, IDLE_MILLIS_OPTION)?.toLongOrNull() ?: error(USAGE)
+        require(idleMillis > 0) { USAGE }
+        val endpoint = CoordinatorEndpoint(socketPath.parent, socketPath)
+        LocalCoordinatorServer(endpoint, idleTimeout = Duration.ofMillis(idleMillis)).use { server
+            ->
+            server.start()
+            server.awaitTermination()
+        }
+    }
+
+    private fun option(arguments: List<String>, name: String): String? {
+        val index = arguments.indexOf(name)
+        return arguments.getOrNull(index + 1).takeIf { index >= 0 }
+    }
+
+    private const val SOCKET_OPTION: String = "--socket"
+    private const val IDLE_MILLIS_OPTION: String = "--idle-millis"
+    private const val USAGE: String =
+        "Usage: spectre-input-coordinator --socket <path> --idle-millis <positive-ms>"
+}
+
+/** Starts the coordinator process entrypoint. */
+@ExperimentalSpectreInputCoordinationApi
+public fun main(arguments: Array<String>): Unit = CoordinatorProcessMain.run(arguments.asList())

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LaunchingInputCoordinatorClientProvider.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LaunchingInputCoordinatorClientProvider.kt
@@ -1,0 +1,57 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import dev.sebastiano.spectre.input.InputCoordinatorClientProvider
+import dev.sebastiano.spectre.input.LocalInputCoordinatorClient
+import java.io.IOException
+import java.time.Duration
+import java.util.concurrent.locks.LockSupport
+
+/** Service-loaded provider that launches the small external coordinator JVM when necessary. */
+@ExperimentalSpectreInputCoordinationApi
+public class LaunchingInputCoordinatorClientProvider : InputCoordinatorClientProvider {
+    override fun connect(
+        endpoint: CoordinatorEndpoint,
+        resourceKey: DesktopResourceKey,
+        ownerLabel: String?,
+    ): LocalInputCoordinatorClient {
+        tryConnect(endpoint, resourceKey, ownerLabel)?.let {
+            return it
+        }
+        CoordinatorProcessLauncher(endpoint).start()
+        val deadline = System.nanoTime() + STARTUP_TIMEOUT.toNanos()
+        var lastFailure: IOException? = null
+        while (System.nanoTime() < deadline) {
+            try {
+                return LocalInputCoordinatorClient.connect(endpoint, resourceKey, ownerLabel)
+            } catch (failure: IOException) {
+                lastFailure = failure
+                LockSupport.parkNanos(STARTUP_RETRY_DELAY.toNanos())
+            }
+        }
+        throw IOException(
+            "Input coordinator did not become ready at ${endpoint.socketPath}",
+            lastFailure,
+        )
+    }
+
+    private fun tryConnect(
+        endpoint: CoordinatorEndpoint,
+        resourceKey: DesktopResourceKey,
+        ownerLabel: String?,
+    ): LocalInputCoordinatorClient? =
+        try {
+            LocalInputCoordinatorClient.connect(endpoint, resourceKey, ownerLabel)
+        } catch (_: IOException) {
+            null
+        }
+
+    private companion object {
+        val STARTUP_TIMEOUT: Duration = Duration.ofSeconds(5)
+        val STARTUP_RETRY_DELAY: Duration = Duration.ofMillis(10)
+    }
+}

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
@@ -210,7 +210,7 @@ internal class LeaseStateMachine(
         return false
     }
 
-    fun release(token: LeaseToken): ReleaseResult {
+    fun release(token: LeaseToken, advanceQueue: Boolean = true): ReleaseResult {
         val state =
             resources[token.resourceKey]
                 ?: return ReleaseResult.Rejected(LeaseErrorCode.STALE_LEASE)
@@ -221,7 +221,7 @@ internal class LeaseStateMachine(
         holder.depth -= 1
         if (holder.depth > 0) return ReleaseResult.StillHeld(holder.depth)
         state.holder = null
-        return ReleaseResult.Released(transitions.grantNext(state))
+        return ReleaseResult.Released(if (advanceQueue) transitions.grantNext(state) else null)
     }
 
     fun heartbeat(token: LeaseToken): ValidationResult {

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
@@ -395,7 +395,10 @@ internal class LeaseStateMachine(
         return forceRevocation(state, holder)
     }
 
-    fun acknowledgeRevocation(token: LeaseToken): RevokeResult {
+    fun acknowledgeRevocation(
+        token: LeaseToken,
+        beforeFinalAcknowledgement: () -> Unit = {},
+    ): RevokeResult {
         if (token.coordinatorEpoch != epoch) {
             return RevokeResult.Rejected(LeaseErrorCode.STALE_EPOCH)
         }
@@ -407,10 +410,11 @@ internal class LeaseStateMachine(
         }
         val revocation =
             holder.revocation ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
-        holder.depth -= 1
-        if (holder.depth > 0) {
+        if (holder.depth > 1) {
+            holder.depth -= 1
             return RevokeResult.Acknowledged(nextGrant = null, remainingDepth = holder.depth)
         }
+        beforeFinalAcknowledgement()
         recordRevocation(holder, revocation, acknowledged = true, unsafeTakeover = false)
         state.holder = null
         return RevokeResult.Acknowledged(transitions.grantNext(state))

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
@@ -117,7 +117,7 @@ internal sealed interface RecoveryResult {
 internal sealed interface RevokeResult {
     data class Requested(val unsafeTakeover: Boolean = false) : RevokeResult
 
-    data class Acknowledged(val nextGrant: LeaseGrant?) : RevokeResult
+    data class Acknowledged(val nextGrant: LeaseGrant?, val remainingDepth: Int = 0) : RevokeResult
 
     data class Forced(val unsafeTakeover: Boolean = true, val nextGrant: LeaseGrant?) : RevokeResult
 
@@ -400,6 +400,10 @@ internal class LeaseStateMachine(
         }
         val revocation =
             holder.revocation ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        holder.depth -= 1
+        if (holder.depth > 0) {
+            return RevokeResult.Acknowledged(nextGrant = null, remainingDepth = holder.depth)
+        }
         recordRevocation(holder, revocation, acknowledged = true, unsafeTakeover = false)
         state.holder = null
         return RevokeResult.Acknowledged(transitions.grantNext(state))

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
@@ -210,7 +210,11 @@ internal class LeaseStateMachine(
         return false
     }
 
-    fun release(token: LeaseToken, advanceQueue: Boolean = true): ReleaseResult {
+    fun release(
+        token: LeaseToken,
+        advanceQueue: Boolean = true,
+        beforeFinalRelease: () -> Unit = {},
+    ): ReleaseResult {
         val state =
             resources[token.resourceKey]
                 ?: return ReleaseResult.Rejected(LeaseErrorCode.STALE_LEASE)
@@ -218,8 +222,11 @@ internal class LeaseStateMachine(
         transitions.validationError(token, holder)?.let {
             return ReleaseResult.Rejected(it)
         }
-        holder.depth -= 1
-        if (holder.depth > 0) return ReleaseResult.StillHeld(holder.depth)
+        if (holder.depth > 1) {
+            holder.depth -= 1
+            return ReleaseResult.StillHeld(holder.depth)
+        }
+        beforeFinalRelease()
         state.holder = null
         return ReleaseResult.Released(if (advanceQueue) transitions.grantNext(state) else null)
     }

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
@@ -289,16 +289,7 @@ internal class LeaseStateMachine(
                     reason = "heartbeat expired",
                 )
             }
-            if (state.quarantine?.releaseEligibleAtMillis?.let { now >= it } == true) {
-                state.quarantine = null
-            }
             if (state.holder == null && state.quarantine == null && globalQuarantine == null) {
-                transitions.grantNext(state)?.let { events += ExpiryEvent(grant = it) }
-            }
-        }
-        if (globalQuarantine?.releaseEligibleAtMillis?.let { now >= it } == true) {
-            globalQuarantine = null
-            resources.values.forEach { state ->
                 transitions.grantNext(state)?.let { events += ExpiryEvent(grant = it) }
             }
         }
@@ -327,11 +318,13 @@ internal class LeaseStateMachine(
         observedLeaseId: String,
         requesterLabel: String,
         reason: String,
+        beforeRecovery: () -> Unit = {},
     ): RecoveryResult {
         globalQuarantine?.let { quarantine ->
             if (quarantine.record.leaseId != observedLeaseId) {
                 return RecoveryResult.Rejected(LeaseErrorCode.STALE_LEASE)
             }
+            beforeRecovery()
             globalQuarantine = null
             auditRecords.recordRecoveryTakeover(
                 clock.nowMillis(),
@@ -352,6 +345,7 @@ internal class LeaseStateMachine(
         if (quarantine.record.leaseId != observedLeaseId) {
             return RecoveryResult.Rejected(LeaseErrorCode.STALE_LEASE)
         }
+        beforeRecovery()
         entry.quarantine = null
         auditRecords.recordRecoveryTakeover(
             clock.nowMillis(),
@@ -371,6 +365,7 @@ internal class LeaseStateMachine(
         requesterLabel: String,
         reason: String,
         force: Boolean,
+        beforeForcedRevocation: () -> Unit = {},
     ): RevokeResult {
         val (state, holder) =
             resources.values.firstNotNullOfOrNull { state ->
@@ -380,7 +375,10 @@ internal class LeaseStateMachine(
             } ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
         if (holder.status == LeaseStatus.HELD) {
             transitions.beginRevocation(state, holder, requesterLabel, reason)
-            if (force && revokeGraceMillis == 0L) return forceRevocation(state, holder)
+            if (force && revokeGraceMillis == 0L) {
+                beforeForcedRevocation()
+                return forceRevocation(state, holder)
+            }
             return if (force) {
                 RevokeResult.Rejected(LeaseErrorCode.REVOKE_GRACE_ACTIVE)
             } else {
@@ -392,6 +390,7 @@ internal class LeaseStateMachine(
         if (clock.nowMillis() - requestedAt < revokeGraceMillis) {
             return RevokeResult.Rejected(LeaseErrorCode.REVOKE_GRACE_ACTIVE)
         }
+        beforeForcedRevocation()
         return forceRevocation(state, holder)
     }
 

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
@@ -94,8 +94,8 @@ internal data class ExpiryEvent(
 }
 
 internal data class DisconnectResult(
-    val grants: List<LeaseGrant>,
     val cancelledRequestIds: List<String>,
+    val retainedLeaseIds: Set<String>,
 )
 
 internal data class RecoveryRecord(
@@ -257,18 +257,26 @@ internal class LeaseStateMachine(
     }
 
     fun disconnect(clientId: String): DisconnectResult {
-        val grants = mutableListOf<LeaseGrant>()
         val cancelledRequestIds = mutableListOf<String>()
+        val retainedLeaseIds = mutableSetOf<String>()
         resources.values.forEach { state ->
             val disconnectedWaiters = state.waiters.filter { it.request.owner.clientId == clientId }
             cancelledRequestIds += disconnectedWaiters.map { it.request.requestId }
             state.waiters.removeAll(disconnectedWaiters.toSet())
-            if (state.holder?.owner?.clientId == clientId) {
-                state.holder = null
-                transitions.grantNext(state)?.let(grants::add)
+            val holder = state.holder
+            if (holder?.owner?.clientId == clientId) {
+                if (holder.status == LeaseStatus.HELD) {
+                    transitions.beginRevocation(
+                        state,
+                        holder,
+                        requesterLabel = "coordinator",
+                        reason = "owner session disconnected",
+                    )
+                }
+                retainedLeaseIds += holder.token.leaseId
             }
         }
-        return DisconnectResult(grants, cancelledRequestIds)
+        return DisconnectResult(cancelledRequestIds, retainedLeaseIds)
     }
 
     fun expire(): List<ExpiryEvent> {

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
@@ -93,6 +93,11 @@ internal data class ExpiryEvent(
         get() = grant?.owner
 }
 
+internal data class DisconnectResult(
+    val grants: List<LeaseGrant>,
+    val cancelledRequestIds: List<String>,
+)
+
 internal data class RecoveryRecord(
     val resourceKey: DesktopResourceKey,
     val predecessorEpoch: String,
@@ -244,16 +249,19 @@ internal class LeaseStateMachine(
         return if (error == null) ValidationResult.Valid else ValidationResult.Rejected(error)
     }
 
-    fun disconnect(clientId: String): List<LeaseGrant> {
+    fun disconnect(clientId: String): DisconnectResult {
         val grants = mutableListOf<LeaseGrant>()
+        val cancelledRequestIds = mutableListOf<String>()
         resources.values.forEach { state ->
-            state.waiters.removeAll { it.request.owner.clientId == clientId }
+            val disconnectedWaiters = state.waiters.filter { it.request.owner.clientId == clientId }
+            cancelledRequestIds += disconnectedWaiters.map { it.request.requestId }
+            state.waiters.removeAll(disconnectedWaiters.toSet())
             if (state.holder?.owner?.clientId == clientId) {
                 state.holder = null
                 transitions.grantNext(state)?.let(grants::add)
             }
         }
-        return grants
+        return DisconnectResult(grants, cancelledRequestIds)
     }
 
     fun expire(): List<ExpiryEvent> {

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
@@ -1,0 +1,590 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseErrorCode
+import dev.sebastiano.spectre.input.LeaseOwner
+import dev.sebastiano.spectre.input.LeaseToken
+
+internal fun interface MonotonicClock {
+    fun nowMillis(): Long
+}
+
+internal fun interface LeaseIdGenerator {
+    fun nextId(): String
+}
+
+internal data class AcquireRequest(
+    val requestId: String,
+    val resourceKey: DesktopResourceKey,
+    val owner: LeaseOwner,
+    val timeoutMillis: Long,
+    val currentOperation: String?,
+)
+
+internal sealed interface AcquireResult {
+    data class Granted(val grant: LeaseGrant) : AcquireResult
+
+    data class Queued(val requestId: String, val position: Int) : AcquireResult
+
+    data class Rejected(val code: LeaseErrorCode) : AcquireResult
+}
+
+internal data class LeaseGrant(val requestId: String, val owner: LeaseOwner, val token: LeaseToken)
+
+internal sealed interface ReleaseResult {
+    data class Released(val nextGrant: LeaseGrant?) : ReleaseResult
+
+    data class StillHeld(val remainingDepth: Int) : ReleaseResult
+
+    data class Rejected(val code: LeaseErrorCode) : ReleaseResult
+}
+
+internal sealed interface ValidationResult {
+    data object Valid : ValidationResult
+
+    data class Rejected(val code: LeaseErrorCode) : ValidationResult
+}
+
+internal enum class LeaseStatus {
+    HELD,
+    REVOKING,
+}
+
+internal data class HolderSnapshot(
+    val token: LeaseToken,
+    val owner: LeaseOwner,
+    val status: LeaseStatus,
+    val fence: Long,
+    val acquisitionAgeMillis: Long,
+    val heartbeatAgeMillis: Long,
+    val currentOperation: String?,
+)
+
+internal data class WaiterSnapshot(val requestId: String, val owner: LeaseOwner, val position: Int)
+
+internal data class QuarantineSnapshot(
+    val predecessorLeaseId: String,
+    val predecessorEpoch: String,
+    val owner: LeaseOwner,
+    val releaseEligibleAtMillis: Long,
+)
+
+internal data class ResourceSnapshot(
+    val holder: HolderSnapshot?,
+    val waiters: List<WaiterSnapshot>,
+    val quarantine: QuarantineSnapshot?,
+)
+
+internal data class AcquisitionTimeout(
+    val requestId: String,
+    val resourceKey: DesktopResourceKey,
+    val queuePosition: Int,
+    val holder: HolderSnapshot?,
+    val quarantine: QuarantineSnapshot?,
+)
+
+internal data class ExpiryEvent(
+    val timeout: AcquisitionTimeout? = null,
+    val grant: LeaseGrant? = null,
+) {
+    val owner: LeaseOwner?
+        get() = grant?.owner
+}
+
+internal data class RecoveryRecord(
+    val resourceKey: DesktopResourceKey,
+    val predecessorEpoch: String,
+    val leaseId: String,
+    val owner: LeaseOwner,
+    val heartbeatExpiryMillis: Long,
+    val blocksAllResources: Boolean = false,
+)
+
+internal sealed interface RecoveryResult {
+    data class Recovered(val unsafeTakeover: Boolean, val nextGrants: List<LeaseGrant>) :
+        RecoveryResult
+
+    data class Rejected(val code: LeaseErrorCode) : RecoveryResult
+}
+
+internal sealed interface RevokeResult {
+    data class Requested(val unsafeTakeover: Boolean = false) : RevokeResult
+
+    data class Acknowledged(val nextGrant: LeaseGrant?) : RevokeResult
+
+    data class Forced(val unsafeTakeover: Boolean = true, val nextGrant: LeaseGrant?) : RevokeResult
+
+    data class Rejected(val code: LeaseErrorCode) : RevokeResult
+}
+
+internal data class RevokeAuditRecord(
+    val timestampMillis: Long,
+    val leaseId: String,
+    val previousOwner: LeaseOwner,
+    val requesterLabel: String,
+    val reason: String,
+    val acknowledged: Boolean,
+    val unsafeTakeover: Boolean,
+)
+
+internal class LeaseStateMachine(
+    private val clock: MonotonicClock,
+    private val epoch: String,
+    private val maxWaitersPerResource: Int,
+    private val heartbeatTimeoutMillis: Long,
+    private val revokeGraceMillis: Long,
+    private val recoveryGraceMillis: Long,
+    recoveryRecord: RecoveryRecord?,
+    private val leaseIdGenerator: LeaseIdGenerator,
+) {
+    private val resources = mutableMapOf<DesktopResourceKey, ResourceState>()
+    private var globalQuarantine: RecoveryQuarantine? = null
+    private val auditRecords = mutableListOf<RevokeAuditRecord>()
+    private val transitions = LeaseTransitions(clock, epoch, leaseIdGenerator)
+
+    init {
+        require(epoch.isNotBlank()) { "Coordinator epoch must not be blank" }
+        require(maxWaitersPerResource >= 0) { "Maximum waiters must not be negative" }
+        require(heartbeatTimeoutMillis > 0) { "Heartbeat timeout must be positive" }
+        require(revokeGraceMillis >= 0) { "Revoke grace must not be negative" }
+        require(recoveryGraceMillis >= 0) { "Recovery grace must not be negative" }
+        recoveryRecord?.let { record ->
+            val quarantine =
+                RecoveryQuarantine(
+                    record = record,
+                    releaseEligibleAtMillis =
+                        saturatingAdd(record.heartbeatExpiryMillis, recoveryGraceMillis),
+                )
+            if (record.blocksAllResources) {
+                globalQuarantine = quarantine
+            } else {
+                resources[record.resourceKey] = ResourceState(quarantine = quarantine)
+            }
+        }
+    }
+
+    fun acquire(request: AcquireRequest): AcquireResult {
+        require(request.requestId.isNotBlank()) { "Request ID must not be blank" }
+        require(request.timeoutMillis >= 0) { "Acquire timeout must not be negative" }
+        val state = resources.getOrPut(request.resourceKey) { ResourceState() }
+        val holder = state.holder
+        if (holder != null && holder.owner.clientId == request.owner.clientId) {
+            if (holder.status != LeaseStatus.HELD) {
+                return AcquireResult.Rejected(LeaseErrorCode.FENCED)
+            }
+            holder.depth += 1
+            return AcquireResult.Granted(LeaseGrant(request.requestId, request.owner, holder.token))
+        }
+        if (
+            holder == null &&
+                state.quarantine == null &&
+                globalQuarantine == null &&
+                state.waiters.isEmpty()
+        ) {
+            return AcquireResult.Granted(transitions.grant(state, request))
+        }
+        if (state.waiters.size >= maxWaitersPerResource) {
+            return AcquireResult.Rejected(LeaseErrorCode.QUEUE_FULL)
+        }
+        state.waiters +=
+            Waiter(
+                request = request,
+                enqueuedAtMillis = clock.nowMillis(),
+                deadlineMillis = saturatingAdd(clock.nowMillis(), request.timeoutMillis),
+            )
+        return AcquireResult.Queued(request.requestId, state.waiters.size)
+    }
+
+    fun cancelWaiter(requestId: String): Boolean {
+        resources.values.forEach { state ->
+            val removed = state.waiters.removeAll { it.request.requestId == requestId }
+            if (removed) return true
+        }
+        return false
+    }
+
+    fun release(token: LeaseToken): ReleaseResult {
+        val state =
+            resources[token.resourceKey]
+                ?: return ReleaseResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        val holder = state.holder ?: return ReleaseResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        transitions.validationError(token, holder)?.let {
+            return ReleaseResult.Rejected(it)
+        }
+        holder.depth -= 1
+        if (holder.depth > 0) return ReleaseResult.StillHeld(holder.depth)
+        state.holder = null
+        return ReleaseResult.Released(transitions.grantNext(state))
+    }
+
+    fun heartbeat(token: LeaseToken): ValidationResult {
+        if (token.coordinatorEpoch != epoch) {
+            return ValidationResult.Rejected(LeaseErrorCode.STALE_EPOCH)
+        }
+        val holder =
+            resources[token.resourceKey]?.holder
+                ?: return ValidationResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        transitions.validationError(token, holder)?.let {
+            return ValidationResult.Rejected(it)
+        }
+        holder.lastHeartbeatMillis = clock.nowMillis()
+        return ValidationResult.Valid
+    }
+
+    fun validate(token: LeaseToken): ValidationResult {
+        if (token.coordinatorEpoch != epoch) {
+            return ValidationResult.Rejected(LeaseErrorCode.STALE_EPOCH)
+        }
+        val holder =
+            resources[token.resourceKey]?.holder
+                ?: return ValidationResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        val error = transitions.validationError(token, holder)
+        return if (error == null) ValidationResult.Valid else ValidationResult.Rejected(error)
+    }
+
+    fun disconnect(clientId: String): List<LeaseGrant> {
+        val grants = mutableListOf<LeaseGrant>()
+        resources.values.forEach { state ->
+            state.waiters.removeAll { it.request.owner.clientId == clientId }
+            if (state.holder?.owner?.clientId == clientId) {
+                state.holder = null
+                transitions.grantNext(state)?.let(grants::add)
+            }
+        }
+        return grants
+    }
+
+    fun expire(): List<ExpiryEvent> {
+        val now = clock.nowMillis()
+        val events = mutableListOf<ExpiryEvent>()
+        resources.forEach { (resourceKey, state) ->
+            expireWaiters(resourceKey, state, now, events, globalQuarantine)
+            val holder = state.holder
+            if (
+                holder != null &&
+                    holder.status == LeaseStatus.HELD &&
+                    now - holder.lastHeartbeatMillis > heartbeatTimeoutMillis
+            ) {
+                transitions.beginRevocation(
+                    state,
+                    holder,
+                    requesterLabel = "coordinator",
+                    reason = "heartbeat expired",
+                )
+            }
+            if (state.quarantine?.releaseEligibleAtMillis?.let { now >= it } == true) {
+                state.quarantine = null
+            }
+            if (state.holder == null && state.quarantine == null && globalQuarantine == null) {
+                transitions.grantNext(state)?.let { events += ExpiryEvent(grant = it) }
+            }
+        }
+        if (globalQuarantine?.releaseEligibleAtMillis?.let { now >= it } == true) {
+            globalQuarantine = null
+            resources.values.forEach { state ->
+                transitions.grantNext(state)?.let { events += ExpiryEvent(grant = it) }
+            }
+        }
+        return events
+    }
+
+    fun status(resourceKey: DesktopResourceKey): ResourceSnapshot {
+        val state = resources[resourceKey] ?: ResourceState()
+        val now = clock.nowMillis()
+        val holder = state.holder
+        return ResourceSnapshot(
+            holder = holder?.toSnapshot(now),
+            waiters =
+                state.waiters.mapIndexed { index, waiter ->
+                    WaiterSnapshot(
+                        requestId = waiter.request.requestId,
+                        owner = waiter.request.owner,
+                        position = index + 1,
+                    )
+                },
+            quarantine = (state.quarantine ?: globalQuarantine)?.toSnapshot(),
+        )
+    }
+
+    fun forceRecover(
+        observedLeaseId: String,
+        requesterLabel: String,
+        reason: String,
+    ): RecoveryResult {
+        globalQuarantine?.let { quarantine ->
+            if (quarantine.record.leaseId != observedLeaseId) {
+                return RecoveryResult.Rejected(LeaseErrorCode.STALE_LEASE)
+            }
+            globalQuarantine = null
+            auditRecords.recordRecoveryTakeover(
+                clock.nowMillis(),
+                quarantine,
+                observedLeaseId,
+                requesterLabel,
+                reason,
+            )
+            return RecoveryResult.Recovered(
+                unsafeTakeover = true,
+                nextGrants = resources.values.mapNotNull(transitions::grantNext),
+            )
+        }
+        val (entry, quarantine) =
+            resources.values.firstNotNullOfOrNull { state ->
+                state.quarantine?.let { quarantine -> state to quarantine }
+            } ?: return RecoveryResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        if (quarantine.record.leaseId != observedLeaseId) {
+            return RecoveryResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        }
+        entry.quarantine = null
+        auditRecords.recordRecoveryTakeover(
+            clock.nowMillis(),
+            quarantine,
+            observedLeaseId,
+            requesterLabel,
+            reason,
+        )
+        return RecoveryResult.Recovered(
+            unsafeTakeover = true,
+            nextGrants = listOfNotNull(transitions.grantNext(entry)),
+        )
+    }
+
+    fun revoke(
+        observedLeaseId: String,
+        requesterLabel: String,
+        reason: String,
+        force: Boolean,
+    ): RevokeResult {
+        val (state, holder) =
+            resources.values.firstNotNullOfOrNull { state ->
+                state.holder
+                    ?.takeIf { holder -> holder.token.leaseId == observedLeaseId }
+                    ?.let { holder -> state to holder }
+            } ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        if (holder.status == LeaseStatus.HELD) {
+            transitions.beginRevocation(state, holder, requesterLabel, reason)
+            if (force && revokeGraceMillis == 0L) return forceRevocation(state, holder)
+            return if (force) {
+                RevokeResult.Rejected(LeaseErrorCode.REVOKE_GRACE_ACTIVE)
+            } else {
+                RevokeResult.Requested()
+            }
+        }
+        val requestedAt = checkNotNull(holder.revocation).requestedAtMillis
+        if (!force) return RevokeResult.Requested()
+        if (clock.nowMillis() - requestedAt < revokeGraceMillis) {
+            return RevokeResult.Rejected(LeaseErrorCode.REVOKE_GRACE_ACTIVE)
+        }
+        return forceRevocation(state, holder)
+    }
+
+    fun acknowledgeRevocation(token: LeaseToken): RevokeResult {
+        if (token.coordinatorEpoch != epoch) {
+            return RevokeResult.Rejected(LeaseErrorCode.STALE_EPOCH)
+        }
+        val state =
+            resources[token.resourceKey] ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        val holder = state.holder ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        if (holder.token.leaseId != token.leaseId) {
+            return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        }
+        val revocation =
+            holder.revocation ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        recordRevocation(holder, revocation, acknowledged = true, unsafeTakeover = false)
+        state.holder = null
+        return RevokeResult.Acknowledged(transitions.grantNext(state))
+    }
+
+    fun auditLog(): List<RevokeAuditRecord> = auditRecords.toList()
+
+    private fun expireWaiters(
+        resourceKey: DesktopResourceKey,
+        state: ResourceState,
+        now: Long,
+        events: MutableList<ExpiryEvent>,
+        globalQuarantine: RecoveryQuarantine?,
+    ) {
+        val iterator = state.waiters.listIterator()
+        var position = 1
+        while (iterator.hasNext()) {
+            val waiter = iterator.next()
+            if (now >= waiter.deadlineMillis) {
+                val holder = state.holder
+                val quarantine = state.quarantine ?: globalQuarantine
+                events +=
+                    ExpiryEvent(
+                        timeout =
+                            AcquisitionTimeout(
+                                requestId = waiter.request.requestId,
+                                resourceKey = resourceKey,
+                                queuePosition = position,
+                                holder = holder?.toSnapshot(now),
+                                quarantine = quarantine?.toSnapshot(),
+                            )
+                    )
+                iterator.remove()
+            } else {
+                position += 1
+            }
+        }
+    }
+
+    private fun forceRevocation(state: ResourceState, holder: Holder): RevokeResult.Forced {
+        val revocation = checkNotNull(holder.revocation)
+        recordRevocation(holder, revocation, acknowledged = false, unsafeTakeover = true)
+        state.holder = null
+        return RevokeResult.Forced(nextGrant = transitions.grantNext(state))
+    }
+
+    private fun recordRevocation(
+        holder: Holder,
+        revocation: Revocation,
+        acknowledged: Boolean,
+        unsafeTakeover: Boolean,
+    ) {
+        auditRecords +=
+            RevokeAuditRecord(
+                timestampMillis = clock.nowMillis(),
+                leaseId = holder.token.leaseId,
+                previousOwner = holder.owner,
+                requesterLabel = revocation.requesterLabel,
+                reason = revocation.reason,
+                acknowledged = acknowledged,
+                unsafeTakeover = unsafeTakeover,
+            )
+    }
+
+    private companion object {
+        fun saturatingAdd(value: Long, increment: Long): Long =
+            if (Long.MAX_VALUE - value < increment) Long.MAX_VALUE else value + increment
+    }
+}
+
+private class LeaseTransitions(
+    private val clock: MonotonicClock,
+    private val epoch: String,
+    private val leaseIdGenerator: LeaseIdGenerator,
+) {
+    fun grant(state: ResourceState, request: AcquireRequest): LeaseGrant {
+        state.fenceGeneration += 1
+        val token =
+            LeaseToken(
+                coordinatorEpoch = epoch,
+                leaseId = leaseIdGenerator.nextId(),
+                resourceKey = request.resourceKey,
+                fence = state.fenceGeneration,
+            )
+        val now = clock.nowMillis()
+        state.holder =
+            Holder(
+                token = token,
+                owner = request.owner,
+                acquiredAtMillis = now,
+                lastHeartbeatMillis = now,
+                currentOperation = request.currentOperation,
+            )
+        return LeaseGrant(request.requestId, request.owner, token)
+    }
+
+    fun grantNext(state: ResourceState): LeaseGrant? {
+        if (state.holder != null || state.quarantine != null) return null
+        val waiter = state.waiters.firstOrNull() ?: return null
+        if (clock.nowMillis() >= waiter.deadlineMillis) return null
+        state.waiters.removeFirst()
+        return grant(state, waiter.request)
+    }
+
+    fun beginRevocation(
+        state: ResourceState,
+        holder: Holder,
+        requesterLabel: String,
+        reason: String,
+    ) {
+        state.fenceGeneration += 1
+        holder.status = LeaseStatus.REVOKING
+        holder.fence = state.fenceGeneration
+        holder.revocation = Revocation(clock.nowMillis(), requesterLabel, reason)
+    }
+
+    fun validationError(token: LeaseToken, holder: Holder): LeaseErrorCode? =
+        when {
+            token.coordinatorEpoch != epoch -> LeaseErrorCode.STALE_EPOCH
+            token.leaseId != holder.token.leaseId -> LeaseErrorCode.STALE_LEASE
+            token.fence != holder.fence || holder.status != LeaseStatus.HELD ->
+                LeaseErrorCode.FENCED
+            else -> null
+        }
+}
+
+private data class ResourceState(
+    var holder: Holder? = null,
+    val waiters: MutableList<Waiter> = mutableListOf(),
+    var fenceGeneration: Long = 0,
+    var quarantine: RecoveryQuarantine? = null,
+)
+
+private data class Holder(
+    val token: LeaseToken,
+    val owner: LeaseOwner,
+    val acquiredAtMillis: Long,
+    var lastHeartbeatMillis: Long,
+    val currentOperation: String?,
+    var depth: Int = 1,
+    var status: LeaseStatus = LeaseStatus.HELD,
+    var fence: Long = token.fence,
+    var revocation: Revocation? = null,
+) {
+    fun toSnapshot(now: Long): HolderSnapshot =
+        HolderSnapshot(
+            token = token,
+            owner = owner,
+            status = status,
+            fence = fence,
+            acquisitionAgeMillis = now - acquiredAtMillis,
+            heartbeatAgeMillis = now - lastHeartbeatMillis,
+            currentOperation = currentOperation,
+        )
+}
+
+private data class Waiter(
+    val request: AcquireRequest,
+    val enqueuedAtMillis: Long,
+    val deadlineMillis: Long,
+)
+
+private data class Revocation(
+    val requestedAtMillis: Long,
+    val requesterLabel: String,
+    val reason: String,
+)
+
+private data class RecoveryQuarantine(val record: RecoveryRecord, val releaseEligibleAtMillis: Long)
+
+private fun RecoveryQuarantine.toSnapshot(): QuarantineSnapshot =
+    QuarantineSnapshot(
+        predecessorLeaseId = record.leaseId,
+        predecessorEpoch = record.predecessorEpoch,
+        owner = record.owner,
+        releaseEligibleAtMillis = releaseEligibleAtMillis,
+    )
+
+private fun MutableList<RevokeAuditRecord>.recordRecoveryTakeover(
+    timestampMillis: Long,
+    quarantine: RecoveryQuarantine,
+    observedLeaseId: String,
+    requesterLabel: String,
+    reason: String,
+) {
+    this +=
+        RevokeAuditRecord(
+            timestampMillis = timestampMillis,
+            leaseId = observedLeaseId,
+            previousOwner = quarantine.record.owner,
+            requesterLabel = requesterLabel,
+            reason = reason,
+            acknowledged = false,
+            unsafeTakeover = true,
+        )
+}

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachine.kt
@@ -369,18 +369,19 @@ internal class LeaseStateMachine(
     }
 
     fun revoke(
+        resourceKey: DesktopResourceKey,
         observedLeaseId: String,
         requesterLabel: String,
         reason: String,
         force: Boolean,
         beforeForcedRevocation: () -> Unit = {},
     ): RevokeResult {
-        val (state, holder) =
-            resources.values.firstNotNullOfOrNull { state ->
-                state.holder
-                    ?.takeIf { holder -> holder.token.leaseId == observedLeaseId }
-                    ?.let { holder -> state to holder }
-            } ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        val state =
+            resources[resourceKey] ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        val holder = state.holder ?: return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        if (holder.token.leaseId != observedLeaseId) {
+            return RevokeResult.Rejected(LeaseErrorCode.STALE_LEASE)
+        }
         if (holder.status == LeaseStatus.HELD) {
             transitions.beginRevocation(state, holder, requesterLabel, reason)
             if (force && revokeGraceMillis == 0L) {

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
@@ -13,6 +13,7 @@ import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.FileChannel
 import java.nio.channels.FileLock
+import java.nio.channels.OverlappingFileLockException
 import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
@@ -42,6 +43,7 @@ public class LocalCoordinatorServer(
     private val codec: CoordinatorWireCodec = CoordinatorWireCodec(),
 ) : AutoCloseable {
     private val running = AtomicBoolean(false)
+    private val closed = AtomicBoolean(false)
     private val terminated = CountDownLatch(1)
     private val activeConnections = AtomicInteger()
     private val lastActivityNanos = AtomicLong(System.nanoTime())
@@ -70,6 +72,7 @@ public class LocalCoordinatorServer(
     /** Binds the endpoint and starts accepting local client sessions. */
     @Synchronized
     public fun start() {
+        check(!closed.get()) { "Coordinator server is closed" }
         check(!running.get()) { "Coordinator server is already started" }
         val protection = OwnerOnlyEndpointProtection.forPath(endpoint.socketPath)
         protection.prepareDirectory(endpoint.socketPath)
@@ -103,8 +106,10 @@ public class LocalCoordinatorServer(
         terminated.await()
     }
 
+    @Synchronized
     override fun close() {
-        if (!running.getAndSet(false)) return
+        if (!closed.compareAndSet(false, true)) return
+        running.set(false)
         runCatching { listener?.close() }
         idleMonitor?.shutdownNow()
         handlers.shutdownNow()
@@ -222,7 +227,16 @@ public class LocalCoordinatorServer(
     private fun acquireElection() {
         val lockPath = endpoint.directory.resolve("coordinator.lock")
         val channel = FileChannel.open(lockPath, CREATE, WRITE)
-        val lock = channel.tryLock()
+        val lock =
+            try {
+                channel.tryLock()
+            } catch (failure: IOException) {
+                runCatching { channel.close() }
+                throw failure
+            } catch (failure: OverlappingFileLockException) {
+                runCatching { channel.close() }
+                throw failure
+            }
         if (lock == null) {
             channel.close()
             throw IOException("A coordinator already owns ${endpoint.socketPath}")

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
@@ -162,14 +162,15 @@ public class LocalCoordinatorServer(
 
     private fun handleSession(channel: SocketChannel, request: CoordinatorWireMessage) {
         val clientId = requireNotNull(request.clientId)
-        codec.write(
-            channel,
-            CoordinatorWireMessage(
-                kind = CoordinatorWireKind.RESPONSE,
-                coordinatorEpoch = service.epoch,
-            ),
-        )
+        service.openSession(clientId)
         try {
+            codec.write(
+                channel,
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.RESPONSE,
+                    coordinatorEpoch = service.epoch,
+                ),
+            )
             while (codec.readOrNull(channel) != null) {
                 // The session connection is a liveness sentinel; operations use bounded
                 // connections.

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
@@ -44,6 +44,7 @@ public class LocalCoordinatorServer(
 ) : AutoCloseable {
     private val running = AtomicBoolean(false)
     private val closed = AtomicBoolean(false)
+    private val ownsSocketPath = AtomicBoolean(false)
     private val terminated = CountDownLatch(1)
     private val activeConnections = AtomicInteger()
     private val lastActivityNanos = AtomicLong(System.nanoTime())
@@ -84,6 +85,7 @@ public class LocalCoordinatorServer(
             val channel = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
             openedChannel = channel
             channel.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+            ownsSocketPath.set(true)
             protection.protectSocket(endpoint.socketPath)
             listener = channel
             running.set(true)
@@ -115,7 +117,9 @@ public class LocalCoordinatorServer(
         handlers.shutdownNow()
         handlers.awaitTermination(CLOSE_WAIT_SECONDS, TimeUnit.SECONDS)
         service.close()
-        runCatching { Files.deleteIfExists(endpoint.socketPath) }
+        if (ownsSocketPath.compareAndSet(true, false)) {
+            runCatching { Files.deleteIfExists(endpoint.socketPath) }
+        }
         releaseElection()
         terminated.countDown()
     }

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
@@ -201,7 +201,7 @@ public class LocalCoordinatorServer(
                     service
                         .acquire(request)
                         .get(
-                            requireNotNull(request.timeoutMillis) + ACQUIRE_RESPONSE_GRACE_MILLIS,
+                            acquireResponseTimeoutMillis(requireNotNull(request.timeoutMillis)),
                             TimeUnit.MILLISECONDS,
                         )
                 } catch (_: TimeoutException) {
@@ -227,6 +227,10 @@ public class LocalCoordinatorServer(
                     message = "Unsupported coordinator operation ${request.kind}",
                 )
         }
+
+    private fun acquireResponseTimeoutMillis(timeoutMillis: Long): Long =
+        timeoutMillis.coerceAtMost(Long.MAX_VALUE - ACQUIRE_RESPONSE_GRACE_MILLIS) +
+            ACQUIRE_RESPONSE_GRACE_MILLIS
 
     private fun acquireElection() {
         val lockPath = endpoint.directory.resolve("coordinator.lock")

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
@@ -1,0 +1,299 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.CoordinatorWireCodec
+import dev.sebastiano.spectre.input.CoordinatorWireKind
+import dev.sebastiano.spectre.input.CoordinatorWireMessage
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import dev.sebastiano.spectre.input.OwnerOnlyEndpointProtection
+import java.io.IOException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.FileChannel
+import java.nio.channels.FileLock
+import java.nio.channels.ServerSocketChannel
+import java.nio.channels.SocketChannel
+import java.nio.file.Files
+import java.nio.file.LinkOption.NOFOLLOW_LINKS
+import java.nio.file.StandardOpenOption.CREATE
+import java.nio.file.StandardOpenOption.WRITE
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicLong
+
+/** Same-user local coordinator server hosted in a small external JVM process. */
+@ExperimentalSpectreInputCoordinationApi
+public class LocalCoordinatorServer(
+    private val endpoint: CoordinatorEndpoint,
+    heartbeatTimeout: Duration = Duration.ofSeconds(DEFAULT_HEARTBEAT_TIMEOUT_SECONDS),
+    private val idleTimeout: Duration = Duration.ofSeconds(DEFAULT_IDLE_TIMEOUT_SECONDS),
+    recoveryGrace: Duration = Duration.ofSeconds(DEFAULT_RECOVERY_GRACE_SECONDS),
+    revokeGrace: Duration = Duration.ofSeconds(DEFAULT_REVOKE_GRACE_SECONDS),
+    private val codec: CoordinatorWireCodec = CoordinatorWireCodec(),
+) : AutoCloseable {
+    private val running = AtomicBoolean(false)
+    private val terminated = CountDownLatch(1)
+    private val activeConnections = AtomicInteger()
+    private val lastActivityNanos = AtomicLong(System.nanoTime())
+    private val handlers: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
+    private val recoveryLedger =
+        RecoveryLedger(endpoint.directory.resolve("recovery.properties"), heartbeatTimeout)
+    private val service =
+        CoordinatorLeaseService(
+            epoch = UUID.randomUUID().toString(),
+            heartbeatTimeout = heartbeatTimeout,
+            revokeGrace = revokeGrace,
+            recoveryGrace = recoveryGrace,
+            recoveryRecord = recoveryLedger.load(),
+            recoveryLedger = recoveryLedger,
+        )
+    private var listener: ServerSocketChannel? = null
+    private var acceptThread: Thread? = null
+    private var electionChannel: FileChannel? = null
+    private var electionLock: FileLock? = null
+    private var idleMonitor: java.util.concurrent.ScheduledExecutorService? = null
+
+    init {
+        require(!idleTimeout.isNegative && !idleTimeout.isZero) { "Idle timeout must be positive" }
+    }
+
+    /** Binds the endpoint and starts accepting local client sessions. */
+    @Synchronized
+    public fun start() {
+        check(!running.get()) { "Coordinator server is already started" }
+        val protection = OwnerOnlyEndpointProtection.forPath(endpoint.socketPath)
+        protection.prepareDirectory(endpoint.socketPath)
+        acquireElection()
+        var started = false
+        var openedChannel: ServerSocketChannel? = null
+        try {
+            prepareSocketPath()
+            val channel = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+            openedChannel = channel
+            channel.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+            protection.protectSocket(endpoint.socketPath)
+            listener = channel
+            running.set(true)
+            lastActivityNanos.set(System.nanoTime())
+            startIdleMonitor()
+            acceptThread =
+                Thread.ofVirtual().name("spectre-input-accept").start { acceptLoop(channel) }
+            started = true
+        } finally {
+            if (!started) {
+                runCatching { openedChannel?.close() }
+                releaseElection()
+            }
+        }
+    }
+
+    /** Blocks until this server's accept loop terminates. */
+    @Throws(InterruptedException::class)
+    public fun awaitTermination() {
+        terminated.await()
+    }
+
+    override fun close() {
+        if (!running.getAndSet(false)) return
+        runCatching { listener?.close() }
+        idleMonitor?.shutdownNow()
+        handlers.shutdownNow()
+        handlers.awaitTermination(CLOSE_WAIT_SECONDS, TimeUnit.SECONDS)
+        service.close()
+        runCatching { Files.deleteIfExists(endpoint.socketPath) }
+        releaseElection()
+        terminated.countDown()
+    }
+
+    private fun acceptLoop(channel: ServerSocketChannel) {
+        while (running.get()) {
+            try {
+                val client = channel.accept()
+                activeConnections.incrementAndGet()
+                lastActivityNanos.set(System.nanoTime())
+                try {
+                    handlers.submit {
+                        try {
+                            handle(client)
+                        } finally {
+                            activeConnections.decrementAndGet()
+                            lastActivityNanos.set(System.nanoTime())
+                        }
+                    }
+                } catch (_: RejectedExecutionException) {
+                    activeConnections.decrementAndGet()
+                    runCatching { client.close() }
+                    if (running.get()) close()
+                    return
+                }
+            } catch (failure: IOException) {
+                if (running.get()) {
+                    Thread.currentThread()
+                        .uncaughtExceptionHandler
+                        .uncaughtException(Thread.currentThread(), failure)
+                    close()
+                }
+                return
+            }
+        }
+    }
+
+    private fun handle(channel: SocketChannel) {
+        channel.use {
+            val request = codec.readOrNull(channel) ?: return
+            if (request.kind == CoordinatorWireKind.SESSION_OPEN) {
+                handleSession(channel, request)
+            } else {
+                val response = handleRequest(request)
+                codec.write(channel, response)
+            }
+        }
+    }
+
+    private fun handleSession(channel: SocketChannel, request: CoordinatorWireMessage) {
+        val clientId = requireNotNull(request.clientId)
+        codec.write(
+            channel,
+            CoordinatorWireMessage(
+                kind = CoordinatorWireKind.RESPONSE,
+                coordinatorEpoch = service.epoch,
+            ),
+        )
+        try {
+            while (codec.readOrNull(channel) != null) {
+                // The session connection is a liveness sentinel; operations use bounded
+                // connections.
+            }
+        } finally {
+            if (running.get()) service.disconnect(clientId)
+        }
+    }
+
+    private fun handleRequest(request: CoordinatorWireMessage): CoordinatorWireMessage =
+        when (request.kind) {
+            CoordinatorWireKind.HEALTH ->
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.RESPONSE,
+                    coordinatorEpoch = service.epoch,
+                )
+            CoordinatorWireKind.ACQUIRE ->
+                try {
+                    service
+                        .acquire(request)
+                        .get(
+                            requireNotNull(request.timeoutMillis) + ACQUIRE_RESPONSE_GRACE_MILLIS,
+                            TimeUnit.MILLISECONDS,
+                        )
+                } catch (_: TimeoutException) {
+                    service.cancel(request.copy(kind = CoordinatorWireKind.CANCEL))
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.RESPONSE,
+                        ok = false,
+                        errorCode = "ACQUIRE_TIMEOUT",
+                        message = "Timed out waiting for the desktop input lease",
+                    )
+                }
+            CoordinatorWireKind.RELEASE -> service.release(request)
+            CoordinatorWireKind.HEARTBEAT -> service.heartbeat(request)
+            CoordinatorWireKind.STATUS -> service.status(request)
+            CoordinatorWireKind.REVOKE -> service.revoke(request)
+            CoordinatorWireKind.CANCEL -> service.cancel(request)
+            CoordinatorWireKind.SESSION_OPEN,
+            CoordinatorWireKind.RESPONSE ->
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.RESPONSE,
+                    ok = false,
+                    errorCode = "UNSUPPORTED_OPERATION",
+                    message = "Unsupported coordinator operation ${request.kind}",
+                )
+        }
+
+    private fun acquireElection() {
+        val lockPath = endpoint.directory.resolve("coordinator.lock")
+        val channel = FileChannel.open(lockPath, CREATE, WRITE)
+        val lock = channel.tryLock()
+        if (lock == null) {
+            channel.close()
+            throw IOException("A coordinator already owns ${endpoint.socketPath}")
+        }
+        electionChannel = channel
+        electionLock = lock
+    }
+
+    private fun startIdleMonitor() {
+        val intervalMillis =
+            (idleTimeout.toMillis() / IDLE_CHECK_DIVISOR).coerceIn(
+                MIN_IDLE_CHECK_MILLIS,
+                MAX_IDLE_CHECK_MILLIS,
+            )
+        idleMonitor =
+            Executors.newSingleThreadScheduledExecutor { task ->
+                    Thread(task, "spectre-input-idle").apply { isDaemon = true }
+                }
+                .also { executor ->
+                    executor.scheduleWithFixedDelay(
+                        ::closeIfIdle,
+                        intervalMillis,
+                        intervalMillis,
+                        TimeUnit.MILLISECONDS,
+                    )
+                }
+    }
+
+    private fun closeIfIdle() {
+        if (!running.get() || activeConnections.get() != 0) return
+        if (System.nanoTime() - lastActivityNanos.get() >= idleTimeout.toNanos()) close()
+    }
+
+    private fun releaseElection() {
+        runCatching { electionLock?.release() }
+        runCatching { electionChannel?.close() }
+        electionLock = null
+        electionChannel = null
+    }
+
+    private fun prepareSocketPath() {
+        if (!Files.exists(endpoint.socketPath, NOFOLLOW_LINKS)) return
+        if (Files.isSymbolicLink(endpoint.socketPath)) {
+            throw IOException(
+                "Coordinator socket ${endpoint.socketPath} must not be a symbolic link"
+            )
+        }
+        if (isLiveCoordinator()) {
+            throw IOException("A coordinator is already listening at ${endpoint.socketPath}")
+        }
+        Files.delete(endpoint.socketPath)
+    }
+
+    private fun isLiveCoordinator(): Boolean =
+        runCatching {
+                SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                    channel.connect(UnixDomainSocketAddress.of(endpoint.socketPath))
+                    codec.write(channel, CoordinatorWireMessage(kind = CoordinatorWireKind.HEALTH))
+                    codec.read(channel).ok
+                }
+            }
+            .getOrDefault(false)
+
+    private companion object {
+        const val DEFAULT_HEARTBEAT_TIMEOUT_SECONDS: Long = 10
+        const val DEFAULT_IDLE_TIMEOUT_SECONDS: Long = 30
+        const val DEFAULT_RECOVERY_GRACE_SECONDS: Long = 2
+        const val DEFAULT_REVOKE_GRACE_SECONDS: Long = 1
+        const val ACQUIRE_RESPONSE_GRACE_MILLIS: Long = 1_000
+        const val CLOSE_WAIT_SECONDS: Long = 2
+        const val IDLE_CHECK_DIVISOR: Long = 4
+        const val MIN_IDLE_CHECK_MILLIS: Long = 10
+        const val MAX_IDLE_CHECK_MILLIS: Long = 1_000
+    }
+}

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServer.kt
@@ -49,6 +49,9 @@ public class LocalCoordinatorServer(
     private val activeConnections = AtomicInteger()
     private val lastActivityNanos = AtomicLong(System.nanoTime())
     private val handlers: ExecutorService = Executors.newVirtualThreadPerTaskExecutor()
+    private val initialFrameDeadlines = Executors.newSingleThreadScheduledExecutor { task ->
+        Thread(task, "spectre-input-frame-deadline").apply { isDaemon = true }
+    }
     private val recoveryLedger =
         RecoveryLedger(endpoint.directory.resolve("recovery.properties"), heartbeatTimeout)
     private val service =
@@ -116,6 +119,7 @@ public class LocalCoordinatorServer(
         idleMonitor?.shutdownNow()
         handlers.shutdownNow()
         handlers.awaitTermination(CLOSE_WAIT_SECONDS, TimeUnit.SECONDS)
+        initialFrameDeadlines.shutdownNow()
         service.close()
         if (ownsSocketPath.compareAndSet(true, false)) {
             runCatching { Files.deleteIfExists(endpoint.socketPath) }
@@ -130,6 +134,11 @@ public class LocalCoordinatorServer(
                 val client = channel.accept()
                 activeConnections.incrementAndGet()
                 lastActivityNanos.set(System.nanoTime())
+                if (activeConnections.get() > MAX_ACTIVE_CONNECTIONS) {
+                    activeConnections.decrementAndGet()
+                    runCatching { client.close() }
+                    continue
+                }
                 try {
                     handlers.submit {
                         try {
@@ -159,7 +168,18 @@ public class LocalCoordinatorServer(
 
     private fun handle(channel: SocketChannel) {
         channel.use {
-            val request = codec.readOrNull(channel) ?: return
+            val deadline =
+                initialFrameDeadlines.schedule(
+                    { runCatching { channel.close() } },
+                    initialFrameTimeoutMillis(),
+                    TimeUnit.MILLISECONDS,
+                )
+            val request =
+                try {
+                    codec.readOrNull(channel) ?: return
+                } finally {
+                    deadline.cancel(false)
+                }
             if (request.kind == CoordinatorWireKind.SESSION_OPEN) {
                 handleSession(channel, request)
             } else {
@@ -231,6 +251,9 @@ public class LocalCoordinatorServer(
     private fun acquireResponseTimeoutMillis(timeoutMillis: Long): Long =
         timeoutMillis.coerceAtMost(Long.MAX_VALUE - ACQUIRE_RESPONSE_GRACE_MILLIS) +
             ACQUIRE_RESPONSE_GRACE_MILLIS
+
+    private fun initialFrameTimeoutMillis(): Long =
+        idleTimeout.toMillis().coerceAtMost(DEFAULT_INITIAL_FRAME_TIMEOUT_MILLIS).coerceAtLeast(1)
 
     private fun acquireElection() {
         val lockPath = endpoint.directory.resolve("coordinator.lock")
@@ -315,6 +338,8 @@ public class LocalCoordinatorServer(
         const val DEFAULT_REVOKE_GRACE_SECONDS: Long = 1
         const val ACQUIRE_RESPONSE_GRACE_MILLIS: Long = 1_000
         const val CLOSE_WAIT_SECONDS: Long = 2
+        private const val MAX_ACTIVE_CONNECTIONS: Int = 64
+        private const val DEFAULT_INITIAL_FRAME_TIMEOUT_MILLIS: Long = 5_000
         const val IDLE_CHECK_DIVISOR: Long = 4
         const val MIN_IDLE_CHECK_MILLIS: Long = 10
         const val MAX_IDLE_CHECK_MILLIS: Long = 1_000

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
@@ -20,13 +20,16 @@ import java.util.concurrent.TimeUnit
 
 internal class RecoveryLedger(private val path: Path, private val heartbeatTimeout: Duration) {
     private val current = mutableMapOf<String, LedgerRecord>()
+    private val recoveryLeaseIds = mutableSetOf<String>()
 
     @Synchronized
     fun load(): RecoveryRecord? {
         if (!Files.exists(path)) return null
         val record = runCatching(::read).getOrElse { corruptRecord() }
         current.clear()
+        recoveryLeaseIds.clear()
         current[record.leaseId] = record
+        recoveryLeaseIds += record.leaseId
         val remainingMillis =
             (record.heartbeatExpiryEpochMillis - System.currentTimeMillis()).coerceAtLeast(0)
         return RecoveryRecord(
@@ -54,12 +57,14 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
                 blocksAllResources = false,
             )
         current[record.leaseId] = record
+        recoveryLeaseIds -= record.leaseId
         persist()
     }
 
     @Synchronized
     fun heartbeat(token: LeaseToken) {
         val record = current[token.leaseId] ?: return
+        recoveryLeaseIds -= token.leaseId
         val refreshed =
             record.copy(
                 heartbeatExpiryEpochMillis =
@@ -72,21 +77,27 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
     @Synchronized
     fun clear(leaseId: String) {
         if (current.remove(leaseId) == null) return
+        recoveryLeaseIds -= leaseId
         persist()
     }
 
     @Synchronized
     fun clearClient(clientId: String) {
-        val removed = current.values.removeAll { it.clientId == clientId }
-        if (removed) persist()
+        val removedLeaseIds =
+            current.values.filter { it.clientId == clientId }.mapTo(mutableSetOf()) { it.leaseId }
+        if (removedLeaseIds.isEmpty()) return
+        current.keys.removeAll(removedLeaseIds)
+        recoveryLeaseIds.removeAll(removedLeaseIds)
+        persist()
     }
 
     @Synchronized
     fun clearExpiredRecovery(recoveryGrace: Duration) {
         val graceMillis = recoveryGrace.toMillis()
         val now = System.currentTimeMillis()
-        val removed =
-            current.values.removeAll { record ->
+        val expiredLeaseIds =
+            recoveryLeaseIds.filterTo(mutableSetOf()) { leaseId ->
+                val record = current[leaseId] ?: return@filterTo true
                 val eligibleAt =
                     if (Long.MAX_VALUE - record.heartbeatExpiryEpochMillis < graceMillis) {
                         Long.MAX_VALUE
@@ -95,7 +106,10 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
                     }
                 now >= eligibleAt
             }
-        if (removed) persist()
+        if (expiredLeaseIds.isEmpty()) return
+        current.keys.removeAll(expiredLeaseIds)
+        recoveryLeaseIds.removeAll(expiredLeaseIds)
+        persist()
     }
 
     private fun read(): LedgerRecord {

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
@@ -1,0 +1,177 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseOwner
+import dev.sebastiano.spectre.input.LeaseToken
+import java.io.IOException
+import java.nio.file.AtomicMoveNotSupportedException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardCopyOption.ATOMIC_MOVE
+import java.nio.file.StandardCopyOption.REPLACE_EXISTING
+import java.nio.file.attribute.PosixFilePermissions
+import java.security.MessageDigest
+import java.time.Duration
+import java.util.HexFormat
+import java.util.Properties
+import java.util.concurrent.TimeUnit
+
+internal class RecoveryLedger(private val path: Path, private val heartbeatTimeout: Duration) {
+    private var current: LedgerRecord? = null
+
+    @Synchronized
+    fun load(): RecoveryRecord? {
+        if (!Files.exists(path)) return null
+        val record = runCatching(::read).getOrElse { corruptRecord() }
+        current = record
+        val remainingMillis =
+            (record.heartbeatExpiryEpochMillis - System.currentTimeMillis()).coerceAtLeast(0)
+        return RecoveryRecord(
+            resourceKey = DesktopResourceKey(record.resourceKey),
+            predecessorEpoch = record.epoch,
+            leaseId = record.leaseId,
+            owner = LeaseOwner(record.clientId, record.processId, record.ownerLabel),
+            heartbeatExpiryMillis = monotonicMillis() + remainingMillis,
+            blocksAllResources = record.corrupt,
+        )
+    }
+
+    @Synchronized
+    fun record(grant: LeaseGrant) {
+        val record =
+            LedgerRecord(
+                epoch = grant.token.coordinatorEpoch,
+                leaseId = grant.token.leaseId,
+                resourceKey = grant.token.resourceKey.value,
+                clientId = grant.owner.clientId,
+                processId = grant.owner.processId,
+                ownerLabel = grant.owner.label,
+                heartbeatExpiryEpochMillis =
+                    System.currentTimeMillis() + heartbeatTimeout.toMillis(),
+                corrupt = false,
+            )
+        write(record)
+        current = record
+    }
+
+    @Synchronized
+    fun heartbeat(token: LeaseToken) {
+        val record = current?.takeIf { it.leaseId == token.leaseId } ?: return
+        val refreshed =
+            record.copy(
+                heartbeatExpiryEpochMillis =
+                    System.currentTimeMillis() + heartbeatTimeout.toMillis()
+            )
+        write(refreshed)
+        current = refreshed
+    }
+
+    @Synchronized
+    fun clear(leaseId: String) {
+        if (current?.leaseId != leaseId) return
+        Files.deleteIfExists(path)
+        current = null
+    }
+
+    @Synchronized
+    fun clearClient(clientId: String) {
+        current?.takeIf { it.clientId == clientId }?.let { clear(it.leaseId) }
+    }
+
+    @Synchronized
+    fun clearExpiredRecovery(recoveryGrace: Duration) {
+        val record = current ?: return
+        val graceMillis = recoveryGrace.toMillis()
+        val eligibleAt =
+            if (Long.MAX_VALUE - record.heartbeatExpiryEpochMillis < graceMillis) {
+                Long.MAX_VALUE
+            } else {
+                record.heartbeatExpiryEpochMillis + graceMillis
+            }
+        if (System.currentTimeMillis() >= eligibleAt) clear(record.leaseId)
+    }
+
+    private fun read(): LedgerRecord {
+        val properties = Properties()
+        Files.newInputStream(path).use(properties::load)
+        return LedgerRecord(
+            epoch = properties.required(EPOCH),
+            leaseId = properties.required(LEASE_ID),
+            resourceKey = properties.required(RESOURCE_KEY),
+            clientId = properties.required(CLIENT_ID),
+            processId = properties.required(PROCESS_ID).toLong(),
+            ownerLabel = properties.getProperty(OWNER_LABEL),
+            heartbeatExpiryEpochMillis = properties.required(HEARTBEAT_EXPIRY).toLong(),
+            corrupt = false,
+        )
+    }
+
+    private fun write(record: LedgerRecord) {
+        val properties =
+            Properties().apply {
+                setProperty(EPOCH, record.epoch)
+                setProperty(LEASE_ID, record.leaseId)
+                setProperty(RESOURCE_KEY, record.resourceKey)
+                setProperty(CLIENT_ID, record.clientId)
+                setProperty(PROCESS_ID, record.processId.toString())
+                record.ownerLabel?.let { setProperty(OWNER_LABEL, it) }
+                setProperty(HEARTBEAT_EXPIRY, record.heartbeatExpiryEpochMillis.toString())
+            }
+        val temporary = path.resolveSibling("${path.fileName}.tmp")
+        Files.newOutputStream(temporary).use { output -> properties.store(output, null) }
+        if (Files.getFileStore(temporary).supportsFileAttributeView("posix")) {
+            Files.setPosixFilePermissions(temporary, PosixFilePermissions.fromString("rw-------"))
+        }
+        try {
+            Files.move(temporary, path, ATOMIC_MOVE, REPLACE_EXISTING)
+        } catch (_: AtomicMoveNotSupportedException) {
+            Files.move(temporary, path, REPLACE_EXISTING)
+        }
+    }
+
+    private fun corruptRecord(): LedgerRecord {
+        val digest = MessageDigest.getInstance("SHA-256").digest(Files.readAllBytes(path))
+        val observedId = "corrupt-${HexFormat.of().formatHex(digest, 0, CORRUPT_HASH_BYTES)}"
+        return LedgerRecord(
+            epoch = "unknown",
+            leaseId = observedId,
+            resourceKey = CORRUPT_RESOURCE_KEY,
+            clientId = "unknown-recovery-owner",
+            processId = 0,
+            ownerLabel = "corrupt recovery ledger",
+            heartbeatExpiryEpochMillis = Long.MAX_VALUE,
+            corrupt = true,
+        )
+    }
+
+    private fun Properties.required(key: String): String =
+        getProperty(key)?.takeIf(String::isNotBlank)
+            ?: throw IOException("Recovery ledger is missing $key")
+
+    private data class LedgerRecord(
+        val epoch: String,
+        val leaseId: String,
+        val resourceKey: String,
+        val clientId: String,
+        val processId: Long,
+        val ownerLabel: String?,
+        val heartbeatExpiryEpochMillis: Long,
+        val corrupt: Boolean,
+    )
+
+    private companion object {
+        const val EPOCH: String = "epoch"
+        const val LEASE_ID: String = "leaseId"
+        const val RESOURCE_KEY: String = "resourceKey"
+        const val CLIENT_ID: String = "clientId"
+        const val PROCESS_ID: String = "processId"
+        const val OWNER_LABEL: String = "ownerLabel"
+        const val HEARTBEAT_EXPIRY: String = "heartbeatExpiryEpochMillis"
+        const val CORRUPT_RESOURCE_KEY: String = "user:unknown/recovery-corrupt"
+        const val CORRUPT_HASH_BYTES: Int = 8
+
+        fun monotonicMillis(): Long = TimeUnit.NANOSECONDS.toMillis(System.nanoTime())
+    }
+}

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
@@ -84,9 +84,16 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
 
     @Synchronized
     fun clear(leaseId: String) {
-        if (current.remove(leaseId) == null) return
+        val removed = current.remove(leaseId) ?: return
+        val wasRecoveryLease = leaseId in recoveryLeaseIds
         recoveryLeaseIds -= leaseId
-        persist()
+        try {
+            persist()
+        } catch (failure: IOException) {
+            current[leaseId] = removed
+            if (wasRecoveryLease) recoveryLeaseIds += leaseId
+            throw failure
+        }
     }
 
     @Synchronized

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeUnit
 
 internal class RecoveryLedger(private val path: Path, private val heartbeatTimeout: Duration) {
     private val current = mutableMapOf<String, LedgerRecord>()
+    private val pendingDiscardedLeaseIds = mutableSetOf<String>()
 
     @Synchronized
     fun load(): RecoveryRecord? {
@@ -90,6 +91,12 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
     @Synchronized
     fun discardUnobserved(leaseId: String) {
         current.remove(leaseId)
+        pendingDiscardedLeaseIds += leaseId
+    }
+
+    @Synchronized
+    fun retryDiscarded() {
+        if (pendingDiscardedLeaseIds.isNotEmpty()) persist()
     }
 
     @Synchronized
@@ -127,6 +134,7 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
             1 -> write(current.values.single())
             else -> write(conservativeRecord(current.values))
         }
+        pendingDiscardedLeaseIds.clear()
     }
 
     private fun write(record: LedgerRecord) {

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
@@ -56,9 +56,17 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
                     System.currentTimeMillis() + heartbeatTimeout.toMillis(),
                 blocksAllResources = false,
             )
-        current[record.leaseId] = record
+        val previous = current.put(record.leaseId, record)
+        val wasRecoveryLease = record.leaseId in recoveryLeaseIds
         recoveryLeaseIds -= record.leaseId
-        persist()
+        try {
+            persist()
+        } catch (failure: IOException) {
+            if (previous == null) current.remove(record.leaseId)
+            else current[record.leaseId] = previous
+            if (wasRecoveryLease) recoveryLeaseIds += record.leaseId
+            throw failure
+        }
     }
 
     @Synchronized

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
@@ -20,16 +20,13 @@ import java.util.concurrent.TimeUnit
 
 internal class RecoveryLedger(private val path: Path, private val heartbeatTimeout: Duration) {
     private val current = mutableMapOf<String, LedgerRecord>()
-    private val recoveryLeaseIds = mutableSetOf<String>()
 
     @Synchronized
     fun load(): RecoveryRecord? {
         if (!Files.exists(path)) return null
         val record = runCatching(::read).getOrElse { corruptRecord() }
         current.clear()
-        recoveryLeaseIds.clear()
         current[record.leaseId] = record
-        recoveryLeaseIds += record.leaseId
         val remainingMillis =
             (record.heartbeatExpiryEpochMillis - System.currentTimeMillis()).coerceAtLeast(0)
         return RecoveryRecord(
@@ -57,14 +54,11 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
                 blocksAllResources = false,
             )
         val previous = current.put(record.leaseId, record)
-        val wasRecoveryLease = record.leaseId in recoveryLeaseIds
-        recoveryLeaseIds -= record.leaseId
         try {
             persist()
         } catch (failure: IOException) {
             if (previous == null) current.remove(record.leaseId)
             else current[record.leaseId] = previous
-            if (wasRecoveryLease) recoveryLeaseIds += record.leaseId
             throw failure
         }
     }
@@ -72,7 +66,6 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
     @Synchronized
     fun heartbeat(token: LeaseToken) {
         val record = current[token.leaseId] ?: return
-        recoveryLeaseIds -= token.leaseId
         val refreshed =
             record.copy(
                 heartbeatExpiryEpochMillis =
@@ -85,46 +78,26 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
     @Synchronized
     fun clear(leaseId: String) {
         val removed = current.remove(leaseId) ?: return
-        val wasRecoveryLease = leaseId in recoveryLeaseIds
-        recoveryLeaseIds -= leaseId
         try {
             persist()
         } catch (failure: IOException) {
             current[leaseId] = removed
-            if (wasRecoveryLease) recoveryLeaseIds += leaseId
             throw failure
         }
     }
 
     @Synchronized
-    fun clearClient(clientId: String) {
+    fun clearClient(clientId: String): Boolean {
         val removedLeaseIds =
             current.values.filter { it.clientId == clientId }.mapTo(mutableSetOf()) { it.leaseId }
-        if (removedLeaseIds.isEmpty()) return
+        if (removedLeaseIds.isEmpty()) return true
         current.keys.removeAll(removedLeaseIds)
-        recoveryLeaseIds.removeAll(removedLeaseIds)
-        persist()
-    }
-
-    @Synchronized
-    fun clearExpiredRecovery(recoveryGrace: Duration) {
-        val graceMillis = recoveryGrace.toMillis()
-        val now = System.currentTimeMillis()
-        val expiredLeaseIds =
-            recoveryLeaseIds.filterTo(mutableSetOf()) { leaseId ->
-                val record = current[leaseId] ?: return@filterTo true
-                val eligibleAt =
-                    if (Long.MAX_VALUE - record.heartbeatExpiryEpochMillis < graceMillis) {
-                        Long.MAX_VALUE
-                    } else {
-                        record.heartbeatExpiryEpochMillis + graceMillis
-                    }
-                now >= eligibleAt
-            }
-        if (expiredLeaseIds.isEmpty()) return
-        current.keys.removeAll(expiredLeaseIds)
-        recoveryLeaseIds.removeAll(expiredLeaseIds)
-        persist()
+        return try {
+            persist()
+            true
+        } catch (_: IOException) {
+            false
+        }
     }
 
     private fun read(): LedgerRecord {

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
@@ -86,6 +86,12 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
         }
     }
 
+    /** Forgets a proven-unobserved grant after persistence already failed to clear it. */
+    @Synchronized
+    fun discardUnobserved(leaseId: String) {
+        current.remove(leaseId)
+    }
+
     @Synchronized
     fun clearClient(clientId: String): Boolean {
         val removedLeaseIds =

--- a/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
+++ b/input-coordinator-server/src/main/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedger.kt
@@ -19,13 +19,14 @@ import java.util.Properties
 import java.util.concurrent.TimeUnit
 
 internal class RecoveryLedger(private val path: Path, private val heartbeatTimeout: Duration) {
-    private var current: LedgerRecord? = null
+    private val current = mutableMapOf<String, LedgerRecord>()
 
     @Synchronized
     fun load(): RecoveryRecord? {
         if (!Files.exists(path)) return null
         val record = runCatching(::read).getOrElse { corruptRecord() }
-        current = record
+        current.clear()
+        current[record.leaseId] = record
         val remainingMillis =
             (record.heartbeatExpiryEpochMillis - System.currentTimeMillis()).coerceAtLeast(0)
         return RecoveryRecord(
@@ -34,7 +35,7 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
             leaseId = record.leaseId,
             owner = LeaseOwner(record.clientId, record.processId, record.ownerLabel),
             heartbeatExpiryMillis = monotonicMillis() + remainingMillis,
-            blocksAllResources = record.corrupt,
+            blocksAllResources = record.blocksAllResources,
         )
     }
 
@@ -50,47 +51,51 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
                 ownerLabel = grant.owner.label,
                 heartbeatExpiryEpochMillis =
                     System.currentTimeMillis() + heartbeatTimeout.toMillis(),
-                corrupt = false,
+                blocksAllResources = false,
             )
-        write(record)
-        current = record
+        current[record.leaseId] = record
+        persist()
     }
 
     @Synchronized
     fun heartbeat(token: LeaseToken) {
-        val record = current?.takeIf { it.leaseId == token.leaseId } ?: return
+        val record = current[token.leaseId] ?: return
         val refreshed =
             record.copy(
                 heartbeatExpiryEpochMillis =
                     System.currentTimeMillis() + heartbeatTimeout.toMillis()
             )
-        write(refreshed)
-        current = refreshed
+        current[token.leaseId] = refreshed
+        persist()
     }
 
     @Synchronized
     fun clear(leaseId: String) {
-        if (current?.leaseId != leaseId) return
-        Files.deleteIfExists(path)
-        current = null
+        if (current.remove(leaseId) == null) return
+        persist()
     }
 
     @Synchronized
     fun clearClient(clientId: String) {
-        current?.takeIf { it.clientId == clientId }?.let { clear(it.leaseId) }
+        val removed = current.values.removeAll { it.clientId == clientId }
+        if (removed) persist()
     }
 
     @Synchronized
     fun clearExpiredRecovery(recoveryGrace: Duration) {
-        val record = current ?: return
         val graceMillis = recoveryGrace.toMillis()
-        val eligibleAt =
-            if (Long.MAX_VALUE - record.heartbeatExpiryEpochMillis < graceMillis) {
-                Long.MAX_VALUE
-            } else {
-                record.heartbeatExpiryEpochMillis + graceMillis
+        val now = System.currentTimeMillis()
+        val removed =
+            current.values.removeAll { record ->
+                val eligibleAt =
+                    if (Long.MAX_VALUE - record.heartbeatExpiryEpochMillis < graceMillis) {
+                        Long.MAX_VALUE
+                    } else {
+                        record.heartbeatExpiryEpochMillis + graceMillis
+                    }
+                now >= eligibleAt
             }
-        if (System.currentTimeMillis() >= eligibleAt) clear(record.leaseId)
+        if (removed) persist()
     }
 
     private fun read(): LedgerRecord {
@@ -104,8 +109,16 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
             processId = properties.required(PROCESS_ID).toLong(),
             ownerLabel = properties.getProperty(OWNER_LABEL),
             heartbeatExpiryEpochMillis = properties.required(HEARTBEAT_EXPIRY).toLong(),
-            corrupt = false,
+            blocksAllResources = properties.getProperty(BLOCKS_ALL)?.toBooleanStrict() ?: false,
         )
+    }
+
+    private fun persist() {
+        when (current.size) {
+            0 -> Files.deleteIfExists(path)
+            1 -> write(current.values.single())
+            else -> write(conservativeRecord(current.values))
+        }
     }
 
     private fun write(record: LedgerRecord) {
@@ -118,6 +131,7 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
                 setProperty(PROCESS_ID, record.processId.toString())
                 record.ownerLabel?.let { setProperty(OWNER_LABEL, it) }
                 setProperty(HEARTBEAT_EXPIRY, record.heartbeatExpiryEpochMillis.toString())
+                setProperty(BLOCKS_ALL, record.blocksAllResources.toString())
             }
         val temporary = path.resolveSibling("${path.fileName}.tmp")
         Files.newOutputStream(temporary).use { output -> properties.store(output, null) }
@@ -142,7 +156,23 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
             processId = 0,
             ownerLabel = "corrupt recovery ledger",
             heartbeatExpiryEpochMillis = Long.MAX_VALUE,
-            corrupt = true,
+            blocksAllResources = true,
+        )
+    }
+
+    private fun conservativeRecord(records: Collection<LedgerRecord>): LedgerRecord {
+        val leaseIds = records.map(LedgerRecord::leaseId).sorted().joinToString("|")
+        val digest = MessageDigest.getInstance("SHA-256").digest(leaseIds.encodeToByteArray())
+        val observedId = "multiple-${HexFormat.of().formatHex(digest, 0, CORRUPT_HASH_BYTES)}"
+        return LedgerRecord(
+            epoch = "multiple",
+            leaseId = observedId,
+            resourceKey = MULTIPLE_RESOURCE_KEY,
+            clientId = "multiple-recovery-owners",
+            processId = 0,
+            ownerLabel = "multiple active desktop resources",
+            heartbeatExpiryEpochMillis = records.maxOf(LedgerRecord::heartbeatExpiryEpochMillis),
+            blocksAllResources = true,
         )
     }
 
@@ -158,7 +188,7 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
         val processId: Long,
         val ownerLabel: String?,
         val heartbeatExpiryEpochMillis: Long,
-        val corrupt: Boolean,
+        val blocksAllResources: Boolean,
     )
 
     private companion object {
@@ -169,7 +199,9 @@ internal class RecoveryLedger(private val path: Path, private val heartbeatTimeo
         const val PROCESS_ID: String = "processId"
         const val OWNER_LABEL: String = "ownerLabel"
         const val HEARTBEAT_EXPIRY: String = "heartbeatExpiryEpochMillis"
+        const val BLOCKS_ALL: String = "blocksAllResources"
         const val CORRUPT_RESOURCE_KEY: String = "user:unknown/recovery-corrupt"
+        const val MULTIPLE_RESOURCE_KEY: String = "user:unknown/recovery-multiple"
         const val CORRUPT_HASH_BYTES: Int = 8
 
         fun monotonicMillis(): Long = TimeUnit.NANOSECONDS.toMillis(System.nanoTime())

--- a/input-coordinator-server/src/main/resources/META-INF/services/dev.sebastiano.spectre.input.InputCoordinatorClientProvider
+++ b/input-coordinator-server/src/main/resources/META-INF/services/dev.sebastiano.spectre.input.InputCoordinatorClientProvider
@@ -1,0 +1,1 @@
+dev.sebastiano.spectre.input.server.LaunchingInputCoordinatorClientProvider

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
@@ -1,0 +1,172 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorWireKind
+import dev.sebastiano.spectre.input.CoordinatorWireMessage
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseOwner
+import dev.sebastiano.spectre.input.LeaseToken
+import java.nio.file.Files
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class CoordinatorForcedRecoveryPersistenceTest {
+
+    @Test
+    fun `failed forced revoke clear retains the fenced holder and queued handoff`() {
+        val directory = Files.createTempDirectory("spc-service-ledger-force-clear-")
+        val path = directory.resolve("recovery.properties")
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ZERO,
+                recoveryGrace = Duration.ofSeconds(1),
+                recoveryLedger = RecoveryLedger(path, Duration.ofSeconds(5)),
+            )
+        try {
+            service.openSession("first-client")
+            service.openSession("second-client")
+            val first = service.acquire(acquire("first", "first-client")).get()
+            val queued = service.acquire(acquire("second", "second-client"))
+            Files.delete(path)
+            Files.createDirectory(path)
+            Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
+
+            val failedForce =
+                service.revoke(revokeMessage(requireNotNull(first.leaseId), force = true))
+
+            assertFalse(failedForce.ok)
+            assertEquals("RECOVERY_PERSISTENCE_FAILED", failedForce.errorCode)
+            val status = status(service)
+            assertEquals("first-client", assertNotNull(status.holder).clientId)
+            assertEquals(1, status.waiters.size)
+
+            Files.delete(path.resolve("blocker"))
+            Files.delete(path)
+            assertTrue(service.revoke(revokeMessage(requireNotNull(first.leaseId), true)).ok)
+            val second = queued.get(1, TimeUnit.SECONDS)
+            assertTrue(service.release(tokenMessage(second, "second-client")).ok)
+        } finally {
+            cleanUp(service, path, directory)
+        }
+    }
+
+    @Test
+    fun `failed forced restart recovery clear retains quarantine and queued handoff`() {
+        val directory = Files.createTempDirectory("spc-service-recovery-force-clear-")
+        val path = directory.resolve("recovery.properties")
+        val ledger = RecoveryLedger(path, Duration.ofSeconds(5))
+        ledger.record(
+            LeaseGrant(
+                requestId = "predecessor-request",
+                owner = LeaseOwner("predecessor-client", 1),
+                token =
+                    LeaseToken(
+                        coordinatorEpoch = "predecessor-epoch",
+                        leaseId = "predecessor-lease",
+                        resourceKey = DesktopResourceKey("test/desktop"),
+                        fence = 1,
+                    ),
+            )
+        )
+        val restartedLedger = RecoveryLedger(path, Duration.ofSeconds(5))
+        val recoveryRecord = assertNotNull(restartedLedger.load())
+        val service =
+            CoordinatorLeaseService(
+                epoch = "replacement-epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ZERO,
+                recoveryGrace = Duration.ZERO,
+                recoveryRecord = recoveryRecord,
+                recoveryLedger = restartedLedger,
+            )
+        try {
+            service.openSession("waiting-client")
+            val queued = service.acquire(acquire("waiting", "waiting-client"))
+            Files.delete(path)
+            Files.createDirectory(path)
+            Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
+
+            val failedForce = service.revoke(revokeMessage("predecessor-lease", force = true))
+
+            assertFalse(failedForce.ok)
+            assertEquals("RECOVERY_PERSISTENCE_FAILED", failedForce.errorCode)
+            val status = status(service)
+            assertEquals("predecessor-lease", assertNotNull(status.quarantine).predecessorLeaseId)
+            assertEquals(1, status.waiters.size)
+
+            Files.delete(path.resolve("blocker"))
+            Files.delete(path)
+            assertTrue(service.revoke(revokeMessage("predecessor-lease", true)).ok)
+            val successor = queued.get(1, TimeUnit.SECONDS)
+            assertTrue(service.release(tokenMessage(successor, "waiting-client")).ok)
+        } finally {
+            cleanUp(service, path, directory)
+        }
+    }
+
+    private fun status(service: CoordinatorLeaseService) =
+        assertNotNull(
+            service
+                .status(
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.STATUS,
+                        resourceKey = "test/desktop",
+                    )
+                )
+                .status
+        )
+
+    private fun acquire(requestId: String, clientId: String): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.ACQUIRE,
+            requestId = requestId,
+            clientId = clientId,
+            resourceKey = "test/desktop",
+            processId = 1,
+            timeoutMillis = 10_000,
+            currentOperation = "click",
+        )
+
+    private fun tokenMessage(
+        grant: CoordinatorWireMessage,
+        clientId: String,
+    ): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.RELEASE,
+            clientId = clientId,
+            resourceKey = "test/desktop",
+            coordinatorEpoch = grant.coordinatorEpoch,
+            leaseId = grant.leaseId,
+            fence = grant.fence,
+        )
+
+    private fun revokeMessage(leaseId: String, force: Boolean): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.REVOKE,
+            resourceKey = "test/desktop",
+            leaseId = leaseId,
+            requesterLabel = "operator",
+            reason = "known stuck",
+            force = force,
+        )
+
+    private fun cleanUp(
+        service: CoordinatorLeaseService,
+        path: java.nio.file.Path,
+        directory: java.nio.file.Path,
+    ) {
+        service.close()
+        Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+        if (Files.isDirectory(path)) Files.deleteIfExists(path.resolve("blocker"))
+        Files.deleteIfExists(path)
+        Files.deleteIfExists(directory)
+    }
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
@@ -19,6 +19,50 @@ import kotlin.test.assertTrue
 class CoordinatorForcedRecoveryPersistenceTest {
 
     @Test
+    fun `failed cancellation release disconnects the affected session`() {
+        val directory = Files.createTempDirectory("spc-service-cancel-clear-")
+        val path = directory.resolve("recovery.properties")
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+                recoveryLedger = RecoveryLedger(path, Duration.ofSeconds(5)),
+            )
+        try {
+            service.openSession("interrupted-client")
+            service.acquire(acquire("unobserved", "interrupted-client")).get()
+            Files.delete(path)
+            Files.createDirectory(path)
+            Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
+
+            service.cancel(
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.CANCEL,
+                    requestId = "unobserved",
+                    clientId = "interrupted-client",
+                    resourceKey = "test/desktop",
+                )
+            )
+
+            assertEquals(null, status(service).holder)
+            val rejected =
+                service.acquire(acquire("late", "interrupted-client")).get(1, TimeUnit.SECONDS)
+            assertFalse(rejected.ok)
+            assertEquals("CLIENT_DISCONNECTED", rejected.errorCode)
+
+            Files.delete(path.resolve("blocker"))
+            Files.delete(path)
+            service.openSession("successor-client")
+            val successor = service.acquire(acquire("successor", "successor-client")).get()
+            assertTrue(service.release(tokenMessage(successor, "successor-client")).ok)
+        } finally {
+            cleanUp(service, path, directory)
+        }
+    }
+
+    @Test
     fun `failed forced revoke clear retains the fenced holder and queued handoff`() {
         val directory = Files.createTempDirectory("spc-service-ledger-force-clear-")
         val path = directory.resolve("recovery.properties")

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertTrue
 class CoordinatorForcedRecoveryPersistenceTest {
 
     @Test
-    fun `failed cancellation release fences the session until exact-id force`() {
+    fun `failed cancellation release abandons a known unobserved grant`() {
         val directory = Files.createTempDirectory("spc-service-cancel-clear-")
         val path = directory.resolve("recovery.properties")
         val service =
@@ -32,7 +32,7 @@ class CoordinatorForcedRecoveryPersistenceTest {
             )
         try {
             service.openSession("interrupted-client")
-            val unobserved = service.acquire(acquire("unobserved", "interrupted-client")).get()
+            service.acquire(acquire("unobserved", "interrupted-client")).get()
             Files.delete(path)
             Files.createDirectory(path)
             Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
@@ -46,20 +46,17 @@ class CoordinatorForcedRecoveryPersistenceTest {
                 )
             )
 
-            assertEquals("revoking", assertNotNull(status(service).holder).state)
-            val rejected =
+            assertEquals(null, status(service).holder)
+            val persistenceFailure =
                 service.acquire(acquire("late", "interrupted-client")).get(1, TimeUnit.SECONDS)
-            assertFalse(rejected.ok)
-            assertEquals("CLIENT_DISCONNECTED", rejected.errorCode)
+            assertFalse(persistenceFailure.ok)
+            assertEquals("RECOVERY_PERSISTENCE_FAILED", persistenceFailure.errorCode)
 
             Files.delete(path.resolve("blocker"))
             Files.delete(path)
             service.openSession("successor-client")
-            val successorFuture = service.acquire(acquire("successor", "successor-client"))
-            assertTrue(
-                service.revoke(revokeMessage(requireNotNull(unobserved.leaseId), force = true)).ok
-            )
-            val successor = successorFuture.get(1, TimeUnit.SECONDS)
+            val successor =
+                service.acquire(acquire("successor", "successor-client")).get(1, TimeUnit.SECONDS)
             assertTrue(service.release(tokenMessage(successor, "successor-client")).ok)
         } finally {
             cleanUp(service, path, directory)

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
@@ -185,6 +185,7 @@ class CoordinatorForcedRecoveryPersistenceTest {
     ): CoordinatorWireMessage =
         CoordinatorWireMessage(
             kind = CoordinatorWireKind.RELEASE,
+            requestId = requireNotNull(grant.requestId),
             clientId = clientId,
             resourceKey = "test/desktop",
             coordinatorEpoch = grant.coordinatorEpoch,

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorForcedRecoveryPersistenceTest.kt
@@ -19,20 +19,20 @@ import kotlin.test.assertTrue
 class CoordinatorForcedRecoveryPersistenceTest {
 
     @Test
-    fun `failed cancellation release disconnects the affected session`() {
+    fun `failed cancellation release fences the session until exact-id force`() {
         val directory = Files.createTempDirectory("spc-service-cancel-clear-")
         val path = directory.resolve("recovery.properties")
         val service =
             CoordinatorLeaseService(
                 epoch = "epoch",
                 heartbeatTimeout = Duration.ofSeconds(5),
-                revokeGrace = Duration.ofSeconds(1),
+                revokeGrace = Duration.ZERO,
                 recoveryGrace = Duration.ofSeconds(1),
                 recoveryLedger = RecoveryLedger(path, Duration.ofSeconds(5)),
             )
         try {
             service.openSession("interrupted-client")
-            service.acquire(acquire("unobserved", "interrupted-client")).get()
+            val unobserved = service.acquire(acquire("unobserved", "interrupted-client")).get()
             Files.delete(path)
             Files.createDirectory(path)
             Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
@@ -46,7 +46,7 @@ class CoordinatorForcedRecoveryPersistenceTest {
                 )
             )
 
-            assertEquals(null, status(service).holder)
+            assertEquals("revoking", assertNotNull(status(service).holder).state)
             val rejected =
                 service.acquire(acquire("late", "interrupted-client")).get(1, TimeUnit.SECONDS)
             assertFalse(rejected.ok)
@@ -55,7 +55,11 @@ class CoordinatorForcedRecoveryPersistenceTest {
             Files.delete(path.resolve("blocker"))
             Files.delete(path)
             service.openSession("successor-client")
-            val successor = service.acquire(acquire("successor", "successor-client")).get()
+            val successorFuture = service.acquire(acquire("successor", "successor-client"))
+            assertTrue(
+                service.revoke(revokeMessage(requireNotNull(unobserved.leaseId), force = true)).ok
+            )
+            val successor = successorFuture.get(1, TimeUnit.SECONDS)
             assertTrue(service.release(tokenMessage(successor, "successor-client")).ok)
         } finally {
             cleanUp(service, path, directory)

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseReleaseIdempotencyTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseReleaseIdempotencyTest.kt
@@ -1,0 +1,72 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorWireKind
+import dev.sebastiano.spectre.input.CoordinatorWireMessage
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CoordinatorLeaseReleaseIdempotencyTest {
+
+    @Test
+    fun `duplicate release succeeds without consuming a reentrant hold twice`() {
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+            )
+        try {
+            service.openSession("holder-client")
+            service.openSession("successor-client")
+            val outer = service.acquire(acquire("outer", "holder-client")).get()
+            val inner = service.acquire(acquire("inner", "holder-client")).get()
+            val successor = service.acquire(acquire("successor", "successor-client"))
+            val innerRelease = tokenMessage(inner, clientId = "holder-client", requestId = "inner")
+
+            assertTrue(service.release(innerRelease).ok)
+            assertTrue(service.release(innerRelease).ok)
+            assertFalse(successor.isDone, "duplicate release consumed the outer hold")
+
+            assertTrue(
+                service
+                    .release(tokenMessage(outer, clientId = "holder-client", requestId = "outer"))
+                    .ok
+            )
+            assertTrue(successor.get(1, TimeUnit.SECONDS).ok)
+        } finally {
+            service.close()
+        }
+    }
+
+    private fun acquire(requestId: String, clientId: String): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.ACQUIRE,
+            requestId = requestId,
+            clientId = clientId,
+            resourceKey = "test/desktop",
+            processId = 1,
+            timeoutMillis = 10_000,
+            currentOperation = "click",
+        )
+
+    private fun tokenMessage(
+        grant: CoordinatorWireMessage,
+        clientId: String,
+        requestId: String,
+    ): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.RELEASE,
+            requestId = requestId,
+            clientId = clientId,
+            resourceKey = "test/desktop",
+            coordinatorEpoch = grant.coordinatorEpoch,
+            leaseId = grant.leaseId,
+            fence = grant.fence,
+        )
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseRevocationIsolationTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseRevocationIsolationTest.kt
@@ -1,0 +1,70 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorWireKind
+import dev.sebastiano.spectre.input.CoordinatorWireMessage
+import java.time.Duration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CoordinatorLeaseRevocationIsolationTest {
+
+    @Test
+    fun `revocation cannot target a lease held on another desktop resource`() {
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+            )
+        try {
+            service.openSession("holder")
+            val held = service.acquire(acquire("desktop-b", "holder")).get()
+
+            val revoke =
+                service.revoke(
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.REVOKE,
+                        resourceKey = "desktop-a",
+                        leaseId = held.leaseId,
+                        requesterLabel = "operator",
+                        reason = "observed elsewhere",
+                    )
+                )
+
+            assertFalse(revoke.ok)
+            assertEquals("STALE_LEASE", revoke.errorCode)
+            assertTrue(service.heartbeat(tokenMessage(held, "holder")).ok)
+        } finally {
+            service.close()
+        }
+    }
+
+    private fun acquire(resourceKey: String, clientId: String): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.ACQUIRE,
+            requestId = "acquire-$resourceKey",
+            clientId = clientId,
+            resourceKey = resourceKey,
+            processId = 1,
+            timeoutMillis = 1_000,
+            currentOperation = "click",
+        )
+
+    private fun tokenMessage(
+        grant: CoordinatorWireMessage,
+        clientId: String,
+    ): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.HEARTBEAT,
+            clientId = clientId,
+            resourceKey = "desktop-b",
+            coordinatorEpoch = grant.coordinatorEpoch,
+            leaseId = grant.leaseId,
+            fence = grant.fence,
+        )
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -359,7 +359,11 @@ class CoordinatorLeaseServiceTest {
             Files.delete(path)
             val successor = service.acquire(acquire("successor", "successor-client")).get()
             assertTrue(successor.ok)
+            val recovered = assertNotNull(RecoveryLedger(path, Duration.ofSeconds(5)).load())
+            assertFalse(recovered.blocksAllResources)
+            assertEquals(successor.leaseId, recovered.leaseId)
             assertTrue(service.release(tokenMessage(successor, "successor-client")).ok)
+            assertNull(RecoveryLedger(path, Duration.ofSeconds(5)).load())
         } finally {
             service.close()
             Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -4,11 +4,13 @@ package dev.sebastiano.spectre.input.server
 
 import dev.sebastiano.spectre.input.CoordinatorWireKind
 import dev.sebastiano.spectre.input.CoordinatorWireMessage
+import java.nio.file.Files
 import java.time.Duration
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class CoordinatorLeaseServiceTest {
@@ -87,6 +89,49 @@ class CoordinatorLeaseServiceTest {
         }
     }
 
+    @Test
+    fun `acknowledged revocation clears its recovery record before advancing FIFO`() {
+        val directory = Files.createTempDirectory("spc-service-ledger-")
+        val path = directory.resolve("recovery.properties")
+        val ledger = RecoveryLedger(path, Duration.ofSeconds(5))
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+                recoveryLedger = ledger,
+            )
+        try {
+            val first = service.acquire(acquire("first", "first-client")).get()
+            val queued = service.acquire(acquire("second", "second-client"))
+            assertTrue(
+                service
+                    .revoke(
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.REVOKE,
+                            resourceKey = "test/desktop",
+                            leaseId = first.leaseId,
+                            requesterLabel = "operator",
+                            reason = "owner should stop",
+                        )
+                    )
+                    .ok
+            )
+
+            assertTrue(service.release(tokenMessage(first, "first-client")).ok)
+            val second = queued.get(1, TimeUnit.SECONDS)
+            assertTrue(service.release(tokenMessage(second, "second-client")).ok)
+
+            assertNull(RecoveryLedger(path, Duration.ofSeconds(5)).load())
+        } finally {
+            service.close()
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
     private fun acquire(requestId: String, clientId: String): CoordinatorWireMessage =
         CoordinatorWireMessage(
             kind = CoordinatorWireKind.ACQUIRE,
@@ -96,5 +141,18 @@ class CoordinatorLeaseServiceTest {
             processId = 1,
             timeoutMillis = 10_000,
             currentOperation = "click",
+        )
+
+    private fun tokenMessage(
+        grant: CoordinatorWireMessage,
+        clientId: String,
+    ): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.RELEASE,
+            clientId = clientId,
+            resourceKey = "test/desktop",
+            coordinatorEpoch = grant.coordinatorEpoch,
+            leaseId = grant.leaseId,
+            fence = grant.fence,
         )
 }

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -119,7 +119,7 @@ class CoordinatorLeaseServiceTest {
     }
 
     @Test
-    fun `disconnect cleanup continues when recovery persistence fails`() {
+    fun `disconnect fences holder until cleanup release can clear recovery state`() {
         val directory = Files.createTempDirectory("spc-service-disconnect-ledger-")
         val path = directory.resolve("recovery.properties")
         val service =
@@ -132,7 +132,7 @@ class CoordinatorLeaseServiceTest {
             )
         try {
             service.openSession("holder-client")
-            service.acquire(acquire("holder", "holder-client")).get()
+            val holder = service.acquire(acquire("holder", "holder-client")).get()
             Files.delete(path)
             Files.createDirectory(path)
             Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
@@ -150,10 +150,11 @@ class CoordinatorLeaseServiceTest {
                         )
                         .status
                 )
-            assertNull(status.holder)
+            assertEquals("revoking", assertNotNull(status.holder).state)
 
             Files.delete(path.resolve("blocker"))
             Files.delete(path)
+            assertTrue(service.release(tokenMessage(holder, "holder-client")).ok)
             service.openSession("successor-client")
             val successor = service.acquire(acquire("successor", "successor-client")).get()
             assertTrue(successor.ok)

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -242,6 +242,72 @@ class CoordinatorLeaseServiceTest {
     }
 
     @Test
+    fun `failed recovery clear retains the fenced holder and queued handoff`() {
+        val directory = Files.createTempDirectory("spc-service-ledger-revoke-clear-")
+        val path = directory.resolve("recovery.properties")
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+                recoveryLedger = RecoveryLedger(path, Duration.ofSeconds(5)),
+            )
+        try {
+            service.openSession("first-client")
+            service.openSession("second-client")
+            val first = service.acquire(acquire("first", "first-client")).get()
+            val queued = service.acquire(acquire("second", "second-client"))
+            assertTrue(
+                service
+                    .revoke(
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.REVOKE,
+                            resourceKey = "test/desktop",
+                            leaseId = first.leaseId,
+                            requesterLabel = "operator",
+                            reason = "owner should stop",
+                        )
+                    )
+                    .ok
+            )
+            Files.delete(path)
+            Files.createDirectory(path)
+            Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
+
+            val failedRelease = service.release(tokenMessage(first, "first-client"))
+
+            assertFalse(failedRelease.ok)
+            assertEquals("RECOVERY_PERSISTENCE_FAILED", failedRelease.errorCode)
+            val status =
+                assertNotNull(
+                    service
+                        .status(
+                            CoordinatorWireMessage(
+                                kind = CoordinatorWireKind.STATUS,
+                                resourceKey = "test/desktop",
+                            )
+                        )
+                        .status
+                )
+            assertEquals("first-client", assertNotNull(status.holder).clientId)
+            assertEquals(1, status.waiters.size)
+
+            Files.delete(path.resolve("blocker"))
+            Files.delete(path)
+            assertTrue(service.release(tokenMessage(first, "first-client")).ok)
+            val second = queued.get(1, TimeUnit.SECONDS)
+            assertTrue(service.release(tokenMessage(second, "second-client")).ok)
+        } finally {
+            service.close()
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            if (Files.isDirectory(path)) Files.deleteIfExists(path.resolve("blocker"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
     fun `failed FIFO grant persistence rolls back the hidden holder`() {
         val directory = Files.createTempDirectory("spc-service-ledger-failure-")
         val path = directory.resolve("recovery.properties")

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -4,6 +4,9 @@ package dev.sebastiano.spectre.input.server
 
 import dev.sebastiano.spectre.input.CoordinatorWireKind
 import dev.sebastiano.spectre.input.CoordinatorWireMessage
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseOwner
+import dev.sebastiano.spectre.input.LeaseToken
 import java.nio.file.Files
 import java.time.Duration
 import java.util.concurrent.TimeUnit
@@ -112,6 +115,117 @@ class CoordinatorLeaseServiceTest {
             assertEquals("CLIENT_DISCONNECTED", response.errorCode)
         } finally {
             service.close()
+        }
+    }
+
+    @Test
+    fun `disconnect cleanup continues when recovery persistence fails`() {
+        val directory = Files.createTempDirectory("spc-service-disconnect-ledger-")
+        val path = directory.resolve("recovery.properties")
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+                recoveryLedger = RecoveryLedger(path, Duration.ofSeconds(5)),
+            )
+        try {
+            service.openSession("holder-client")
+            service.acquire(acquire("holder", "holder-client")).get()
+            Files.delete(path)
+            Files.createDirectory(path)
+            Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
+
+            service.disconnect("holder-client")
+
+            val status =
+                assertNotNull(
+                    service
+                        .status(
+                            CoordinatorWireMessage(
+                                kind = CoordinatorWireKind.STATUS,
+                                resourceKey = "test/desktop",
+                            )
+                        )
+                        .status
+                )
+            assertNull(status.holder)
+
+            Files.delete(path.resolve("blocker"))
+            Files.delete(path)
+            service.openSession("successor-client")
+            val successor = service.acquire(acquire("successor", "successor-client")).get()
+            assertTrue(successor.ok)
+            assertTrue(service.release(tokenMessage(successor, "successor-client")).ok)
+        } finally {
+            service.close()
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            if (Files.isDirectory(path)) Files.deleteIfExists(path.resolve("blocker"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
+    fun `restart quarantine stays closed and waiter expiry survives ledger IO failure`() {
+        val directory = Files.createTempDirectory("spc-service-recovery-expiry-")
+        val path = directory.resolve("recovery.properties")
+        val ledger = RecoveryLedger(path, Duration.ofMillis(-1))
+        ledger.record(
+            LeaseGrant(
+                requestId = "predecessor-request",
+                owner = LeaseOwner("predecessor-client", 1),
+                token =
+                    LeaseToken(
+                        coordinatorEpoch = "predecessor-epoch",
+                        leaseId = "predecessor-lease",
+                        resourceKey = DesktopResourceKey("test/desktop"),
+                        fence = 1,
+                    ),
+            )
+        )
+        val restartedLedger = RecoveryLedger(path, Duration.ofSeconds(5))
+        val recoveryRecord = assertNotNull(restartedLedger.load())
+        Files.delete(path)
+        Files.createDirectory(path)
+        Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
+        val service =
+            CoordinatorLeaseService(
+                epoch = "replacement-epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ZERO,
+                recoveryRecord = recoveryRecord,
+                recoveryLedger = restartedLedger,
+            )
+        try {
+            service.openSession("waiting-client")
+            val waiting =
+                service.acquire(acquire("waiting", "waiting-client").copy(timeoutMillis = 50))
+
+            val response = waiting.get(1, TimeUnit.SECONDS)
+
+            assertFalse(response.ok)
+            assertEquals("ACQUIRE_TIMEOUT", response.errorCode)
+            val status =
+                assertNotNull(
+                    service
+                        .status(
+                            CoordinatorWireMessage(
+                                kind = CoordinatorWireKind.STATUS,
+                                resourceKey = "test/desktop",
+                            )
+                        )
+                        .status
+                )
+            assertEquals("predecessor-lease", assertNotNull(status.quarantine).predecessorLeaseId)
+        } finally {
+            service.close()
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            if (Files.isDirectory(path)) Files.deleteIfExists(path.resolve("blocker"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
         }
     }
 

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -1,0 +1,63 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorWireKind
+import dev.sebastiano.spectre.input.CoordinatorWireMessage
+import java.time.Duration
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class CoordinatorLeaseServiceTest {
+
+    @Test
+    fun `cancelling an unknown request does not disconnect an active lease`() {
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+            )
+        try {
+            val grant =
+                service
+                    .acquire(
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.ACQUIRE,
+                            requestId = "held",
+                            clientId = "client",
+                            resourceKey = "test/desktop",
+                            processId = 1,
+                            timeoutMillis = 1_000,
+                            currentOperation = "click",
+                        )
+                    )
+                    .get()
+
+            service.cancel(
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.CANCEL,
+                    requestId = "already-completed",
+                    clientId = "client",
+                    resourceKey = "test/desktop",
+                )
+            )
+
+            val heartbeat =
+                service.heartbeat(
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.HEARTBEAT,
+                        clientId = "client",
+                        resourceKey = "test/desktop",
+                        coordinatorEpoch = grant.coordinatorEpoch,
+                        leaseId = grant.leaseId,
+                        fence = grant.fence,
+                    )
+                )
+            assertTrue(heartbeat.ok)
+        } finally {
+            service.close()
+        }
+    }
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -281,6 +281,60 @@ class CoordinatorLeaseServiceTest {
         }
     }
 
+    @Test
+    fun `failed recovery clear retains the holder and queued handoff`() {
+        val directory = Files.createTempDirectory("spc-service-ledger-clear-")
+        val path = directory.resolve("recovery.properties")
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+                recoveryLedger = RecoveryLedger(path, Duration.ofSeconds(5)),
+            )
+        try {
+            service.openSession("holder-client")
+            service.openSession("waiting-client")
+            val holder = service.acquire(acquire("holder", "holder-client")).get()
+            val waiting = service.acquire(acquire("waiting", "waiting-client"))
+            Files.delete(path)
+            Files.createDirectory(path)
+            Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
+
+            val failedRelease = service.release(tokenMessage(holder, "holder-client"))
+
+            assertFalse(failedRelease.ok)
+            assertEquals("RECOVERY_PERSISTENCE_FAILED", failedRelease.errorCode)
+            val status =
+                assertNotNull(
+                    service
+                        .status(
+                            CoordinatorWireMessage(
+                                kind = CoordinatorWireKind.STATUS,
+                                resourceKey = "test/desktop",
+                            )
+                        )
+                        .status
+                )
+            assertEquals("holder-client", assertNotNull(status.holder).clientId)
+            assertEquals(1, status.waiters.size)
+
+            Files.delete(path.resolve("blocker"))
+            Files.delete(path)
+            assertTrue(service.release(tokenMessage(holder, "holder-client")).ok)
+            val handedOff = waiting.get(1, TimeUnit.SECONDS)
+            assertTrue(handedOff.ok)
+            assertTrue(service.release(tokenMessage(handedOff, "waiting-client")).ok)
+        } finally {
+            service.close()
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            if (Files.isDirectory(path)) Files.deleteIfExists(path.resolve("blocker"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
     private fun acquire(requestId: String, clientId: String): CoordinatorWireMessage =
         CoordinatorWireMessage(
             kind = CoordinatorWireKind.ACQUIRE,

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -311,6 +311,48 @@ class CoordinatorLeaseServiceTest {
     }
 
     @Test
+    fun `observed reentrant release preserves an unobserved request for cancellation`() {
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+            )
+        try {
+            service.openSession("interrupted-client")
+            service.openSession("successor-client")
+            service.acquire(acquire("unobserved", "interrupted-client")).get()
+            val observed = service.acquire(acquire("observed", "interrupted-client")).get()
+            val successor = service.acquire(acquire("successor", "successor-client"))
+
+            assertTrue(
+                service
+                    .release(
+                        tokenMessage(
+                            observed,
+                            clientId = "interrupted-client",
+                            requestId = "observed",
+                        )
+                    )
+                    .ok
+            )
+            service.cancel(
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.CANCEL,
+                    requestId = "unobserved",
+                    clientId = "interrupted-client",
+                    resourceKey = "test/desktop",
+                )
+            )
+
+            assertTrue(successor.get(1, TimeUnit.SECONDS).ok)
+        } finally {
+            service.close()
+        }
+    }
+
+    @Test
     fun `acknowledged revocation clears its recovery record before advancing FIFO`() {
         val directory = Files.createTempDirectory("spc-service-ledger-")
         val path = directory.resolve("recovery.properties")
@@ -529,9 +571,11 @@ class CoordinatorLeaseServiceTest {
     private fun tokenMessage(
         grant: CoordinatorWireMessage,
         clientId: String,
+        requestId: String? = null,
     ): CoordinatorWireMessage =
         CoordinatorWireMessage(
             kind = CoordinatorWireKind.RELEASE,
+            requestId = requestId ?: requireNotNull(grant.requestId),
             clientId = clientId,
             resourceKey = "test/desktop",
             coordinatorEpoch = grant.coordinatorEpoch,

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -90,6 +90,27 @@ class CoordinatorLeaseServiceTest {
     }
 
     @Test
+    fun `acquire arriving after session disconnect is rejected`() {
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+            )
+        try {
+            service.disconnect("closed-client")
+
+            val response = service.acquire(acquire("late", "closed-client")).get()
+
+            assertFalse(response.ok)
+            assertEquals("CLIENT_DISCONNECTED", response.errorCode)
+        } finally {
+            service.close()
+        }
+    }
+
+    @Test
     fun `cancel arriving before acquire rejects the delayed request`() {
         val service =
             CoordinatorLeaseService(

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -5,7 +5,10 @@ package dev.sebastiano.spectre.input.server
 import dev.sebastiano.spectre.input.CoordinatorWireKind
 import dev.sebastiano.spectre.input.CoordinatorWireMessage
 import java.time.Duration
+import java.util.concurrent.TimeUnit
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class CoordinatorLeaseServiceTest {
@@ -60,4 +63,38 @@ class CoordinatorLeaseServiceTest {
             service.close()
         }
     }
+
+    @Test
+    fun `disconnect completes queued acquisitions for that client`() {
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+            )
+        try {
+            service.acquire(acquire("holder", "holder-client")).get(1, TimeUnit.SECONDS)
+            val queued = service.acquire(acquire("waiting", "waiting-client"))
+
+            service.disconnect("waiting-client")
+            val response = queued.get(1, TimeUnit.SECONDS)
+
+            assertFalse(response.ok)
+            assertEquals("CLIENT_DISCONNECTED", response.errorCode)
+        } finally {
+            service.close()
+        }
+    }
+
+    private fun acquire(requestId: String, clientId: String): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.ACQUIRE,
+            requestId = requestId,
+            clientId = clientId,
+            resourceKey = "test/desktop",
+            processId = 1,
+            timeoutMillis = 10_000,
+            currentOperation = "click",
+        )
 }

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -90,6 +90,62 @@ class CoordinatorLeaseServiceTest {
     }
 
     @Test
+    fun `cancel arriving before acquire rejects the delayed request`() {
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+            )
+        try {
+            service.cancel(
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.CANCEL,
+                    requestId = "delayed",
+                    clientId = "client",
+                    resourceKey = "test/desktop",
+                )
+            )
+
+            val response = service.acquire(acquire("delayed", "client")).get()
+
+            assertFalse(response.ok)
+            assertEquals("ACQUIRE_CANCELLED", response.errorCode)
+        } finally {
+            service.close()
+        }
+    }
+
+    @Test
+    fun `cancel arriving after an unobserved grant releases that exact request`() {
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+            )
+        try {
+            service.acquire(acquire("unobserved", "interrupted-client")).get()
+
+            service.cancel(
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.CANCEL,
+                    requestId = "unobserved",
+                    clientId = "interrupted-client",
+                    resourceKey = "test/desktop",
+                )
+            )
+
+            val successor = service.acquire(acquire("successor", "next-client")).get()
+            assertTrue(successor.ok)
+        } finally {
+            service.close()
+        }
+    }
+
+    @Test
     fun `acknowledged revocation clears its recovery record before advancing FIFO`() {
         val directory = Files.createTempDirectory("spc-service-ledger-")
         val path = directory.resolve("recovery.properties")

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -10,6 +10,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -232,6 +233,46 @@ class CoordinatorLeaseServiceTest {
             assertTrue(service.release(tokenMessage(second, "second-client")).ok)
 
             assertNull(RecoveryLedger(path, Duration.ofSeconds(5)).load())
+        } finally {
+            service.close()
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
+    fun `failed FIFO grant persistence rolls back the hidden holder`() {
+        val directory = Files.createTempDirectory("spc-service-ledger-failure-")
+        val path = directory.resolve("recovery.properties")
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+                recoveryLedger = RecoveryLedger(path, Duration.ofSeconds(5)),
+            )
+        try {
+            service.openSession("holder-client")
+            service.openSession("waiting-client")
+            service.openSession("successor-client")
+            val holder = service.acquire(acquire("holder", "holder-client")).get()
+            val waiting = service.acquire(acquire("waiting", "waiting-client"))
+            Files.delete(path)
+            Files.delete(directory)
+
+            assertTrue(service.release(tokenMessage(holder, "holder-client")).ok)
+            val failedHandoff = waiting.get(1, TimeUnit.SECONDS)
+
+            assertFalse(failedHandoff.ok)
+            assertEquals("RECOVERY_PERSISTENCE_FAILED", failedHandoff.errorCode)
+
+            Files.createDirectory(directory)
+            assertTrue(service.acquire(acquire("successor", "successor-client")).get().ok)
+            val recovered = assertNotNull(RecoveryLedger(path, Duration.ofSeconds(5)).load())
+            assertFalse(recovered.blocksAllResources)
+            assertEquals("successor-client", recovered.owner.clientId)
         } finally {
             service.close()
             Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -16,6 +16,28 @@ import kotlin.test.assertTrue
 class CoordinatorLeaseServiceTest {
 
     @Test
+    fun `acquire requires a session opened in the current coordinator epoch`() {
+        val service =
+            CoordinatorLeaseService(
+                epoch = "replacement-epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+            )
+        try {
+            val staleEpochResponse = service.acquire(acquire("stale", "old-client")).get()
+
+            assertFalse(staleEpochResponse.ok)
+            assertEquals("CLIENT_DISCONNECTED", staleEpochResponse.errorCode)
+
+            service.openSession("old-client")
+            assertTrue(service.acquire(acquire("current", "old-client")).get().ok)
+        } finally {
+            service.close()
+        }
+    }
+
+    @Test
     fun `cancelling an unknown request does not disconnect an active lease`() {
         val service =
             CoordinatorLeaseService(
@@ -25,6 +47,7 @@ class CoordinatorLeaseServiceTest {
                 recoveryGrace = Duration.ofSeconds(1),
             )
         try {
+            service.openSession("client")
             val grant =
                 service
                     .acquire(
@@ -76,6 +99,8 @@ class CoordinatorLeaseServiceTest {
                 recoveryGrace = Duration.ofSeconds(1),
             )
         try {
+            service.openSession("holder-client")
+            service.openSession("waiting-client")
             service.acquire(acquire("holder", "holder-client")).get(1, TimeUnit.SECONDS)
             val queued = service.acquire(acquire("waiting", "waiting-client"))
 
@@ -99,6 +124,7 @@ class CoordinatorLeaseServiceTest {
                 recoveryGrace = Duration.ofSeconds(1),
             )
         try {
+            service.openSession("closed-client")
             service.disconnect("closed-client")
 
             val response = service.acquire(acquire("late", "closed-client")).get()
@@ -120,6 +146,7 @@ class CoordinatorLeaseServiceTest {
                 recoveryGrace = Duration.ofSeconds(1),
             )
         try {
+            service.openSession("client")
             service.cancel(
                 CoordinatorWireMessage(
                     kind = CoordinatorWireKind.CANCEL,
@@ -148,6 +175,8 @@ class CoordinatorLeaseServiceTest {
                 recoveryGrace = Duration.ofSeconds(1),
             )
         try {
+            service.openSession("interrupted-client")
+            service.openSession("next-client")
             service.acquire(acquire("unobserved", "interrupted-client")).get()
 
             service.cancel(
@@ -180,6 +209,8 @@ class CoordinatorLeaseServiceTest {
                 recoveryLedger = ledger,
             )
         try {
+            service.openSession("first-client")
+            service.openSession("second-client")
             val first = service.acquire(acquire("first", "first-client")).get()
             val queued = service.acquire(acquire("second", "second-client"))
             assertTrue(

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorLeaseServiceTest.kt
@@ -312,6 +312,64 @@ class CoordinatorLeaseServiceTest {
     }
 
     @Test
+    fun `failed compensating release abandons a known unobserved grant`() {
+        val directory = Files.createTempDirectory("spc-service-unobserved-release-")
+        val path = directory.resolve("recovery.properties")
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+                recoveryLedger = RecoveryLedger(path, Duration.ofSeconds(5)),
+            )
+        try {
+            service.openSession("interrupted-client")
+            service.openSession("successor-client")
+            service.acquire(acquire("unobserved", "interrupted-client")).get()
+            Files.delete(path)
+            Files.createDirectory(path)
+            Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
+
+            val cancelled =
+                service.cancel(
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.CANCEL,
+                        requestId = "unobserved",
+                        clientId = "interrupted-client",
+                        resourceKey = "test/desktop",
+                    )
+                )
+
+            assertTrue(cancelled.ok)
+            val status =
+                assertNotNull(
+                    service
+                        .status(
+                            CoordinatorWireMessage(
+                                kind = CoordinatorWireKind.STATUS,
+                                resourceKey = "test/desktop",
+                            )
+                        )
+                        .status
+                )
+            assertNull(status.holder)
+
+            Files.delete(path.resolve("blocker"))
+            Files.delete(path)
+            val successor = service.acquire(acquire("successor", "successor-client")).get()
+            assertTrue(successor.ok)
+            assertTrue(service.release(tokenMessage(successor, "successor-client")).ok)
+        } finally {
+            service.close()
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            if (Files.isDirectory(path)) Files.deleteIfExists(path.resolve("blocker"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
     fun `observed reentrant release preserves an unobserved request for cancellation`() {
         val service =
             CoordinatorLeaseService(

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorProcessLauncherTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorProcessLauncherTest.kt
@@ -59,10 +59,15 @@ class CoordinatorProcessLauncherTest {
     @Test
     fun `forked coordinator accepts a real client lease`() {
         val launcher =
-            CoordinatorProcessLauncher(endpoint = endpoint, idleTimeout = Duration.ofSeconds(5))
+            CoordinatorProcessLauncher(
+                endpoint = endpoint,
+                idleTimeout = Duration.ofSeconds(FORKED_COORDINATOR_TIMEOUT_SECONDS),
+            )
         process = launcher.start()
-        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        val deadline =
+            System.nanoTime() + TimeUnit.SECONDS.toNanos(FORKED_COORDINATOR_TIMEOUT_SECONDS)
         var acquired = false
+        var lastFailure: Throwable? = null
 
         while (!acquired && System.nanoTime() < deadline) {
             runCatching {
@@ -75,9 +80,19 @@ class CoordinatorProcessLauncherTest {
                             client.acquire(Duration.ofSeconds(1), "click").use { acquired = true }
                         }
                 }
-                .onFailure { Thread.onSpinWait() }
+                .onFailure {
+                    lastFailure = it
+                    Thread.onSpinWait()
+                }
         }
 
-        assertTrue(acquired, "Forked coordinator did not accept a lease before the deadline")
+        assertTrue(
+            acquired,
+            "Forked coordinator did not accept a lease before the deadline; last failure: $lastFailure",
+        )
+    }
+
+    private companion object {
+        const val FORKED_COORDINATOR_TIMEOUT_SECONDS: Long = 30
     }
 }

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorProcessLauncherTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorProcessLauncherTest.kt
@@ -1,0 +1,83 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LocalInputCoordinatorClient
+import java.nio.file.Files
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CoordinatorProcessLauncherTest {
+
+    private val temporaryDirectory = Files.createTempDirectory("spc-p-")
+    private val endpoint =
+        CoordinatorEndpoint(temporaryDirectory, temporaryDirectory.resolve("coordinator.sock"))
+    private var process: Process? = null
+
+    @AfterTest
+    fun cleanUp() {
+        process?.destroy()
+        process?.waitFor(2, TimeUnit.SECONDS)
+        Files.deleteIfExists(endpoint.socketPath)
+        Files.deleteIfExists(temporaryDirectory.resolve("coordinator.lock"))
+        Files.deleteIfExists(temporaryDirectory.resolve("recovery.properties.tmp"))
+        Files.deleteIfExists(temporaryDirectory.resolve("recovery.properties"))
+        Files.deleteIfExists(temporaryDirectory)
+    }
+
+    @Test
+    fun `launcher builds a dedicated coordinator Java command`() {
+        val launcher =
+            CoordinatorProcessLauncher(
+                endpoint = endpoint,
+                javaExecutable = "/jdk/bin/java",
+                classPath = "client.jar:server.jar",
+                idleTimeout = Duration.ofSeconds(7),
+            )
+
+        assertEquals(
+            listOf(
+                "/jdk/bin/java",
+                "-cp",
+                "client.jar:server.jar",
+                "dev.sebastiano.spectre.input.server.CoordinatorProcessMainKt",
+                "--socket",
+                endpoint.socketPath.toString(),
+                "--idle-millis",
+                "7000",
+            ),
+            launcher.command(),
+        )
+    }
+
+    @Test
+    fun `forked coordinator accepts a real client lease`() {
+        val launcher =
+            CoordinatorProcessLauncher(endpoint = endpoint, idleTimeout = Duration.ofSeconds(5))
+        process = launcher.start()
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5)
+        var acquired = false
+
+        while (!acquired && System.nanoTime() < deadline) {
+            runCatching {
+                    LocalInputCoordinatorClient.connect(
+                            endpoint,
+                            DesktopResourceKey("user:501/macos-console"),
+                            "forked test",
+                        )
+                        .use { client ->
+                            client.acquire(Duration.ofSeconds(1), "click").use { acquired = true }
+                        }
+                }
+                .onFailure { Thread.onSpinWait() }
+        }
+
+        assertTrue(acquired, "Forked coordinator did not accept a lease before the deadline")
+    }
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorRecoveryRetryTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/CoordinatorRecoveryRetryTest.kt
@@ -1,0 +1,88 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorWireKind
+import dev.sebastiano.spectre.input.CoordinatorWireMessage
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseOwner
+import dev.sebastiano.spectre.input.LeaseToken
+import java.nio.file.Files
+import java.time.Duration
+import kotlin.test.Test
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CoordinatorRecoveryRetryTest {
+    @Test
+    fun `close retries deletion of an abandoned unobserved recovery record`() {
+        val directory = Files.createTempDirectory("spc-service-unobserved-close-")
+        val path = directory.resolve("recovery.properties")
+        val ledger = RecoveryLedger(path, Duration.ofSeconds(5))
+        val service =
+            CoordinatorLeaseService(
+                epoch = "epoch",
+                heartbeatTimeout = Duration.ofSeconds(5),
+                revokeGrace = Duration.ofSeconds(1),
+                recoveryGrace = Duration.ofSeconds(1),
+                recoveryLedger = ledger,
+            )
+        try {
+            service.openSession("interrupted-client")
+            val unobserved = service.acquire(acquire()).get()
+            Files.delete(path)
+            Files.createDirectory(path)
+            Files.writeString(path.resolve("blocker"), "prevent ledger deletion")
+            assertTrue(
+                service
+                    .cancel(
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.CANCEL,
+                            requestId = "unobserved",
+                            clientId = "interrupted-client",
+                            resourceKey = "test/desktop",
+                        )
+                    )
+                    .ok
+            )
+
+            Files.delete(path.resolve("blocker"))
+            Files.delete(path)
+            RecoveryLedger(path, Duration.ofSeconds(5))
+                .record(
+                    LeaseGrant(
+                        requestId = "unobserved",
+                        owner = LeaseOwner("interrupted-client", 1, "interrupted-client"),
+                        token =
+                            LeaseToken(
+                                coordinatorEpoch = requireNotNull(unobserved.coordinatorEpoch),
+                                leaseId = requireNotNull(unobserved.leaseId),
+                                resourceKey = DesktopResourceKey("test/desktop"),
+                                fence = requireNotNull(unobserved.fence),
+                            ),
+                    )
+                )
+
+            service.close()
+
+            assertNull(RecoveryLedger(path, Duration.ofSeconds(5)).load())
+        } finally {
+            service.close()
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            if (Files.isDirectory(path)) Files.deleteIfExists(path.resolve("blocker"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    private fun acquire(): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = CoordinatorWireKind.ACQUIRE,
+            requestId = "unobserved",
+            clientId = "interrupted-client",
+            resourceKey = "test/desktop",
+            processId = 1,
+            timeoutMillis = 10_000,
+            currentOperation = "click",
+        )
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/ExperimentalInputCoordinationServerApiTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/ExperimentalInputCoordinationServerApiTest.kt
@@ -1,0 +1,31 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class ExperimentalInputCoordinationServerApiTest {
+
+    @Test
+    fun `the published server surface remains experimental`() {
+        listOf(
+                CoordinatorProcessLauncher::class.java,
+                CoordinatorProcessMain::class.java,
+                LaunchingInputCoordinatorClientProvider::class.java,
+                LocalCoordinatorServer::class.java,
+            )
+            .forEach { type ->
+                assertNotNull(
+                    type.getAnnotation(ExperimentalSpectreInputCoordinationApi::class.java),
+                    "${type.name} must remain experimental until the coordination API graduates",
+                )
+            }
+
+        val main =
+            Class.forName("dev.sebastiano.spectre.input.server.CoordinatorProcessMainKt")
+                .getDeclaredMethod("main", Array<String>::class.java)
+        assertNotNull(main.getAnnotation(ExperimentalSpectreInputCoordinationApi::class.java))
+    }
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
@@ -1,0 +1,299 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseErrorCode
+import dev.sebastiano.spectre.input.LeaseOwner
+import dev.sebastiano.spectre.input.LeaseToken
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class LeaseStateMachineTest {
+
+    private val clock = FakeMonotonicClock()
+    private val resource = DesktopResourceKey("user-1/desktop-1")
+    private val ownerA = LeaseOwner(clientId = "client-a", processId = 10, label = "first")
+    private val ownerB = LeaseOwner(clientId = "client-b", processId = 20, label = "second")
+    private val ownerC = LeaseOwner(clientId = "client-c", processId = 30, label = "third")
+
+    @Test
+    fun `waiters are granted in FIFO order and cancellation preserves the remaining order`() {
+        val machine = machine()
+        val first = machine.acquire(request("a", ownerA)).grantedToken()
+        assertEquals(1, machine.acquire(request("b", ownerB)).queuedPosition())
+        assertEquals(2, machine.acquire(request("c", ownerC)).queuedPosition())
+
+        assertTrue(machine.cancelWaiter("b"))
+        val release = assertIs<ReleaseResult.Released>(machine.release(first))
+
+        assertEquals(ownerC, release.nextGrant?.owner)
+        assertEquals("c", release.nextGrant?.requestId)
+    }
+
+    @Test
+    fun `same owner acquisition is reentrant and mismatched release is rejected`() {
+        val machine = machine()
+        val first = machine.acquire(request("a", ownerA)).grantedToken()
+        val nested = machine.acquire(request("nested", ownerA)).grantedToken()
+        assertEquals(first, nested)
+
+        val mismatched = machine.release(first.copy(leaseId = "not-the-holder"))
+        assertEquals(LeaseErrorCode.STALE_LEASE, mismatched.rejectedCode())
+
+        assertIs<ReleaseResult.StillHeld>(machine.release(first))
+        assertIs<ReleaseResult.Released>(machine.release(first))
+    }
+
+    @Test
+    fun `timed out waiter reports holder metadata and its queue position`() {
+        val machine = machine()
+        val holder = machine.acquire(request("a", ownerA)).grantedToken()
+        machine.acquire(request("b", ownerB, timeoutMillis = 50))
+        clock.advanceBy(51)
+
+        val timeout = assertNotNull(machine.expire().single().timeout)
+        val timeoutHolder = assertNotNull(timeout.holder)
+
+        assertEquals("b", timeout.requestId)
+        assertEquals(1, timeout.queuePosition)
+        assertEquals(holder.leaseId, timeoutHolder.token.leaseId)
+        assertEquals(ownerA, timeoutHolder.owner)
+        assertEquals(51, timeoutHolder.acquisitionAgeMillis)
+        assertEquals(51, timeoutHolder.heartbeatAgeMillis)
+    }
+
+    @Test
+    fun `release does not silently discard an expired waiter before timeout completion`() {
+        val machine = machine()
+        val holder = machine.acquire(request("a", ownerA)).grantedToken()
+        machine.acquire(request("b", ownerB, timeoutMillis = 50))
+        machine.acquire(request("c", ownerC, timeoutMillis = 500))
+        clock.advanceBy(51)
+
+        val released = assertIs<ReleaseResult.Released>(machine.release(holder))
+        assertEquals(null, released.nextGrant)
+        val events = machine.expire()
+
+        assertTrue(events.any { it.timeout?.requestId == "b" }, "events=$events")
+        assertTrue(events.any { it.grant?.owner == ownerC }, "events=$events")
+    }
+
+    @Test
+    fun `heartbeat expiry fences holder but disconnect confirms release and grants next`() {
+        val machine = machine(heartbeatTimeoutMillis = 100)
+        val first = machine.acquire(request("a", ownerA)).grantedToken()
+        machine.acquire(request("b", ownerB))
+        clock.advanceBy(101)
+
+        machine.expire()
+
+        assertEquals(LeaseErrorCode.FENCED, machine.validate(first).rejectedCode())
+        assertEquals(LeaseStatus.REVOKING, machine.status(resource).holder?.status)
+        val disconnect = machine.disconnect(ownerA.clientId)
+        assertEquals(ownerB, disconnect.single().owner)
+    }
+
+    @Test
+    fun `new coordinator epoch invalidates old tokens`() {
+        val oldMachine = machine(epoch = "epoch-1")
+        val oldToken = oldMachine.acquire(request("a", ownerA)).grantedToken()
+        val newMachine = machine(epoch = "epoch-2")
+
+        assertEquals(LeaseErrorCode.STALE_EPOCH, newMachine.validate(oldToken).rejectedCode())
+    }
+
+    @Test
+    fun `restart recovery quarantines resource until expiry or exact-id unsafe recovery`() {
+        val record =
+            RecoveryRecord(
+                resourceKey = resource,
+                predecessorEpoch = "epoch-1",
+                leaseId = "old-lease",
+                owner = ownerA,
+                heartbeatExpiryMillis = 100,
+            )
+        val machine = machine(recoveryRecord = record, recoveryGraceMillis = 25)
+
+        assertEquals(1, machine.acquire(request("b", ownerB)).queuedPosition())
+        assertEquals("old-lease", machine.status(resource).quarantine?.predecessorLeaseId)
+        clock.advanceBy(124)
+        assertTrue(machine.expire().isEmpty())
+        clock.advanceBy(1)
+        assertEquals(ownerB, machine.expire().single().owner)
+
+        val forcedMachine = machine(recoveryRecord = record)
+        forcedMachine.acquire(request("c", ownerC))
+        val stale = forcedMachine.forceRecover("another-lease", "operator", "known dead")
+        assertEquals(LeaseErrorCode.STALE_LEASE, stale.rejectedCode())
+        val forced =
+            assertIs<RecoveryResult.Recovered>(
+                forcedMachine.forceRecover("old-lease", "operator", "known dead")
+            )
+        assertTrue(forced.unsafeTakeover)
+        assertEquals(ownerC, forced.nextGrants.singleOrNull()?.owner)
+    }
+
+    @Test
+    fun `compare-and-revoke rejects stale ids then acknowledgement advances FIFO`() {
+        val machine = machine()
+        val token = machine.acquire(request("a", ownerA)).grantedToken()
+        machine.acquire(request("b", ownerB))
+
+        val stale =
+            machine.revoke("old", requesterLabel = "operator", reason = "stuck", force = false)
+        assertEquals(LeaseErrorCode.STALE_LEASE, stale.rejectedCode())
+        val requested =
+            assertIs<RevokeResult.Requested>(
+                machine.revoke(
+                    token.leaseId,
+                    requesterLabel = "operator",
+                    reason = "stuck",
+                    force = false,
+                )
+            )
+        assertFalse(requested.unsafeTakeover)
+        assertEquals(LeaseErrorCode.FENCED, machine.validate(token).rejectedCode())
+
+        val acknowledged = assertIs<RevokeResult.Acknowledged>(machine.acknowledgeRevocation(token))
+        assertEquals(ownerB, acknowledged.nextGrant?.owner)
+        assertTrue(machine.auditLog().single().acknowledged)
+        assertFalse(machine.auditLog().single().unsafeTakeover)
+    }
+
+    @Test
+    fun `explicit force takeover requires grace and records unsafe outcome`() {
+        val machine = machine(revokeGraceMillis = 20)
+        val token = machine.acquire(request("a", ownerA)).grantedToken()
+        machine.acquire(request("b", ownerB))
+        machine.revoke(token.leaseId, requesterLabel = "operator", reason = "wedged", force = false)
+
+        val tooEarly =
+            machine.revoke(
+                token.leaseId,
+                requesterLabel = "operator",
+                reason = "wedged",
+                force = true,
+            )
+        assertEquals(LeaseErrorCode.REVOKE_GRACE_ACTIVE, tooEarly.rejectedCode())
+        clock.advanceBy(20)
+        val forced =
+            assertIs<RevokeResult.Forced>(
+                machine.revoke(
+                    token.leaseId,
+                    requesterLabel = "operator",
+                    reason = "wedged",
+                    force = true,
+                )
+            )
+
+        assertTrue(forced.unsafeTakeover)
+        assertEquals(ownerB, forced.nextGrant?.owner)
+        assertFalse(machine.auditLog().single().acknowledged)
+        assertTrue(machine.auditLog().single().unsafeTakeover)
+    }
+
+    @Test
+    fun `fence generation prevents an older token from starting work`() {
+        val machine = machine()
+        val token = machine.acquire(request("a", ownerA)).grantedToken()
+        machine.revoke(token.leaseId, requesterLabel = "operator", reason = "stop", force = false)
+
+        assertEquals(LeaseErrorCode.FENCED, machine.validate(token).rejectedCode())
+        assertTrue(machine.status(resource).holder!!.fence > token.fence)
+    }
+
+    @Test
+    fun `bounded waiter queue rejects overflow with stable taxonomy`() {
+        val machine = machine(maxWaiters = 1)
+        machine.acquire(request("a", ownerA))
+        machine.acquire(request("b", ownerB))
+
+        val overflow = machine.acquire(request("c", ownerC))
+
+        assertEquals(LeaseErrorCode.QUEUE_FULL, overflow.rejectedCode())
+        assertEquals(1, machine.status(resource).waiters.size)
+    }
+
+    @Test
+    fun `disconnect removes queued requests without disturbing holder`() {
+        val machine = machine()
+        val token = machine.acquire(request("a", ownerA)).grantedToken()
+        machine.acquire(request("b", ownerB))
+
+        assertTrue(machine.disconnect(ownerB.clientId).isEmpty())
+        assertEquals(token, machine.status(resource).holder?.token)
+        assertTrue(machine.status(resource).waiters.isEmpty())
+    }
+
+    private fun machine(
+        epoch: String = "epoch",
+        maxWaiters: Int = 8,
+        heartbeatTimeoutMillis: Long = 1_000,
+        revokeGraceMillis: Long = 10,
+        recoveryGraceMillis: Long = 10,
+        recoveryRecord: RecoveryRecord? = null,
+    ): LeaseStateMachine =
+        LeaseStateMachine(
+            clock = clock,
+            epoch = epoch,
+            maxWaitersPerResource = maxWaiters,
+            heartbeatTimeoutMillis = heartbeatTimeoutMillis,
+            revokeGraceMillis = revokeGraceMillis,
+            recoveryGraceMillis = recoveryGraceMillis,
+            recoveryRecord = recoveryRecord,
+            leaseIdGenerator = SequentialLeaseIdGenerator(),
+        )
+
+    private fun request(
+        requestId: String,
+        owner: LeaseOwner,
+        timeoutMillis: Long = 10_000,
+    ): AcquireRequest =
+        AcquireRequest(
+            requestId = requestId,
+            resourceKey = resource,
+            owner = owner,
+            timeoutMillis = timeoutMillis,
+            currentOperation = "test input",
+        )
+}
+
+private fun AcquireResult.grantedToken(): LeaseToken =
+    assertIs<AcquireResult.Granted>(this).grant.token
+
+private fun AcquireResult.queuedPosition(): Int = assertIs<AcquireResult.Queued>(this).position
+
+private fun AcquireResult.rejectedCode(): LeaseErrorCode =
+    assertIs<AcquireResult.Rejected>(this).code
+
+private fun ReleaseResult.rejectedCode(): LeaseErrorCode =
+    assertIs<ReleaseResult.Rejected>(this).code
+
+private fun ValidationResult.rejectedCode(): LeaseErrorCode =
+    assertIs<ValidationResult.Rejected>(this).code
+
+private fun RecoveryResult.rejectedCode(): LeaseErrorCode =
+    assertIs<RecoveryResult.Rejected>(this).code
+
+private fun RevokeResult.rejectedCode(): LeaseErrorCode = assertIs<RevokeResult.Rejected>(this).code
+
+private class FakeMonotonicClock : MonotonicClock {
+    private var currentMillis: Long = 0
+
+    override fun nowMillis(): Long = currentMillis
+
+    fun advanceBy(millis: Long) {
+        currentMillis += millis
+    }
+}
+
+private class SequentialLeaseIdGenerator : LeaseIdGenerator {
+    private var next: Int = 1
+
+    override fun nextId(): String = "lease-${next++}"
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
@@ -108,7 +108,7 @@ class LeaseStateMachineTest {
     }
 
     @Test
-    fun `restart recovery quarantines resource until expiry or exact-id unsafe recovery`() {
+    fun `restart recovery remains quarantined until exact-id unsafe recovery`() {
         val record =
             RecoveryRecord(
                 resourceKey = resource,
@@ -121,10 +121,9 @@ class LeaseStateMachineTest {
 
         assertEquals(1, machine.acquire(request("b", ownerB)).queuedPosition())
         assertEquals("old-lease", machine.status(resource).quarantine?.predecessorLeaseId)
-        clock.advanceBy(124)
-        assertTrue(machine.expire().isEmpty())
-        clock.advanceBy(1)
-        assertEquals(ownerB, machine.expire().single().owner)
+        clock.advanceBy(1_000_000)
+        assertTrue(machine.expire().none { it.grant != null })
+        assertEquals("old-lease", machine.status(resource).quarantine?.predecessorLeaseId)
 
         val forcedMachine = machine(recoveryRecord = record)
         forcedMachine.acquire(request("c", ownerC))

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
@@ -166,6 +166,23 @@ class LeaseStateMachineTest {
     }
 
     @Test
+    fun `revocation acknowledgement waits for every reentrant hold`() {
+        val machine = machine()
+        val token = machine.acquire(request("a-1", ownerA)).grantedToken()
+        machine.acquire(request("a-2", ownerA))
+        machine.acquire(request("b", ownerB))
+        machine.revoke(token.leaseId, requesterLabel = "operator", reason = "stuck", force = false)
+
+        val first = assertIs<RevokeResult.Acknowledged>(machine.acknowledgeRevocation(token))
+        assertEquals(null, first.nextGrant)
+        assertEquals(ownerA, machine.status(token.resourceKey).holder?.owner)
+
+        val final = assertIs<RevokeResult.Acknowledged>(machine.acknowledgeRevocation(token))
+        assertEquals(ownerB, final.nextGrant?.owner)
+        assertEquals(1, machine.auditLog().size)
+    }
+
+    @Test
     fun `explicit force takeover requires grace and records unsafe outcome`() {
         val machine = machine(revokeGraceMillis = 20)
         val token = machine.acquire(request("a", ownerA)).grantedToken()

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
@@ -147,11 +147,18 @@ class LeaseStateMachineTest {
         machine.acquire(request("b", ownerB))
 
         val stale =
-            machine.revoke("old", requesterLabel = "operator", reason = "stuck", force = false)
+            machine.revoke(
+                resource,
+                "old",
+                requesterLabel = "operator",
+                reason = "stuck",
+                force = false,
+            )
         assertEquals(LeaseErrorCode.STALE_LEASE, stale.rejectedCode())
         val requested =
             assertIs<RevokeResult.Requested>(
                 machine.revoke(
+                    resource,
                     token.leaseId,
                     requesterLabel = "operator",
                     reason = "stuck",
@@ -173,7 +180,13 @@ class LeaseStateMachineTest {
         val token = machine.acquire(request("a-1", ownerA)).grantedToken()
         machine.acquire(request("a-2", ownerA))
         machine.acquire(request("b", ownerB))
-        machine.revoke(token.leaseId, requesterLabel = "operator", reason = "stuck", force = false)
+        machine.revoke(
+            resource,
+            token.leaseId,
+            requesterLabel = "operator",
+            reason = "stuck",
+            force = false,
+        )
 
         val first = assertIs<RevokeResult.Acknowledged>(machine.acknowledgeRevocation(token))
         assertEquals(null, first.nextGrant)
@@ -189,10 +202,17 @@ class LeaseStateMachineTest {
         val machine = machine(revokeGraceMillis = 20)
         val token = machine.acquire(request("a", ownerA)).grantedToken()
         machine.acquire(request("b", ownerB))
-        machine.revoke(token.leaseId, requesterLabel = "operator", reason = "wedged", force = false)
+        machine.revoke(
+            resource,
+            token.leaseId,
+            requesterLabel = "operator",
+            reason = "wedged",
+            force = false,
+        )
 
         val tooEarly =
             machine.revoke(
+                resource,
                 token.leaseId,
                 requesterLabel = "operator",
                 reason = "wedged",
@@ -203,6 +223,7 @@ class LeaseStateMachineTest {
         val forced =
             assertIs<RevokeResult.Forced>(
                 machine.revoke(
+                    resource,
                     token.leaseId,
                     requesterLabel = "operator",
                     reason = "wedged",
@@ -220,7 +241,13 @@ class LeaseStateMachineTest {
     fun `fence generation prevents an older token from starting work`() {
         val machine = machine()
         val token = machine.acquire(request("a", ownerA)).grantedToken()
-        machine.revoke(token.leaseId, requesterLabel = "operator", reason = "stop", force = false)
+        machine.revoke(
+            resource,
+            token.leaseId,
+            requesterLabel = "operator",
+            reason = "stop",
+            force = false,
+        )
 
         assertEquals(LeaseErrorCode.FENCED, machine.validate(token).rejectedCode())
         assertTrue(machine.status(resource).holder!!.fence > token.fence)

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
@@ -84,7 +84,7 @@ class LeaseStateMachineTest {
     }
 
     @Test
-    fun `heartbeat expiry fences holder but disconnect confirms release and grants next`() {
+    fun `heartbeat expiry and disconnect stay fenced until cleanup acknowledgement`() {
         val machine = machine(heartbeatTimeoutMillis = 100)
         val first = machine.acquire(request("a", ownerA)).grantedToken()
         machine.acquire(request("b", ownerB))
@@ -94,8 +94,11 @@ class LeaseStateMachineTest {
 
         assertEquals(LeaseErrorCode.FENCED, machine.validate(first).rejectedCode())
         assertEquals(LeaseStatus.REVOKING, machine.status(resource).holder?.status)
-        val disconnect = machine.disconnect(ownerA.clientId)
-        assertEquals(ownerB, disconnect.grants.single().owner)
+        machine.disconnect(ownerA.clientId)
+        assertEquals(LeaseStatus.REVOKING, machine.status(resource).holder?.status)
+
+        val acknowledged = assertIs<RevokeResult.Acknowledged>(machine.acknowledgeRevocation(first))
+        assertEquals(ownerB, acknowledged.nextGrant?.owner)
     }
 
     @Test
@@ -242,7 +245,6 @@ class LeaseStateMachineTest {
         machine.acquire(request("b", ownerB))
 
         val disconnect = machine.disconnect(ownerB.clientId)
-        assertTrue(disconnect.grants.isEmpty())
         assertEquals(listOf("b"), disconnect.cancelledRequestIds)
         assertEquals(token, machine.status(resource).holder?.token)
         assertTrue(machine.status(resource).waiters.isEmpty())

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LeaseStateMachineTest.kt
@@ -95,7 +95,7 @@ class LeaseStateMachineTest {
         assertEquals(LeaseErrorCode.FENCED, machine.validate(first).rejectedCode())
         assertEquals(LeaseStatus.REVOKING, machine.status(resource).holder?.status)
         val disconnect = machine.disconnect(ownerA.clientId)
-        assertEquals(ownerB, disconnect.single().owner)
+        assertEquals(ownerB, disconnect.grants.single().owner)
     }
 
     @Test
@@ -225,7 +225,9 @@ class LeaseStateMachineTest {
         val token = machine.acquire(request("a", ownerA)).grantedToken()
         machine.acquire(request("b", ownerB))
 
-        assertTrue(machine.disconnect(ownerB.clientId).isEmpty())
+        val disconnect = machine.disconnect(ownerB.clientId)
+        assertTrue(disconnect.grants.isEmpty())
+        assertEquals(listOf("b"), disconnect.cancelledRequestIds)
         assertEquals(token, machine.status(resource).holder?.token)
         assertTrue(machine.status(resource).waiters.isEmpty())
     }

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
@@ -86,11 +86,11 @@ class LocalCoordinatorServerTest {
     }
 
     @Test
-    fun `closing owner session releases its lease and advances FIFO`() {
+    fun `closing owner session fences its lease until operation cleanup acknowledges release`() {
         startServer()
         val firstClient = client("first")
         val secondClient = client("second")
-        firstClient.acquire(Duration.ofSeconds(2), "first click")
+        val firstLease = firstClient.acquire(Duration.ofSeconds(2), "first click")
         val executor = Executors.newSingleThreadExecutor()
         resources += AutoCloseable { executor.shutdownNow() }
         val secondFuture =
@@ -100,6 +100,9 @@ class LocalCoordinatorServerTest {
         awaitWaiterCount(1)
 
         firstClient.close()
+        awaitHolderState("revoking")
+        assertFalse(secondFuture.isDone)
+        firstLease.close()
 
         resources.add(secondFuture.get(2, TimeUnit.SECONDS))
     }
@@ -420,6 +423,17 @@ class LocalCoordinatorServerTest {
             Thread.onSpinWait()
         }
         assertTrue(false, "Timed out waiting for $expected queued lease request")
+    }
+
+    private fun awaitHolderState(expected: String) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+        while (System.nanoTime() < deadline) {
+            val status = LocalInputCoordinatorControl(endpoint).status(resource)
+            val active = status as? CoordinatorControlResult.Active
+            if (active?.status?.holder?.state == expected) return
+            Thread.onSpinWait()
+        }
+        assertTrue(false, "Timed out waiting for holder state $expected")
     }
 
     private fun awaitLeaseInvalid(lease: CoordinatedInputLease) {

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
@@ -9,6 +9,9 @@ import dev.sebastiano.spectre.input.DesktopResourceKey
 import dev.sebastiano.spectre.input.InputCoordinatorException
 import dev.sebastiano.spectre.input.LocalInputCoordinatorClient
 import dev.sebastiano.spectre.input.LocalInputCoordinatorControl
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.time.Duration
@@ -305,6 +308,27 @@ class LocalCoordinatorServerTest {
             )
         server.start()
         resources += server
+        val executor = Executors.newSingleThreadExecutor()
+        resources += AutoCloseable { executor.shutdownNow() }
+
+        executor.submit { server.awaitTermination() }.get(2, TimeUnit.SECONDS)
+
+        assertFalse(Files.exists(endpoint.socketPath))
+    }
+
+    @Test
+    fun `client that never sends its first frame cannot suppress idle shutdown`() {
+        val server =
+            LocalCoordinatorServer(
+                endpoint = endpoint,
+                heartbeatTimeout = Duration.ofSeconds(5),
+                idleTimeout = Duration.ofMillis(100),
+            )
+        server.start()
+        resources += server
+        val stalled = SocketChannel.open(StandardProtocolFamily.UNIX)
+        stalled.connect(UnixDomainSocketAddress.of(endpoint.socketPath))
+        resources += stalled
         val executor = Executors.newSingleThreadExecutor()
         resources += AutoCloseable { executor.shutdownNow() }
 

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
@@ -86,6 +86,27 @@ class LocalCoordinatorServerTest {
     }
 
     @Test
+    fun `maximum acquisition timeout remains queued until the holder releases`() {
+        startServer()
+        val firstClient = client("first")
+        val secondClient = client("second")
+        val firstLease = firstClient.acquire(Duration.ofSeconds(2), "first click")
+        resources += firstLease
+        val executor = Executors.newSingleThreadExecutor()
+        resources += AutoCloseable { executor.shutdownNow() }
+
+        val secondFuture =
+            executor.submit<CoordinatedInputLease> {
+                secondClient.acquire(Duration.ofMillis(Long.MAX_VALUE), "long wait")
+            }
+        awaitWaiterCount(1)
+        assertFalse(secondFuture.isDone)
+
+        firstLease.close()
+        resources += secondFuture.get(2, TimeUnit.SECONDS)
+    }
+
+    @Test
     fun `closing owner session fences its lease until operation cleanup acknowledges release`() {
         startServer()
         val firstClient = client("first")

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
@@ -54,6 +54,8 @@ class LocalCoordinatorServerTest {
 
         assertFailsWith<java.nio.channels.OverlappingFileLockException> { contender.start() }
         contender.close()
+        assertTrue(Files.exists(endpoint.socketPath))
+        resources += client("winner-remains-reachable").acquire(Duration.ofSeconds(2), "click")
         first.close()
 
         val failure = assertFailsWith<IllegalStateException> { contender.start() }

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
@@ -1,0 +1,415 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatedInputLease
+import dev.sebastiano.spectre.input.CoordinatorControlResult
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.InputCoordinatorException
+import dev.sebastiano.spectre.input.LocalInputCoordinatorClient
+import dev.sebastiano.spectre.input.LocalInputCoordinatorControl
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class LocalCoordinatorServerTest {
+
+    private val resources = mutableListOf<AutoCloseable>()
+    private val temporaryDirectory: Path = Files.createTempDirectory("spc-input-")
+    private val endpoint =
+        CoordinatorEndpoint(
+            directory = temporaryDirectory,
+            socketPath = temporaryDirectory.resolve("coordinator.sock"),
+        )
+    private val resource = DesktopResourceKey("user:501/macos-console")
+
+    @AfterTest
+    fun cleanUp() {
+        resources.asReversed().forEach { runCatching { it.close() } }
+        Files.deleteIfExists(endpoint.socketPath)
+        Files.deleteIfExists(temporaryDirectory.resolve("coordinator.lock"))
+        Files.deleteIfExists(temporaryDirectory.resolve("recovery.properties.tmp"))
+        Files.deleteIfExists(temporaryDirectory.resolve("recovery.properties"))
+        Files.deleteIfExists(temporaryDirectory)
+    }
+
+    @Test
+    fun `two independent clients receive one desktop lease in FIFO order`() {
+        startServer()
+        val firstClient = client("first")
+        val secondClient = client("second")
+        val firstLease = firstClient.acquire(Duration.ofSeconds(2), "first click")
+        resources += firstLease
+        val executor = Executors.newSingleThreadExecutor()
+        resources += AutoCloseable { executor.shutdownNow() }
+
+        val secondFuture =
+            executor.submit<CoordinatedInputLease> {
+                secondClient.acquire(Duration.ofSeconds(2), "second click")
+            }
+        awaitWaiterCount(1)
+        assertFalse(secondFuture.isDone)
+
+        firstLease.close()
+        val secondLease = secondFuture.get(2, TimeUnit.SECONDS)
+        resources.add(secondLease)
+        assertNotEquals(firstLease.token.leaseId, secondLease.token.leaseId)
+    }
+
+    @Test
+    fun `closing owner session releases its lease and advances FIFO`() {
+        startServer()
+        val firstClient = client("first")
+        val secondClient = client("second")
+        firstClient.acquire(Duration.ofSeconds(2), "first click")
+        val executor = Executors.newSingleThreadExecutor()
+        resources += AutoCloseable { executor.shutdownNow() }
+        val secondFuture =
+            executor.submit<CoordinatedInputLease> {
+                secondClient.acquire(Duration.ofSeconds(2), "second click")
+            }
+        awaitWaiterCount(1)
+
+        firstClient.close()
+
+        resources.add(secondFuture.get(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun `interrupting a queued acquisition removes it without disturbing FIFO`() {
+        startServer()
+        val firstClient = client("first")
+        val cancelledClient = client("cancelled")
+        val thirdClient = client("third")
+        val firstLease = firstClient.acquire(Duration.ofSeconds(2), "first click")
+        resources += firstLease
+        val executor = Executors.newFixedThreadPool(2)
+        resources += AutoCloseable { executor.shutdownNow() }
+        val cancelled =
+            executor.submit<CoordinatedInputLease> {
+                cancelledClient.acquire(Duration.ofSeconds(10), "cancelled click")
+            }
+        awaitWaiterCount(1)
+        val third =
+            executor.submit<CoordinatedInputLease> {
+                thirdClient.acquire(Duration.ofSeconds(2), "third click")
+            }
+        awaitWaiterCount(2)
+
+        assertTrue(cancelled.cancel(true))
+        awaitWaiterCount(1)
+        firstLease.close()
+
+        resources += third.get(2, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `cancelling one queued acquire preserves a sibling on the same client session`() {
+        startServer()
+        val holderClient = client("holder")
+        val waitingClient = client("waiting")
+        val holder = holderClient.acquire(Duration.ofSeconds(2), "holder click")
+        resources += holder
+        val executor = Executors.newFixedThreadPool(2)
+        resources += AutoCloseable { executor.shutdownNow() }
+        val cancelled =
+            executor.submit<CoordinatedInputLease> {
+                waitingClient.acquire(Duration.ofSeconds(10), "cancelled click")
+            }
+        awaitWaiterCount(1)
+        val sibling =
+            executor.submit<CoordinatedInputLease> {
+                waitingClient.acquire(Duration.ofSeconds(5), "sibling click")
+            }
+        awaitWaiterCount(2)
+
+        assertTrue(cancelled.cancel(true))
+        awaitWaiterCount(1)
+        holder.close()
+
+        resources += sibling.get(2, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `coordinator restart changes epoch and old lease checkpoint fails closed`() {
+        val firstServer = startServer()
+        val firstClient = client("first")
+        val oldLease = firstClient.acquire(Duration.ofSeconds(2), "click")
+        firstServer.close()
+        firstClient.close()
+        Files.deleteIfExists(endpoint.socketPath)
+
+        startServer()
+
+        val secondClient = client("second")
+        assertNotEquals(firstClient.coordinatorEpoch, secondClient.coordinatorEpoch)
+        assertFalse(oldLease.isValid())
+    }
+
+    @Test
+    fun `successor quarantines a crashed holder until exact-id unsafe recovery`() {
+        val firstServer = startServer(recoveryGrace = Duration.ofMinutes(1))
+        val firstClient = client("first")
+        val oldLease = firstClient.acquire(Duration.ofSeconds(2), "click")
+        firstServer.close()
+        Files.deleteIfExists(endpoint.socketPath)
+
+        startServer(recoveryGrace = Duration.ofMinutes(1))
+        val status =
+            assertIs<CoordinatorControlResult.Active>(
+                    LocalInputCoordinatorControl(endpoint).status(resource)
+                )
+                .status
+        assertEquals(oldLease.token.leaseId, status.quarantine?.predecessorLeaseId)
+        val secondClient = client("second")
+        val executor = Executors.newSingleThreadExecutor()
+        resources += AutoCloseable { executor.shutdownNow() }
+        val waiting =
+            executor.submit<CoordinatedInputLease> {
+                secondClient.acquire(Duration.ofSeconds(2), "second click")
+            }
+        awaitWaiterCount(1)
+        assertFalse(waiting.isDone)
+
+        val stale =
+            assertFailsWith<InputCoordinatorException> {
+                LocalInputCoordinatorControl(endpoint)
+                    .revoke(resource, "stale", "operator", "predecessor is dead", force = true)
+            }
+        assertEquals("STALE_LEASE", stale.errorCode)
+        val forced =
+            LocalInputCoordinatorControl(endpoint)
+                .revoke(
+                    resource,
+                    oldLease.token.leaseId,
+                    "operator",
+                    "predecessor is dead",
+                    force = true,
+                )
+        assertTrue(forced.unsafeTakeover)
+        resources.add(waiting.get(2, TimeUnit.SECONDS))
+    }
+
+    @Test
+    fun `corrupt recovery ledger quarantines every desktop key until exact force`() {
+        Files.writeString(temporaryDirectory.resolve("recovery.properties"), "not-properties")
+        startServer(recoveryGrace = Duration.ofMinutes(1))
+        val control = LocalInputCoordinatorControl(endpoint)
+        val status = assertIs<CoordinatorControlResult.Active>(control.status(resource)).status
+        val predecessorId = requireNotNull(status.quarantine?.predecessorLeaseId)
+        val waitingClient = client("waiting")
+        val executor = Executors.newSingleThreadExecutor()
+        resources += AutoCloseable { executor.shutdownNow() }
+        val waiting =
+            executor.submit<CoordinatedInputLease> {
+                waitingClient.acquire(Duration.ofSeconds(2), "click")
+            }
+        awaitWaiterCount(1)
+        assertFalse(waiting.isDone)
+
+        val forced =
+            control.revoke(
+                resource,
+                predecessorId,
+                "operator",
+                "corrupt recovery record inspected",
+                force = true,
+            )
+
+        assertTrue(forced.unsafeTakeover)
+        resources += waiting.get(2, TimeUnit.SECONDS)
+    }
+
+    @Test
+    fun `acquisition timeout while quarantined returns stable diagnostics`() {
+        Files.writeString(temporaryDirectory.resolve("recovery.properties"), "not-properties")
+        startServer(recoveryGrace = Duration.ofMinutes(1))
+
+        val failure =
+            assertFailsWith<InputCoordinatorException> {
+                client("waiting").acquire(Duration.ofMillis(50), "click")
+            }
+
+        assertEquals("ACQUIRE_TIMEOUT", failure.errorCode)
+        assertTrue(failure.message.orEmpty().contains("quarantine"))
+    }
+
+    @Test
+    fun `status without active coordinator is observe-only and clean`() {
+        val result = LocalInputCoordinatorControl(endpoint).status(resource)
+
+        assertEquals(CoordinatorControlResult.NoActiveCoordinator, result)
+        assertFalse(Files.exists(endpoint.socketPath))
+    }
+
+    @Test
+    fun `coordinator exits after bounded idle period with no holder or waiters`() {
+        val server =
+            LocalCoordinatorServer(
+                endpoint = endpoint,
+                heartbeatTimeout = Duration.ofSeconds(5),
+                idleTimeout = Duration.ofMillis(50),
+            )
+        server.start()
+        resources += server
+        val executor = Executors.newSingleThreadExecutor()
+        resources += AutoCloseable { executor.shutdownNow() }
+
+        executor.submit { server.awaitTermination() }.get(2, TimeUnit.SECONDS)
+
+        assertFalse(Files.exists(endpoint.socketPath))
+    }
+
+    @Test
+    fun `exact-id revoke rejects stale observation and fences the actual holder`() {
+        startServer()
+        val client = client("first")
+        val lease = client.acquire(Duration.ofSeconds(2), "click")
+        resources += lease
+        val control = LocalInputCoordinatorControl(endpoint)
+
+        val stale =
+            assertFailsWith<InputCoordinatorException> {
+                control.revoke(resource, "stale-id", "operator", "known stuck")
+            }
+        assertEquals("STALE_LEASE", stale.errorCode)
+        assertTrue(lease.isValid())
+
+        val requested = control.revoke(resource, lease.token.leaseId, "operator", "known stuck")
+
+        assertFalse(requested.unsafeTakeover)
+        val fenced = assertFailsWith<InputCoordinatorException> { lease.checkpoint() }
+        assertEquals("FENCED", fenced.errorCode)
+    }
+
+    @Test
+    fun `normal revoke invalidates only its lease and client can acquire again`() {
+        startServer(revokeGrace = Duration.ofSeconds(5))
+        val firstClient = client("first")
+        val secondClient = client("second")
+        val firstLease = firstClient.acquire(Duration.ofSeconds(2), "first click")
+        resources += firstLease
+        val executor = Executors.newSingleThreadExecutor()
+        resources += AutoCloseable { executor.shutdownNow() }
+        val waiting =
+            executor.submit<CoordinatedInputLease> {
+                secondClient.acquire(Duration.ofSeconds(5), "second click")
+            }
+        awaitWaiterCount(1)
+
+        LocalInputCoordinatorControl(endpoint)
+            .revoke(resource, firstLease.token.leaseId, "operator", "owner should stop")
+        awaitLeaseInvalid(firstLease)
+        firstLease.close()
+
+        val secondLease = waiting.get(2, TimeUnit.SECONDS)
+        resources += secondLease
+        secondLease.close()
+        resources += firstClient.acquire(Duration.ofSeconds(2), "client reused after revoke")
+    }
+
+    @Test
+    fun `closing a reentrant lease preserves heartbeats for the outer lease`() {
+        startServer(heartbeatTimeout = Duration.ofMillis(1_500))
+        val client = client("reentrant")
+        val outer = client.acquire(Duration.ofSeconds(2), "outer transaction")
+        resources += outer
+        val nested = client.acquire(Duration.ofSeconds(2), "nested focus")
+
+        assertEquals(outer.token, nested.token)
+        nested.close()
+        Thread.sleep(2_500)
+
+        outer.checkpoint()
+        assertTrue(outer.isValid())
+    }
+
+    @Test
+    fun `explicit force advances FIFO and reports unsafe takeover`() {
+        startServer(revokeGrace = Duration.ZERO)
+        val firstClient = client("first")
+        val secondClient = client("second")
+        val firstLease = firstClient.acquire(Duration.ofSeconds(2), "first click")
+        resources += firstLease
+        val executor = Executors.newSingleThreadExecutor()
+        resources += AutoCloseable { executor.shutdownNow() }
+        val secondFuture =
+            executor.submit<CoordinatedInputLease> {
+                secondClient.acquire(Duration.ofSeconds(2), "second click")
+            }
+        awaitWaiterCount(1)
+
+        val forced =
+            LocalInputCoordinatorControl(endpoint)
+                .revoke(
+                    resourceKey = resource,
+                    observedLeaseId = firstLease.token.leaseId,
+                    requesterLabel = "operator",
+                    reason = "owner is wedged",
+                    force = true,
+                )
+
+        assertTrue(forced.unsafeTakeover)
+        resources.add(secondFuture.get(2, TimeUnit.SECONDS))
+    }
+
+    private fun startServer(
+        revokeGrace: Duration = Duration.ofSeconds(1),
+        recoveryGrace: Duration = Duration.ofSeconds(2),
+        heartbeatTimeout: Duration = Duration.ofSeconds(5),
+    ): LocalCoordinatorServer {
+        val server =
+            LocalCoordinatorServer(
+                endpoint = endpoint,
+                heartbeatTimeout = heartbeatTimeout,
+                idleTimeout = Duration.ofMinutes(1),
+                revokeGrace = revokeGrace,
+                recoveryGrace = recoveryGrace,
+            )
+        server.start()
+        resources += server
+        return server
+    }
+
+    private fun client(label: String): LocalInputCoordinatorClient {
+        val client =
+            LocalInputCoordinatorClient.connect(
+                endpoint = endpoint,
+                resourceKey = resource,
+                ownerLabel = label,
+            )
+        resources += client
+        return client
+    }
+
+    private fun awaitWaiterCount(expected: Int) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
+        while (System.nanoTime() < deadline) {
+            val status = LocalInputCoordinatorControl(endpoint).status(resource)
+            val active = status as? CoordinatorControlResult.Active
+            if (active?.status?.waiters?.size == expected) return
+            Thread.onSpinWait()
+        }
+        assertTrue(false, "Timed out waiting for $expected queued lease request")
+    }
+
+    private fun awaitLeaseInvalid(lease: CoordinatedInputLease) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(3)
+        while (System.nanoTime() < deadline) {
+            if (!lease.isValid()) return
+            Thread.sleep(10)
+        }
+        assertFalse(lease.isValid(), "Timed out waiting for revoked lease heartbeat fencing")
+    }
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/LocalCoordinatorServerTest.kt
@@ -45,6 +45,22 @@ class LocalCoordinatorServerTest {
     }
 
     @Test
+    fun `closing a server after failed election permanently closes its resources`() {
+        val first = LocalCoordinatorServer(endpoint, idleTimeout = Duration.ofMinutes(1))
+        val contender = LocalCoordinatorServer(endpoint, idleTimeout = Duration.ofMinutes(1))
+        resources += first
+        resources += contender
+        first.start()
+
+        assertFailsWith<java.nio.channels.OverlappingFileLockException> { contender.start() }
+        contender.close()
+        first.close()
+
+        val failure = assertFailsWith<IllegalStateException> { contender.start() }
+        assertTrue(requireNotNull(failure.message).contains("closed"))
+    }
+
+    @Test
     fun `two independent clients receive one desktop lease in FIFO order`() {
         startServer()
         val firstClient = client("first")

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedgerTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedgerTest.kt
@@ -1,0 +1,72 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LeaseOwner
+import dev.sebastiano.spectre.input.LeaseToken
+import java.nio.file.Files
+import java.time.Duration
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class RecoveryLedgerTest {
+
+    @Test
+    fun `multiple active resources recover through a conservative global quarantine`() {
+        val directory = Files.createTempDirectory("spc-ledger-")
+        val path = directory.resolve("recovery.properties")
+        try {
+            val ledger = RecoveryLedger(path, Duration.ofMinutes(1))
+            ledger.record(grant("lease-a", "desktop-a", "client-a"))
+            ledger.record(grant("lease-b", "desktop-b", "client-b"))
+
+            val recovered = assertNotNull(RecoveryLedger(path, Duration.ofMinutes(1)).load())
+
+            assertTrue(recovered.blocksAllResources)
+            assertTrue(recovered.leaseId.startsWith("multiple-"))
+        } finally {
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
+    fun `clearing one of two active resources persists the exact survivor`() {
+        val directory = Files.createTempDirectory("spc-ledger-")
+        val path = directory.resolve("recovery.properties")
+        try {
+            val ledger = RecoveryLedger(path, Duration.ofMinutes(1))
+            ledger.record(grant("lease-a", "desktop-a", "client-a"))
+            ledger.record(grant("lease-b", "desktop-b", "client-b"))
+
+            ledger.clear("lease-b")
+            val recovered = assertNotNull(RecoveryLedger(path, Duration.ofMinutes(1)).load())
+
+            assertFalse(recovered.blocksAllResources)
+            assertEquals("lease-a", recovered.leaseId)
+            assertEquals(DesktopResourceKey("desktop-a"), recovered.resourceKey)
+        } finally {
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    private fun grant(leaseId: String, resourceKey: String, clientId: String): LeaseGrant =
+        LeaseGrant(
+            requestId = "request-$leaseId",
+            owner = LeaseOwner(clientId, processId = 1, label = clientId),
+            token =
+                LeaseToken(
+                    coordinatorEpoch = "epoch",
+                    leaseId = leaseId,
+                    resourceKey = DesktopResourceKey(resourceKey),
+                    fence = 1,
+                ),
+        )
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedgerTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedgerTest.kt
@@ -59,28 +59,7 @@ class RecoveryLedgerTest {
     }
 
     @Test
-    fun `expiry pruning never removes a live runtime record`() {
-        val directory = Files.createTempDirectory("spc-ledger-")
-        val path = directory.resolve("recovery.properties")
-        try {
-            val ledger = RecoveryLedger(path, Duration.ofMillis(-1))
-            val activeGrant = grant("lease-live", "desktop-live", "client-live")
-            ledger.record(activeGrant)
-
-            ledger.clearExpiredRecovery(Duration.ZERO)
-            ledger.heartbeat(activeGrant.token)
-
-            val recovered = RecoveryLedger(path, Duration.ofMinutes(1)).load()
-            assertEquals("lease-live", assertNotNull(recovered).leaseId)
-        } finally {
-            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
-            Files.deleteIfExists(path)
-            Files.deleteIfExists(directory)
-        }
-    }
-
-    @Test
-    fun `expiry pruning removes an eligible record loaded into restart quarantine`() {
+    fun `loaded restart record remains until explicitly cleared`() {
         val directory = Files.createTempDirectory("spc-ledger-")
         val path = directory.resolve("recovery.properties")
         try {
@@ -89,7 +68,11 @@ class RecoveryLedgerTest {
             val restarted = RecoveryLedger(path, Duration.ofMinutes(1))
             assertNotNull(restarted.load())
 
-            restarted.clearExpiredRecovery(Duration.ZERO)
+            assertEquals(
+                "lease-recovery",
+                assertNotNull(RecoveryLedger(path, Duration.ofMinutes(1)).load()).leaseId,
+            )
+            restarted.clear("lease-recovery")
 
             assertNull(RecoveryLedger(path, Duration.ofMinutes(1)).load())
         } finally {

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedgerTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/RecoveryLedgerTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class RecoveryLedgerTest {
@@ -50,6 +51,47 @@ class RecoveryLedgerTest {
             assertFalse(recovered.blocksAllResources)
             assertEquals("lease-a", recovered.leaseId)
             assertEquals(DesktopResourceKey("desktop-a"), recovered.resourceKey)
+        } finally {
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
+    fun `expiry pruning never removes a live runtime record`() {
+        val directory = Files.createTempDirectory("spc-ledger-")
+        val path = directory.resolve("recovery.properties")
+        try {
+            val ledger = RecoveryLedger(path, Duration.ofMillis(-1))
+            val activeGrant = grant("lease-live", "desktop-live", "client-live")
+            ledger.record(activeGrant)
+
+            ledger.clearExpiredRecovery(Duration.ZERO)
+            ledger.heartbeat(activeGrant.token)
+
+            val recovered = RecoveryLedger(path, Duration.ofMinutes(1)).load()
+            assertEquals("lease-live", assertNotNull(recovered).leaseId)
+        } finally {
+            Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
+            Files.deleteIfExists(path)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
+    fun `expiry pruning removes an eligible record loaded into restart quarantine`() {
+        val directory = Files.createTempDirectory("spc-ledger-")
+        val path = directory.resolve("recovery.properties")
+        try {
+            RecoveryLedger(path, Duration.ofMillis(-1))
+                .record(grant("lease-recovery", "desktop-recovery", "client-recovery"))
+            val restarted = RecoveryLedger(path, Duration.ofMinutes(1))
+            assertNotNull(restarted.load())
+
+            restarted.clearExpiredRecovery(Duration.ZERO)
+
+            assertNull(RecoveryLedger(path, Duration.ofMinutes(1)).load())
         } finally {
             Files.deleteIfExists(path.resolveSibling("${path.fileName}.tmp"))
             Files.deleteIfExists(path)

--- a/input-coordinator/api/input-coordinator.api
+++ b/input-coordinator/api/input-coordinator.api
@@ -1,0 +1,578 @@
+public abstract interface class dev/sebastiano/spectre/input/CanonicalPathResolver {
+	public abstract fun canonicalize (Ljava/nio/file/Path;)Ljava/nio/file/Path;
+}
+
+public abstract interface class dev/sebastiano/spectre/input/CoordinatedInputLease : java/lang/AutoCloseable {
+	public abstract fun checkpoint ()V
+	public abstract fun close ()V
+	public abstract fun getToken ()Ldev/sebastiano/spectre/input/LeaseToken;
+	public abstract fun isValid ()Z
+}
+
+public abstract interface class dev/sebastiano/spectre/input/CoordinatorControlResult {
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorControlResult$Active : dev/sebastiano/spectre/input/CoordinatorControlResult {
+	public fun <init> (Ldev/sebastiano/spectre/input/CoordinatorStatus;)V
+	public final fun component1 ()Ldev/sebastiano/spectre/input/CoordinatorStatus;
+	public final fun copy (Ldev/sebastiano/spectre/input/CoordinatorStatus;)Ldev/sebastiano/spectre/input/CoordinatorControlResult$Active;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorControlResult$Active;Ldev/sebastiano/spectre/input/CoordinatorStatus;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorControlResult$Active;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getStatus ()Ldev/sebastiano/spectre/input/CoordinatorStatus;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorControlResult$NoActiveCoordinator : dev/sebastiano/spectre/input/CoordinatorControlResult {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/CoordinatorControlResult$NoActiveCoordinator;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorEndpoint {
+	public fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;)V
+	public final fun component1 ()Ljava/nio/file/Path;
+	public final fun component2 ()Ljava/nio/file/Path;
+	public final fun copy (Ljava/nio/file/Path;Ljava/nio/file/Path;)Ldev/sebastiano/spectre/input/CoordinatorEndpoint;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ljava/nio/file/Path;Ljava/nio/file/Path;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorEndpoint;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDirectory ()Ljava/nio/file/Path;
+	public final fun getSocketPath ()Ljava/nio/file/Path;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorEndpointResolver {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/CoordinatorEndpointResolver;
+	public final fun resolve (Ljava/nio/file/Path;Ljava/lang/String;)Ldev/sebastiano/spectre/input/CoordinatorEndpoint;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorFrame {
+	public fun <init> (I[B)V
+	public final fun component1 ()I
+	public final fun component2 ()[B
+	public final fun copy (I[B)Ldev/sebastiano/spectre/input/CoordinatorFrame;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorFrame;I[BILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorFrame;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPayload ()[B
+	public final fun getProtocolVersion ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorFrameCodec {
+	public static final field HEADER_BYTES I
+	public static final field UNSIGNED_SHORT_MASK I
+	public fun <init> (I)V
+	public final fun decode ([B)Ldev/sebastiano/spectre/input/CoordinatorFrame;
+	public final fun encode ([B)[B
+	public final fun getMaxPayloadBytes ()I
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorFrameCodecKt {
+	public static final field INPUT_COORDINATOR_PROTOCOL_VERSION I
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorHolderStatus {
+	public fun <init> (Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;Ljava/lang/String;JJJLjava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ldev/sebastiano/spectre/input/LeaseOwner;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun component5 ()J
+	public final fun component6 ()J
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;Ljava/lang/String;JJJLjava/lang/String;)Ldev/sebastiano/spectre/input/CoordinatorHolderStatus;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorHolderStatus;Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;Ljava/lang/String;JJJLjava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorHolderStatus;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAcquisitionAgeMillis ()J
+	public final fun getCurrentOperation ()Ljava/lang/String;
+	public final fun getFence ()J
+	public final fun getHeartbeatAgeMillis ()J
+	public final fun getLeaseId ()Ljava/lang/String;
+	public final fun getOwner ()Ldev/sebastiano/spectre/input/LeaseOwner;
+	public final fun getState ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorProtocolError : java/lang/Enum {
+	public static final field FRAME_TOO_LARGE Ldev/sebastiano/spectre/input/CoordinatorProtocolError;
+	public static final field INCOMPATIBLE_VERSION Ldev/sebastiano/spectre/input/CoordinatorProtocolError;
+	public static final field MALFORMED_FRAME Ldev/sebastiano/spectre/input/CoordinatorProtocolError;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/input/CoordinatorProtocolError;
+	public static fun values ()[Ldev/sebastiano/spectre/input/CoordinatorProtocolError;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorProtocolException : java/lang/IllegalArgumentException {
+	public fun <init> (Ldev/sebastiano/spectre/input/CoordinatorProtocolError;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/input/CoordinatorProtocolError;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getError ()Ldev/sebastiano/spectre/input/CoordinatorProtocolError;
+	public final fun getPeerVersion ()Ljava/lang/Integer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorQuarantineStatus {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ldev/sebastiano/spectre/input/LeaseOwner;
+	public final fun component4 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;J)Ldev/sebastiano/spectre/input/CoordinatorQuarantineStatus;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorQuarantineStatus;Ljava/lang/String;Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;JILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorQuarantineStatus;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOwner ()Ldev/sebastiano/spectre/input/LeaseOwner;
+	public final fun getPredecessorEpoch ()Ljava/lang/String;
+	public final fun getPredecessorLeaseId ()Ljava/lang/String;
+	public final fun getReleaseEligibleAtMillis ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorRevokeResult {
+	public fun <init> (Z)V
+	public final fun component1 ()Z
+	public final fun copy (Z)Ldev/sebastiano/spectre/input/CoordinatorRevokeResult;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorRevokeResult;ZILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorRevokeResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnsafeTakeover ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorStatus {
+	public fun <init> (Ldev/sebastiano/spectre/input/DesktopResourceKey;Ldev/sebastiano/spectre/input/CoordinatorHolderStatus;Ljava/util/List;Ldev/sebastiano/spectre/input/CoordinatorQuarantineStatus;)V
+	public final fun component1 ()Ldev/sebastiano/spectre/input/DesktopResourceKey;
+	public final fun component2 ()Ldev/sebastiano/spectre/input/CoordinatorHolderStatus;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ldev/sebastiano/spectre/input/CoordinatorQuarantineStatus;
+	public final fun copy (Ldev/sebastiano/spectre/input/DesktopResourceKey;Ldev/sebastiano/spectre/input/CoordinatorHolderStatus;Ljava/util/List;Ldev/sebastiano/spectre/input/CoordinatorQuarantineStatus;)Ldev/sebastiano/spectre/input/CoordinatorStatus;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorStatus;Ldev/sebastiano/spectre/input/DesktopResourceKey;Ldev/sebastiano/spectre/input/CoordinatorHolderStatus;Ljava/util/List;Ldev/sebastiano/spectre/input/CoordinatorQuarantineStatus;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorStatus;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHolder ()Ldev/sebastiano/spectre/input/CoordinatorHolderStatus;
+	public final fun getQuarantine ()Ldev/sebastiano/spectre/input/CoordinatorQuarantineStatus;
+	public final fun getResourceKey ()Ldev/sebastiano/spectre/input/DesktopResourceKey;
+	public final fun getWaiters ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWaiterStatus {
+	public fun <init> (Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;I)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ldev/sebastiano/spectre/input/LeaseOwner;
+	public final fun component3 ()I
+	public final fun copy (Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;I)Ldev/sebastiano/spectre/input/CoordinatorWaiterStatus;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorWaiterStatus;Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;IILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorWaiterStatus;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOwner ()Ldev/sebastiano/spectre/input/LeaseOwner;
+	public final fun getPosition ()I
+	public final fun getRequestId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireCodec {
+	public static final field Companion Ldev/sebastiano/spectre/input/CoordinatorWireCodec$Companion;
+	public static final field DEFAULT_MAX_PAYLOAD_BYTES I
+	public fun <init> ()V
+	public fun <init> (ILkotlinx/serialization/json/Json;)V
+	public synthetic fun <init> (ILkotlinx/serialization/json/Json;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun decode ([B)Ldev/sebastiano/spectre/input/CoordinatorWireMessage;
+	public final fun encode (Ldev/sebastiano/spectre/input/CoordinatorWireMessage;)[B
+	public final fun read (Ljava/nio/channels/SocketChannel;)Ldev/sebastiano/spectre/input/CoordinatorWireMessage;
+	public final fun readOrNull (Ljava/nio/channels/SocketChannel;)Ldev/sebastiano/spectre/input/CoordinatorWireMessage;
+	public final fun write (Ljava/nio/channels/SocketChannel;Ldev/sebastiano/spectre/input/CoordinatorWireMessage;)V
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireCodec$Companion {
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireHolder {
+	public static final field Companion Ldev/sebastiano/spectre/input/CoordinatorWireHolder$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;JJJLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;JJJLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()J
+	public final fun component7 ()J
+	public final fun component8 ()J
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;JJJLjava/lang/String;)Ldev/sebastiano/spectre/input/CoordinatorWireHolder;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorWireHolder;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;JJJLjava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorWireHolder;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAcquisitionAgeMillis ()J
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getCurrentOperation ()Ljava/lang/String;
+	public final fun getFence ()J
+	public final fun getHeartbeatAgeMillis ()J
+	public final fun getLeaseId ()Ljava/lang/String;
+	public final fun getOwnerLabel ()Ljava/lang/String;
+	public final fun getProcessId ()J
+	public final fun getState ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/input/CoordinatorWireHolder$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/CoordinatorWireHolder$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/input/CoordinatorWireHolder;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/input/CoordinatorWireHolder;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireHolder$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireKind : java/lang/Enum {
+	public static final field ACQUIRE Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static final field CANCEL Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static final field Companion Ldev/sebastiano/spectre/input/CoordinatorWireKind$Companion;
+	public static final field HEALTH Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static final field HEARTBEAT Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static final field RELEASE Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static final field RESPONSE Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static final field REVOKE Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static final field SESSION_OPEN Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static final field STATUS Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public static fun values ()[Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireKind$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireMessage {
+	public static final field Companion Ldev/sebastiano/spectre/input/CoordinatorWireMessage$Companion;
+	public fun <init> (Ldev/sebastiano/spectre/input/CoordinatorWireKind;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZLdev/sebastiano/spectre/input/CoordinatorWireStatus;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/input/CoordinatorWireKind;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZLdev/sebastiano/spectre/input/CoordinatorWireStatus;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/Long;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Z
+	public final fun component16 ()Z
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Z
+	public final fun component21 ()Ldev/sebastiano/spectre/input/CoordinatorWireStatus;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Long;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Long;
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ldev/sebastiano/spectre/input/CoordinatorWireKind;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZLdev/sebastiano/spectre/input/CoordinatorWireStatus;)Ldev/sebastiano/spectre/input/CoordinatorWireMessage;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorWireMessage;Ldev/sebastiano/spectre/input/CoordinatorWireKind;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;ZLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;ZZLjava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ZLdev/sebastiano/spectre/input/CoordinatorWireStatus;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorWireMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getCoordinatorEpoch ()Ljava/lang/String;
+	public final fun getCurrentOperation ()Ljava/lang/String;
+	public final fun getErrorCode ()Ljava/lang/String;
+	public final fun getFence ()Ljava/lang/Long;
+	public final fun getForce ()Z
+	public final fun getKind ()Ldev/sebastiano/spectre/input/CoordinatorWireKind;
+	public final fun getLeaseId ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
+	public final fun getOk ()Z
+	public final fun getOwnerLabel ()Ljava/lang/String;
+	public final fun getProcessId ()Ljava/lang/Long;
+	public final fun getQueuePosition ()Ljava/lang/Integer;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getRequestId ()Ljava/lang/String;
+	public final fun getRequesterLabel ()Ljava/lang/String;
+	public final fun getResourceKey ()Ljava/lang/String;
+	public final fun getStatus ()Ldev/sebastiano/spectre/input/CoordinatorWireStatus;
+	public final fun getTimeoutMillis ()Ljava/lang/Long;
+	public final fun getUnsafeTakeover ()Z
+	public final fun getWaitForLease ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/input/CoordinatorWireMessage$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/CoordinatorWireMessage$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/input/CoordinatorWireMessage;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/input/CoordinatorWireMessage;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireMessage$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireQuarantine {
+	public static final field Companion Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;J)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()J
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;J)Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;JILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getOwnerLabel ()Ljava/lang/String;
+	public final fun getPredecessorEpoch ()Ljava/lang/String;
+	public final fun getPredecessorLeaseId ()Ljava/lang/String;
+	public final fun getProcessId ()J
+	public final fun getReleaseEligibleAtMillis ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/input/CoordinatorWireQuarantine$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireQuarantine$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireStatus {
+	public static final field Companion Ldev/sebastiano/spectre/input/CoordinatorWireStatus$Companion;
+	public fun <init> (Ljava/lang/String;Ldev/sebastiano/spectre/input/CoordinatorWireHolder;Ljava/util/List;Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;)V
+	public synthetic fun <init> (Ljava/lang/String;Ldev/sebastiano/spectre/input/CoordinatorWireHolder;Ljava/util/List;Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ldev/sebastiano/spectre/input/CoordinatorWireHolder;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;
+	public final fun copy (Ljava/lang/String;Ldev/sebastiano/spectre/input/CoordinatorWireHolder;Ljava/util/List;Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;)Ldev/sebastiano/spectre/input/CoordinatorWireStatus;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorWireStatus;Ljava/lang/String;Ldev/sebastiano/spectre/input/CoordinatorWireHolder;Ljava/util/List;Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorWireStatus;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHolder ()Ldev/sebastiano/spectre/input/CoordinatorWireHolder;
+	public final fun getQuarantine ()Ldev/sebastiano/spectre/input/CoordinatorWireQuarantine;
+	public final fun getResourceKey ()Ljava/lang/String;
+	public final fun getWaiters ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/input/CoordinatorWireStatus$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/CoordinatorWireStatus$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/input/CoordinatorWireStatus;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/input/CoordinatorWireStatus;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireStatus$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireWaiter {
+	public static final field Companion Ldev/sebastiano/spectre/input/CoordinatorWireWaiter$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;I)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()J
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;I)Ldev/sebastiano/spectre/input/CoordinatorWireWaiter;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/CoordinatorWireWaiter;Ljava/lang/String;Ljava/lang/String;JLjava/lang/String;IILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorWireWaiter;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getOwnerLabel ()Ljava/lang/String;
+	public final fun getPosition ()I
+	public final fun getProcessId ()J
+	public final fun getRequestId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/sebastiano/spectre/input/CoordinatorWireWaiter$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/CoordinatorWireWaiter$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/sebastiano/spectre/input/CoordinatorWireWaiter;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/sebastiano/spectre/input/CoordinatorWireWaiter;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/CoordinatorWireWaiter$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/sebastiano/spectre/input/DesktopIdentityEnvironment {
+	public fun <init> (Ldev/sebastiano/spectre/input/DesktopPlatform;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/input/DesktopPlatform;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/sebastiano/spectre/input/DesktopPlatform;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ldev/sebastiano/spectre/input/DesktopPlatform;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Ldev/sebastiano/spectre/input/DesktopIdentityEnvironment;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/DesktopIdentityEnvironment;Ldev/sebastiano/spectre/input/DesktopPlatform;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/DesktopIdentityEnvironment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEffectiveUserId ()Ljava/lang/String;
+	public final fun getEnvironment ()Ljava/util/Map;
+	public final fun getPlatform ()Ldev/sebastiano/spectre/input/DesktopPlatform;
+	public final fun getWindowsLogonSessionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/DesktopIdentityResolver {
+	public fun <init> ()V
+	public fun <init> (Ldev/sebastiano/spectre/input/CanonicalPathResolver;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/input/CanonicalPathResolver;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun resolve (Ldev/sebastiano/spectre/input/DesktopIdentityEnvironment;)Ldev/sebastiano/spectre/input/DesktopResourceKey;
+}
+
+public final class dev/sebastiano/spectre/input/DesktopPlatform : java/lang/Enum {
+	public static final field LINUX Ldev/sebastiano/spectre/input/DesktopPlatform;
+	public static final field MACOS Ldev/sebastiano/spectre/input/DesktopPlatform;
+	public static final field WINDOWS Ldev/sebastiano/spectre/input/DesktopPlatform;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/input/DesktopPlatform;
+	public static fun values ()[Ldev/sebastiano/spectre/input/DesktopPlatform;
+}
+
+public final class dev/sebastiano/spectre/input/DesktopResourceKey {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Ldev/sebastiano/spectre/input/DesktopResourceKey;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/DesktopResourceKey;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface annotation class dev/sebastiano/spectre/input/ExperimentalSpectreInputCoordinationApi : java/lang/annotation/Annotation {
+}
+
+public final class dev/sebastiano/spectre/input/InputCoordinatorClientFactory {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/InputCoordinatorClientFactory;
+	public final fun connectOrStart (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;)Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient;
+	public static synthetic fun connectOrStart$default (Ldev/sebastiano/spectre/input/InputCoordinatorClientFactory;Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient;
+}
+
+public abstract interface class dev/sebastiano/spectre/input/InputCoordinatorClientProvider {
+	public abstract fun connect (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;)Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient;
+}
+
+public final class dev/sebastiano/spectre/input/InputCoordinatorException : java/lang/IllegalStateException {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun getErrorCode ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/LeaseErrorCode : java/lang/Enum {
+	public static final field FENCED Ldev/sebastiano/spectre/input/LeaseErrorCode;
+	public static final field QUEUE_FULL Ldev/sebastiano/spectre/input/LeaseErrorCode;
+	public static final field REVOKE_GRACE_ACTIVE Ldev/sebastiano/spectre/input/LeaseErrorCode;
+	public static final field STALE_EPOCH Ldev/sebastiano/spectre/input/LeaseErrorCode;
+	public static final field STALE_LEASE Ldev/sebastiano/spectre/input/LeaseErrorCode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/input/LeaseErrorCode;
+	public static fun values ()[Ldev/sebastiano/spectre/input/LeaseErrorCode;
+}
+
+public final class dev/sebastiano/spectre/input/LeaseOwner {
+	public fun <init> (Ljava/lang/String;JLjava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()J
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;JLjava/lang/String;)Ldev/sebastiano/spectre/input/LeaseOwner;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/LeaseOwner;Ljava/lang/String;JLjava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/LeaseOwner;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClientId ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getProcessId ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/LeaseToken {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ldev/sebastiano/spectre/input/DesktopResourceKey;J)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ldev/sebastiano/spectre/input/DesktopResourceKey;
+	public final fun component4 ()J
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ldev/sebastiano/spectre/input/DesktopResourceKey;J)Ldev/sebastiano/spectre/input/LeaseToken;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/input/LeaseToken;Ljava/lang/String;Ljava/lang/String;Ldev/sebastiano/spectre/input/DesktopResourceKey;JILjava/lang/Object;)Ldev/sebastiano/spectre/input/LeaseToken;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCoordinatorEpoch ()Ljava/lang/String;
+	public final fun getFence ()J
+	public final fun getLeaseId ()Ljava/lang/String;
+	public final fun getResourceKey ()Ldev/sebastiano/spectre/input/DesktopResourceKey;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/input/LocalCoordinatorEnvironment {
+	public static final field INSTANCE Ldev/sebastiano/spectre/input/LocalCoordinatorEnvironment;
+	public final fun defaultDesktopResourceKey ()Ldev/sebastiano/spectre/input/DesktopResourceKey;
+	public final fun defaultEndpoint ()Ldev/sebastiano/spectre/input/CoordinatorEndpoint;
+}
+
+public final class dev/sebastiano/spectre/input/LocalInputCoordinatorClient : java/lang/AutoCloseable {
+	public static final field Companion Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient$Companion;
+	public synthetic fun <init> (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;Ldev/sebastiano/spectre/input/LeaseOwner;Ljava/nio/channels/SocketChannel;Ljava/lang/String;Ldev/sebastiano/spectre/input/CoordinatorWireCodec;Ljava/util/concurrent/ScheduledExecutorService;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun acquire (Ljava/time/Duration;Ljava/lang/String;)Ldev/sebastiano/spectre/input/CoordinatedInputLease;
+	public static synthetic fun acquire$default (Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient;Ljava/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatedInputLease;
+	public fun close ()V
+	public final fun getCoordinatorEpoch ()Ljava/lang/String;
+	public final fun tryAcquire (Ljava/lang/String;)Ldev/sebastiano/spectre/input/CoordinatedInputLease;
+	public static synthetic fun tryAcquire$default (Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatedInputLease;
+}
+
+public final class dev/sebastiano/spectre/input/LocalInputCoordinatorClient$Companion {
+	public final fun connect (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;Ldev/sebastiano/spectre/input/CoordinatorWireCodec;)Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient;
+	public static synthetic fun connect$default (Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient$Companion;Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;Ldev/sebastiano/spectre/input/CoordinatorWireCodec;ILjava/lang/Object;)Ldev/sebastiano/spectre/input/LocalInputCoordinatorClient;
+}
+
+public final class dev/sebastiano/spectre/input/LocalInputCoordinatorControl {
+	public fun <init> (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ldev/sebastiano/spectre/input/CoordinatorWireCodec;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/input/CoordinatorEndpoint;Ldev/sebastiano/spectre/input/CoordinatorWireCodec;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun revoke (Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)Ldev/sebastiano/spectre/input/CoordinatorRevokeResult;
+	public static synthetic fun revoke$default (Ldev/sebastiano/spectre/input/LocalInputCoordinatorControl;Ldev/sebastiano/spectre/input/DesktopResourceKey;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Ldev/sebastiano/spectre/input/CoordinatorRevokeResult;
+	public final fun status (Ldev/sebastiano/spectre/input/DesktopResourceKey;)Ldev/sebastiano/spectre/input/CoordinatorControlResult;
+}
+
+public abstract interface class dev/sebastiano/spectre/input/OwnerOnlyEndpointProtection {
+	public static final field Companion Ldev/sebastiano/spectre/input/OwnerOnlyEndpointProtection$Companion;
+	public abstract fun prepareDirectory (Ljava/nio/file/Path;)V
+	public abstract fun protectSocket (Ljava/nio/file/Path;)V
+}
+
+public final class dev/sebastiano/spectre/input/OwnerOnlyEndpointProtection$Companion {
+	public final fun forPath (Ljava/nio/file/Path;)Ldev/sebastiano/spectre/input/OwnerOnlyEndpointProtection;
+}
+

--- a/input-coordinator/build.gradle.kts
+++ b/input-coordinator/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    alias(libs.plugins.detekt)
+    alias(libs.plugins.kotlinJvm)
+    alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.ktfmt)
+    alias(libs.plugins.mavenPublish)
+}
+
+kotlin {
+    jvmToolchain(21)
+    explicitApi()
+
+    @OptIn(org.jetbrains.kotlin.gradle.dsl.abi.ExperimentalAbiValidation::class)
+    abiValidation { enabled.set(true) }
+}
+
+dependencies {
+    api(libs.kotlinx.serialization.json)
+    testImplementation(libs.kotlin.testJunit5)
+}
+
+tasks.withType<Test>().configureEach { useJUnitPlatform() }

--- a/input-coordinator/gradle.properties
+++ b/input-coordinator/gradle.properties
@@ -1,0 +1,3 @@
+POM_ARTIFACT_ID=spectre-input-coordinator
+POM_NAME=Spectre Input Coordinator
+POM_DESCRIPTION=Client and local protocol foundation for cooperative desktop input coordination.

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -1,0 +1,146 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.io.IOException
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.LinkOption.NOFOLLOW_LINKS
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermission
+import java.security.MessageDigest
+import java.util.HexFormat
+
+/** Canonical per-user directory and Unix-domain socket used by the local coordinator. */
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorEndpoint(public val directory: Path, public val socketPath: Path)
+
+/** Resolves a short endpoint that is independent of the launching process's environment. */
+@ExperimentalSpectreInputCoordinationApi
+public object CoordinatorEndpointResolver {
+    /** Creates the canonical endpoint names without touching the filesystem. */
+    @Throws(IOException::class)
+    public fun resolve(baseDirectory: Path, effectiveUserId: String): CoordinatorEndpoint {
+        require(effectiveUserId.isNotBlank()) { "Effective user ID must not be blank" }
+        val canonicalBase =
+            if (Files.exists(baseDirectory)) baseDirectory.toRealPath()
+            else baseDirectory.normalize()
+        val userHash = stableHash(effectiveUserId)
+        val directory = canonicalBase.resolve("spectre-input-$userHash")
+        val socketPath = directory.resolve("input-v1-${userHash.take(SOCKET_HASH_LENGTH)}.sock")
+        val encodedLength = socketPath.toString().toByteArray(StandardCharsets.UTF_8).size
+        if (encodedLength > MAX_UNIX_SOCKET_PATH_BYTES) {
+            throw IOException(
+                "Unix-domain socket path is $encodedLength bytes; the safe maximum is " +
+                    "$MAX_UNIX_SOCKET_PATH_BYTES: $socketPath"
+            )
+        }
+        return CoordinatorEndpoint(directory = directory, socketPath = socketPath)
+    }
+
+    private fun stableHash(value: String): String =
+        HexFormat.of()
+            .formatHex(
+                MessageDigest.getInstance("SHA-256")
+                    .digest(value.toByteArray(StandardCharsets.UTF_8)),
+                0,
+                HASH_BYTES,
+            )
+
+    private const val HASH_BYTES: Int = 8
+    private const val SOCKET_HASH_LENGTH: Int = 8
+    private const val MAX_UNIX_SOCKET_PATH_BYTES: Int = 100
+}
+
+/** Enforces the same-user trust boundary for a coordinator endpoint and its socket file. */
+@ExperimentalSpectreInputCoordinationApi
+public sealed interface OwnerOnlyEndpointProtection {
+    /** Creates or validates the socket's parent directory without following a substituted link. */
+    @Throws(IOException::class) public fun prepareDirectory(socketPath: Path)
+
+    /** Applies owner-only access to a socket after it has been bound. */
+    @Throws(IOException::class) public fun protectSocket(socketPath: Path)
+
+    public companion object {
+        /** Selects protection from the filesystem that will contain [path]. */
+        public fun forPath(path: Path): OwnerOnlyEndpointProtection {
+            val existingAncestor =
+                generateSequence(path.toAbsolutePath()) { it.parent }.first(Files::exists)
+            return if (Files.getFileStore(existingAncestor).supportsFileAttributeView("posix")) {
+                PosixOwnerOnlyEndpointProtection
+            } else {
+                BasicOwnerOnlyEndpointProtection
+            }
+        }
+    }
+}
+
+private object PosixOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
+    override fun prepareDirectory(socketPath: Path) {
+        val directory = socketPath.toAbsolutePath().parent
+        if (Files.exists(directory, NOFOLLOW_LINKS)) {
+            rejectSubstitutedDirectory(directory)
+            val permissions = Files.getPosixFilePermissions(directory, NOFOLLOW_LINKS)
+            if (permissions != OWNER_ONLY_DIRECTORY_PERMISSIONS) {
+                throw IOException("Existing coordinator directory $directory must be owner-only")
+            }
+        } else {
+            rejectSymbolicParent(directory.parent)
+            Files.createDirectory(
+                directory,
+                java.nio.file.attribute.PosixFilePermissions.asFileAttribute(
+                    OWNER_ONLY_DIRECTORY_PERMISSIONS
+                ),
+            )
+        }
+    }
+
+    override fun protectSocket(socketPath: Path) {
+        if (Files.isSymbolicLink(socketPath)) {
+            throw IOException("Coordinator socket $socketPath must not be a symbolic link")
+        }
+        Files.setPosixFilePermissions(socketPath, OWNER_ONLY_SOCKET_PERMISSIONS)
+    }
+
+    private val OWNER_ONLY_DIRECTORY_PERMISSIONS: Set<PosixFilePermission> =
+        setOf(
+            PosixFilePermission.OWNER_READ,
+            PosixFilePermission.OWNER_WRITE,
+            PosixFilePermission.OWNER_EXECUTE,
+        )
+    private val OWNER_ONLY_SOCKET_PERMISSIONS: Set<PosixFilePermission> =
+        setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
+}
+
+private object BasicOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
+    override fun prepareDirectory(socketPath: Path) {
+        val directory = socketPath.toAbsolutePath().parent
+        if (Files.exists(directory, NOFOLLOW_LINKS)) {
+            rejectSubstitutedDirectory(directory)
+        } else {
+            rejectSymbolicParent(directory.parent)
+            Files.createDirectory(directory)
+        }
+    }
+
+    override fun protectSocket(socketPath: Path) {
+        if (Files.isSymbolicLink(socketPath)) {
+            throw IOException("Coordinator socket $socketPath must not be a symbolic link")
+        }
+    }
+}
+
+private fun rejectSubstitutedDirectory(directory: Path) {
+    if (Files.isSymbolicLink(directory)) {
+        throw IOException("Coordinator directory $directory must not be a symbolic link")
+    }
+    if (!Files.isDirectory(directory, NOFOLLOW_LINKS)) {
+        throw IOException("Coordinator directory $directory is not a directory")
+    }
+}
+
+private fun rejectSymbolicParent(parent: Path?) {
+    if (parent != null && Files.isSymbolicLink(parent)) {
+        throw IOException("Coordinator parent $parent must not be a symbolic link")
+    }
+}

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorFrameCodec.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorFrameCodec.kt
@@ -1,0 +1,107 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.nio.ByteBuffer
+
+/** Current major version of the local coordinator framing protocol. */
+@ExperimentalSpectreInputCoordinationApi
+public const val INPUT_COORDINATOR_PROTOCOL_VERSION: Int = 1
+
+/** Stable failures produced before a protocol payload is decoded. */
+@ExperimentalSpectreInputCoordinationApi
+public enum class CoordinatorProtocolError {
+    FRAME_TOO_LARGE,
+    MALFORMED_FRAME,
+    INCOMPATIBLE_VERSION,
+}
+
+/** A validated protocol payload and the peer version that framed it. */
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorFrame(public val protocolVersion: Int, public val payload: ByteArray) {
+    override fun equals(other: Any?): Boolean =
+        this === other ||
+            (other is CoordinatorFrame &&
+                protocolVersion == other.protocolVersion &&
+                payload.contentEquals(other.payload))
+
+    override fun hashCode(): Int = 31 * protocolVersion + payload.contentHashCode()
+}
+
+/** A framing failure that can be mapped to a stable local-protocol response. */
+@ExperimentalSpectreInputCoordinationApi
+public class CoordinatorProtocolException(
+    public val error: CoordinatorProtocolError,
+    public val peerVersion: Int? = null,
+    message: String,
+) : IllegalArgumentException(message)
+
+/** Length-prefix codec that rejects unbounded, truncated, and incompatible local frames. */
+@ExperimentalSpectreInputCoordinationApi
+public class CoordinatorFrameCodec(public val maxPayloadBytes: Int) {
+    init {
+        require(maxPayloadBytes >= 0) { "Maximum payload size must not be negative" }
+    }
+
+    /** Encodes one payload with a bounded length prefix and protocol version. */
+    public fun encode(payload: ByteArray): ByteArray {
+        rejectOversized(payload.size)
+        return ByteBuffer.allocate(HEADER_BYTES + payload.size)
+            .putInt(payload.size)
+            .putShort(INPUT_COORDINATOR_PROTOCOL_VERSION.toShort())
+            .put(payload)
+            .array()
+    }
+
+    /** Validates and decodes exactly one complete frame. */
+    public fun decode(frame: ByteArray): CoordinatorFrame {
+        if (frame.size < HEADER_BYTES) {
+            malformed("Frame is shorter than its $HEADER_BYTES-byte header")
+        }
+        val buffer = ByteBuffer.wrap(frame)
+        val payloadSize = buffer.int
+        if (payloadSize < 0) {
+            malformed("Frame declares a negative payload length")
+        }
+        rejectOversized(payloadSize)
+        val protocolVersion = buffer.short.toInt() and UNSIGNED_SHORT_MASK
+        if (frame.size != HEADER_BYTES + payloadSize) {
+            malformed(
+                "Frame length ${frame.size} does not match declared payload length $payloadSize"
+            )
+        }
+        if (protocolVersion != INPUT_COORDINATOR_PROTOCOL_VERSION) {
+            throw CoordinatorProtocolException(
+                error = CoordinatorProtocolError.INCOMPATIBLE_VERSION,
+                peerVersion = protocolVersion,
+                message =
+                    "Input coordinator protocol $protocolVersion is incompatible with " +
+                        "supported version $INPUT_COORDINATOR_PROTOCOL_VERSION",
+            )
+        }
+        val payload = ByteArray(payloadSize)
+        buffer.get(payload)
+        return CoordinatorFrame(protocolVersion = protocolVersion, payload = payload)
+    }
+
+    private fun rejectOversized(payloadSize: Int) {
+        if (payloadSize > maxPayloadBytes) {
+            throw CoordinatorProtocolException(
+                error = CoordinatorProtocolError.FRAME_TOO_LARGE,
+                message =
+                    "Input coordinator payload is $payloadSize bytes; maximum is $maxPayloadBytes",
+            )
+        }
+    }
+
+    private fun malformed(message: String): Nothing =
+        throw CoordinatorProtocolException(
+            error = CoordinatorProtocolError.MALFORMED_FRAME,
+            message = message,
+        )
+
+    private companion object {
+        const val HEADER_BYTES: Int = Int.SIZE_BYTES + Short.SIZE_BYTES
+        const val UNSIGNED_SHORT_MASK: Int = 0xffff
+    }
+}

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorProtocol.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorProtocol.kt
@@ -1,0 +1,174 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.io.EOFException
+import java.nio.ByteBuffer
+import java.nio.channels.SocketChannel
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/** Request and response operations carried by the local coordinator protocol. */
+@Serializable
+@ExperimentalSpectreInputCoordinationApi
+public enum class CoordinatorWireKind {
+    HEALTH,
+    SESSION_OPEN,
+    ACQUIRE,
+    CANCEL,
+    RELEASE,
+    HEARTBEAT,
+    STATUS,
+    REVOKE,
+    RESPONSE,
+}
+
+/** Redacted holder status carried across the local control protocol. */
+@Serializable
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorWireHolder(
+    public val leaseId: String,
+    public val clientId: String,
+    public val processId: Long,
+    public val ownerLabel: String? = null,
+    public val state: String,
+    public val fence: Long,
+    public val acquisitionAgeMillis: Long,
+    public val heartbeatAgeMillis: Long,
+    public val currentOperation: String? = null,
+)
+
+/** Redacted queued-owner status carried across the local control protocol. */
+@Serializable
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorWireWaiter(
+    public val requestId: String,
+    public val clientId: String,
+    public val processId: Long,
+    public val ownerLabel: String? = null,
+    public val position: Int,
+)
+
+/** Recovery quarantine details needed for an exact-ID unsafe recovery decision. */
+@Serializable
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorWireQuarantine(
+    public val predecessorLeaseId: String,
+    public val predecessorEpoch: String,
+    public val clientId: String,
+    public val processId: Long,
+    public val ownerLabel: String? = null,
+    public val releaseEligibleAtMillis: Long,
+)
+
+/** Machine-readable status payload for one desktop resource. */
+@Serializable
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorWireStatus(
+    public val resourceKey: String,
+    public val holder: CoordinatorWireHolder? = null,
+    public val waiters: List<CoordinatorWireWaiter> = emptyList(),
+    public val quarantine: CoordinatorWireQuarantine? = null,
+)
+
+/** Versioned request/response envelope for the trusted-local coordinator boundary. */
+@Serializable
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorWireMessage(
+    public val kind: CoordinatorWireKind,
+    public val requestId: String? = null,
+    public val clientId: String? = null,
+    public val resourceKey: String? = null,
+    public val processId: Long? = null,
+    public val ownerLabel: String? = null,
+    public val timeoutMillis: Long? = null,
+    public val waitForLease: Boolean = true,
+    public val currentOperation: String? = null,
+    public val coordinatorEpoch: String? = null,
+    public val leaseId: String? = null,
+    public val fence: Long? = null,
+    public val requesterLabel: String? = null,
+    public val reason: String? = null,
+    public val force: Boolean = false,
+    public val ok: Boolean = true,
+    public val errorCode: String? = null,
+    public val message: String? = null,
+    public val queuePosition: Int? = null,
+    public val unsafeTakeover: Boolean = false,
+    public val status: CoordinatorWireStatus? = null,
+)
+
+/** Bounded JSON payload codec layered over [CoordinatorFrameCodec]. */
+@ExperimentalSpectreInputCoordinationApi
+public class CoordinatorWireCodec(
+    maxPayloadBytes: Int = DEFAULT_MAX_PAYLOAD_BYTES,
+    private val json: Json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = false
+    },
+) {
+    private val frameCodec = CoordinatorFrameCodec(maxPayloadBytes)
+
+    /** Encodes one local request or response. */
+    public fun encode(message: CoordinatorWireMessage): ByteArray =
+        frameCodec.encode(json.encodeToString(message).encodeToByteArray())
+
+    /** Decodes one complete local request or response. */
+    public fun decode(frame: ByteArray): CoordinatorWireMessage =
+        json.decodeFromString(frameCodec.decode(frame).payload.decodeToString())
+
+    /** Writes one complete frame to [channel]. */
+    public fun write(channel: SocketChannel, message: CoordinatorWireMessage) {
+        val buffer = ByteBuffer.wrap(encode(message))
+        while (buffer.hasRemaining()) channel.write(buffer)
+    }
+
+    /** Reads one frame, returning null only for clean EOF before any header byte. */
+    public fun readOrNull(channel: SocketChannel): CoordinatorWireMessage? {
+        val header = ByteBuffer.allocate(HEADER_BYTES)
+        if (!readFully(channel, header, allowInitialEof = true)) return null
+        header.flip()
+        val payloadSize = header.int
+        if (payloadSize < 0 || payloadSize > frameCodec.maxPayloadBytes) {
+            throw CoordinatorProtocolException(
+                error =
+                    if (payloadSize > frameCodec.maxPayloadBytes) {
+                        CoordinatorProtocolError.FRAME_TOO_LARGE
+                    } else {
+                        CoordinatorProtocolError.MALFORMED_FRAME
+                    },
+                message = "Invalid coordinator payload length $payloadSize",
+            )
+        }
+        val payload = ByteBuffer.allocate(payloadSize)
+        readFully(channel, payload, allowInitialEof = false)
+        return decode(header.array() + payload.array())
+    }
+
+    /** Reads one required frame. */
+    public fun read(channel: SocketChannel): CoordinatorWireMessage =
+        readOrNull(channel) ?: throw EOFException("Coordinator closed before sending a frame")
+
+    private fun readFully(
+        channel: SocketChannel,
+        buffer: ByteBuffer,
+        allowInitialEof: Boolean,
+    ): Boolean {
+        var readAny = false
+        while (buffer.hasRemaining()) {
+            val count = channel.read(buffer)
+            if (count < 0) {
+                if (!readAny && allowInitialEof) return false
+                throw EOFException("Coordinator closed in the middle of a frame")
+            }
+            readAny = readAny || count > 0
+        }
+        return true
+    }
+
+    public companion object {
+        public const val DEFAULT_MAX_PAYLOAD_BYTES: Int = 64 * 1024
+        private const val HEADER_BYTES: Int = Int.SIZE_BYTES + Short.SIZE_BYTES
+    }
+}

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
@@ -18,6 +18,9 @@ public data class DesktopIdentityEnvironment(
     public val platform: DesktopPlatform,
     public val effectiveUserId: String,
     public val environment: Map<String, String> = emptyMap(),
+    /**
+     * Verified numeric Windows process-session ID; transport names such as SESSIONNAME are invalid.
+     */
     public val windowsLogonSessionId: String? = null,
 )
 
@@ -47,8 +50,10 @@ public class DesktopIdentityResolver(
         return DesktopResourceKey(prefix + desktopIdentity)
     }
 
-    private fun windowsIdentity(logonSessionId: String?): String =
-        logonSessionId?.takeIf(String::isNotBlank)?.let { "windows-session:$it" } ?: "windows-user"
+    private fun windowsIdentity(logonSessionId: String?): String {
+        val verified = logonSessionId?.trim()?.takeIf { it.isNotEmpty() && it.all(Char::isDigit) }
+        return verified?.let { "windows-session:$it" } ?: "windows-user"
+    }
 
     private fun linuxIdentity(environment: Map<String, String>): String {
         val waylandDisplay = environment["WAYLAND_DISPLAY"]?.takeIf(String::isNotBlank)

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
@@ -76,7 +76,8 @@ public class DesktopIdentityResolver(
             "x11-local:${localMatch.groupValues[1]}"
         } else {
             val remoteServer =
-                REMOTE_X11_SCREEN_SUFFIX.matchEntire(display)?.groupValues?.get(1) ?: display
+                (REMOTE_X11_SCREEN_SUFFIX.matchEntire(display)?.groupValues?.get(1) ?: display)
+                    .lowercase()
             "x11-remote:$remoteServer"
         }
     }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
@@ -82,7 +82,7 @@ public class DesktopIdentityResolver(
     }
 
     private companion object {
-        val LOCAL_X11_DISPLAY: Regex = Regex("^(?:unix/)?:(\\d+)(?:\\.\\d+)?$")
+        val LOCAL_X11_DISPLAY: Regex = Regex("^(?:unix/?)?:(\\d+)(?:\\.\\d+)?$")
         val REMOTE_X11_SCREEN_SUFFIX: Regex = Regex("^(.*:\\d+)\\.\\d+$")
     }
 }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
@@ -75,6 +75,6 @@ public class DesktopIdentityResolver(
     }
 
     private companion object {
-        val LOCAL_X11_DISPLAY: Regex = Regex("^(?:unix/)?:(\\d+)(?:\\.0)?$")
+        val LOCAL_X11_DISPLAY: Regex = Regex("^(?:unix/)?:(\\d+)(?:\\.\\d+)?$")
     }
 }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
@@ -75,11 +75,14 @@ public class DesktopIdentityResolver(
         return if (localMatch != null) {
             "x11-local:${localMatch.groupValues[1]}"
         } else {
-            "x11-remote:$display"
+            val remoteServer =
+                REMOTE_X11_SCREEN_SUFFIX.matchEntire(display)?.groupValues?.get(1) ?: display
+            "x11-remote:$remoteServer"
         }
     }
 
     private companion object {
         val LOCAL_X11_DISPLAY: Regex = Regex("^(?:unix/)?:(\\d+)(?:\\.\\d+)?$")
+        val REMOTE_X11_SCREEN_SUFFIX: Regex = Regex("^(.*:\\d+)\\.\\d+$")
     }
 }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
@@ -82,7 +82,11 @@ public class DesktopIdentityResolver(
     }
 
     private companion object {
-        val LOCAL_X11_DISPLAY: Regex = Regex("^(?:unix/?)?:(\\d+)(?:\\.\\d+)?$")
+        val LOCAL_X11_DISPLAY: Regex =
+            Regex(
+                "^(?:(?:unix/?)?:|(?:localhost|127\\.0\\.0\\.1):)(\\d+)(?:\\.\\d+)?$",
+                RegexOption.IGNORE_CASE,
+            )
         val REMOTE_X11_SCREEN_SUFFIX: Regex = Regex("^(.*:\\d+)\\.\\d+$")
     }
 }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/DesktopIdentity.kt
@@ -1,0 +1,80 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.nio.file.Path
+
+/** Operating-system family used while deriving a conservative desktop identity. */
+@ExperimentalSpectreInputCoordinationApi
+public enum class DesktopPlatform {
+    LINUX,
+    MACOS,
+    WINDOWS,
+}
+
+/** Inputs captured from the target process when deriving its desktop resource key. */
+@ExperimentalSpectreInputCoordinationApi
+public data class DesktopIdentityEnvironment(
+    public val platform: DesktopPlatform,
+    public val effectiveUserId: String,
+    public val environment: Map<String, String> = emptyMap(),
+    public val windowsLogonSessionId: String? = null,
+)
+
+/** Resolves an existing filesystem path without exposing a production key override. */
+@ExperimentalSpectreInputCoordinationApi
+public fun interface CanonicalPathResolver {
+    public fun canonicalize(path: Path): Path
+}
+
+/** Derives a deliberately conservative per-user/per-desktop coordination key. */
+@ExperimentalSpectreInputCoordinationApi
+public class DesktopIdentityResolver(
+    private val canonicalPathResolver: CanonicalPathResolver = CanonicalPathResolver { path ->
+        path.toRealPath()
+    }
+) {
+    /** Resolves the desktop identity observed inside the process that will dispatch input. */
+    public fun resolve(environment: DesktopIdentityEnvironment): DesktopResourceKey {
+        require(environment.effectiveUserId.isNotBlank()) { "Effective user ID must not be blank" }
+        val prefix = "user:${environment.effectiveUserId}/"
+        val desktopIdentity =
+            when (environment.platform) {
+                DesktopPlatform.MACOS -> "macos-console"
+                DesktopPlatform.WINDOWS -> windowsIdentity(environment.windowsLogonSessionId)
+                DesktopPlatform.LINUX -> linuxIdentity(environment.environment)
+            }
+        return DesktopResourceKey(prefix + desktopIdentity)
+    }
+
+    private fun windowsIdentity(logonSessionId: String?): String =
+        logonSessionId?.takeIf(String::isNotBlank)?.let { "windows-session:$it" } ?: "windows-user"
+
+    private fun linuxIdentity(environment: Map<String, String>): String {
+        val waylandDisplay = environment["WAYLAND_DISPLAY"]?.takeIf(String::isNotBlank)
+        if (waylandDisplay != null) {
+            val rawPath = Path.of(waylandDisplay)
+            val socketPath =
+                if (rawPath.isAbsolute) {
+                    rawPath
+                } else {
+                    environment["XDG_RUNTIME_DIR"]?.let(Path::of)?.resolve(rawPath) ?: rawPath
+                }
+            val canonical =
+                runCatching { canonicalPathResolver.canonicalize(socketPath) }
+                    .getOrElse { socketPath.normalize() }
+            return "wayland:$canonical"
+        }
+        val display = environment["DISPLAY"]?.takeIf(String::isNotBlank) ?: return "linux-user"
+        val localMatch = LOCAL_X11_DISPLAY.matchEntire(display)
+        return if (localMatch != null) {
+            "x11-local:${localMatch.groupValues[1]}"
+        } else {
+            "x11-remote:$display"
+        }
+    }
+
+    private companion object {
+        val LOCAL_X11_DISPLAY: Regex = Regex("^(?:unix/)?:(\\d+)(?:\\.0)?$")
+    }
+}

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/ExperimentalSpectreInputCoordinationApi.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/ExperimentalSpectreInputCoordinationApi.kt
@@ -1,0 +1,25 @@
+package dev.sebastiano.spectre.input
+
+/**
+ * Marks the cooperative desktop-input coordination surface as experimental.
+ *
+ * The API is intentionally opt-in while its cross-platform identity, recovery, and lifecycle
+ * contracts settle. It may change or be removed in any release, including patch releases.
+ */
+@MustBeDocumented
+@Retention(AnnotationRetention.RUNTIME)
+@RequiresOptIn(
+    level = RequiresOptIn.Level.WARNING,
+    message =
+        "Spectre desktop input coordination is experimental and may change in any release. " +
+            "Opt in with @OptIn(ExperimentalSpectreInputCoordinationApi::class).",
+)
+@Target(
+    AnnotationTarget.CLASS,
+    AnnotationTarget.FUNCTION,
+    AnnotationTarget.PROPERTY,
+    AnnotationTarget.PROPERTY_GETTER,
+    AnnotationTarget.CONSTRUCTOR,
+    AnnotationTarget.TYPEALIAS,
+)
+public annotation class ExperimentalSpectreInputCoordinationApi

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -20,6 +20,7 @@ import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.concurrent.atomic.AtomicReference
+import kotlinx.serialization.SerializationException
 
 /** Public, redacted holder diagnostics returned by coordinator inspection. */
 @ExperimentalSpectreInputCoordinationApi
@@ -166,34 +167,41 @@ private constructor(
                     )
                 )
             } catch (failure: IOException) {
-                val interrupted = Thread.currentThread().isInterrupted
-                val cancellationAcknowledged = cancelAcquire(requestId)
-                if (!interrupted || !cancellationAcknowledged) close()
-                throw failure
+                failAmbiguousAcquire(requestId, failure, ::cancelAcquire, ::close)
+            } catch (failure: CoordinatorProtocolException) {
+                failAmbiguousAcquire(requestId, failure, ::cancelAcquire, ::close)
+            } catch (failure: SerializationException) {
+                failAmbiguousAcquire(requestId, failure, ::cancelAcquire, ::close)
             }
         response.requireSuccess()
-        val token =
-            LeaseToken(
-                coordinatorEpoch = requireNotNull(response.coordinatorEpoch),
-                leaseId = requireNotNull(response.leaseId),
-                resourceKey = resourceKey,
-                fence = requireNotNull(response.fence),
-            )
-        val registration =
-            requireNotNull(
-                leaseRegistrations.compute(token.leaseId) { _, existing ->
-                    if (existing == null) {
-                        LeaseRegistration(token)
-                    } else {
-                        check(existing.token == token) {
-                            "Coordinator reused lease ID ${token.leaseId} for a different token"
+        return try {
+            val token =
+                LeaseToken(
+                    coordinatorEpoch = requireNotNull(response.coordinatorEpoch),
+                    leaseId = requireNotNull(response.leaseId),
+                    resourceKey = resourceKey,
+                    fence = requireNotNull(response.fence),
+                )
+            val registration =
+                requireNotNull(
+                    leaseRegistrations.compute(token.leaseId) { _, existing ->
+                        if (existing == null) {
+                            LeaseRegistration(token)
+                        } else {
+                            check(existing.token == token) {
+                                "Coordinator reused lease ID ${token.leaseId} for a different token"
+                            }
+                            existing.retain()
+                            existing
                         }
-                        existing.retain()
-                        existing
                     }
-                }
-            )
-        return LocalLease(registration, requestId)
+                )
+            LocalLease(registration, requestId)
+        } catch (failure: IllegalArgumentException) {
+            failAmbiguousAcquire(requestId, failure, ::cancelAcquire, ::close)
+        } catch (failure: IllegalStateException) {
+            failAmbiguousAcquire(requestId, failure, ::cancelAcquire, ::close)
+        }
     }
 
     @Synchronized
@@ -590,6 +598,18 @@ internal fun sendCoordinatorMessage(
             codec.read(channel)
         }
     }
+
+private fun failAmbiguousAcquire(
+    requestId: String,
+    failure: Exception,
+    cancelAcquire: (String) -> Boolean,
+    closeSession: () -> Unit,
+): Nothing {
+    val interrupted = Thread.currentThread().isInterrupted
+    val cancellationAcknowledged = cancelAcquire(requestId)
+    if (!interrupted || !cancellationAcknowledged) closeSession()
+    throw failure
+}
 
 private fun <T> runCoordinatorIo(timeout: Duration, block: () -> T): T {
     require(!timeout.isNegative && !timeout.isZero) { "Coordinator I/O timeout must be positive" }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -185,7 +185,7 @@ private constructor(
                     }
                 }
             )
-        return LocalLease(registration)
+        return LocalLease(registration, requestId)
     }
 
     override fun close() {
@@ -247,9 +247,14 @@ private constructor(
                 )
         }
 
-    private fun tokenMessage(kind: CoordinatorWireKind, token: LeaseToken): CoordinatorWireMessage =
+    private fun tokenMessage(
+        kind: CoordinatorWireKind,
+        token: LeaseToken,
+        requestId: String? = null,
+    ): CoordinatorWireMessage =
         CoordinatorWireMessage(
             kind = kind,
+            requestId = requestId,
             clientId = clientId,
             resourceKey = token.resourceKey.value,
             coordinatorEpoch = token.coordinatorEpoch,
@@ -267,8 +272,10 @@ private constructor(
         }
     }
 
-    private inner class LocalLease(private val registration: LeaseRegistration) :
-        CoordinatedInputLease {
+    private inner class LocalLease(
+        private val registration: LeaseRegistration,
+        private val requestId: String,
+    ) : CoordinatedInputLease {
         private val closed = AtomicBoolean()
 
         override val token: LeaseToken
@@ -309,7 +316,8 @@ private constructor(
             }
             if (connected.get()) {
                 runCatching {
-                        send(tokenMessage(CoordinatorWireKind.RELEASE, token)).requireSuccess()
+                        send(tokenMessage(CoordinatorWireKind.RELEASE, token, requestId))
+                            .requireSuccess()
                     }
                     .onFailure { this@LocalInputCoordinatorClient.close() }
             }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -159,8 +159,8 @@ private constructor(
                 )
             } catch (failure: IOException) {
                 val interrupted = Thread.currentThread().isInterrupted
-                cancelAcquire(requestId)
-                if (!interrupted) close()
+                val cancellationAcknowledged = cancelAcquire(requestId)
+                if (!interrupted || !cancellationAcknowledged) close()
                 throw failure
             }
         response.requireSuccess()
@@ -216,19 +216,21 @@ private constructor(
         }
     }
 
-    private fun cancelAcquire(requestId: String) {
+    private fun cancelAcquire(requestId: String): Boolean {
         val wasInterrupted = Thread.interrupted()
-        try {
+        return try {
             runCatching {
-                send(
-                    CoordinatorWireMessage(
-                        kind = CoordinatorWireKind.CANCEL,
-                        requestId = requestId,
-                        clientId = clientId,
-                        resourceKey = resourceKey.value,
-                    )
-                )
-            }
+                    send(
+                            CoordinatorWireMessage(
+                                kind = CoordinatorWireKind.CANCEL,
+                                requestId = requestId,
+                                clientId = clientId,
+                                resourceKey = resourceKey.value,
+                            )
+                        )
+                        .requireSuccess()
+                }
+                .isSuccess
         } finally {
             if (wasInterrupted) Thread.currentThread().interrupt()
         }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -319,11 +319,15 @@ private constructor(
             leaseRegistrations.computeIfPresent(token.leaseId) { _, existing ->
                 if (existing !== registration || existing.release() > 0) existing else null
             }
-            runCatching {
-                    send(tokenMessage(CoordinatorWireKind.RELEASE, token, requestId))
-                        .requireSuccess()
+            val release = tokenMessage(CoordinatorWireKind.RELEASE, token, requestId)
+            val firstAttempt = runCatching { send(release).requireSuccess() }
+            val result =
+                if (firstAttempt.exceptionOrNull() is IOException && connected.get()) {
+                    runCatching { send(release).requireSuccess() }
+                } else {
+                    firstAttempt
                 }
-                .onFailure { this@LocalInputCoordinatorClient.close() }
+            result.onFailure { this@LocalInputCoordinatorClient.close() }
         }
     }
 

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -1,0 +1,532 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.io.IOException
+import java.io.InterruptedIOException
+import java.net.SocketTimeoutException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.SocketChannel
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Executors
+import java.util.concurrent.FutureTask
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.TimeoutException
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
+
+/** Public, redacted holder diagnostics returned by coordinator inspection. */
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorHolderStatus(
+    public val leaseId: String,
+    public val owner: LeaseOwner,
+    public val state: String,
+    public val fence: Long,
+    public val acquisitionAgeMillis: Long,
+    public val heartbeatAgeMillis: Long,
+    public val currentOperation: String?,
+)
+
+/** Public, redacted queued-owner diagnostics returned by coordinator inspection. */
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorWaiterStatus(
+    public val requestId: String,
+    public val owner: LeaseOwner,
+    public val position: Int,
+)
+
+/** Public recovery quarantine details returned by coordinator inspection. */
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorQuarantineStatus(
+    public val predecessorLeaseId: String,
+    public val predecessorEpoch: String,
+    public val owner: LeaseOwner,
+    public val releaseEligibleAtMillis: Long,
+)
+
+/** Current redacted coordination state for one desktop key. */
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorStatus(
+    public val resourceKey: DesktopResourceKey,
+    public val holder: CoordinatorHolderStatus?,
+    public val waiters: List<CoordinatorWaiterStatus>,
+    public val quarantine: CoordinatorQuarantineStatus?,
+)
+
+/** Result of an observe/control request that deliberately never launches a coordinator. */
+@ExperimentalSpectreInputCoordinationApi
+public sealed interface CoordinatorControlResult {
+    public data object NoActiveCoordinator : CoordinatorControlResult
+
+    public data class Active(public val status: CoordinatorStatus) : CoordinatorControlResult
+}
+
+/** Result of an exact-ID revoke request. */
+@ExperimentalSpectreInputCoordinationApi
+public data class CoordinatorRevokeResult(public val unsafeTakeover: Boolean)
+
+/** Stable coordinator acquisition or fencing failure. */
+@ExperimentalSpectreInputCoordinationApi
+public class InputCoordinatorException(public val errorCode: String, message: String) :
+    IllegalStateException(message)
+
+/** One epoch- and generation-fenced desktop input lease. */
+@ExperimentalSpectreInputCoordinationApi
+public interface CoordinatedInputLease : AutoCloseable {
+    public val token: LeaseToken
+
+    /** Returns false after release, coordinator disconnect, epoch change, or fencing. */
+    public fun isValid(): Boolean
+
+    /** Fails closed when the lease can no longer start coordinated work. */
+    public fun checkpoint()
+
+    override fun close()
+}
+
+/** Client session for one desktop resource and one local owner identity. */
+@ExperimentalSpectreInputCoordinationApi
+public class LocalInputCoordinatorClient
+private constructor(
+    private val endpoint: CoordinatorEndpoint,
+    private val resourceKey: DesktopResourceKey,
+    private val clientId: String,
+    private val owner: LeaseOwner,
+    private val sessionChannel: SocketChannel,
+    public val coordinatorEpoch: String,
+    private val codec: CoordinatorWireCodec,
+    private val heartbeatExecutor: ScheduledExecutorService,
+) : AutoCloseable {
+    private val connected = AtomicBoolean(true)
+    private val closed = AtomicBoolean()
+    private val leaseRegistrations = ConcurrentHashMap<String, LeaseRegistration>()
+
+    init {
+        Thread.ofVirtual().name("spectre-input-session-watch").start {
+            try {
+                codec.readOrNull(sessionChannel)
+            } catch (_: IOException) {
+                // Connection loss is represented by the shared connected fence below.
+            } finally {
+                connected.set(false)
+            }
+        }
+        heartbeatExecutor.scheduleWithFixedDelay(
+            ::heartbeatAll,
+            HEARTBEAT_INTERVAL_MILLIS,
+            HEARTBEAT_INTERVAL_MILLIS,
+            TimeUnit.MILLISECONDS,
+        )
+    }
+
+    /** Acquires or queues for this client's desktop resource for at most [timeout]. */
+    public fun acquire(timeout: Duration, currentOperation: String? = null): CoordinatedInputLease {
+        return acquire(timeout, currentOperation, waitForLease = true)
+    }
+
+    /** Acquires only when immediately available, without joining the FIFO waiter queue. */
+    public fun tryAcquire(currentOperation: String? = null): CoordinatedInputLease {
+        return acquire(MINIMUM_ACQUIRE_TIMEOUT, currentOperation, waitForLease = false)
+    }
+
+    private fun acquire(
+        timeout: Duration,
+        currentOperation: String?,
+        waitForLease: Boolean,
+    ): CoordinatedInputLease {
+        require(!timeout.isNegative && !timeout.isZero) { "Acquire timeout must be positive" }
+        ensureConnected()
+        val requestId = UUID.randomUUID().toString()
+        val response =
+            try {
+                send(
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.ACQUIRE,
+                        requestId = requestId,
+                        clientId = clientId,
+                        resourceKey = resourceKey.value,
+                        processId = owner.processId,
+                        ownerLabel = owner.label,
+                        timeoutMillis = timeout.toMillis(),
+                        waitForLease = waitForLease,
+                        currentOperation = currentOperation,
+                    )
+                )
+            } catch (failure: IOException) {
+                cancelAcquire(requestId)
+                throw failure
+            }
+        response.requireSuccess()
+        val token =
+            LeaseToken(
+                coordinatorEpoch = requireNotNull(response.coordinatorEpoch),
+                leaseId = requireNotNull(response.leaseId),
+                resourceKey = resourceKey,
+                fence = requireNotNull(response.fence),
+            )
+        val registration =
+            requireNotNull(
+                leaseRegistrations.compute(token.leaseId) { _, existing ->
+                    if (existing == null) {
+                        LeaseRegistration(token)
+                    } else {
+                        check(existing.token == token) {
+                            "Coordinator reused lease ID ${token.leaseId} for a different token"
+                        }
+                        existing.retain()
+                        existing
+                    }
+                }
+            )
+        return LocalLease(registration)
+    }
+
+    override fun close() {
+        if (!closed.compareAndSet(false, true)) return
+        connected.set(false)
+        heartbeatExecutor.shutdownNow()
+        runCatching { sessionChannel.close() }
+        leaseRegistrations.values.forEach(LeaseRegistration::invalidate)
+        leaseRegistrations.clear()
+    }
+
+    private fun heartbeatAll() {
+        if (!connected.get()) return
+        leaseRegistrations.values.filter(LeaseRegistration::isValid).forEach { registration ->
+            runCatching {
+                    send(tokenMessage(CoordinatorWireKind.HEARTBEAT, registration.token))
+                        .requireSuccess()
+                }
+                .onFailure {
+                    registration.invalidate()
+                    if (
+                        it !is InputCoordinatorException ||
+                            it.errorCode == LeaseErrorCode.STALE_EPOCH.name
+                    ) {
+                        connected.set(false)
+                    }
+                }
+        }
+    }
+
+    private fun cancelAcquire(requestId: String) {
+        val wasInterrupted = Thread.interrupted()
+        try {
+            runCatching {
+                send(
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.CANCEL,
+                        requestId = requestId,
+                        clientId = clientId,
+                        resourceKey = resourceKey.value,
+                    )
+                )
+            }
+        } finally {
+            if (wasInterrupted) Thread.currentThread().interrupt()
+        }
+    }
+
+    private fun send(message: CoordinatorWireMessage): CoordinatorWireMessage =
+        sendCoordinatorMessage(endpoint, codec, message, responseTimeout(message))
+
+    private fun responseTimeout(message: CoordinatorWireMessage): Duration =
+        when {
+            message.kind != CoordinatorWireKind.ACQUIRE -> REQUEST_RESPONSE_TIMEOUT
+            !message.waitForLease -> IMMEDIATE_RESPONSE_TIMEOUT
+            else ->
+                Duration.ofMillis(
+                    requireNotNull(message.timeoutMillis) + ACQUIRE_RESPONSE_GRACE_MILLIS
+                )
+        }
+
+    private fun tokenMessage(kind: CoordinatorWireKind, token: LeaseToken): CoordinatorWireMessage =
+        CoordinatorWireMessage(
+            kind = kind,
+            clientId = clientId,
+            resourceKey = token.resourceKey.value,
+            coordinatorEpoch = token.coordinatorEpoch,
+            leaseId = token.leaseId,
+            fence = token.fence,
+        )
+
+    private fun ensureConnected() {
+        if (!connected.get()) {
+            throw InputCoordinatorException(
+                errorCode = LeaseErrorCode.STALE_EPOCH.name,
+                message =
+                    "Input coordinator session is disconnected; acquire from the current epoch",
+            )
+        }
+    }
+
+    private inner class LocalLease(private val registration: LeaseRegistration) :
+        CoordinatedInputLease {
+        private val closed = AtomicBoolean()
+
+        override val token: LeaseToken
+            get() = registration.token
+
+        override fun isValid(): Boolean =
+            !closed.get() &&
+                registration.isValid() &&
+                connected.get() &&
+                token.coordinatorEpoch == coordinatorEpoch
+
+        override fun checkpoint() {
+            if (isValid()) {
+                val response =
+                    try {
+                        send(tokenMessage(CoordinatorWireKind.HEARTBEAT, token))
+                    } catch (failure: IOException) {
+                        registration.invalidate()
+                        connected.set(false)
+                        throw failure
+                    }
+                if (response.ok) return
+                registration.invalidate()
+            }
+            if (!isValid()) {
+                throw InputCoordinatorException(
+                    errorCode = LeaseErrorCode.FENCED.name,
+                    message =
+                        "Input lease ${token.leaseId} is released, fenced, or from a stale epoch",
+                )
+            }
+        }
+
+        override fun close() {
+            if (!closed.compareAndSet(false, true)) return
+            leaseRegistrations.computeIfPresent(token.leaseId) { _, existing ->
+                if (existing !== registration || existing.release() > 0) existing else null
+            }
+            if (connected.get())
+                runCatching { send(tokenMessage(CoordinatorWireKind.RELEASE, token)) }
+        }
+    }
+
+    private class LeaseRegistration(val token: LeaseToken) {
+        private val valid = AtomicBoolean(true)
+        private val references = AtomicInteger(1)
+
+        fun isValid(): Boolean = valid.get()
+
+        fun retain() {
+            references.incrementAndGet()
+        }
+
+        fun release(): Int = references.decrementAndGet()
+
+        fun invalidate() {
+            valid.set(false)
+        }
+    }
+
+    public companion object {
+        /** Connects to an already-running compatible coordinator and opens an owner session. */
+        @Throws(IOException::class)
+        public fun connect(
+            endpoint: CoordinatorEndpoint,
+            resourceKey: DesktopResourceKey,
+            ownerLabel: String? = null,
+            codec: CoordinatorWireCodec = CoordinatorWireCodec(),
+        ): LocalInputCoordinatorClient {
+            val clientId = UUID.randomUUID().toString()
+            val processId = ProcessHandle.current().pid()
+            val session = SocketChannel.open(StandardProtocolFamily.UNIX)
+            var sessionTransferred = false
+            try {
+                val response =
+                    runCoordinatorIo(SESSION_OPEN_TIMEOUT) {
+                        session.connect(UnixDomainSocketAddress.of(endpoint.socketPath))
+                        codec.write(
+                            session,
+                            CoordinatorWireMessage(
+                                kind = CoordinatorWireKind.SESSION_OPEN,
+                                clientId = clientId,
+                                processId = processId,
+                                ownerLabel = ownerLabel,
+                            ),
+                        )
+                        codec.read(session)
+                    }
+                response.requireSuccess()
+                val client =
+                    LocalInputCoordinatorClient(
+                        endpoint = endpoint,
+                        resourceKey = resourceKey,
+                        clientId = clientId,
+                        owner = LeaseOwner(clientId, processId, ownerLabel),
+                        sessionChannel = session,
+                        coordinatorEpoch = requireNotNull(response.coordinatorEpoch),
+                        codec = codec,
+                        heartbeatExecutor = daemonScheduler(),
+                    )
+                sessionTransferred = true
+                return client
+            } finally {
+                if (!sessionTransferred) session.close()
+            }
+        }
+
+        private fun daemonScheduler(): ScheduledExecutorService =
+            Executors.newSingleThreadScheduledExecutor { task ->
+                Thread(task, "spectre-input-heartbeat").apply { isDaemon = true }
+            }
+
+        private const val HEARTBEAT_INTERVAL_MILLIS: Long = 1_000
+        private const val ACQUIRE_RESPONSE_GRACE_MILLIS: Long = 1_000
+        private val MINIMUM_ACQUIRE_TIMEOUT: Duration = Duration.ofMillis(1)
+        private val IMMEDIATE_RESPONSE_TIMEOUT: Duration = Duration.ofSeconds(1)
+        private val REQUEST_RESPONSE_TIMEOUT: Duration = Duration.ofSeconds(5)
+        private val SESSION_OPEN_TIMEOUT: Duration = Duration.ofSeconds(5)
+    }
+}
+
+/** Observe/revoke client that never launches a missing coordinator. */
+@ExperimentalSpectreInputCoordinationApi
+public class LocalInputCoordinatorControl(
+    private val endpoint: CoordinatorEndpoint,
+    private val codec: CoordinatorWireCodec = CoordinatorWireCodec(),
+) {
+    /** Returns cleanly when no coordinator is accepting connections. */
+    public fun status(resourceKey: DesktopResourceKey): CoordinatorControlResult {
+        if (!java.nio.file.Files.exists(endpoint.socketPath)) {
+            return CoordinatorControlResult.NoActiveCoordinator
+        }
+        val response =
+            try {
+                send(
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.STATUS,
+                        resourceKey = resourceKey.value,
+                    )
+                )
+            } catch (_: IOException) {
+                return CoordinatorControlResult.NoActiveCoordinator
+            }
+        response.requireSuccess()
+        return CoordinatorControlResult.Active(requireNotNull(response.status).toDomain())
+    }
+
+    /** Revokes only the exact observed lease ID; [force] is an explicitly unsafe takeover. */
+    public fun revoke(
+        resourceKey: DesktopResourceKey,
+        observedLeaseId: String,
+        requesterLabel: String,
+        reason: String,
+        force: Boolean = false,
+    ): CoordinatorRevokeResult {
+        require(observedLeaseId.isNotBlank()) { "Observed lease ID must not be blank" }
+        require(requesterLabel.isNotBlank()) { "Requester label must not be blank" }
+        require(reason.isNotBlank()) { "Revoke reason must not be blank" }
+        val response =
+            send(
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.REVOKE,
+                    resourceKey = resourceKey.value,
+                    leaseId = observedLeaseId,
+                    requesterLabel = requesterLabel,
+                    reason = reason,
+                    force = force,
+                )
+            )
+        response.requireSuccess()
+        return CoordinatorRevokeResult(unsafeTakeover = response.unsafeTakeover)
+    }
+
+    private fun send(message: CoordinatorWireMessage): CoordinatorWireMessage =
+        sendCoordinatorMessage(endpoint, codec, message, CONTROL_RESPONSE_TIMEOUT)
+
+    private companion object {
+        val CONTROL_RESPONSE_TIMEOUT: Duration = Duration.ofSeconds(5)
+    }
+}
+
+internal fun sendCoordinatorMessage(
+    endpoint: CoordinatorEndpoint,
+    codec: CoordinatorWireCodec,
+    message: CoordinatorWireMessage,
+    timeout: Duration,
+): CoordinatorWireMessage =
+    runCoordinatorIo(timeout) {
+        SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+            channel.connect(UnixDomainSocketAddress.of(endpoint.socketPath))
+            codec.write(channel, message)
+            codec.read(channel)
+        }
+    }
+
+private fun <T> runCoordinatorIo(timeout: Duration, block: () -> T): T {
+    require(!timeout.isNegative && !timeout.isZero) { "Coordinator I/O timeout must be positive" }
+    val task = FutureTask<T> { block() }
+    Thread.ofVirtual().name("spectre-input-request").start(task)
+    try {
+        return task.get(timeout.toMillis(), TimeUnit.MILLISECONDS)
+    } catch (_: TimeoutException) {
+        task.cancel(true)
+        throw SocketTimeoutException(
+            "Input coordinator did not respond within ${timeout.toMillis()} ms"
+        )
+    } catch (_: InterruptedException) {
+        task.cancel(true)
+        Thread.currentThread().interrupt()
+        throw InterruptedIOException("Input coordinator request was interrupted")
+    } catch (failure: ExecutionException) {
+        val cause = failure.cause ?: failure
+        when (cause) {
+            is IOException -> throw cause
+            is RuntimeException -> throw cause
+            is Error -> throw cause
+            else -> throw IOException("Input coordinator request failed", cause)
+        }
+    }
+}
+
+private fun CoordinatorWireMessage.requireSuccess() {
+    if (!ok) {
+        throw InputCoordinatorException(
+            errorCode = errorCode ?: "UNKNOWN",
+            message = message ?: "Input coordinator request failed",
+        )
+    }
+}
+
+private fun CoordinatorWireStatus.toDomain(): CoordinatorStatus =
+    CoordinatorStatus(
+        resourceKey = DesktopResourceKey(resourceKey),
+        holder =
+            holder?.let {
+                CoordinatorHolderStatus(
+                    leaseId = it.leaseId,
+                    owner = LeaseOwner(it.clientId, it.processId, it.ownerLabel),
+                    state = it.state,
+                    fence = it.fence,
+                    acquisitionAgeMillis = it.acquisitionAgeMillis,
+                    heartbeatAgeMillis = it.heartbeatAgeMillis,
+                    currentOperation = it.currentOperation,
+                )
+            },
+        waiters =
+            waiters.map {
+                CoordinatorWaiterStatus(
+                    requestId = it.requestId,
+                    owner = LeaseOwner(it.clientId, it.processId, it.ownerLabel),
+                    position = it.position,
+                )
+            },
+        quarantine =
+            quarantine?.let {
+                CoordinatorQuarantineStatus(
+                    predecessorLeaseId = it.predecessorLeaseId,
+                    predecessorEpoch = it.predecessorEpoch,
+                    owner = LeaseOwner(it.clientId, it.processId, it.ownerLabel),
+                    releaseEligibleAtMillis = it.releaseEligibleAtMillis,
+                )
+            },
+    )

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -242,6 +242,7 @@ private constructor(
                     disconnect()
                     return
                 }
+                return@forEach
             }
             runCatching {
                     send(tokenMessage(CoordinatorWireKind.HEARTBEAT, registration.token))

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -405,11 +405,20 @@ private constructor(
                     firstAttempt
                 }
             val failure = result.exceptionOrNull()
-            if (failure.isReleasePersistenceFailure() && connected.get()) {
+            val persistenceFailure =
+                if (result.isSuccess) {
+                    null
+                } else {
+                    failure.takeIf { it.isReleasePersistenceFailure() }
+                        ?: firstAttempt.exceptionOrNull().takeIf {
+                            it.isReleasePersistenceFailure()
+                        }
+                }
+            if (persistenceFailure != null && connected.get()) {
                 registration.markReleasePending(requestId)
                 closed.set(true)
                 releaseRegistration(registration)
-                throw requireNotNull(failure)
+                throw persistenceFailure
             }
 
             closed.set(true)

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -308,10 +308,10 @@ private constructor(
                 if (existing !== registration || existing.release() > 0) existing else null
             }
             if (connected.get()) {
-                runCatching { send(tokenMessage(CoordinatorWireKind.RELEASE, token)) }
-                    .onFailure { failure ->
-                        if (failure is IOException) this@LocalInputCoordinatorClient.close()
+                runCatching {
+                        send(tokenMessage(CoordinatorWireKind.RELEASE, token)).requireSuccess()
                     }
+                    .onFailure { this@LocalInputCoordinatorClient.close() }
             }
         }
     }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -243,11 +243,14 @@ private constructor(
         when {
             message.kind != CoordinatorWireKind.ACQUIRE -> REQUEST_RESPONSE_TIMEOUT
             !message.waitForLease -> IMMEDIATE_RESPONSE_TIMEOUT
-            else ->
-                Duration.ofMillis(
-                    requireNotNull(message.timeoutMillis) + ACQUIRE_RESPONSE_GRACE_MILLIS
-                )
+            else -> acquireResponseTimeout(requireNotNull(message.timeoutMillis))
         }
+
+    private fun acquireResponseTimeout(timeoutMillis: Long): Duration =
+        Duration.ofMillis(
+            timeoutMillis.coerceAtMost(Long.MAX_VALUE - ACQUIRE_RESPONSE_GRACE_MILLIS) +
+                ACQUIRE_RESPONSE_GRACE_MILLIS
+        )
 
     private fun tokenMessage(
         kind: CoordinatorWireKind,

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -316,13 +316,11 @@ private constructor(
             leaseRegistrations.computeIfPresent(token.leaseId) { _, existing ->
                 if (existing !== registration || existing.release() > 0) existing else null
             }
-            if (connected.get()) {
-                runCatching {
-                        send(tokenMessage(CoordinatorWireKind.RELEASE, token, requestId))
-                            .requireSuccess()
-                    }
-                    .onFailure { this@LocalInputCoordinatorClient.close() }
-            }
+            runCatching {
+                    send(tokenMessage(CoordinatorWireKind.RELEASE, token, requestId))
+                        .requireSuccess()
+                }
+                .onFailure { this@LocalInputCoordinatorClient.close() }
         }
     }
 

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -158,7 +158,9 @@ private constructor(
                     )
                 )
             } catch (failure: IOException) {
+                val interrupted = Thread.currentThread().isInterrupted
                 cancelAcquire(requestId)
+                if (!interrupted) close()
                 throw failure
             }
         response.requireSuccess()

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -113,7 +113,7 @@ private constructor(
             } catch (_: IOException) {
                 // Connection loss is represented by the shared connected fence below.
             } finally {
-                connected.set(false)
+                close()
             }
         }
         heartbeatExecutor.scheduleWithFixedDelay(
@@ -208,7 +208,7 @@ private constructor(
                         it !is InputCoordinatorException ||
                             it.errorCode == LeaseErrorCode.STALE_EPOCH.name
                     ) {
-                        connected.set(false)
+                        close()
                     }
                 }
         }
@@ -285,7 +285,7 @@ private constructor(
                         send(tokenMessage(CoordinatorWireKind.HEARTBEAT, token))
                     } catch (failure: IOException) {
                         registration.invalidate()
-                        connected.set(false)
+                        this@LocalInputCoordinatorClient.close()
                         throw failure
                     }
                 if (response.ok) return
@@ -305,8 +305,12 @@ private constructor(
             leaseRegistrations.computeIfPresent(token.leaseId) { _, existing ->
                 if (existing !== registration || existing.release() > 0) existing else null
             }
-            if (connected.get())
+            if (connected.get()) {
                 runCatching { send(tokenMessage(CoordinatorWireKind.RELEASE, token)) }
+                    .onFailure { failure ->
+                        if (failure is IOException) this@LocalInputCoordinatorClient.close()
+                    }
+            }
         }
     }
 

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClient.kt
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.TimeoutException
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
 
 /** Public, redacted holder diagnostics returned by coordinator inspection. */
 @ExperimentalSpectreInputCoordinationApi
@@ -86,6 +87,12 @@ public interface CoordinatedInputLease : AutoCloseable {
     /** Fails closed when the lease can no longer start coordinated work. */
     public fun checkpoint()
 
+    /**
+     * Releases this hold.
+     *
+     * @throws InputCoordinatorException when release persistence fails. The client retains the
+     *   exact release request and retries it in the background while its session is connected.
+     */
     override fun close()
 }
 
@@ -103,6 +110,7 @@ private constructor(
     private val heartbeatExecutor: ScheduledExecutorService,
 ) : AutoCloseable {
     private val connected = AtomicBoolean(true)
+    private val closeRequested = AtomicBoolean()
     private val closed = AtomicBoolean()
     private val leaseRegistrations = ConcurrentHashMap<String, LeaseRegistration>()
 
@@ -113,7 +121,7 @@ private constructor(
             } catch (_: IOException) {
                 // Connection loss is represented by the shared connected fence below.
             } finally {
-                close()
+                disconnect()
             }
         }
         heartbeatExecutor.scheduleWithFixedDelay(
@@ -188,7 +196,15 @@ private constructor(
         return LocalLease(registration, requestId)
     }
 
+    @Synchronized
     override fun close() {
+        closeRequested.set(true)
+        if (leaseRegistrations.values.any(LeaseRegistration::hasPendingRelease)) return
+        disconnect()
+    }
+
+    @Synchronized
+    private fun disconnect() {
         if (!closed.compareAndSet(false, true)) return
         connected.set(false)
         heartbeatExecutor.shutdownNow()
@@ -200,6 +216,33 @@ private constructor(
     private fun heartbeatAll() {
         if (!connected.get()) return
         leaseRegistrations.values.filter(LeaseRegistration::isValid).forEach { registration ->
+            if (!connected.get()) return
+            val pendingRequestId = registration.pendingReleaseRequestId()
+            if (pendingRequestId != null) {
+                val releaseFailure =
+                    runCatching {
+                            send(
+                                    tokenMessage(
+                                        CoordinatorWireKind.RELEASE,
+                                        registration.token,
+                                        pendingRequestId,
+                                    )
+                                )
+                                .requireSuccess()
+                        }
+                        .exceptionOrNull()
+                if (releaseFailure == null) {
+                    completePendingRelease(registration, pendingRequestId)
+                    return@forEach
+                }
+                if (
+                    releaseFailure !is IOException && !releaseFailure.isReleasePersistenceFailure()
+                ) {
+                    registration.invalidate()
+                    disconnect()
+                    return
+                }
+            }
             runCatching {
                     send(tokenMessage(CoordinatorWireKind.HEARTBEAT, registration.token))
                         .requireSuccess()
@@ -210,9 +253,36 @@ private constructor(
                         it !is InputCoordinatorException ||
                             it.errorCode == LeaseErrorCode.STALE_EPOCH.name
                     ) {
-                        close()
+                        disconnect()
                     }
                 }
+        }
+    }
+
+    @Synchronized
+    private fun releaseRegistration(registration: LeaseRegistration) {
+        leaseRegistrations.computeIfPresent(registration.token.leaseId) { _, existing ->
+            if (
+                existing !== registration || existing.release() > 0 || existing.hasPendingRelease()
+            ) {
+                existing
+            } else {
+                null
+            }
+        }
+    }
+
+    @Synchronized
+    private fun completePendingRelease(registration: LeaseRegistration, requestId: String) {
+        registration.completePendingRelease(requestId)
+        leaseRegistrations.computeIfPresent(registration.token.leaseId) { _, existing ->
+            if (existing !== registration || !existing.canRemove()) existing else null
+        }
+        if (
+            closeRequested.get() &&
+                leaseRegistrations.values.none(LeaseRegistration::hasPendingRelease)
+        ) {
+            disconnect()
         }
     }
 
@@ -299,7 +369,7 @@ private constructor(
                         send(tokenMessage(CoordinatorWireKind.HEARTBEAT, token))
                     } catch (failure: IOException) {
                         registration.invalidate()
-                        this@LocalInputCoordinatorClient.close()
+                        this@LocalInputCoordinatorClient.disconnect()
                         throw failure
                     }
                 if (response.ok) return
@@ -314,26 +384,41 @@ private constructor(
             }
         }
 
+        @Synchronized
         override fun close() {
-            if (!closed.compareAndSet(false, true)) return
-            leaseRegistrations.computeIfPresent(token.leaseId) { _, existing ->
-                if (existing !== registration || existing.release() > 0) existing else null
-            }
+            if (closed.get()) return
             val release = tokenMessage(CoordinatorWireKind.RELEASE, token, requestId)
             val firstAttempt = runCatching { send(release).requireSuccess() }
             val result =
-                if (firstAttempt.exceptionOrNull() is IOException && connected.get()) {
+                if (firstAttempt.exceptionOrNull().isRetryableReleaseFailure() && connected.get()) {
                     runCatching { send(release).requireSuccess() }
                 } else {
                     firstAttempt
                 }
-            result.onFailure { this@LocalInputCoordinatorClient.close() }
+            val failure = result.exceptionOrNull()
+            if (failure.isReleasePersistenceFailure() && connected.get()) {
+                registration.markReleasePending(requestId)
+                closed.set(true)
+                releaseRegistration(registration)
+                throw requireNotNull(failure)
+            }
+
+            closed.set(true)
+            releaseRegistration(registration)
+            if (failure != null) this@LocalInputCoordinatorClient.disconnect()
         }
+
+        private fun Throwable?.isRetryableReleaseFailure(): Boolean =
+            this is IOException || isReleasePersistenceFailure()
+
+        private fun Throwable?.isReleasePersistenceFailure(): Boolean =
+            this is InputCoordinatorException && errorCode == RELEASE_PERSISTENCE_ERROR
     }
 
     private class LeaseRegistration(val token: LeaseToken) {
         private val valid = AtomicBoolean(true)
         private val references = AtomicInteger(1)
+        private val pendingReleaseRequestId = AtomicReference<String?>()
 
         fun isValid(): Boolean = valid.get()
 
@@ -343,10 +428,31 @@ private constructor(
 
         fun release(): Int = references.decrementAndGet()
 
+        fun markReleasePending(requestId: String) {
+            check(pendingReleaseRequestId.compareAndSet(null, requestId)) {
+                "Lease ${token.leaseId} already has a pending release"
+            }
+        }
+
+        fun pendingReleaseRequestId(): String? = pendingReleaseRequestId.get()
+
+        fun hasPendingRelease(): Boolean = pendingReleaseRequestId.get() != null
+
+        fun completePendingRelease(requestId: String) {
+            check(pendingReleaseRequestId.compareAndSet(requestId, null)) {
+                "Lease ${token.leaseId} pending release changed before acknowledgement"
+            }
+        }
+
+        fun canRemove(): Boolean = references.get() == 0 && !hasPendingRelease()
+
         fun invalidate() {
             valid.set(false)
         }
     }
+
+    private fun Throwable?.isReleasePersistenceFailure(): Boolean =
+        this is InputCoordinatorException && errorCode == RELEASE_PERSISTENCE_ERROR
 
     public companion object {
         /** Connects to an already-running compatible coordinator and opens an owner session. */
@@ -402,6 +508,7 @@ private constructor(
 
         private const val HEARTBEAT_INTERVAL_MILLIS: Long = 1_000
         private const val ACQUIRE_RESPONSE_GRACE_MILLIS: Long = 1_000
+        private const val RELEASE_PERSISTENCE_ERROR: String = "RECOVERY_PERSISTENCE_FAILED"
         private val MINIMUM_ACQUIRE_TIMEOUT: Duration = Duration.ofMillis(1)
         private val IMMEDIATE_RESPONSE_TIMEOUT: Duration = Duration.ofSeconds(1)
         private val REQUEST_RESPONSE_TIMEOUT: Duration = Duration.ofSeconds(5)

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientProvider.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientProvider.kt
@@ -1,0 +1,39 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.util.ServiceLoader
+
+/** Runtime provider that can make the external coordinator available and open a client session. */
+@ExperimentalSpectreInputCoordinationApi
+public fun interface InputCoordinatorClientProvider {
+    /** Connects to, or safely starts and then connects to, the coordinator for [endpoint]. */
+    public fun connect(
+        endpoint: CoordinatorEndpoint,
+        resourceKey: DesktopResourceKey,
+        ownerLabel: String?,
+    ): LocalInputCoordinatorClient
+}
+
+/**
+ * Discovers the process artifact without making `spectre-core` embed coordinator server classes.
+ */
+@ExperimentalSpectreInputCoordinationApi
+public object InputCoordinatorClientFactory {
+    /** Connects through the installed process provider or fails closed when it is absent. */
+    public fun connectOrStart(
+        endpoint: CoordinatorEndpoint = LocalCoordinatorEnvironment.defaultEndpoint(),
+        resourceKey: DesktopResourceKey = LocalCoordinatorEnvironment.defaultDesktopResourceKey(),
+        ownerLabel: String? = null,
+    ): LocalInputCoordinatorClient {
+        val provider =
+            ServiceLoader.load(InputCoordinatorClientProvider::class.java).firstOrNull()
+                ?: throw InputCoordinatorException(
+                    errorCode = "COORDINATOR_PROVIDER_MISSING",
+                    message =
+                        "No Spectre input coordinator process provider is installed; add " +
+                            "spectre-input-coordinator-server to the runtime classpath",
+                )
+        return provider.connect(endpoint, resourceKey, ownerLabel)
+    }
+}

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LeaseModels.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LeaseModels.kt
@@ -1,0 +1,43 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+/** Identifies one conservatively normalized desktop input resource. */
+@ExperimentalSpectreInputCoordinationApi
+public data class DesktopResourceKey(public val value: String) {
+    init {
+        require(value.isNotBlank()) { "Desktop resource key must not be blank" }
+    }
+}
+
+/** Redacted metadata describing a cooperative lease owner. */
+@ExperimentalSpectreInputCoordinationApi
+public data class LeaseOwner(
+    public val clientId: String,
+    public val processId: Long,
+    public val label: String? = null,
+) {
+    init {
+        require(clientId.isNotBlank()) { "Client ID must not be blank" }
+        require(processId >= 0) { "Process ID must not be negative" }
+    }
+}
+
+/** Epoch- and generation-fenced proof that a client currently owns a desktop resource. */
+@ExperimentalSpectreInputCoordinationApi
+public data class LeaseToken(
+    public val coordinatorEpoch: String,
+    public val leaseId: String,
+    public val resourceKey: DesktopResourceKey,
+    public val fence: Long,
+)
+
+/** Stable failure taxonomy shared by coordinator clients and servers. */
+@ExperimentalSpectreInputCoordinationApi
+public enum class LeaseErrorCode {
+    QUEUE_FULL,
+    STALE_LEASE,
+    STALE_EPOCH,
+    FENCED,
+    REVOKE_GRACE_ACTIVE,
+}

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LocalCoordinatorEnvironment.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LocalCoordinatorEnvironment.kt
@@ -1,0 +1,68 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.nio.file.Path
+
+/**
+ * Production-only discovery of the current process's canonical coordinator endpoint and desktop.
+ */
+@ExperimentalSpectreInputCoordinationApi
+public object LocalCoordinatorEnvironment {
+    /**
+     * Resolves the stable same-user coordinator endpoint without consulting the working directory.
+     */
+    public fun defaultEndpoint(): CoordinatorEndpoint {
+        val platform = currentPlatform()
+        val baseDirectory =
+            if (platform == DesktopPlatform.WINDOWS) {
+                System.getenv("LOCALAPPDATA")?.takeIf(String::isNotBlank)?.let(Path::of)
+                    ?: Path.of(System.getProperty("java.io.tmpdir"))
+            } else {
+                Path.of("/tmp")
+            }
+        return CoordinatorEndpointResolver.resolve(baseDirectory, effectiveUserId(platform))
+    }
+
+    /** Derives the desktop key from the environment inside the process that will dispatch input. */
+    public fun defaultDesktopResourceKey(): DesktopResourceKey {
+        val platform = currentPlatform()
+        return DesktopIdentityResolver()
+            .resolve(
+                DesktopIdentityEnvironment(
+                    platform = platform,
+                    effectiveUserId = effectiveUserId(platform),
+                    environment = System.getenv(),
+                    windowsLogonSessionId =
+                        if (platform == DesktopPlatform.WINDOWS) System.getenv("SESSIONNAME")
+                        else null,
+                )
+            )
+    }
+
+    private fun currentPlatform(): DesktopPlatform {
+        val osName = System.getProperty("os.name").orEmpty()
+        return when {
+            osName.startsWith("Mac", ignoreCase = true) -> DesktopPlatform.MACOS
+            osName.startsWith("Windows", ignoreCase = true) -> DesktopPlatform.WINDOWS
+            else -> DesktopPlatform.LINUX
+        }
+    }
+
+    private fun effectiveUserId(platform: DesktopPlatform): String {
+        if (platform == DesktopPlatform.WINDOWS) return System.getProperty("user.name")
+        return try {
+            val unixSystem =
+                Class.forName("com.sun.security.auth.module.UnixSystem")
+                    .getDeclaredConstructor()
+                    .newInstance()
+            (unixSystem.javaClass.getMethod("getUid").invoke(unixSystem) as Number)
+                .toLong()
+                .toString()
+        } catch (_: ReflectiveOperationException) {
+            System.getProperty("user.name")
+        } catch (_: SecurityException) {
+            System.getProperty("user.name")
+        }
+    }
+}

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LocalCoordinatorEnvironment.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LocalCoordinatorEnvironment.kt
@@ -49,5 +49,7 @@ public object LocalCoordinatorEnvironment {
         }
     }
 
-    private fun effectiveUserId(): String = System.getProperty("user.name")
+    private fun effectiveUserId(): String =
+        ProcessHandle.current().info().user().orElse(null)?.takeIf(String::isNotBlank)
+            ?: error("Could not determine the current process owner identity")
 }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LocalCoordinatorEnvironment.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LocalCoordinatorEnvironment.kt
@@ -21,7 +21,7 @@ public object LocalCoordinatorEnvironment {
             } else {
                 Path.of("/tmp")
             }
-        return CoordinatorEndpointResolver.resolve(baseDirectory, effectiveUserId(platform))
+        return CoordinatorEndpointResolver.resolve(baseDirectory, effectiveUserId())
     }
 
     /** Derives the desktop key from the environment inside the process that will dispatch input. */
@@ -31,7 +31,7 @@ public object LocalCoordinatorEnvironment {
             .resolve(
                 DesktopIdentityEnvironment(
                     platform = platform,
-                    effectiveUserId = effectiveUserId(platform),
+                    effectiveUserId = effectiveUserId(),
                     environment = System.getenv(),
                     // SESSIONNAME is a mutable transport label, not the numeric process session
                     // ID. Until a verified native ID is available, serialize Windows per user.
@@ -49,20 +49,5 @@ public object LocalCoordinatorEnvironment {
         }
     }
 
-    private fun effectiveUserId(platform: DesktopPlatform): String {
-        if (platform == DesktopPlatform.WINDOWS) return System.getProperty("user.name")
-        return try {
-            val unixSystem =
-                Class.forName("com.sun.security.auth.module.UnixSystem")
-                    .getDeclaredConstructor()
-                    .newInstance()
-            (unixSystem.javaClass.getMethod("getUid").invoke(unixSystem) as Number)
-                .toLong()
-                .toString()
-        } catch (_: ReflectiveOperationException) {
-            System.getProperty("user.name")
-        } catch (_: SecurityException) {
-            System.getProperty("user.name")
-        }
-    }
+    private fun effectiveUserId(): String = System.getProperty("user.name")
 }

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LocalCoordinatorEnvironment.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/LocalCoordinatorEnvironment.kt
@@ -33,9 +33,9 @@ public object LocalCoordinatorEnvironment {
                     platform = platform,
                     effectiveUserId = effectiveUserId(platform),
                     environment = System.getenv(),
-                    windowsLogonSessionId =
-                        if (platform == DesktopPlatform.WINDOWS) System.getenv("SESSIONNAME")
-                        else null,
+                    // SESSIONNAME is a mutable transport label, not the numeric process session
+                    // ID. Until a verified native ID is available, serialize Windows per user.
+                    windowsLogonSessionId = null,
                 )
             )
     }

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
@@ -1,0 +1,112 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.io.IOException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import kotlin.io.path.createSymbolicLinkPointingTo
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
+
+class CoordinatorEndpointTest {
+
+    @TempDir lateinit var temporaryDirectory: Path
+
+    @Test
+    fun `endpoint name depends on effective user identity but not launcher environment`() {
+        val first =
+            CoordinatorEndpointResolver.resolve(
+                baseDirectory = Path.of("/tmp"),
+                effectiveUserId = "501",
+            )
+        val second =
+            CoordinatorEndpointResolver.resolve(
+                baseDirectory = Path.of("/tmp"),
+                effectiveUserId = "501",
+            )
+
+        assertEquals(first, second)
+        assertTrue(first.socketPath.fileName.toString().startsWith("input-v1-"))
+        assertFalse(first.socketPath.toString().contains("501"))
+    }
+
+    @Test
+    fun `UDS path length is rejected before bind or connect`() {
+        val longBase = temporaryDirectory.resolve("x".repeat(120))
+
+        val failure =
+            assertFailsWith<IOException> {
+                CoordinatorEndpointResolver.resolve(longBase, effectiveUserId = "501")
+            }
+
+        assertTrue(failure.message.orEmpty().contains("Unix-domain socket path"))
+    }
+
+    @Test
+    fun `owner-only directory is created with private POSIX permissions`() {
+        val endpoint =
+            CoordinatorEndpoint(
+                directory = temporaryDirectory.resolve("coordinator"),
+                socketPath = temporaryDirectory.resolve("coordinator/input.sock"),
+            )
+        val protection = OwnerOnlyEndpointProtection.forPath(endpoint.socketPath)
+
+        protection.prepareDirectory(endpoint.socketPath)
+
+        if (Files.getFileStore(endpoint.directory).supportsFileAttributeView("posix")) {
+            assertEquals(
+                PosixFilePermissions.fromString("rwx------"),
+                Files.getPosixFilePermissions(endpoint.directory),
+            )
+        }
+    }
+
+    @Test
+    fun `symbolic-link endpoint directory is rejected without following it`() {
+        val target = temporaryDirectory.resolve("target")
+        Files.createDirectory(target)
+        val link = temporaryDirectory.resolve("spectre-input-link")
+        try {
+            link.createSymbolicLinkPointingTo(target)
+        } catch (_: UnsupportedOperationException) {
+            return
+        }
+        val socket = link.resolve("input.sock")
+
+        val failure =
+            assertFailsWith<IOException> {
+                OwnerOnlyEndpointProtection.forPath(socket).prepareDirectory(socket)
+            }
+
+        assertTrue(failure.message.orEmpty().contains("symbolic link"))
+    }
+
+    @Test
+    fun `existing broad POSIX directory is rejected instead of silently chmodded`() {
+        val endpoint =
+            CoordinatorEndpoint(
+                directory = temporaryDirectory.resolve("coordinator"),
+                socketPath = temporaryDirectory.resolve("coordinator/input.sock"),
+            )
+        Files.createDirectory(endpoint.directory)
+        if (!Files.getFileStore(endpoint.directory).supportsFileAttributeView("posix")) return
+        Files.setPosixFilePermissions(
+            endpoint.directory,
+            PosixFilePermissions.fromString("rwxrwxrwx"),
+        )
+
+        val failure =
+            assertFailsWith<IOException> {
+                OwnerOnlyEndpointProtection.forPath(endpoint.socketPath)
+                    .prepareDirectory(endpoint.socketPath)
+            }
+
+        assertTrue(failure.message.orEmpty().contains("owner-only"))
+    }
+}

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
@@ -19,6 +19,18 @@ class CoordinatorEndpointTest {
     @TempDir lateinit var temporaryDirectory: Path
 
     @Test
+    fun `default POSIX endpoint uses the runtime-independent username identity`() {
+        if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) return
+        val expected =
+            CoordinatorEndpointResolver.resolve(
+                baseDirectory = Path.of("/tmp"),
+                effectiveUserId = System.getProperty("user.name"),
+            )
+
+        assertEquals(expected, LocalCoordinatorEnvironment.defaultEndpoint())
+    }
+
+    @Test
     fun `endpoint name depends on effective user identity but not launcher environment`() {
         val first =
             CoordinatorEndpointResolver.resolve(

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
@@ -19,15 +19,30 @@ class CoordinatorEndpointTest {
     @TempDir lateinit var temporaryDirectory: Path
 
     @Test
-    fun `default POSIX endpoint uses the runtime-independent username identity`() {
+    fun `default POSIX endpoint uses the process owner identity`() {
         if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) return
         val expected =
             CoordinatorEndpointResolver.resolve(
                 baseDirectory = Path.of("/tmp"),
-                effectiveUserId = System.getProperty("user.name"),
+                effectiveUserId = requireNotNull(ProcessHandle.current().info().user().orElse(null)),
             )
 
         assertEquals(expected, LocalCoordinatorEnvironment.defaultEndpoint())
+    }
+
+    @Test
+    fun `default endpoint and desktop key ignore the mutable JVM username`() {
+        val originalUserName = System.getProperty("user.name")
+        val expectedEndpoint = LocalCoordinatorEnvironment.defaultEndpoint()
+        val expectedResource = LocalCoordinatorEnvironment.defaultDesktopResourceKey()
+        try {
+            System.setProperty("user.name", "isolated-jvm-user")
+
+            assertEquals(expectedEndpoint, LocalCoordinatorEnvironment.defaultEndpoint())
+            assertEquals(expectedResource, LocalCoordinatorEnvironment.defaultDesktopResourceKey())
+        } finally {
+            System.setProperty("user.name", originalUserName)
+        }
     }
 
     @Test

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorFrameCodecTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorFrameCodecTest.kt
@@ -1,0 +1,62 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.nio.ByteBuffer
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class CoordinatorFrameCodecTest {
+
+    private val codec = CoordinatorFrameCodec(maxPayloadBytes = 32)
+
+    @Test
+    fun `frame round-trips with the current protocol version`() {
+        val payload = byteArrayOf(1, 2, 3, 4)
+
+        val decoded = codec.decode(codec.encode(payload))
+
+        assertEquals(INPUT_COORDINATOR_PROTOCOL_VERSION, decoded.protocolVersion)
+        assertContentEquals(payload, decoded.payload)
+    }
+
+    @Test
+    fun `oversized outbound and inbound frames are rejected with stable taxonomy`() {
+        val outbound = assertFailsWith<CoordinatorProtocolException> { codec.encode(ByteArray(33)) }
+        assertEquals(CoordinatorProtocolError.FRAME_TOO_LARGE, outbound.error)
+
+        val inbound = ByteBuffer.allocate(Int.SIZE_BYTES).putInt(33).array() + ByteArray(33)
+        val inboundFailure = assertFailsWith<CoordinatorProtocolException> { codec.decode(inbound) }
+        assertEquals(CoordinatorProtocolError.FRAME_TOO_LARGE, inboundFailure.error)
+    }
+
+    @Test
+    fun `truncated and length-mismatched frames are rejected as malformed`() {
+        val truncated =
+            assertFailsWith<CoordinatorProtocolException> { codec.decode(byteArrayOf(0)) }
+        assertEquals(CoordinatorProtocolError.MALFORMED_FRAME, truncated.error)
+
+        val mismatched =
+            ByteBuffer.allocate(Int.SIZE_BYTES + Short.SIZE_BYTES + 1)
+                .putInt(2)
+                .putShort(INPUT_COORDINATOR_PROTOCOL_VERSION.toShort())
+                .put(7)
+                .array()
+        val mismatchFailure =
+            assertFailsWith<CoordinatorProtocolException> { codec.decode(mismatched) }
+        assertEquals(CoordinatorProtocolError.MALFORMED_FRAME, mismatchFailure.error)
+    }
+
+    @Test
+    fun `incompatible protocol version fails closed`() {
+        val frame = codec.encode(byteArrayOf(9)).copyOf()
+        ByteBuffer.wrap(frame, Int.SIZE_BYTES, Short.SIZE_BYTES).putShort(99)
+
+        val failure = assertFailsWith<CoordinatorProtocolException> { codec.decode(frame) }
+
+        assertEquals(CoordinatorProtocolError.INCOMPATIBLE_VERSION, failure.error)
+        assertEquals(99, failure.peerVersion)
+    }
+}

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorIoDeadlineTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorIoDeadlineTest.kt
@@ -1,0 +1,43 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.ServerSocketChannel
+import java.nio.file.Files
+import java.time.Duration
+import java.util.concurrent.Executors
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class CoordinatorIoDeadlineTest {
+
+    @Test
+    fun `bounded request fails when an accepted coordinator never responds`() {
+        val directory = Files.createTempDirectory("spc-io-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val server = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        val accepter = Executors.newSingleThreadExecutor()
+        try {
+            server.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+            val accepted = accepter.submit { server.accept().use { Thread.sleep(5_000) } }
+
+            assertFailsWith<java.net.SocketTimeoutException> {
+                sendCoordinatorMessage(
+                    endpoint = endpoint,
+                    codec = CoordinatorWireCodec(),
+                    message = CoordinatorWireMessage(kind = CoordinatorWireKind.HEALTH),
+                    timeout = Duration.ofMillis(50),
+                )
+            }
+
+            accepted.cancel(true)
+        } finally {
+            accepter.shutdownNow()
+            server.close()
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory)
+        }
+    }
+}

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
@@ -57,6 +57,11 @@ class DesktopIdentityResolverTest {
     }
 
     @Test
+    fun `remote X11 host names ignore DNS casing`() {
+        assertEquals(linux("host.example:10.0"), linux("Host.Example:10.1"))
+    }
+
+    @Test
     fun `Wayland socket spellings use canonical path`() {
         val key =
             resolver.resolve(

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
@@ -1,0 +1,103 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.nio.file.Path
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class DesktopIdentityResolverTest {
+
+    private val resolver = DesktopIdentityResolver { path ->
+        Path.of("/canonical", path.fileName.toString())
+    }
+
+    @Test
+    fun `equivalent local X11 display spellings resolve to one resource`() {
+        val variants = listOf(":0", ":0.0", "unix/:0")
+
+        val keys = variants.map { display ->
+            resolver.resolve(
+                DesktopIdentityEnvironment(
+                    platform = DesktopPlatform.LINUX,
+                    effectiveUserId = "1000",
+                    environment = mapOf("DISPLAY" to display),
+                )
+            )
+        }
+
+        assertEquals(1, keys.distinct().size)
+        assertEquals("user:1000/x11-local:0", keys.distinct().single().value)
+    }
+
+    @Test
+    fun `remote X11 displays remain distinct`() {
+        val first = linux(display = "host-a:10.0")
+        val second = linux(display = "host-b:10.0")
+
+        assertEquals("user:1000/x11-remote:host-a:10.0", first.value)
+        assertEquals("user:1000/x11-remote:host-b:10.0", second.value)
+    }
+
+    @Test
+    fun `Wayland socket spellings use canonical path`() {
+        val key =
+            resolver.resolve(
+                DesktopIdentityEnvironment(
+                    platform = DesktopPlatform.LINUX,
+                    effectiveUserId = "1000",
+                    environment =
+                        mapOf(
+                            "WAYLAND_DISPLAY" to "wayland-0",
+                            "XDG_RUNTIME_DIR" to "/run/user/1000",
+                        ),
+                )
+            )
+
+        assertEquals("user:1000/wayland:/canonical/wayland-0", key.value)
+    }
+
+    @Test
+    fun `macOS conservatively serializes per console user`() {
+        val key =
+            resolver.resolve(
+                DesktopIdentityEnvironment(
+                    platform = DesktopPlatform.MACOS,
+                    effectiveUserId = "501",
+                )
+            )
+
+        assertEquals("user:501/macos-console", key.value)
+    }
+
+    @Test
+    fun `Windows uses logon session when present and otherwise serializes per user`() {
+        val withSession =
+            resolver.resolve(
+                DesktopIdentityEnvironment(
+                    platform = DesktopPlatform.WINDOWS,
+                    effectiveUserId = "seb",
+                    windowsLogonSessionId = "session-7",
+                )
+            )
+        val fallback =
+            resolver.resolve(
+                DesktopIdentityEnvironment(
+                    platform = DesktopPlatform.WINDOWS,
+                    effectiveUserId = "seb",
+                )
+            )
+
+        assertEquals("user:seb/windows-session:session-7", withSession.value)
+        assertEquals("user:seb/windows-user", fallback.value)
+    }
+
+    private fun linux(display: String): DesktopResourceKey =
+        resolver.resolve(
+            DesktopIdentityEnvironment(
+                platform = DesktopPlatform.LINUX,
+                effectiveUserId = "1000",
+                environment = mapOf("DISPLAY" to display),
+            )
+        )
+}

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
@@ -14,7 +14,7 @@ class DesktopIdentityResolverTest {
 
     @Test
     fun `equivalent local X11 display spellings resolve to one resource`() {
-        val variants = listOf(":0", ":0.0", ":0.1", "unix/:0", "unix/:0.99")
+        val variants = listOf(":0", ":0.0", ":0.1", "unix:0", "unix:0.1", "unix/:0", "unix/:0.99")
 
         val keys = variants.map { display ->
             resolver.resolve(

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
@@ -35,8 +35,14 @@ class DesktopIdentityResolverTest {
         val first = linux(display = "host-a:10.0")
         val second = linux(display = "host-b:10.0")
 
-        assertEquals("user:1000/x11-remote:host-a:10.0", first.value)
-        assertEquals("user:1000/x11-remote:host-b:10.0", second.value)
+        assertEquals("user:1000/x11-remote:host-a:10", first.value)
+        assertEquals("user:1000/x11-remote:host-b:10", second.value)
+    }
+
+    @Test
+    fun `remote X11 screens share one server identity`() {
+        assertEquals(linux("host.example:10"), linux("host.example:10.0"))
+        assertEquals(linux("host.example:10"), linux("host.example:10.1"))
     }
 
     @Test

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
@@ -8,9 +8,7 @@ import kotlin.test.assertEquals
 
 class DesktopIdentityResolverTest {
 
-    private val resolver = DesktopIdentityResolver { path ->
-        Path.of("/canonical", path.fileName.toString())
-    }
+    private val resolver = DesktopIdentityResolver { path -> Path.of("canonical-${path.fileName}") }
 
     @Test
     fun `equivalent local X11 display spellings resolve to one resource`() {
@@ -73,7 +71,7 @@ class DesktopIdentityResolverTest {
                 )
             )
 
-        assertEquals("user:1000/wayland:/canonical/wayland-0", key.value)
+        assertEquals("user:1000/wayland:canonical-wayland-0", key.value)
     }
 
     @Test

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
@@ -14,7 +14,7 @@ class DesktopIdentityResolverTest {
 
     @Test
     fun `equivalent local X11 display spellings resolve to one resource`() {
-        val variants = listOf(":0", ":0.0", "unix/:0")
+        val variants = listOf(":0", ":0.0", ":0.1", "unix/:0", "unix/:0.99")
 
         val keys = variants.map { display ->
             resolver.resolve(

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
@@ -71,13 +71,21 @@ class DesktopIdentityResolverTest {
     }
 
     @Test
-    fun `Windows uses logon session when present and otherwise serializes per user`() {
+    fun `Windows uses only verified numeric session ids and otherwise serializes per user`() {
         val withSession =
             resolver.resolve(
                 DesktopIdentityEnvironment(
                     platform = DesktopPlatform.WINDOWS,
                     effectiveUserId = "seb",
-                    windowsLogonSessionId = "session-7",
+                    windowsLogonSessionId = "7",
+                )
+            )
+        val transportName =
+            resolver.resolve(
+                DesktopIdentityEnvironment(
+                    platform = DesktopPlatform.WINDOWS,
+                    effectiveUserId = "seb",
+                    windowsLogonSessionId = "RDP-Tcp#5",
                 )
             )
         val fallback =
@@ -88,7 +96,8 @@ class DesktopIdentityResolverTest {
                 )
             )
 
-        assertEquals("user:seb/windows-session:session-7", withSession.value)
+        assertEquals("user:seb/windows-session:7", withSession.value)
+        assertEquals("user:seb/windows-user", transportName.value)
         assertEquals("user:seb/windows-user", fallback.value)
     }
 

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/DesktopIdentityResolverTest.kt
@@ -14,7 +14,20 @@ class DesktopIdentityResolverTest {
 
     @Test
     fun `equivalent local X11 display spellings resolve to one resource`() {
-        val variants = listOf(":0", ":0.0", ":0.1", "unix:0", "unix:0.1", "unix/:0", "unix/:0.99")
+        val variants =
+            listOf(
+                ":0",
+                ":0.0",
+                ":0.1",
+                "unix:0",
+                "unix:0.1",
+                "unix/:0",
+                "unix/:0.99",
+                "localhost:0",
+                "localhost:0.1",
+                "127.0.0.1:0",
+                "127.0.0.1:0.99",
+            )
 
         val keys = variants.map { display ->
             resolver.resolve(

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/ExperimentalInputCoordinationApiTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/ExperimentalInputCoordinationApiTest.kt
@@ -1,0 +1,75 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.nio.file.Path
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class ExperimentalInputCoordinationApiTest {
+
+    @Test
+    fun `the marker is warning-level and runtime-visible`() {
+        val source =
+            Path.of(
+                    "src/main/kotlin/dev/sebastiano/spectre/input/ExperimentalSpectreInputCoordinationApi.kt"
+                )
+                .readText()
+
+        assertTrue(source.contains("RequiresOptIn.Level.WARNING"))
+        assertTrue(source.contains("AnnotationRetention.RUNTIME"))
+    }
+
+    @Test
+    fun `the published coordinator surface remains experimental`() {
+        PUBLISHED_COORDINATOR_TYPES.forEach { type ->
+            assertNotNull(
+                type.getAnnotation(ExperimentalSpectreInputCoordinationApi::class.java),
+                "${type.name} must remain experimental until the coordination API graduates",
+            )
+        }
+    }
+
+    private companion object {
+        val PUBLISHED_COORDINATOR_TYPES: List<Class<*>> =
+            listOf(
+                CanonicalPathResolver::class.java,
+                CoordinatedInputLease::class.java,
+                CoordinatorControlResult::class.java,
+                CoordinatorEndpoint::class.java,
+                CoordinatorEndpointResolver::class.java,
+                CoordinatorFrame::class.java,
+                CoordinatorFrameCodec::class.java,
+                CoordinatorHolderStatus::class.java,
+                CoordinatorProtocolError::class.java,
+                CoordinatorProtocolException::class.java,
+                CoordinatorQuarantineStatus::class.java,
+                CoordinatorRevokeResult::class.java,
+                CoordinatorStatus::class.java,
+                CoordinatorWaiterStatus::class.java,
+                CoordinatorWireCodec::class.java,
+                CoordinatorWireHolder::class.java,
+                CoordinatorWireKind::class.java,
+                CoordinatorWireMessage::class.java,
+                CoordinatorWireQuarantine::class.java,
+                CoordinatorWireStatus::class.java,
+                CoordinatorWireWaiter::class.java,
+                DesktopIdentityEnvironment::class.java,
+                DesktopIdentityResolver::class.java,
+                DesktopPlatform::class.java,
+                DesktopResourceKey::class.java,
+                InputCoordinatorClientFactory::class.java,
+                InputCoordinatorClientProvider::class.java,
+                InputCoordinatorException::class.java,
+                LeaseErrorCode::class.java,
+                LeaseOwner::class.java,
+                LeaseToken::class.java,
+                LocalCoordinatorEnvironment::class.java,
+                LocalInputCoordinatorClient::class.java,
+                LocalInputCoordinatorControl::class.java,
+                OwnerOnlyEndpointProtection::class.java,
+            )
+    }
+}

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientAcquireValidationTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientAcquireValidationTest.kt
@@ -1,0 +1,106 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.ServerSocketChannel
+import java.nio.file.Files
+import java.time.Duration
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class InputCoordinatorClientAcquireValidationTest {
+
+    @Test
+    fun `malformed granted response cancels the exact acquisition and fences the session`() {
+        val directory = Files.createTempDirectory("spc-cv-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val codec = CoordinatorWireCodec()
+        val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+        val acquireRequestId = CompletableFuture<String>()
+        val cancellation = CompletableFuture<CoordinatorWireMessage>()
+        val sentinelClosed = CountDownLatch(1)
+        val serverThread =
+            Thread.ofVirtual().name("coordinator-malformed-grant-test").start {
+                val session = listener.accept()
+                assertEquals(CoordinatorWireKind.SESSION_OPEN, codec.read(session).kind)
+                codec.write(
+                    session,
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.RESPONSE,
+                        coordinatorEpoch = EPOCH,
+                    ),
+                )
+                Thread.ofVirtual().start {
+                    codec.readOrNull(session)
+                    sentinelClosed.countDown()
+                }
+
+                listener.accept().use { acquireChannel ->
+                    val acquire = codec.read(acquireChannel)
+                    acquireRequestId.complete(requireNotNull(acquire.requestId))
+                    codec.write(
+                        acquireChannel,
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.RESPONSE,
+                            requestId = acquire.requestId,
+                            coordinatorEpoch = EPOCH,
+                            leaseId = LEASE_ID,
+                            resourceKey = acquire.resourceKey,
+                            // A committed grant without a fence is not a valid grant response.
+                            fence = null,
+                        ),
+                    )
+                }
+                runCatching {
+                        listener.accept().use { cancelChannel ->
+                            val cancel = codec.read(cancelChannel)
+                            cancellation.complete(cancel)
+                            codec.write(
+                                cancelChannel,
+                                CoordinatorWireMessage(kind = CoordinatorWireKind.RESPONSE),
+                            )
+                        }
+                    }
+                    .onFailure(cancellation::completeExceptionally)
+            }
+        val client =
+            LocalInputCoordinatorClient.connect(
+                endpoint,
+                DesktopResourceKey("test/malformed-grant"),
+                "malformed-grant-test",
+                codec,
+            )
+        try {
+            assertFailsWith<IllegalArgumentException> {
+                client.acquire(Duration.ofSeconds(2), "malformed grant")
+            }
+
+            val cancel = cancellation.get(2, TimeUnit.SECONDS)
+            assertEquals(CoordinatorWireKind.CANCEL, cancel.kind)
+            assertEquals(acquireRequestId.get(2, TimeUnit.SECONDS), cancel.requestId)
+            assertTrue(
+                sentinelClosed.await(2, TimeUnit.SECONDS),
+                "an invalid grant response must fence the owner session",
+            )
+        } finally {
+            client.close()
+            listener.close()
+            serverThread.join(2_000)
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    private companion object {
+        const val EPOCH: String = "epoch"
+        const val LEASE_ID: String = "lease"
+    }
+}

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -1,0 +1,94 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.io.IOException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.ServerSocketChannel
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class InputCoordinatorClientDisconnectTest {
+
+    @Test
+    fun `heartbeat IO failure closes the sentinel session`() {
+        val directory = Files.createTempDirectory(Path.of("/tmp"), "spc-cd-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val codec = CoordinatorWireCodec()
+        val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+        val sentinelClosed = CountDownLatch(1)
+        val serverThread =
+            Thread.ofVirtual().name("coordinator-disconnect-test").start {
+                val session = listener.accept()
+                val sessionOpen = codec.read(session)
+                assertEquals(CoordinatorWireKind.SESSION_OPEN, sessionOpen.kind)
+                codec.write(
+                    session,
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.RESPONSE,
+                        coordinatorEpoch = EPOCH,
+                    ),
+                )
+                Thread.ofVirtual().start {
+                    codec.readOrNull(session)
+                    sentinelClosed.countDown()
+                }
+
+                listener.accept().use { acquireChannel ->
+                    val acquire = codec.read(acquireChannel)
+                    codec.write(
+                        acquireChannel,
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.RESPONSE,
+                            requestId = acquire.requestId,
+                            coordinatorEpoch = EPOCH,
+                            leaseId = LEASE_ID,
+                            resourceKey = acquire.resourceKey,
+                            fence = 1,
+                        ),
+                    )
+                }
+                listener.accept().use { heartbeatChannel ->
+                    codec.read(heartbeatChannel)
+                    // Closing without a response simulates a failed short-lived heartbeat while
+                    // the long-lived sentinel session is still healthy.
+                }
+            }
+        val client =
+            LocalInputCoordinatorClient.connect(
+                endpoint,
+                DesktopResourceKey("test/disconnect"),
+                "disconnect-test",
+                codec,
+            )
+        try {
+            val lease = client.acquire(Duration.ofSeconds(2), "test")
+
+            assertFailsWith<IOException> { lease.checkpoint() }
+            assertTrue(
+                sentinelClosed.await(2, TimeUnit.SECONDS),
+                "heartbeat I/O failure should close the sentinel session immediately",
+            )
+        } finally {
+            client.close()
+            listener.close()
+            serverThread.join(2_000)
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    private companion object {
+        const val EPOCH: String = "test-epoch"
+        const val LEASE_ID: String = "test-lease"
+    }
+}

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class InputCoordinatorClientDisconnectTest {
@@ -348,6 +349,86 @@ class InputCoordinatorClientDisconnectTest {
             assertTrue(
                 sentinelClosed.await(2, TimeUnit.SECONDS),
                 "release failure should close the session so the retained grant is released",
+            )
+        } finally {
+            client.close()
+            listener.close()
+            serverThread.join(2_000)
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
+    fun `release IO failure retries before closing the sentinel session`() {
+        val directory = Files.createTempDirectory("spc-rr-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val codec = CoordinatorWireCodec()
+        val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+        val sentinelClosed = CountDownLatch(1)
+        val retryReceived = CountDownLatch(1)
+        val serverThread =
+            Thread.ofVirtual().name("coordinator-release-retry-test").start {
+                val session = listener.accept()
+                assertEquals(CoordinatorWireKind.SESSION_OPEN, codec.read(session).kind)
+                codec.write(
+                    session,
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.RESPONSE,
+                        coordinatorEpoch = EPOCH,
+                    ),
+                )
+                Thread.ofVirtual().start {
+                    codec.readOrNull(session)
+                    sentinelClosed.countDown()
+                }
+
+                var acquireRequestId: String? = null
+                listener.accept().use { acquireChannel ->
+                    val acquire = codec.read(acquireChannel)
+                    acquireRequestId = acquire.requestId
+                    codec.write(
+                        acquireChannel,
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.RESPONSE,
+                            requestId = acquire.requestId,
+                            coordinatorEpoch = EPOCH,
+                            leaseId = LEASE_ID,
+                            resourceKey = acquire.resourceKey,
+                            fence = 1,
+                        ),
+                    )
+                }
+                listener.accept().use { firstReleaseChannel ->
+                    val release = codec.read(firstReleaseChannel)
+                    assertEquals(CoordinatorWireKind.RELEASE, release.kind)
+                    assertEquals(acquireRequestId, release.requestId)
+                    // Drop the operation connection without a response. The sentinel is healthy,
+                    // so the client can safely retry this exact request-correlated release.
+                }
+                listener.accept().use { retryChannel ->
+                    val retry = codec.read(retryChannel)
+                    assertEquals(CoordinatorWireKind.RELEASE, retry.kind)
+                    assertEquals(acquireRequestId, retry.requestId)
+                    codec.write(retryChannel, CoordinatorWireMessage(CoordinatorWireKind.RESPONSE))
+                    retryReceived.countDown()
+                }
+            }
+        val client =
+            LocalInputCoordinatorClient.connect(
+                endpoint,
+                DesktopResourceKey("test/release-retry"),
+                "release-retry-test",
+                codec,
+            )
+        try {
+            client.acquire(Duration.ofSeconds(2), "test").close()
+
+            assertTrue(retryReceived.await(2, TimeUnit.SECONDS), "release was not retried")
+            assertFalse(
+                sentinelClosed.await(200, TimeUnit.MILLISECONDS),
+                "a successful release retry should keep the sentinel session open",
             )
         } finally {
             client.close()

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -153,6 +153,7 @@ class InputCoordinatorClientDisconnectTest {
         val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
         listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
         val sentinelClosed = CountDownLatch(1)
+        var acquireRequestId: String? = null
         val serverThread =
             Thread.ofVirtual().name("coordinator-release-error-test").start {
                 val session = listener.accept()
@@ -171,6 +172,7 @@ class InputCoordinatorClientDisconnectTest {
 
                 listener.accept().use { acquireChannel ->
                     val acquire = codec.read(acquireChannel)
+                    acquireRequestId = acquire.requestId
                     codec.write(
                         acquireChannel,
                         CoordinatorWireMessage(
@@ -184,7 +186,9 @@ class InputCoordinatorClientDisconnectTest {
                     )
                 }
                 listener.accept().use { releaseChannel ->
-                    assertEquals(CoordinatorWireKind.RELEASE, codec.read(releaseChannel).kind)
+                    val release = codec.read(releaseChannel)
+                    assertEquals(CoordinatorWireKind.RELEASE, release.kind)
+                    assertEquals(acquireRequestId, release.requestId)
                     codec.write(
                         releaseChannel,
                         CoordinatorWireMessage(

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -7,7 +7,6 @@ import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.ServerSocketChannel
 import java.nio.file.Files
-import java.nio.file.Path
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
@@ -20,7 +19,7 @@ class InputCoordinatorClientDisconnectTest {
 
     @Test
     fun `heartbeat IO failure closes the sentinel session`() {
-        val directory = Files.createTempDirectory(Path.of("/tmp"), "spc-cd-")
+        val directory = Files.createTempDirectory("spc-cd-")
         val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
         val codec = CoordinatorWireCodec()
         val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
@@ -89,7 +88,7 @@ class InputCoordinatorClientDisconnectTest {
 
     @Test
     fun `ambiguous acquisition IO failure closes the sentinel session`() {
-        val directory = Files.createTempDirectory(Path.of("/tmp"), "spc-ca-")
+        val directory = Files.createTempDirectory("spc-ca-")
         val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
         val codec = CoordinatorWireCodec()
         val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
@@ -147,7 +146,7 @@ class InputCoordinatorClientDisconnectTest {
 
     @Test
     fun `release error closes the sentinel session`() {
-        val directory = Files.createTempDirectory(Path.of("/tmp"), "spc-cr-")
+        val directory = Files.createTempDirectory("spc-cr-")
         val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
         val codec = CoordinatorWireCodec()
         val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -282,13 +282,14 @@ class InputCoordinatorClientDisconnectTest {
     }
 
     @Test
-    fun `release error closes the sentinel session`() {
+    fun `release persistence failure remains retryable on the same live session`() {
         val directory = Files.createTempDirectory("spc-cr-")
         val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
         val codec = CoordinatorWireCodec()
         val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
         listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
         val sentinelClosed = CountDownLatch(1)
+        val backgroundReleaseCompleted = CountDownLatch(1)
         var acquireRequestId: String? = null
         val serverThread =
             Thread.ofVirtual().name("coordinator-release-error-test").start {
@@ -321,19 +322,31 @@ class InputCoordinatorClientDisconnectTest {
                         ),
                     )
                 }
+                repeat(2) {
+                    listener.accept().use { releaseChannel ->
+                        val release = codec.read(releaseChannel)
+                        assertEquals(CoordinatorWireKind.RELEASE, release.kind)
+                        assertEquals(acquireRequestId, release.requestId)
+                        codec.write(
+                            releaseChannel,
+                            CoordinatorWireMessage(
+                                kind = CoordinatorWireKind.RESPONSE,
+                                ok = false,
+                                errorCode = "RECOVERY_PERSISTENCE_FAILED",
+                                message = "Could not persist lease release",
+                            ),
+                        )
+                    }
+                }
                 listener.accept().use { releaseChannel ->
                     val release = codec.read(releaseChannel)
                     assertEquals(CoordinatorWireKind.RELEASE, release.kind)
                     assertEquals(acquireRequestId, release.requestId)
                     codec.write(
                         releaseChannel,
-                        CoordinatorWireMessage(
-                            kind = CoordinatorWireKind.RESPONSE,
-                            ok = false,
-                            errorCode = "RECOVERY_PERSISTENCE_FAILED",
-                            message = "Could not persist lease release",
-                        ),
+                        CoordinatorWireMessage(CoordinatorWireKind.RESPONSE),
                     )
+                    backgroundReleaseCompleted.countDown()
                 }
             }
         val client =
@@ -344,11 +357,25 @@ class InputCoordinatorClientDisconnectTest {
                 codec,
             )
         try {
-            client.acquire(Duration.ofSeconds(2), "test").close()
+            val lease = client.acquire(Duration.ofSeconds(2), "test")
 
+            val failure = assertFailsWith<InputCoordinatorException> { lease.close() }
+            assertEquals("RECOVERY_PERSISTENCE_FAILED", failure.errorCode)
+            assertFalse(
+                sentinelClosed.await(200, TimeUnit.MILLISECONDS),
+                "retryable persistence failure closed the sentinel session",
+            )
+
+            client.close()
+
+            assertFalse(lease.isValid())
             assertTrue(
-                sentinelClosed.await(2, TimeUnit.SECONDS),
-                "release failure should close the session so the retained grant is released",
+                backgroundReleaseCompleted.await(3, TimeUnit.SECONDS),
+                "client did not retry the persisted release in the background",
+            )
+            assertTrue(
+                sentinelClosed.await(3, TimeUnit.SECONDS),
+                "requested session close did not wait for release acknowledgement",
             )
         } finally {
             client.close()

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -3,11 +3,13 @@
 package dev.sebastiano.spectre.input
 
 import java.io.IOException
+import java.io.InterruptedIOException
 import java.net.StandardProtocolFamily
 import java.net.UnixDomainSocketAddress
 import java.nio.channels.ServerSocketChannel
 import java.nio.file.Files
 import java.time.Duration
+import java.util.concurrent.CompletableFuture
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
@@ -134,6 +136,75 @@ class InputCoordinatorClientDisconnectTest {
             assertTrue(
                 sentinelClosed.await(2, TimeUnit.SECONDS),
                 "ambiguous acquisition should close the session so an unknown grant is released",
+            )
+        } finally {
+            client.close()
+            listener.close()
+            serverThread.join(2_000)
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
+    fun `unacknowledged cancellation after interrupted acquisition closes the sentinel session`() {
+        val directory = Files.createTempDirectory("spc-ci-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val codec = CoordinatorWireCodec()
+        val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+        val acquireReceived = CountDownLatch(1)
+        val sentinelClosed = CountDownLatch(1)
+        val serverThread =
+            Thread.ofVirtual().name("coordinator-interrupted-cancel-test").start {
+                val session = listener.accept()
+                assertEquals(CoordinatorWireKind.SESSION_OPEN, codec.read(session).kind)
+                codec.write(
+                    session,
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.RESPONSE,
+                        coordinatorEpoch = EPOCH,
+                    ),
+                )
+                Thread.ofVirtual().start {
+                    codec.readOrNull(session)
+                    sentinelClosed.countDown()
+                }
+
+                listener.accept().use { acquireChannel ->
+                    assertEquals(CoordinatorWireKind.ACQUIRE, codec.read(acquireChannel).kind)
+                    acquireReceived.countDown()
+                    codec.readOrNull(acquireChannel)
+                }
+                listener.accept().use { cancelChannel ->
+                    assertEquals(CoordinatorWireKind.CANCEL, codec.read(cancelChannel).kind)
+                    // Closing without a response leaves cancellation unacknowledged.
+                }
+            }
+        val client =
+            LocalInputCoordinatorClient.connect(
+                endpoint,
+                DesktopResourceKey("test/interrupted-cancel"),
+                "interrupted-cancel-test",
+                codec,
+            )
+        try {
+            val failure = CompletableFuture<Throwable>()
+            val acquireThread =
+                Thread.ofVirtual().start {
+                    failure.complete(
+                        runCatching { client.acquire(Duration.ofSeconds(2), "interrupted acquire") }
+                            .exceptionOrNull()
+                            ?: AssertionError("Interrupted acquisition unexpectedly succeeded")
+                    )
+                }
+            assertTrue(acquireReceived.await(2, TimeUnit.SECONDS))
+            acquireThread.interrupt()
+
+            assertTrue(failure.get(2, TimeUnit.SECONDS) is InterruptedIOException)
+            assertTrue(
+                sentinelClosed.await(2, TimeUnit.SECONDS),
+                "unacknowledged cancellation must fence the session and release an unknown grant",
             )
         } finally {
             client.close()

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -20,6 +20,71 @@ import kotlin.test.assertTrue
 class InputCoordinatorClientDisconnectTest {
 
     @Test
+    fun `maximum acquisition timeout does not overflow the response deadline`() {
+        val directory = Files.createTempDirectory("spc-cl-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val codec = CoordinatorWireCodec()
+        val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+        val receivedTimeout = CompletableFuture<Long>()
+        val serverThread =
+            Thread.ofVirtual().name("coordinator-long-acquire-test").start {
+                val session = listener.accept()
+                assertEquals(CoordinatorWireKind.SESSION_OPEN, codec.read(session).kind)
+                codec.write(
+                    session,
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.RESPONSE,
+                        coordinatorEpoch = EPOCH,
+                    ),
+                )
+
+                listener.accept().use { acquireChannel ->
+                    val acquire = codec.read(acquireChannel)
+                    receivedTimeout.complete(requireNotNull(acquire.timeoutMillis))
+                    codec.write(
+                        acquireChannel,
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.RESPONSE,
+                            requestId = acquire.requestId,
+                            coordinatorEpoch = EPOCH,
+                            leaseId = LEASE_ID,
+                            resourceKey = acquire.resourceKey,
+                            fence = 1,
+                        ),
+                    )
+                }
+                listener.accept().use { releaseChannel ->
+                    val release = codec.read(releaseChannel)
+                    assertEquals(CoordinatorWireKind.RELEASE, release.kind)
+                    codec.write(
+                        releaseChannel,
+                        CoordinatorWireMessage(kind = CoordinatorWireKind.RESPONSE),
+                    )
+                }
+                session.close()
+            }
+        val client =
+            LocalInputCoordinatorClient.connect(
+                endpoint,
+                DesktopResourceKey("test/long-acquire"),
+                "long-acquire-test",
+                codec,
+            )
+        try {
+            client.acquire(Duration.ofMillis(Long.MAX_VALUE), "long acquire").close()
+
+            assertEquals(Long.MAX_VALUE, receivedTimeout.get(2, TimeUnit.SECONDS))
+        } finally {
+            client.close()
+            listener.close()
+            serverThread.join(2_000)
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    @Test
     fun `heartbeat IO failure closes the sentinel session`() {
         val directory = Files.createTempDirectory("spc-cd-")
         val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -322,7 +322,7 @@ class InputCoordinatorClientDisconnectTest {
                         ),
                     )
                 }
-                repeat(2) {
+                repeat(3) {
                     listener.accept().use { releaseChannel ->
                         val release = codec.read(releaseChannel)
                         assertEquals(CoordinatorWireKind.RELEASE, release.kind)

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -87,6 +87,64 @@ class InputCoordinatorClientDisconnectTest {
         }
     }
 
+    @Test
+    fun `ambiguous acquisition IO failure closes the sentinel session`() {
+        val directory = Files.createTempDirectory(Path.of("/tmp"), "spc-ca-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val codec = CoordinatorWireCodec()
+        val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+        val sentinelClosed = CountDownLatch(1)
+        val serverThread =
+            Thread.ofVirtual().name("coordinator-ambiguous-acquire-test").start {
+                val session = listener.accept()
+                val sessionOpen = codec.read(session)
+                assertEquals(CoordinatorWireKind.SESSION_OPEN, sessionOpen.kind)
+                codec.write(
+                    session,
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.RESPONSE,
+                        coordinatorEpoch = EPOCH,
+                    ),
+                )
+                Thread.ofVirtual().start {
+                    codec.readOrNull(session)
+                    sentinelClosed.countDown()
+                }
+
+                listener.accept().use { acquireChannel ->
+                    assertEquals(CoordinatorWireKind.ACQUIRE, codec.read(acquireChannel).kind)
+                    // The server-side state granted the request, but the response was lost.
+                }
+                listener.accept().use { cancelChannel ->
+                    assertEquals(CoordinatorWireKind.CANCEL, codec.read(cancelChannel).kind)
+                    codec.write(cancelChannel, CoordinatorWireMessage(CoordinatorWireKind.RESPONSE))
+                }
+            }
+        val client =
+            LocalInputCoordinatorClient.connect(
+                endpoint,
+                DesktopResourceKey("test/ambiguous-acquire"),
+                "ambiguous-acquire-test",
+                codec,
+            )
+        try {
+            assertFailsWith<IOException> {
+                client.acquire(Duration.ofSeconds(2), "ambiguous acquire")
+            }
+            assertTrue(
+                sentinelClosed.await(2, TimeUnit.SECONDS),
+                "ambiguous acquisition should close the session so an unknown grant is released",
+            )
+        } finally {
+            client.close()
+            listener.close()
+            serverThread.join(2_000)
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory)
+        }
+    }
+
     private companion object {
         const val EPOCH: String = "test-epoch"
         const val LEASE_ID: String = "test-lease"

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientDisconnectTest.kt
@@ -145,6 +145,80 @@ class InputCoordinatorClientDisconnectTest {
         }
     }
 
+    @Test
+    fun `release error closes the sentinel session`() {
+        val directory = Files.createTempDirectory(Path.of("/tmp"), "spc-cr-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val codec = CoordinatorWireCodec()
+        val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+        val sentinelClosed = CountDownLatch(1)
+        val serverThread =
+            Thread.ofVirtual().name("coordinator-release-error-test").start {
+                val session = listener.accept()
+                assertEquals(CoordinatorWireKind.SESSION_OPEN, codec.read(session).kind)
+                codec.write(
+                    session,
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.RESPONSE,
+                        coordinatorEpoch = EPOCH,
+                    ),
+                )
+                Thread.ofVirtual().start {
+                    codec.readOrNull(session)
+                    sentinelClosed.countDown()
+                }
+
+                listener.accept().use { acquireChannel ->
+                    val acquire = codec.read(acquireChannel)
+                    codec.write(
+                        acquireChannel,
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.RESPONSE,
+                            requestId = acquire.requestId,
+                            coordinatorEpoch = EPOCH,
+                            leaseId = LEASE_ID,
+                            resourceKey = acquire.resourceKey,
+                            fence = 1,
+                        ),
+                    )
+                }
+                listener.accept().use { releaseChannel ->
+                    assertEquals(CoordinatorWireKind.RELEASE, codec.read(releaseChannel).kind)
+                    codec.write(
+                        releaseChannel,
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.RESPONSE,
+                            ok = false,
+                            errorCode = "RECOVERY_PERSISTENCE_FAILED",
+                            message = "Could not persist lease release",
+                        ),
+                    )
+                }
+            }
+        val client =
+            LocalInputCoordinatorClient.connect(
+                endpoint,
+                DesktopResourceKey("test/release-error"),
+                "release-error-test",
+                codec,
+            )
+        try {
+            client.acquire(Duration.ofSeconds(2), "test").close()
+
+            assertTrue(
+                sentinelClosed.await(2, TimeUnit.SECONDS),
+                "release failure should close the session so the retained grant is released",
+            )
+        } finally {
+            client.close()
+            listener.close()
+            serverThread.join(2_000)
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory)
+        }
+    }
+
     private companion object {
         const val EPOCH: String = "test-epoch"
         const val LEASE_ID: String = "test-lease"

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientMixedReleaseFailureTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/InputCoordinatorClientMixedReleaseFailureTest.kt
@@ -1,0 +1,139 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.ServerSocketChannel
+import java.nio.file.Files
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InputCoordinatorClientMixedReleaseFailureTest {
+
+    @Test
+    fun `persistence rejection followed by IO failure retains the exact release request`() {
+        val directory = Files.createTempDirectory("spc-mr-")
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
+        val codec = CoordinatorWireCodec()
+        val listener = ServerSocketChannel.open(StandardProtocolFamily.UNIX)
+        listener.bind(UnixDomainSocketAddress.of(endpoint.socketPath))
+        val backgroundReleaseCompleted = CountDownLatch(1)
+        val sentinelClosed = CountDownLatch(1)
+        val serverThread = startServer(listener, codec, sentinelClosed, backgroundReleaseCompleted)
+        val client =
+            LocalInputCoordinatorClient.connect(
+                endpoint,
+                DesktopResourceKey("test/mixed-release"),
+                "mixed-release-test",
+                codec,
+            )
+        try {
+            val lease = client.acquire(Duration.ofSeconds(2), "test")
+
+            val failure = assertFailsWith<InputCoordinatorException> { lease.close() }
+            assertEquals("RECOVERY_PERSISTENCE_FAILED", failure.errorCode)
+            assertFalse(
+                sentinelClosed.await(200, TimeUnit.MILLISECONDS),
+                "the retained release request must keep its session alive for retry",
+            )
+
+            client.close()
+
+            assertTrue(
+                backgroundReleaseCompleted.await(3, TimeUnit.SECONDS),
+                "the exact release request was not retried after the mixed failure",
+            )
+            assertTrue(
+                sentinelClosed.await(3, TimeUnit.SECONDS),
+                "deferred close did not complete after release acknowledgement",
+            )
+        } finally {
+            client.close()
+            listener.close()
+            serverThread.join(2_000)
+            Files.deleteIfExists(endpoint.socketPath)
+            Files.deleteIfExists(directory)
+        }
+    }
+
+    private fun startServer(
+        listener: ServerSocketChannel,
+        codec: CoordinatorWireCodec,
+        sentinelClosed: CountDownLatch,
+        backgroundReleaseCompleted: CountDownLatch,
+    ): Thread =
+        Thread.ofVirtual().name("coordinator-mixed-release-failure-test").start {
+            val session = listener.accept()
+            assertEquals(CoordinatorWireKind.SESSION_OPEN, codec.read(session).kind)
+            codec.write(
+                session,
+                CoordinatorWireMessage(
+                    kind = CoordinatorWireKind.RESPONSE,
+                    coordinatorEpoch = EPOCH,
+                ),
+            )
+            Thread.ofVirtual().start {
+                codec.readOrNull(session)
+                sentinelClosed.countDown()
+            }
+
+            val requestId =
+                listener.accept().use { acquireChannel ->
+                    val acquire = codec.read(acquireChannel)
+                    codec.write(
+                        acquireChannel,
+                        CoordinatorWireMessage(
+                            kind = CoordinatorWireKind.RESPONSE,
+                            requestId = acquire.requestId,
+                            coordinatorEpoch = EPOCH,
+                            leaseId = LEASE_ID,
+                            resourceKey = acquire.resourceKey,
+                            fence = 1,
+                        ),
+                    )
+                    requireNotNull(acquire.requestId)
+                }
+            listener.accept().use { releaseChannel ->
+                val release = codec.read(releaseChannel)
+                assertEquals(CoordinatorWireKind.RELEASE, release.kind)
+                assertEquals(requestId, release.requestId)
+                codec.write(
+                    releaseChannel,
+                    CoordinatorWireMessage(
+                        kind = CoordinatorWireKind.RESPONSE,
+                        ok = false,
+                        errorCode = "RECOVERY_PERSISTENCE_FAILED",
+                        message = "Could not persist lease release",
+                    ),
+                )
+            }
+            listener.accept().use { retryChannel ->
+                val retry = codec.read(retryChannel)
+                assertEquals(CoordinatorWireKind.RELEASE, retry.kind)
+                assertEquals(requestId, retry.requestId)
+                // The retry never reaches the coordinator response path.
+            }
+            listener.accept().use { backgroundChannel ->
+                val retry = codec.read(backgroundChannel)
+                assertEquals(CoordinatorWireKind.RELEASE, retry.kind)
+                assertEquals(requestId, retry.requestId)
+                codec.write(
+                    backgroundChannel,
+                    CoordinatorWireMessage(kind = CoordinatorWireKind.RESPONSE),
+                )
+                backgroundReleaseCompleted.countDown()
+            }
+        }
+
+    private companion object {
+        const val EPOCH: String = "test-epoch"
+        const val LEASE_ID: String = "test-lease"
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - The automator: guide/automator.md
       - Finding nodes: guide/selectors.md
       - Driving input: guide/interactions.md
+      - Experimental input coordination: guide/input-coordination.md
       - Synchronization: guide/synchronization.md
       - JUnit integration: guide/junit.md
       - Running on CI: guide/ci.md

--- a/scripts/central_portal_check.py
+++ b/scripts/central_portal_check.py
@@ -64,6 +64,15 @@ MIN_MAIN_JAR_SIZES = {
     "spectre-testing": 1_000,
 }
 
+REQUIRED_MAIN_JAR_ENTRIES = {
+    "spectre-input-coordinator": (
+        "dev/sebastiano/spectre/input/LocalInputCoordinatorClient.class",
+    ),
+    "spectre-input-coordinator-server": (
+        "dev/sebastiano/spectre/input/server/LocalCoordinatorServer.class",
+    ),
+}
+
 # Aligns with :verifyMavenLocalPublication / WindowsGraphicsCaptureHelperPackagingContract
 # fixed basenames (deps.json asset closure remains Gradle-owned).
 WINDOWS_HELPER_ARCHES = ("x64", "arm64")
@@ -339,6 +348,12 @@ def validate_jar(component: str, jar_path: Path) -> list[str]:
     errors: list[str] = []
     with zipfile.ZipFile(jar_path) as jar:
         entries = {entry.filename: entry.file_size for entry in jar.infolist()}
+
+        for required_entry in REQUIRED_MAIN_JAR_ENTRIES.get(component, ()):
+            if required_entry not in entries:
+                errors.append(f"{component} is missing required entry {required_entry}")
+            elif entries[required_entry] <= 0:
+                errors.append(f"{component} required entry {required_entry} is empty")
 
         if component == "spectre-recording":
             native_entries = sorted(name for name in entries if name.startswith("native/"))

--- a/scripts/central_portal_check.py
+++ b/scripts/central_portal_check.py
@@ -32,6 +32,8 @@ COMPONENTS = (
     "spectre-agent",
     "spectre-agent-runtime",
     "spectre-core",
+    "spectre-input-coordinator",
+    "spectre-input-coordinator-server",
     "spectre-recording",
     "spectre-recording-linux",
     "spectre-recording-macos",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -80,6 +80,10 @@ plugins {
 
 include(":core")
 
+include(":input-coordinator")
+
+include(":input-coordinator-server")
+
 include(":server")
 
 include(":recording")

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: spectre
-description: Use when writing, debugging, or reviewing tests that drive a real, on-screen Compose Desktop window with Spectre — the JVM/Kotlin library for automating live Compose Desktop UIs (and IntelliJ/Jewel-hosted Compose) via the semantics tree plus java.awt.Robot, synthetic AWT input, HTTP, or Java-agent attach. Trigger on mentions of `ComposeAutomator`, `RobotDriver`, `AutomatorNode`, `AgentAttach`, `AttachedAutomator`, `AttachOptions`, `findByTestTag`, `waitForNode`, `waitForIdle`, "automate a Compose window", "live/real-window Compose Desktop UI test", cross-JVM Compose automation, attaching to a running Compose JVM, screenshotting or recording a Compose Desktop window, or any task involving `dev.sebastiano.spectre.*` imports. Also use when the user is writing JUnit 4/5 tests against Compose Desktop **and** the test opens a real top-level window — but NOT when the user wants the off-screen `runComposeUiTest` / `createComposeRule` / `onNodeWithTag` framework, which is a different tool.
+description: Use when writing, debugging, or reviewing tests that drive a real on-screen Compose Desktop window with Spectre through semantics plus real/synthetic input, cooperative desktop leases, HTTP, or agent attach. Trigger on `ComposeAutomator`, `RobotDriver`, `AutomatorNode`, `InputLeasePolicy`, `InputIsolationConfig`, `spectre input-lock`, `AgentAttach`, `AttachedAutomator`, `findByTestTag`, `waitForNode`, `waitForIdle`, parallel JVM focus contention, cross-JVM Compose automation, screenshots/recording, IntelliJ/Jewel-hosted Compose, or `dev.sebastiano.spectre.*` imports. Also use for JUnit 4/5 tests that open a real top-level Compose window. Do not use for the off-screen `runComposeUiTest` / `createComposeRule` / `onNodeWithTag` framework.
 ---
 
 # Spectre
@@ -19,6 +19,7 @@ IntelliJ/Jewel-hosted Compose, or to record a real video of the UI.
 Use the published docs as the source of truth when answering setup questions:
 
 - Installation and coordinates: <https://spectre.sebastiano.dev/guide/installation/>
+- Experimental desktop input coordination: <https://spectre.sebastiano.dev/guide/input-coordination/>
 - Agent attach: <https://spectre.sebastiano.dev/guide/agent/>
 - Cross-JVM HTTP transport: <https://spectre.sebastiano.dev/guide/cross-jvm/>
 - Compose Hot Reload awareness (CLI/MCP only): <https://spectre.sebastiano.dev/guide/hot-reload/>
@@ -97,7 +98,9 @@ on the host OS. Three variants:
 
 - **`RobotDriver()`** — real `java.awt.Robot` input on the host. Highest
   fidelity, but contends for global focus. Use for the default
-  single-process test run.
+  single-process test run. The no-argument form remains uncoordinated while the feature is
+  experimental; when several processes genuinely require real input, use
+  `RobotDriver(InputLeasePolicy.Required)` and read `references/input-coordination.md`.
 - **`RobotDriver.synthetic(rootWindow = someTopLevelWindow)`** — dispatches
   AWT events directly into the given `java.awt.Window` hierarchy. No global
   focus contention, so safe for **parallel test JVMs** and for IDE-hosted
@@ -305,6 +308,9 @@ touches that area*; they are not needed for the common case.
 - **JUnit 4 vs JUnit 5 integration** → `references/junit.md` —
   `ComposeAutomatorExtension`, `ComposeAutomatorRule`, parameter resolution,
   lifecycle.
+- **Experimental desktop input coordination** → `references/input-coordination.md` — real-input
+  contention across JVMs, `InputLeasePolicy`, JUnit `InputIsolationConfig`, runtime dependency,
+  exact revoke, and unsafe forced recovery.
 - **IntelliJ/Jewel-hosted Compose** → `references/intellij.md` — running
   the automator from an `AnAction` against the IDE frame, the
   pooled-thread requirement, and the `synthetic` driver. If the work also
@@ -324,6 +330,7 @@ touches that area*; they are not needed for the common case.
 | Test deadlocks or throws inside any `waitFor…` | Called from the AWT EDT | Wrap in `withContext(Dispatchers.Default) { … }` — applies to all three waits, including `waitForNode` |
 | `longClick`/`swipe`/`typeText` complete instantly and miss | Test body uses `runTest` | Switch to `runSpectreTest` |
 | Two parallel test JVMs steal focus from each other | Both use real `RobotDriver()` | Use `RobotDriver.synthetic(rootWindow)` |
+| Parallel JVMs must preserve real OS input behavior | Real focus/pointer/clipboard state is shared across processes | Opt in to experimental coordination, add `spectre-input-coordinator-server` at runtime, use `Required` and JUnit `InputIsolationConfig.perTest()` |
 | Cmd+Tab or OS shortcuts don't work under synthetic driver | Synthetic events bypass HID | Use real `RobotDriver()` for those tests |
 | Screenshot is blurry / mid-animation | Captured before frame stabilised | `waitForVisualIdle()` first |
 | Windows WGC helper missing or fails to start | `spectre-recording-windows` is not on the runtime classpath, the helper was not built/staged locally, or .NET / Windows App Runtime is missing | Add `testRuntimeOnly("dev.sebastiano.spectre:spectre-recording-windows")`; install .NET 8 Desktop Runtime + Windows App Runtime 1.8 for runtime; for source builds install .NET 8 SDK and run `:recording-windows:verifyRecordingWindowsHelper` |
@@ -343,6 +350,9 @@ touches that area*; they are not needed for the common case.
 - It does **not** capture audio. Recording is video-only.
 - The cross-JVM **HTTP server is experimental** and security-caveated — do
   not recommend it for general use without flagging that.
+- Desktop input coordination is experimental, cooperative, and opt-in. Do not call it an OS input
+  grab, imply `RobotDriver()` coordinates by default, or suggest `--force` without its
+  `unsafeTakeover=true` overlap warning.
 - It does **not** auto-wait on queries. Don't write tests that assume it
   does.
 

--- a/skills/spectre/evals/evals.json
+++ b/skills/spectre/evals/evals.json
@@ -64,6 +64,21 @@
         "Does NOT recommend Thread.sleep before the screenshot",
         "Does NOT suggest using AutoRecorder / recording APIs"
       ]
+    },
+    {
+      "id": 5,
+      "name": "parallel-real-input-junit-isolation",
+      "prompt": "Our JUnit 5 Spectre suite uses four Gradle forks and must keep real java.awt.Robot behavior. The forks steal focus from each other. Show the supported coordination setup, including dependencies and any experimental opt-in. Also tell me how to recover if a lease is stuck.",
+      "assertions": [
+        "States that desktop input coordination is experimental and includes @OptIn(ExperimentalSpectreInputCoordinationApi::class)",
+        "Adds spectre-input-coordinator-server as a runtime dependency, or correctly explains that spectre-testing already wires it",
+        "Uses InputIsolationConfig.perTest() on ComposeAutomatorExtension",
+        "Uses InputLeasePolicy.Required or explains why Required fails closed for real input",
+        "Recommends spectre input-lock status before revocation",
+        "Requires the exact observed lease ID and a reason for revoke",
+        "Describes --force as unsafe and mentions unsafeTakeover=true or possible overlap with an in-flight native call",
+        "Does NOT claim the coordinator blocks humans or other automation tools"
+      ]
     }
   ]
 }

--- a/skills/spectre/references/input-coordination.md
+++ b/skills/spectre/references/input-coordination.md
@@ -1,0 +1,76 @@
+# Experimental desktop input coordination
+
+Read this reference when a user has multiple Spectre processes or Gradle forks that need real OS
+mouse, keyboard, focus, or clipboard access; asks about `InputLeasePolicy`,
+`InputIsolationConfig`, `withExclusiveInput`, or `spectre input-lock`; or reports that real-input
+tests steal focus from each other.
+
+## Source of truth
+
+- Published guide: <https://spectre.sebastiano.dev/guide/input-coordination/>
+- JUnit guide: <https://spectre.sebastiano.dev/guide/junit/>
+- CI guide: <https://spectre.sebastiano.dev/guide/ci/>
+- Repo docs: `docs/guide/input-coordination.md`, `docs/guide/junit.md`, and
+  `docs/guide/ci.md`
+
+The feature is experimental and opt-in. Include:
+
+```kotlin
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+```
+
+Do not describe the coordinator as an OS mutex or input grab. It serialises participating Spectre
+clients only; people, older versions, and other automation tools remain outside the boundary.
+
+## Decide whether coordination is appropriate
+
+1. If the test does not need real OS behaviour, prefer
+   `RobotDriver.synthetic(rootWindow = topLevelWindow)`. It avoids shared focus entirely.
+2. If multiple processes genuinely need real input, add
+   `spectre-input-coordinator-server` at runtime and use
+   `RobotDriver(InputLeasePolicy.Required)` so missing coordination fails closed.
+3. Use `InputLeasePolicy.Auto` only when opportunistic availability is intended. Use `Off` only
+   when an external harness already serialises input or the caller deliberately accepts races.
+4. Keep the no-argument `RobotDriver()` uncoordinated while the feature is experimental; do not
+   imply that the next release changes its default.
+
+For JUnit 4/5 in-process real-input suites, recommend `InputIsolationConfig.perTest()` when setup,
+failure capture, or teardown can touch focus. It spans factory creation, test execution, evidence,
+and teardown. `PerInteraction` is narrower. `LaunchAndAttachExtension`/Rule rely on target-JVM
+operation leases and do not offer a test-JVM `PerTest` mode because two leases would self-deadlock.
+
+For several related operations that must not interleave, use `automator.withExclusiveInput { ... }`.
+The scope is reentrant. Screenshots and recording are not automatically leased; place a capture in
+the scope only when its visible state must be protected from other Spectre input.
+
+Agent attach starts the coordinator best-effort so semantics inspection is still usable when the
+runtime cannot launch. A current target core uses `Required` for real input and therefore fails
+closed in that state. A target with an older pre-coordination core falls back to its legacy
+uncoordinated `RobotDriver`; call out that compatibility boundary when version skew is involved.
+
+## Recovery guidance
+
+Inspect first:
+
+```text
+spectre input-lock status --json
+```
+
+Normal recovery uses the exact current ID and a meaningful reason:
+
+```text
+spectre input-lock revoke --lease <observed-id> --reason <text>
+```
+
+Only suggest `--force` when normal cleanup cannot complete and the user accepts possible overlap
+with an in-flight native call. A forced result reports `unsafeTakeover=true`; it does not kill the
+holder or prove input stopped. Never suggest parsing a PID and killing it as the coordinator's
+normal escape hatch.
+
+## Release-status honesty
+
+The coordinator ships as Experimental on macOS, Windows with native `AF_UNIX`, and Linux
+Xorg/Xvfb. Linux Wayland real Robot input is not claimed. Do not call the API stable or default-on
+until cross-platform headed smoke and a later graduation decision say so.

--- a/skills/spectre/references/junit.md
+++ b/skills/spectre/references/junit.md
@@ -5,6 +5,10 @@ the `ComposeAutomator` lifecycle — building it before each test, tearing
 down after. You don't construct `ComposeAutomator.inProcess()` yourself when
 using them.
 
+For real-input suites running across multiple processes, read
+[input-coordination.md](input-coordination.md). `InputIsolationConfig` is experimental and
+requires `@OptIn(ExperimentalSpectreInputCoordinationApi::class)`.
+
 ## JUnit 5 — `ComposeAutomatorExtension`
 
 Use `@RegisterExtension` on a `@JvmField` (required for JUnit 5 to see the
@@ -95,6 +99,28 @@ val automatorExt = ComposeAutomatorExtension {
 ```
 
 The JUnit 4 rule is identical: `ComposeAutomatorRule { ComposeAutomator.inProcess(...) }`.
+
+## Experimental whole-test input isolation
+
+Use `InputIsolationConfig.perTest()` when multiple JVMs require real OS input and setup, failure
+evidence, or teardown can touch focus:
+
+```kotlin
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+@JvmField
+@RegisterExtension
+val automatorExt =
+    ComposeAutomatorExtension(
+        inputIsolation = InputIsolationConfig.perTest(),
+    )
+```
+
+Add `spectre-input-coordinator-server` at runtime for a core-only setup; `spectre-testing`
+already wires it. JUnit 5 owns the lease per invocation, while JUnit 4 wraps the complete
+`Statement.evaluate()` lifecycle. Do not add a test-JVM whole-test lease around
+`LaunchAndAttachExtension`/Rule: input is coordinated in the target JVM and a second lease would
+self-deadlock.
 
 ## Failure video (#206)
 

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -2,11 +2,14 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorExtension : or
 	public fun <init> ()V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Ldev/sebastiano/spectre/testing/InputIsolationConfig;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Ldev/sebastiano/spectre/testing/InputIsolationConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/InputIsolationConfig;)V
 	public fun afterEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun afterTestExecution (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
 	public fun beforeEach (Lorg/junit/jupiter/api/extension/ExtensionContext;)V
@@ -21,11 +24,14 @@ public final class dev/sebastiano/spectre/testing/ComposeAutomatorRule : org/jun
 	public fun <init> ()V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Ldev/sebastiano/spectre/testing/InputIsolationConfig;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Ldev/sebastiano/spectre/testing/InputIsolationConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Ldev/sebastiano/spectre/testing/FailureVideoConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;)V
 	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/FailureArtifactsConfig;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ldev/sebastiano/spectre/testing/FailureVideoConfig;)V
+	public fun <init> (Ldev/sebastiano/spectre/testing/InputIsolationConfig;)V
 	public fun after ()V
 	public fun apply (Lorg/junit/runners/model/Statement;Lorg/junit/runner/Description;)Lorg/junit/runners/model/Statement;
 	public fun before ()V
@@ -90,6 +96,40 @@ public final class dev/sebastiano/spectre/testing/FailureVideoPolicy : java/lang
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
 	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/testing/FailureVideoPolicy;
 	public static fun values ()[Ldev/sebastiano/spectre/testing/FailureVideoPolicy;
+}
+
+public final class dev/sebastiano/spectre/testing/InputIsolationConfig {
+	public static final field Companion Ldev/sebastiano/spectre/testing/InputIsolationConfig$Companion;
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/InputIsolationMode;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ldev/sebastiano/spectre/testing/InputIsolationMode;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ldev/sebastiano/spectre/testing/InputIsolationMode;
+	public final fun component2-UwyO8pc ()J
+	public final fun copy-HG0u8IE (Ldev/sebastiano/spectre/testing/InputIsolationMode;J)Ldev/sebastiano/spectre/testing/InputIsolationConfig;
+	public static synthetic fun copy-HG0u8IE$default (Ldev/sebastiano/spectre/testing/InputIsolationConfig;Ldev/sebastiano/spectre/testing/InputIsolationMode;JILjava/lang/Object;)Ldev/sebastiano/spectre/testing/InputIsolationConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAcquireTimeout-UwyO8pc ()J
+	public final fun getMode ()Ldev/sebastiano/spectre/testing/InputIsolationMode;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/testing/InputIsolationConfig$Companion {
+	public final fun auto-LRDsOJo (J)Ldev/sebastiano/spectre/testing/InputIsolationConfig;
+	public static synthetic fun auto-LRDsOJo$default (Ldev/sebastiano/spectre/testing/InputIsolationConfig$Companion;JILjava/lang/Object;)Ldev/sebastiano/spectre/testing/InputIsolationConfig;
+	public final fun off ()Ldev/sebastiano/spectre/testing/InputIsolationConfig;
+	public final fun perInteraction ()Ldev/sebastiano/spectre/testing/InputIsolationConfig;
+	public final fun perTest-LRDsOJo (J)Ldev/sebastiano/spectre/testing/InputIsolationConfig;
+	public static synthetic fun perTest-LRDsOJo$default (Ldev/sebastiano/spectre/testing/InputIsolationConfig$Companion;JILjava/lang/Object;)Ldev/sebastiano/spectre/testing/InputIsolationConfig;
+}
+
+public final class dev/sebastiano/spectre/testing/InputIsolationMode : java/lang/Enum {
+	public static final field Auto Ldev/sebastiano/spectre/testing/InputIsolationMode;
+	public static final field Off Ldev/sebastiano/spectre/testing/InputIsolationMode;
+	public static final field PerInteraction Ldev/sebastiano/spectre/testing/InputIsolationMode;
+	public static final field PerTest Ldev/sebastiano/spectre/testing/InputIsolationMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/testing/InputIsolationMode;
+	public static fun values ()[Ldev/sebastiano/spectre/testing/InputIsolationMode;
 }
 
 public final class dev/sebastiano/spectre/testing/LaunchAndAttachExtension : org/junit/jupiter/api/extension/AfterEachCallback, org/junit/jupiter/api/extension/BeforeEachCallback, org/junit/jupiter/api/extension/ParameterResolver {

--- a/testing/build.gradle.kts
+++ b/testing/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
 
 dependencies {
     api(projects.core)
+    implementation(projects.inputCoordinatorServer)
     // Launch-and-attach JUnit surface (#208) composes over the experimental agent launch API.
     // Kept as `api` so consumers see `LaunchSpec` / `LaunchedSession` types from the extension.
     api(projects.agent)

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -1,6 +1,9 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
 package dev.sebastiano.spectre.testing
 
 import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
 import java.lang.reflect.Method
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback
@@ -66,6 +69,9 @@ internal constructor(
     private val failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
     private val failureVideo: FailureVideoConfig = FailureVideoConfig(),
     private val videoStarter: FailureVideoStarter = AutoFailureVideoStarter,
+    private val inputIsolation: InputIsolationConfig = InputIsolationConfig.perInteraction(),
+    private val leaseFactory: InputTestLeaseFactory = ProductionInputTestLeaseFactory,
+    private val acquireBeforeAutoFactory: Boolean = false,
     private val factory: AutomatorFactory,
 ) :
     BeforeEachCallback,
@@ -82,6 +88,29 @@ internal constructor(
         failureArtifacts = failureArtifacts,
         failureVideo = failureVideo,
         videoStarter = AutoFailureVideoStarter,
+        factory = factory,
+    )
+
+    @ExperimentalSpectreInputCoordinationApi
+    public constructor(
+        inputIsolation: InputIsolationConfig
+    ) : this(
+        inputIsolation = inputIsolation,
+        acquireBeforeAutoFactory = true,
+        factory = { ComposeAutomator.inProcess() },
+    )
+
+    @ExperimentalSpectreInputCoordinationApi
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+        failureVideo: FailureVideoConfig = FailureVideoConfig(),
+        inputIsolation: InputIsolationConfig,
+        factory: AutomatorFactory,
+    ) : this(
+        failureArtifacts = failureArtifacts,
+        failureVideo = failureVideo,
+        videoStarter = AutoFailureVideoStarter,
+        inputIsolation = inputIsolation,
         factory = factory,
     )
 
@@ -133,11 +162,31 @@ internal constructor(
             }
 
     override fun beforeEach(context: ExtensionContext) {
-        val automator = factory()
         val store = context.getStore(NAMESPACE)
-        store.put(STORE_KEY, automator)
-        lastInstance = automator
-        startFailureVideo(context, automator)
+        val isolation =
+            InputIsolationSession(
+                config = inputIsolation,
+                acquireBeforeAutoFactory = acquireBeforeAutoFactory,
+                ownerLabel = ownerLabel(context),
+                leaseFactory = leaseFactory,
+            )
+        val isolationKey = isolationStoreKey(context)
+        store.put(isolationKey, isolation)
+        runCatching {
+                isolation.acquireBeforeFactory()
+                val automator = factory()
+                isolation.bindAfterFactory(automator)
+                store.put(STORE_KEY, automator)
+                lastInstance = automator
+                startFailureVideo(context, automator)
+            }
+            .onFailure {
+                store.remove(STORE_KEY)
+                store.remove(isolationKey)
+                lastInstance = null
+                isolation.close()
+            }
+            .getOrThrow()
     }
 
     override fun afterTestExecution(context: ExtensionContext) {
@@ -201,9 +250,14 @@ internal constructor(
         // Finalize video before clearing the automator so window-targeted backends still see
         // live windows during stop if needed; then drop the automator.
         val failure = context.executionException.orElse(null)
-        finalizeFailureVideo(context, failure)
-        context.getStore(NAMESPACE).remove(STORE_KEY)
-        lastInstance = null
+        try {
+            finalizeFailureVideo(context, failure)
+        } finally {
+            val store = context.getStore(NAMESPACE)
+            store.remove(STORE_KEY)
+            lastInstance = null
+            store.remove(isolationStoreKey(context), InputIsolationSession::class.java)?.close()
+        }
     }
 
     private fun startFailureVideo(context: ExtensionContext, automator: ComposeAutomator) {
@@ -266,6 +320,15 @@ internal constructor(
         // test invocations from clobbering each other.
         val NAMESPACE: ExtensionContext.Namespace =
             ExtensionContext.Namespace.create(ComposeAutomatorExtension::class.java)
+
+        fun isolationStoreKey(context: ExtensionContext): String =
+            "inputIsolation:${context.uniqueId}"
+
+        fun ownerLabel(context: ExtensionContext): String {
+            val className = context.testClass.map { it.simpleName }.orElse("UnknownClass")
+            val methodName = context.testMethod.map { it.name }.orElse("unknown")
+            return "$className#$methodName"
+        }
     }
 }
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -97,7 +97,7 @@ internal constructor(
     ) : this(
         inputIsolation = inputIsolation,
         acquireBeforeAutoFactory = true,
-        factory = { ComposeAutomator.inProcess() },
+        factory = defaultAutomatorFactory(inputIsolation),
     )
 
     @ExperimentalSpectreInputCoordinationApi

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -72,6 +72,7 @@ internal constructor(
     private val inputIsolation: InputIsolationConfig = InputIsolationConfig.perInteraction(),
     private val leaseFactory: InputTestLeaseFactory = ProductionInputTestLeaseFactory,
     private val acquireBeforeAutoFactory: Boolean = false,
+    private val managedFactory: ManagedAutomatorFactory? = null,
     private val factory: AutomatorFactory,
 ) :
     BeforeEachCallback,
@@ -97,7 +98,8 @@ internal constructor(
     ) : this(
         inputIsolation = inputIsolation,
         acquireBeforeAutoFactory = true,
-        factory = defaultAutomatorFactory(inputIsolation),
+        managedFactory = defaultManagedAutomatorFactory(inputIsolation),
+        factory = { ComposeAutomator.inProcess() },
     )
 
     @ExperimentalSpectreInputCoordinationApi
@@ -174,7 +176,7 @@ internal constructor(
         store.put(isolationKey, isolation)
         runCatching {
                 isolation.acquireBeforeFactory()
-                val automator = isolation.createAutomator(factory)
+                val automator = isolation.createAutomator(factory, managedFactory)
                 isolation.bindAfterFactory(automator)
                 store.put(STORE_KEY, automator)
                 lastInstance = automator

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -174,7 +174,7 @@ internal constructor(
         store.put(isolationKey, isolation)
         runCatching {
                 isolation.acquireBeforeFactory()
-                val automator = factory()
+                val automator = isolation.createAutomator(factory)
                 isolation.bindAfterFactory(automator)
                 store.put(STORE_KEY, automator)
                 lastInstance = automator

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -90,7 +90,7 @@ internal constructor(
     ) : this(
         inputIsolation = inputIsolation,
         acquireBeforeAutoFactory = true,
-        factory = { ComposeAutomator.inProcess() },
+        factory = defaultAutomatorFactory(inputIsolation),
     )
 
     @ExperimentalSpectreInputCoordinationApi

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -70,6 +70,7 @@ internal constructor(
     private val inputIsolation: InputIsolationConfig = InputIsolationConfig.perInteraction(),
     private val leaseFactory: InputTestLeaseFactory = ProductionInputTestLeaseFactory,
     private val acquireBeforeAutoFactory: Boolean = false,
+    private val managedFactory: ManagedAutomatorFactory? = null,
     private val factory: AutomatorFactory,
 ) : ExternalResource() {
 
@@ -90,7 +91,8 @@ internal constructor(
     ) : this(
         inputIsolation = inputIsolation,
         acquireBeforeAutoFactory = true,
-        factory = defaultAutomatorFactory(inputIsolation),
+        managedFactory = defaultManagedAutomatorFactory(inputIsolation),
+        factory = { ComposeAutomator.inProcess() },
     )
 
     @ExperimentalSpectreInputCoordinationApi
@@ -184,7 +186,7 @@ internal constructor(
                     )
                 try {
                     isolation.acquireBeforeFactory()
-                    instance = isolation.createAutomator(factory)
+                    instance = isolation.createAutomator(factory, managedFactory)
                     isolation.bindAfterFactory(automator)
                     startFailureVideo(lastDescription)
                     // runCatching so both Exception and AssertionError (JUnit 4 failures) are

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -1,6 +1,9 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
 package dev.sebastiano.spectre.testing
 
 import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
 import org.junit.rules.ExternalResource
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
@@ -64,6 +67,9 @@ internal constructor(
     private val failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
     private val failureVideo: FailureVideoConfig = FailureVideoConfig(),
     private val videoStarter: FailureVideoStarter = AutoFailureVideoStarter,
+    private val inputIsolation: InputIsolationConfig = InputIsolationConfig.perInteraction(),
+    private val leaseFactory: InputTestLeaseFactory = ProductionInputTestLeaseFactory,
+    private val acquireBeforeAutoFactory: Boolean = false,
     private val factory: AutomatorFactory,
 ) : ExternalResource() {
 
@@ -75,6 +81,29 @@ internal constructor(
         failureArtifacts = failureArtifacts,
         failureVideo = failureVideo,
         videoStarter = AutoFailureVideoStarter,
+        factory = factory,
+    )
+
+    @ExperimentalSpectreInputCoordinationApi
+    public constructor(
+        inputIsolation: InputIsolationConfig
+    ) : this(
+        inputIsolation = inputIsolation,
+        acquireBeforeAutoFactory = true,
+        factory = { ComposeAutomator.inProcess() },
+    )
+
+    @ExperimentalSpectreInputCoordinationApi
+    public constructor(
+        failureArtifacts: FailureArtifactsConfig = FailureArtifactsConfig(),
+        failureVideo: FailureVideoConfig = FailureVideoConfig(),
+        inputIsolation: InputIsolationConfig,
+        factory: AutomatorFactory,
+    ) : this(
+        failureArtifacts = failureArtifacts,
+        failureVideo = failureVideo,
+        videoStarter = AutoFailureVideoStarter,
+        inputIsolation = inputIsolation,
         factory = factory,
     )
 
@@ -146,8 +175,18 @@ internal constructor(
                     failureVideo.invocationId?.takeIf { it.isNotBlank() }
                         ?: failureArtifacts.invocationId?.takeIf { it.isNotBlank() }
                         ?: "${testClass}#${testMethod}#${System.nanoTime()}"
-                before()
+                val isolation =
+                    InputIsolationSession(
+                        config = inputIsolation,
+                        acquireBeforeAutoFactory = acquireBeforeAutoFactory,
+                        ownerLabel = ownerLabel(description),
+                        leaseFactory = leaseFactory,
+                    )
                 try {
+                    isolation.acquireBeforeFactory()
+                    instance = factory()
+                    isolation.bindAfterFactory(automator)
+                    startFailureVideo(lastDescription)
                     // runCatching so both Exception and AssertionError (JUnit 4 failures) are
                     // captured without a broad catch-Throwable detekt hit at this boundary.
                     val outcome = runCatching { base.evaluate() }
@@ -171,7 +210,11 @@ internal constructor(
                     // Safety net: never leave an active recorder if evaluate exits oddly.
                     videoSession?.abandon()
                     videoSession = null
-                    after()
+                    try {
+                        after()
+                    } finally {
+                        isolation.close()
+                    }
                     lastDescription = null
                     evaluateInvocationId = null
                 }
@@ -232,5 +275,11 @@ internal constructor(
                 // Paths still land on disk under build/reports/spectre for CI globs.
             },
         )
+    }
+
+    private fun ownerLabel(description: Description): String {
+        val className = description.testClass?.simpleName ?: "UnknownClass"
+        val methodName = description.methodName?.substringBefore('[') ?: "unknown"
+        return "$className#$methodName"
     }
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -184,7 +184,7 @@ internal constructor(
                     )
                 try {
                     isolation.acquireBeforeFactory()
-                    instance = factory()
+                    instance = isolation.createAutomator(factory)
                     isolation.bindAfterFactory(automator)
                     startFailureVideo(lastDescription)
                     // runCatching so both Exception and AssertionError (JUnit 4 failures) are

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
@@ -9,6 +9,8 @@ import dev.sebastiano.spectre.core.AutomatorInputLease
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.DesktopInputIsolation
 import dev.sebastiano.spectre.core.InputLeaseOptions
+import dev.sebastiano.spectre.core.InputLeasePolicy
+import dev.sebastiano.spectre.core.RobotDriver
 import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -58,6 +60,19 @@ internal object ProductionInputTestLeaseFactory : InputTestLeaseFactory {
     override fun acquire(options: InputLeaseOptions, ownerLabel: String): AutomatorInputLease =
         DesktopInputIsolation.acquire(options.copy(ownerLabel = ownerLabel))
 }
+
+internal fun defaultAutomatorFactory(
+    inputIsolation: InputIsolationConfig,
+    legacyFactory: AutomatorFactory = { ComposeAutomator.inProcess() },
+    coordinatedFactory: AutomatorFactory = {
+        ComposeAutomator.inProcess(RobotDriver(InputLeasePolicy.Required))
+    },
+): AutomatorFactory =
+    if (inputIsolation.mode == InputIsolationMode.PerInteraction) {
+        coordinatedFactory
+    } else {
+        legacyFactory
+    }
 
 internal class InputIsolationSession(
     private val config: InputIsolationConfig,

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
@@ -1,0 +1,109 @@
+@file:OptIn(
+    dev.sebastiano.spectre.core.InternalSpectreApi::class,
+    dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class,
+)
+
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.AutomatorInputLease
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.DesktopInputIsolation
+import dev.sebastiano.spectre.core.InputLeaseOptions
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/** Whole-test desktop-input isolation mode for in-process JUnit wrappers. */
+@ExperimentalSpectreInputCoordinationApi
+public enum class InputIsolationMode {
+    /** Chooses per-test isolation only when the created automator touches shared OS input state. */
+    Auto,
+
+    /** Holds one desktop lease across factory setup, test execution, evidence, and teardown. */
+    PerTest,
+
+    /** Uses the core operation and explicit-scope leases without a whole-test lease. */
+    PerInteraction,
+
+    /** Disables wrapper-owned isolation because the caller coordinates externally. */
+    Off,
+}
+
+/** Configuration for in-process JUnit desktop-input isolation. */
+@ExperimentalSpectreInputCoordinationApi
+public data class InputIsolationConfig(
+    public val mode: InputIsolationMode = InputIsolationMode.PerInteraction,
+    public val acquireTimeout: Duration = 30.seconds,
+) {
+    public companion object {
+        public fun auto(acquireTimeout: Duration = 30.seconds): InputIsolationConfig =
+            InputIsolationConfig(InputIsolationMode.Auto, acquireTimeout)
+
+        public fun perTest(acquireTimeout: Duration = 30.seconds): InputIsolationConfig =
+            InputIsolationConfig(InputIsolationMode.PerTest, acquireTimeout)
+
+        public fun perInteraction(): InputIsolationConfig =
+            InputIsolationConfig(InputIsolationMode.PerInteraction)
+
+        public fun off(): InputIsolationConfig = InputIsolationConfig(InputIsolationMode.Off)
+    }
+}
+
+internal fun interface InputTestLeaseFactory {
+    fun acquire(options: InputLeaseOptions, ownerLabel: String): AutomatorInputLease
+}
+
+internal object ProductionInputTestLeaseFactory : InputTestLeaseFactory {
+    override fun acquire(options: InputLeaseOptions, ownerLabel: String): AutomatorInputLease =
+        DesktopInputIsolation.acquire(options.copy(ownerLabel = ownerLabel))
+}
+
+internal class InputIsolationSession(
+    private val config: InputIsolationConfig,
+    private val acquireBeforeAutoFactory: Boolean,
+    private val ownerLabel: String,
+    private val leaseFactory: InputTestLeaseFactory,
+) : ExtensionContext.Store.CloseableResource {
+    private var lease: AutomatorInputLease? = null
+    private var binding: AutoCloseable? = null
+
+    fun acquireBeforeFactory() {
+        if (
+            config.mode == InputIsolationMode.PerTest ||
+                (config.mode == InputIsolationMode.Auto && acquireBeforeAutoFactory)
+        ) {
+            acquire()
+        }
+    }
+
+    fun bindAfterFactory(automator: ComposeAutomator) {
+        if (
+            config.mode == InputIsolationMode.Auto &&
+                !acquireBeforeAutoFactory &&
+                automator.inputCapabilities.requiresDesktopCoordination
+        ) {
+            acquire()
+        }
+        lease?.let { acquired -> binding = acquired.bind(automator) }
+    }
+
+    override fun close() {
+        try {
+            binding?.close()
+        } finally {
+            binding = null
+            lease?.close()
+            lease = null
+        }
+    }
+
+    private fun acquire() {
+        check(lease == null) { "Input isolation lease has already been acquired" }
+        lease =
+            leaseFactory.acquire(
+                InputLeaseOptions(acquireTimeout = config.acquireTimeout),
+                ownerLabel,
+            )
+    }
+}

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
@@ -88,6 +88,9 @@ internal class InputIsolationSession(
         lease?.let { acquired -> binding = acquired.bind(automator) }
     }
 
+    fun createAutomator(factory: () -> ComposeAutomator): ComposeAutomator =
+        lease?.withLease(factory) ?: factory()
+
     override fun close() {
         try {
             binding?.close()

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
@@ -61,18 +61,26 @@ internal object ProductionInputTestLeaseFactory : InputTestLeaseFactory {
         DesktopInputIsolation.acquire(options.copy(ownerLabel = ownerLabel))
 }
 
-internal fun defaultAutomatorFactory(
+internal class ManagedAutomator(
+    internal val automator: ComposeAutomator,
+    internal val resource: AutoCloseable,
+)
+
+internal fun interface ManagedAutomatorFactory {
+    fun create(): ManagedAutomator
+}
+
+internal fun defaultManagedAutomatorFactory(
     inputIsolation: InputIsolationConfig,
-    legacyFactory: AutomatorFactory = { ComposeAutomator.inProcess() },
-    coordinatedFactory: AutomatorFactory = {
-        ComposeAutomator.inProcess(RobotDriver(InputLeasePolicy.Required))
+    coordinatedFactory: ManagedAutomatorFactory = ManagedAutomatorFactory {
+        val driver = RobotDriver(InputLeasePolicy.Required)
+        runCatching { ManagedAutomator(ComposeAutomator.inProcess(driver), driver) }
+            .onFailure { driver.close() }
+            .getOrThrow()
     },
-): AutomatorFactory =
-    if (inputIsolation.mode == InputIsolationMode.PerInteraction) {
-        coordinatedFactory
-    } else {
-        legacyFactory
-    }
+): ManagedAutomatorFactory? = coordinatedFactory.takeIf {
+    inputIsolation.mode == InputIsolationMode.PerInteraction
+}
 
 internal class InputIsolationSession(
     private val config: InputIsolationConfig,
@@ -82,6 +90,7 @@ internal class InputIsolationSession(
 ) : ExtensionContext.Store.CloseableResource {
     private var lease: AutomatorInputLease? = null
     private var binding: AutoCloseable? = null
+    private var managedResource: AutoCloseable? = null
 
     fun acquireBeforeFactory() {
         if (
@@ -103,16 +112,37 @@ internal class InputIsolationSession(
         lease?.let { acquired -> binding = acquired.bind(automator) }
     }
 
-    fun createAutomator(factory: () -> ComposeAutomator): ComposeAutomator =
-        lease?.withLease(factory) ?: factory()
+    fun createAutomator(
+        factory: () -> ComposeAutomator,
+        managedFactory: ManagedAutomatorFactory? = null,
+    ): ComposeAutomator {
+        val create = {
+            if (managedFactory == null) {
+                factory()
+            } else {
+                check(managedResource == null) { "Managed automator resource is already active" }
+                managedFactory
+                    .create()
+                    .also { managed -> managedResource = managed.resource }
+                    .automator
+            }
+        }
+        return lease?.withLease(create) ?: create()
+    }
 
     override fun close() {
         try {
             binding?.close()
         } finally {
             binding = null
-            lease?.close()
-            lease = null
+            try {
+                lease?.close()
+            } finally {
+                lease = null
+                val resource = managedResource
+                managedResource = null
+                resource?.close()
+            }
         }
     }
 

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ExperimentalInputIsolationApiTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ExperimentalInputIsolationApiTest.kt
@@ -1,0 +1,40 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+
+class ExperimentalInputIsolationApiTest {
+
+    @Test
+    fun `JUnit input isolation remains experimental`() {
+        listOf(InputIsolationConfig::class.java, InputIsolationMode::class.java).forEach { type ->
+            assertNotNull(
+                type.getAnnotation(ExperimentalSpectreInputCoordinationApi::class.java),
+                "${type.name} must remain experimental until the coordination API graduates",
+            )
+        }
+
+        listOf(ComposeAutomatorExtension::class.java, ComposeAutomatorRule::class.java).forEach {
+            type ->
+            listOf(
+                    type.getConstructor(InputIsolationConfig::class.java),
+                    type.getConstructor(
+                        FailureArtifactsConfig::class.java,
+                        FailureVideoConfig::class.java,
+                        InputIsolationConfig::class.java,
+                        Function0::class.java,
+                    ),
+                )
+                .forEach { constructor ->
+                    assertNotNull(
+                        constructor.getAnnotation(
+                            ExperimentalSpectreInputCoordinationApi::class.java
+                        )
+                    )
+                }
+        }
+    }
+}

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
@@ -12,6 +12,8 @@ import java.lang.reflect.Method
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
@@ -133,33 +135,71 @@ class InputIsolationLifecycleTest {
     }
 
     @Test
-    fun `explicit default factory enables per-interaction operation leases`() {
-        val selectedFactories = mutableListOf<String>()
-        val legacyFactory = {
-            selectedFactories += "legacy"
-            newHeadlessAutomator()
-        }
-        val coordinatedFactory = {
-            selectedFactories += "coordinated"
-            newHeadlessAutomator()
-        }
-
-        listOf(
-                InputIsolationConfig.perInteraction() to "coordinated",
-                InputIsolationConfig.perTest() to "legacy",
-                InputIsolationConfig.auto() to "legacy",
-                InputIsolationConfig.off() to "legacy",
+    fun `explicit default factory owns per-interaction driver only`() {
+        val managedFactory =
+            defaultManagedAutomatorFactory(
+                inputIsolation = InputIsolationConfig.perInteraction(),
+                coordinatedFactory = { ManagedAutomator(newHeadlessAutomator(), AutoCloseable {}) },
             )
-            .forEach { (config, expectedFactory) ->
-                defaultAutomatorFactory(
-                        inputIsolation = config,
-                        legacyFactory = legacyFactory,
-                        coordinatedFactory = coordinatedFactory,
-                    )
-                    .invoke()
 
-                assertEquals(expectedFactory, selectedFactories.removeLast())
+        assertNotNull(managedFactory)
+        assertNull(defaultManagedAutomatorFactory(InputIsolationConfig.perTest()))
+        assertNull(defaultManagedAutomatorFactory(InputIsolationConfig.auto()))
+        assertNull(defaultManagedAutomatorFactory(InputIsolationConfig.off()))
+    }
+
+    @Test
+    fun `managed per-interaction driver closes with isolation session`() {
+        val events = mutableListOf<String>()
+        val session =
+            InputIsolationSession(
+                config = InputIsolationConfig.perInteraction(),
+                acquireBeforeAutoFactory = true,
+                ownerLabel = "managed",
+                leaseFactory = recordingLeaseFactory(events),
+            )
+
+        session.createAutomator(
+            factory = { error("legacy factory must not run") },
+            managedFactory =
+                ManagedAutomatorFactory {
+                    ManagedAutomator(
+                        automator = newHeadlessAutomator(),
+                        resource = AutoCloseable { events += "close-driver" },
+                    )
+                },
+        )
+        session.close()
+
+        assertEquals(listOf("close-driver"), events)
+    }
+
+    @Test
+    fun `JUnit wrappers close their managed per-interaction drivers`() {
+        val events = mutableListOf<String>()
+        val extension =
+            ComposeAutomatorExtension(
+                inputIsolation = InputIsolationConfig.perInteraction(),
+                managedFactory = managedFactory("extension", events),
+                factory = { error("legacy extension factory must not run") },
+            )
+        val context = recordingContext("managed extension")
+        extension.beforeEach(context)
+        extension.afterEach(context)
+
+        val rule =
+            ComposeAutomatorRule(
+                inputIsolation = InputIsolationConfig.perInteraction(),
+                managedFactory = managedFactory("rule", events),
+                factory = { error("legacy rule factory must not run") },
+            )
+        val body =
+            object : Statement() {
+                override fun evaluate(): Unit = Unit
             }
+        rule.apply(body, Description.createTestDescription(javaClass, "managed rule")).evaluate()
+
+        assertEquals(listOf("close-extension", "close-rule"), events)
     }
 
     private fun recordingContext(displayName: String): RecordingExtensionContext =
@@ -174,6 +214,14 @@ class InputIsolationLifecycleTest {
 
     @Suppress("unused") private fun extensionTestFixture(): Unit = Unit
 }
+
+private fun managedFactory(name: String, events: MutableList<String>): ManagedAutomatorFactory =
+    ManagedAutomatorFactory {
+        ManagedAutomator(
+            automator = newHeadlessAutomator(),
+            resource = AutoCloseable { events += "close-$name" },
+        )
+    }
 
 private fun recordingLeaseFactory(events: MutableList<String>): InputTestLeaseFactory =
     InputTestLeaseFactory { _: InputLeaseOptions, ownerLabel: String ->

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
@@ -1,0 +1,155 @@
+@file:OptIn(
+    dev.sebastiano.spectre.core.InternalSpectreApi::class,
+    dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class,
+)
+
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.AutomatorInputLease
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.core.InputLeaseOptions
+import java.lang.reflect.Method
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import org.junit.runner.Description
+import org.junit.runners.model.Statement
+
+class InputIsolationLifecycleTest {
+
+    @Test
+    fun `JUnit 5 per-test lease spans factory and lifecycle`() {
+        val events = mutableListOf<String>()
+        val leaseFactory = recordingLeaseFactory(events)
+        val extension =
+            ComposeAutomatorExtension(
+                inputIsolation = InputIsolationConfig.perTest(),
+                leaseFactory = leaseFactory,
+                factory = {
+                    events += "factory"
+                    newHeadlessAutomator()
+                },
+            )
+        val context = recordingContext("extension test")
+
+        extension.beforeEach(context)
+        events += "body"
+        extension.afterEach(context)
+
+        assertEquals(
+            listOf(
+                "acquire:InputIsolationLifecycleTest#extensionTestFixture",
+                "factory",
+                "bind",
+                "body",
+                "unbind",
+                "release",
+            ),
+            events,
+        )
+    }
+
+    @Test
+    fun `JUnit 5 factory failure releases an acquired lease`() {
+        val events = mutableListOf<String>()
+        val extension =
+            ComposeAutomatorExtension(
+                inputIsolation = InputIsolationConfig.perTest(),
+                leaseFactory = recordingLeaseFactory(events),
+                factory = {
+                    events += "factory"
+                    error("factory failed")
+                },
+            )
+
+        assertFailsWith<IllegalStateException> { extension.beforeEach(recordingContext("failure")) }
+
+        assertEquals(
+            listOf(
+                "acquire:InputIsolationLifecycleTest#extensionTestFixture",
+                "factory",
+                "release",
+            ),
+            events,
+        )
+    }
+
+    @Test
+    fun `JUnit 4 per-test lease wraps factory body and teardown`() {
+        val events = mutableListOf<String>()
+        val rule =
+            ComposeAutomatorRule(
+                inputIsolation = InputIsolationConfig.perTest(),
+                leaseFactory = recordingLeaseFactory(events),
+                factory = {
+                    events += "factory"
+                    newHeadlessAutomator()
+                },
+            )
+        val body =
+            object : Statement() {
+                override fun evaluate() {
+                    events += "body"
+                }
+            }
+
+        rule.apply(body, Description.createTestDescription(javaClass, "rule test")).evaluate()
+
+        assertEquals(
+            listOf(
+                "acquire:InputIsolationLifecycleTest#rule test",
+                "factory",
+                "bind",
+                "body",
+                "unbind",
+                "release",
+            ),
+            events,
+        )
+    }
+
+    @Test
+    fun `preserving default per-interaction mode does not acquire a whole-test lease`() {
+        val events = mutableListOf<String>()
+        val rule =
+            ComposeAutomatorRule(
+                leaseFactory = recordingLeaseFactory(events),
+                factory = { newHeadlessAutomator() },
+            )
+        val body =
+            object : Statement() {
+                override fun evaluate(): Unit = Unit
+            }
+
+        rule.apply(body, Description.createTestDescription(javaClass, "compatibility")).evaluate()
+
+        assertEquals(emptyList(), events)
+    }
+
+    private fun recordingContext(displayName: String): RecordingExtensionContext =
+        RecordingExtensionContext(
+            failure = null,
+            testClass = javaClass,
+            methodName = fixtureMethod().name,
+            uniqueId = "[test:$displayName]",
+        )
+
+    private fun fixtureMethod(): Method = javaClass.getDeclaredMethod("extensionTestFixture")
+
+    @Suppress("unused") private fun extensionTestFixture(): Unit = Unit
+}
+
+private fun recordingLeaseFactory(events: MutableList<String>): InputTestLeaseFactory =
+    InputTestLeaseFactory { _: InputLeaseOptions, ownerLabel: String ->
+        events += "acquire:$ownerLabel"
+        object : AutomatorInputLease {
+            override fun bind(automator: ComposeAutomator): AutoCloseable {
+                events += "bind"
+                return AutoCloseable { events += "unbind" }
+            }
+
+            override fun close() {
+                events += "release"
+            }
+        }
+    }

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
@@ -132,6 +132,36 @@ class InputIsolationLifecycleTest {
         assertEquals(emptyList(), events)
     }
 
+    @Test
+    fun `explicit default factory enables per-interaction operation leases`() {
+        val selectedFactories = mutableListOf<String>()
+        val legacyFactory = {
+            selectedFactories += "legacy"
+            newHeadlessAutomator()
+        }
+        val coordinatedFactory = {
+            selectedFactories += "coordinated"
+            newHeadlessAutomator()
+        }
+
+        listOf(
+                InputIsolationConfig.perInteraction() to "coordinated",
+                InputIsolationConfig.perTest() to "legacy",
+                InputIsolationConfig.auto() to "legacy",
+                InputIsolationConfig.off() to "legacy",
+            )
+            .forEach { (config, expectedFactory) ->
+                defaultAutomatorFactory(
+                        inputIsolation = config,
+                        legacyFactory = legacyFactory,
+                        coordinatedFactory = coordinatedFactory,
+                    )
+                    .invoke()
+
+                assertEquals(expectedFactory, selectedFactories.removeLast())
+            }
+    }
+
     private fun recordingContext(displayName: String): RecordingExtensionContext =
         RecordingExtensionContext(
             failure = null,

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
@@ -39,7 +39,9 @@ class InputIsolationLifecycleTest {
         assertEquals(
             listOf(
                 "acquire:InputIsolationLifecycleTest#extensionTestFixture",
+                "enter-factory-lease",
                 "factory",
+                "exit-factory-lease",
                 "bind",
                 "body",
                 "unbind",
@@ -67,7 +69,9 @@ class InputIsolationLifecycleTest {
         assertEquals(
             listOf(
                 "acquire:InputIsolationLifecycleTest#extensionTestFixture",
+                "enter-factory-lease",
                 "factory",
+                "exit-factory-lease",
                 "release",
             ),
             events,
@@ -98,7 +102,9 @@ class InputIsolationLifecycleTest {
         assertEquals(
             listOf(
                 "acquire:InputIsolationLifecycleTest#rule test",
+                "enter-factory-lease",
                 "factory",
+                "exit-factory-lease",
                 "bind",
                 "body",
                 "unbind",
@@ -143,6 +149,15 @@ private fun recordingLeaseFactory(events: MutableList<String>): InputTestLeaseFa
     InputTestLeaseFactory { _: InputLeaseOptions, ownerLabel: String ->
         events += "acquire:$ownerLabel"
         object : AutomatorInputLease {
+            override fun <T> withLease(block: () -> T): T {
+                events += "enter-factory-lease"
+                return try {
+                    block()
+                } finally {
+                    events += "exit-factory-lease"
+                }
+            }
+
             override fun bind(automator: ComposeAutomator): AutoCloseable {
                 events += "bind"
                 return AutoCloseable { events += "unbind" }

--- a/tests/test_central_portal_check.py
+++ b/tests/test_central_portal_check.py
@@ -236,6 +236,31 @@ class CentralPortalCheckTest(unittest.TestCase):
 
         self.assertIn("AttachSpike", "\n".join(errors))
 
+    def test_input_coordinator_artifacts_require_representative_classes(self):
+        required_entries = {
+            "spectre-input-coordinator": (
+                "dev/sebastiano/spectre/input/LocalInputCoordinatorClient.class"
+            ),
+            "spectre-input-coordinator-server": (
+                "dev/sebastiano/spectre/input/server/LocalCoordinatorServer.class"
+            ),
+        }
+
+        for component, required_entry in required_entries.items():
+            with self.subTest(component=component, payload="missing"):
+                jar = self._jar({"META-INF/MANIFEST.MF": "Manifest-Version: 1.0\n\n"})
+
+                errors = central.validate_jar(component, jar)
+
+                self.assertIn(required_entry, "\n".join(errors))
+
+            with self.subTest(component=component, payload="present"):
+                jar = self._jar({required_entry: b"class"})
+
+                errors = central.validate_jar(component, jar)
+
+                self.assertEqual(errors, [])
+
     def test_print_files_lists_actual_central_file_listing(self):
         expected_path = (
             "dev/sebastiano/spectre/spectre-core/0.2.0/"

--- a/tests/test_central_portal_check.py
+++ b/tests/test_central_portal_check.py
@@ -81,7 +81,17 @@ class CentralPortalCheckTest(unittest.TestCase):
             "spectre-core-0.2.0.jar.asc.sha512",
             files,
         )
-        self.assertEqual(len(files), 450)
+        self.assertIn(
+            "dev/sebastiano/spectre/spectre-input-coordinator/0.2.0/"
+            "spectre-input-coordinator-0.2.0.jar",
+            files,
+        )
+        self.assertIn(
+            "dev/sebastiano/spectre/spectre-input-coordinator-server/0.2.0/"
+            "spectre-input-coordinator-server-0.2.0.pom.asc.sha512",
+            files,
+        )
+        self.assertEqual(len(files), 550)
 
     def test_agent_runtime_manifest_validation(self):
         jar = self._jar(


### PR DESCRIPTION
## Summary

- add an experimental FIFO, fenced local desktop-input coordinator with heartbeat recovery and exact-ID revoke/force recovery
- integrate coordinated Robot input, agent input lanes, CLI inspection/recovery, and JUnit 4/5 per-test isolation
- document the API, limitations, security model, website guidance, consumer skill, and cross-platform release-smoke gates

The feature remains opt-in and the existing no-argument RobotDriver behavior is unchanged.

## Validation

- ./gradlew check
- ./gradlew verifyMavenLocalPublication (11 modules)
- python3 -m mkdocs build --strict
- Spectre skill validation and eval JSON validation
- independent implementation review with no blocking findings

## Review gate

Cursor Bugbot is currently unavailable; its gate is explicitly waived by the maintainer for this PR.