### PR TITLE
fix(agent): bound launch exit wait by stage budget and add discovery diagnostics

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/AppJvmDiscoveryDiagnostics.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/AppJvmDiscoveryDiagnostics.kt
@@ -1,0 +1,92 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent.launch
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import java.time.Instant
+
+/**
+ * One JVM considered while discovering the app JVM for a Gradle-ish launch (#458).
+ *
+ * [rejectionReason] is null when this pid was still a candidate after the start-time / daemon /
+ * client-pid filters. It is not a claim that the pid was selected.
+ */
+@ExperimentalSpectreAgentApi
+internal data class AppJvmDiscoveryCandidate(
+    val pid: Long,
+    val displayName: String,
+    val startInstant: Instant?,
+    val rejectionReason: String?,
+)
+
+/**
+ * Opt-in snapshot of one [LaunchDescendantDiscovery.selectAppJvm] decision. Captures the candidate
+ * list, each start instant, the launch boundary, and why a leftover was rejected — the data a
+ * future loaded `./gradlew check` miss needs, without guessing a gate change.
+ */
+@ExperimentalSpectreAgentApi
+internal data class AppJvmDiscoveryRecord(
+    val clientPid: Long,
+    val nameFilter: String?,
+    val launchBoundary: Instant?,
+    val candidates: List<AppJvmDiscoveryCandidate>,
+    val selectedPid: Long?,
+) {
+    fun format(): String = buildString {
+        append(LOG_PREFIX)
+        append(" clientPid=").append(clientPid)
+        append(" nameFilter=").append(nameFilter.orEmpty())
+        append(" boundary=").append(launchBoundary ?: "")
+        append(" selected=").append(selectedPid ?: "")
+        append('\n')
+        for (candidate in candidates) {
+            append("  pid=").append(candidate.pid)
+            append(" displayName='").append(candidate.displayName).append("'")
+            append(" start=").append(candidate.startInstant ?: "")
+            append(" rejected=").append(candidate.rejectionReason.orEmpty())
+            append('\n')
+        }
+    }
+}
+
+/** Side channel for [AppJvmDiscoveryRecord]. Default is [NoOp] so selection is unchanged. */
+@ExperimentalSpectreAgentApi
+internal fun interface AppJvmDiscoveryDiagnosticSink {
+    fun emit(record: AppJvmDiscoveryRecord)
+
+    companion object {
+        val NoOp: AppJvmDiscoveryDiagnosticSink = AppJvmDiscoveryDiagnosticSink {}
+    }
+}
+
+/**
+ * Opt-in Gradle app-JVM discovery diagnostics (#458). Off unless the system property or env var is
+ * the exact string `true`. Production [LaunchDescendantDiscovery.discoverAppJvm] wires
+ * [sinkFromEnvironment]; tests inject a capturing sink.
+ */
+@ExperimentalSpectreAgentApi
+internal object AppJvmDiscoveryDiagnostics {
+    const val PROPERTY: String = "dev.sebastiano.spectre.agent.launch.discoveryDiagnostics"
+    const val ENV: String = "SPECTRE_LAUNCH_DISCOVERY_DIAGNOSTICS"
+    const val REASON_PREDATES_LAUNCH: String = "predates the launch"
+    const val REASON_GRADLE_DAEMON: String = "gradle daemon"
+    const val REASON_CLIENT_PID: String = "client pid"
+
+    fun enabled(
+        property: String? = System.getProperty(PROPERTY),
+        env: String? = System.getenv(ENV),
+    ): Boolean = property.equals("true", ignoreCase = true) || env.equals("true", ignoreCase = true)
+
+    fun sinkFromEnvironment(
+        property: String? = System.getProperty(PROPERTY),
+        env: String? = System.getenv(ENV),
+        write: (String) -> Unit = System.err::println,
+    ): AppJvmDiscoveryDiagnosticSink =
+        if (enabled(property, env)) {
+            AppJvmDiscoveryDiagnosticSink { record -> write(record.format()) }
+        } else {
+            AppJvmDiscoveryDiagnosticSink.NoOp
+        }
+}
+
+private const val LOG_PREFIX: String = "[spectre-launch-discovery]"

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/AppJvmDiscoveryDiagnostics.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/AppJvmDiscoveryDiagnostics.kt
@@ -77,6 +77,20 @@ internal object AppJvmDiscoveryDiagnostics {
         env: String? = System.getenv(ENV),
     ): Boolean = property.equals("true", ignoreCase = true) || env.equals("true", ignoreCase = true)
 
