### PR TITLE
ci(windows): trigger the Windows check job on buildSrc changes

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,6 +8,8 @@ name: Windows
 #     when the host OS picks a different FfmpegBackend by default.
 #   - Compose Desktop renderer regressions that only surface under skiko-windows-x64.dll.
 #   - Any future Windows-conditional test that an `os.name` check would skip on Linux.
+#   - Windows-conditional *build* logic in `buildSrc/` (e.g. `VerifyCliDistributionZip`'s
+#     cmd.exe launcher smoke), which the Linux job compiles but never executes.
 # Without this job, those regressions reach an end user before they reach CI.
 #
 # Notes:
@@ -33,6 +35,13 @@ on:
       # (#455). Without this path, a Windows-only fix in `:cli` cannot be verified before
       # merge and `:cli` regressions reach main before CI sees them.
       - "cli/**"
+      # `buildSrc/` carries Windows-conditional *build* logic, not just Windows-conditional
+      # tests: `VerifyCliDistributionZip.verifyLauncher` shells out through cmd.exe to run the
+      # packaged `spectre.bat` under a scrubbed PATH, and only that branch can break. #475 was
+      # exactly that regression — it reached main because the change touched `buildSrc/**`
+      # only, so this job never fired, and Linux `ci.yml` runs the same `:check` task but
+      # always takes the non-Windows branch. Mirrors `macos-check.yml`, which already lists it.
+      - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"
@@ -56,6 +65,13 @@ on:
       # (#455). Without this path, a Windows-only fix in `:cli` cannot be verified before
       # merge and `:cli` regressions reach main before CI sees them.
       - "cli/**"
+      # `buildSrc/` carries Windows-conditional *build* logic, not just Windows-conditional
+      # tests: `VerifyCliDistributionZip.verifyLauncher` shells out through cmd.exe to run the
+      # packaged `spectre.bat` under a scrubbed PATH, and only that branch can break. #475 was
+      # exactly that regression — it reached main because the change touched `buildSrc/**`
+      # only, so this job never fired, and Linux `ci.yml` runs the same `:check` task but
+      # always takes the non-Windows branch. Mirrors `macos-check.yml`, which already lists it.
+      - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"
       - "recording-macos/**"


### PR DESCRIPTION
## Summary

