### PR TITLE
fix(core): fail loudly when the OS discards injected input (#460)

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -141,6 +141,22 @@ internal class ReflectiveAutomatorHandler(
                 category =
                     dev.sebastiano.spectre.agent.transport.AgentErrorCategory.Timeout.wireName,
             )
+        } catch (ex: IllegalStateException) {
+            // A core guard that throws *after* a suspension point — #460's input-delivery
+            // verification does exactly that — resumes the continuation with failure, so
+            // `BlockingSuspendInvoker` rethrows it raw via `Result.getOrThrow()`. It never passes
+            // through `Method.invoke`, so the ReflectiveOperationException branch above cannot see
+            // it, and an input refusal would be misreported as an InternalError.
+            //
+            // Deliberately narrow: every *other* IllegalStateException keeps propagating out of
+            // `handle`, because the reflective layer uses it to fail loudly on automator API
+            // mismatches and that contract is asserted elsewhere.
+            if (!isInputRejectionMessage(ex.message)) throw ex
+            AgentResponse.Error(
+                message = "${ex.javaClass.simpleName}: ${ex.message ?: "<no message>"}",
+                category =
+                    dev.sebastiano.spectre.agent.transport.AgentErrorCategory.InputRejected.wireName,
+            )
         }
 
     @Suppress("CyclomaticComplexMethod") // Exhaustive wire dispatch table.
