### PR TITLE
Order the macOS bundle contract check after the packaging that produces its input

### DIFF
--- a/.github/scripts/test-macos-bundle-verify-ordering.sh
+++ b/.github/scripts/test-macos-bundle-verify-ordering.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Fail-closed ordering contract for verifyMacosCliBundleReleaseContract (#456).
+#
+# That task runs test-macos-cli-seal-preservation.sh, which reads
+#   cli/build/construo/distributions/macos*/spectre-macos*.zip
+# produced by :cli:packageMacosArm64 / :cli:packageMacosX64.
+#
+# An absent zip is handled gracefully — the seal script skips the mutation probe.
+# A *partially written* one is not: `ditto -x -k` fails with "Couldn't read pkzip
+# signature" and the build dies. That is what happens when Gradle schedules the
+# verification alongside, or ahead of, the packaging that produces the archive,
+# which it is free to do while no ordering is declared.
+#
+# Asserted against the build script rather than a --dry-run listing: --dry-run
+# prints a sequential order that says nothing about parallel scheduling, and the
+# failure this guards against was a parallel one. Same shape as the other
+# source-level contracts in this directory.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+build_script="$root/build.gradle.kts"
+
+wiring="$(grep -n 'verifyMacosCliBundleReleaseContract\.configure' "$build_script" || true)"
+if [[ -z "$wiring" ]]; then
+  echo "test-macos-bundle-verify-ordering: FAIL — no ordering configured for" >&2
+  echo "  verifyMacosCliBundleReleaseContract, so it can read a half-written zip (#456)." >&2
+  exit 1
+fi
+
+# The configure block may span several lines, so read from the match to the end of the block.
+line_no="${wiring%%:*}"
+clause="$(sed -n "${line_no},$((line_no + 5))p" "$build_script")"
+
+missing=()
+for required in ':cli:packageMacosArm64' ':cli:packageMacosX64'; do
+  if [[ "$clause" != *"$required"* ]]; then
+    missing+=("$required")
+  fi
+done
+
+if (( ${#missing[@]} > 0 )); then
+  echo "test-macos-bundle-verify-ordering: FAIL — verifyMacosCliBundleReleaseContract is not" >&2
+  echo "  ordered after ${missing[*]}, so it can read a half-written zip (#456)." >&2
+  echo "  found: $clause" >&2
+  exit 1
+fi
+
+echo "test-macos-bundle-verify-ordering: OK — ordered after macOS packaging"

--- a/.github/scripts/test-verify-macos-cli-bundle.sh
+++ b/.github/scripts/test-verify-macos-cli-bundle.sh
@@ -7,11 +7,13 @@ verifier="$repo_root/.github/scripts/verify-macos-cli-bundle.sh"
 seal_probe="$repo_root/.github/scripts/test-macos-cli-seal-preservation.sh"
 workflow_contract="$repo_root/.github/scripts/test-macos-release-artifact-workflows.sh"
 dual_package="$repo_root/.github/scripts/test-macos-roast-dual-package-graph.sh"
+verify_ordering="$repo_root/.github/scripts/test-macos-bundle-verify-ordering.sh"
 
 test -x "$verifier"
 test -x "$seal_probe"
 test -x "$workflow_contract"
 test -x "$dual_package"
+test -x "$verify_ordering"
 grep -Fq 'verify-macos-cli-bundle.sh "$archive" "$RELEASE_VERSION"' "$workflow"
 grep -Fq 'app="$workspace/$expected_root/Spectre.app"' "$verifier"
 grep -Fq 'codesign --verify --deep --strict --verbose=4 "$app"' "$verifier"
@@ -34,5 +36,6 @@ if grep -E 'codesign --verify --strict --verbose=4 "\$app"' "$workflow" | grep -
   exit 1
 fi
 
+bash "$verify_ordering"
 bash "$workflow_contract"
 bash "$seal_probe"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -178,6 +178,7 @@ val verifyMacosCliBundleReleaseContract by
                 ".github/scripts/test-macos-cli-seal-preservation.sh",
                 ".github/scripts/test-macos-release-artifact-workflows.sh",
                 ".github/scripts/test-macos-roast-dual-package-graph.sh",
+                ".github/scripts/test-macos-bundle-verify-ordering.sh",
                 ".github/scripts/inspect-macos-roast-package-dests.init.gradle.kts",
                 "docs/PUBLISHING.md",
                 "docs/RELEASE-SMOKE.md",
@@ -271,7 +272,13 @@ val buildSrcUnitTests by
 
 // Both tasks launch nested Gradle builds that write buildSrc/build. Running them concurrently can
 // corrupt a cache restore or expose a partially compiled buildSrc classpath on clean CI workers.
-verifyMacosCliBundleReleaseContract.configure { mustRunAfter(buildSrcUnitTests) }
+// #456: the seal-preservation script this task runs reads the packaged macOS zips under
+// cli/build/construo/distributions. An absent zip is fine — it skips the mutation probe — but a
+// half-written one fails `ditto -x -k` outright, which is what happens when Gradle schedules the
+// two together. Ordering only: `check` must not be made to build the macOS bundles.
+verifyMacosCliBundleReleaseContract.configure {
+    mustRunAfter(buildSrcUnitTests, ":cli:packageMacosArm64", ":cli:packageMacosX64")
+}
 
 tasks.named("check") {
     dependsOn(


### PR DESCRIPTION
## Summary

`verifyMacosCliBundleReleaseContract` runs `test-macos-cli-seal-preservation.sh`, which reads the packaged zips under `cli/build/construo/distributions`. It declared no dependency or ordering on `:cli:packageMacos*`, so Gradle was free to schedule it alongside or ahead of them.

An absent zip was already handled — the seal script skips the mutation probe. A **half-written** one was not: `ditto -x -k` fails with `Couldn't read pkzip signature` and the build dies. Observed twice on macOS during `./gradlew check`, with `:cli:packageMacosArm64` starting *after* the verification had already failed, and the task passing when re-run on its own afterwards.

`mustRunAfter` rather than `dependsOn` or an input declaration: this only needs ordering when both tasks are already in the graph, and `check` must not be made to build the macOS bundles.

Closes #456

## On the test

It asserts the **declared** ordering rather than a `--dry-run` listing. That matters: `--dry-run` prints a sequential order that says nothing about how a parallel build schedules the two, and the failure being guarded against was a parallel one. An earlier draft asserting on `--dry-run` **passed against the unfixed build**, which is why it was replaced.

Confirmed red without the ordering:

```
test-macos-bundle-verify-ordering: FAIL — verifyMacosCliBundleReleaseContract is not
  ordered after :cli:packageMacosArm64 :cli:packageMacosX64, so it can read a half-written zip (#456).
  found: verifyMacosCliBundleReleaseContract.configure { mustRunAfter(buildSrcUnitTests) }
```

## Test plan

- [x] New contract test red before the fix, green after
- [x] Chained into `test-verify-macos-cli-bundle.sh` and declared as a task input
- [x] `./gradlew check` green
- [x] `./gradlew ktfmtFormat` produced no changes

First `check` run hit two known flakes unrelated to this change — the macOS ScreenCaptureKit capture flake in `:cli`, and an `EOFException` at `IpcClient.kt:224` in `:agent`. Both passed on rerun. The second is the same failure site as #471, which was filed as Windows-only; I've noted the macOS sighting there.

## Confirmations

- [ ] ~I read CONTRIBUTING.md and this PR is **not** LLM-generated.~ — **Written by Claude Code at the repo owner's direction.**
- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)