### PR TITLE
Add hasTag/hasText presence checks to ComposeAutomator

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -100,6 +100,10 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public final fun focusWindow (Ldev/sebastiano/spectre/core/AutomatorNode;)V
 	public final fun getInputCapabilities ()Ldev/sebastiano/spectre/core/InputCapabilities;
 	public final fun getWindows ()Ljava/util/List;
+	public final fun hasTag (Ljava/lang/String;)Z
+	public final fun hasText (Ldev/sebastiano/spectre/core/TextQuery;)Z
+	public final fun hasText (Ljava/lang/String;Z)Z
+	public static synthetic fun hasText$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;ZILjava/lang/Object;)Z
 	public final fun longClick-8Mi8wO0 (Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun longClick-8Mi8wO0$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ldev/sebastiano/spectre/core/AutomatorNode;JLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun monitorRecompositions-LRDsOJo (J)Ldev/sebastiano/spectre/core/perf/RecompositionMonitor;

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -144,6 +144,34 @@ private constructor(
     public fun findOneByText(text: String, exact: Boolean = true): AutomatorNode? =
         findByText(text, exact).firstOrNull()
 
+    /**
+     * Whether any tracked node currently has [tag] as its test tag.
+     *
+     * Reads the current tracked-windows snapshot without calling [refreshWindows], matching
+     * [findByTestTag]. Call [refreshWindows] first when a popup or window may have appeared or
+     * vanished since the last refresh.
+     */
+    public fun hasTag(tag: String): Boolean = findByTestTag(tag).isNotEmpty()
+
+    /**
+     * Whether any tracked node currently matches [text].
+     *
+     * Reads the current tracked-windows snapshot without calling [refreshWindows], matching
+     * [findByText]. Call [refreshWindows] first when a popup or window may have appeared or
+     * vanished since the last refresh.
+     */
+    public fun hasText(text: String, exact: Boolean = true): Boolean =
+        findByText(text, exact).isNotEmpty()
+
+    /**
+     * Whether any tracked node currently matches [query].
+     *
+     * Reads the current tracked-windows snapshot without calling [refreshWindows], matching
+     * [findByText]. Call [refreshWindows] first when a popup or window may have appeared or
+     * vanished since the last refresh.
+     */
+    public fun hasText(query: TextQuery): Boolean = findByText(query).isNotEmpty()
+
     public fun findByContentDescription(description: String): List<AutomatorNode> =
         semanticsReader.findByContentDescription(description, windows)
 
@@ -522,10 +550,11 @@ private constructor(
      * [refreshWindows] call (and `tree()`, which refreshes internally) emits the new surface set,
      * and the monitor reconciles its CompositionObserver attachments automatically.
      *
-     * Note: query helpers like [findByTestTag] / [findByText] read the *current* tracked-windows
-     * snapshot without driving a refresh, so they do not by themselves discover newly opened
-     * windows. Call [refreshWindows] (or [tree], or [waitForIdle], all of which refresh) after
-     * opening a new window if you need the monitor to attach to it before continuing.
+     * Note: query helpers like [findByTestTag] / [findByText] / [hasTag] / [hasText] read the
+     * *current* tracked-windows snapshot without driving a refresh, so they do not by themselves
+     * discover newly opened windows. Call [refreshWindows] (or [tree], or [waitForIdle], all of
+     * which refresh) after opening a new window if you need the monitor to attach to it before
+     * continuing.
      *
      * The caller owns the returned monitor's lifecycle: [RecompositionMonitor.close] cancels its
      * internal scope and disposes every CompositionObserver handle. Failing to close it leaks the

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -360,6 +360,8 @@ class ComposeAutomatorPublicSurfaceTest {
                 "findOneByTestTag",
                 "findByText",
                 "findOneByText",
+                "hasTag",
+                "hasText",
                 "findByContentDescription",
                 "findByRole",
                 "click",

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/HasTagHasTextTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/HasTagHasTextTest.kt
@@ -1,0 +1,47 @@
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * Unit-level tests for [ComposeAutomator.hasTag] / [ComposeAutomator.hasText]: they are boolean
+ * presence checks over the same current-snapshot finders, with no extra
+ * [ComposeAutomator.refreshWindows] of their own. True-positive matches against live Compose live
+ * in the sample-desktop validation suite (`HasTagHasTextValidationTest`).
+ */
+class HasTagHasTextTest {
+
+    @Test
+    fun `hasTag is false on an empty tracked-window snapshot`() {
+        val automator = emptySnapshotAutomator()
+        assertFalse(automator.hasTag("anything"))
+        assertEquals(automator.findByTestTag("anything").isNotEmpty(), automator.hasTag("anything"))
+    }
+
+    @Test
+    fun `hasText is false on an empty tracked-window snapshot`() {
+        val automator = emptySnapshotAutomator()
+        assertFalse(automator.hasText("anything"))
+        assertEquals(automator.findByText("anything").isNotEmpty(), automator.hasText("anything"))
+    }
+
+    @Test
+    fun `hasText substring overload matches findByText exact false`() {
+        val automator = emptySnapshotAutomator()
+        assertEquals(
+            automator.findByText("any", exact = false).isNotEmpty(),
+            automator.hasText("any", exact = false),
+        )
+    }
+
+    @Test
+    fun `hasText TextQuery overload matches findByText query`() {
+        val automator = emptySnapshotAutomator()
+        val query = TextQuery.substring("any")
+        assertEquals(automator.findByText(query).isNotEmpty(), automator.hasText(query))
+    }
+
+    private fun emptySnapshotAutomator(): ComposeAutomator =
+        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless(), discoverWindows = false)
+}

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -93,16 +93,16 @@ change that touches a public signature.
 These have bitten reviews already; they're worth re-verifying every time the
 corresponding doc page is touched:
 
-- **No auto-wait.** Queries (`findByTestTag`, `findByText`, etc.) do a single read.
-  They never retry. Document them as such.
+- **No auto-wait.** Queries (`findByTestTag`, `findByText`, `hasTag`, `hasText`, etc.)
+  do a single read. They never retry. Document them as such.
 - **EDT rule applies to all three waits.** `waitForNode`, `waitForIdle`, and
   `waitForVisualIdle` all reject EDT callers via `rejectEdtCaller` (see
   `WaitForNodeTest.waitForNode rejects EDT callers with valid arguments`). Earlier
   drafts of the docs carved out `waitForNode` as exempt — that exemption is gone in
   current code. Do say "all wait helpers reject the EDT".
-- **`refreshWindows` is only auto-called by `tree()`.** `findBy*` and `allNodes`
-  read against the last refresh. If a popup may have appeared since the last call,
-  the user has to refresh.
+- **`refreshWindows` is only auto-called by `tree()`.** `findBy*`, `hasTag`/`hasText`,
+  and `allNodes` read against the last refresh. If a popup may have appeared since the
+  last call, the user has to refresh.
 - **`findOneBy*` exists only for `testTag` and `text`.** Not for content
   description, not for role.
 - **`waitForNode(tag, text)` is AND, not OR.** Both criteria must match the same

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -42,9 +42,10 @@ one in the main window.
 
 Calling `automator.refreshWindows()` rescans the live surface list. Only `tree()`
 refreshes for you; the per-query helpers (`findByTestTag`, `findByText`,
-`findByContentDescription`, `findByRole`, `allNodes`) read against the windows that
-were tracked at the last refresh. If a window or popup may have appeared or closed
-since the last query, call `refreshWindows()` (or `tree()`) before reading.
+`findByContentDescription`, `findByRole`, `allNodes`, `hasTag`, `hasText`) read
+against the windows that were tracked at the last refresh. If a window or popup may
+have appeared or closed since the last query, call `refreshWindows()` (or `tree()`)
+before reading.
 
 `automator.tree()` returns an `AutomatorTree` snapshot — a list of `AutomatorWindow`s,
 each with its own root nodes:
@@ -66,10 +67,10 @@ The API is split into two layers:
 
 - **Queries** — `tree()`, `allNodes()`, `findByTestTag(...)`, `findByText(...)`,
   `findByContentDescription(...)`, `findByRole(...)`, plus `findOneByTestTag(...)` and
-  `findOneByText(...)` for the single-result cases. (Content-description and role
-  selectors don't have `findOneBy…` variants — call `.firstOrNull()` on the list result
-  yourself if you want one.) These do a single read against the current semantics state
-  and return what they see.
+  `findOneByText(...)` for the single-result cases, and `hasTag(...)` / `hasText(...)`
+  for boolean presence. (Content-description and role selectors don't have `findOneBy…`
+  variants — call `.firstOrNull()` on the list result yourself if you want one.) These
+  do a single read against the current semantics state and return what they see.
 - **Interactions** — `click`, `doubleClick`, `longClick`, `moveTo`, `moveBy`, `swipe`, `scrollWheel`,
   `typeText`, `pasteText`, `clearAndTypeText`, `pressKey`, `pressEnter`, `screenshot`. These dispatch
   input via `RobotDriver` (or capture pixels).

--- a/docs/guide/selectors.md
+++ b/docs/guide/selectors.md
@@ -4,8 +4,8 @@ Selectors are how you locate a Compose node in the semantics tree. The `ComposeA
 exposes four families of selectors plus a handful of convenience overloads.
 
 !!! note "All selectors are non-waiting"
-    Every `findBy…`/`findOneBy…` call is a single read against the current semantics
-    state. If you need to wait for a node to appear, use
+    Every `findBy…`/`findOneBy…`/`hasTag`/`hasText` call is a single read against the
+    current semantics state. If you need to wait for a node to appear, use
     [`waitForNode(...)`](synchronization.md#waitfornode) instead.
 
 ## By test tag
@@ -73,6 +73,24 @@ val checkboxes = automator.findByRole(Role.Checkbox)
 Roles come from `Modifier.semantics { role = Role.Button }` (or, more often, are set
 implicitly by the standard Material/Compose components). Use this for "all buttons in
 this dialog" style assertions, not as a primary selector.
+
+## Presence checks
+
+When you only need a boolean — state-snapshot tests, `"popupOpen=" + hasTag(POPUP_TAG)` —
+use the presence helpers instead of `findByTestTag(tag).isNotEmpty()`:
+
+```kotlin
+import dev.sebastiano.spectre.core.TextQuery
+
+val popupOpen: Boolean = automator.hasTag("popup.body")
+val showsSubmit: Boolean = automator.hasText("Submit")
+val showsPartial: Boolean = automator.hasText("Sub", exact = false)
+val caseInsensitive: Boolean = automator.hasText(TextQuery.exact("submit", ignoreCase = true))
+```
+
+These are the same single snapshot read as the finders: they do **not** call
+`refreshWindows()`. If a popup window may have just appeared or vanished, call
+`refreshWindows()` (or `tree()`) first.
 
 ## Working with the result
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -61,7 +61,8 @@ familiar — Spectre brings the same "find a node, do a thing, assert" loop to C
 - :material-book-open-page-variant: **[The automator](guide/automator.md)** — Concepts:
   semantics surfaces, queries vs. interactions, why there is no auto-wait.
 - :material-target: **[Finding nodes](guide/selectors.md)** — `findByTestTag`, `findByText`,
-  `findByContentDescription`, `findByRole`, and the `printTree()` debugger.
+  `hasTag`/`hasText`, `findByContentDescription`, `findByRole`, and the `printTree()`
+  debugger.
 - :material-clock-fast: **[Synchronization](guide/synchronization.md)**
   — `waitForIdle`, `waitForVisualIdle`, `waitForNode`, and the EDT rule.
 - :material-monitor-dashboard: **[Running on CI](guide/ci.md)** — `xvfb`, required test-JVM

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/HasTagHasTextValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/HasTagHasTextValidationTest.kt
@@ -1,0 +1,69 @@
+package dev.sebastiano.spectre.sample.validation
+
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Live-Compose coverage for
+ * [`ComposeAutomator.hasTag`][dev.sebastiano.spectre.core.ComposeAutomator.hasTag] /
+ * [`ComposeAutomator.hasText`][dev.sebastiano.spectre.core.ComposeAutomator.hasText].
+ *
+ * Empty-snapshot equivalence with the finders is covered in `HasTagHasTextTest`. Presence against a
+ * real semantics tree has to walk live Compose, so it lives here.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class HasTagHasTextValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre hasTag/hasText validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `hasTag matches findByTestTag presence on a live counter`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            waitForTestTag("incrementButton")
+
+            assertTrue(hasTag("incrementButton"), "expected incrementButton to be present")
+            assertEquals(findByTestTag("incrementButton").isNotEmpty(), hasTag("incrementButton"))
+            assertFalse(hasTag("this.tag.definitely.does.not.exist"))
+            assertEquals(
+                findByTestTag("this.tag.definitely.does.not.exist").isNotEmpty(),
+                hasTag("this.tag.definitely.does.not.exist"),
+            )
+        }
+    }
+
+    @Test
+    fun `hasText matches findByText presence on a live counter`() = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.counter")
+            val button = waitForTestTag("incrementButton")
+            val buttonText = button.text
+            assertNotNull(buttonText, "incrementButton must expose its 'Count: N' text")
+
+            assertTrue(hasText(buttonText), "expected visible button text to be present")
+            assertEquals(findByText(buttonText).isNotEmpty(), hasText(buttonText))
+            assertFalse(hasText("this text definitely does not exist"))
+            assertEquals(
+                findByText("this text definitely does not exist").isNotEmpty(),
+                hasText("this text definitely does not exist"),
+            )
+        }
+    }
+}

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -149,9 +149,11 @@ Use, in order of preference:
 
 1. **`findByTestTag(tag)` / `findOneByTestTag(tag)`** — relies on
    `Modifier.testTag("…")` on the composable. The default. Most reliable.
+   `hasTag(tag)` is the boolean form of the same snapshot read.
 2. **`findByText(text, exact = true)` / `findOneByText(...)`** — match
    semantics `Text`. Brittle to i18n; OK for affordances written in test
-   harness code.
+   harness code. `hasText(text)` is the boolean form of the same snapshot
+   read.
 3. **`findByContentDescription(...)`** — accessibility descriptions.
 4. **`findByRole(Role.Button)`** — semantics roles.
 5. **`allNodes()`** / **`tree()`** / **`printTree()`** — for debugging.
@@ -198,9 +200,9 @@ This is the #1 source of flakes. Internalize three rules:
 
 ### Rule 1: queries don't wait
 
-`findByTestTag("Submit")` returns whatever is in the semantics tree *right
-now*. If the screen hasn't rendered yet, it returns null. Always wait before
-querying state that depends on a prior action.
+`findByTestTag("Submit")` / `hasTag("Submit")` read whatever is in the semantics
+tree *right now*. If the screen hasn't rendered yet, they return empty / `false`.
+Always wait before querying state that depends on a prior action.
 
 ### Rule 2: pick the right wait
 


### PR DESCRIPTION
## Summary
- Add `ComposeAutomator.hasTag` / `hasText` as boolean presence helpers over the existing finders.
- They read the current tracked-window snapshot and do **not** auto-call `refreshWindows()`, matching `findByTestTag` / `findByText` (callers refresh separately; waits like `waitForNode` still refresh on each poll).
- Cover empty-snapshot equivalence in unit tests, live presence on the sample-desktop validation suite, ABI dump, public-surface allowlist, and user-guide / skill docs.

Closes #463

## Test plan
- [ ] `./gradlew :core:test --tests '*HasTagHasTextTest*'`
- [ ] `./gradlew :core:check`
- [ ] Optional live: `:sample-desktop:validationTest --tests '*HasTagHasTextValidationTest*'`
- [ ] Confirm docs on Finding nodes describe presence checks as non-refreshing