Adds `buildSrc/**` to both the `pull_request` and `push` path filters in
`.github/workflows/windows.yml`, with an inline comment following the prior art of the
`cli/**` entry (which documents #455 as its motivation).

`buildSrc/` holds Windows-**conditional build logic**, not just Windows-conditional tests.
`VerifyCliDistributionZip.verifyLauncher` has an `isWindows()` branch that shells out through
`cmd.exe` to run the packaged `spectre.bat` under a deliberately scrubbed `PATH`. That task is
wired into `:cli:check` (`cli/build.gradle.kts:283`), so it is part of `./gradlew check` — but
only the Windows job ever executes the Windows half of it.

Refs #475.

### Why CI could not have caught #475

#475 fixed a Windows-only bug in exactly that branch: the launcher was invoked by bare name,
which `cmd.exe` cannot resolve once `PATH` is scrubbed to System32 and
`NoDefaultCurrentDirectoryInExePath` is set. It reached `main` and was only found by running
`gradlew.bat check` by hand. Every existing job was blind to it:

| Workflow | Runner | Has `buildSrc/**`? | Runs `:check`? | Would have caught #475 |
|---|---|---|---|---|
| `ci.yml` | ubuntu | n/a (ungated) | yes | No — always takes the non-Windows branch |
| `windows.yml` | windows | **no** | yes | No — never triggered |
| `validation-windows.yml` | windows | yes | **no** | No — runs `:sample-desktop:validationTest` and a targeted `:cli:test`, never `:check` |
| `macos-check.yml` | macOS | yes | yes | No — non-Windows branch |

So the one job that both runs `:check` and runs on Windows is the one that was not listening for
`buildSrc` changes. This PR closes that.

### Consistency

`macos-check.yml`, `validation-linux.yml`, and `validation-windows.yml` have all carried
`buildSrc/**` since their earliest revision in this repo's history; `windows.yml` never has. That
is notable because `windows.yml`'s own header comment states it "Mirrors the broad path-filter
pattern from `macos-check.yml`" — this entry is precisely where it diverged from the file it
claims to mirror.

### `macos-check.yml`: checked, no change needed

The task asked whether `macos-check.yml` has the same gap. **It does not** — it already lists
`buildSrc/**` in both filters (lines 30 and 51), and its `check-macos` job runs `./gradlew check`.
The non-Windows branch of `verifyLauncher` is therefore already covered there today (and on every
`ci.yml` run, which is ungated). No change is warranted, and I have not made one.

## The trade-off

This is the explicit cost, stated plainly: **every `buildSrc` change now pays for a
GitHub-hosted Windows runner.** The `check-windows` job took ~12 minutes on #475.

Two honest details worth flagging:

- **Path filters are workflow-scoped, not job-scoped.** Adding the path also makes the small
  `windows-helper-tests` job (`dotnet test` on the WGC helper) fire on `buildSrc` changes, where
  it is unrelated. It is short, and gating it separately would add an `if:` condition and more
  moving parts than the saving justifies — but it is part of the cost, not hidden.
- **The repo is public**, so standard GitHub-hosted runners are not billed. The real cost is PR
  wall-clock latency and concurrency-slot contention, not minutes on an invoice. The existing
  "so unrelated PRs don't pay the windows-runner cost" comment still holds, just in that currency.

Sizing the cost against this repo's actual history — of the 51 commits visible in `main`, 3
touched `buildSrc/`, and only **1** of those touched `buildSrc/` *without* also touching a path
already in the filter:

| Commit | Also matched an existing path? | Newly triggers? |
|---|---|---|
| `fd27ca7` (#405) | yes | no |
| `14a37a4` (#450) | yes | no |
| `3341693` (#475) | **no** | **yes** |

So the marginal cost is roughly **one extra ~12-minute Windows run per ~50 commits**, and the one
commit it would have newly caught is exactly the regression that motivated this PR. The other two
already triggered the job through other paths and cost nothing additional.

My read is that this clears the bar comfortably: `buildSrc` is low-churn, the failure mode is
Windows-only-by-construction, and the only alternative signal is a maintainer remembering to run
`gradlew.bat check` locally. If the churn profile changes later, the entry is a one-line revert.

## Test plan

The diff is 16 added lines in a GitHub Actions YAML file — 14 of them comments. Gradle never reads
`.github/`, so `./gradlew check` cannot be affected by it. I ran it anyway per the pre-push
checklist, and am reporting exactly what happened rather than ticking the box.

- [x] YAML parses; both filters contain `buildSrc/**` (17 entries each); comment width ≤ 95 chars,
      within this file's existing style. No `yamllint`/`actionlint` config exists in the repo.
- [ ] `./gradlew check` passes locally — **it does not pass in my Linux container**, for four
      environmental reasons, all of which I verified reproduce on **pristine `origin/main`**:
    1. `:recording:buildWaylandHelper` — `cargo` exit 101, missing `libdbus-1-dev`. This is the
       dependency `ci.yml` installs explicitly for this task. Installing it fixed the task.
    2. `UdsPathLimitsTest > an accented Windows path fits a legacy code page but not UTF-8()` —
       `InvalidPathException`. Container locale is `POSIX`, so `sun.jnu.encoding=ANSI_X3.4-1968`
       and a non-ASCII path cannot be encoded. Passes under `LANG=C.UTF-8`, which GitHub's
       `ubuntu-latest` sets; `ci.yml` is unaffected.
    3. `LongOpInfrastructureTest > ordinary EOF accepts a replacement client while input
       finishes()` — fails under full-`check` parallel load on this 4-CPU container, passes 3/3
       when run in isolation.
    4. `:cli:verifyCliDistributionZip` — "Could not determine the Java version from
       .../runtime/bin/java" on the **non-Windows** branch. Reproduces on unmodified
       `origin/main`.
- [x] Confirmed on `main` with no changes applied that (4) — and, under load, (3) — fail
      identically, so none of this is attributable to the diff.
- [ ] `./gradlew ktfmtFormat` produced no changes — not applicable; no Kotlin was touched.

**What a reviewer should check:** that CI on this PR runs the Windows workflow. This PR modifies
`.github/workflows/windows.yml`, which is itself already in the filter, so the job should fire
here and is a live end-to-end test of the change. The real proof lands on the next
`buildSrc`-only PR.

## Confirmations

- [ ] ~~I read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR is **not** LLM-generated.~~
      **I cannot check this box.** This PR was written by Claude at the maintainer's direction,
      and I am not going to tick a box saying otherwise. Flagging it explicitly so you can apply
      the "no clanker PRs" rule as you see fit — the rule's stated concern is people shipping AI
      output "as if you wrote it", which this note is intended to defuse rather than sidestep.
- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJbZvtvCUmezXecfK3krFd)_