### PR TITLE
Stop the Windows smoke recipe claiming it exercises pressKey

### DIFF
--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -522,9 +522,13 @@ Optional **full UI e2e** on a physical Windows desktop (not hosted CI default):
   --tests '*AgentAttachIntegration*'
 ```
 
-`-Pspectre.agent.realKeyboard=true` keeps the Robot keyboard paths — `AgentAttachIntegrationTest`'s
-`typeText` subpath and the corpus' `press-key-tab-after-focus` scenario. Both are opt-in off CI so
+`-Pspectre.agent.realKeyboard=true` keeps the Robot `typeText` subpath, which is opt-in off CI so
 `./gradlew check` stays runnable on a machine in use. Leave the smoke desktop idle while it runs.
+
+This Windows recipe does **not** cover `press-key-tab-after-focus`: that scenario lives in
+`AgentContractCorpusTest`, which the command above does not select and which is
+`@EnabledOnOs(LINUX, MAC)` anyway. On Linux and macOS the same property gates both paths — see the
+`agent-contract-corpus` scenario in [scripts/release-smoke.py](https://github.com/rock3r/spectre/blob/main/scripts/release-smoke.py).
 
 See [Agent attach](guide/agent.md). Do not enable this property on headless
 `windows-latest` as a fail-closed gate without a headed runner story.


### PR DESCRIPTION
## Summary

Follow-up to #450. Codex raised this on that PR and I merged before reading the thread — my mistake, so it lands separately.

The physical-Windows recipe in `docs/RELEASE-SMOKE.md` filters to `*AgentAttachIntegration*`, which exercises `typeText` but not `press-key-tab-after-focus`. That scenario lives in `AgentContractCorpusTest`, which the command does not select and which is `@EnabledOnOs(LINUX, MAC)` regardless. The prose claimed the property kept both paths.

The text now says what the command actually covers and points at the `agent-contract-corpus` scenario for the platforms where the same property does gate both. `scripts/windows-release-smoke.ps1` already carried a comment saying the corpus is n/a on Windows; the docs now agree with it.

## Test plan

- [x] `./gradlew check` passes locally (includes the `mkdocs build --strict` link check)
- [x] `./gradlew ktfmtFormat` produced no changes

## Confirmations

- [ ] ~I read CONTRIBUTING.md and this PR is **not** LLM-generated.~ — **This PR was written by Claude Code at the repo owner's direction.** Not ticking a box that would say otherwise.
- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)