### PR TITLE
Cancel the queued lease waiter on a signal, not a wall clock

### DIFF
--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -5,6 +5,7 @@ package dev.sebastiano.spectre.core
 import dev.sebastiano.spectre.input.CoordinatedInputLease
 import dev.sebastiano.spectre.input.CoordinatorControlResult
 import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.CoordinatorStatus
 import dev.sebastiano.spectre.input.DesktopResourceKey
 import dev.sebastiano.spectre.input.InputCoordinatorException
 import dev.sebastiano.spectre.input.LeaseToken
@@ -25,6 +26,11 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.asCoroutineDispatcher
@@ -438,20 +444,22 @@ class InputLeaseGuardTest {
             try {
                 val cancelled =
                     async(acquisitionDispatcher) {
-                        assertFailsWith<kotlinx.coroutines.TimeoutCancellationException> {
-                            withTimeout(100) {
-                                coordinator.acquire(
-                                    InputLeaseOptions(
-                                        acquireTimeout = kotlin.time.Duration.parse("10s")
-                                    ),
-                                    "cancelled",
-                                    immediate = false,
-                                )
-                            }
-                        }
+                        coordinator.acquire(
+                            InputLeaseOptions(acquireTimeout = QUEUED_ACQUIRE_TIMEOUT),
+                            "cancelled",
+                            immediate = false,
+                        )
                     }
+
+                // Cancel only once the waiter is observably queued. A wall-clock timeout around
+                // the acquisition would race its own connect and dispatch cost: under load those
+                // can eat the whole budget, so the waiter is retired before any status poll can
+                // see it. That race, not the poll budget, is what made this test flaky (#468).
                 awaitWaiterCount(endpoint, resource, 1)
-                cancelled.await()
+                cancelled.cancel()
+                cancelled.join()
+                assertFailsWith<CancellationException> { cancelled.await() }
+
                 awaitWaiterCount(endpoint, resource, 0)
                 holder.close()
 
@@ -664,25 +672,49 @@ class InputLeaseGuardTest {
         resource: DesktopResourceKey,
         expected: Int,
     ) {
-        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
-        while (System.nanoTime() < deadline) {
-            val status = LocalInputCoordinatorControl(endpoint).status(resource)
-            val active = status as? CoordinatorControlResult.Active
-            if (active?.status?.waiters?.size == expected) return
-            Thread.onSpinWait()
+        awaitCoordinatorStatus(endpoint, resource, "$expected queued lease request(s)") { status ->
+            status.waiters.size == expected
         }
-        assertTrue(false, "Timed out waiting for $expected queued lease request")
     }
 
     private fun awaitHolder(endpoint: CoordinatorEndpoint, resource: DesktopResourceKey) {
-        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2)
-        while (System.nanoTime() < deadline) {
-            val status = LocalInputCoordinatorControl(endpoint).status(resource)
-            val active = status as? CoordinatorControlResult.Active
-            if (active?.status?.holder != null) return
-            Thread.onSpinWait()
+        awaitCoordinatorStatus(endpoint, resource, "a granted lease") { status ->
+            status.holder != null
         }
-        assertTrue(false, "Timed out waiting for a granted lease")
+    }
+
+    /**
+     * Polls coordinator status until [predicate] holds, or fails after [STATUS_POLL_BUDGET].
+     *
+     * Callers must wait on a condition that stays true until the test itself retires it, so the
+     * budget only has to absorb scheduling delay rather than win a race. It is deliberately
+     * generous because a full `check` run puts many Gradle workers on the same CPUs, where the
+     * previous two-second budget was not enough (#468). Sleeping between polls keeps this wait off
+     * the CPU instead of busy-spinning against the very workers it is waiting for.
+     */
+    private fun awaitCoordinatorStatus(
+        endpoint: CoordinatorEndpoint,
+        resource: DesktopResourceKey,
+        expectation: String,
+        predicate: (CoordinatorStatus) -> Boolean,
+    ) {
+        val control = LocalInputCoordinatorControl(endpoint)
+        val deadline = System.nanoTime() + STATUS_POLL_BUDGET.inWholeNanoseconds
+        while (true) {
+            val active = control.status(resource) as? CoordinatorControlResult.Active
+            if (active != null && predicate(active.status)) return
+            if (System.nanoTime() >= deadline) break
+            Thread.sleep(STATUS_POLL_INTERVAL.inWholeMilliseconds)
+        }
+        fail("Timed out after $STATUS_POLL_BUDGET waiting for $expectation")
+    }
+
+    private companion object {
+        /** Long enough that a queued waiter never expires before the test cancels it. */
+        val QUEUED_ACQUIRE_TIMEOUT: Duration = 30.seconds
+
+        val STATUS_POLL_BUDGET: Duration = 15.seconds
+        val STATUS_POLL_INTERVAL: Duration = 10.milliseconds
     }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -454,7 +454,7 @@ class InputLeaseGuardTest {
                 // Cancel only once the waiter is observably queued. A wall-clock timeout around
                 // the acquisition would race its own connect and dispatch cost: under load those
                 // can eat the whole budget, so the waiter is retired before any status poll can
-                // see it. That race, not the poll budget, is what made this test flaky (#468).
+                // see it. That race, not the poll budget, is what made this test flaky.
                 awaitWaiterCount(endpoint, resource, 1)
                 cancelled.cancel()
                 cancelled.join()
@@ -689,8 +689,8 @@ class InputLeaseGuardTest {
      * Callers must wait on a condition that stays true until the test itself retires it, so the
      * budget only has to absorb scheduling delay rather than win a race. It is deliberately
      * generous because a full `check` run puts many Gradle workers on the same CPUs, where the
-     * previous two-second budget was not enough (#468). Sleeping between polls keeps this wait off
-     * the CPU instead of busy-spinning against the very workers it is waiting for.
+     * previous two-second budget was not enough. Sleeping between polls keeps this wait off the CPU
+     * instead of busy-spinning against the very workers it is waiting for.
      */
     private fun awaitCoordinatorStatus(
         endpoint: CoordinatorEndpoint,


### PR DESCRIPTION
## Summary

`InputLeaseGuardTest > cancelling queued production acquisition removes waiter and permits successor` was flaky under full-suite load, failing with `Timed out waiting for 1 queued lease request`. This makes it deterministic by cancelling the queued waiter once it is *observably* queued, rather than on a fixed 100 ms wall-clock timeout.

The `awaitWaiterCount` poll deadline was **not** the cause. The test wrapped the acquisition in `withTimeout(100)`, so the waiter existed only between the `ACQUIRE` reaching the server and that deadline firing — and the acquisition's own cost lives inside that same window: dispatch onto `Dispatchers.IO` (shared with every other test in the worker JVM), the socket connect, the session open. Under load that can consume the whole 100 ms, so the waiter is retired before any poll can see it, or exists too briefly to catch. No poll budget can fix a window that has already closed.

Assertions are not weakened. `assertFailsWith<CancellationException> { cancelled.await() }` still proves the acquisition never completed — a `Deferred` that had already succeeded would return its value from `await()` — and the waiter-removal and successor assertions are untouched. The test now also genuinely exercises "cancel a *queued* waiter", which the timeout version only did when it happened to win the race.

Secondary hardening, as suggested in the report: `awaitWaiterCount` and `awaitHolder` now share one predicate-based poller with a 15 s budget and a 10 ms sleep backoff, replacing the 2 s `Thread.onSpinWait()` busy loop that competed for CPU with the workers it was waiting on.

Test-only change; no production code touched.

## Test plan

Root cause was confirmed with two probes rather than by inference:

- **Deadline ruled out.** Shrinking `withTimeout(100)` → `withTimeout(1)` reproduces the exact reported failure *while the poll budget was raised to 30 seconds*. If the deadline were the problem, 30 s would have found the waiter.
- **A/B on the real mechanism.** Injecting a 250 ms delay into `connectClient` (simulating what load does to connect + dispatch): the old test fails with the reported message, the new test passes.
- New test 6/6 under 4× CPU oversubscription (12 busy-loop hogs on a 4-core box).
- The original flake was *not* reproduced by CPU load alone in 6 baseline runs — it is rare, which is why the deterministic probes above were used instead.

Checks run on Linux:

- [x] `./gradlew :core:check` passes locally
- [x] `./gradlew check` passes (all 190 tasks, `--rerun-tasks`), excluding three tasks that fail identically on an unmodified `main` in this container: `:recording:buildWaylandHelper` (`libdbus-1-dev` not installed), `:recording-linux:verifyRecordingLinuxHelpers` (depends on it), and `:cli:verifyCliDistributionZip` (bundled JRE will not execute here)
- [x] `./gradlew ktfmtFormat` produced no changes

Unrelated environment note, in case anyone else trips on it: a container defaulting to `sun.jnu.encoding=ANSI_X3.4-1968` fails `UdsPathLimitsTest` and two `FailureArtifactPathsTest` cases on non-ASCII paths. Setting a UTF-8 locale clears them, so CI presumably already runs with one — not a regression from this PR.

## Confirmations

- [ ] I read [CONTRIBUTING.md](https://github.com/rock3r/spectre/blob/main/CONTRIBUTING.md) and this PR is **not** LLM-generated. (See the "no clanker PRs or issues" rule.) — **Left unchecked deliberately: this PR was written by Claude Code at the repository owner's request, so the statement would be false. Flagging rather than ticking it.**
- [x] I'm licensing this contribution under [Apache-2.0](https://github.com/rock3r/spectre/blob/main/LICENSE).

---
_Generated by [Claude Code](https://claude.ai/code/session_014qKxXsS1wizsPJVYMog83R)_