### PR TITLE
Run the CLI launcher by explicit path in verifyCliDistributionZip

### DIFF
--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/VerifyCliDistributionZip.kt
@@ -89,8 +89,11 @@ abstract class VerifyCliDistributionZip : DefaultTask() {
         val processBuilder =
             if (isWindows()) {
                 // Run from bin/ via `call` so APP_HOME resolves stably and path quoting is less
-                // fragile than `cmd /c D:\long\path\spectre.bat`.
-                ProcessBuilder("cmd.exe", "/c", "call", launcher.name, "--help")
+                // fragile than `cmd /c D:\long\path\spectre.bat`. The `.\` prefix is required:
+                // a bare name makes cmd.exe resolve through PATH, which the scrubbing below
+                // trims to System32, and NoDefaultCurrentDirectoryInExePath (set on some hosts
+                // and CI images) disables the working-directory fallback.
+                ProcessBuilder("cmd.exe", "/c", "call", ".\\${launcher.name}", "--help")
                     .directory(launcher.parentFile)
             } else {
                 ProcessBuilder(launcher.absolutePath, "--help")


### PR DESCRIPTION
## Problem

`:cli:verifyCliDistributionZip` fails on Windows on a pristine `main` checkout:

```
* What went wrong: Execution failed for task ':cli:verifyCliDistributionZip'.
> spectre.bat did not run with its bundled runtime: 'spectre.bat' is not recognized
  as an internal or external command, operable program or batch file.
```

This is a pre-existing failure, hit incidentally while running `gradlew.bat check` as a pre-push gate.

## Root cause

`verifyLauncher` invoked the extracted launcher by bare name:

```kotlin
ProcessBuilder("cmd.exe", "/c", "call", launcher.name, "--help")
    .directory(launcher.parentFile)
```

That relies on `cmd.exe` resolving `spectre.bat` from the working directory. It does not always do so. When `NoDefaultCurrentDirectoryInExePath` is set, `cmd.exe` resolves a bare command name through `PATH` **only** and never falls back to the working directory — and a few lines below, the task deliberately scrubs `PATH` down to `%SystemRoot%\System32` so that only the bundled jlink runtime can supply `java.exe`. With both in play there is no route left to the launcher.

Confirmed directly on the failing host, which has `NoDefaultCurrentDirectoryInExePath=1`. Running the extracted launcher under exactly the task's conditions (`PATH` scrubbed to System32, `JAVA_HOME` cleared):

```
=== NoDefaultCurrentDirectoryInExePath=[1]
=== BARE
'spectre.bat' is not recognized as an internal or external command,
=== BARE exit=1
=== DOTSLASH
Usage: spectre [<options>] <command> [<args>]...
```

So the runtime isolation was working correctly all along — the bundled runtime does start the CLI. Only the *lookup* of the launcher was broken.

## Fix

Prefix the launcher with `.\` so resolution is explicit. This is strictly more robust than the bare name: `.\` is valid regardless of whether `NoDefaultCurrentDirectoryInExePath` is set, so it works on hosts and CI images that set it and on those that don't.

Both existing rationales are preserved — the process still runs from `bin/` so `APP_HOME` resolves stably, and the short relative path still avoids the quoting fragility of `cmd /c D:\long\path\spectre.bat`. The comment above the call was updated to describe what the code now does.

**The runtime isolation is unchanged**: `JAVA_HOME` is still removed and `PATH`/`Path` are still scrubbed to System32, as intended.

## Verification

- `:cli:verifyCliDistributionZip` fails on the unmodified base and passes with this change, on Windows.
- The sibling `VerifyRoastCliDistribution` invokes `launcher.absolutePath` directly with no `cmd.exe` indirection, so it never had this bug and is untouched.

Two failures remain in a full local `check --continue` on my Windows host. Both are independent of this change and were each verified as such:

- `:input-coordinator:test` → `CoordinatorEndpointTest > symbolic-link endpoint directory is rejected without following it()` — `FileSystemException: A required privilege is not held by the client`. This account lacks `SeCreateSymbolicLinkPrivilege`. Reverting this PR's file to the base version reproduces the failure identically, so it is pre-existing and environmental. Already being addressed on `fix/coordinator-endpoint-symlink-privilege`.
- `:core:test` → `InputLeaseGuardTest > production coordinator reconnects after server epoch changes()` — `InputCoordinatorException: Client session disconnected`. Failed once under full-`check` parallel load, then passed 3/3 when run in isolation. A flake, unrelated to this change.

## Note for reviewers

`windows.yml` path filters do **not** include `buildSrc/**`, so the Windows CI job will not trigger on this PR and cannot exercise this fix — the Linux `ci.yml` job never reaches the Windows branch of `verifyLauncher`. That gap is plausibly why this bug reached `main` in the first place.

Adding `buildSrc/**` to those filters is deliberately **not** bundled here, since it means every `buildSrc` change pays for a Windows runner — a cost trade-off worth deciding separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