@@ -993,9 +1009,25 @@ internal class ReflectiveAutomatorHandler(
 private fun reflectiveIsInputRejection(ex: ReflectiveOperationException): Boolean {
     val root = ex.cause ?: ex
     if (root !is IllegalStateException) return false
-    val msg = root.message.orEmpty().lowercase()
+    return isInputRejectionMessage(root.message)
+}
+
+/**
+ * Whether an [IllegalStateException] from `:core` is the OS refusing input rather than a bug.
+ *
+ * Message matching rather than a typed exception because `:agent`'s production runtime has no
+ * compile dependency on `:core` — it drives the automator purely reflectively, so the guard types
+ * are not on its classpath. Shared by the wrapped and raw throw paths.
+ */
+private fun isInputRejectionMessage(message: String?): Boolean {
+    val msg = message.orEmpty().lowercase()
     return "accessibility" in msg ||
         "tcc" in msg ||
         "permission" in msg ||
-        "screen recording" in msg
+        "screen recording" in msg ||
+        // #460: the injected event never reached the target JVM. Matched two ways because the
+        // agent jar and the target's own spectre-core can be different versions: the prose may be
+        // reworded, the issue URL in it will not be.
+        "input desktop" in msg ||
+        "issues/460" in msg
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/Issue460NonInputDesktopTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/Issue460NonInputDesktopTest.kt
@@ -1,0 +1,259 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import dev.sebastiano.spectre.agent.fixture.BUTTON_CLICKED_PREFIX
+import dev.sebastiano.spectre.agent.fixture.READY_SENTINEL
+import dev.sebastiano.spectre.agent.fixture.TAG_BUTTON
+import dev.sebastiano.spectre.agent.fixture.TAG_TEXT_FIELD
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * Regression guard for #460 — Robot-backed input is silently discarded when the target is not on
+ * the **input desktop**, while attach, semantics reads, and composition all keep working.
+ *
+ * Windows discards `SendInput` from a process whose desktop is not the session's input desktop, and
+ * the JDK ignores that failure, so `click()` returns normally having done nothing. That is what
+ * makes #460 present to users as "the semantics tree went stale" rather than "input was refused".
+ * The condition is reached here by creating a second desktop inside the current window station and
+ * launching the fixture onto it — no lock, no session 0, no elevation, no credentials.
+ *
+ * The two arms must be read together. **Control** is the same code on the ordinary desktop; if its
+ * click does not land, the host is not usable for this test and the condition arm proves nothing.
+ *
+ * This is the end-to-end proof of #460's fix: the condition arm asserts that `click` now *raises*
+ * rather than silently succeeding, and that the failure survives the whole chain — the `:core`
+ * delivery guard, the wire taxonomy (`inputRejected`), and the attacher-side exception.
+ *
+ * Opt-in on Windows via [WindowsAttachE2eGate], like the other Robot-backed attach e2e tests:
+ * ```
+ * ./gradlew :agent:test --tests '*Issue460NonInputDesktopTest*' \
+ *   -Pspectre.agent.attachE2e.allowWindows=true
+ * ```
+ */
+@EnabledOnOs(OS.WINDOWS)
+class Issue460NonInputDesktopTest {
+
+    @Test
+    fun `input is discarded off the input desktop while reads keep working`() {
+        assumeFalse(java.awt.GraphicsEnvironment.isHeadless(), "needs a desktop")
+        assumeTrue(
+            WindowsAttachE2eGate.isAllowed(),
+            "Robot-backed attach e2e is opt-in on Windows " +
+                "(-P${"spectre.agent.attachE2e.allowWindows"}=true on a physical desktop).",
+        )
+        val agentJar = agentJar()
+        assumeTrue(isPwshAvailable(), "the hidden-desktop launcher needs PowerShell 7 (pwsh)")
+
+        // Control first: if a click cannot land on the ordinary desktop right now, nothing this
+        // test observes on the hidden desktop is attributable to the desktop.
+        val control = clickOutcome(agentJar, desktop = null)
+        assertTrue(
+            control.textAfterClick.startsWith(BUTTON_CLICKED_PREFIX),
+            "control click did not land on the ordinary desktop (host unusable for this test): " +
+                "'${control.textBeforeClick}' -> '${control.textAfterClick}'",
+        )
+        assertNull(control.clickFailure, "a deliverable click must not be rejected")
+
+        val hidden = clickOutcome(agentJar, desktop = "spectre460-${System.nanoTime()}")
+
+        // Reads keep working: attach succeeded and the semantics tree came back populated.
+        assertTrue(
+            hidden.buttonNodes > 0,
+            "semantics read failed off the input desktop; expected the button node to be found",
+        )
+        // Input does not, and Spectre must now say so rather than returning normally.
+        val failure = hidden.clickFailure
+        assertNotNull(failure, "click() silently succeeded off the input desktop -- #460 regressed")
+        assertTrue(
+            failure is SpectreAgentException &&
+                failure.category == AgentErrorCategory.InputRejected,
+            "undeliverable input must surface as inputRejected, was: $failure",
+        )
+        assertTrue(
+            failure.message.orEmpty().contains("input desktop"),
+            "the failure must name the platform constraint, was: ${failure.message}",
+        )
+        assertEquals(
+            hidden.textBeforeClick,
+            hidden.textAfterClick,
+            "click was delivered off the input desktop; #460's premise no longer holds",
+        )
+    }
+
+    private class Outcome(
+        val textBeforeClick: String,
+        val textAfterClick: String,
+        val buttonNodes: Int,
+        val clickFailure: Throwable?,
+    )
+
+    /**
+     * Spawns the stock fixture (on [desktop], or the ordinary one when null), clicks, reads back.
+     */
+    private fun clickOutcome(agentJar: Path, desktop: String?): Outcome {
+        val process = spawnFixture(desktop)
+        try {
+            val pid = process.second
+            AgentAttach.attach(pid, attachOptions(agentJar, pid)).use { a ->
+                Thread.sleep(SETTLE_MS)
+                val before = a.findByTestTag(TAG_TEXT_FIELD).first().editableText.orEmpty()
+                val buttons = a.findByTestTag(TAG_BUTTON)
+                val clickFailure = runCatching { a.click(buttons.first()) }.exceptionOrNull()
+                Thread.sleep(SETTLE_MS)
+                val after = a.findByTestTag(TAG_TEXT_FIELD).first().editableText.orEmpty()
+                return Outcome(before, after, buttons.size, clickFailure)
+            }
+        } finally {
+            killTree(process.first)
+        }
+    }
+
+    /**
+     * Returns the launcher process and the **fixture's own** pid. When a desktop is named the JVM
+     * is a grandchild of this process, so the pid is parsed off the READY sentinel rather than
+     * taken from the [Process] handle.
+     *
+     * The classpath travels in the environment: `CreateProcess` takes one command-line string with
+     * a 32k limit that a Gradle test classpath can approach, and `java` honours `CLASSPATH`.
+     */
+    private fun spawnFixture(desktop: String?): Pair<Process, Long> {
+        val javaExe = FixtureJavaHome.javaExecutable().toString()
+        val args =
+            listOf(
+                "-XX:+EnableDynamicAgentLoading",
+                "-Djava.awt.headless=false",
+                "-Dcompose.application.configure.swing.globals=true",
+                FIXTURE_MAIN,
+            )
+        val builder =
+            if (desktop == null) {
+                ProcessBuilder(listOf(javaExe) + args)
+            } else {
+                ProcessBuilder(
+                    "pwsh",
+                    "-NoProfile",
+                    "-File",
+                    launcherScript().toString(),
+                    "-DesktopName",
+                    desktop,
+                )
+            }
+        builder.environment()["CLASSPATH"] = System.getProperty("java.class.path")
+        // The exe and command line travel in the environment, never as arguments: both can contain
+        // spaces, and Java's legacy Windows argument quoting does not escape embedded quotes, so a
+        // JDK under Program Files would be split before pwsh ever parsed it.
+        builder.environment()["SPECTRE_LAUNCH_EXE"] = javaExe
+        builder.environment()["SPECTRE_LAUNCH_CMDLINE"] =
+            (listOf("\"$javaExe\"") + args).joinToString(" ")
+        builder.redirectErrorStream(true)
+
+        val process = builder.start()
+        val reader = BufferedReader(InputStreamReader(process.inputStream, Charsets.UTF_8))
+        val pid = AtomicLong(-1)
+        val ready = CountDownLatch(1)
+        Thread {
+                runCatching {
+                    generateSequence(reader::readLine).forEach { line ->
+                        if (line.startsWith(READY_SENTINEL) && ready.count > 0) {
+                            pid.set(
+                                line
+                                    .substringAfter("pid=", "")
+                                    .substringBefore(' ')
+                                    .trim()
+                                    .toLongOrNull() ?: -1L
+                            )
+                            ready.countDown()
+                        }
+                    }
+                }
+            }
+            .apply {
+                isDaemon = true
+                name = "issue460-fixture-drainer"
+                start()
+            }
+        try {
+            check(ready.await(READY_TIMEOUT_S, TimeUnit.SECONDS)) {
+                "fixture never signalled READY"
+            }
+            check(pid.get() > 0) { "could not parse the fixture pid from the READY sentinel" }
+        } catch (failure: IllegalStateException) {
+            // Nothing owns the process yet, so the caller's finally cannot reach it. Leaving a JVM
+            // running on a desktop nobody can see or close is the worst possible leak.
+            killTree(process)
+            throw failure
+        }
+        Thread.sleep(SETTLE_MS)
+        return process to pid.get()
+    }
+
+    /** The fixture JVM is a grandchild behind the launcher, so kill descendants first. */
+    private fun killTree(process: Process) {
+        process.descendants().forEach { runCatching { it.destroyForcibly() } }
+        process.destroyForcibly()
+        process.waitFor(SHUTDOWN_S, TimeUnit.SECONDS)
+    }
+
+    /** A box with only Windows PowerShell 5.1 should skip, not error. */
+    private fun isPwshAvailable(): Boolean =
+        runCatching {
+                val probe = ProcessBuilder("pwsh", "-NoProfile", "-Command", "exit 0").start()
+                probe.waitFor(PWSH_PROBE_S, TimeUnit.SECONDS) && probe.exitValue() == 0
+            }
+            .getOrDefault(false)
+
+    /** The launcher ships as a test resource; PowerShell needs it as a real file on disk. */
+    private fun launcherScript(): Path {
+        // Unique per call: a fixed name in the shared temp dir races parallel test JVMs.
+        val target =
+            Paths.get(System.getProperty("java.io.tmpdir"), "spectre460-${System.nanoTime()}.ps1")
+        javaClass.getResourceAsStream(LAUNCHER).use { stream ->
+            checkNotNull(stream) { "missing test resource $LAUNCHER" }
+            Files.copy(stream, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING)
+        }
+        return target
+    }
+
+    private fun agentJar(): Path {
+        val prop = System.getProperty("dev.sebastiano.spectre.agent.runtimeJar")
+        assumeFalse(prop.isNullOrBlank(), "needs -Ddev.sebastiano.spectre.agent.runtimeJar")
+        val path = Paths.get(prop!!)
+        assumeFalse(!Files.isRegularFile(path), "agent runtime jar missing at $path")
+        return path
+    }
+
+    private fun attachOptions(agentJar: Path, pid: Long) =
+        AttachOptions(
+            agentJarPath = agentJar,
+            udsPath = AttachOptions.defaultUdsPath(pid),
+            attachTimeoutMs = ATTACH_TIMEOUT_MS,
+        )
+
+    private companion object {
+        const val FIXTURE_MAIN = "dev.sebastiano.spectre.agent.fixture.ComposeFixtureMainKt"
+        const val LAUNCHER = "launch-on-desktop.ps1"
+        const val SETTLE_MS = 900L
+        const val ATTACH_TIMEOUT_MS = 15_000L
+        const val READY_TIMEOUT_S = 60L
+        const val SHUTDOWN_S = 3L
+        const val PWSH_PROBE_S = 10L
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerInputRejectionTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandlerInputRejectionTest.kt
@@ -1,0 +1,90 @@
+@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.runtime
+
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+import dev.sebastiano.spectre.agent.transport.AgentRequest
+import dev.sebastiano.spectre.agent.transport.AgentResponse
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.COROUTINE_SUSPENDED
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * How [ReflectiveAutomatorHandler] classifies a `:core` guard that throws **after a suspension
+ * point** — the shape #460's input-delivery verification has.
+ *
+ * Such a guard resumes the continuation with failure instead of throwing through `Method.invoke`,
+ * so [BlockingSuspendInvoker] rethrows it raw from `Result.getOrThrow()` with no
+ * `ReflectiveOperationException` wrapper. The handler's reflective-exception branch therefore
+ * cannot see it, and without a dedicated branch the very failure #460's fix raises would reach the
+ * attacher as an `internalError`.
+ *
+ * Lives apart from `ReflectiveAutomatorHandlerMappingTest` because that class is already at the
+ * project's size ceiling.
+ */
+class ReflectiveAutomatorHandlerInputRejectionTest {
+
+    @Test
+    fun `input rejection thrown after a suspension point maps to inputRejected`() {
+        val response =
+            clickFailingAfterSuspension(
+                IllegalStateException(
+                    "Spectre dispatched a click at (1, 2) but no mouse event was delivered to " +
+                        "this JVM. Real OS input requires the target process to be on the " +
+                        "session's active input desktop."
+                )
+            )
+
+        check(response is AgentResponse.Error) { "expected an Error response, got $response" }
+        assertEquals(AgentErrorCategory.InputRejected.wireName, response.category)
+    }
+
+    /**
+     * The narrowness matters as much as the catch: every other [IllegalStateException] must keep
+     * propagating out of `handle`, because the reflective layer uses it to fail loudly on automator
+     * API mismatches and that contract is asserted elsewhere.
+     */
+    @Test
+    fun `unrelated failure after a suspension point still propagates`() {
+        assertFailsWith<IllegalStateException> {
+            clickFailingAfterSuspension(IllegalStateException("something else broke"))
+        }
+    }
+
+    private fun clickFailingAfterSuspension(failure: IllegalStateException): AgentResponse {
+        val automator = ClickFailingAfterSuspensionAutomator(FakeKeyedNode("k1"), failure)
+        return ReflectiveAutomatorHandler(automator).handle(AgentRequest.Click(nodeKey = "k1"))
+    }
+}
+
+/** Minimal stand-in for `AutomatorNode`: the handler only needs `getKey()` to resolve it. */
+private class FakeKeyedNode(private val keyValue: String) {
+    @Suppress("unused") fun getKey(): String = keyValue
+}
+
+/**
+ * Exposes exactly the method set [ReflectiveAutomatorHandler]'s constructor requires, and fails the
+ * click the way a real post-suspension guard does: resume the continuation with the failure, then
+ * report having suspended.
+ */
+private class ClickFailingAfterSuspensionAutomator(
+    private val node: Any,
+    private val failure: Throwable,
+) {
+    @Suppress("unused") fun refreshWindows() = Unit
+
+    @Suppress("unused") fun getWindows(): List<Any> = emptyList()
+
+    @Suppress("unused") fun allNodes(): List<Any> = listOf(node)
+
+    @Suppress("unused", "UNUSED_PARAMETER") fun findByTestTag(tag: String): List<Any> = emptyList()
+
+    // Matches Kotlin's bytecode shape for `suspend fun click(node: AutomatorNode)`.
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun click(node: Any, continuation: Continuation<Any?>): Any? {
+        continuation.resumeWith(Result.failure(failure))
+        return COROUTINE_SUSPENDED
+    }
+}

--- a/agent/src/test/resources/dev/sebastiano/spectre/agent/launch-on-desktop.ps1
+++ b/agent/src/test/resources/dev/sebastiano/spectre/agent/launch-on-desktop.ps1
@@ -1,0 +1,101 @@
+#Requires -Version 7
+<#
+Launches a command onto a NEWLY CREATED desktop inside the current window station, so the child
+process has a real desktop that is never the *input* desktop. Its windows exist and are genuine,
+nothing presents them, and it cannot inject input -- the same condition a locked workstation
+imposes, but reachable with no credentials, no elevation, and without disturbing the user.
+
+Std handles are passed through to the child (STARTF_USESTDHANDLES + bInheritHandles), so a parent
+that spawned THIS script with pipes talks to the child over those same pipes and any existing
+stdin/stdout protocol keeps working unchanged.
+
+Blocks until the child exits, and propagates its exit code.
+#>
+param([Parameter(Mandatory = $true)][string]$DesktopName)
+
+# The executable and command line arrive in the environment rather than as arguments. Both can
+# contain spaces, and the JDK's legacy Windows argument quoting does not escape embedded quotes,
+# so a JDK installed under Program Files would be split apart before pwsh ever parsed it.
+$Exe = $env:SPECTRE_LAUNCH_EXE
+$CommandLine = $env:SPECTRE_LAUNCH_CMDLINE
+if ([string]::IsNullOrWhiteSpace($Exe) -or [string]::IsNullOrWhiteSpace($CommandLine)) {
+    [Console]::Error.WriteLine(
+        '[hidden-desktop] SPECTRE_LAUNCH_EXE / SPECTRE_LAUNCH_CMDLINE must both be set')
+    exit 92
+}
+
+Add-Type -Namespace SpectreHidden -Name Native -MemberDefinition @'
+[DllImport("user32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+public static extern IntPtr CreateDesktop(string lpszDesktop, IntPtr lpszDevice,
+    IntPtr pDevmode, int dwFlags, uint dwDesiredAccess, IntPtr lpsa);
+
+[DllImport("kernel32.dll", SetLastError=true)]
+public static extern IntPtr GetStdHandle(int nStdHandle);
+
+[DllImport("kernel32.dll", SetLastError=true)]
+public static extern uint WaitForSingleObject(IntPtr hHandle, uint dwMilliseconds);
+
+[DllImport("kernel32.dll", SetLastError=true)]
+public static extern bool GetExitCodeProcess(IntPtr hProcess, out uint lpExitCode);
+
+[StructLayout(LayoutKind.Sequential)]
+public struct PROCESS_INFORMATION { public IntPtr hProcess; public IntPtr hThread;
+    public uint dwProcessId; public uint dwThreadId; }
+
+[StructLayout(LayoutKind.Sequential, CharSet=CharSet.Unicode)]
+public struct STARTUPINFO { public int cb; public string lpReserved; public string lpDesktop;
+    public string lpTitle; public int dwX; public int dwY; public int dwXSize; public int dwYSize;
+    public int dwXCountChars; public int dwYCountChars; public int dwFillAttribute;
+    public int dwFlags; public short wShowWindow; public short cbReserved2; public IntPtr lpReserved2;
+    public IntPtr hStdInput; public IntPtr hStdOutput; public IntPtr hStdError; }
+
+[DllImport("kernel32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+public static extern bool CreateProcess(string lpApplicationName,
+    System.Text.StringBuilder lpCommandLine, IntPtr lpProcessAttributes,
+    IntPtr lpThreadAttributes, bool bInheritHandles, uint dwCreationFlags,
+    IntPtr lpEnvironment, string lpCurrentDirectory,
+    ref STARTUPINFO lpStartupInfo, out PROCESS_INFORMATION lpProcessInformation);
+'@
+
+$GENERIC_ALL = 0x10000000
+$STARTF_USESTDHANDLES = 0x00000100
+$CREATE_NO_WINDOW = 0x08000000
+
+# Idempotent: CreateDesktop returns a handle to the existing desktop if the name is taken.
+$hDesk = [SpectreHidden.Native]::CreateDesktop($DesktopName, [IntPtr]::Zero, [IntPtr]::Zero, 0,
+    $GENERIC_ALL, [IntPtr]::Zero)
+if ($hDesk -eq [IntPtr]::Zero) {
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    [Console]::Error.WriteLine("[hidden-desktop] CreateDesktop failed err=$err")
+    exit 90
+}
+[Console]::Error.WriteLine("[hidden-desktop] desktop ready: WinSta0\$DesktopName")
+
+$si = New-Object SpectreHidden.Native+STARTUPINFO
+$si.cb = [System.Runtime.InteropServices.Marshal]::SizeOf([type][SpectreHidden.Native+STARTUPINFO])
+$si.lpDesktop = "WinSta0\$DesktopName"
+$si.dwFlags = $STARTF_USESTDHANDLES
+# -10/-11/-12 = STD_INPUT/STD_OUTPUT/STD_ERROR. Handing our own pipes to the child keeps the
+# parent's existing line protocol intact across the desktop boundary.
+$si.hStdInput = [SpectreHidden.Native]::GetStdHandle(-10)
+$si.hStdOutput = [SpectreHidden.Native]::GetStdHandle(-11)
+$si.hStdError = [SpectreHidden.Native]::GetStdHandle(-12)
+
+$pi = New-Object SpectreHidden.Native+PROCESS_INFORMATION
+$cmd = New-Object System.Text.StringBuilder 32768
+[void]$cmd.Append($CommandLine)
+
+$ok = [SpectreHidden.Native]::CreateProcess($Exe, $cmd, [IntPtr]::Zero, [IntPtr]::Zero,
+    $true, $CREATE_NO_WINDOW, [IntPtr]::Zero, [NullString]::Value, [ref]$si, [ref]$pi)
+if (-not $ok) {
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    [Console]::Error.WriteLine("[hidden-desktop] CreateProcess failed err=$err")
+    exit 91
+}
+[Console]::Error.WriteLine("[hidden-desktop] launched pid=$($pi.dwProcessId) on WinSta0\$DesktopName")
+
+# INFINITE. Must be [uint32]::MaxValue -- PowerShell binds the 0xFFFFFFFF literal as signed -1.
+[void][SpectreHidden.Native]::WaitForSingleObject($pi.hProcess, [uint32]::MaxValue)
+$code = 0
+[void][SpectreHidden.Native]::GetExitCodeProcess($pi.hProcess, [ref]$code)
+exit $code

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -178,19 +178,29 @@ private constructor(
     public fun findByRole(role: Role): List<AutomatorNode> =
         semanticsReader.findByRole(role, windows)
 
+    /**
+     * Clicks [node]'s centre with real OS input.
+     *
+     * Unlike the coordinate overloads, this verifies the OS actually delivered the press to this
+     * JVM and throws [IllegalStateException] when it did not — the target is aimed at one of this
+     * JVM's own nodes, so a press that never arrives can only be a failure. Silently succeeding
+     * here is what made #460 present as a stale semantics tree.
+     */
     public suspend fun click(node: AutomatorNode) {
         val center = node.centerOnScreen
-        robotDriver.click(center.x, center.y)
+        robotDriver.clickVerified(center.x, center.y)
     }
 
+    /** Double-clicks [node]'s centre, with the delivery guarantee described on [click]. */
     public suspend fun doubleClick(node: AutomatorNode) {
         val center = node.centerOnScreen
-        robotDriver.doubleClick(center.x, center.y)
+        robotDriver.doubleClickVerified(center.x, center.y)
     }
 
+    /** Long-clicks [node]'s centre, with the delivery guarantee described on [click]. */
     public suspend fun longClick(node: AutomatorNode, holdFor: Duration = 500.milliseconds) {
         val center = node.centerOnScreen
-        robotDriver.longClick(center.x, center.y, holdFor)
+        robotDriver.longClickVerified(center.x, center.y, holdFor)
     }
 
     /** Moves the pointer to [node]'s centre without pressing a button. */
@@ -226,6 +236,11 @@ private constructor(
         robotDriver.swipe(startX, startY, endX, endY, steps, duration)
     }
 
+    /**
+     * Swipes from [from]'s centre to [to]'s centre, with the delivery guarantee described on
+     * [click]. Calls the driver directly rather than delegating to the coordinate overload, which
+     * is deliberately unverified.
+     */
     public suspend fun swipe(
         from: AutomatorNode,
         to: AutomatorNode,
@@ -234,7 +249,14 @@ private constructor(
     ) {
         val fromCenter = from.centerOnScreen
         val toCenter = to.centerOnScreen
-        swipe(fromCenter.x, fromCenter.y, toCenter.x, toCenter.y, steps, duration)
+        robotDriver.swipeVerified(
+            fromCenter.x,
+            fromCenter.y,
+            toCenter.x,
+            toCenter.y,
+            steps,
+            duration,
+        )
     }
 
     /**
@@ -244,7 +266,7 @@ private constructor(
      */
     public suspend fun scrollWheel(node: AutomatorNode, wheelClicks: Int) {
         val center = node.centerOnScreen
-        robotDriver.scrollWheel(center.x, center.y, wheelClicks)
+        robotDriver.scrollWheelVerified(center.x, center.y, wheelClicks)
     }
 
     public suspend fun typeText(text: String) {

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputDeliveryWitness.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputDeliveryWitness.kt
@@ -169,6 +169,13 @@ internal suspend fun RobotDriver.swipeVerified(
  * oracle would report every scroll as undelivered.
  */
 internal suspend fun RobotDriver.scrollWheelVerified(screenX: Int, screenY: Int, wheelClicks: Int) {
+    if (wheelClicks == 0) {
+        // A zero-notch scroll is a legitimate no-op that emits no wheel event on any backend -- on
+        // X11 the wheel is button 4/5 presses, so zero notches dispatches nothing at all. Waiting
+        // for an event here would invent a failure out of a request that did exactly what it said.
+        scrollWheel(screenX, screenY, wheelClicks)
+        return
+    }
     verifyingDelivery("scrollWheel", screenX, screenY, DispatchedInput.Wheel) {
         scrollWheel(screenX, screenY, wheelClicks)
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputDeliveryWitness.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputDeliveryWitness.kt
@@ -78,6 +78,7 @@ internal interface InputDeliveryWitness {
 internal object AwtInputDeliveryWitness : InputDeliveryWitness {
 
     override fun observe(input: DispatchedInput): InputDeliveryWitness.Observation? {
+        if (!inputDeliveryVerifiable()) return null
         val toolkit = runCatching { Toolkit.getDefaultToolkit() }.getOrNull() ?: return null
         val delivered = CountDownLatch(1)
         val listener = AWTEventListener { event ->
@@ -108,6 +109,24 @@ internal object AwtInputDeliveryWitness : InputDeliveryWitness {
         }
     }
 }
+
+/**
+ * Whether "no AWT event arrived" is sound evidence that input was discarded, on this platform.
+ *
+ * Only on Windows. #460 is a Windows problem and Windows is where the behaviour was measured, but
+ * the real constraint is that the oracle is **unsound elsewhere**: on macOS, AppKit consumes the
+ * click that activates an inactive application without delivering it to the window at all, so a
+ * perfectly healthy first click legitimately produces no event. `AgentAttachIntegrationTest`
+ * already compensates for exactly that by retrying, and treating the swallowed activation click as
+ * a failure would break the retry it depends on. X11 has its own divergences (the wheel is button
+ * 4/5 presses, so it emits nothing for a zero-notch scroll).
+ *
+ * Declining to observe reuses the existing "cannot testify" path, so non-Windows behaviour is
+ * exactly what it was before this guard existed.
+ */
+internal fun inputDeliveryVerifiable(
+    osName: String = System.getProperty("os.name").orEmpty()
+): Boolean = osName.startsWith("Windows", ignoreCase = true)
 
 /**
  * [RobotDriver.click], plus verification that the OS actually delivered the press to this JVM.

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputDeliveryWitness.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputDeliveryWitness.kt
@@ -1,0 +1,247 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.AWTEvent
+import java.awt.EventQueue
+import java.awt.Toolkit
+import java.awt.event.AWTEventListener
+import java.awt.event.MouseEvent
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlin.time.Duration
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runInterruptible
+
+/** The AWT event a dispatched input verb should produce in this JVM if the OS delivered it. */
+internal enum class DispatchedInput(internal val awtEventId: Int) {
+    /** Click, double-click, long-click and swipe all begin with a button press. */
+    Press(MouseEvent.MOUSE_PRESSED),
+
+    /** `scrollWheel` never presses a button, so a press would never arrive for it. */
+    Wheel(MouseEvent.MOUSE_WHEEL),
+}
+
+/**
+ * Answers one question from inside the JVM that owns the target UI: **did injected input actually
+ * arrive?**
+ *
+ * `java.awt.Robot` drives `SendInput` on Windows, which the OS discards when the calling process is
+ * not on the session's active input desktop — a locked workstation, or a non-interactive desktop.
+ * The JDK does not surface that refusal, so the verb returns normally having done nothing and the
+ * failure only shows up downstream as "the semantics tree went stale" (#460).
+ *
+ * An AWT event listener is the best available oracle: it sits below Compose, below hit-testing and
+ * below focus, so it separates "no event ever arrived" from every downstream reason input might not
+ * change anything. Be precise about what it proves, though — it fires during *dispatch on the EDT*,
+ * so it attests that a matching event was dispatched in this JVM, not that this particular dispatch
+ * was the cause. Two consequences follow, and both are handled deliberately: an event that is
+ * queued but not dispatched (a busy or blocked EDT) must not be reported as a discarded one, which
+ * is what [Observation.awaitQueueDrain] exists for; and an unrelated matching event can satisfy the
+ * wait, which fails open to the old silent behaviour rather than inventing a failure.
+ *
+ * Observation is best-effort by contract. [observe] returns `null` when it cannot watch — the
+ * caller then dispatches unverified rather than failing, because being unable to check is not
+ * evidence of a problem.
+ */
+internal interface InputDeliveryWitness {
+
+    /** Begins watching for [input], or returns `null` when watching is not possible. */
+    fun observe(input: DispatchedInput): Observation?
+
+    /** An active watch. Must be closed; closing detaches the listener. */
+    interface Observation : AutoCloseable {
+        /** Waits up to [timeoutMs] for the watched event to be dispatched in this JVM. */
+        fun awaitDelivery(timeoutMs: Long): Boolean
+
+        /**
+         * Waits up to [timeoutMs] for this JVM's event queue to drain past the point the watched
+         * event would have been dispatched, returning false if it never does.
+         *
+         * This is what makes a non-delivery verdict trustworthy. An AWT listener only fires during
+         * dispatch, so "no event seen" also describes a JVM whose EDT is busy or blocked — for
+         * instance a caller doing `runBlocking { click(node) }` on the EDT itself, which parks the
+         * very thread that would dispatch the press. Posting a marker behind whatever is already
+         * queued distinguishes the two: if the marker runs, the queue drained past our event's
+         * slot, so the event genuinely never arrived.
+         */
+        fun awaitQueueDrain(timeoutMs: Long): Boolean
+    }
+}
+
+/**
+ * Default [InputDeliveryWitness], backed by a scoped `Toolkit` AWT event listener.
+ *
+ * The listener is attached per dispatch rather than kept alive for the lifetime of the driver:
+ * Spectre runs inside someone else's application, and a permanent global hook on every mouse event
+ * in the host app is a bigger imposition than the microseconds it costs to add and remove one.
+ */
+internal object AwtInputDeliveryWitness : InputDeliveryWitness {
+
+    override fun observe(input: DispatchedInput): InputDeliveryWitness.Observation? {
+        val toolkit = runCatching { Toolkit.getDefaultToolkit() }.getOrNull() ?: return null
+        val delivered = CountDownLatch(1)
+        val listener = AWTEventListener { event ->
+            if (event is MouseEvent && event.id == input.awtEventId) delivered.countDown()
+        }
+        // Wheel events need their own mask; subscribing to both keeps one code path for all verbs.
+        val mask = AWTEvent.MOUSE_EVENT_MASK or AWTEvent.MOUSE_WHEEL_EVENT_MASK
+        // Headless toolkits and (historically) a restrictive SecurityManager can refuse the hook.
+        if (runCatching { toolkit.addAWTEventListener(listener, mask) }.isFailure) return null
+
+        return object : InputDeliveryWitness.Observation {
+            override fun awaitDelivery(timeoutMs: Long): Boolean =
+                delivered.await(timeoutMs, TimeUnit.MILLISECONDS)
+
+            // invokeLater is FIFO behind already-queued events, so a press that was merely late
+            // will have been dispatched by the time this marker runs.
+            override fun awaitQueueDrain(timeoutMs: Long): Boolean =
+                runCatching {
+                        val drained = CountDownLatch(1)
+                        EventQueue.invokeLater { drained.countDown() }
+                        drained.await(timeoutMs, TimeUnit.MILLISECONDS)
+                    }
+                    .getOrDefault(false)
+
+            override fun close() {
+                runCatching { toolkit.removeAWTEventListener(listener) }
+            }
+        }
+    }
+}
+
+/**
+ * [RobotDriver.click], plus verification that the OS actually delivered the press to this JVM.
+ *
+ * Reserved for node-targeted callers ([ComposeAutomator.click]), where the input is aimed at one of
+ * this JVM's own Compose nodes and an event that never arrives is unambiguously a failure. The
+ * public coordinate overloads stay unverified on purpose: a caller may quite legitimately drive
+ * input outside this JVM's windows, for instance to dismiss a popup.
+ *
+ * These live outside [RobotDriver] as extensions rather than members because the driver is already
+ * at the project's per-class function ceiling, and because keeping the whole delivery-verification
+ * feature in one file makes it easier to reason about than five methods scattered through the input
+ * surface.
+ *
+ * Throws [IllegalStateException] when the input was discarded — see #460.
+ */
+internal suspend fun RobotDriver.clickVerified(screenX: Int, screenY: Int) {
+    verifyingDelivery("click", screenX, screenY, DispatchedInput.Press) { click(screenX, screenY) }
+}
+
+/** [RobotDriver.doubleClick] with the delivery verification described on [clickVerified]. */
+internal suspend fun RobotDriver.doubleClickVerified(screenX: Int, screenY: Int) {
+    verifyingDelivery("doubleClick", screenX, screenY, DispatchedInput.Press) {
+        doubleClick(screenX, screenY)
+    }
+}
+
+/** [RobotDriver.longClick] with the delivery verification described on [clickVerified]. */
+internal suspend fun RobotDriver.longClickVerified(screenX: Int, screenY: Int, holdFor: Duration) {
+    verifyingDelivery("longClick", screenX, screenY, DispatchedInput.Press) {
+        longClick(screenX, screenY, holdFor)
+    }
+}
+
+/**
+ * [RobotDriver.swipe] with the delivery verification described on [clickVerified].
+ *
+ * A swipe opens with a button press at the start point, so the press is the event to watch. The
+ * intermediate moves are deliberately not verified: a drag that starts is a drag that was
+ * delivered, and per-move checking would be noise.
+ */
+internal suspend fun RobotDriver.swipeVerified(
+    startX: Int,
+    startY: Int,
+    endX: Int,
+    endY: Int,
+    steps: Int,
+    duration: Duration,
+) {
+    verifyingDelivery("swipe", startX, startY, DispatchedInput.Press) {
+        swipe(startX, startY, endX, endY, steps, duration)
+    }
+}
+
+/**
+ * [RobotDriver.scrollWheel] with the delivery verification described on [clickVerified].
+ *
+ * Watches for a wheel event rather than a press: scrolling never presses a button, so a press
+ * oracle would report every scroll as undelivered.
+ */
+internal suspend fun RobotDriver.scrollWheelVerified(screenX: Int, screenY: Int, wheelClicks: Int) {
+    verifyingDelivery("scrollWheel", screenX, screenY, DispatchedInput.Wheel) {
+        scrollWheel(screenX, screenY, wheelClicks)
+    }
+}
+
+/**
+ * Runs [dispatch] while watching for the event it should produce, and fails loudly if none arrives.
+ *
+ * Verification is **skipped rather than failed** whenever it could not mean anything: backends that
+ * do not drive real OS input (synthetic, headless, test fakes) never produce an AWT event for a
+ * dispatch, and a witness that cannot attach cannot testify either way. Being unable to check is
+ * not evidence of a problem.
+ */
+private suspend fun RobotDriver.verifyingDelivery(
+    operation: String,
+    screenX: Int,
+    screenY: Int,
+    input: DispatchedInput,
+    dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    dispatch: suspend () -> Unit,
+) {
+    if (!inputCapabilities.realOsInput) {
+        dispatch()
+        return
+    }
+    val observation = deliveryWitness.observe(input)
+    if (observation == null) {
+        dispatch()
+        return
+    }
+    observation.use {
+        dispatch()
+        // runInterruptible, not withContext: docs/guide/interactions.md promises a cancelled
+        // coroutine cancels rather than parking a worker, and a bare latch await would park one
+        // for the full budget.
+        if (runInterruptible(dispatcher) { it.awaitDelivery(INPUT_DELIVERY_TIMEOUT_MS) }) return
+        // Nothing dispatched. Before accusing the OS, establish that this JVM was actually
+        // dispatching at all — see Observation.awaitQueueDrain.
+        if (!runInterruptible(dispatcher) { it.awaitQueueDrain(EDT_DRAIN_TIMEOUT_MS) }) return
+        // The queue drained past our event's slot, so a merely-late event would already have
+        // landed. Re-check before failing.
+        if (runInterruptible(dispatcher) { it.awaitDelivery(0) }) return
+        error(undeliveredInputMessage(operation, screenX, screenY))
+    }
+}
+
+/**
+ * Generous on purpose. The success path returns the instant the event lands (single-digit
+ * milliseconds in practice), so this budget is only ever spent when the input really was discarded;
+ * a tight one would turn a loaded machine into a spurious "input was discarded".
+ */
+private const val INPUT_DELIVERY_TIMEOUT_MS = 2_000L
+
+/**
+ * Short: by the time this is consulted the input budget has already elapsed, and a queue that is
+ * draining at all will run a freshly posted marker almost immediately.
+ */
+private const val EDT_DRAIN_TIMEOUT_MS = 500L
+
+/**
+ * Names the platform constraint rather than the symptom. The silent-no-op shape of #460 is exactly
+ * what made it hard to diagnose, so the message has to say what was not delivered and why the OS
+ * does that. It distinguishes what Spectre has actually measured from what it infers, because
+ * overstating the cause is how the original investigation lost time.
+ */
+private fun undeliveredInputMessage(operation: String, screenX: Int, screenY: Int): String =
+    "Spectre dispatched $operation at ($screenX, $screenY) but no matching mouse event reached " +
+        "this JVM within ${INPUT_DELIVERY_TIMEOUT_MS}ms, and this JVM was dispatching events " +
+        "normally, so the input was not delivered here. Real OS input needs the target process " +
+        "to be on the session's active input desktop, and needs the event to land on one of its " +
+        "own windows. Measured causes: the workstation is locked, or the process is on a desktop " +
+        "that is not the input desktop. The same is expected for a non-interactive session " +
+        "(Windows session 0, an SSH shell, a scheduled task run while logged out). Input routed " +
+        "elsewhere looks identical from here — another window covering the target, or a scroll " +
+        "sent to the focused window instead of the one under the pointer. " +
+        "See https://github.com/rock3r/spectre/issues/460"

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -34,6 +34,7 @@ internal constructor(
     inputLeasePolicy: InputLeasePolicy = InputLeasePolicy.Off,
     inputLeaseCoordinator: InputLeaseCoordinator = ProductionInputLeaseCoordinator(),
     inputCapabilities: InputCapabilities? = null,
+    internal val deliveryWitness: InputDeliveryWitness = AwtInputDeliveryWitness,
 ) : AutoCloseable by inputLeaseCoordinator {
 
     /** Shared-OS-resource capabilities used by isolation integrations. */

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -565,6 +565,145 @@ class RobotDriverTest {
         val driver = RobotDriver.headless()
         assertFailsWith<UnsupportedOperationException> { driver.moveBy(deltaX = 1, deltaY = 1) }
     }
+
+    // --- #460: input delivery verification on node-targeted clicks ------------------------
+
+    @Test
+    fun `clickVerified fails when real OS input is never delivered`() = runTest {
+        val witness = FakeInputDeliveryWitness(delivered = false)
+        val driver = realInputDriver(witness)
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                driver.clickVerified(screenX = 3, screenY = 4)
+            }
+
+        assertTrue(
+            failure.message.orEmpty().contains("input desktop"),
+            "message must name the platform constraint, was: ${failure.message}",
+        )
+        assertTrue(failure.message.orEmpty().contains("(3, 4)"), "message must name the target")
+        assertEquals(1, witness.closed, "the observation must be detached even when it fails")
+    }
+
+    @Test
+    fun `clickVerified passes when the press is delivered`() = runTest {
+        val witness = FakeInputDeliveryWitness(delivered = true)
+        val driver = realInputDriver(witness)
+
+        driver.clickVerified(screenX = 1, screenY = 2)
+
+        assertEquals(1, witness.observations)
+        assertEquals(1, witness.closed)
+    }
+
+    /**
+     * The decisive gate. A fake or synthetic backend never produces an AWT press, which is
+     * indistinguishable from a discarded real one — so verification must not run there, or every
+     * synthetic test in the suite would start failing.
+     */
+    @Test
+    fun `clickVerified skips verification when the backend is not real OS input`() = runTest {
+        val witness = FakeInputDeliveryWitness(delivered = false)
+        val driver = realInputDriver(witness, realOsInput = false)
+
+        driver.clickVerified(screenX = 1, screenY = 2)
+
+        assertEquals(0, witness.observations, "a non-real backend must not be verified at all")
+    }
+
+    @Test
+    fun `clickVerified proceeds when the witness cannot attach`() = runTest {
+        val witness = FakeInputDeliveryWitness(delivered = false, canObserve = false)
+        val driver = realInputDriver(witness)
+
+        driver.clickVerified(screenX = 1, screenY = 2)
+
+        assertEquals(0, witness.observations, "being unable to check is not evidence of a problem")
+    }
+
+    /** Coordinate clicks may legitimately land outside this JVM, so they stay unverified. */
+    @Test
+    fun `coordinate click is not delivery-verified`() = runTest {
+        val witness = FakeInputDeliveryWitness(delivered = false)
+        val driver = realInputDriver(witness)
+
+        driver.click(screenX = 1, screenY = 2)
+
+        assertEquals(0, witness.observations)
+    }
+
+    /**
+     * #460: an AWT listener only fires during dispatch, so "no event seen" also describes a JVM
+     * whose EDT never ran — `runBlocking { click(node) }` on the EDT parks the very thread that
+     * would dispatch the press. That must not be reported as the OS discarding input.
+     */
+    @Test
+    fun `clickVerified does not accuse the OS when this JVM is not dispatching events`() = runTest {
+        val witness = FakeInputDeliveryWitness(delivered = false, queueDrains = false)
+        val driver = realInputDriver(witness)
+
+        driver.clickVerified(screenX = 1, screenY = 2)
+
+        assertEquals(1, witness.closed, "the observation must still be detached")
+    }
+
+    @Test
+    fun `scrollWheelVerified watches for a wheel event, not a press`() = runTest {
+        val witness = FakeInputDeliveryWitness(delivered = true)
+        val driver = realInputDriver(witness)
+
+        driver.clickVerified(screenX = 1, screenY = 2)
+        driver.scrollWheelVerified(screenX = 1, screenY = 2, wheelClicks = 1)
+
+        // A press oracle would report every scroll as undelivered, since scrolling never presses.
+        assertEquals(listOf(DispatchedInput.Press, DispatchedInput.Wheel), witness.watched)
+    }
+
+    private fun realInputDriver(
+        witness: InputDeliveryWitness,
+        realOsInput: Boolean = true,
+    ): RobotDriver =
+        RobotDriver(
+            robot = RecordingRobotAdapter(),
+            clipboard = RecordingClipboardAdapter(),
+            tccGuard = RecordingTccGuard(),
+            inputCapabilities =
+                InputCapabilities(realOsInput = realOsInput, sharedSystemClipboard = false),
+            deliveryWitness = witness,
+        )
+}
+
+/** Reports a fixed verdict so delivery-verification policy can be tested without a real desktop. */
+private class FakeInputDeliveryWitness(
+    private val delivered: Boolean,
+    private val canObserve: Boolean = true,
+    private val queueDrains: Boolean = true,
+) : InputDeliveryWitness {
+
+    /** Which event each dispatch asked to watch for — presses for clicks, a wheel for scrolls. */
+    val watched: MutableList<DispatchedInput> = mutableListOf()
+
+    var observations: Int = 0
+        private set
+
+    var closed: Int = 0
+        private set
+
+    override fun observe(input: DispatchedInput): InputDeliveryWitness.Observation? {
+        if (!canObserve) return null
+        observations++
+        watched += input
+        return object : InputDeliveryWitness.Observation {
+            override fun awaitDelivery(timeoutMs: Long): Boolean = delivered
+
+            override fun awaitQueueDrain(timeoutMs: Long): Boolean = queueDrains
+
+            override fun close() {
+                closed++
+            }
+        }
+    }
 }
 
 private class RecordingTccGuard(

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -11,6 +11,7 @@ import java.awt.image.BufferedImage
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.ZERO
 import kotlin.time.Duration.Companion.milliseconds
@@ -672,6 +673,18 @@ class RobotDriverTest {
         driver.scrollWheelVerified(screenX = 1, screenY = 2, wheelClicks = 0)
 
         assertEquals(0, witness.observations, "a no-op scroll must not be verified")
+    }
+
+    /**
+     * The oracle is only sound on Windows. On macOS AppKit swallows the click that activates an
+     * inactive app without delivering it, so a healthy first click produces no event —
+     * `AgentAttachIntegrationTest` relies on retrying exactly that.
+     */
+    @Test
+    fun `input delivery is only verifiable on Windows`() {
+        assertTrue(inputDeliveryVerifiable("Windows 11"))
+        assertFalse(inputDeliveryVerifiable("Mac OS X"))
+        assertFalse(inputDeliveryVerifiable("Linux"))
     }
 
     private fun realInputDriver(

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -660,6 +660,20 @@ class RobotDriverTest {
         assertEquals(listOf(DispatchedInput.Press, DispatchedInput.Wheel), witness.watched)
     }
 
+    /**
+     * A zero-notch scroll emits no wheel event anywhere, so verifying it would turn a valid no-op
+     * into an `IllegalStateException` blaming the input desktop.
+     */
+    @Test
+    fun `scrollWheelVerified does not verify a zero-notch scroll`() = runTest {
+        val witness = FakeInputDeliveryWitness(delivered = false)
+        val driver = realInputDriver(witness)
+
+        driver.scrollWheelVerified(screenX = 1, screenY = 2, wheelClicks = 0)
+
+        assertEquals(0, witness.observations, "a no-op scroll must not be verified")
+    }
+
     private fun realInputDriver(
         witness: InputDeliveryWitness,
         realOsInput: Boolean = true,


### PR DESCRIPTION
Fixes #460 **on Windows**. See "Scope" below — other platforms keep their existing behaviour.

## The bug

`java.awt.Robot` drives `SendInput` on Windows, which the OS discards when the calling process is not on the session's active input desktop. The JDK ignores that refusal, so `click(node)` returned normally having done nothing — and the failure surfaced downstream as "the semantics tree went stale", with no error anywhere. That silent success is what made this hard to diagnose.

Measured on a physical Windows desktop, two independent ways:

| | Locked workstation | Fixture born on a non-input desktop |
|---|---|---|
| Rounds | 11 | 6 (+6 matched control) |
| `click()` returned | `OK` every time | `OK` every time |
| `MOUSE_PRESSED` in target JVM | **0** every time | **0** every time |
| Input-free state change applied | yes every time | yes every time |
| Semantics read over attach path | fine | fine |

Notably, on the hidden desktop the window reports `isShowing=true`, `isFocused=true`, `isActive=true` while every click is discarded — so focus/active flags are useless as a detector, in both directions.

## The fix

Node-targeted verbs (`click`, `doubleClick`, `longClick`, `swipe(from, to)`, `scrollWheel(node)`) verify delivery: a scoped AWT event listener is attached for the dispatch, and if the corresponding event never reaches the JVM the verb throws instead of silently succeeding. The AWT listener is the oracle because it sits below Compose, hit-testing and focus.

Deliberate non-behaviours, each covered by a test:

- **Skipped off Windows.** See Scope.
- **Skipped when the backend isn't real OS input.** Fake/synthetic/headless adapters never produce an AWT event, which is indistinguishable from a discarded real one.
- **Skipped when the listener can't attach.** Being unable to check is not evidence of a problem.
- **Skipped when this JVM isn't dispatching events.** An AWT listener only fires during dispatch, so "no event seen" also describes a busy or blocked EDT — `runBlocking { click(node) }` on the EDT parks the very thread that would dispatch the press. The guard posts a marker behind whatever is already queued; if it never runs, the result is unverifiable and the guard stays silent.
- **Skipped for zero-notch scrolls.** `mouseWheel(0)` emits nothing on any backend.
- **Coordinate overloads stay unverified.** A caller may legitimately drive input outside this JVM's windows.

On the attach path the guard throws *after* a suspension point, so it resumes the continuation with failure and arrives raw rather than wrapped in a `ReflectiveOperationException`; without a dedicated branch it would have reached users as `internalError`. That branch is narrow — every other `IllegalStateException` still propagates, preserving the fail-loudly contract on automator API mismatches.

## Scope: Windows only

The oracle is **unsound on other platforms**, which CI demonstrated rather than theory:

- **macOS** — AppKit consumes the click that activates an inactive application without delivering it to the window, so a healthy first click produces no AWT event. `AgentAttachIntegrationTest.waitForFocusedTextField` already compensates by retrying; verifying broke the retry it depends on.
- **X11** — the wheel is button 4/5 presses, so it emits nothing where a Windows backend would.

Windows is also the only platform where any of this was measured. The default witness therefore declines to observe elsewhere, reusing the existing "cannot testify" path, so **non-Windows behaviour is byte-for-byte what it was before this PR**. Tests inject their own witness, so the policy logic stays covered on every platform, and `inputDeliveryVerifiable(osName)` is unit-tested directly.

## Behaviour changes on Windows

- **`click(node)` now throws for an occluded target too**, not just an absent input desktop. The oracle cannot distinguish them, and both were previously silent misfires. This is wider than #460's literal scope.
- **`clearAndTypeText(node, text)` inherits verification** transitively through `click(node)`.
- **A genuine failure now costs up to 2s** before throwing.
- **Still unverified:** `typeText`, `pressKey`, `moveTo(node)`, `hover`. `typeText`/`pressKey` at least refuse loudly via their existing focus gate.

## Tests

- 9 unit tests in `RobotDriverTest` covering every skip condition, the Press-vs-Wheel distinction, the platform predicate, and the failure path.
- 2 in `ReflectiveAutomatorHandlerInputRejectionTest` for the raw post-suspension mapping and the narrow rethrow.
- An opt-in end-to-end `Issue460NonInputDesktopTest` that reproduces #460's condition **with no lock, no session 0, no elevation and no credentials**, by launching the fixture onto a second desktop in the current window station. It runs a matched control on the ordinary desktop first, so a broken host can't masquerade as a positive result.

`:core:check` and `:agent:check` pass, plus the Robot-backed attach e2e and contract corpus on a physical Windows desktop with `-Pspectre.agent.attachE2e.allowWindows=true`. The unit test was mutation-checked: neutering the guard makes it fail.

## Known gaps

- **Windows session 0 is still unmeasured.** The locked and hidden-desktop runs are the evidence; SSH / `schtasks` are inference, and the error message says so rather than asserting it.
- **`scrollWheel` verification can false-fail** if "scroll inactive windows on hover" is disabled and the target isn't focused — the wheel then goes to the focused window. The scroll genuinely didn't reach the target, so throwing is defensible, but the cause differs from the message's primary explanation.
- **Docs not updated.** `docs/guide/troubleshooting.md`'s "input either no-ops" guidance is now stale on Windows, and `interactions.md` doesn't describe the throw-on-non-delivery contract. Deliberately left for a follow-up to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
