### PR TITLE
test(input): skip the coordinator symlink guard when the host forbids links

### DIFF
--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
@@ -3,6 +3,7 @@
 package dev.sebastiano.spectre.input
 
 import java.io.IOException
+import java.nio.file.FileSystemException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermissions
@@ -114,9 +115,19 @@ class CoordinatorEndpointTest {
         val target = temporaryDirectory.resolve("target")
         Files.createDirectory(target)
         val link = temporaryDirectory.resolve("spectre-input-link")
+        // Both branches mean "this host cannot make a symlink, so there is nothing to guard
+        // against here". UnsupportedOperationException is a file system that has no symlinks at
+        // all; FileSystemException is a host that has them but refuses this process the right to
+        // create one -- on Windows that is the usual case, since createSymbolicLink needs
+        // Developer Mode or SeCreateSymbolicLinkPrivilege and otherwise fails with "A required
+        // privilege is not held by the client". Failing there would make `./gradlew check`, the
+        // documented pre-push gate, impossible to get green on an ordinary Windows checkout. The
+        // assertion below is unchanged, so hosts that can create symlinks still cover the guard.
         try {
             link.createSymbolicLinkPointingTo(target)
         } catch (_: UnsupportedOperationException) {
+            return
+        } catch (_: FileSystemException) {
             return
         }
         val socket = link.resolve("input.sock")


### PR DESCRIPTION
`CoordinatorEndpointTest.symbolic-link endpoint directory is rejected without following it` fails on any Windows host that lacks `SeCreateSymbolicLinkPrivilege` and has Developer Mode off.

The test wraps `createSymbolicLinkPointingTo` in a `try` that only catches `UnsupportedOperationException`. On such a host the JDK instead throws:

```
java.nio.file.FileSystemException: ...\spectre-input-link: A required privilege is not held by the client
```

which escapes the catch and fails the test — making `./gradlew check`, the documented pre-push gate, impossible to get green on an ordinary Windows checkout.

## Fix

Treat `FileSystemException` the same way as `UnsupportedOperationException`: both mean this host cannot produce a symlink, so there is nothing for the guard to reject. A comment in the test explains why both branches mean "cannot test here".

The assertion itself is unchanged, so CI and any host that *can* create symlinks still cover the guard — no coverage is lost.

This matches the handling already used elsewhere in the repo for exactly this problem: `AgentJarResolutionTest` uses the same catch-and-return shape, and `DaemonServerTest` wraps both exception types in an `assumeCanCreateSymbolicLinks()` helper. I swept every `createSymbolicLink` call site; this was the only unguarded one left.

## Verification

Verified on a Windows host that actually reproduces the report (no `SeCreateSymbolicLinkPrivilege`, Developer Mode off):

- **Before:** `:input-coordinator:test` FAILED with the `FileSystemException` above.
- **After:** `:input-coordinator:check` green — 8 tests, 0 failures, 0 errors, including `ktfmtCheck` and `detekt`.
- **Full `./gradlew check` green** on that host, rebased on current `main` (which now carries the #475 `verifyCliDistributionZip` fix).

Noticed while working on #472; unrelated to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
