### PR TITLE
Decode gh output and the watcher state file as UTF-8

### DIFF
--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -198,11 +198,28 @@ def gh_text(args, repo=None):
         cmd.extend(["-R", repo])
     cmd.extend(args)
     try:
-        proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        proc = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            # GitHub CLI/API output is UTF-8. Without an explicit encoding Python
+            # decodes it with the locale default (cp1252 on Windows), which fails
+            # on em-dashes or emoji in review comments.
+            encoding="utf-8",
+            errors="replace",
+        )
     except FileNotFoundError as err:
         raise GhCommandError("`gh` command not found") from err
     except subprocess.CalledProcessError as err:
         raise GhCommandError(_format_gh_error(cmd, err)) from err
+    if proc.stdout is None:
+        # `subprocess` leaves stdout as None when its reader thread dies (for
+        # example on a decode error), which would otherwise surface downstream
+        # as a confusing AttributeError on None.
+        raise GhCommandError(
+            f"No output captured from GitHub CLI command: {' '.join(cmd)}"
+        )
     return proc.stdout
 
 

--- a/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -348,7 +348,7 @@ def is_state_stale(state, now_seconds=None):
 def load_state(path):
     if path.exists():
         try:
-            data = json.loads(path.read_text())
+            data = json.loads(path.read_text(encoding="utf-8"))
         except json.JSONDecodeError as err:
             raise RuntimeError(f"State file is not valid JSON: {path}") from err
         if not isinstance(data, dict):

--- a/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -980,6 +981,72 @@ class NeedsAgentAttentionTests(unittest.TestCase):
 
     def test_none_actions_needs_attention(self):
         self.assertTrue(watch.needs_agent_attention(None))
+
+
+class GhTextTests(unittest.TestCase):
+    def _run_emitting(self, payload):
+        """Run gh_text against a real child process that writes `payload` as UTF-8."""
+        emitter = "import sys; sys.stdout.buffer.write({}.encode('utf-8'))".format(
+            ascii(payload)
+        )
+        real_run = subprocess.run
+
+        def fake_run(cmd, **kwargs):
+            return real_run([sys.executable, "-c", emitter], **kwargs)
+
+        return patch.object(watch.subprocess, "run", side_effect=fake_run)
+
+    def test_gh_text_requests_utf8_decoding(self):
+        """gh output must be decoded as UTF-8, never with the locale default."""
+        captured = {}
+
+        def fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return SimpleNamespace(stdout="{}", stderr="")
+
+        with patch.object(watch.subprocess, "run", side_effect=fake_run):
+            watch.gh_text(["pr", "view"])
+
+        self.assertEqual(captured.get("encoding"), "utf-8")
+        self.assertEqual(captured.get("errors"), "replace")
+
+    def test_gh_text_decodes_non_ascii_output(self):
+        """An em-dash or emoji in a review body must not blow up on a cp1252 locale."""
+        body = "Codex review \u2014 nit \U0001f41b"
+
+        with self._run_emitting(body):
+            out = watch.gh_text(["pr", "view"])
+
+        self.assertEqual(out, body)
+
+    def test_gh_json_parses_non_ascii_output(self):
+        """The full gh_json path must survive non-ASCII review comment bodies."""
+        body = "Bugbot \u2014 found an issue \U0001f41b"
+        payload = json.dumps({"body": body}, ensure_ascii=False)
+
+        with self._run_emitting(payload):
+            data = watch.gh_json(["pr", "view", "--json", "body"])
+
+        self.assertEqual(data["body"], body)
+
+    def test_gh_text_raises_when_stdout_is_missing(self):
+        """A dead stdout reader thread must not leak out as an AttributeError."""
+        with patch.object(
+            watch.subprocess, "run", return_value=SimpleNamespace(stdout=None, stderr="")
+        ):
+            with self.assertRaises(watch.GhCommandError) as context:
+                watch.gh_text(["pr", "view"])
+
+        self.assertIn("No output captured", str(context.exception))
+
+    def test_gh_json_reports_a_clear_error_when_stdout_is_missing(self):
+        with patch.object(
+            watch.subprocess, "run", return_value=SimpleNamespace(stdout=None, stderr="")
+        ):
+            with self.assertRaises(watch.GhCommandError) as context:
+                watch.gh_json(["pr", "view", "--json", "number"])
+
+        self.assertIn("No output captured", str(context.exception))
 
 
 class RunOnceTests(unittest.TestCase):

