### PR TITLE
fix(core): fail loudly when an X11 click never reaches this JVM

### DIFF
--- a/core/api/core.api
+++ b/core/api/core.api
@@ -210,6 +210,12 @@ public final class dev/sebastiano/spectre/core/InputCapabilities {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class dev/sebastiano/spectre/core/InputDeliveryWitnessKt {
+	public static final fun clickPressDeliveryVerifiable (Ljava/lang/String;)Z
+	public static synthetic fun clickPressDeliveryVerifiable$default (Ljava/lang/String;ILjava/lang/Object;)Z
+	public static final fun clickVerified (Ldev/sebastiano/spectre/core/RobotDriver;IILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public final class dev/sebastiano/spectre/core/InputLeaseOptions {
 	public synthetic fun <init> (JLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (JLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -184,7 +184,8 @@ private constructor(
      * Unlike the coordinate overloads, this verifies the OS actually delivered the press to this
      * JVM and throws [IllegalStateException] when it did not — the target is aimed at one of this
      * JVM's own nodes, so a press that never arrives can only be a failure. Silently succeeding
-     * here is what made #460 present as a stale semantics tree.
+     * here is what made #460 present as a stale semantics tree. Verification runs on Windows for
+     * every mouse verb and on X11 for clicks; macOS and X11 wheel stay unverified.
      */
     public suspend fun click(node: AutomatorNode) {
         val center = node.centerOnScreen

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputDeliveryWitness.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputDeliveryWitness.kt
@@ -78,7 +78,19 @@ internal interface InputDeliveryWitness {
 internal object AwtInputDeliveryWitness : InputDeliveryWitness {
 
     override fun observe(input: DispatchedInput): InputDeliveryWitness.Observation? {
-        if (!inputDeliveryVerifiable()) return null
+        if (!inputDeliveryVerifiable(input = input)) return null
+        return attachListener(input)
+    }
+
+    /**
+     * Attaches the Toolkit listener without consulting [inputDeliveryVerifiable].
+     *
+     * Production dispatch still goes through [observe], which applies the OS/verb gate. Tests that
+     * need the oracle's dispatched-vs-never-dispatched verdict on a host where the gate would
+     * decline (macOS; X11 wheel) call this directly so they exercise the shipped listener rather
+     * than a reimplementation.
+     */
+    internal fun attachListener(input: DispatchedInput): InputDeliveryWitness.Observation? {
         val toolkit = runCatching { Toolkit.getDefaultToolkit() }.getOrNull() ?: return null
         val delivered = CountDownLatch(1)
         val listener = AWTEventListener { event ->
@@ -111,39 +123,58 @@ internal object AwtInputDeliveryWitness : InputDeliveryWitness {
 }
 
 /**
- * Whether "no AWT event arrived" is sound evidence that input was discarded, on this platform.
+ * Whether "no AWT event arrived" is sound evidence that input was discarded, on this platform and
+ * for this verb.
  *
- * Only on Windows. #460 is a Windows problem and Windows is where the behaviour was measured, but
- * the real constraint is that the oracle is **unsound elsewhere**: on macOS, AppKit consumes the
- * click that activates an inactive application without delivering it to the window at all, so a
- * perfectly healthy first click legitimately produces no event. `AgentAttachIntegrationTest`
- * already compensates for exactly that by retrying, and treating the swallowed activation click as
- * a failure would break the retry it depends on. X11 has its own divergences (the wheel is button
- * 4/5 presses, so it emits nothing for a zero-notch scroll).
+ * Windows: every mouse verb. #460 is the measured case (SendInput discarded off the input desktop).
+ * X11: **click/press only** (#470) — a real-OS click aimed at this JVM that produces no matching
+ * press is a delivery miss, not a Compose miss. macOS stays off because AppKit consumes the click
+ * that activates an inactive application without delivering it, so a perfectly healthy first click
+ * legitimately produces no event; `AgentAttachIntegrationTest` retries exactly that, and treating
+ * the swallowed activation click as a failure would break the retry it depends on. X11 wheel stays
+ * off because the wheel is button 4/5 presses, so a wheel oracle is unsound (including a zero-notch
+ * scroll, which emits nothing at all).
  *
- * Declining to observe reuses the existing "cannot testify" path, so non-Windows behaviour is
- * exactly what it was before this guard existed.
+ * Declining to observe reuses the existing "cannot testify" path.
  */
 internal fun inputDeliveryVerifiable(
+    osName: String = System.getProperty("os.name").orEmpty(),
+    input: DispatchedInput = DispatchedInput.Press,
+): Boolean {
+    if (osName.startsWith("Windows", ignoreCase = true)) return true
+    if (osName.contains("mac", ignoreCase = true)) return false
+    val linux = osName.contains("linux", ignoreCase = true)
+    return linux && input == DispatchedInput.Press
+}
+
+/**
+ * Whether a node-targeted click's press can be witnessed on this OS.
+ *
+ * Escape hatch for in-repo smokes that aim a coordinate click at this JVM and need to know if a
+ * miss should be read as **never dispatched** versus **unverifiable here**.
+ */
+@InternalSpectreApi
+public fun clickPressDeliveryVerifiable(
     osName: String = System.getProperty("os.name").orEmpty()
-): Boolean = osName.startsWith("Windows", ignoreCase = true)
+): Boolean = inputDeliveryVerifiable(osName, DispatchedInput.Press)
 
 /**
  * [RobotDriver.click], plus verification that the OS actually delivered the press to this JVM.
  *
- * Reserved for node-targeted callers ([ComposeAutomator.click]), where the input is aimed at one of
- * this JVM's own Compose nodes and an event that never arrives is unambiguously a failure. The
- * public coordinate overloads stay unverified on purpose: a caller may quite legitimately drive
- * input outside this JVM's windows, for instance to dismiss a popup.
+ * Reserved for callers who know the target is one of this JVM's own windows: node-targeted
+ * [ComposeAutomator.click], and in-repo smokes such as the unfocused-counter click. The public
+ * coordinate overloads stay unverified on purpose: a caller may quite legitimately drive input
+ * outside this JVM's windows, for instance to dismiss a popup.
  *
  * These live outside [RobotDriver] as extensions rather than members because the driver is already
  * at the project's per-class function ceiling, and because keeping the whole delivery-verification
  * feature in one file makes it easier to reason about than five methods scattered through the input
  * surface.
  *
- * Throws [IllegalStateException] when the input was discarded — see #460.
+ * Throws [IllegalStateException] when the input was discarded — see #460 and #470.
  */
-internal suspend fun RobotDriver.clickVerified(screenX: Int, screenY: Int) {
+@InternalSpectreApi
+public suspend fun RobotDriver.clickVerified(screenX: Int, screenY: Int) {
     verifyingDelivery("click", screenX, screenY, DispatchedInput.Press) { click(screenX, screenY) }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/AwtInputDeliveryWitnessTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/AwtInputDeliveryWitnessTest.kt
@@ -1,0 +1,69 @@
+package dev.sebastiano.spectre.core
+
+import java.awt.Panel
+import java.awt.Toolkit
+import java.awt.event.MouseEvent
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+
+/**
+ * Exercises the shipped Toolkit AWT listener, not a reimplementation. Distinguishes **dispatched in
+ * this JVM** from **never dispatched** independently of `clickCount` / `typeText` — the
+ * diagnostic #470 needs for an unfocused Xvfb click miss.
+ *
+ * Bypasses [inputDeliveryVerifiable] via [AwtInputDeliveryWitness.attachListener] so the oracle can
+ * be proven on hosts where the production gate declines (macOS).
+ */
+class AwtInputDeliveryWitnessTest {
+
+    @Test
+    fun `shipped AWT listener reports dispatched when a matching press is posted`() {
+        val observation = AwtInputDeliveryWitness.attachListener(DispatchedInput.Press)
+        assumeTrue(observation != null, "toolkit refused the AWT listener")
+        checkNotNull(observation).use { watch ->
+            val press =
+                MouseEvent(
+                    Panel(),
+                    MouseEvent.MOUSE_PRESSED,
+                    System.currentTimeMillis(),
+                    0,
+                    1,
+                    1,
+                    1,
+                    false,
+                )
+            Toolkit.getDefaultToolkit().systemEventQueue.postEvent(press)
+            val dispatched = watch.awaitDelivery(INPUT_WITNESS_WAIT_MS)
+            println("AWT click verdict: dispatched in this JVM (posted MOUSE_PRESSED)=$dispatched")
+            assertTrue(dispatched, "posted MOUSE_PRESSED must count as dispatched in this JVM")
+        }
+    }
+
+    @Test
+    fun `shipped AWT listener reports never dispatched when the queue drains with no press`() {
+        val observation = AwtInputDeliveryWitness.attachListener(DispatchedInput.Press)
+        assumeTrue(observation != null, "toolkit refused the AWT listener")
+        checkNotNull(observation).use { watch ->
+            val seen = watch.awaitDelivery(NO_EVENT_WAIT_MS)
+            val drained = watch.awaitQueueDrain(DRAIN_WAIT_MS)
+            val late = watch.awaitDelivery(0)
+            val neverDispatched = !seen && drained && !late
+            println(
+                "AWT click verdict: never dispatched in this JVM=$neverDispatched " +
+                    "(seen=$seen drained=$drained late=$late; no press posted)"
+            )
+            assertFalse(seen, "no press was posted, so none should have been dispatched")
+            assertTrue(drained, "EDT must drain for a never-dispatched verdict to be trustworthy")
+            assertFalse(late)
+            assertTrue(neverDispatched)
+        }
+    }
+
+    private companion object {
+        const val INPUT_WITNESS_WAIT_MS = 2_000L
+        const val NO_EVENT_WAIT_MS = 50L
+        const val DRAIN_WAIT_MS = 500L
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/RobotDriverTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.core
 
 import java.awt.Point
@@ -676,15 +678,57 @@ class RobotDriverTest {
     }
 
     /**
-     * The oracle is only sound on Windows. On macOS AppKit swallows the click that activates an
-     * inactive app without delivering it, so a healthy first click produces no event —
-     * `AgentAttachIntegrationTest` relies on retrying exactly that.
+     * The oracle is sound on Windows for every mouse verb, and on X11 for click/press (#470). macOS
+     * AppKit swallows the click that activates an inactive app, so a healthy first click produces
+     * no event — `AgentAttachIntegrationTest` relies on retrying exactly that. X11's wheel is
+     * button 4/5 presses, so a wheel oracle is still unsound there.
      */
     @Test
-    fun `input delivery is only verifiable on Windows`() {
-        assertTrue(inputDeliveryVerifiable("Windows 11"))
-        assertFalse(inputDeliveryVerifiable("Mac OS X"))
-        assertFalse(inputDeliveryVerifiable("Linux"))
+    fun `input delivery is verifiable for click presses on Windows and X11`() {
+        assertTrue(inputDeliveryVerifiable("Windows 11", DispatchedInput.Press))
+        assertTrue(inputDeliveryVerifiable("Linux", DispatchedInput.Press))
+        assertFalse(inputDeliveryVerifiable("Mac OS X", DispatchedInput.Press))
+    }
+
+    @Test
+    fun `input delivery is not verifiable for wheel on X11 or any verb on macOS`() {
+        assertTrue(inputDeliveryVerifiable("Windows 11", DispatchedInput.Wheel))
+        assertFalse(inputDeliveryVerifiable("Linux", DispatchedInput.Wheel))
+        assertFalse(inputDeliveryVerifiable("Mac OS X", DispatchedInput.Wheel))
+        assertFalse(inputDeliveryVerifiable("Mac OS X", DispatchedInput.Press))
+    }
+
+    @Test
+    fun `Linux is not a blanket skip for click presses`() {
+        assertTrue(
+            inputDeliveryVerifiable("Linux", DispatchedInput.Press),
+            "Linux remaining a blanket skip would let an Xvfb click miss fail silently (#470)",
+        )
+        assertTrue(clickPressDeliveryVerifiable("Linux"))
+        assertTrue(clickPressDeliveryVerifiable("Windows 11"))
+        assertFalse(clickPressDeliveryVerifiable("Mac OS X"))
+    }
+
+    @Test
+    fun `never-delivered click fails naming the click delivery miss`() = runTest {
+        val witness = FakeInputDeliveryWitness(delivered = false)
+        val driver = realInputDriver(witness)
+
+        val failure =
+            assertFailsWith<IllegalStateException> {
+                driver.clickVerified(screenX = 8, screenY = 9)
+            }
+
+        val message = failure.message.orEmpty()
+        assertTrue(message.contains("click"), "must name the click, was: $message")
+        assertTrue(
+            message.contains("no matching mouse event"),
+            "must name the delivery miss, was: $message",
+        )
+        assertFalse(
+            message.contains("typeText"),
+            "must not report the downstream typeText symptom, was: $message",
+        )
     }
 
     private fun realInputDriver(

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -93,8 +93,9 @@ which compensates for HiDPI/display scaling.
 ### Undelivered input fails loudly on Windows
 
 On Windows, node-targeted `click`, `doubleClick`, `longClick`, `swipe(from, to)` and
-`scrollWheel(node)` check that the event actually arrived. If Spectre dispatches the input
-and no matching mouse event reaches the target JVM, the call throws
+`scrollWheel(node)` check that the event actually arrived. On X11, the same check runs for
+clicks (`click`, `doubleClick`, `longClick`, `swipe`) but not for the wheel. If Spectre
+dispatches the input and no matching mouse event reaches the target JVM, the call throws
 `IllegalStateException` in process, or reports `inputRejected` over the attach path.
 Earlier versions returned normally without doing anything.
 
@@ -103,14 +104,15 @@ input desktop. The common causes are a locked workstation, or a process running 
 desktop that is not the input one — including a non-interactive session such as Windows
 session 0, an SSH shell, or a scheduled task started while logged out. Input that lands
 somewhere else looks the same from inside the target: another window covering it, or a
-scroll delivered to the focused window rather than the one under the pointer.
+scroll delivered to the focused window rather than the one under the pointer. On X11 the
+same silent no-op can happen for a click that never reaches this JVM.
 
-The check runs on Windows only. macOS swallows the click that activates an application,
-and on X11 the wheel arrives as button presses, so a missing event does not prove
-anything on those platforms. Behaviour there is unchanged.
+The check does not run on macOS, where AppKit swallows the click that activates an
+application, or for X11 wheel events, which arrive as button presses.
 
 If you hit this, fix the environment rather than the test: run on an unlocked, interactive
-desktop. See [#460](https://github.com/rock3r/spectre/issues/460) for the investigation.
+desktop. See [#460](https://github.com/rock3r/spectre/issues/460) for the Windows
+investigation.
 
 ## Mouse: hover and pointer moves
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -223,8 +223,9 @@ previous clipboard contents. A few failure modes follow from those contracts:
   focused text field. If your test never clicked into the field — or the click landed
   on something else, e.g., a parent that absorbed it — the input lands in the wrong
   place, or does nothing. Use `clearAndTypeText(node, …)` (which clicks first) or
-  precede the call with an explicit `automator.click(field)`. On Windows, a click that
-  never reaches the target JVM now throws instead of doing nothing quietly — see
+  precede the call with an explicit `automator.click(field)`. On Windows, and for clicks
+  on X11, a node-targeted click that never reaches the target JVM now throws instead of
+  doing nothing quietly — see
   [undelivered input](interactions.md#undelivered-input-fails-loudly-on-windows).
 - **The field doesn't accept paste.** Some Compose components (and any read-only
   text field) ignore the system paste shortcut. Verify the field accepts pasted

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotUnfocusedSmoke.kt
@@ -42,6 +42,9 @@ import kotlinx.coroutines.runBlocking
  *    the same scenario step, on both XWayland and Xvfb. (Reflects the X11 click-to-focus
  *    convention; differs from macOS, where the first click on an inactive app traditionally
  *    activates without delivering — to be verified separately when MacOsRobotUnfocusedSmoke runs.)
+ *    An intermittent Xvfb miss that never reaches this JVM is reported at the click, with an AWT
+ *    press verdict (never dispatched vs dispatched with no Compose effect), not at the downstream
+ *    `typeText` assertion.
  * 4. **typeText-after-focus-click works through XWayland.** `typeText` sends key events rather than
  *    touching the clipboard. Both XWayland and Xvfb produce the expected text after the
  *    focus-handoff click.

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/RobotSmokeRig.kt
@@ -1,3 +1,5 @@
+@file:OptIn(InternalSpectreApi::class)
+
 package dev.sebastiano.spectre.sample
 
 import androidx.compose.foundation.background
@@ -31,7 +33,10 @@ import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
+import dev.sebastiano.spectre.core.InternalSpectreApi
 import dev.sebastiano.spectre.core.RobotDriver
+import dev.sebastiano.spectre.core.clickPressDeliveryVerifiable
+import dev.sebastiano.spectre.core.clickVerified
 import java.awt.Rectangle
 import java.awt.Window
 import java.util.Locale
@@ -507,16 +512,45 @@ internal suspend fun scenarioClickOnUnfocusedCounter(
     }
     val before = state.clickCount
     val sutFocusedBefore = state.frame?.isFocused == true
-    driver.click(target.x, target.y)
+    val verifiable = clickPressDeliveryVerifiable()
+    val awtVerdict =
+        try {
+            driver.clickVerified(target.x, target.y)
+            if (verifiable) {
+                "AWT mouse press dispatched in this JVM"
+            } else {
+                "AWT mouse press unverifiable on this OS"
+            }
+        } catch (failure: IllegalStateException) {
+            val message = failure.message.orEmpty()
+            if ("no matching mouse event" in message) {
+                return ScenarioResult(
+                    "click on unfocused counter increments + transfers focus",
+                    passed = false,
+                    detail =
+                        "never dispatched in this JVM — clickCount $before → $before; " +
+                            "sut.isFocused $sutFocusedBefore → $sutFocusedBefore " +
+                            "at (${target.x},${target.y}); $message",
+                )
+            }
+            throw failure
+        }
     delay(POST_CLICK_SETTLE_MS.milliseconds)
     val after = state.clickCount
     val sutFocusedAfter = state.frame?.isFocused == true
+    val passed = after == before + 1 && sutFocusedAfter
+    val effect =
+        if (!passed && verifiable) {
+            "dispatched with no Compose effect"
+        } else {
+            awtVerdict
+        }
     return ScenarioResult(
         "click on unfocused counter increments + transfers focus",
-        passed = after == before + 1 && sutFocusedAfter,
+        passed = passed,
         detail =
             "clickCount $before → $after; sut.isFocused $sutFocusedBefore → $sutFocusedAfter " +
-                "at (${target.x},${target.y})",
+                "at (${target.x},${target.y}); $effect",
     )
 }
 
@@ -556,7 +590,11 @@ internal suspend fun runUnfocusedScenarios(
     delay(POST_CLICK_SETTLE_MS.milliseconds)
     results += scenarioPressKeyOnUnfocusedField(driver, state)
     results += scenarioClickOnUnfocusedCounter(driver, state)
-    results += scenarioTypeTextAfterFocusClick(driver, state)
+    // A click miss is the root failure (#470). Do not run typeText on top of it — that
+    // downstream assertion is what made the Xvfb flake look like a paste problem.
+    if (results.last().passed) {
+        results += scenarioTypeTextAfterFocusClick(driver, state)
+    }
     return results
 }
 


### PR DESCRIPTION
## Summary

Fixes #470. An unfocused Robot click under Xvfb could miss entirely (`clickCount 0 → 0`, `sut.isFocused false → false`) and only fail later at `typeText`. The click is the root; the paste assertion is downstream.

The 8da3f90 input-delivery witness now runs for **click/press on X11** as well as Windows. A real-OS click aimed at this JVM that produces no matching mouse press throws immediately, naming the click/delivery miss. Wheel on X11 and macOS activation clicks stay unverified — those oracles are still unsound.

No retries, no extra click settles, no "click until `clickCount` ticks".

## What changed

- `inputDeliveryVerifiable` is verb-aware: Windows = all mouse verbs; Linux/X11 = `Press` only; macOS = none.
- `AwtInputDeliveryWitness.observe` consults that gate per dispatch. Tests of the shipped Toolkit listener distinguish **dispatched in this JVM** vs **never dispatched** independently of `clickCount` / `typeText`.
- Unfocused-counter smoke (`RobotSmokeRig.scenarioClickOnUnfocusedCounter`) uses `clickVerified` and records the AWT press verdict. A click miss skips the downstream `typeText` scenario.
- Docs: undelivered-input guidance now covers X11 clicks.

## How to judge this

Local host is macOS; `:sample-desktop:runLinuxRobotUnfocusedSmoke` is `onlyIf` Linux and skipped twice here. The in-repo bar is the RobotDriver delivery-policy tests plus `./gradlew check`.

**Do not merge on a single `validation-linux` green.** The original flake passed on a re-run of the same run id with no code change. Require more than one `runLinuxRobotUnfocusedSmoke` result under Xvfb, and if it fails, the first attributed failure should be the click (with an AWT press verdict), not `typeText`.

## Non-goals

- Making the flake always pass.
- Enabling the witness for X11 wheel or macOS.
- #460's Windows mouse half.
- Merging this PR.