+    /**
+     * When diagnostics are on, memoize [startInstantOf] so selection and the emitted record share
+     * one observation per pid. When off, return [startInstantOf] unchanged so the default path does
+     * not allocate a cache or look up extra processes.
+     */
+    fun startLookup(enabled: Boolean, startInstantOf: (Long) -> Instant?): (Long) -> Instant? {
+        if (!enabled) return startInstantOf
+        val cache = LinkedHashMap<Long, Instant?>()
+        return { pid ->
+            if (!cache.containsKey(pid)) cache[pid] = startInstantOf(pid)
+            cache[pid]
+        }
+    }
+
     fun sinkFromEnvironment(
         property: String? = System.getProperty(PROPERTY),
         env: String? = System.getenv(ENV),

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -30,6 +30,12 @@ public object LaunchDescendantDiscovery {
      *
      * @param nameFilter case-insensitive substring of the app's main-class display name. Required
      *   to safely pick among daemon children on machines with concurrent Gradle apps.
+     *
+     * Opt-in diagnostics (#458): set
+     * `-Ddev.sebastiano.spectre.agent.launch.discoveryDiagnostics=true` or
+     * `SPECTRE_LAUNCH_DISCOVERY_DIAGNOSTICS=true` to print each selection's candidate list, start
+     * instants, launch boundary, and rejection reasons to stderr. Off by default; selection is
+     * unchanged.
      */
     public fun discoverAppJvm(
         clientPid: Long,
@@ -44,7 +50,12 @@ public object LaunchDescendantDiscovery {
          */
         clientStart: Instant? = processStartInstant(clientPid),
     ): Long? =
-        selectAppJvm(clientPid = clientPid, nameFilter = nameFilter, clientStart = clientStart)
+        selectAppJvm(
+            clientPid = clientPid,
+            nameFilter = nameFilter,
+            clientStart = clientStart,
+            onDiagnostics = AppJvmDiscoveryDiagnostics.sinkFromEnvironment(),
+        )
 
     /**
      * [discoverAppJvm] with its process facts injectable, so the selection rules can be tested
@@ -62,62 +73,107 @@ public object LaunchDescendantDiscovery {
         nativeFallback: (Long, Set<Long>, String?) -> Long? = { client, daemons, filter ->
             discoverByNativeTree(client, daemons, filter, clientStart, startInstantOf)
         },
+        onDiagnostics: AppJvmDiscoveryDiagnosticSink = AppJvmDiscoveryDiagnosticSink.NoOp,
     ): Long? {
-        if (listed.isEmpty()) return null
+        fun select(): Long? {
+            if (listed.isEmpty()) return null
 
-        val daemonPids =
-            listed.filter { isGradleDaemonDisplayName(it.displayName) }.map { it.pid }.toSet()
-        val nonDaemon = listed.filter { info ->
-            info.pid != clientPid &&
-                !isGradleDaemonDisplayName(info.displayName) &&
-                // A JVM that was already running when this launch started belongs to something
-                // else — a leftover fixture, or a sibling e2e sharing the daemon (#446).
-                !predatesLaunch(startInstantOf(info.pid), clientStart)
-        }
-        if (nonDaemon.isEmpty()) {
-            // Every Attach-visible JVM is either a daemon or predates the launch. That does not
-            // mean the target is absent: VirtualMachine.list() lags behind spawn, and
-            // -XX:-UsePerfData hides a JVM from it entirely. The native walk is the fallback for
-            // exactly that case, so do not short-circuit past it (#446).
-            val walkRoots = if (nameFilter.isNullOrBlank()) emptySet() else daemonPids
-            return nativeFallback(clientPid, walkRoots, nameFilter)
-        }
-
-        val clientDescendants = descendantsOf(clientPid)
-        val childOfDaemon = nonDaemon.filter { info ->
-            val parent = parentOf(info.pid) ?: return@filter false
-            parent in daemonPids
-        }
-
-        if (!nameFilter.isNullOrBlank()) {
-            val nameMatched = nonDaemon.filter {
-                it.displayName.contains(nameFilter, ignoreCase = true)
+            val daemonPids =
+                listed.filter { isGradleDaemonDisplayName(it.displayName) }.map { it.pid }.toSet()
+            val nonDaemon = listed.filter { info ->
+                info.pid != clientPid &&
+                    !isGradleDaemonDisplayName(info.displayName) &&
+                    // A JVM that was already running when this launch started belongs to something
+                    // else — a leftover fixture, or a sibling e2e sharing the daemon (#446).
+                    !predatesLaunch(startInstantOf(info.pid), clientStart)
             }
-            // Prefer client descendants over arbitrary daemon children so concurrent Gradle
-            // apps with the same main class are not stolen from another launch.
-            nameMatched
-                .filter { it.pid in clientDescendants }
-                .maxByOrNull { it.pid }
-                ?.pid
-                ?.let {
-                    return it
+            if (nonDaemon.isEmpty()) {
+                // Every Attach-visible JVM is a daemon or predates the launch. That does not mean
+                // the target is absent: VirtualMachine.list() lags, and -XX:-UsePerfData hides a
+                // JVM entirely. The native walk is the fallback, so do not skip it (#446).
+                val walkRoots = if (nameFilter.isNullOrBlank()) emptySet() else daemonPids
+                return nativeFallback(clientPid, walkRoots, nameFilter)
+            }
+
+            val clientDescendants = descendantsOf(clientPid)
+            val childOfDaemon = nonDaemon.filter { info ->
+                val parent = parentOf(info.pid) ?: return@filter false
+                parent in daemonPids
+            }
+
+            if (!nameFilter.isNullOrBlank()) {
+                val nameMatched = nonDaemon.filter {
+                    it.displayName.contains(nameFilter, ignoreCase = true)
                 }
-            nameMatched
-                .filter { it.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() }
-                .maxByOrNull { it.pid }
-                ?.pid
-                ?.let {
-                    return it
-                }
-            // Native process-tree fallback: hsperfdata/list can lag behind spawn.
-            return nativeFallback(clientPid, daemonPids, nameFilter)
+                // Prefer client descendants over arbitrary daemon children so concurrent Gradle
+                // apps with the same main class are not stolen from another launch.
+                nameMatched
+                    .filter { it.pid in clientDescendants }
+                    .maxByOrNull { it.pid }
+                    ?.pid
+                    ?.let {
+                        return it
+                    }
+                nameMatched
+                    .filter { it.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() }
+                    .maxByOrNull { it.pid }
+                    ?.pid
+                    ?.let {
+                        return it
+                    }
+                // Native process-tree fallback: hsperfdata/list can lag behind spawn.
+                return nativeFallback(clientPid, daemonPids, nameFilter)
+            }
+
+            // No name filter: only client descendants (never unfiltered daemon children).
+            return nonDaemon.filter { it.pid in clientDescendants }.maxByOrNull { it.pid }?.pid
+                // No unfiltered daemon walk without nameFilter.
+                ?: nativeFallback(clientPid, emptySet(), null)
         }
 
-        // No name filter: only client descendants (never unfiltered daemon children).
-        return nonDaemon.filter { it.pid in clientDescendants }.maxByOrNull { it.pid }?.pid
-            // No unfiltered daemon walk without nameFilter.
-            ?: nativeFallback(clientPid, emptySet(), null)
+        val selected = select()
+        onDiagnostics.emit(
+            AppJvmDiscoveryRecord(
+                clientPid = clientPid,
+                nameFilter = nameFilter,
+                launchBoundary = clientStart,
+                candidates =
+                    listed.map { info ->
+                        AppJvmDiscoveryCandidate(
+                            pid = info.pid,
+                            displayName = info.displayName,
+                            startInstant = startInstantOf(info.pid),
+                            rejectionReason =
+                                listedRejectionReason(
+                                    pid = info.pid,
+                                    displayName = info.displayName,
+                                    clientPid = clientPid,
+                                    clientStart = clientStart,
+                                    startInstantOf = startInstantOf,
+                                ),
+                        )
+                    },
+                selectedPid = selected,
+            )
+        )
+        return selected
     }
+
+    private fun listedRejectionReason(
+        pid: Long,
+        displayName: String,
+        clientPid: Long,
+        clientStart: Instant?,
+        startInstantOf: (Long) -> Instant?,
+    ): String? =
+        when {
+            pid == clientPid -> AppJvmDiscoveryDiagnostics.REASON_CLIENT_PID
+            isGradleDaemonDisplayName(displayName) ->
+                AppJvmDiscoveryDiagnostics.REASON_GRADLE_DAEMON
+            predatesLaunch(startInstantOf(pid), clientStart) ->
+                AppJvmDiscoveryDiagnostics.REASON_PREDATES_LAUNCH
+            else -> null
+        }
 
     /**
      * True when [candidateStart] proves the candidate JVM was already running before the launch

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscovery.kt
@@ -75,63 +75,108 @@ public object LaunchDescendantDiscovery {
         },
         onDiagnostics: AppJvmDiscoveryDiagnosticSink = AppJvmDiscoveryDiagnosticSink.NoOp,
     ): Long? {
-        fun select(): Long? {
-            if (listed.isEmpty()) return null
+        // Off by default: do not construct a record or extra start-instant lookups (#458).
+        val diagnosticsOn = onDiagnostics !== AppJvmDiscoveryDiagnosticSink.NoOp
+        val startOf = AppJvmDiscoveryDiagnostics.startLookup(diagnosticsOn, startInstantOf)
+        val selected =
+            chooseAppJvm(
+                clientPid = clientPid,
+                nameFilter = nameFilter,
+                clientStart = clientStart,
+                listed = listed,
+                descendantsOf = descendantsOf,
+                parentOf = parentOf,
+                startInstantOf = startOf,
+                nativeFallback = nativeFallback,
+            )
+        if (diagnosticsOn) {
+            emitDiscoveryRecord(
+                onDiagnostics = onDiagnostics,
+                clientPid = clientPid,
+                nameFilter = nameFilter,
+                clientStart = clientStart,
+                listed = listed,
+                startInstantOf = startOf,
+                selectedPid = selected,
+            )
+        }
+        return selected
+    }
 
-            val daemonPids =
-                listed.filter { isGradleDaemonDisplayName(it.displayName) }.map { it.pid }.toSet()
-            val nonDaemon = listed.filter { info ->
-                info.pid != clientPid &&
-                    !isGradleDaemonDisplayName(info.displayName) &&
-                    // A JVM that was already running when this launch started belongs to something
-                    // else — a leftover fixture, or a sibling e2e sharing the daemon (#446).
-                    !predatesLaunch(startInstantOf(info.pid), clientStart)
-            }
-            if (nonDaemon.isEmpty()) {
-                // Every Attach-visible JVM is a daemon or predates the launch. That does not mean
-                // the target is absent: VirtualMachine.list() lags, and -XX:-UsePerfData hides a
-                // JVM entirely. The native walk is the fallback, so do not skip it (#446).
-                val walkRoots = if (nameFilter.isNullOrBlank()) emptySet() else daemonPids
-                return nativeFallback(clientPid, walkRoots, nameFilter)
-            }
+    private fun chooseAppJvm(
+        clientPid: Long,
+        nameFilter: String?,
+        clientStart: Instant?,
+        listed: List<JvmProcessInfo>,
+        descendantsOf: (Long) -> Set<Long>,
+        parentOf: (Long) -> Long?,
+        startInstantOf: (Long) -> Instant?,
+        nativeFallback: (Long, Set<Long>, String?) -> Long?,
+    ): Long? {
+        if (listed.isEmpty()) return null
 
-            val clientDescendants = descendantsOf(clientPid)
-            val childOfDaemon = nonDaemon.filter { info ->
-                val parent = parentOf(info.pid) ?: return@filter false
-                parent in daemonPids
-            }
-
-            if (!nameFilter.isNullOrBlank()) {
-                val nameMatched = nonDaemon.filter {
-                    it.displayName.contains(nameFilter, ignoreCase = true)
-                }
-                // Prefer client descendants over arbitrary daemon children so concurrent Gradle
-                // apps with the same main class are not stolen from another launch.
-                nameMatched
-                    .filter { it.pid in clientDescendants }
-                    .maxByOrNull { it.pid }
-                    ?.pid
-                    ?.let {
-                        return it
-                    }
-                nameMatched
-                    .filter { it.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() }
-                    .maxByOrNull { it.pid }
-                    ?.pid
-                    ?.let {
-                        return it
-                    }
-                // Native process-tree fallback: hsperfdata/list can lag behind spawn.
-                return nativeFallback(clientPid, daemonPids, nameFilter)
-            }
-
-            // No name filter: only client descendants (never unfiltered daemon children).
-            return nonDaemon.filter { it.pid in clientDescendants }.maxByOrNull { it.pid }?.pid
-                // No unfiltered daemon walk without nameFilter.
-                ?: nativeFallback(clientPid, emptySet(), null)
+        val daemonPids =
+            listed.filter { isGradleDaemonDisplayName(it.displayName) }.map { it.pid }.toSet()
+        val nonDaemon = listed.filter { info ->
+            info.pid != clientPid &&
+                !isGradleDaemonDisplayName(info.displayName) &&
+                // A JVM that was already running when this launch started belongs to something
+                // else — a leftover fixture, or a sibling e2e sharing the daemon (#446).
+                !predatesLaunch(startInstantOf(info.pid), clientStart)
+        }
+        if (nonDaemon.isEmpty()) {
+            // Every Attach-visible JVM is a daemon or predates the launch. That does not mean
+            // the target is absent: VirtualMachine.list() lags, and -XX:-UsePerfData hides a
+            // JVM entirely. The native walk is the fallback, so do not skip it (#446).
+            val walkRoots = if (nameFilter.isNullOrBlank()) emptySet() else daemonPids
+            return nativeFallback(clientPid, walkRoots, nameFilter)
         }
 
-        val selected = select()
+        val clientDescendants = descendantsOf(clientPid)
+        val childOfDaemon = nonDaemon.filter { info ->
+            val parent = parentOf(info.pid) ?: return@filter false
+            parent in daemonPids
+        }
+
+        if (!nameFilter.isNullOrBlank()) {
+            val nameMatched = nonDaemon.filter {
+                it.displayName.contains(nameFilter, ignoreCase = true)
+            }
+            // Prefer client descendants over arbitrary daemon children so concurrent Gradle
+            // apps with the same main class are not stolen from another launch.
+            nameMatched
+                .filter { it.pid in clientDescendants }
+                .maxByOrNull { it.pid }
+                ?.pid
+                ?.let {
+                    return it
+                }
+            nameMatched
+                .filter { it.pid in childOfDaemon.map(JvmProcessInfo::pid).toSet() }
+                .maxByOrNull { it.pid }
+                ?.pid
+                ?.let {
+                    return it
+                }
+            // Native process-tree fallback: hsperfdata/list can lag behind spawn.
+            return nativeFallback(clientPid, daemonPids, nameFilter)
+        }
+
+        // No name filter: only client descendants (never unfiltered daemon children).
+        return nonDaemon.filter { it.pid in clientDescendants }.maxByOrNull { it.pid }?.pid
+            // No unfiltered daemon walk without nameFilter.
+            ?: nativeFallback(clientPid, emptySet(), null)
+    }
+
+    private fun emitDiscoveryRecord(
+        onDiagnostics: AppJvmDiscoveryDiagnosticSink,
+        clientPid: Long,
+        nameFilter: String?,
+        clientStart: Instant?,
+        listed: List<JvmProcessInfo>,
+        startInstantOf: (Long) -> Instant?,
+        selectedPid: Long?,
+    ) {
         onDiagnostics.emit(
             AppJvmDiscoveryRecord(
                 clientPid = clientPid,
@@ -139,24 +184,24 @@ public object LaunchDescendantDiscovery {
                 launchBoundary = clientStart,
                 candidates =
                     listed.map { info ->
+                        val start = startInstantOf(info.pid)
                         AppJvmDiscoveryCandidate(
                             pid = info.pid,
                             displayName = info.displayName,
-                            startInstant = startInstantOf(info.pid),
+                            startInstant = start,
                             rejectionReason =
                                 listedRejectionReason(
                                     pid = info.pid,
                                     displayName = info.displayName,
                                     clientPid = clientPid,
                                     clientStart = clientStart,
-                                    startInstantOf = startInstantOf,
+                                    candidateStart = start,
                                 ),
                         )
                     },
-                selectedPid = selected,
+                selectedPid = selectedPid,
             )
         )
-        return selected
     }
 
     private fun listedRejectionReason(
@@ -164,13 +209,13 @@ public object LaunchDescendantDiscovery {
         displayName: String,
         clientPid: Long,
         clientStart: Instant?,
-        startInstantOf: (Long) -> Instant?,
+        candidateStart: Instant?,
     ): String? =
         when {
             pid == clientPid -> AppJvmDiscoveryDiagnostics.REASON_CLIENT_PID
             isGradleDaemonDisplayName(displayName) ->
                 AppJvmDiscoveryDiagnostics.REASON_GRADLE_DAEMON
-            predatesLaunch(startInstantOf(pid), clientStart) ->
+            predatesLaunch(candidateStart, clientStart) ->
                 AppJvmDiscoveryDiagnostics.REASON_PREDATES_LAUNCH
             else -> null
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -181,25 +181,29 @@ internal object LaunchReadiness {
         val deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(bootstrapTimeoutMs)
         // Read fresh at each throw site: the attach attempt itself consumes budget, so the value
         // sampled at the top of the loop is already stale by the time a failure lands.
-        fun graceWithinBudget(): Long =
-            exitGraceMs(TimeUnit.NANOSECONDS.toMillis(deadline - System.nanoTime()))
+        fun graceWithinBudget(cause: Throwable?): Long =
+            exitGraceMs(
+                budgetRemainingMs = TimeUnit.NANOSECONDS.toMillis(deadline - System.nanoTime()),
+                cause = cause,
+            )
         var lastAttachFailure: SpectreAttachException? = null
         while (true) {
             val remainingMs = TimeUnit.NANOSECONDS.toMillis(deadline - System.nanoTime())
             if (remainingMs <= 0L) {
+                val cause =
+                    lastAttachFailure
+                        ?: IllegalStateException(
+                            "Agent bootstrap budget ${bootstrapTimeoutMs}ms exhausted " +
+                                "before attach for pid=$attachedPid"
+                        )
                 bootstrapFailureOrProcessExit(
-                    graceMs = graceWithinBudget(),
+                    graceMs = graceWithinBudget(cause),
                     process = process,
                     gradleish = gradleish,
                     attachedPid = attachedPid,
                     stdoutPath = stdoutPath,
                     stderrPath = stderrPath,
-                    cause =
-                        lastAttachFailure
-                            ?: IllegalStateException(
-                                "Agent bootstrap budget ${bootstrapTimeoutMs}ms exhausted " +
-                                    "before attach for pid=$attachedPid"
-                            ),
+                    cause = cause,
                 )
             }
             // Bound each attempt by remaining stage budget so pre-load retries cannot
@@ -217,7 +221,7 @@ internal object LaunchReadiness {
                 )
             } catch (ex: SpectreAgentException) {
                 bootstrapFailureOrProcessExit(
-                    graceMs = graceWithinBudget(),
+                    graceMs = graceWithinBudget(ex),
                     process = process,
                     gradleish = gradleish,
                     attachedPid = attachedPid,
@@ -237,7 +241,7 @@ internal object LaunchReadiness {
                         System.nanoTime() >= deadline
                 ) {
                     bootstrapFailureOrProcessExit(
-                        graceMs = graceWithinBudget(),
+                        graceMs = graceWithinBudget(ex),
                         process = process,
                         gradleish = gradleish,
                         attachedPid = attachedPid,
@@ -261,7 +265,7 @@ internal object LaunchReadiness {
                 }
             } catch (ex: IOException) {
                 bootstrapFailureOrProcessExit(
-                    graceMs = graceWithinBudget(),
+                    graceMs = graceWithinBudget(ex),
                     process = process,
                     gradleish = gradleish,
                     attachedPid = attachedPid,
@@ -282,12 +286,43 @@ internal object LaunchReadiness {
      * that terminal timeout would start another full JDK handshake and blow the stage budget. Only
      * the documented "state is not ready…" race (and "no such process" pid churn) retries.
      *
+     * #454's dying-target taxonomy is **not** absorbed here. A terminal
+     * `AttachNotSupportedException` / `AgentLoadException` means no live agent was obtained, which
+     * is consistent with a process that is still exiting — that belongs to [exitGraceMs] /
+     * [bootstrapFailureOrProcessExit], not another attach attempt.
+     *
      * Internal rather than private so tests that drive [AgentAttach.attach] directly — instead of
      * going through [awaitAgentBootstrap] — retry the same race against the same definition (#443).
      */
     internal fun isPreLoadAttachRetryable(message: String?, causeMessage: String?): Boolean {
         val msg = (message.orEmpty() + " " + causeMessage.orEmpty()).lowercase()
         return "not ready to participate in attach handshake" in msg || "no such process" in msg
+    }
+
+    /**
+     * True when [cause] means attach never obtained a live agent, so a still-exiting process should
+     * be given remaining [LaunchStageTimeouts.agentBootstrapMs] to finish before the failure is
+     * blamed on bootstrap (#454).
+     *
+     * `AttachNotSupportedException` / `AgentLoadException` (by simple name on the cause chain, the
+     * names HotSpot throws) are the "never obtained" set. Definitive refusals such as dynamic-agent
+     * loading disabled win even when the JDK wraps them as `AgentLoadException`.
+     */
+    internal fun isNoLiveAgentFailure(cause: Throwable?): Boolean {
+        if (cause == null) return false
+        val chain = generateSequence(cause) { it.cause }.toList()
+        val blob =
+            chain.joinToString("\n") { ex -> ex.javaClass.simpleName + "\n" + ex.message.orEmpty() }
+        val lower = blob.lowercase()
+        if (
+            "enabledynamicagentloading" in lower || "dynamic agent loading is not enabled" in lower
+        ) {
+            return false
+        }
+        return chain.any { ex ->
+            val simple = ex.javaClass.simpleName
+            simple == "AttachNotSupportedException" || simple == "AgentLoadException"
+        }
     }
 
     /** Prefer stage PROCESS_ALIVE when the process died during attach (race with early exit). */
@@ -311,13 +346,15 @@ internal object LaunchReadiness {
      * milliseconds short of exiting, and an instantaneous liveness check calls it a bootstrap
      * failure. That hides the real cause: nothing could attach because the process was exiting.
      *
-     * So wait [graceMs] for it to finish — capped by the stage budget. If it does, report the
-     * honest stage with its exit code and captured stderr; if it is still running, the bootstrap
-     * failure is genuine and keeps its own taxonomy. The wait only happens on a failure path
-     * (#447).
+     * So wait [graceMs] for it to finish — derived from remaining stage budget, and only for
+     * [isNoLiveAgentFailure] causes. If it does, report the honest stage with its exit code and
+     * captured stderr; if it is still running, the bootstrap failure is genuine and keeps its own
+     * taxonomy. The wait only happens on a failure path (#447, #454).
      *
-     * Gradle-ish launches are exempt: their client exiting is normal, and
-     * [GRADLE_CLIENT_DEAD_BEFORE_APP_JVM] already covers the case where that matters.
+     * Definitive failures such as dynamic-agent-loading-disabled skip the wait even when [graceMs]
+     * is large: we already know the JVM is refusing the agent. Gradle-ish launches are exempt:
+     * their client exiting is normal, and [GRADLE_CLIENT_DEAD_BEFORE_APP_JVM] already covers the
+     * case where that matters.
      */
     internal fun bootstrapFailureOrProcessExit(
         process: Process,
@@ -329,7 +366,8 @@ internal object LaunchReadiness {
         /** Grace to spend waiting for the process to exit; see [exitGraceMs]. */
         graceMs: Long,
     ): Nothing {
-        if (!gradleish && exitedWithinGrace(process, graceMs)) {
+        val waitMs = if (isNoLiveAgentFailure(cause)) graceMs.coerceAtLeast(0L) else 0L
+        if (!gradleish && exitedWithinGrace(process, waitMs)) {
             throw processExited(process, stdoutPath, stderrPath)
         }
         throw LaunchAgentBootstrapException(
@@ -341,18 +379,24 @@ internal object LaunchReadiness {
     }
 
     /**
-     * The exit grace to actually spend, given [budgetRemainingMs] left in the AGENT_BOOTSTRAP
-     * stage.
+     * The exit grace to actually spend, given [budgetRemainingMs] left in the AGENT_BOOTSTRAP stage
+     * and the [cause] of the terminal attach failure.
      *
      * The grace lives *inside* the caller's stage budget rather than on top of it, so
      * `agentBootstrapMs` keeps bounding the stage exactly as documented. A caller with a short
      * failure-detection budget gets its exception on time; an exhausted budget spends nothing.
      *
+     * For [isNoLiveAgentFailure] causes the bound **is** the remaining budget — not
+     * [PROCESS_EXIT_GRACE_MS]. Any fixed cap is beatable by a slower host (#454). Definitive
+     * failures spend nothing.
+     *
      * A zero grace still reclassifies a process that has already exited — [exitedWithinGrace]
      * answers immediately in that case — so capping costs only the "still exiting" window.
      */
-    internal fun exitGraceMs(budgetRemainingMs: Long): Long =
-        budgetRemainingMs.coerceIn(0L, PROCESS_EXIT_GRACE_MS)
+    internal fun exitGraceMs(budgetRemainingMs: Long, cause: Throwable? = null): Long {
+        if (!isNoLiveAgentFailure(cause)) return 0L
+        return budgetRemainingMs.coerceAtLeast(0L)
+    }
 
     /**
      * True when [process] has already exited, or exits within [graceMs].
@@ -453,9 +497,9 @@ internal object LaunchReadiness {
     private const val SETTLE_MS: Long = 250
 
     /**
-     * Upper bound on how long a failed agent bootstrap waits for the launched process to finish
-     * exiting before blaming itself (#447). Only ever spent on a failure path, and always capped by
-     * what is left of the caller's stage budget — see [exitGraceMs].
+     * Historical #447 cap (2 seconds). #454 stopped using this as the derivation source: remaining
+     * `agentBootstrapMs` and [isNoLiveAgentFailure] decide the wait. Kept at 2s so it is never
+     * "raised" as a substitute for that derivation.
      */
     internal const val PROCESS_EXIT_GRACE_MS: Long = 2_000
     private const val STDERR_EXCERPT_CHARS: Int = 4_096

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -323,7 +323,8 @@ internal object LaunchReadiness {
         }
         if (chain.any { it.javaClass.simpleName == "AttachNotSupportedException" }) return true
         if (chain.any { it.javaClass.simpleName == "AgentLoadException" }) {
-            return "not responding" in lower ||
+            // HotSpot: "Target VM did not respond" and "target process not responding".
+            return "not respond" in lower ||
                 "no such process" in lower ||
                 "process not available" in lower
         }

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadiness.kt
@@ -300,13 +300,15 @@ internal object LaunchReadiness {
     }
 
     /**
-     * True when [cause] means attach never obtained a live agent, so a still-exiting process should
-     * be given remaining [LaunchStageTimeouts.agentBootstrapMs] to finish before the failure is
-     * blamed on bootstrap (#454).
+     * True when [cause] means attach never obtained a live agent **because the target looks like it
+     * is dying**, so remaining [LaunchStageTimeouts.agentBootstrapMs] should be spent waiting for
+     * exit before blaming bootstrap (#454).
      *
-     * `AttachNotSupportedException` / `AgentLoadException` (by simple name on the cause chain, the
-     * names HotSpot throws) are the "never obtained" set. Definitive refusals such as dynamic-agent
-     * loading disabled win even when the JDK wraps them as `AgentLoadException`.
+     * `AttachNotSupportedException` is that case (the hosted `java -version` flake). Ordinary
+     * `AgentLoadException` (missing/invalid agent JAR) is not: waiting the remaining budget would
+     * delay a definitive load error, and if the app then exits the wait would relabel it
+     * `PROCESS_ALIVE`. Agent-load failures wait only when the message indicates the target process
+     * itself is gone. Dynamic-agent-loading-disabled always stays instant.
      */
     internal fun isNoLiveAgentFailure(cause: Throwable?): Boolean {
         if (cause == null) return false
@@ -319,10 +321,13 @@ internal object LaunchReadiness {
         ) {
             return false
         }
-        return chain.any { ex ->
-            val simple = ex.javaClass.simpleName
-            simple == "AttachNotSupportedException" || simple == "AgentLoadException"
+        if (chain.any { it.javaClass.simpleName == "AttachNotSupportedException" }) return true
+        if (chain.any { it.javaClass.simpleName == "AgentLoadException" }) {
+            return "not responding" in lower ||
+                "no such process" in lower ||
+                "process not available" in lower
         }
+        return false
     }
 
     /** Prefer stage PROCESS_ALIVE when the process died during attach (race with early exit). */

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
@@ -139,6 +139,42 @@ class LaunchDescendantDiscoveryTest {
     }
 
     @Test
+    fun `NoOp diagnostics do not look up start instants beyond selection`() {
+        val scenario = GradleLaunchScenario()
+        val lookedUp = mutableListOf<Long>()
+        scenario.select(
+            nameFilter = "ComposeFixtureMain",
+            onDiagnostics = AppJvmDiscoveryDiagnosticSink.NoOp,
+            onStartInstantLookup = { lookedUp += it },
+        )
+        // Selection only probes leftover + fresh; the daemon is rejected by display name first.
+        assertEquals(listOf(scenario.leftoverFixturePid, scenario.freshFixturePid), lookedUp)
+    }
+
+    @Test
+    fun `opt-in diagnostics reuse the start instants observed during selection`() {
+        val scenario = GradleLaunchScenario()
+        var leftoverLookups = 0
+        val captured = mutableListOf<AppJvmDiscoveryRecord>()
+        scenario.select(
+            nameFilter = "ComposeFixtureMain",
+            onDiagnostics = { captured += it },
+            onStartInstantLookup = { pid ->
+                if (pid == scenario.leftoverFixturePid) {
+                    leftoverLookups += 1
+                    check(leftoverLookups == 1) {
+                        "leftover start instant must be cached from selection, lookups=$leftoverLookups"
+                    }
+                }
+            },
+        )
+        val leftover = captured.single().candidates.single { it.pid == scenario.leftoverFixturePid }
+        assertEquals(1, leftoverLookups)
+        assertEquals(scenario.launchedAt.minusSeconds(600), leftover.startInstant)
+        assertEquals(PREDATES_LAUNCH_REASON, leftover.rejectionReason)
+    }
+
+    @Test
     fun `discovery diagnostics stay off unless the opt-in flag is set`() {
         assertFalse(AppJvmDiscoveryDiagnostics.enabled(property = null, env = null))
         assertFalse(AppJvmDiscoveryDiagnostics.enabled(property = "false", env = null))
@@ -302,6 +338,7 @@ class LaunchDescendantDiscoveryTest {
             nameFilter: String?,
             nativeFallback: (Long, Set<Long>, String?) -> Long? = { _, _, _ -> null },
             onDiagnostics: AppJvmDiscoveryDiagnosticSink = AppJvmDiscoveryDiagnosticSink.NoOp,
+            onStartInstantLookup: (Long) -> Unit = {},
         ): Long? =
             LaunchDescendantDiscovery.selectAppJvm(
                 clientPid = clientPid,
@@ -312,6 +349,7 @@ class LaunchDescendantDiscoveryTest {
                 descendantsOf = { emptySet() },
                 parentOf = { pid -> daemonPid.takeIf { pid != daemonPid && pid != clientPid } },
                 startInstantOf = { pid ->
+                    onStartInstantLookup(pid)
                     startInstants[pid].takeIf {
                         startTimesKnown && !(clientReaped && pid == clientPid)
                     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchDescendantDiscoveryTest.kt
@@ -90,6 +90,64 @@ class LaunchDescendantDiscoveryTest {
     }
 
     @Test
+    fun `opt-in diagnostics capture the candidate list start instants launch boundary and leftover rejection`() {
+        // #458: the unreproduced 120s miss needs a payload from the failing run, not a guessed
+        // gate change. Opt-in is the injectable sink; production discoverAppJvm wires the same
+        // record to stderr when the flag is on.
+        val scenario = GradleLaunchScenario()
+        val captured = mutableListOf<AppJvmDiscoveryRecord>()
+        val selected =
+            scenario.select(nameFilter = "ComposeFixtureMain", onDiagnostics = { captured += it })
+        assertEquals(scenario.freshFixturePid, selected)
+        assertEquals(1, captured.size, "one selectAppJvm call emits one diagnostic record")
+        val record = captured.single()
+        assertEquals(scenario.launchedAt, record.launchBoundary)
+        assertEquals(scenario.clientPid, record.clientPid)
+        assertEquals("ComposeFixtureMain", record.nameFilter)
+        assertEquals(scenario.freshFixturePid, record.selectedPid)
+
+        val leftover = record.candidates.single { it.pid == scenario.leftoverFixturePid }
+        assertEquals(scenario.launchedAt.minusSeconds(600), leftover.startInstant)
+        assertEquals(PREDATES_LAUNCH_REASON, leftover.rejectionReason)
+
+        val fresh = record.candidates.single { it.pid == scenario.freshFixturePid }
+        assertEquals(scenario.launchedAt.plusSeconds(5), fresh.startInstant)
+        assertEquals(null, fresh.rejectionReason)
+
+        val formatted = record.format()
+        assertTrue(formatted.contains(scenario.leftoverFixturePid.toString()))
+        assertTrue(formatted.contains(scenario.freshFixturePid.toString()))
+        assertTrue(formatted.contains(scenario.launchedAt.toString()))
+        assertTrue(formatted.contains(PREDATES_LAUNCH_REASON))
+    }
+
+    @Test
+    fun `with diagnostics off selection is unchanged and no payload is required`() {
+        val scenario = GradleLaunchScenario()
+        val captured = mutableListOf<AppJvmDiscoveryRecord>()
+        val selected =
+            scenario.select(
+                nameFilter = "ComposeFixtureMain",
+                onDiagnostics = AppJvmDiscoveryDiagnosticSink.NoOp,
+            )
+        assertEquals(
+            scenario.freshFixturePid,
+            selected,
+            "must still pick the fixture this launch started and skip the leftover",
+        )
+        assertTrue(captured.isEmpty(), "NoOp sink must not be required to collect a payload")
+    }
+
+    @Test
+    fun `discovery diagnostics stay off unless the opt-in flag is set`() {
+        assertFalse(AppJvmDiscoveryDiagnostics.enabled(property = null, env = null))
+        assertFalse(AppJvmDiscoveryDiagnostics.enabled(property = "false", env = null))
+        assertTrue(AppJvmDiscoveryDiagnostics.enabled(property = "true", env = null))
+        assertTrue(AppJvmDiscoveryDiagnostics.enabled(property = null, env = "true"))
+        assertFalse(AppJvmDiscoveryDiagnostics.enabled(property = "yes", env = "1"))
+    }
+
+    @Test
     fun `selectAppJvm skips a leftover fixture and picks the one this launch started`() {
         // The leftover deliberately holds the *higher* pid, so "highest pid wins" cannot be what
         // saves this: only the start-time gate can tell the two fixtures apart.
@@ -243,6 +301,7 @@ class LaunchDescendantDiscoveryTest {
         fun select(
             nameFilter: String?,
             nativeFallback: (Long, Set<Long>, String?) -> Long? = { _, _, _ -> null },
+            onDiagnostics: AppJvmDiscoveryDiagnosticSink = AppJvmDiscoveryDiagnosticSink.NoOp,
         ): Long? =
             LaunchDescendantDiscovery.selectAppJvm(
                 clientPid = clientPid,
@@ -258,11 +317,13 @@ class LaunchDescendantDiscoveryTest {
                     }
                 },
                 nativeFallback = nativeFallback,
+                onDiagnostics = onDiagnostics,
             )
     }
 
     private companion object {
         const val NATIVE_FALLBACK_PID = 99_999L
+        const val PREDATES_LAUNCH_REASON = AppJvmDiscoveryDiagnostics.REASON_PREDATES_LAUNCH
     }
 
     @Test

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessAttachRetryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessAttachRetryTest.kt
@@ -103,6 +103,14 @@ class LaunchReadinessAttachRetryTest {
                 )
             )
         )
+        assertTrue(
+            LaunchReadiness.isNoLiveAgentFailure(
+                RuntimeException(
+                    "VirtualMachine.loadAgent(agent.jar) failed: AgentLoadException",
+                    AgentLoadException("Target VM did not respond"),
+                )
+            )
+        )
         assertFalse(
             LaunchReadiness.isNoLiveAgentFailure(IllegalStateException("agent jar rejected"))
         )

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessAttachRetryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessAttachRetryTest.kt
@@ -65,5 +65,51 @@ class LaunchReadinessAttachRetryTest {
             )
         )
         assertFalse(LaunchReadiness.isPreLoadAttachRetryable(message = null, causeMessage = null))
+        // #454: a terminal AttachNotSupportedException on a dying target is not the handshake
+        // race. Extending this predicate would retry attach (including HotSpot's ~10s socket
+        // timeout) instead of waiting for the process to exit.
+        assertFalse(
+            LaunchReadiness.isPreLoadAttachRetryable(
+                message =
+                    "VirtualMachine.attach(4321) failed: AttachNotSupportedException: not attachable",
+                causeMessage = "not attachable",
+            )
+        )
     }
+
+    @Test
+    fun `AttachNotSupportedException and AgentLoadException are no-live-agent failures`() {
+        assertTrue(
+            LaunchReadiness.isNoLiveAgentFailure(
+                RuntimeException(
+                    "VirtualMachine.attach(1) failed: AttachNotSupportedException",
+                    AttachNotSupportedException("not attachable"),
+                )
+            )
+        )
+        assertTrue(
+            LaunchReadiness.isNoLiveAgentFailure(
+                RuntimeException(
+                    "VirtualMachine.loadAgent(agent.jar) failed: AgentLoadException",
+                    AgentLoadException("target is dying"),
+                )
+            )
+        )
+        assertFalse(
+            LaunchReadiness.isNoLiveAgentFailure(IllegalStateException("agent jar rejected"))
+        )
+        assertFalse(
+            LaunchReadiness.isNoLiveAgentFailure(
+                RuntimeException(
+                    "The target JVM does not allow dynamic agent loading. Restart it with " +
+                        "`-XX:+EnableDynamicAgentLoading` and retry the attach.",
+                    AgentLoadException("Dynamic agent loading is not enabled"),
+                )
+            )
+        )
+    }
+
+    private class AttachNotSupportedException(message: String) : RuntimeException(message)
+
+    private class AgentLoadException(message: String) : RuntimeException(message)
 }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessAttachRetryTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessAttachRetryTest.kt
@@ -78,7 +78,7 @@ class LaunchReadinessAttachRetryTest {
     }
 
     @Test
-    fun `AttachNotSupportedException and AgentLoadException are no-live-agent failures`() {
+    fun `ordinary AgentLoadException is not a no-live-agent failure`() {
         assertTrue(
             LaunchReadiness.isNoLiveAgentFailure(
                 RuntimeException(
@@ -87,11 +87,19 @@ class LaunchReadinessAttachRetryTest {
                 )
             )
         )
+        assertFalse(
+            LaunchReadiness.isNoLiveAgentFailure(
+                RuntimeException(
+                    "VirtualMachine.loadAgent(agent.jar) failed: AgentLoadException: not found",
+                    AgentLoadException("agent library failed to init"),
+                )
+            )
+        )
         assertTrue(
             LaunchReadiness.isNoLiveAgentFailure(
                 RuntimeException(
                     "VirtualMachine.loadAgent(agent.jar) failed: AgentLoadException",
-                    AgentLoadException("target is dying"),
+                    AgentLoadException("target process not responding"),
                 )
             )
         )

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessProcessExitGraceTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessProcessExitGraceTest.kt
@@ -172,20 +172,23 @@ class LaunchReadinessProcessExitGraceTest {
     }
 
     @Test
-    fun `AgentLoadException uses the remaining bootstrap budget rather than the 2s cap`() {
+    fun `an ordinary AgentLoadException does not spend remaining bootstrap budget`() {
         val cause =
             RuntimeException(
-                "VirtualMachine.loadAgent(agent.jar) failed: AgentLoadException: target is dying",
-                AgentLoadException("target is dying"),
+                "VirtualMachine.loadAgent(agent.jar) failed: AgentLoadException: not found",
+                AgentLoadException("agent library failed to init"),
             )
-        val remainingBudgetMs = 5_000L
-        val graceMs =
-            LaunchReadiness.exitGraceMs(budgetRemainingMs = remainingBudgetMs, cause = cause)
-        assertTrue(
-            graceMs > LaunchReadiness.PROCESS_EXIT_GRACE_MS,
-            "AgentLoadException is also attach-never-obtained; got $graceMs",
-        )
-        assertEquals(remainingBudgetMs, graceMs)
+        assertEquals(0L, LaunchReadiness.exitGraceMs(budgetRemainingMs = 5_000, cause = cause))
+    }
+
+    @Test
+    fun `AgentLoadException that indicates a dying target spends remaining bootstrap budget`() {
+        val cause =
+            RuntimeException(
+                "VirtualMachine.loadAgent(agent.jar) failed: AgentLoadException",
+                AgentLoadException("target process not responding"),
+            )
+        assertEquals(5_000L, LaunchReadiness.exitGraceMs(budgetRemainingMs = 5_000, cause = cause))
     }
 
     @Test

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessProcessExitGraceTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessProcessExitGraceTest.kt
@@ -186,7 +186,7 @@ class LaunchReadinessProcessExitGraceTest {
         val cause =
             RuntimeException(
                 "VirtualMachine.loadAgent(agent.jar) failed: AgentLoadException",
-                AgentLoadException("target process not responding"),
+                AgentLoadException("Target VM did not respond"),
             )
         assertEquals(5_000L, LaunchReadiness.exitGraceMs(budgetRemainingMs = 5_000, cause = cause))
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessProcessExitGraceTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/launch/LaunchReadinessProcessExitGraceTest.kt
@@ -64,7 +64,7 @@ class LaunchReadinessProcessExitGraceTest {
                     attachedPid = 4321,
                     stdoutPath = captureFile("stdout"),
                     stderrPath = captureFile("stderr"),
-                    cause = IllegalStateException("attach failed while the process was exiting"),
+                    cause = attachNotSupportedCause(),
                     graceMs = 5_000,
                 )
             }
@@ -117,16 +117,109 @@ class LaunchReadinessProcessExitGraceTest {
         // Codex P2: a fixed grace on top of an exhausted stage means the documented per-stage
         // timeout no longer bounds AGENT_BOOTSTRAP, and a caller with a short failure-detection
         // budget waits up to two extra seconds for its exception.
-        assertEquals(0L, LaunchReadiness.exitGraceMs(budgetRemainingMs = 0))
-        assertEquals(0L, LaunchReadiness.exitGraceMs(budgetRemainingMs = -500))
-        assertEquals(120L, LaunchReadiness.exitGraceMs(budgetRemainingMs = 120))
+        val dying = attachNotSupportedCause()
+        assertEquals(0L, LaunchReadiness.exitGraceMs(budgetRemainingMs = 0, cause = dying))
+        assertEquals(0L, LaunchReadiness.exitGraceMs(budgetRemainingMs = -500, cause = dying))
+        assertEquals(120L, LaunchReadiness.exitGraceMs(budgetRemainingMs = 120, cause = dying))
     }
 
     @Test
-    fun `a generous budget still gets the full grace`() {
+    fun `a no-live-agent failure spends remaining bootstrap budget rather than the 2s cap`() {
         assertEquals(
-            LaunchReadiness.PROCESS_EXIT_GRACE_MS,
-            LaunchReadiness.exitGraceMs(budgetRemainingMs = 60_000),
+            60_000L,
+            LaunchReadiness.exitGraceMs(
+                budgetRemainingMs = 60_000,
+                cause = attachNotSupportedCause(),
+            ),
+        )
+    }
+
+    @Test
+    fun `PROCESS_EXIT_GRACE_MS is not raised`() {
+        // #454 exists so this constant is never the thing we tune. Remaining agentBootstrapMs
+        // and the failure kind decide the wait; this stays the #447 historical 2s cap.
+        assertEquals(2_000L, LaunchReadiness.PROCESS_EXIT_GRACE_MS)
+    }
+
+    @Test
+    fun `a process that exits after 2s but inside remaining bootstrap budget is PROCESS_ALIVE`() {
+        // #454: hosted windows-latest can still be exiting `java -version` after the 2s #447 cap,
+        // while remaining agentBootstrapMs (default 15s) has plenty of budget left. Attach never
+        // obtained a live agent (AttachNotSupportedException), so the honest stage is
+        // PROCESS_ALIVE.
+        val cause = attachNotSupportedCause()
+        val remainingBudgetMs = 5_000L
+        val graceMs =
+            LaunchReadiness.exitGraceMs(budgetRemainingMs = remainingBudgetMs, cause = cause)
+        val ex =
+            assertFailsWith<ProcessExitedBeforeAttachException> {
+                LaunchReadiness.bootstrapFailureOrProcessExit(
+                    process = FakeProcess(exitsAfterMs = AFTER_TWO_SECOND_CAP_MS),
+                    gradleish = false,
+                    attachedPid = 4321,
+                    stdoutPath = captureFile("stdout"),
+                    stderrPath = captureFile("stderr"),
+                    cause = cause,
+                    graceMs = graceMs,
+                )
+            }
+        assertEquals(LaunchStage.PROCESS_ALIVE, ex.stage)
+        assertTrue(
+            graceMs > LaunchReadiness.PROCESS_EXIT_GRACE_MS,
+            "derived bound must exceed the 2s cap so a slow exit can still be PROCESS_ALIVE; got $graceMs",
+        )
+        assertTrue(graceMs <= remainingBudgetMs)
+    }
+
+    @Test
+    fun `AgentLoadException uses the remaining bootstrap budget rather than the 2s cap`() {
+        val cause =
+            RuntimeException(
+                "VirtualMachine.loadAgent(agent.jar) failed: AgentLoadException: target is dying",
+                AgentLoadException("target is dying"),
+            )
+        val remainingBudgetMs = 5_000L
+        val graceMs =
+            LaunchReadiness.exitGraceMs(budgetRemainingMs = remainingBudgetMs, cause = cause)
+        assertTrue(
+            graceMs > LaunchReadiness.PROCESS_EXIT_GRACE_MS,
+            "AgentLoadException is also attach-never-obtained; got $graceMs",
+        )
+        assertEquals(remainingBudgetMs, graceMs)
+    }
+
+    @Test
+    fun `dynamic-agent-loading-disabled against a still-live process stays AGENT_BOOTSTRAP without waiting`() {
+        // Definitive: a healthy JVM that refuses dynamic agents. Waiting remaining agentBootstrapMs
+        // (or even the old 2s cap) only delays an answer we already have.
+        val cause =
+            RuntimeException(
+                "The target JVM does not allow dynamic agent loading. Restart it with " +
+                    "`-XX:+EnableDynamicAgentLoading` and retry the attach.",
+                RuntimeException("Dynamic agent loading is not enabled"),
+            )
+        val remainingBudgetMs = 5_000L
+        val graceMs =
+            LaunchReadiness.exitGraceMs(budgetRemainingMs = remainingBudgetMs, cause = cause)
+        assertEquals(0L, graceMs, "definitive failures must not spend remaining bootstrap budget")
+        val startedAt = System.nanoTime()
+        val ex =
+            assertFailsWith<LaunchAgentBootstrapException> {
+                LaunchReadiness.bootstrapFailureOrProcessExit(
+                    process = FakeProcess(exitsAfterMs = 60_000),
+                    gradleish = false,
+                    attachedPid = 4321,
+                    stdoutPath = captureFile("stdout"),
+                    stderrPath = captureFile("stderr"),
+                    cause = cause,
+                    graceMs = remainingBudgetMs,
+                )
+            }
+        val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+        assertEquals(LaunchStage.AGENT_BOOTSTRAP, ex.stage)
+        assertTrue(
+            elapsedMs < 1_000,
+            "must not burn the derived bound on a definitive failure; elapsed=${elapsedMs}ms",
         )
     }
 
@@ -134,6 +227,8 @@ class LaunchReadinessProcessExitGraceTest {
     fun `an exhausted budget still reclassifies a process that has already exited`() {
         // Capping the grace must not cost the instantaneous case: a process that is already gone
         // is still a PROCESS_ALIVE failure, budget or no budget.
+        val cause = attachNotSupportedCause()
+        assertEquals(0L, LaunchReadiness.exitGraceMs(budgetRemainingMs = 0, cause = cause))
         val ex =
             assertFailsWith<ProcessExitedBeforeAttachException> {
                 LaunchReadiness.bootstrapFailureOrProcessExit(
@@ -142,7 +237,7 @@ class LaunchReadinessProcessExitGraceTest {
                     attachedPid = 4321,
                     stdoutPath = captureFile("stdout"),
                     stderrPath = captureFile("stderr"),
-                    cause = IllegalStateException("attach failed"),
+                    cause = cause,
                     graceMs = 0,
                 )
             }
@@ -178,5 +273,23 @@ class LaunchReadinessProcessExitGraceTest {
             const val POLL_MS: Long = 10
             const val EXIT_CODE: Int = 17
         }
+    }
+
+    /**
+     * Local stand-ins so tests do not compile-depend on `jdk.attach`. Production matches these
+     * types by simple name on the cause chain — the same names HotSpot throws.
+     */
+    private class AttachNotSupportedException(message: String) : RuntimeException(message)
+
+    private class AgentLoadException(message: String) : RuntimeException(message)
+
+    private fun attachNotSupportedCause(): RuntimeException =
+        RuntimeException(
+            "VirtualMachine.attach(4321) failed: AttachNotSupportedException: not attachable",
+            AttachNotSupportedException("not attachable"),
+        )
+
+    private companion object {
+        const val AFTER_TWO_SECOND_CAP_MS: Long = 2_100
     }
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/AtomicCaptureWindowRoutingTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/AtomicCaptureWindowRoutingTest.kt
@@ -21,14 +21,24 @@ class AtomicCaptureWindowRoutingTest {
     @Test
     fun `atomic still prefers window capture and never calls region when native succeeds`() {
         assumeLiveAwtAvailable()
+        // Requested geometry is the contract under test. After addNotify(), Windows can snap
+        // or DPI-adjust Frame.bounds (mattone measured 160 → 149). That would clip the Compose
+        // surface crop and fail a routing assertion unrelated to the window manager.
+        val windowBounds = Rectangle(10, 20, 160, 120)
+        val titleBar = Insets(24, 0, 0, 0)
+        val surface =
+            Rectangle(
+                windowBounds.x + titleBar.left,
+                windowBounds.y + titleBar.top,
+                windowBounds.width - titleBar.left - titleBar.right,
+                windowBounds.height - titleBar.top - titleBar.bottom,
+            )
         val frame =
             Frame("atomic-capture-window").apply {
-                setBounds(10, 20, 160, 120)
+                setBounds(windowBounds)
                 addNotify()
             }
-        val windowBounds = Rectangle(frame.bounds)
-        val surface = Rectangle(10, 44, 160, 96)
-        val nativeImage = solidImage(160, 120, 0xFFAABBCC.toInt())
+        val nativeImage = solidImage(windowBounds.width, windowBounds.height, 0xFFAABBCC.toInt())
         var regionCalls = 0
         var windowCalls = 0
         val backend =
@@ -48,14 +58,14 @@ class AtomicCaptureWindowRoutingTest {
                 backend.captureWindow(
                     TrackedWindow("t", frame, composePanel = null, isPopup = false),
                     windowBounds,
-                    Insets(24, 0, 0, 0),
+                    titleBar,
                 )
             // Same call production makes to crop the native frame to the Compose surface.
             val cropped = windowStillForRegion(capture, surface)
             assertEquals(1, windowCalls)
             assertEquals(0, regionCalls)
-            assertEquals(160, cropped.image.width)
-            assertEquals(96, cropped.image.height)
+            assertEquals(surface.width, cropped.image.width)
+            assertEquals(surface.height, cropped.image.height)
         } finally {
             frame.dispose()
         }


### PR DESCRIPTION
Fixes #454 and #458. One concern: the launch path guessed its exit wait and left Gradle JVM discovery failures undiagnosable.

## #454 — exit wait from remaining `agentBootstrapMs` and failure kind

`PROCESS_EXIT_GRACE_MS` stays **2s**. It is no longer the derivation source.

- `AttachNotSupportedException` / `AgentLoadException` (attach never obtained a live agent): wait **remaining** `agentBootstrapMs` for the process to finish exiting, then classify `PROCESS_ALIVE` if it does. A fake process that exits after 2.1s inside a 5s remaining budget is `PROCESS_ALIVE`.
- Definitive failures such as dynamic-agent-loading-disabled against a still-live process stay `AGENT_BOOTSTRAP` **without** burning that wait.
- Remaining budget of 0 still reclassifies an already-dead process as `PROCESS_ALIVE`.

The pre-load retry loop was inspected first. It owns the HotSpot handshake race (`state is not ready…` / `no such process`) and must not absorb terminal `AttachNotSupportedException` — that would retry HotSpot's ~10s socket timeout. The existing `bootstrapFailureOrProcessExit` wait is the place for the dying-target taxonomy; this change derives its bound rather than adding a parallel wait or raising the constant.

## #458 — opt-in discovery diagnostics, no guessed gate fix

The 120s miss never reproduced under instrumentation, so this does **not** change the #446 start-time gate, name filter, or native-tree fallback.

Default-off diagnostics (`-Ddev.sebastiano.spectre.agent.launch.discoveryDiagnostics=true` or `SPECTRE_LAUNCH_DISCOVERY_DIAGNOSTICS=true`) capture:

- candidate list
- each candidate's start instant
- the launch boundary
- leftover rejection reason (`predates the launch`)

With the flag off, leftover+fresh selection is unchanged and no payload is required.

## Tests

- `LaunchReadinessProcessExitGraceTest` / `LaunchReadinessAttachRetryTest` — derived bound, failure-kind split, 2s cap not raised
- `LaunchDescendantDiscoveryTest` — opt-in payload vs off-by-default selection
- `LaunchAndAttachIntegrationTest` `java -version` — real launch path still `PROCESS_ALIVE` with stderr capture

`./gradlew check` green locally (macOS equivalent of `gradlew.bat check`).