### PR TITLE
fix(agent): give a wedged input coordinator a way out (#472)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -54,6 +54,7 @@ public final class dev/sebastiano/spectre/agent/AttachInputCoordination : java/l
 	public static final field REQUIRE_VALUE Ljava/lang/String;
 	public static final field Required Ldev/sebastiano/spectre/agent/AttachInputCoordination;
 	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getWireValue ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/AttachInputCoordination;
 	public static fun values ()[Ldev/sebastiano/spectre/agent/AttachInputCoordination;
 }
@@ -61,6 +62,8 @@ public final class dev/sebastiano/spectre/agent/AttachInputCoordination : java/l
 public final class dev/sebastiano/spectre/agent/AttachInputCoordination$Companion {
 	public final fun fromProperty (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/AttachInputCoordination;
 	public static synthetic fun fromProperty$default (Ldev/sebastiano/spectre/agent/AttachInputCoordination$Companion;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+	public final fun requestedFromProperty (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+	public static synthetic fun requestedFromProperty$default (Ldev/sebastiano/spectre/agent/AttachInputCoordination$Companion;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AttachInputCoordination;
 }
 
 public final class dev/sebastiano/spectre/agent/AttachInterruptedException : dev/sebastiano/spectre/agent/SpectreAttachException {

--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -46,6 +46,23 @@ public final class dev/sebastiano/spectre/agent/AtomicCaptureResult {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/sebastiano/spectre/agent/AttachInputCoordination : java/lang/Enum {
+	public static final field Companion Ldev/sebastiano/spectre/agent/AttachInputCoordination$Companion;
+	public static final field DISABLE_VALUE Ljava/lang/String;
+	public static final field Disabled Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+	public static final field PROPERTY Ljava/lang/String;
+	public static final field REQUIRE_VALUE Ljava/lang/String;
+	public static final field Required Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+	public static fun values ()[Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+}
+
+public final class dev/sebastiano/spectre/agent/AttachInputCoordination$Companion {
+	public final fun fromProperty (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+	public static synthetic fun fromProperty$default (Ldev/sebastiano/spectre/agent/AttachInputCoordination$Companion;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+}
+
 public final class dev/sebastiano/spectre/agent/AttachInterruptedException : dev/sebastiano/spectre/agent/SpectreAttachException {
 	public fun <init> (Ljava/nio/file/Path;Ljava/lang/InterruptedException;)V
 }
@@ -54,17 +71,19 @@ public final class dev/sebastiano/spectre/agent/AttachOptions {
 	public static final field Companion Ldev/sebastiano/spectre/agent/AttachOptions$Companion;
 	public static final field DEFAULT_ATTACH_TIMEOUT_MS J
 	public fun <init> ()V
-	public fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;)V
-	public synthetic fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;Ldev/sebastiano/spectre/agent/AttachInputCoordination;)V
+	public synthetic fun <init> (Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;Ldev/sebastiano/spectre/agent/AttachInputCoordination;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/nio/file/Path;
 	public final fun component2 ()Ljava/nio/file/Path;
 	public final fun component3 ()J
 	public final fun component4 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;)Ldev/sebastiano/spectre/agent/AttachOptions;
-	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/AttachOptions;Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AttachOptions;
+	public final fun component5 ()Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+	public final fun copy (Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;Ldev/sebastiano/spectre/agent/AttachInputCoordination;)Ldev/sebastiano/spectre/agent/AttachOptions;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/AttachOptions;Ljava/nio/file/Path;Ljava/nio/file/Path;JLjava/lang/Integer;Ldev/sebastiano/spectre/agent/AttachInputCoordination;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/AttachOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAgentJarPath ()Ljava/nio/file/Path;
 	public final fun getAttachTimeoutMs ()J
+	public final fun getInputCoordination ()Ldev/sebastiano/spectre/agent/AttachInputCoordination;
 	public final fun getMaxFrameBytes ()Ljava/lang/Integer;
 	public final fun getUdsPath ()Ljava/nio/file/Path;
 	public fun hashCode ()I
@@ -366,15 +385,19 @@ public final class dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs {
 	public static final field INSTANCE Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs;
 	public final fun parse (Ljava/lang/String;)Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;
 	public final fun render (Ljava/lang/String;I)Ljava/lang/String;
+	public final fun render (Ljava/lang/String;ILdev/sebastiano/spectre/agent/AttachInputCoordination;)Ljava/lang/String;
 }
 
 public final class dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed {
-	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ldev/sebastiano/spectre/agent/AttachInputCoordination;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ldev/sebastiano/spectre/agent/AttachInputCoordination;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/Integer;
-	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;)Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;
-	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;
+	public final fun component3 ()Ldev/sebastiano/spectre/agent/AttachInputCoordination;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ldev/sebastiano/spectre/agent/AttachInputCoordination;)Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;Ljava/lang/String;Ljava/lang/Integer;Ldev/sebastiano/spectre/agent/AttachInputCoordination;ILjava/lang/Object;)Ldev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs$Parsed;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInputCoordination ()Ldev/sebastiano/spectre/agent/AttachInputCoordination;
 	public final fun getMaxFrameBytes ()Ljava/lang/Integer;
 	public final fun getUdsPath ()Ljava/lang/String;
 	public fun hashCode ()I

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -39,11 +39,33 @@ public object AgentAttach {
      * JVM it injected disagreeing about the hop between them — a 16MiB target under a 64MiB daemon
      * would fail captures the daemon could carry.
      */
-    private fun agentArgsFor(options: AttachOptions, udsPath: Path): String =
+    private fun agentArgsFor(
+        options: AttachOptions,
+        udsPath: Path,
+        inputCoordination: AttachInputCoordination,
+    ): String =
         AgentBootstrapArgs.render(
             udsPath = udsPath.toString(),
             maxFrameBytes = options.maxFrameBytes ?: FrameLimits.maxFrameBytes,
+            inputCoordination = inputCoordination,
         )
+
+    /**
+     * Resolves the coordination mode for one attach: the explicit option if there is one, otherwise
+     * [AttachInputCoordination.PROPERTY], otherwise [AttachInputCoordination.Required].
+     *
+     * The property is not redundant with the option. `DaemonSessionRegistry` attaches with
+     * `AgentAttach.attach(pid)` and no options at all, so for anyone driving Spectre through the
+     * CLI the property is the *only* channel that reaches this decision; the option is for
+     * embedders, and for tests that must not depend on a JVM-global.
+     *
+     * [property] is a parameter so the precedence above can be tested without mutating a global.
+     */
+    internal fun resolveInputCoordination(
+        options: AttachOptions,
+        property: String? = System.getProperty(AttachInputCoordination.PROPERTY),
+    ): AttachInputCoordination =
+        options.inputCoordination ?: AttachInputCoordination.fromProperty(property)
 
     /** Attach to the JVM identified by [pid] and return a connected [AttachedAutomator]. */
     @Throws(SpectreAttachException::class)
@@ -64,7 +86,18 @@ public object AgentAttach {
         // generic ("Operation not permitted") and hard to diagnose; this gives a clear message
         // before we even open the VM connection.
         checkSameUser(pid)
-        val coordinatorClient = runCatching(::ensureInputCoordinator).getOrNull()
+        val inputCoordination = resolveInputCoordination(options)
+        announceInputCoordination(inputCoordination)
+        // Opting out means not standing one up either. Beyond consistency this is what makes the
+        // hatch usable on the host that motivated it: `connectOrStart` spends a 5s startup budget
+        // before giving up, so an attach that has already decided not to coordinate would
+        // otherwise still stall for it on every wedged-coordinator run.
+        val coordinatorClient =
+            if (inputCoordination == AttachInputCoordination.Required) {
+                runCatching(::ensureInputCoordinator).getOrNull()
+            } else {
+                null
+            }
         var coordinatorOwnedByResult = false
         try {
 
@@ -74,7 +107,7 @@ public object AgentAttach {
                     vmClass,
                     vm,
                     agentJar.toString(),
-                    agentArgsFor(options, udsPath),
+                    agentArgsFor(options, udsPath, inputCoordination),
                 )
             } finally {
                 detachVirtualMachine(vmClass, vm)
@@ -111,6 +144,25 @@ public object AgentAttach {
 
     private fun ensureInputCoordinator() =
         InputCoordinatorClientFactory.connectOrStart(ownerLabel = "spectre-agent-attacher")
+
+    /**
+     * Says on stderr that the escape hatch is in force, for as long as it is.
+     *
+     * A session running without desktop coordination has to be identifiable as one after the fact.
+     * The interesting failures here are the ones that only make sense once you know two runs were
+     * driving the same mouse, and by then the only evidence left is the log.
+     */
+    private fun announceInputCoordination(mode: AttachInputCoordination) {
+        if (mode == AttachInputCoordination.Required) return
+        val switch =
+            "-D${AttachInputCoordination.PROPERTY}=${AttachInputCoordination.DISABLE_VALUE}"
+        System.err.println(
+            "[spectre-attach] desktop input coordination is DISABLED for this attach " +
+                "($switch, or AttachOptions.inputCoordination). Nothing will stop another " +
+                "Spectre process from driving the same mouse and keyboard concurrently. " +
+                "See https://github.com/rock3r/spectre/issues/472"
+        )
+    }
 
     /**
      * Resolve the agent runtime JAR by trying in order:

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AgentAttach.kt
@@ -88,16 +88,15 @@ public object AgentAttach {
         checkSameUser(pid)
         val inputCoordination = resolveInputCoordination(options)
         announceInputCoordination(inputCoordination)
-        // Opting out means not standing one up either. Beyond consistency this is what makes the
-        // hatch usable on the host that motivated it: `connectOrStart` spends a 5s startup budget
-        // before giving up, so an attach that has already decided not to coordinate would
-        // otherwise still stall for it on every wedged-coordinator run.
-        val coordinatorClient =
-            if (inputCoordination == AttachInputCoordination.Required) {
-                runCatching(::ensureInputCoordinator).getOrNull()
-            } else {
-                null
-            }
+        // Started unconditionally, including when this attach has opted out. Skipping it would save
+        // `connectOrStart`'s 5s budget on a wedged host, but the runtime jar is selectable
+        // (AttachOptions.agentJarPath, or the runtime-jar property) and one predating #472 ignores
+        // the unknown agentArgs field and builds a Required driver regardless. Not standing a
+        // coordinator up would leave that pairing with nothing to reach — turning a working
+        // coordinated session into a broken one, in the name of an opt-out it never received.
+        // Five seconds on an already-broken host is the cheaper side of that trade. Codex caught
+        // this on the first review of #472.
+        val coordinatorClient = runCatching(::ensureInputCoordinator).getOrNull()
         var coordinatorOwnedByResult = false
         try {
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachInputCoordination.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachInputCoordination.kt
@@ -1,0 +1,83 @@
+package dev.sebastiano.spectre.agent
+
+/**
+ * Whether an attached target coordinates its use of the shared desktop, and the deliberate way to
+ * say it should not (#472).
+ *
+ * The attach path drives real OS input into a process Spectre does not own. Coordination is the
+ * mutual exclusion that keeps two Spectre runs from interleaving mouse and keyboard events on one
+ * desktop — the failure mode behind #446, #447, #449 and #460 — so [Required] is the default and
+ * stays the default. A coordinator it cannot reach fails the operation loudly rather than quietly
+ * dropping the guarantee.
+ *
+ * [Disabled] exists because "loud" was, until #472, also "terminal": #462 wedged the coordinator on
+ * a Windows host and every input verb on the attach path died with no way for the user to proceed.
+ * Someone who knows their coordinator is broken and knows nothing else is driving the desktop needs
+ * a way through. This is that way, and it is deliberately awkward:
+ * - it is off unless [PROPERTY] holds exactly [DISABLE_VALUE], or [AttachOptions.inputCoordination]
+ *   names it in code;
+ * - nothing infers it — no timeout, no failure, and no "we could not reach the coordinator so we
+ *   assume you meant this" ever selects it;
+ * - both sides announce it on stderr while it is in force, so a session running uncoordinated says
+ *   so in its log rather than looking like an ordinary one.
+ *
+ * **What you give up.** Nothing then stops a second Spectre process from driving the same mouse and
+ * keyboard at the same time. Two runs interleaving real input produce failures that look like
+ * anything but their cause, which is why this is an explicit choice and not a fallback.
+ *
+ * Not offered here: a best-effort middle ground. `InputLeasePolicy.Auto` degrades for exactly two
+ * error codes — `COORDINATOR_PROVIDER_MISSING` and `COORDINATOR_SESSION_UNAVAILABLE` — and a wedged
+ * coordinator is neither: the launching provider's startup timeout arrives as `COORDINATOR_IO`. So
+ * `Auto` would hard-fail the very situation this exists for, while also weakening every case where
+ * coordination is merely absent. Opting out means opting out.
+ */
+@ExperimentalSpectreAgentApi
+public enum class AttachInputCoordination(
+    internal val leasePolicyName: String,
+    internal val wireValue: String,
+) {
+    /** Coordinate every shared-desktop capability; an unreachable coordinator is an error. */
+    Required(leasePolicyName = "Required", wireValue = "required"),
+
+    /** Drive the desktop without coordinating. Deliberate, announced, and never inferred. */
+    Disabled(leasePolicyName = "Off", wireValue = "disabled");
+
+    public companion object {
+        /** System property read on the **attaching** JVM. See [fromProperty]. */
+        public const val PROPERTY: String = "dev.sebastiano.spectre.agent.inputCoordination"
+
+        /** The only value that opts out. Anything else means [Required]. */
+        public const val DISABLE_VALUE: String = "disabled"
+
+        /** The value that pins the default explicitly, for a caller who wants it in writing. */
+        public const val REQUIRE_VALUE: String = "required"
+
+        /**
+         * Resolves [value] (by default [PROPERTY] on this JVM) to a coordination mode.
+         *
+         * Case and surrounding whitespace are forgiven; nothing else is. Unset, blank, a typo, and
+         * an affirmative-looking `true` all mean [Required], because falling back *to* coordination
+         * is the only safe direction: a boolean switch would put "stop policing the desktop" one
+         * stray property away, and a mistyped opt-out that silently coordinated anyway would be
+         * indistinguishable from a working one. A typo is not silent in practice either — the
+         * failure the user still gets names the exact spelling that would have worked.
+         *
+         * Read on the attacher, not in the target: the target is somebody else's application, and
+         * letting a property *it* happens to carry downgrade the attacher's coordination is exactly
+         * the silent degradation this design refuses. The attacher's decision travels to the target
+         * through `agentArgs` instead.
+         */
+        public fun fromProperty(
+            value: String? = System.getProperty(PROPERTY)
+        ): AttachInputCoordination =
+            when (value?.trim()?.lowercase()) {
+                DISABLE_VALUE -> Disabled
+                REQUIRE_VALUE -> Required
+                else -> Required
+            }
+
+        /** Reverses [AttachInputCoordination.wireValue] for the `agentArgs` field. */
+        internal fun fromWireValue(value: String?): AttachInputCoordination =
+            entries.firstOrNull { it.wireValue == value } ?: Required
+    }
+}

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachInputCoordination.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachInputCoordination.kt
@@ -34,7 +34,12 @@ package dev.sebastiano.spectre.agent
 @ExperimentalSpectreAgentApi
 public enum class AttachInputCoordination(
     internal val leasePolicyName: String,
-    internal val wireValue: String,
+    /**
+     * Canonical string spelling, used on both wires that carry this decision: the injected
+     * runtime's `agentArgs`, and the CLI daemon's `Hello`. Public because the daemon protocol lives
+     * in another module and a second spelling of the same two words is a drift risk, not a saving.
+     */
+    public val wireValue: String,
 ) {
     /** Coordinate every shared-desktop capability; an unreachable coordinator is an error. */
     Required(leasePolicyName = "Required", wireValue = "required"),
@@ -75,6 +80,22 @@ public enum class AttachInputCoordination(
                 REQUIRE_VALUE -> Required
                 else -> Required
             }
+
+        /**
+         * The mode [value] explicitly *asks* for, or `null` when it asks for nothing.
+         *
+         * Distinct from [fromProperty], which answers "what mode do we run in" and therefore never
+         * returns null. This answers "did the user say something about coordination", which is what
+         * a long-lived daemon has to compare against the mode it booted with: a client that asked
+         * for nothing is happy with any daemon, exactly as with the frame budget.
+         *
+         * A typo counts as a request. It resolves to [Required] like any unrecognised value, and
+         * reporting that against a [Disabled] daemon is the useful answer — the user meant to say
+         * something about coordination and did not get what they typed.
+         */
+        public fun requestedFromProperty(
+            value: String? = System.getProperty(PROPERTY)
+        ): AttachInputCoordination? = value?.takeIf { it.isNotBlank() }?.let(::fromProperty)
 
         /** Reverses [AttachInputCoordination.wireValue] for the `agentArgs` field. */
         internal fun fromWireValue(value: String?): AttachInputCoordination =

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachOptions.kt
@@ -42,6 +42,14 @@ import java.util.UUID
  *   `--max-frame-bytes` propagates it to every JVM it injects. The target cannot read the
  *   attacher's environment, and it is the side that writes screenshot frames, so this is the only
  *   channel that reaches it.
+ * @property inputCoordination whether the attached target coordinates its use of the shared
+ *   desktop. `null` (default) resolves [AttachInputCoordination.PROPERTY] on this JVM, which itself
+ *   defaults to [AttachInputCoordination.Required] — so leaving this alone coordinates, and so does
+ *   every value of that property except the one word that opts out. Setting it explicitly wins over
+ *   the property in **both** directions: an integration that pins `Required` cannot be unpinned by
+ *   a property left lying around in the environment. Read [AttachInputCoordination] before reaching
+ *   for [AttachInputCoordination.Disabled] — it is deliberate, it is announced on stderr, and it
+ *   costs you the guarantee that nothing else is driving this desktop.
  */
 @ExperimentalSpectreAgentApi
 public data class AttachOptions(
@@ -49,6 +57,7 @@ public data class AttachOptions(
     public val udsPath: Path? = null,
     public val attachTimeoutMs: Long = DEFAULT_ATTACH_TIMEOUT_MS,
     public val maxFrameBytes: Int? = null,
+    public val inputCoordination: AttachInputCoordination? = null,
 ) {
     init {
         // The agent logs and ignores a budget it cannot apply, so an unusable value here would let

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgs.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.agent.runtime
 
+import dev.sebastiano.spectre.agent.AttachInputCoordination
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.FrameLimits
 
@@ -31,8 +32,20 @@ import dev.sebastiano.spectre.agent.transport.FrameLimits
 @ExperimentalSpectreAgentApi
 public object AgentBootstrapArgs {
 
-    /** Parsed view of an `agentArgs` string. */
-    public data class Parsed(public val udsPath: String?, public val maxFrameBytes: Int?)
+    /**
+     * Parsed view of an `agentArgs` string.
+     *
+     * [inputCoordination] defaults to [AttachInputCoordination.Required] rather than being nullable
+     * on purpose: "the field is absent" and "the field is corrupt" must both mean *coordinate*, and
+     * a nullable field invites a caller to treat absence as "no opinion" and pick something else.
+     * An older attacher, a hand-written `-javaagent:` line, and a truncated value therefore all
+     * land on the behaviour Spectre has always had.
+     */
+    public data class Parsed(
+        public val udsPath: String?,
+        public val maxFrameBytes: Int?,
+        public val inputCoordination: AttachInputCoordination = AttachInputCoordination.Required,
+    )
 
     /** Parses [agentArgs]; a null/blank string means diagnostic mode (no UDS, no IPC server). */
     public fun parse(agentArgs: String?): Parsed {
@@ -52,13 +65,40 @@ public object AgentBootstrapArgs {
         return Parsed(
             udsPath = fields[UDS_KEY]?.let(::decodeValue)?.takeIf { it.isNotEmpty() },
             maxFrameBytes = FrameLimits.parseMaxFrameBytes(fields[MAX_FRAME_BYTES_KEY]),
+            inputCoordination =
+                AttachInputCoordination.fromWireValue(fields[INPUT_COORDINATION_KEY]),
         )
     }
 
-    /** Renders [udsPath] and [maxFrameBytes] as a structured, escaped argument string. */
+    /**
+     * Renders [udsPath] and [maxFrameBytes] as a structured, escaped argument string, leaving the
+     * target coordinated.
+     *
+     * Kept as its own overload rather than folded into the three-argument form with a default
+     * value: this is published API, and a defaulted parameter would move the signature every
+     * existing caller binds. It renders byte-for-byte what it always rendered, and [parse] reads
+     * the missing field back as [AttachInputCoordination.Required].
+     */
     public fun render(udsPath: String, maxFrameBytes: Int): String =
         "$STRUCTURED_PREFIX${encodeValue(udsPath)}" +
             "$SEPARATOR$MAX_FRAME_BYTES_KEY$KEY_VALUE$maxFrameBytes"
+
+    /**
+     * Renders [udsPath], [maxFrameBytes] and [inputCoordination] as a structured, escaped argument
+     * string.
+     *
+     * The coordination field is emitted for [AttachInputCoordination.Required] too, not only for
+     * the opt-out. It costs a dozen bytes and it puts the attacher's decision on the wire
+     * explicitly, so the target's stderr reports the mode it was asked for rather than one inferred
+     * from an absence.
+     */
+    public fun render(
+        udsPath: String,
+        maxFrameBytes: Int,
+        inputCoordination: AttachInputCoordination,
+    ): String =
+        render(udsPath, maxFrameBytes) +
+            "$SEPARATOR$INPUT_COORDINATION_KEY$KEY_VALUE${inputCoordination.wireValue}"
 
     /**
      * Escapes the delimiters this format reserves. `%` goes first so its escape is not re-escaped.
@@ -74,6 +114,7 @@ public object AgentBootstrapArgs {
 
     private const val UDS_KEY: String = "uds"
     private const val MAX_FRAME_BYTES_KEY: String = "maxFrameBytes"
+    private const val INPUT_COORDINATION_KEY: String = "inputCoordination"
     private const val KEY_VALUE: String = "="
     private const val SEPARATOR: String = ","
     private const val STRUCTURED_PREFIX: String = "$UDS_KEY$KEY_VALUE"

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.agent.runtime
 
+import dev.sebastiano.spectre.agent.AttachInputCoordination
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.FrameLimits
 import dev.sebastiano.spectre.agent.transport.IpcServer
@@ -100,12 +101,15 @@ public object SpectreAgent {
             // failures are logged and identity falls back to null handles.
             AwtPeerModuleOpener.openFor(loader, instrumentation)
 
-            val agentAutomator = createAutomatorReflectively(loader)
+            // Parsed before the automator is built, not after: the driver's coordination policy is
+            // fixed at construction, and the attacher's decision about it arrives in agentArgs.
+            val parsedArgs = AgentBootstrapArgs.parse(agentArgs)
+
+            val agentAutomator = createAutomatorReflectively(loader, parsedArgs.inputCoordination)
             val automator = agentAutomator.instance
             targetInputResource = agentAutomator.targetInputResource
             System.err.println("[spectre-agent] ComposeAutomator ready: $automator")
 
-            val parsedArgs = AgentBootstrapArgs.parse(agentArgs)
             // The attacher's frame budget has to be adopted before the IPC server can answer: this
             // JVM writes the bulky screenshot frames and cannot read the daemon's environment.
             parsedArgs.maxFrameBytes?.let { budget ->
@@ -200,13 +204,20 @@ public object SpectreAgent {
         System.err.println("[spectre-agent] detached cleanly; resources released")
     }
 
-    private fun createAutomatorReflectively(classLoader: ClassLoader): AgentAutomator {
+    private fun createAutomatorReflectively(
+        classLoader: ClassLoader,
+        inputCoordination: AttachInputCoordination,
+    ): AgentAutomator {
         val automatorClass = classLoader.loadClass(COMPOSE_AUTOMATOR_FQN)
         val companion = automatorClass.getField("Companion").get(null)
 
         val robotDriverClass = classLoader.loadClass(ROBOT_DRIVER_FQN)
         val robotDriver =
-            createCoordinatedRobotDriverOrLegacyFallback(classLoader, robotDriverClass)
+            createCoordinatedRobotDriverOrLegacyFallback(
+                classLoader,
+                robotDriverClass,
+                inputCoordination,
+            )
 
         val inProcessMethod =
             companion.javaClass.methods.firstOrNull {
@@ -222,16 +233,39 @@ public object SpectreAgent {
         )
     }
 
+    /**
+     * Builds the target's `RobotDriver` on the coordination policy [inputCoordination] names.
+     *
+     * The default is and stays [AttachInputCoordination.Required] (#472): coordination is the
+     * mutual exclusion that stops two Spectre processes interleaving real input on one desktop, so
+     * an unreachable coordinator has to fail loudly rather than quietly stop policing. The
+     * parameter only ever carries a choice the *attacher* made deliberately — nothing on this side
+     * infers it from a failure, a timeout, or a property the target happens to carry.
+     *
+     * Targets predating `InputLeasePolicy` still fall back to the no-argument driver, which was
+     * never coordinated; the opt-out is a no-op there rather than an error, since it asks for what
+     * that target already does.
+     */
     internal fun createCoordinatedRobotDriverOrLegacyFallback(
         classLoader: ClassLoader,
         robotDriverClass: Class<*>,
+        inputCoordination: AttachInputCoordination = AttachInputCoordination.Required,
     ): Any =
         try {
             val policyClass = classLoader.loadClass(INPUT_LEASE_POLICY_FQN)
-            val requiredPolicy =
-                policyClass.enumConstants.firstOrNull { (it as Enum<*>).name == "Required" }
-                    ?: error("Could not resolve InputLeasePolicy.Required from $policyClass")
-            robotDriverClass.getDeclaredConstructor(policyClass).newInstance(requiredPolicy)
+            val policyName = inputCoordination.leasePolicyName
+            val policy =
+                policyClass.enumConstants.firstOrNull { (it as Enum<*>).name == policyName }
+                    ?: error("Could not resolve InputLeasePolicy.$policyName from $policyClass")
+            if (inputCoordination != AttachInputCoordination.Required) {
+                System.err.println(
+                    "[spectre-agent] desktop input coordination is DISABLED in this target " +
+                        "(InputLeasePolicy.$policyName), by explicit request from the attacher. " +
+                        "Concurrent Spectre runs can now interleave real input on this desktop. " +
+                        "See https://github.com/rock3r/spectre/issues/472"
+                )
+            }
+            robotDriverClass.getDeclaredConstructor(policyClass).newInstance(policy)
         } catch (_: ClassNotFoundException) {
             robotDriverClass.getDeclaredConstructor().newInstance()
         } catch (_: NoSuchMethodException) {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachInputCoordinationTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachInputCoordinationTest.kt
@@ -1,0 +1,95 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+
+/**
+ * The truth table for the #472 escape hatch.
+ *
+ * The point of the hatch is to be *hard to trip over*. Coordination is what stops two Spectre
+ * processes driving the same mouse and keyboard, so a value that merely looks affirmative must not
+ * turn it off: only the exact word wins, and everything else — unset, blank, `true`, a typo — lands
+ * back on [AttachInputCoordination.Required]. Falling back that way is the safe direction, and the
+ * failure the user then still gets names the exact spelling, so a typo surfaces rather than hides.
+ */
+class AttachInputCoordinationTest {
+
+    @Test
+    fun `an unset property keeps coordination required`() {
+        assertEquals(AttachInputCoordination.Required, AttachInputCoordination.fromProperty(null))
+    }
+
+    @Test
+    fun `a blank property keeps coordination required`() {
+        assertEquals(AttachInputCoordination.Required, AttachInputCoordination.fromProperty(""))
+        assertEquals(AttachInputCoordination.Required, AttachInputCoordination.fromProperty("   "))
+    }
+
+    @Test
+    fun `the exact word disables coordination`() {
+        assertEquals(
+            AttachInputCoordination.Disabled,
+            AttachInputCoordination.fromProperty("disabled"),
+        )
+    }
+
+    @Test
+    fun `case and surrounding whitespace do not change the verdict`() {
+        assertEquals(
+            AttachInputCoordination.Disabled,
+            AttachInputCoordination.fromProperty("  DiSaBlEd  "),
+        )
+    }
+
+    @Test
+    fun `required can be pinned explicitly`() {
+        assertEquals(
+            AttachInputCoordination.Required,
+            AttachInputCoordination.fromProperty("required"),
+        )
+    }
+
+    @Test
+    fun `affirmative-looking values are not the escape hatch`() {
+        // A boolean switch would be one stray `-Dsomething=true` away from silently unpolicing the
+        // desktop. Requiring the word is the whole point.
+        for (value in listOf("true", "1", "yes", "on", "off", "false", "none", "auto")) {
+            assertEquals(
+                AttachInputCoordination.Required,
+                AttachInputCoordination.fromProperty(value),
+                "\"$value\" must not disable coordination",
+            )
+        }
+    }
+
+    @Test
+    fun `a typo falls back to required rather than disabling`() {
+        assertEquals(
+            AttachInputCoordination.Required,
+            AttachInputCoordination.fromProperty("disable"),
+        )
+        assertEquals(
+            AttachInputCoordination.Required,
+            AttachInputCoordination.fromProperty("disabledd"),
+        )
+    }
+
+    @Test
+    fun `the property is namespaced with the other agent switches`() {
+        assertEquals(
+            "dev.sebastiano.spectre.agent.inputCoordination",
+            AttachInputCoordination.PROPERTY,
+        )
+    }
+
+    @Test
+    fun `the documented value is the one the parser accepts`() {
+        assertSame(
+            AttachInputCoordination.Disabled,
+            AttachInputCoordination.fromProperty(AttachInputCoordination.DISABLE_VALUE),
+        )
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AttachOptionsTest.kt
@@ -9,6 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class AttachOptionsTest {
@@ -215,6 +216,55 @@ class AttachOptionsTest {
         assertTrue(
             candidates.any { p.startsWith(Path.of(it)) },
             "UDS path $p should live under one of $candidates",
+        )
+    }
+
+    // ---- input coordination (#472) ----
+    //
+    // The daemon calls `AgentAttach.attach(pid)` with no options at all, so the property is the
+    // only channel a CLI user has; an embedder gets the field. The field is the deliberate one, so
+    // it wins over the property in both directions — an integration that pins `Required` must not
+    // be quietly unpinned by a property left over in the environment.
+
+    @Test
+    fun `coordination is deferred to the property by default`() {
+        assertNull(
+            AttachOptions().inputCoordination,
+            "null means 'resolve from the property', which defaults to Required",
+        )
+    }
+
+    @Test
+    fun `an unset property leaves the attach path coordinated`() {
+        assertEquals(
+            AttachInputCoordination.Required,
+            AgentAttach.resolveInputCoordination(AttachOptions(), property = null),
+        )
+    }
+
+    @Test
+    fun `the property reaches an attach that passes no options`() {
+        assertEquals(
+            AttachInputCoordination.Disabled,
+            AgentAttach.resolveInputCoordination(AttachOptions(), property = "disabled"),
+        )
+    }
+
+    @Test
+    fun `an explicit option wins over the property`() {
+        assertEquals(
+            AttachInputCoordination.Required,
+            AgentAttach.resolveInputCoordination(
+                AttachOptions(inputCoordination = AttachInputCoordination.Required),
+                property = "disabled",
+            ),
+        )
+        assertEquals(
+            AttachInputCoordination.Disabled,
+            AgentAttach.resolveInputCoordination(
+                AttachOptions(inputCoordination = AttachInputCoordination.Disabled),
+                property = null,
+            ),
         )
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/AgentBootstrapArgsTest.kt
@@ -2,6 +2,7 @@
 
 package dev.sebastiano.spectre.agent.runtime
 
+import dev.sebastiano.spectre.agent.AttachInputCoordination
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -112,5 +113,92 @@ class AgentBootstrapArgsTest {
         val parsed = AgentBootstrapArgs.parse(AgentBootstrapArgs.render(awkward, 4096))
 
         assertEquals(awkward, parsed.udsPath)
+    }
+
+    // ---- input coordination (#472) ----
+    //
+    // The injected runtime cannot read the attacher's system properties any more than it can read
+    // its environment, so the attacher's coordination decision has to ride in `agentArgs` too. The
+    // *absence* of that field must mean Required: an older attacher, a hand-written `-javaagent:`
+    // line, and a corrupted value all have to land on the coordinated behaviour, not off it.
+
+    @Test
+    fun `a missing coordination field means coordination is required`() {
+        val parsed = AgentBootstrapArgs.parse("uds=/tmp/sp-a-1/agent.sock,maxFrameBytes=1024")
+
+        assertEquals(AttachInputCoordination.Required, parsed.inputCoordination)
+    }
+
+    @Test
+    fun `a bare path means coordination is required`() {
+        val parsed = AgentBootstrapArgs.parse("/tmp/sp-a-123-abcd/agent.sock")
+
+        assertEquals(AttachInputCoordination.Required, parsed.inputCoordination)
+    }
+
+    @Test
+    fun `null args mean coordination is required`() {
+        assertEquals(
+            AttachInputCoordination.Required,
+            AgentBootstrapArgs.parse(null).inputCoordination,
+        )
+    }
+
+    @Test
+    fun `the two-argument render keeps the coordinated behaviour it always had`() {
+        val rendered =
+            AgentBootstrapArgs.render(udsPath = "/tmp/sp-a-1/agent.sock", maxFrameBytes = 1024)
+
+        assertEquals("uds=/tmp/sp-a-1/agent.sock,maxFrameBytes=1024", rendered)
+        assertEquals(
+            AttachInputCoordination.Required,
+            AgentBootstrapArgs.parse(rendered).inputCoordination,
+        )
+    }
+
+    @Test
+    fun `a disabled attach carries the opt-out to the target`() {
+        val rendered =
+            AgentBootstrapArgs.render(
+                udsPath = "/tmp/sp-a-1/agent.sock",
+                maxFrameBytes = 1024,
+                inputCoordination = AttachInputCoordination.Disabled,
+            )
+
+        assertEquals(
+            "uds=/tmp/sp-a-1/agent.sock,maxFrameBytes=1024,inputCoordination=disabled",
+            rendered,
+        )
+        assertEquals(
+            AttachInputCoordination.Disabled,
+            AgentBootstrapArgs.parse(rendered).inputCoordination,
+        )
+    }
+
+    @Test
+    fun `a required attach renders the field explicitly and round-trips`() {
+        val rendered =
+            AgentBootstrapArgs.render(
+                udsPath = "/tmp/sp-a-1/agent.sock",
+                maxFrameBytes = 1024,
+                inputCoordination = AttachInputCoordination.Required,
+            )
+
+        assertEquals(
+            AttachInputCoordination.Required,
+            AgentBootstrapArgs.parse(rendered).inputCoordination,
+        )
+    }
+
+    @Test
+    fun `an unrecognised coordination value stays coordinated`() {
+        // Same safe direction as the property parser: a corrupted or truncated field must not be
+        // the thing that quietly stops policing the desktop.
+        val parsed =
+            AgentBootstrapArgs.parse(
+                "uds=/tmp/sp-a-1/agent.sock,inputCoordination=true,maxFrameBytes=1"
+            )
+
+        assertEquals(AttachInputCoordination.Required, parsed.inputCoordination)
     }
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgentInputCoordinationCompatibilityTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgentInputCoordinationCompatibilityTest.kt
@@ -1,8 +1,14 @@
-@file:OptIn(dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class)
+@file:OptIn(
+    dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi::class,
+    dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class,
+)
 
 package dev.sebastiano.spectre.agent.runtime
 
+import dev.sebastiano.spectre.agent.AttachInputCoordination
+import dev.sebastiano.spectre.core.InputLeasePolicy
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertIs
 
 class SpectreAgentInputCoordinationCompatibilityTest {
@@ -28,5 +34,82 @@ class SpectreAgentInputCoordinationCompatibilityTest {
         assertIs<LegacyRobotDriver>(driver)
     }
 
+    /**
+     * The #472 default pin.
+     *
+     * `Required` is the only policy that never degrades, and that is deliberate: coordination is
+     * the mutual exclusion that stops two Spectre processes interleaving real input on one desktop
+     * (#446, #447, #449, #460). Moving this default would trade a loud failure for a silent
+     * correctness risk, so it is asserted here rather than left to review.
+     */
+    @Test
+    fun `the attach path coordinates by default`() {
+        val driver =
+            SpectreAgent.createCoordinatedRobotDriverOrLegacyFallback(
+                javaClass.classLoader,
+                PolicyRecordingRobotDriver::class.java,
+            )
+
+        assertEquals(InputLeasePolicy.Required, assertIs<PolicyRecordingRobotDriver>(driver).policy)
+    }
+
+    @Test
+    fun `an explicitly required attach coordinates`() {
+        val driver =
+            SpectreAgent.createCoordinatedRobotDriverOrLegacyFallback(
+                javaClass.classLoader,
+                PolicyRecordingRobotDriver::class.java,
+                AttachInputCoordination.Required,
+            )
+
+        assertEquals(InputLeasePolicy.Required, assertIs<PolicyRecordingRobotDriver>(driver).policy)
+    }
+
+    /**
+     * The escape hatch lands on [InputLeasePolicy.Off], not [InputLeasePolicy.Auto].
+     *
+     * `Auto` degrades for exactly two error codes (`COORDINATOR_PROVIDER_MISSING`,
+     * `COORDINATOR_SESSION_UNAVAILABLE`) and a wedged coordinator surfaces as neither — the
+     * launching provider's startup timeout becomes an `IOException`, which the production
+     * coordinator reports as `COORDINATOR_IO`. `Auto` would therefore hard-fail the very case this
+     * hatch exists for, so opting out has to mean opting out.
+     */
+    @Test
+    fun `the escape hatch turns coordination off rather than making it best-effort`() {
+        val driver =
+            SpectreAgent.createCoordinatedRobotDriverOrLegacyFallback(
+                javaClass.classLoader,
+                PolicyRecordingRobotDriver::class.java,
+                AttachInputCoordination.Disabled,
+            )
+
+        assertEquals(InputLeasePolicy.Off, assertIs<PolicyRecordingRobotDriver>(driver).policy)
+    }
+
+    @Test
+    fun `a legacy target ignores the escape hatch instead of failing the attach`() {
+        val legacyLoader =
+            object : ClassLoader(javaClass.classLoader) {
+                override fun loadClass(name: String): Class<*> {
+                    if (name == "dev.sebastiano.spectre.core.InputLeasePolicy") {
+                        throw ClassNotFoundException(name)
+                    }
+                    return super.loadClass(name)
+                }
+            }
+
+        val driver =
+            SpectreAgent.createCoordinatedRobotDriverOrLegacyFallback(
+                legacyLoader,
+                LegacyRobotDriver::class.java,
+                AttachInputCoordination.Disabled,
+            )
+
+        assertIs<LegacyRobotDriver>(driver)
+    }
+
     private class LegacyRobotDriver
+
+    /** Stands in for `RobotDriver`'s `(InputLeasePolicy)` constructor and records what it got. */
+    private class PolicyRecordingRobotDriver(val policy: InputLeasePolicy)
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -161,8 +161,8 @@ internal fun ignoresInputCoordination(request: DaemonRequest): Boolean =
  * as the daemon is up, so on this path the announcement reaches nobody.
  *
  * A daemon that reports no mode is the exception: it predates the setting, and therefore predates
- * the opt-out, which makes it coordinated by construction. Only an explicit request is worth
- * failing one of those over.
+ * the opt-out, which makes it coordinated by construction. It satisfies a `required` request —
+ * explicit or defaulted — and only an opt-out needs it restarted.
  */
 @OptIn(ExperimentalSpectreAgentApi::class)
 internal fun inputCoordinationMismatchFailure(
@@ -170,30 +170,57 @@ internal fun inputCoordinationMismatchFailure(
     daemonMode: String?,
 ): String? {
     val effective = requested ?: AttachInputCoordination.Required
-    if (daemonMode == effective.wireValue) return null
     if (daemonMode == null) {
-        if (requested == null) return null
+        // Predates the setting, so predates the opt-out, so it is coordinated by construction --
+        // which is exactly what Required asks for. Only an opt-out needs a restart against one.
+        if (effective == AttachInputCoordination.Required) return null
         return coordinationMismatchMessage(
-            asked = "-D${AttachInputCoordination.PROPERTY}=${requested.wireValue}",
+            asked = "-D${AttachInputCoordination.PROPERTY}=${effective.wireValue}",
             running = "a version that predates the setting",
+            keepRunningMode = null,
         )
     }
+    if (daemonMode == effective.wireValue) return null
     val asked =
         if (requested == null) {
             "the default desktop input coordination mode (${effective.wireValue})"
         } else {
             "-D${AttachInputCoordination.PROPERTY}=${requested.wireValue}"
         }
-    return coordinationMismatchMessage(asked = asked, running = daemonMode)
+    return coordinationMismatchMessage(
+        asked = asked,
+        running = daemonMode,
+        keepRunningMode = daemonMode,
+    )
 }
 
-private fun coordinationMismatchMessage(asked: String, running: String): String =
-    "Cannot honour $asked: the running Spectre daemon started with $running, and a daemon keeps " +
-        "the desktop input coordination mode it booted with. It resolves that mode once, and " +
-        "every target it injects inherits it. Run `spectre daemon kill` and retry so the mode " +
-        "applies to the daemon and to the JVMs it injects, or pass " +
-        "-D${AttachInputCoordination.PROPERTY} on this command if you meant to keep the mode the " +
-        "daemon is already running. See https://github.com/rock3r/spectre/issues/472"
+/**
+ * [keepRunningMode] is the daemon's mode spelled as the property value that would ask for it, or
+ * `null` when there is no such spelling to offer.
+ *
+ * It has to carry the value. A bare `-D<property>` sets the property to the empty string, which
+ * [AttachInputCoordination.requestedFromProperty] reads as blank, which is no request at all, which
+ * resolves back to `Required` and produces this same failure — advice that loops straight back to
+ * the error it is attached to.
+ */
+private fun coordinationMismatchMessage(
+    asked: String,
+    running: String,
+    keepRunningMode: String?,
+): String {
+    val keep =
+        keepRunningMode
+            ?.let {
+                ", or pass -D${AttachInputCoordination.PROPERTY}=$it on this command if you " +
+                    "meant to keep the mode the daemon is already running"
+            }
+            .orEmpty()
+    return "Cannot honour $asked: the running Spectre daemon started with $running, and a daemon " +
+        "keeps the desktop input coordination mode it booted with. It resolves that mode once, " +
+        "and every target it injects inherits it. Run `spectre daemon kill` and retry so the " +
+        "mode applies to the daemon and to the JVMs it injects$keep. " +
+        "See https://github.com/rock3r/spectre/issues/472"
+}
 
 /**
  * Explains why a requested frame budget cannot take effect, or `null` when it can.

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.AttachInputCoordination
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.FrameLimits
 import java.io.EOFException
@@ -85,6 +86,13 @@ public class DaemonClient(public val socketPath: Path) : AutoCloseable {
                         )
                         ?.let { throw IOException(it) }
                 }
+                if (!ignoresInputCoordination(request)) {
+                    inputCoordinationMismatchFailure(
+                            requested = AttachInputCoordination.requestedFromProperty(),
+                            daemonMode = response.inputCoordination,
+                        )
+                        ?.let { throw IOException(it) }
+                }
             }
             is DaemonResponse.Error ->
                 throw IOException(daemonHandshakeFailure(requiredVersion, response))
@@ -116,6 +124,48 @@ internal class DaemonConnectionClosedException(cause: Throwable? = null) :
  * costs nothing.
  */
 internal fun ignoresFrameBudget(request: DaemonRequest): Boolean = request is DaemonRequest.Shutdown
+
+/**
+ * Requests exempt from the coordination-mode check, for the same reason as [ignoresFrameBudget]:
+ * the mismatch error tells the user to run `spectre daemon kill`, which inherits the same `-D` and
+ * would hit this check, leaving the documented recovery a dead end.
+ */
+internal fun ignoresInputCoordination(request: DaemonRequest): Boolean =
+    request is DaemonRequest.Shutdown
+
+/**
+ * Explains why a requested desktop input coordination mode cannot take effect, or `null` when it
+ * can.
+ *
+ * The daemon resolves the mode once, from its own system properties, and every target it injects
+ * inherits that. A `-D` on a later invocation therefore reaches the CLI process and nothing else.
+ *
+ * That would be a footnote for most settings, but this one is the #472 escape hatch, and the
+ * journey it exists for *guarantees* a daemon is already running: you only reach for it after an
+ * attach has failed. Silently ignoring it there would make the documented recovery appear broken —
+ * the exact failure the hatch was added to remove.
+ *
+ * Checked in both directions. Asking to disable coordination on a coordinated daemon leaves the
+ * user stuck; asking to restore it on a daemon left disabled by an earlier recovery session is
+ * worse, because that daemon attaches every new target uncoordinated. Only an explicit request is
+ * worth failing over, mirroring [frameBudgetMismatchFailure] — a client that asked for nothing gets
+ * whatever the daemon runs, and both the attacher and the target already announce a disabled attach
+ * on stderr.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal fun inputCoordinationMismatchFailure(
+    requested: AttachInputCoordination?,
+    daemonMode: String?,
+): String? {
+    if (requested == null) return null
+    if (daemonMode == requested.wireValue) return null
+    val running = if (daemonMode == null) "a version that predates the setting" else "`$daemonMode`"
+    return "Cannot honour -D${AttachInputCoordination.PROPERTY}=${requested.wireValue}: the " +
+        "running Spectre daemon started with $running, and a daemon keeps the desktop input " +
+        "coordination mode it booted with — it resolves that once and every target it injects " +
+        "inherits it. Run `spectre daemon kill` and retry so the mode applies to the daemon and " +
+        "to the JVMs it injects. See https://github.com/rock3r/spectre/issues/472"
+}
 
 /**
  * Explains why a requested frame budget cannot take effect, or `null` when it can.

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -147,25 +147,53 @@ internal fun ignoresInputCoordination(request: DaemonRequest): Boolean =
  *
  * Checked in both directions. Asking to disable coordination on a coordinated daemon leaves the
  * user stuck; asking to restore it on a daemon left disabled by an earlier recovery session is
- * worse, because that daemon attaches every new target uncoordinated. Only an explicit request is
- * worth failing over, mirroring [frameBudgetMismatchFailure] — a client that asked for nothing gets
- * whatever the daemon runs, and both the attacher and the target already announce a disabled attach
- * on stderr.
+ * worse, because that daemon attaches every new target uncoordinated.
+ *
+ * **Asking for nothing means asking for [AttachInputCoordination.Required]**, and this is the one
+ * place the [frameBudgetMismatchFailure] analogy breaks. A budget is a capacity setting, so a
+ * client that requested none is genuinely happy with any daemon. Coordination is a safety property:
+ * a user who has taken the opt-out back off is asking for the documented default, and accepting a
+ * still-disabled daemon would leave every later attach uncoordinated until they happened to restart
+ * it.
+ *
+ * That would also be silent. An earlier revision of this function reasoned that a disabled daemon
+ * announces itself on stderr. It does — into a startup log `DaemonProcessLauncher` deletes as soon
+ * as the daemon is up, so on this path the announcement reaches nobody.
+ *
+ * A daemon that reports no mode is the exception: it predates the setting, and therefore predates
+ * the opt-out, which makes it coordinated by construction. Only an explicit request is worth
+ * failing one of those over.
  */
 @OptIn(ExperimentalSpectreAgentApi::class)
 internal fun inputCoordinationMismatchFailure(
     requested: AttachInputCoordination?,
     daemonMode: String?,
 ): String? {
-    if (requested == null) return null
-    if (daemonMode == requested.wireValue) return null
-    val running = if (daemonMode == null) "a version that predates the setting" else "`$daemonMode`"
-    return "Cannot honour -D${AttachInputCoordination.PROPERTY}=${requested.wireValue}: the " +
-        "running Spectre daemon started with $running, and a daemon keeps the desktop input " +
-        "coordination mode it booted with — it resolves that once and every target it injects " +
-        "inherits it. Run `spectre daemon kill` and retry so the mode applies to the daemon and " +
-        "to the JVMs it injects. See https://github.com/rock3r/spectre/issues/472"
+    val effective = requested ?: AttachInputCoordination.Required
+    if (daemonMode == effective.wireValue) return null
+    if (daemonMode == null) {
+        if (requested == null) return null
+        return coordinationMismatchMessage(
+            asked = "-D${AttachInputCoordination.PROPERTY}=${requested.wireValue}",
+            running = "a version that predates the setting",
+        )
+    }
+    val asked =
+        if (requested == null) {
+            "the default desktop input coordination mode (${effective.wireValue})"
+        } else {
+            "-D${AttachInputCoordination.PROPERTY}=${requested.wireValue}"
+        }
+    return coordinationMismatchMessage(asked = asked, running = daemonMode)
 }
+
+private fun coordinationMismatchMessage(asked: String, running: String): String =
+    "Cannot honour $asked: the running Spectre daemon started with $running, and a daemon keeps " +
+        "the desktop input coordination mode it booted with. It resolves that mode once, and " +
+        "every target it injects inherits it. Run `spectre daemon kill` and retry so the mode " +
+        "applies to the daemon and to the JVMs it injects, or pass " +
+        "-D${AttachInputCoordination.PROPERTY} on this command if you meant to keep the mode the " +
+        "daemon is already running. See https://github.com/rock3r/spectre/issues/472"
 
 /**
  * Explains why a requested frame budget cannot take effect, or `null` when it can.

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonClient.kt
@@ -160,9 +160,9 @@ internal fun ignoresInputCoordination(request: DaemonRequest): Boolean =
  * announces itself on stderr. It does — into a startup log `DaemonProcessLauncher` deletes as soon
  * as the daemon is up, so on this path the announcement reaches nobody.
  *
- * A daemon that reports no mode is the exception: it predates the setting, and therefore predates
- * the opt-out, which makes it coordinated by construction. It satisfies a `required` request —
- * explicit or defaulted — and only an opt-out needs it restarted.
+ * A daemon that reports no mode is refused outright, whatever was asked. It cannot say whether it
+ * coordinates, and for a safety property an unanswerable question is not a yes — see the comment on
+ * that branch for why its protocol version cannot stand in for the answer.
  */
 @OptIn(ExperimentalSpectreAgentApi::class)
 internal fun inputCoordinationMismatchFailure(
@@ -171,12 +171,22 @@ internal fun inputCoordinationMismatchFailure(
 ): String? {
     val effective = requested ?: AttachInputCoordination.Required
     if (daemonMode == null) {
-        // Predates the setting, so predates the opt-out, so it is coordinated by construction --
-        // which is exactly what Required asks for. Only an opt-out needs a restart against one.
-        if (effective == AttachInputCoordination.Required) return null
+        // Fails closed, and deliberately so. It is tempting to reason that a daemon predating this
+        // field also predates the opt-out and is therefore coordinated -- but the dates rule that
+        // out: DaemonProtocol.CurrentVersion reached 1.12 on 2026-08-19 (9a15371) and coordination
+        // itself only landed on 2026-08-24 (b5edbc5). A daemon built in between reports 1.12,
+        // satisfies every compatibility floor, answers nothing here, and injects the legacy
+        // no-argument RobotDriver, which coordinates nothing at all. Nothing on this wire tells it
+        // apart from a daemon that would coordinate properly.
+        //
+        // "I cannot tell" must not be reported as "yes" for a safety property; doing so is the
+        // silent default-defeat #472 exists to remove. One `spectre daemon kill` after upgrading
+        // is the whole cost.
         return coordinationMismatchMessage(
             asked = "-D${AttachInputCoordination.PROPERTY}=${effective.wireValue}",
-            running = "a version that predates the setting",
+            running =
+                "a version that predates coordination reporting, so it cannot say whether it " +
+                    "coordinates at all",
             keepRunningMode = null,
         )
     }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncher.kt
@@ -1,5 +1,6 @@
 package dev.sebastiano.spectre.cli.daemon
 
+import dev.sebastiano.spectre.agent.AttachInputCoordination
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.transport.FrameLimits
 import java.io.IOException
@@ -12,6 +13,7 @@ public class DaemonProcessLauncher(
     private val socketPath: Path,
     private val javaExecutable: String = defaultJavaExecutable(),
     private val classPath: String = System.getProperty("java.class.path"),
+    private val readProperty: (String) -> String? = System::getProperty,
 ) {
     private var startupErrorLog: Path? = null
     private var daemonProcess: Process? = null
@@ -53,7 +55,7 @@ public class DaemonProcessLauncher(
     /** Returns the isolated daemon command without starting a process. */
     public fun command(): List<String> = buildList {
         add(javaExecutable)
-        addAll(agentRuntimePropertyArgument())
+        addAll(forwardedPropertyArguments())
         add("-cp")
         add(classPath)
         add(DAEMON_MAIN_CLASS)
@@ -69,10 +71,20 @@ public class DaemonProcessLauncher(
         }
     }
 
-    private fun agentRuntimePropertyArgument(): List<String> =
-        System.getProperty("dev.sebastiano.spectre.agent.runtimeJar")
-            ?.let { listOf("-Ddev.sebastiano.spectre.agent.runtimeJar=$it") }
-            .orEmpty()
+    /**
+     * Re-states on the daemon's command line the switches this process was given.
+     *
+     * The daemon is a fresh JVM launched from an explicit argument list, so it inherits this
+     * process's environment but none of its `-D`s. Anything the daemon reads as a system property
+     * has to be listed here or a user who sets it on the CLI watches it be silently ignored — which
+     * for [AttachInputCoordination.PROPERTY] would look exactly like an escape hatch that does not
+     * work, since `DaemonSessionRegistry` attaches with no `AttachOptions` at all and the property
+     * is that user's only channel into the decision.
+     */
+    private fun forwardedPropertyArguments(): List<String> =
+        FORWARDED_PROPERTIES.mapNotNull { name ->
+            readProperty(name)?.let { value -> "-D$name=$value" }
+        }
 
     private fun restoreBundledRuntimeExecutePermissions() {
         if (javaExecutable != defaultJavaExecutable()) return
@@ -88,6 +100,10 @@ public class DaemonProcessLauncher(
     private companion object {
         private const val DAEMON_MAIN_CLASS: String =
             "dev.sebastiano.spectre.cli.daemon.DaemonMainKt"
+
+        /** System properties the daemon reads, and therefore has to be handed. */
+        private val FORWARDED_PROPERTIES: List<String> =
+            listOf("dev.sebastiano.spectre.agent.runtimeJar", AttachInputCoordination.PROPERTY)
 
         private fun defaultJavaExecutable(): String {
             val executable =

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -324,11 +324,18 @@ public sealed interface DaemonResponse {
      * @property maxFrameBytes the frame write budget this daemon booted with. `null` from a daemon
      *   that predates budget reporting, which is indistinguishable from "not the budget you asked
      *   for" — see `frameBudgetMismatchFailure`.
+     * @property inputCoordination the desktop input coordination mode this daemon booted with, as
+     *   [dev.sebastiano.spectre.agent.AttachInputCoordination.wireValue]. Reported for the same
+     *   reason as [maxFrameBytes]: the daemon resolves it once from its own system properties and
+     *   every attach it makes inherits that, so a later invocation's `-D` cannot reach it and has
+     *   to be told so rather than silently ignored (#472). `null` from a daemon that predates the
+     *   setting.
      */
     @Serializable
     public data class Hello(
         public val daemonVersion: DaemonProtocolVersion,
         public val maxFrameBytes: Int? = null,
+        public val inputCoordination: String? = null,
     ) : DaemonResponse
 
     @Serializable

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -1,6 +1,7 @@
 package dev.sebastiano.spectre.cli.daemon
 
 import dev.sebastiano.spectre.agent.AgentAttach
+import dev.sebastiano.spectre.agent.AttachInputCoordination
 import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
 import dev.sebastiano.spectre.agent.SpectreAttachException
 import dev.sebastiano.spectre.agent.transport.FrameLimits
@@ -72,6 +73,9 @@ internal constructor(
                 DaemonResponse.Hello(
                     daemonVersion = DaemonProtocol.CurrentVersion,
                     maxFrameBytes = FrameLimits.maxFrameBytes,
+                    // Resolved from this JVM's properties, which do not change while it lives, so
+                    // this is the mode every attach this daemon makes will use.
+                    inputCoordination = AttachInputCoordination.fromProperty().wireValue,
                 )
             is DaemonRequest.Attach -> error("attach must use attach() outside the monitor")
             is DaemonRequest.Detach -> error("detach must use handleDetachOutsideLock")

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonInputCoordinationHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonInputCoordinationHandshakeTest.kt
@@ -1,0 +1,137 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.AttachInputCoordination
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * A running daemon keeps the coordination mode it booted with, exactly as it keeps its frame
+ * budget, so `-Ddev.sebastiano.spectre.agent.inputCoordination=disabled` on a later invocation
+ * cannot reach it.
+ *
+ * This matters more than it sounds. The escape hatch is something you reach for *after* an attach
+ * has already failed, which means a daemon is already running — with the mode it was started under.
+ * Forwarding the property only when this invocation happens to launch the daemon would make the
+ * documented recovery silently do nothing on the one journey it exists for. Codex caught that on
+ * the first review of #472.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+class DaemonInputCoordinationHandshakeTest {
+
+    @Test
+    fun `no explicit request accepts whatever the daemon booted with`() {
+        // Mirrors the frame-budget rule: a client that asked for nothing is happy with any daemon.
+        // A daemon running uncoordinated is not silent either way -- both the attacher and the
+        // target announce it on stderr at attach time.
+        assertNull(inputCoordinationMismatchFailure(requested = null, daemonMode = "required"))
+        assertNull(inputCoordinationMismatchFailure(requested = null, daemonMode = "disabled"))
+        assertNull(inputCoordinationMismatchFailure(requested = null, daemonMode = null))
+    }
+
+    @Test
+    fun `an explicit request the daemon already satisfies is accepted`() {
+        assertNull(
+            inputCoordinationMismatchFailure(
+                requested = AttachInputCoordination.Disabled,
+                daemonMode = "disabled",
+            )
+        )
+        assertNull(
+            inputCoordinationMismatchFailure(
+                requested = AttachInputCoordination.Required,
+                daemonMode = "required",
+            )
+        )
+    }
+
+    @Test
+    fun `asking to disable coordination on a coordinated daemon is refused`() {
+        val failure =
+            assertNotNull(
+                inputCoordinationMismatchFailure(
+                    requested = AttachInputCoordination.Disabled,
+                    daemonMode = "required",
+                )
+            )
+
+        assertTrue(
+            failure.contains(AttachInputCoordination.PROPERTY),
+            "should name the switch that cannot take effect: $failure",
+        )
+        assertTrue(failure.contains("disabled"), "should name what was asked for: $failure")
+        assertTrue(failure.contains("required"), "should name what the daemon runs: $failure")
+        assertTrue(
+            failure.contains("spectre daemon kill"),
+            "should say how to make the mode stick: $failure",
+        )
+    }
+
+    @Test
+    fun `asking to restore coordination on a disabled daemon is refused`() {
+        // The dangerous direction. A daemon left over from a recovery session attaches every new
+        // target uncoordinated; a user who has since put the switch back must not be told nothing.
+        val failure =
+            assertNotNull(
+                inputCoordinationMismatchFailure(
+                    requested = AttachInputCoordination.Required,
+                    daemonMode = "disabled",
+                )
+            )
+
+        assertTrue(failure.contains("spectre daemon kill"), failure)
+    }
+
+    @Test
+    fun `a daemon too old to report its mode cannot satisfy an explicit request`() {
+        val failure =
+            assertNotNull(
+                inputCoordinationMismatchFailure(
+                    requested = AttachInputCoordination.Disabled,
+                    daemonMode = null,
+                )
+            )
+
+        assertTrue(
+            failure.contains("predates", ignoreCase = true),
+            "should say the daemon is too old to answer: $failure",
+        )
+        assertTrue(failure.contains("spectre daemon kill"), failure)
+    }
+
+    @Test
+    fun `shutdown is exempt so the documented recovery is not a dead end`() {
+        // `spectre daemon kill` inherits the same -D and would hit this very check, leaving the
+        // user told to run a command that cannot run. Same exemption the frame budget needed.
+        assertTrue(ignoresInputCoordination(DaemonRequest.Shutdown))
+        assertTrue(!ignoresInputCoordination(DaemonRequest.ListSessions))
+    }
+
+    // ---- what counts as an explicit request ----
+
+    @Test
+    fun `an unset or blank property is not a request`() {
+        assertNull(AttachInputCoordination.requestedFromProperty(null))
+        assertNull(AttachInputCoordination.requestedFromProperty("   "))
+    }
+
+    @Test
+    fun `a set property is a request, including a typo`() {
+        // A typo still resolves to Required, and saying so against a Disabled daemon is right:
+        // the user meant to say something about coordination and did not get what they typed.
+        assertTrue(
+            AttachInputCoordination.requestedFromProperty("disabled") ==
+                AttachInputCoordination.Disabled
+        )
+        assertTrue(
+            AttachInputCoordination.requestedFromProperty("required") ==
+                AttachInputCoordination.Required
+        )
+        assertTrue(
+            AttachInputCoordination.requestedFromProperty("disabledd") ==
+                AttachInputCoordination.Required
+        )
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonInputCoordinationHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonInputCoordinationHandshakeTest.kt
@@ -12,22 +12,62 @@ import kotlin.test.assertTrue
  * budget, so `-Ddev.sebastiano.spectre.agent.inputCoordination=disabled` on a later invocation
  * cannot reach it.
  *
- * This matters more than it sounds. The escape hatch is something you reach for *after* an attach
- * has already failed, which means a daemon is already running — with the mode it was started under.
- * Forwarding the property only when this invocation happens to launch the daemon would make the
- * documented recovery silently do nothing on the one journey it exists for. Codex caught that on
- * the first review of #472.
+ * This matters more than it sounds, in both directions.
+ *
+ * Going *into* the hatch: it is something you reach for **after** an attach has already failed,
+ * which means a daemon is already running with the mode it was started under. Forwarding the
+ * property only when this invocation happens to launch the daemon would make the documented
+ * recovery silently do nothing on the one journey it exists for.
+ *
+ * Coming *out* of it is the sharper case, because nothing else catches it: a user who removes the
+ * temporary property still has the disabled daemon, and it goes on attaching every new target
+ * uncoordinated. The daemon's own "coordination is DISABLED" line goes to a startup log that
+ * `DaemonProcessLauncher` deletes once it is up, so that user is told nothing at all — the precise
+ * silent degradation #472 exists to remove. Hence "asked for nothing" means `Required` here, unlike
+ * the frame budget.
+ *
+ * Both were caught by Codex reviewing #474.
  */
 @OptIn(ExperimentalSpectreAgentApi::class)
 class DaemonInputCoordinationHandshakeTest {
 
     @Test
-    fun `no explicit request accepts whatever the daemon booted with`() {
-        // Mirrors the frame-budget rule: a client that asked for nothing is happy with any daemon.
-        // A daemon running uncoordinated is not silent either way -- both the attacher and the
-        // target announce it on stderr at attach time.
+    fun `no explicit request means the documented default, not whatever is running`() {
+        // NOT the frame-budget rule, and this is the one place the analogy breaks. A budget is a
+        // capacity setting, so "asked for nothing" genuinely means "any daemon will do".
+        // Coordination is a safety property: asking for nothing means asking for the documented
+        // default, which is Required. Accepting a still-disabled daemon here would leave every
+        // later attach uncoordinated after the user had already taken the opt-out back off.
         assertNull(inputCoordinationMismatchFailure(requested = null, daemonMode = "required"))
-        assertNull(inputCoordinationMismatchFailure(requested = null, daemonMode = "disabled"))
+        assertNotNull(inputCoordinationMismatchFailure(requested = null, daemonMode = "disabled"))
+    }
+
+    @Test
+    fun `removing the opt-out is refused while the disabled daemon is still up`() {
+        // The #472 recovery journey in reverse, and the failure mode that makes it matter: the
+        // daemon's stderr is redirected to a startup log that is deleted once it starts, so the
+        // "coordination is DISABLED" announcement never reaches this user. Without this check the
+        // daemon would go on attaching every new target uncoordinated, silently -- which is the
+        // exact thing #472 exists to not do.
+        val failure =
+            assertNotNull(
+                inputCoordinationMismatchFailure(requested = null, daemonMode = "disabled")
+            )
+
+        assertTrue(
+            failure.contains("spectre daemon kill"),
+            "should say how to get the default back: $failure",
+        )
+        assertTrue(
+            failure.contains(AttachInputCoordination.PROPERTY),
+            "should name the property, for a user who did mean to keep it off: $failure",
+        )
+    }
+
+    @Test
+    fun `a daemon too old to report its mode is accepted when nothing was asked`() {
+        // Daemons that predate the setting predate the opt-out too, so they are coordinated by
+        // construction. Nothing to warn about, and failing here would break every older daemon.
         assertNull(inputCoordinationMismatchFailure(requested = null, daemonMode = null))
     }
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonInputCoordinationHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonInputCoordinationHandshakeTest.kt
@@ -59,9 +59,37 @@ class DaemonInputCoordinationHandshakeTest {
             "should say how to get the default back: $failure",
         )
         assertTrue(
-            failure.contains(AttachInputCoordination.PROPERTY),
-            "should name the property, for a user who did mean to keep it off: $failure",
+            failure.contains("${AttachInputCoordination.PROPERTY}=disabled"),
+            "the keep-it-off switch must carry its value or it cannot be followed: $failure",
         )
+    }
+
+    @Test
+    fun `every switch the message suggests is one that would actually work`() {
+        // A bare `-Dproperty` with no value sets it to the empty string, which is blank, which is
+        // "no request", which resolves to Required -- the same mismatch again. Advice that loops
+        // back to the error it is attached to is worse than no advice.
+        for (daemonMode in listOf("disabled", "required")) {
+            val failure =
+                inputCoordinationMismatchFailure(
+                    requested =
+                        if (daemonMode == "disabled") AttachInputCoordination.Required
+                        else AttachInputCoordination.Disabled,
+                    daemonMode = daemonMode,
+                )
+            val message = assertNotNull(failure)
+            val switches =
+                message.split(' ', '\n').filter {
+                    it.startsWith("-D${AttachInputCoordination.PROPERTY}")
+                }
+            assertTrue(switches.isNotEmpty(), "no switch suggested at all: $message")
+            switches.forEach { suggestion ->
+                assertTrue(
+                    suggestion.trimEnd('.', ',').contains('='),
+                    "suggested a valueless switch that resolves to no request: $suggestion",
+                )
+            }
+        }
     }
 
     @Test
@@ -69,6 +97,19 @@ class DaemonInputCoordinationHandshakeTest {
         // Daemons that predate the setting predate the opt-out too, so they are coordinated by
         // construction. Nothing to warn about, and failing here would break every older daemon.
         assertNull(inputCoordinationMismatchFailure(requested = null, daemonMode = null))
+    }
+
+    @Test
+    fun `a daemon too old to report its mode satisfies an explicit required request`() {
+        // Same construction argument, so rejecting this was inconsistent with the branch's own
+        // reasoning: the daemon predates the opt-out, which is exactly what `required` asks for.
+        // Only an explicit `disabled` needs a restart against one of these.
+        assertNull(
+            inputCoordinationMismatchFailure(
+                requested = AttachInputCoordination.Required,
+                daemonMode = null,
+            )
+        )
     }
 
     @Test

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonInputCoordinationHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonInputCoordinationHandshakeTest.kt
@@ -93,22 +93,40 @@ class DaemonInputCoordinationHandshakeTest {
     }
 
     @Test
-    fun `a daemon too old to report its mode is accepted when nothing was asked`() {
-        // Daemons that predate the setting predate the opt-out too, so they are coordinated by
-        // construction. Nothing to warn about, and failing here would break every older daemon.
-        assertNull(inputCoordinationMismatchFailure(requested = null, daemonMode = null))
-    }
-
-    @Test
-    fun `a daemon too old to report its mode satisfies an explicit required request`() {
-        // Same construction argument, so rejecting this was inconsistent with the branch's own
-        // reasoning: the daemon predates the opt-out, which is exactly what `required` asks for.
-        // Only an explicit `disabled` needs a restart against one of these.
-        assertNull(
+    fun `a daemon that cannot state its mode is never assumed to be coordinated`() {
+        // "It predates the setting, so it predates the opt-out, so it is coordinated" is wrong, and
+        // the dates say so: DaemonProtocol.CurrentVersion reached 1.12 on 2026-08-19 (9a15371) and
+        // coordination landed on 2026-08-24 (b5edbc5). A daemon built in between is 1.12, passes
+        // every compatibility check, reports no mode -- and injects the legacy no-argument
+        // RobotDriver, which coordinates nothing. It is indistinguishable here from a safe one.
+        //
+        // So this fails closed. "I cannot tell" must never be reported as "yes" for a safety
+        // property; that is the silent default-defeat #472 exists to remove. The cost is one
+        // `spectre daemon kill` after upgrading past this change.
+        assertNotNull(inputCoordinationMismatchFailure(requested = null, daemonMode = null))
+        assertNotNull(
             inputCoordinationMismatchFailure(
                 requested = AttachInputCoordination.Required,
                 daemonMode = null,
             )
+        )
+    }
+
+    @Test
+    fun `the too-old daemon message says why a restart is the only answer`() {
+        val failure =
+            assertNotNull(inputCoordinationMismatchFailure(requested = null, daemonMode = null))
+
+        assertTrue(failure.contains("spectre daemon kill"), failure)
+        assertTrue(
+            failure.contains("predates", ignoreCase = true),
+            "should say the daemon cannot answer, not that it answered wrongly: $failure",
+        )
+        // There is no property value that makes an unknown mode acceptable, so offering one would
+        // be advice that cannot be followed.
+        assertTrue(
+            !failure.contains("if you meant to keep"),
+            "must not offer to keep a mode nobody can name: $failure",
         )
     }
 

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncherTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessLauncherTest.kt
@@ -27,4 +27,66 @@ class DaemonProcessLauncherTest {
             command,
         )
     }
+
+    // ---- forwarded switches (#472) ----
+    //
+    // The daemon is a fresh JVM with an explicit command line, so a system property set on the CLI
+    // reaches it only if this launcher passes it on. `DaemonSessionRegistry` attaches with
+    // `AgentAttach.attach(pid)` and no options, which makes the property the only channel a CLI
+    // user has for the coordination opt-out — a `-D` the CLI silently dropped would look exactly
+    // like an opt-out that does not work.
+
+    @Test
+    fun `forwards the input coordination opt-out to the daemon`() {
+        val command =
+            DaemonProcessLauncher(
+                    socketPath = Path.of("/tmp/spectre/daemon.sock"),
+                    javaExecutable = "/jdk/bin/java",
+                    classPath = "spectre.jar",
+                    readProperty = { name ->
+                        "disabled"
+                            .takeIf { name == "dev.sebastiano.spectre.agent.inputCoordination" }
+                    },
+                )
+                .command()
+
+        assertEquals(
+            listOf("-Ddev.sebastiano.spectre.agent.inputCoordination=disabled"),
+            command.filter { it.startsWith("-D") },
+        )
+    }
+
+    @Test
+    fun `forwards the agent runtime jar override`() {
+        val command =
+            DaemonProcessLauncher(
+                    socketPath = Path.of("/tmp/spectre/daemon.sock"),
+                    javaExecutable = "/jdk/bin/java",
+                    classPath = "spectre.jar",
+                    readProperty = { name ->
+                        "/jars/agent.jar"
+                            .takeIf { name == "dev.sebastiano.spectre.agent.runtimeJar" }
+                    },
+                )
+                .command()
+
+        assertEquals(
+            listOf("-Ddev.sebastiano.spectre.agent.runtimeJar=/jars/agent.jar"),
+            command.filter { it.startsWith("-D") },
+        )
+    }
+
+    @Test
+    fun `forwards nothing when nothing is set`() {
+        val command =
+            DaemonProcessLauncher(
+                    socketPath = Path.of("/tmp/spectre/daemon.sock"),
+                    javaExecutable = "/jdk/bin/java",
+                    classPath = "spectre.jar",
+                    readProperty = { null },
+                )
+                .command()
+
+        assertEquals(emptyList(), command.filter { it.startsWith("-D") })
+    }
 }

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProcessTest.kt
@@ -56,7 +56,13 @@ class DaemonProcessTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
+                    DaemonResponse.Hello(
+                        DaemonProtocol.CurrentVersion,
+                        FrameLimits.maxFrameBytes,
+                        // Literal, not AttachInputCoordination.fromProperty(): this pins that a
+                        // daemon with nothing configured reports itself coordinated (#472).
+                        "required",
+                    ),
                     DaemonWireCodec.readResponse(input),
                 )
             }
@@ -111,7 +117,13 @@ class DaemonProcessTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
+                    DaemonResponse.Hello(
+                        DaemonProtocol.CurrentVersion,
+                        FrameLimits.maxFrameBytes,
+                        // Literal, not AttachInputCoordination.fromProperty(): this pins that a
+                        // daemon with nothing configured reports itself coordinated (#472).
+                        "required",
+                    ),
                     DaemonWireCodec.readResponse(input),
                 )
                 DaemonWireCodec.writeRequest(output, DaemonRequest.Shutdown)

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonServerTest.kt
@@ -148,7 +148,13 @@ class DaemonServerTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
+                    DaemonResponse.Hello(
+                        DaemonProtocol.CurrentVersion,
+                        FrameLimits.maxFrameBytes,
+                        // Literal, not AttachInputCoordination.fromProperty(): this pins that a
+                        // daemon with nothing configured reports itself coordinated (#472).
+                        "required",
+                    ),
                     DaemonWireCodec.readResponse(input),
                 )
                 DaemonWireCodec.writeRequest(output, DaemonRequest.ListSessions)
@@ -207,7 +213,13 @@ class DaemonServerTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
+                    DaemonResponse.Hello(
+                        DaemonProtocol.CurrentVersion,
+                        FrameLimits.maxFrameBytes,
+                        // Literal, not AttachInputCoordination.fromProperty(): this pins that a
+                        // daemon with nothing configured reports itself coordinated (#472).
+                        "required",
+                    ),
                     DaemonWireCodec.readResponse(input),
                 )
             }
@@ -403,7 +415,13 @@ class DaemonServerTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
+                    DaemonResponse.Hello(
+                        DaemonProtocol.CurrentVersion,
+                        FrameLimits.maxFrameBytes,
+                        // Literal, not AttachInputCoordination.fromProperty(): this pins that a
+                        // daemon with nothing configured reports itself coordinated (#472).
+                        "required",
+                    ),
                     DaemonWireCodec.readResponse(input),
                 )
 
@@ -449,7 +467,13 @@ class DaemonServerTest {
                     DaemonRequest.Hello(DaemonProtocol.CurrentVersion),
                 )
                 assertEquals(
-                    DaemonResponse.Hello(DaemonProtocol.CurrentVersion, FrameLimits.maxFrameBytes),
+                    DaemonResponse.Hello(
+                        DaemonProtocol.CurrentVersion,
+                        FrameLimits.maxFrameBytes,
+                        // Literal, not AttachInputCoordination.fromProperty(): this pins that a
+                        // daemon with nothing configured reports itself coordinated (#472).
+                        "required",
+                    ),
                     DaemonWireCodec.readResponse(input),
                 )
                 DaemonWireCodec.writeRequest(output, DaemonRequest.ListSessions)

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -207,7 +207,7 @@ internal class InputLeaseGuard(
                             failure,
                         )
                     }
-                    throw failure
+                    throw withRecoveryAdvice(failure)
                 }
             try {
                 lease.checkpoint()
@@ -253,6 +253,24 @@ internal class InputLeaseGuard(
             "This RobotDriver is already bound to a live per-test input lease"
         }
         return AutoCloseable { boundLease.compareAndSet(lease, null) }
+    }
+
+    /**
+     * Adds the recovery story to a failure that leaves a [InputLeasePolicy.Required] driver with no
+     * way forward, and returns every other failure untouched.
+     *
+     * Scoped tightly on purpose. Only [UNREACHABLE_COORDINATOR_ERROR_CODES] mean *there is no
+     * coordinator to talk to*, which is the one situation where proceeding uncoordinated is a
+     * sensible thing for a human to choose. `ACQUIRE_TIMEOUT` and `FENCED` are the opposite: the
+     * coordinator worked, and somebody else holds the desktop. Answering those with "you can turn
+     * coordination off" would talk a user into the exact interleaved-input corruption the lease had
+     * just prevented, so they keep the plain message.
+     */
+    private fun withRecoveryAdvice(failure: InputCoordinatorException): InputCoordinatorException {
+        if (policy != InputLeasePolicy.Required) return failure
+        if (failure.errorCode !in UNREACHABLE_COORDINATOR_ERROR_CODES) return failure
+        return InputCoordinatorException(failure.errorCode, unreachableCoordinatorMessage(failure))
+            .apply { initCause(failure) }
     }
 
     private fun coordinates(resource: CoordinatedResource): Boolean {
@@ -326,8 +344,50 @@ internal class InputLeaseGuard(
     private companion object {
         val AUTO_DEGRADE_ERROR_CODES: Set<String> =
             setOf("COORDINATOR_PROVIDER_MISSING", "COORDINATOR_SESSION_UNAVAILABLE")
+
+        /**
+         * Failures that mean no coordinator could be reached at all, as opposed to one that
+         * answered and said no.
+         *
+         * `COORDINATOR_IO` is the wedged case from #462: the launching provider spends its startup
+         * budget, gives up with an `IOException`, and `ProductionInputLeaseCoordinator` reports it
+         * under this code. `COORDINATOR_PROVIDER_MISSING` is the coordinator artifact being absent
+         * from the classpath — a different cause, same dead end for the user.
+         */
+        val UNREACHABLE_COORDINATOR_ERROR_CODES: Set<String> =
+            setOf("COORDINATOR_IO", "COORDINATOR_PROVIDER_MISSING")
     }
 }
+
+/**
+ * Tells a user stuck behind an unreachable coordinator what they can do and what it will cost them.
+ *
+ * Modelled on `undeliveredInputMessage` in `InputDeliveryWitness.kt`: keep the measured cause
+ * verbatim, say plainly which part is inference, name the escape hatch precisely enough to paste,
+ * and link the issue.
+ *
+ * Two spellings are given because there are two ways to be here and the reader knows which one they
+ * are. A property name from the attach path is listed even though this code also runs in-process:
+ * the attach path is where the dead end was total (#472), it is where a user has no other lever,
+ * and an unmistakably-labelled line that does not apply costs a reader a second — whereas omitting
+ * it costs the CLI user the only route they have.
+ *
+ * The cost sentence is not decoration. Coordination is mutual exclusion, and a user who disables it
+ * without understanding that has been handed a subtler bug than the one they were trying to escape.
+ */
+private fun unreachableCoordinatorMessage(failure: InputCoordinatorException): String =
+    "${failure.message.orEmpty().trimEnd('.', ' ')}. " +
+        "Spectre could not reach the desktop input coordinator " +
+        "(${failure.errorCode}), and this driver runs with InputLeasePolicy.Required, which fails " +
+        "rather than continuing uncoordinated. Measured: no coordinator answered. Not measured: " +
+        "whether it is wedged, absent, or merely slower than its startup budget. " +
+        "To proceed without coordination, deliberately, when attaching to a target: pass " +
+        "-Ddev.sebastiano.spectre.agent.inputCoordination=disabled on the attaching JVM, or set " +
+        "AttachOptions.inputCoordination = AttachInputCoordination.Disabled; in-process: construct " +
+        "the driver as RobotDriver(InputLeasePolicy.Off). What that costs you: coordination is " +
+        "what stops two Spectre processes driving the same mouse and keyboard at once, so only do " +
+        "it when you know nothing else is automating this desktop. " +
+        "See https://github.com/rock3r/spectre/issues/472"
 
 internal class DriverInputCoordination(private val guard: InputLeaseGuard) {
     suspend fun checkpoint() {

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -655,18 +655,6 @@ class InputLeaseGuardTest {
         assertEquals(listOf("press:65", "release:65"), robot.events)
     }
 
-    private fun realDriver(
-        coordinator: InputLeaseCoordinator,
-        policy: InputLeasePolicy = InputLeasePolicy.Required,
-    ): RobotDriver =
-        RobotDriver(
-            robot = LeaseTestRobotAdapter(),
-            clipboard = LeaseTestClipboardAdapter(),
-            inputLeasePolicy = policy,
-            inputLeaseCoordinator = coordinator,
-            inputCapabilities = InputCapabilities(realOsInput = true, sharedSystemClipboard = true),
-        )
-
     private fun awaitWaiterCount(
         endpoint: CoordinatorEndpoint,
         resource: DesktopResourceKey,
@@ -717,6 +705,152 @@ class InputLeaseGuardTest {
         val STATUS_POLL_INTERVAL: Duration = 10.milliseconds
     }
 }
+
+/**
+ * What a `Required` driver is told when no coordinator can be reached (#472).
+ *
+ * Split out of [InputLeaseGuardTest] rather than added to it: these are about the *wording* of one
+ * failure, not about lease mechanics, and the guard suite is already at the project's class-size
+ * ceiling. They share this file's fixtures because the behaviour under test is the guard's.
+ *
+ * `Required` never degrades, which is the point of it — but until #472 the resulting failure said
+ * what broke and nothing about what to do, so a wedged coordinator took down every input verb with
+ * no way forward. The message has to name the escape hatch *and* what it costs, and it must not
+ * offer that advice for failures where taking it would be actively harmful.
+ */
+class UnreachableCoordinatorRecoveryTest {
+
+    @Test
+    fun `an unreachable coordinator failure names the escape hatch and its cost`() = runTest {
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure =
+                    InputCoordinatorException(
+                        "COORDINATOR_IO",
+                        "Input coordinator connection failed: did not become ready",
+                    )
+            )
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Required)
+
+        val failure = assertFailsWith<InputCoordinatorException> { driver.click(1, 2) }
+
+        val message = failure.message.orEmpty()
+        assertEquals("COORDINATOR_IO", failure.errorCode, "the taxonomy must survive enrichment")
+        assertTrue(
+            message.contains("did not become ready"),
+            "the measured cause must survive: $message",
+        )
+        assertTrue(
+            message.contains("dev.sebastiano.spectre.agent.inputCoordination=disabled"),
+            "the attach-path escape hatch must be named verbatim: $message",
+        )
+        assertTrue(
+            message.contains("InputLeasePolicy.Off"),
+            "the in-process escape hatch must be named: $message",
+        )
+        assertTrue(
+            message.contains("same mouse and keyboard", ignoreCase = true),
+            "the cost of opting out must be stated: $message",
+        )
+        assertTrue(
+            message.contains("https://github.com/rock3r/spectre/issues/472"),
+            "the message must link the issue: $message",
+        )
+    }
+
+    @Test
+    fun `the recovery advice is plain ASCII`() = runTest {
+        // It is read off a Windows console more often than anywhere else, and a code page that is
+        // not UTF-8 turns a stray em dash into a question mark in the middle of a copy-pasteable
+        // recovery instruction.
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure = InputCoordinatorException("COORDINATOR_IO", "did not become ready")
+            )
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Required)
+
+        val failure = assertFailsWith<InputCoordinatorException> { driver.click(1, 2) }
+
+        val offending = failure.message.orEmpty().filterNot { it.code in 0x20..0x7E }
+        assertEquals("", offending, "non-ASCII in the recovery message: ${failure.message}")
+    }
+
+    @Test
+    fun `a provider-missing failure also gets the recovery story`() = runTest {
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure =
+                    InputCoordinatorException(
+                        "COORDINATOR_PROVIDER_MISSING",
+                        "runtime artifact unavailable",
+                    )
+            )
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Required)
+
+        val failure = assertFailsWith<InputCoordinatorException> { driver.click(1, 2) }
+
+        assertEquals("COORDINATOR_PROVIDER_MISSING", failure.errorCode)
+        assertTrue(
+            failure.message.orEmpty().contains("dev.sebastiano.spectre.agent.inputCoordination"),
+            "${failure.message}",
+        )
+    }
+
+    @Test
+    fun `a contended lease is not answered with advice to stop coordinating`() = runTest {
+        // ACQUIRE_TIMEOUT means the coordinator worked perfectly and someone else holds the
+        // desktop. Telling that user to disable coordination would hand them the exact
+        // interleaved-input corruption the lease just prevented.
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure =
+                    InputCoordinatorException("ACQUIRE_TIMEOUT", "another owner holds the desktop")
+            )
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Required)
+
+        val failure = assertFailsWith<InputCoordinatorException> { driver.click(1, 2) }
+
+        assertEquals("another owner holds the desktop", failure.message)
+    }
+
+    @Test
+    fun `a fenced lease is not answered with advice to stop coordinating`() = runTest {
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure = InputCoordinatorException("FENCED", "lease was revoked")
+            )
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Required)
+
+        val failure = assertFailsWith<InputCoordinatorException> { driver.click(1, 2) }
+
+        assertEquals("lease was revoked", failure.message)
+    }
+
+    @Test
+    fun `off never reaches the coordinator so it never needs the recovery story`() = runTest {
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure = InputCoordinatorException("COORDINATOR_IO", "did not become ready")
+            )
+        val driver = realDriver(coordinator, policy = InputLeasePolicy.Off)
+
+        driver.click(1, 2)
+
+        assertEquals(emptyList(), coordinator.operations)
+    }
+}
+
+private fun realDriver(
+    coordinator: InputLeaseCoordinator,
+    policy: InputLeasePolicy = InputLeasePolicy.Required,
+): RobotDriver =
+    RobotDriver(
+        robot = LeaseTestRobotAdapter(),
+        clipboard = LeaseTestClipboardAdapter(),
+        inputLeasePolicy = policy,
+        inputLeaseCoordinator = coordinator,
+        inputCapabilities = InputCapabilities(realOsInput = true, sharedSystemClipboard = true),
+    )
 
 private fun recordingLease(failCheckpointAt: Int? = null): RecordingCoordinatedInputLease =
     RecordingCoordinatedInputLease(failCheckpointAt)

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -126,6 +126,14 @@ listed in `java.class.path`; Spectre scans that classpath, takes the physical ja
 that path to `VirtualMachine.loadAgent(...)`. The attacher does not call classes from the runtime
 jar directly, and the target still does not need `spectre-agent-runtime` declared as a dependency.
 
+One further attacher-side switch exists, and it is not one to set casually:
+`-Ddev.sebastiano.spectre.agent.inputCoordination=disabled` (or
+`AttachOptions.inputCoordination = AttachInputCoordination.Disabled`) drops the attach path from
+`InputLeasePolicy.Required` to `Off` in the target. It exists so a broken input coordinator is
+recoverable rather than terminal, and it costs you the guarantee that no other Spectre process is
+driving the same desktop. Read
+[When the coordinator cannot be reached](input-coordination.md#coordinator-unreachable) first.
+
 Classpath and directory discovery require exactly one runtime-jar candidate. If more than one
 `spectre-agent-runtime-*.jar` / `agent-runtime-*.jar` is present, attach fails with
 `AmbiguousAgentRuntimeJarException` naming every candidate rather than picking by classpath

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -162,10 +162,16 @@ as long as it is in force.
     spectre daemon kill
     ```
 
-    You do not have to remember: a `-D` that cannot take effect is refused at the handshake with a
-    message naming that command, in both directions — including a daemon left *disabled* by an
-    earlier recovery session, which would otherwise attach every new target uncoordinated. If you
-    launch the daemon yourself, pass the property through `JAVA_TOOL_OPTIONS`.
+    You do not have to remember: a mode that cannot take effect is refused at the handshake with a
+    message naming that command. If you launch the daemon yourself, pass the property through
+    `JAVA_TOOL_OPTIONS`.
+
+    **Taking the opt-out back off needs the same restart**, and Spectre insists on it. Removing the
+    property does not re-coordinate a daemon that is already running disabled; it would go on
+    attaching every new target uncoordinated, and its own warning goes to a startup log that is
+    deleted once it is up, so nothing would tell you. Commands are refused until you restart it —
+    running without the property means asking for the default, and Spectre will not quietly give
+    you something else.
 
 !!! danger "Opting out removes the mutual exclusion, it does not repair it"
     Coordination is what stops two Spectre processes driving the same mouse and keyboard at the

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -109,6 +109,61 @@ Automatic leases cover real pointer, keyboard, focus, and system-clipboard work.
 waits, screenshots, and recording do not acquire automatically. Put a visibility-sensitive
 capture inside `withExclusiveInput` when it must not race another client's input.
 
+## When the coordinator cannot be reached {#coordinator-unreachable}
+
+`Required` never degrades — that is what it is for. Every capability that touches shared OS state
+(`focusWindow`, `click`, `typeText`, `pasteText`, …) fails when no coordinator answers, and
+[agent attach](agent.md) always uses `Required`, so on that path a broken coordinator takes down
+the whole input surface at once.
+
+The failure names what it measured and what you can do about it:
+
+```text
+Input coordinator connection failed: Input coordinator did not become ready at …. Spectre could
+not reach the desktop input coordinator (COORDINATOR_IO), and this driver runs with
+InputLeasePolicy.Required, which fails rather than continuing uncoordinated. …
+```
+
+First **fix the coordinator**, because that keeps the guarantee:
+
+- Check `spectre-input-coordinator-server` and its dependencies are on `java.class.path` —
+  a `COORDINATOR_PROVIDER_MISSING` code means the artifact is simply absent.
+- Run `spectre input-lock status --json` to see whether a coordinator is up and who holds the
+  desktop, and recover a stuck lease as described below.
+- Run the command from `CoordinatorProcessLauncher.command()` by hand to keep the child JVM's
+  stderr, which automatic launches discard.
+
+If the coordinator is genuinely unusable and you need to make progress anyway, opt out
+**explicitly**. In-process, construct the driver as `RobotDriver(InputLeasePolicy.Off)`. On the
+attach path, either set the system property on the **attaching** JVM:
+
+```text
+-Ddev.sebastiano.spectre.agent.inputCoordination=disabled
+```
+
+or say it in code:
+
+```kotlin
+AgentAttach.attach(pid, AttachOptions(inputCoordination = AttachInputCoordination.Disabled))
+```
+
+The property is the channel that reaches the CLI, which attaches without `AttachOptions`. The
+`spectre` command forwards it to the daemon it starts; if you launch the daemon another way, pass
+it through `JAVA_TOOL_OPTIONS` instead. Only the exact word `disabled` opts out — unset, blank,
+`true`, and a misspelling all keep coordination on, so this cannot be tripped by accident. Both the
+attacher and the target print a line to stderr for as long as it is in force.
+
+!!! danger "Opting out removes the mutual exclusion, it does not repair it"
+    Coordination is what stops two Spectre processes driving the same mouse and keyboard at the
+    same time. With it off nothing does, and two runs interleaving real input produce failures that
+    look like anything but their cause. Use this only when you know your coordinator is broken
+    **and** you know nothing else is automating this desktop, and take it back out afterwards.
+
+`Auto` is deliberately not the answer here. It degrades for exactly two error codes —
+`COORDINATOR_PROVIDER_MISSING` and `COORDINATOR_SESSION_UNAVAILABLE` — and a coordinator that
+cannot be reached reports `COORDINATOR_IO`, so `Auto` would fail this case anyway while weakening
+every other one.
+
 ## JUnit 4 and JUnit 5
 
 Whole-test isolation is available on both in-process wrappers:

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -147,11 +147,25 @@ or say it in code:
 AgentAttach.attach(pid, AttachOptions(inputCoordination = AttachInputCoordination.Disabled))
 ```
 
-The property is the channel that reaches the CLI, which attaches without `AttachOptions`. The
-`spectre` command forwards it to the daemon it starts; if you launch the daemon another way, pass
-it through `JAVA_TOOL_OPTIONS` instead. Only the exact word `disabled` opts out — unset, blank,
-`true`, and a misspelling all keep coordination on, so this cannot be tripped by accident. Both the
-attacher and the target print a line to stderr for as long as it is in force.
+The property is the channel that reaches the CLI, which attaches without `AttachOptions`. Only the
+exact word `disabled` opts out — unset, blank, `true`, and a misspelling all keep coordination on,
+so this cannot be tripped by accident. Both the attacher and the target print a line to stderr for
+as long as it is in force.
+
+!!! important "A running daemon keeps the mode it booted with"
+    `spectre` forwards the property to a daemon it *starts*, but a daemon is long-lived and shared,
+    and it resolves the mode once — every target it injects inherits that. Since you only reach for
+    this switch after an attach has already failed, there is almost always a daemon already running
+    without it. Kill it first:
+
+    ```text
+    spectre daemon kill
+    ```
+
+    You do not have to remember: a `-D` that cannot take effect is refused at the handshake with a
+    message naming that command, in both directions — including a daemon left *disabled* by an
+    earlier recovery session, which would otherwise attach every new target uncoordinated. If you
+    launch the daemon yourself, pass the property through `JAVA_TOOL_OPTIONS`.
 
 !!! danger "Opting out removes the mutual exclusion, it does not repair it"
     Coordination is what stops two Spectre processes driving the same mouse and keyboard at the

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -166,6 +166,10 @@ as long as it is in force.
     message naming that command. If you launch the daemon yourself, pass the property through
     `JAVA_TOOL_OPTIONS`.
 
+    A daemon left running from a Spectre build older than this feature is refused for the same
+    reason: it cannot say whether it coordinates, and Spectre will not assume it does. Restart it
+    once after upgrading.
+
     **Taking the opt-out back off needs the same restart**, and Spectre insists on it. Removing the
     property does not re-coordinate a daemon that is already running disabled; it would go on
     attaching every new target uncoordinated, and its own warning goes to a startup log that is

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -68,6 +68,12 @@ test thread or use JUnit per-test isolation instead of blocking the AUT's event 
 `Auto` also avoids opening a new coordinator session from the EDT: without an already-connected
 session it proceeds uncoordinated. Choose `Required` when that fallback is unacceptable.
 
+The **attach path always uses `Required`** — an injected agent drives real input into a process you
+do not own, so a coordinator it cannot reach fails the input verb rather than quietly stopping
+policing the desktop. When the coordinator itself is broken and that leaves you with no way
+forward, there is one deliberate opt-out; see
+[When the coordinator cannot be reached](input-coordination.md#coordinator-unreachable).
+
 ## Mouse: clicks and drags
 
 ```kotlin

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -68,11 +68,15 @@ test thread or use JUnit per-test isolation instead of blocking the AUT's event 
 `Auto` also avoids opening a new coordinator session from the EDT: without an already-connected
 session it proceeds uncoordinated. Choose `Required` when that fallback is unacceptable.
 
-The **attach path always uses `Required`** — an injected agent drives real input into a process you
-do not own, so a coordinator it cannot reach fails the input verb rather than quietly stopping
-policing the desktop. When the coordinator itself is broken and that leaves you with no way
-forward, there is one deliberate opt-out; see
+The **attach path uses `Required`** whenever the target can coordinate at all — an injected agent
+drives real input into a process you do not own, so a coordinator it cannot reach fails the input
+verb rather than quietly stopping policing the desktop. When the coordinator itself is broken and
+that leaves you with no way forward, there is one deliberate opt-out; see
 [When the coordinator cannot be reached](input-coordination.md#coordinator-unreachable).
+
+The exception is a target whose preinstalled Spectre core predates `InputLeasePolicy`. The agent
+falls back to the legacy no-argument driver there, which coordinates nothing — see
+[Attach](agent.md). Injected targets and current-core targets are unaffected.
 
 ## Mouse: clicks and drags
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -194,6 +194,11 @@ startup and every target it injects inherits it, so the switch cannot reach the 
 already up when your attach failed. Spectre refuses the mismatch at the handshake and names that
 command, so you will be told rather than left wondering why the switch did nothing.
 
+**And kill it again when you are done.** Dropping the property does not re-coordinate a daemon
+already running disabled — it keeps attaching new targets uncoordinated, and nothing on your
+terminal says so. Commands are refused until you restart it, on purpose: running without the
+property means asking for the default.
+
 `spectre` forwards the property to a daemon it starts; pass it through `JAVA_TOOL_OPTIONS` if you
 launch the daemon yourself. Only the exact word `disabled` opts out, and both the attacher and the
 target announce it on stderr while it is in force. It costs you the guarantee that nothing else is

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -135,7 +135,9 @@ If the coordinator process does not become ready, check that
 `spectre-input-coordinator-server` and its dependencies are present in `java.class.path`. This is
 especially relevant for thin `java -jar` launchers and module-path-only applications. Run the
 command returned by `CoordinatorProcessLauncher.command()` directly when you need to retain the
-child JVM's standard error; automatic launches intentionally discard child output.
+child JVM's standard error; automatic launches intentionally discard child output. See
+["Every input verb fails and the coordinator will not start"](#coordinator-unreachable) when the
+coordinator cannot be repaired and you need a way through.
 
 Use synthetic input:
 
@@ -152,6 +154,47 @@ Synthetic input posts AWT events directly into the target window's event queue �
 global focus, no cursor motion. The trade-off is that some interactions (system-level
 shortcuts, real OS drag-and-drop) won't behave the same way. See
 [Driving input](interactions.md#real-vs-synthetic-input).
+
+## "Every input verb fails and the coordinator will not start" {#coordinator-unreachable}
+
+Symptom: semantics reads, `windows()`, `findByTestTag` and screenshots all keep working, while
+`focusWindow`, `click`, `typeText` and `pasteText` all fail at once with a message about the input
+coordinator. That split is the signature — everything that touches the shared desktop is gated on a
+lease, and nothing else is.
+
+The failure now names its own way out:
+
+```text
+… Spectre could not reach the desktop input coordinator (COORDINATOR_IO), and this driver runs
+with InputLeasePolicy.Required, which fails rather than continuing uncoordinated. Measured: no
+coordinator answered. Not measured: whether it is wedged, absent, or merely slower than its
+startup budget. …
+```
+
+Read the error code first, because two of them mean different repairs:
+
+| Code | What it means | First thing to try |
+| --- | --- | --- |
+| `COORDINATOR_PROVIDER_MISSING` | the coordinator artifact is not on the classpath | add `spectre-input-coordinator-server` to the **attacher's** runtime classpath |
+| `COORDINATOR_IO` | a coordinator was launched but no client could reach it | run `CoordinatorProcessLauncher.command()` by hand and read the child's stderr |
+| `ACQUIRE_TIMEOUT` | the coordinator is fine; another owner holds the desktop | `spectre input-lock status --json`, then revoke the exact lease ID |
+
+Do **not** answer `ACQUIRE_TIMEOUT` by turning coordination off: that failure means the lease is
+doing its job — see "Tests fight over OS focus when run in parallel" above.
+
+If the coordinator is genuinely unusable — for instance a host where the socket path itself is
+broken — there is one deliberate opt-out for the attach path. Set it on the **attaching** JVM:
+
+```text
+-Ddev.sebastiano.spectre.agent.inputCoordination=disabled
+```
+
+`spectre` forwards that property to the daemon it starts; pass it through `JAVA_TOOL_OPTIONS` if
+you launch the daemon yourself. Only the exact word `disabled` opts out, and both the attacher and
+the target announce it on stderr while it is in force. It costs you the guarantee that nothing else
+is driving this desktop — read
+[When the coordinator cannot be reached](input-coordination.md#coordinator-unreachable) before
+using it.
 
 ## "`typeText` or `pasteText` didn't reach my field"
 
@@ -474,7 +517,9 @@ implies the IDE’s bundled JBR — do not ship a second skiko into the plugin c
 If an attached session can inspect semantics but real input reports that the coordinator provider
 is missing, add `spectre-input-coordinator-server` to the attacher's runtime classpath and retry.
 Read-only attach deliberately remains available when the experimental coordinator cannot start;
-current-core real input uses `Required` and fails closed instead of running uncoordinated.
+current-core real input uses `Required` and fails closed instead of running uncoordinated. When the
+coordinator cannot be repaired, see
+["Every input verb fails and the coordinator will not start"](#coordinator-unreachable).
 
 The sample IntelliJ plugin module configures its sandbox JDK via the IntelliJ Platform
 Gradle plugin; you do not pick Temurin for that path.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -189,10 +189,15 @@ broken — there is one deliberate opt-out for the attach path. Set it on the **
 -Ddev.sebastiano.spectre.agent.inputCoordination=disabled
 ```
 
-`spectre` forwards that property to the daemon it starts; pass it through `JAVA_TOOL_OPTIONS` if
-you launch the daemon yourself. Only the exact word `disabled` opts out, and both the attacher and
-the target announce it on stderr while it is in force. It costs you the guarantee that nothing else
-is driving this desktop — read
+**Kill the running daemon first** — `spectre daemon kill`. A daemon resolves this mode once at
+startup and every target it injects inherits it, so the switch cannot reach the daemon that was
+already up when your attach failed. Spectre refuses the mismatch at the handshake and names that
+command, so you will be told rather than left wondering why the switch did nothing.
+
+`spectre` forwards the property to a daemon it starts; pass it through `JAVA_TOOL_OPTIONS` if you
+launch the daemon yourself. Only the exact word `disabled` opts out, and both the attacher and the
+target announce it on stderr while it is in force. It costs you the guarantee that nothing else is
+driving this desktop — read
 [When the coordinator cannot be reached](input-coordination.md#coordinator-unreachable) before
 using it.
 


### PR DESCRIPTION
Fixes #472.

## Shape chosen

`Required` stays the default, and I did not touch it. The change is that it stops being a dead end.

**The opt-out is both a system property and an `AttachOptions` field, and it lands on `Off`, not `Auto`.**

`AttachInputCoordination` in `:agent` has two values — `Required` and `Disabled` — with a strict truth table:

| `dev.sebastiano.spectre.agent.inputCoordination` | resolves to |
|---|---|
| unset / blank | `Required` |
| `disabled` (any case, trimmed) | `Disabled` |
| `required` | `Required` |
| `true`, `1`, `yes`, `on`, `off`, `false`, `auto` | `Required` |
| `disable`, `disabledd`, anything else | `Required` |

Only the word opts out. A boolean would have put "stop policing the desktop" one stray `-D` away, and falling back *to* coordination is the only safe direction for a typo — which is not silent in practice either, because the failure the user still gets names the exact spelling that would have worked.

`AttachOptions.inputCoordination` is `null` by default, meaning "resolve the property", the same shape `maxFrameBytes` already uses. An explicit value wins over the property **in both directions**, so an integration that pins `Required` cannot be unpinned by a property left lying around.

**Why both, and not just one.** `DaemonSessionRegistry` attaches with `AgentAttach.attach(targetPid)` and no options at all, so for anyone driving Spectre through the CLI the property is the *only* channel that reaches this decision. The field is for embedders, and for tests that must not mutate a JVM-global. `DaemonProcessLauncher` now forwards the property to the daemon it launches, next to the `runtimeJar` forwarding that was already there for exactly this reason.

**Read on the attacher, never in the target.** The decision travels to the injected runtime through `agentArgs`, next to `maxFrameBytes`. Letting a property the *target* happens to carry downgrade the *attacher's* coordination would be precisely the silent degradation this design refuses. A missing or unrecognised field parses as `Required`, so an older attacher, a hand-written `-javaagent:` line and a truncated value all land on the behaviour Spectre has always had.

**Announced while in force.** Both the attacher (`[spectre-attach]`) and the target (`[spectre-agent]`) print a line to stderr. The failures this enables are the ones that only make sense once you know two runs were driving the same mouse, and by then the log is the only evidence left.

Attaching with the hatch on also stops standing up a coordinator it has decided not to use — `connectOrStart` spends a 5s startup budget before giving up, so otherwise every wedged-coordinator attach would still stall for it.

### Rejected

- **`Auto` as the escape hatch** (not just as the default). It degrades for exactly two error codes, `COORDINATOR_PROVIDER_MISSING` and `COORDINATOR_SESSION_UNAVAILABLE`. A wedged coordinator is neither: the launching provider's startup timeout arrives as an `IOException`, which `ProductionInputLeaseCoordinator` reports as `COORDINATOR_IO`. So `Auto` would **hard-fail the very case this exists for** while weakening every case where coordination is merely absent. This is measured, not argued — see the verification below, where the real wedge produced `COORDINATOR_IO`.
- **A boolean field or `=true` property.** Too easy to set by accident for something that removes a mutual-exclusion guarantee.
- **A target-side property.** Same reason as "read on the attacher" above.
- **Reading the property inside `SpectreAgent`.** The target JVM is already running when you attach to it; a property there is not something the user can set at the moment they need it.

## The recovery story

`undeliveredInputMessage` was the model: keep the measured cause verbatim, say plainly which part is inference, name the hatch precisely enough to paste, and link the issue. Real output from a genuinely wedged coordinator:

```text
Input coordinator connection failed: Input coordinator did not become ready at
C:\Users\…\Temp\spectre-input-…\input-v1-….sock. Spectre could not reach the desktop input
coordinator (COORDINATOR_IO), and this driver runs with InputLeasePolicy.Required, which fails
rather than continuing uncoordinated. Measured: no coordinator answered. Not measured: whether it
is wedged, absent, or merely slower than its startup budget. To proceed without coordination,
deliberately, when attaching to a target: pass
-Ddev.sebastiano.spectre.agent.inputCoordination=disabled on the attaching JVM, or set
AttachOptions.inputCoordination = AttachInputCoordination.Disabled; in-process: construct the
driver as RobotDriver(InputLeasePolicy.Off). What that costs you: coordination is what stops two
Spectre processes driving the same mouse and keyboard at once, so only do it when you know nothing
else is automating this desktop. See https://github.com/rock3r/spectre/issues/472
```

**Scoped deliberately** to `COORDINATOR_IO` and `COORDINATOR_PROVIDER_MISSING` — the two codes that mean *no coordinator could be reached at all*. `ACQUIRE_TIMEOUT` and `FENCED` mean the opposite: the coordinator worked and somebody else holds the desktop. Answering those with "you can turn coordination off" would talk a user into the exact interleaved-input corruption the lease had just prevented. There are tests pinning that they keep the plain message.

The message is plain ASCII, with a test enforcing it. The first real run had em dashes in it and they came back as `?` in the middle of a copy-pasteable recovery instruction on a Windows console.

## Red-then-green

Every test was written first and observed failing.

| Test | Red | Green |
|---|---|---|
| `InputLeaseGuardTest` → recovery message (2 tests) | assertion failure: `the attach-path escape hatch must be named verbatim: Input coordinator connection failed: did not become ready` | pass |
| `ACQUIRE_TIMEOUT` / `FENCED` / `Off` negatives (3) | passed from the start — they pin behaviour that must *not* change | pass |
| `AttachInputCoordinationTest` (9) | `Unresolved reference 'AttachInputCoordination'` | pass |
| `AgentBootstrapArgsTest` +7 | same | pass |
| `SpectreAgentInputCoordinationCompatibilityTest` +4 | same | pass |
| `AttachOptionsTest` +4 | same | pass |
| `DaemonProcessLauncherTest` +3 | `No parameter with name 'readProperty' found` | pass |

## The default did not move, and here is how it is pinned

Four independent layers assert `Required`, and I verified each one is load-bearing by mutating the production default to `Disabled` and confirming the suite catches it:

| Mutation | Caught by |
|---|---|
| `fromProperty`'s fallback → `Disabled` | `an unset property keeps coordination required`, `a blank property…`, `affirmative-looking values…`, `a typo falls back to required…` |
| `Parsed.inputCoordination` default → `Disabled` | `a bare path means coordination is required`, `null args mean coordination is required` |
| `createCoordinatedRobotDriverOrLegacyFallback`'s default → `Disabled` | `the attach path coordinates by default` |
| — resolution at attach time | `an unset property leaves the attach path coordinated` |

All mutations reverted; the final tree is the unmutated one.

## Verified against a real wedged coordinator, not a synthetic one

This host still carries the #462 corpse (`%LOCALAPPDATA%\spectre-input-5a48ec98426959f3\input-v1-5a48ec98.sock`, listed by a directory read while `Files.exists` reports `false`). I probed whether the underlying poisoning is still live, and it is — and it is scoped exactly as #464 described:

| path | bind | connect | `exists()` | delete |
|---|---|---|---|---|
| `%LOCALAPPDATA%\Temp\…` | OK | **OK** | true | OK |
| `%LOCALAPPDATA%\<sub>\…` | OK | `SocketException: Invalid argument` | false | `The file cannot be accessed by the system` |
| `%LOCALAPPDATA%\<sub>\Temp\…` | OK | same | false | same |
| `%LOCALAPPDATA%\<sub>\Temp\<sub>\…` | OK | same | false | same |

So #464's move to `%LOCALAPPDATA%\Temp` is the reason current code works, and pointing `LOCALAPPDATA` at any *other* subdirectory reproduces the original wedge with real OS behaviour. Driving a real `RobotDriver` through that, in a child JVM:

```text
endpoint: CoordinatorEndpoint(directory=…\s472\Temp\spectre-input-…, socketPath=…\input-v1-….sock)
=== InputLeasePolicy.Required (10167ms)
  moveTo: dev.sebastiano.spectre.input.InputCoordinatorException
  message: Input coordinator connection failed: Input coordinator did not become ready at … [full message above]
=== InputLeasePolicy.Off (22ms)
  moveTo: OK — input was dispatched
```

10.2s is the launcher genuinely trying twice with its real 5s budget. The probe was a scratch file and is not in this diff.

## API surface

`:core` and `:testing` ABI dumps are **unchanged** — the recovery message added no public API. `agent/api/agent.api` grows by the new enum and the three-argument `render` overload, and carries **7 binary removals**, all of them signature moves on two `@ExperimentalSpectreAgentApi` data classes from adding a defaulted parameter:

- `AttachOptions.<init>` / `copy` / `copy$default` (4-arg → 5-arg)
- `AgentBootstrapArgs.Parsed.<init>` / `copy` / `copy$default` (2-arg → 3-arg)

Source compatibility is preserved by the defaults. I kept `AgentBootstrapArgs.render(String, Int)` as a separate overload rather than adding a defaulted parameter, specifically so that published signature does not move; it still renders byte-for-byte what it always did. `@JvmOverloads` could have restored the old `AttachOptions` constructor too, but it would add five constructors to the ABI for one signature and `copy` would move regardless, so I took the removals on an experimental type instead. Flagging it rather than deciding it quietly.

## Docs

- `docs/guide/input-coordination.md` — new "When the coordinator cannot be reached" section: fix it first, then the opt-out, with a `!!! danger` admonition on what it costs.
- `docs/guide/troubleshooting.md` — new section keyed on the actual symptom (reads keep working, every input verb fails at once), with an error-code table that routes `ACQUIRE_TIMEOUT` *away* from the hatch.
- `docs/guide/interactions.md`, `docs/guide/agent.md` — short pointers from where the attach contract and the agent properties are already documented.

## One thing for you to decide

I did **not** change the default, and I do not think it should change. But `Auto` gets the plain message too: an in-process caller on `Auto` hitting `COORDINATOR_IO` reaches the same dead end with none of the new advice, because I scoped the enrichment to `Required` to match the issue exactly. Extending it to `Auto` is a one-condition change and I can do it in this PR if you want it.

## Local verification

`gradlew.bat check` is green apart from one pre-existing, host-specific failure unrelated to this change:

- `CoordinatorEndpointTest > symbolic-link endpoint directory is rejected without following it` fails at `Files.createSymbolicLink` with *"A required privilege is not held by the client"*. This machine has Developer Mode off and the session is not elevated, so no process here can create a symlink; the test only guards `UnsupportedOperationException`, not `FileSystemException`. Untouched by this diff, and it will pass on CI.

(`:cli:verifyCliDistributionZip` also failed until I noticed this shell has `NoDefaultCurrentDirectoryInExePath=1`, which stops `cmd /c call spectre.bat` resolving from the working directory. With that cleared the task passes — the distribution is fine.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
