### PR TITLE
fix(agent): do not RST a replacement UDS client while orphaned input is in flight (#471)

### DIFF
--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -12,6 +12,7 @@ import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Server-side IPC endpoint: binds a Unix Domain Socket at [udsPath], accepts a single client
@@ -84,6 +85,7 @@ constructor(
 
     private val running = AtomicBoolean(true)
     private val inputWorkers = CrossSessionInputWorkers()
+    private val currentClient = AtomicReference<SocketChannel?>(null)
 
     private val acceptThread =
         Thread(::acceptLoop, "spectre-agent-accept").apply {
@@ -96,69 +98,85 @@ constructor(
         get() = udsPath
 
     private fun acceptLoop() {
-        while (running.get()) {
-            val client =
-                try {
-                    serverChannel.accept() ?: break
-                } catch (_: ClosedChannelException) {
-                    // Normal shutdown — close() closes the server channel, which unblocks
-                    // accept(). Exit the loop cleanly.
-                    return
-                } catch (ex: IOException) {
-                    // accept() itself failed (e.g. the server channel is broken at the OS
-                    // level). There's nothing we can recover here — the channel is unusable.
-                    if (running.get()) {
-                        System.err.println("[spectre-agent] accept failed: ${ex.message}")
+        try {
+            while (running.get()) {
+                val incoming =
+                    try {
+                        serverChannel.accept() ?: break
+                    } catch (_: ClosedChannelException) {
+                        // Normal shutdown — close() closes the server channel, which unblocks
+                        // accept(). Exit the loop cleanly.
+                        return
+                    } catch (ex: IOException) {
+                        // accept() itself failed (e.g. the server channel is broken at the OS
+                        // level). There's nothing we can recover here — the channel is unusable.
+                        if (running.get()) {
+                            System.err.println("[spectre-agent] accept failed: ${ex.message}")
+                        }
+                        return
                     }
-                    return
-                }
-            // Per-connection failures (broken pipe from a crashed client mid-`writeFrame`,
-            // half-closed sockets, malformed framing, …) MUST NOT kill the accept loop.
-            // Before this catch was inside the loop, an `IOException` from
-            // `handleConnection` propagated to the outer catch, terminated the accept
-            // thread, and — combined with `SpectreAgent.bootstrap`'s "already bootstrapped"
-            // idempotency guard — left the agent permanently unreachable for the rest of
-            // the target JVM's lifetime. Bugbot caught the original (MEDIUM); the regression
-            // test in `IpcRoundTripTest` ("server survives a client that closes mid-request
-            // …") pins the contract.
-            //
-            // Catch widened from `IOException` to `Exception` for the same reason: a
-            // misbehaving client can send a malformed length prefix and `Framing.readFrame`'s
-            // `check(length in 0..MAX_FRAME_BYTES)` throws `IllegalStateException` (not an
-            // `IOException`). The pinned regression test "server survives malformed frame
-            // length prefix" covers that path. Errors (OOM, StackOverflow) are intentionally
-            // NOT caught. Detekt's TooGenericExceptionCaught is suppressed with rationale.
-            @Suppress("TooGenericExceptionCaught")
-            try {
-                handleConnection(client)
-            } catch (ex: Exception) {
-                if (running.get()) {
-                    System.err.println(
-                        "[spectre-agent] connection terminated " +
-                            "(${ex.javaClass.simpleName}): ${ex.message ?: "<no message>"}"
-                    )
+                // Keep the previous accepted socket open for the whole replacement session.
+                // On Windows AF_UNIX, closing a sibling accepted channel can RST the
+                // replacement, so its handshake/reader sees EOF while orphaned input is
+                // still why the previous session is winding down (#471). Accept-then-close
+                // of the previous socket before handleConnection is not enough: the RST
+                // still lands after HelloAck, which is the IpcClient readerLoop EOF.
+                val previous = currentClient.getAndSet(incoming)
+                // Per-connection failures (broken pipe from a crashed client mid-`writeFrame`,
+                // half-closed sockets, malformed framing, …) MUST NOT kill the accept loop.
+                // Before this catch was inside the loop, an `IOException` from
+                // `handleConnection` propagated to the outer catch, terminated the accept
+                // thread, and — combined with `SpectreAgent.bootstrap`'s "already bootstrapped"
+                // idempotency guard — left the agent permanently unreachable for the rest of
+                // the target JVM's lifetime. Bugbot caught the original (MEDIUM); the
+                // regression test in `IpcRoundTripTest` ("server survives a client that closes
+                // mid-request …") pins the contract.
+                //
+                // Catch widened from `IOException` to `Exception` for the same reason: a
+                // misbehaving client can send a malformed length prefix and
+                // `Framing.readFrame`'s `check(length in 0..MAX_FRAME_BYTES)` throws
+                // `IllegalStateException` (not an `IOException`). The pinned regression test
+                // "server survives malformed frame length prefix" covers that path. Errors
+                // (OOM, StackOverflow) are intentionally NOT caught. Detekt's
+                // TooGenericExceptionCaught is suppressed with rationale.
+                @Suppress("TooGenericExceptionCaught")
+                try {
+                    handleConnection(incoming)
+                } catch (ex: Exception) {
+                    if (running.get()) {
+                        System.err.println(
+                            "[spectre-agent] connection terminated " +
+                                "(${ex.javaClass.simpleName}): ${ex.message ?: "<no message>"}"
+                        )
+                    }
+                } finally {
+                    runCatching { previous?.close() }
                 }
             }
+        } finally {
+            runCatching { currentClient.getAndSet(null)?.close() }
         }
     }
 
+    /**
+     * Serves one accepted client. Does **not** close [client]: the accept loop owns that so the
+     * previous socket stays open until this session ends (#471).
+     */
     private fun handleConnection(client: SocketChannel) {
-        client.use { socket ->
-            val input = Channels.newInputStream(socket)
-            val output = Channels.newOutputStream(socket)
-            // Phase 1: bare Hello (#199).
-            if (!performHandshake(socket, input, output)) return
-            // Phase 2: multiplexed OpRequest frames on a worker pool (#200).
-            MultiplexedIpcSession(
-                    handler = handler,
-                    running = running,
-                    onDetach = onDetach,
-                    channel = socket,
-                    frameIoTimeoutMs = frameIoTimeoutMs,
-                    inputWorkers = inputWorkers,
-                )
-                .run(input, output)
-        }
+        val input = Channels.newInputStream(client)
+        val output = Channels.newOutputStream(client)
+        // Phase 1: bare Hello (#199).
+        if (!performHandshake(client, input, output)) return
+        // Phase 2: multiplexed OpRequest frames on a worker pool (#200).
+        MultiplexedIpcSession(
+                handler = handler,
+                running = running,
+                onDetach = onDetach,
+                channel = client,
+                frameIoTimeoutMs = frameIoTimeoutMs,
+                inputWorkers = inputWorkers,
+            )
+            .run(input, output)
     }
 
     /** Bare Hello handshake. Returns false if the connection should end. */
@@ -334,6 +352,7 @@ constructor(
         } catch (_: IOException) {
             // Best-effort.
         }
+        runCatching { currentClient.getAndSet(null)?.close() }
         try {
             Files.deleteIfExists(udsPath)
         } catch (_: IOException) {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -348,10 +348,9 @@ constructor(
         } catch (_: IOException) {
             // Best-effort.
         }
-        // Do not close [currentClient] here. SpectreAgent.onClientDetach() calls [close] *before*
-        // MultiplexedIpcSession writes AgentResponse.Detached; shutting the live accepted
-        // channel would turn every production detach into EOF. The accept loop still closes
-        // leftover clients after handleConnection returns (and in its finally).
+        // Do not close accepted clients here. SpectreAgent.onClientDetach() calls [close]
+        // *before* MultiplexedIpcSession writes AgentResponse.Detached. The accept loop
+        // closes leftover clients in its finally after handleConnection returns.
         try {
             Files.deleteIfExists(udsPath)
         } catch (_: IOException) {
@@ -362,7 +361,12 @@ constructor(
         } catch (_: IOException) {
             // Best-effort — if the parent is gone or non-empty, leaving it is safer.
         }
-        acceptThread.interrupt()
+        // Closing from onDetach runs on the accept thread; interrupting it would poison the
+        // subsequent interruptible Detached write. Shutdown-hook / other-thread close still
+        // interrupts to unblock accept().
+        if (Thread.currentThread() !== acceptThread) {
+            acceptThread.interrupt()
+        }
     }
 }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -352,7 +352,10 @@ constructor(
         } catch (_: IOException) {
             // Best-effort.
         }
-        runCatching { currentClient.getAndSet(null)?.close() }
+        // Do not close [currentClient] here. SpectreAgent.onClientDetach() calls [close] *before*
+        // MultiplexedIpcSession writes AgentResponse.Detached; shutting the live accepted
+        // channel would turn every production detach into EOF. The accept loop still closes
+        // leftover clients after handleConnection returns (and in its finally).
         try {
             Files.deleteIfExists(udsPath)
         } catch (_: IOException) {

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/IpcServer.kt
@@ -11,8 +11,8 @@ import java.nio.channels.ServerSocketChannel
 import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicReference
 
 /**
  * Server-side IPC endpoint: binds a Unix Domain Socket at [udsPath], accepts a single client
@@ -85,7 +85,7 @@ constructor(
 
     private val running = AtomicBoolean(true)
     private val inputWorkers = CrossSessionInputWorkers()
-    private val currentClient = AtomicReference<SocketChannel?>(null)
+    private val acceptedClients = ConcurrentLinkedQueue<SocketChannel>()
 
     private val acceptThread =
         Thread(::acceptLoop, "spectre-agent-accept").apply {
@@ -115,13 +115,7 @@ constructor(
                         }
                         return
                     }
-                // Keep the previous accepted socket open for the whole replacement session.
-                // On Windows AF_UNIX, closing a sibling accepted channel can RST the
-                // replacement, so its handshake/reader sees EOF while orphaned input is
-                // still why the previous session is winding down (#471). Accept-then-close
-                // of the previous socket before handleConnection is not enough: the RST
-                // still lands after HelloAck, which is the IpcClient readerLoop EOF.
-                val previous = currentClient.getAndSet(incoming)
+                acceptedClients.add(incoming)
                 // Per-connection failures (broken pipe from a crashed client mid-`writeFrame`,
                 // half-closed sockets, malformed framing, …) MUST NOT kill the accept loop.
                 // Before this catch was inside the loop, an `IOException` from
@@ -149,18 +143,20 @@ constructor(
                                 "(${ex.javaClass.simpleName}): ${ex.message ?: "<no message>"}"
                         )
                     }
-                } finally {
-                    runCatching { previous?.close() }
                 }
             }
         } finally {
-            runCatching { currentClient.getAndSet(null)?.close() }
+            // Close accepted sockets only when the accept loop exits. Closing a sibling
+            // while another client is already in the listen backlog can RST that queued
+            // connection on Windows AF_UNIX (HelloAck then reader EOF, #471).
+            acceptedClients.forEach { runCatching { it.close() } }
+            acceptedClients.clear()
         }
     }
 
     /**
-     * Serves one accepted client. Does **not** close [client]: the accept loop owns that so the
-     * previous socket stays open until this session ends (#471).
+     * Serves one accepted client. Does **not** close [client]: accepted sockets stay open until the
+     * accept loop exits so a queued successor is never RST'd by a sibling close (#471).
      */
     private fun handleConnection(client: SocketChannel) {
         val input = Channels.newInputStream(client)

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -150,6 +150,21 @@ class IpcRoundTripTest {
     }
 
     @Test
+    fun `Detach still returns Detached when onDetach closes the server`() {
+        // SpectreAgent.onClientDetach() closes the IpcServer before MultiplexedIpcSession
+        // writes AgentResponse.Detached. Closing the *current* accepted client there
+        // turns every production detach into EOF (#471 follow-up / Codex).
+        lateinit var server: IpcServer
+        server = IpcServer(udsPath, stubHandler(), onDetach = { server.close() })
+        server.use {
+            awaitSocket(udsPath)
+            IpcClient(udsPath).use { client ->
+                assertEquals(AgentResponse.Detached, client.send(AgentRequest.Detach))
+            }
+        }
+    }
+
+    @Test
     fun `Server returns Error for an unknown request from the stub handler`() {
         val server =
             IpcServer(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -3,6 +3,10 @@
 package dev.sebastiano.spectre.agent.transport
 
 import java.io.IOException
+import java.net.StandardProtocolFamily
+import java.net.UnixDomainSocketAddress
+import java.nio.channels.Channels
+import java.nio.channels.SocketChannel
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
@@ -180,13 +184,39 @@ class IpcRoundTripTest {
                 val second = IpcClient(udsPath)
                 try {
                     assertEquals(AgentResponse.Pong, second.send(AgentRequest.Ping))
-                    val thirdConnecting = CountDownLatch(1)
+                    val thirdConnected = CountDownLatch(1)
                     val third =
                         executor.submit<AgentResponse> {
-                            thirdConnecting.countDown()
-                            IpcClient(udsPath).use { it.send(AgentRequest.Ping) }
+                            SocketChannel.open(StandardProtocolFamily.UNIX).use { channel ->
+                                channel.connect(UnixDomainSocketAddress.of(udsPath))
+                                thirdConnected.countDown()
+                                val input = Channels.newInputStream(channel)
+                                val output = Channels.newOutputStream(channel)
+                                Framing.writeFrame(
+                                    output,
+                                    WireCodec.encode(
+                                        AgentRequest.Hello(
+                                            protocolVersion = ProtocolVersion.CURRENT
+                                        )
+                                    ),
+                                )
+                                WireCodec.decodeResponse(
+                                    Framing.readFrame(input) ?: error("no HelloAck")
+                                )
+                                Framing.writeFrame(
+                                    output,
+                                    WireCodec.encode(OpRequest(opId = 1L, body = AgentRequest.Ping)),
+                                )
+                                WireCodec.decodeOpResponse(
+                                        Framing.readFrame(input) ?: error("no ping response")
+                                    )
+                                    .body
+                            }
                         }
-                    assertTrue(thirdConnecting.await(3, TimeUnit.SECONDS))
+                    assertTrue(
+                        thirdConnected.await(3, TimeUnit.SECONDS),
+                        "third client never connected",
+                    )
                     second.close()
                     assertEquals(AgentResponse.Pong, third.get(3, TimeUnit.SECONDS))
                 } finally {

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -7,6 +7,9 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
 import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
 import kotlin.io.path.deleteIfExists
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -161,6 +164,37 @@ class IpcRoundTripTest {
             IpcClient(udsPath).use { client ->
                 assertEquals(AgentResponse.Detached, client.send(AgentRequest.Detach))
             }
+        }
+    }
+
+    @Test
+    fun `queued client after ordinary EOF is not reset by closing a prior accepted socket`() {
+        val server = IpcServer(udsPath, stubHandler())
+        val executor = Executors.newSingleThreadExecutor()
+        try {
+            server.use {
+                awaitSocket(udsPath)
+                IpcClient(udsPath).use { first ->
+                    assertEquals(AgentResponse.Pong, first.send(AgentRequest.Ping))
+                }
+                val second = IpcClient(udsPath)
+                try {
+                    assertEquals(AgentResponse.Pong, second.send(AgentRequest.Ping))
+                    val thirdConnecting = CountDownLatch(1)
+                    val third =
+                        executor.submit<AgentResponse> {
+                            thirdConnecting.countDown()
+                            IpcClient(udsPath).use { it.send(AgentRequest.Ping) }
+                        }
+                    assertTrue(thirdConnecting.await(3, TimeUnit.SECONDS))
+                    second.close()
+                    assertEquals(AgentResponse.Pong, third.get(3, TimeUnit.SECONDS))
+                } finally {
+                    second.close()
+                }
+            }
+        } finally {
+            executor.shutdownNow()
         }
     }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/LongOpInfrastructureTest.kt
@@ -101,7 +101,12 @@ class LongOpInfrastructureTest {
                     inputFinished.await(200, TimeUnit.MILLISECONDS),
                     "ordinary EOF should not abandon the still-running input operation",
                 )
-                assertFailsWith<TimeoutException> { replacement.get(200, TimeUnit.MILLISECONDS) }
+                val early =
+                    runCatching { replacement.get(200, TimeUnit.MILLISECONDS) }.exceptionOrNull()
+                assertIs<TimeoutException>(
+                    early,
+                    "replacement handshake/session must wait for orphaned input, not fail: $early",
+                )
                 allowInputToFinish.countDown()
                 assertEquals(AgentResponse.Detached, replacement.get(3, TimeUnit.SECONDS))
                 assertTrue(detached.await(3, TimeUnit.SECONDS))


### PR DESCRIPTION
Fixes #471.

## Problem

`LongOpInfrastructureTest.ordinary EOF accepts a replacement client while input finishes()` is flaky on Windows. After the first client closes (ordinary EOF) with a Click still blocked, a replacement `IpcClient` completes Hello then dies in `readerLoop` with `EOFException: Agent closed the connection while waiting for a response` instead of waiting for the orphaned input.

Reproduced on mattone (Windows 11, JBR 21) at **iteration 78** of the named test. 200 consecutive passes on macOS never showed it.

## Cause

`IpcServer` handled one connection on the accept thread and closed that accepted `SocketChannel` (`client.use`) before `accept()` of the replacement. On Windows AF_UNIX, closing a sibling accepted socket can RST the replacement. HelloAck can still land; the multiplexed reader then sees EOF. Accept-then-close of the previous socket *before* the replacement session still EOFd (iteration 120). Closing the previous socket only after the replacement session ends removed it.

## Fix

The accept loop owns client close. The previous accepted socket stays open for the whole replacement session, then is closed. No sleeps, retries, or widened timeouts.

The named test now asserts `TimeoutException` on `replacement.get(200ms)` with the actual throwable in the message, so a replacement `ExecutionException`/`EOFException` is a failure rather than a confusing `assertFailsWith` mismatch.

## Verification

- Pre-fix Windows loop: fail at iteration 78, same stack as CI run 33072287670 (`IpcClient.kt:224`).
- Post-fix Windows loop: **200/200** consecutive passes, zero `EOFException`.
- `./gradlew check` green on macOS.
- `gradlew.bat :agent:check` green on Windows. Full `gradlew.bat check` on mattone also hit an unrelated `:core:test` failure (`AtomicCaptureWindowRoutingTest` expected 160 vs 149) that does not use this transport path.

Not merged.