--- a/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
+++ b/.agents/skills/babysit-pr/scripts/test_gh_pr_watch.py
@@ -792,6 +792,29 @@ class RetryEligibilityTests(unittest.TestCase):
 
         self.assertEqual(state["pending_checks_first_seen_at"], {})
 
+    def test_load_state_reads_non_ascii_state_files_as_utf8(self):
+        """save_state pins UTF-8, so load_state must not decode with the locale default."""
+        # Emoji reach the state dict through pending_check_key(), which embeds
+        # the GitHub check and workflow names verbatim.
+        key = "build \U0001f680|CI \u2014 main|https://example.test/1"
+
+        state = {
+            # A fresh snapshot timestamp keeps load_state from treating this as
+            # stale and resetting the seen-tracking fields.
+            "last_snapshot_at": watch.time.time(),
+            "pending_checks_first_seen_at": {key: 1},
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = watch.Path(tmp_dir) / "state.json"
+            # Written as raw UTF-8 rather than via save_state: json.dumps escapes
+            # non-ASCII by default, so save_state cannot currently produce the
+            # bytes this guards against.
+            path.write_bytes(json.dumps(state, ensure_ascii=False).encode("utf-8"))
+            loaded, _ = watch.load_state(path)
+
+        self.assertEqual(loaded["pending_checks_first_seen_at"], {key: 1})
+
     def test_load_state_resets_seen_tracking_when_stale(self):
         stale_state = {
             "seen_issue_comment_ids": ["1"],


### PR DESCRIPTION
The PR watcher script crashed on Windows whenever a review comment contained a
non-ASCII byte — an em-dash or emoji from a Codex or Bugbot review was enough.

```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 11231
  at subprocess._readerthread -> encodings/cp1252.py
AttributeError: 'NoneType' object has no attribute 'strip'   (gh_json)
```

## What was wrong

`gh_text` ran `gh` with `text=True` but no explicit `encoding`, so Python
decoded the child's stdout with the locale default (cp1252 here) instead of
UTF-8. GitHub CLI/API output is always UTF-8.

The second error is a consequence of the first: CPython's Windows
`Popen._communicate` ends with `stdout = stdout[0] if stdout else None`, so a
reader thread that dies mid-decode leaves `proc.stdout` as `None`, which then
hit `.strip()` in `gh_json`.

## Changes

**`fix(scripts): decode gh output as UTF-8 in the PR watcher`**
- `gh_text` passes `encoding="utf-8", errors="replace"` to `subprocess.run`.
- Raises a clear `GhCommandError` naming the failing command when `proc.stdout`
  is `None`. The guard sits in `gh_text` rather than `gh_json` because that is
  where the `None` originates, and it also covers the other caller
  (`gh run rerun`); `gh_json`'s existing "empty but successful → `None`"
  contract is unchanged.

**`fix(scripts): read the PR watcher state file as UTF-8`**
- `save_state` pinned UTF-8 but `load_state` read back with a bare
  `read_text()`. Latent rather than live — `json.dumps` escapes non-ASCII by
  default — but non-ASCII does reach the state dict via `pending_check_key()`,
  and a `UnicodeDecodeError` there is a `ValueError`, so it would escape the
  `except (GhCommandError, RuntimeError)` retry handlers and kill the watch
  loop rather than being retried.

## Tests

+6 tests (56 → 62). New `GhTextTests` covers the subprocess kwargs
(locale-independent), a real child process emitting em-dash + emoji as raw
UTF-8 through both `gh_text` and `gh_json`, and both `stdout is None` paths.
The state-file test writes raw UTF-8 bytes directly, since `save_state` cannot
produce them today.

Every new test was verified to fail against the unfixed source and pass against
the fix. Test sources are kept pure-ASCII (`\u` escapes produce the non-ASCII at
runtime) so the suite does not itself depend on how the file is encoded on disk.

## Verification

- 62/62 pass under the cp1252 locale and under `PYTHONUTF8=1`.
- The original repro now completes with `PYTHONUTF8` unset. Fetching PR #469's
  review comments returns both Codex bot comments intact, highest codepoint
  U+1F44E, with zero U+FFFD replacement characters — so `errors="replace"` is
  not papering over a bad decode.
- `PYTHONUTF8=1` is no longer needed as a workaround.

## Notes

- The shared skill copy at `~/.claude/skills/babysit-pr/` got the same fixes
  locally. It lives outside the repo so it is not part of this PR, and the two
  copies have pre-existing feature divergence that was deliberately left alone.
- `gradlew check` fails on `:cli:verifyCliDistributionZip` on Windows, with an
  identical failure fingerprint on pristine `main`. Pre-existing and unrelated
  to this Python-only change; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
