### PR TITLE
feat(core): add waitUntilGone, the wait-for-absence counterpart to waitForNode

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -257,7 +257,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest NewInteractionsValidationTest SampleAppFixtureStartupDiagnosticsTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest WaitUntilGoneValidationTest NewInteractionsValidationTest SampleAppFixtureStartupDiagnosticsTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -164,7 +164,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest SampleAppFixtureStartupDiagnosticsTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest WaitUntilGoneValidationTest SampleAppFixtureStartupDiagnosticsTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -141,6 +141,8 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public static synthetic fun waitForNode-ck1zr5g$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun waitForVisualIdle-t_idYME (JIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun waitForVisualIdle-t_idYME$default (Ldev/sebastiano/spectre/core/ComposeAutomator;JIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun waitUntilGone-ck1zr5g (Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun waitUntilGone-ck1zr5g$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun windowIdentities ()Ljava/util/List;
 	public final fun windowIdentity (I)Ldev/sebastiano/spectre/core/WindowIdentitySnapshot;
 	public final fun withExclusiveInput (Ldev/sebastiano/spectre/core/InputLeaseOptions;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -875,14 +875,40 @@ private constructor(
         require(tag != null || text != null) { "Either tag or text must be specified" }
         rejectEdtCaller("waitForNode")
         return waitUntil(timeout = timeout, pollInterval = pollInterval) {
-            readOnEdt {
-                refreshWindows()
-                allNodes().firstOrNull { node ->
-                    (tag == null || node.testTag == tag) &&
-                        (text == null || node.texts.any { it == text } || node.editableText == text)
-                }
-            }
+            refreshedNodes().firstOrNull { it.matchesSelector(tag, text) }
         }
+    }
+
+    /**
+     * Waits until no node in any tracked window matches [tag] and/or [text]: the absence
+     * counterpart to [waitForNode], for dismissed popups, menus, and dialogs.
+     *
+     * Compose Desktop popups can render in their own `Window`, so dismissing one removes the whole
+     * window — and every node in it — from the tracked set; there is no node left to query, only
+     * its absence across all tracked windows. Each poll therefore calls [refreshWindows] first, the
+     * same cadence as [waitForNode], so a window vanishing between polls is observed rather than
+     * answered from a stale snapshot.
+     *
+     * Returns as soon as nothing matches. When both criteria are given they must match the same
+     * node, mirroring [waitForNode]. On timeout throws [IllegalStateException] naming the selector,
+     * the timeout, and how many matching nodes were still present.
+     */
+    public suspend fun waitUntilGone(
+        tag: String? = null,
+        text: String? = null,
+        timeout: Duration = 5.seconds,
+        pollInterval: Duration = 100.milliseconds,
+    ) {
+        // Same ordering as waitForNode: bad arguments are the more actionable error for an EDT
+        // caller doing both things wrong.
+        require(tag != null || text != null) { "Either tag or text must be specified" }
+        rejectEdtCaller("waitUntilGone")
+        waitUntilGoneInternal(
+            timeout = timeout,
+            pollInterval = pollInterval,
+            selector = describeNodeSelector(tag, text),
+            countPresent = { refreshedNodes().count { it.matchesSelector(tag, text) } },
+        )
     }
 
     public fun printTree(): String {
@@ -926,6 +952,25 @@ private const val FRAME_HASH_BUDGET_MS: Long = 2_000
 private const val FINGERPRINT_BUDGET_MS: Long = 500
 private const val WORKER_INTERRUPT_GRACE_MS: Long = 50
 private const val EMPTY_FINGERPRINT_PREFIX: String = "spectre-fingerprint-budget-elapsed:"
+
+/**
+ * One poll of the selector waits ([ComposeAutomator.waitForNode],
+ * [ComposeAutomator.waitUntilGone]): refresh the tracked windows, then read every live node, both
+ * on the EDT so a popup window that appeared or vanished since the last poll is part of the
+ * snapshot.
+ */
+private fun ComposeAutomator.refreshedNodes(): List<AutomatorNode> = readOnEdt {
+    refreshWindows()
+    allNodes()
+}
+
+/**
+ * Shared tag/text criterion for [ComposeAutomator.waitForNode] and
+ * [ComposeAutomator.waitUntilGone]: every non-null criterion must hold on this one node.
+ */
+private fun AutomatorNode.matchesSelector(tag: String?, text: String?): Boolean =
+    (tag == null || testTag == tag) &&
+        (text == null || texts.any { it == text } || editableText == text)
 
 private fun StringBuilder.appendNodeTree(node: AutomatorNode, depth: Int) {
     append("  ".repeat(depth))

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
@@ -21,3 +21,45 @@ internal suspend fun <T : Any> waitUntil(
 
         @Suppress("UNREACHABLE_CODE") error("unreachable")
     }
+
+/**
+ * Absence-wait loop behind [ComposeAutomator.waitUntilGone]: samples [countPresent] until it
+ * reports zero matching nodes, then returns.
+ *
+ * Unlike [waitUntil], the timeout is a deadline the loop checks itself rather than a `withTimeout`
+ * cancellation, so running out of time raises a plain [IllegalStateException] naming [selector],
+ * the timeout, and how many nodes were still present at the last observation — the diagnostics an
+ * absence wait exists to report. A bare `TimeoutCancellationException` says nothing about what
+ * stayed on screen.
+ *
+ * The loop always samples at least once and takes one final sample at the deadline, so a zero
+ * timeout still gets a real observation and the count in the error is the last thing seen.
+ *
+ * The injectable [clock]/[sleep] seam mirrors [waitForIdleInternal] so the loop can run on virtual
+ * time in tests without a live Compose tree.
+ */
+internal suspend fun waitUntilGoneInternal(
+    timeout: Duration,
+    pollInterval: Duration,
+    selector: String,
+    countPresent: () -> Int,
+    clock: MonotonicClock = SystemClock(),
+    sleep: suspend (Duration) -> Unit = { delay(it) },
+) {
+    val deadline = clock.now() + timeout.inWholeMilliseconds
+    while (true) {
+        val present = countPresent()
+        if (present == 0) return
+        if (clock.now() >= deadline) {
+            error(
+                "waitUntilGone timed out after ${timeout.inWholeMilliseconds}ms: " +
+                    "$present node(s) matching $selector still present in tracked windows"
+            )
+        }
+        sleep(pollInterval)
+    }
+}
+
+/** Renders a tag/text node selector as `tag="…"`, `text="…"` for wait diagnostics. */
+internal fun describeNodeSelector(tag: String?, text: String?): String =
+    listOfNotNull(tag?.let { "tag=\"$it\"" }, text?.let { "text=\"$it\"" }).joinToString(", ")

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
@@ -33,7 +33,9 @@ internal suspend fun <T : Any> waitUntil(
  * stayed on screen.
  *
  * The loop always samples at least once and takes one final sample at the deadline, so a zero
- * timeout still gets a real observation and the count in the error is the last thing seen.
+ * timeout still gets a real observation and the count in the error is the last thing seen. Each
+ * sleep is clamped to the time left, so a [pollInterval] longer than the remaining timeout never
+ * carries the wait a full interval past the deadline (Codex on #482).
  *
  * The injectable [clock]/[sleep] seam mirrors [waitForIdleInternal] so the loop can run on virtual
  * time in tests without a live Compose tree.
@@ -50,13 +52,14 @@ internal suspend fun waitUntilGoneInternal(
     while (true) {
         val present = countPresent()
         if (present == 0) return
-        if (clock.now() >= deadline) {
+        val remainingMs = deadline - clock.now()
+        if (remainingMs <= 0) {
             error(
                 "waitUntilGone timed out after ${timeout.inWholeMilliseconds}ms: " +
                     "$present node(s) matching $selector still present in tracked windows"
             )
         }
-        sleep(pollInterval)
+        sleep(minOf(pollInterval, remainingMs.milliseconds))
     }
 }
 

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -387,6 +387,7 @@ class ComposeAutomatorPublicSurfaceTest {
                 "waitForIdle",
                 "waitForVisualIdle",
                 "waitForNode",
+                "waitUntilGone",
                 "printTree",
                 "monitorRecompositions",
             )

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUntilGoneTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUntilGoneTest.kt
@@ -1,0 +1,192 @@
+package dev.sebastiano.spectre.core
+
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Unit-level tests for [ComposeAutomator.waitUntilGone] (#438), the wait-for-absence counterpart to
+ * [ComposeAutomator.waitForNode].
+ *
+ * The public-boundary contracts (argument validation, EDT rejection, immediate return on an empty
+ * tracked-window set) run against a headless automator. The polling loop itself is exercised
+ * through [waitUntilGoneInternal] on virtual time, the same seam `waitForIdleInternal` uses, so the
+ * timeout diagnostics are pinned without a live Compose tree. The end-to-end paths that need real
+ * Compose — a dismissed popup, a closed secondary `Window`, a node that stays on screen — live in
+ * the sample-desktop validation suite (`WaitUntilGoneValidationTest`).
+ */
+class WaitUntilGoneTest {
+
+    @Test
+    fun `waitUntilGone requires tag or text`() = runBlocking {
+        val automator = headlessAutomator()
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                automator.waitUntilGone(tag = null, text = null)
+            }
+        assertEquals("Either tag or text must be specified", error.message)
+    }
+
+    @Test
+    fun `waitUntilGone returns at once when no tracked window holds a matching node`() =
+        runBlocking {
+            // With window discovery off the tracked set is empty, so nothing can match: the
+            // wait must return on its first poll instead of sitting out the timeout.
+            val automator =
+                ComposeAutomator.inProcess(
+                    robotDriver = RobotDriver.headless(),
+                    discoverWindows = false,
+                )
+            val started = TimeSource.Monotonic.markNow()
+            automator.waitUntilGone(tag = "never-present", timeout = 10.seconds)
+            assertTrue(
+                started.elapsedNow() < 5.seconds,
+                "waitUntilGone should return as soon as the selector matches nothing, " +
+                    "took ${started.elapsedNow()}",
+            )
+        }
+
+    @Test
+    fun `waitUntilGone reports the bad-argument error when called from the EDT with null inputs`() {
+        // Argument validation must run BEFORE the EDT check, mirroring waitForNode: the bad
+        // input is the more actionable diagnostic for a caller doing two things wrong.
+        assumeLiveAwtAvailable()
+        val automator = headlessAutomator()
+        val errorRef = AtomicReference<Throwable?>()
+        SwingUtilities.invokeAndWait {
+            runBlocking {
+                errorRef.set(runCatching { automator.waitUntilGone() }.exceptionOrNull())
+            }
+        }
+        val error = errorRef.get()
+        assertTrue(
+            error is IllegalArgumentException,
+            "expected IllegalArgumentException, got $error",
+        )
+        assertEquals("Either tag or text must be specified", error.message)
+    }
+
+    @Test
+    fun `waitUntilGone rejects EDT callers with valid arguments`() {
+        assumeLiveAwtAvailable()
+        val automator = headlessAutomator()
+        val errorRef = AtomicReference<Throwable?>()
+        SwingUtilities.invokeAndWait {
+            runBlocking {
+                errorRef.set(
+                    runCatching { automator.waitUntilGone(tag = "irrelevant") }.exceptionOrNull()
+                )
+            }
+        }
+        val error = errorRef.get()
+        assertTrue(error is IllegalStateException, "expected IllegalStateException, got $error")
+        assertTrue(
+            error.message?.contains(
+                "waitUntilGone must not be called from the AWT event dispatch thread"
+            ) == true,
+            "expected curated EDT message, got: ${error.message}",
+        )
+    }
+
+    @Test
+    fun `waitUntilGoneInternal returns as soon as the selector matches nothing`() = runTest {
+        val clock = FakeClock()
+        val presentPerPoll = ArrayDeque(listOf(2, 1, 0))
+        var polls = 0
+
+        waitUntilGoneInternal(
+            timeout = 1.seconds,
+            pollInterval = 100.milliseconds,
+            selector = "tag=\"popup.body\"",
+            countPresent = {
+                polls++
+                presentPerPoll.removeFirst()
+            },
+            clock = clock,
+            sleep = clock::advance,
+        )
+
+        assertEquals(3, polls, "should stop polling on the first empty observation")
+    }
+
+    @Test
+    fun `waitUntilGoneInternal fails naming the selector, the timeout and what stayed on screen`() =
+        runTest {
+            val clock = FakeClock()
+            var polls = 0
+
+            // A bare withTimeout cancellation would surface as TimeoutCancellationException
+            // (a CancellationException) and say nothing about the selector; the contract is a
+            // plain IllegalStateException carrying the diagnostics.
+            val error =
+                assertFailsWith<IllegalStateException> {
+                    waitUntilGoneInternal(
+                        timeout = 500.milliseconds,
+                        pollInterval = 100.milliseconds,
+                        selector = "tag=\"popup.body\"",
+                        countPresent = {
+                            polls++
+                            2
+                        },
+                        clock = clock,
+                        sleep = clock::advance,
+                    )
+                }
+
+            val message = error.message.orEmpty()
+            assertTrue(
+                message.contains("waitUntilGone timed out after 500ms"),
+                "expected the timeout in the message, got: $message",
+            )
+            assertTrue(
+                message.contains("tag=\"popup.body\""),
+                "expected the selector in the message, got: $message",
+            )
+            assertTrue(
+                message.contains("2 node(s)"),
+                "expected the still-present count in the message, got: $message",
+            )
+            // Polls at t=0,100,...,500: the loop keeps observing until the deadline and takes
+            // one final observation at it, so the reported count is the last thing seen.
+            assertEquals(6, polls)
+        }
+
+    @Test
+    fun `waitUntilGoneInternal observes the selector once even with a zero timeout`() = runTest {
+        val clock = FakeClock()
+        var polls = 0
+
+        waitUntilGoneInternal(
+            timeout = Duration.ZERO,
+            pollInterval = 100.milliseconds,
+            selector = "text=\"Dismiss\"",
+            countPresent = {
+                polls++
+                0
+            },
+            clock = clock,
+            sleep = clock::advance,
+        )
+
+        assertEquals(1, polls, "a zero timeout must still take one observation")
+    }
+
+    @Test
+    fun `describeNodeSelector names every non-null criterion`() {
+        assertEquals("tag=\"a\"", describeNodeSelector(tag = "a", text = null))
+        assertEquals("text=\"b\"", describeNodeSelector(tag = null, text = "b"))
+        assertEquals("tag=\"a\", text=\"b\"", describeNodeSelector(tag = "a", text = "b"))
+    }
+
+    private fun headlessAutomator(): ComposeAutomator =
+        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUntilGoneTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUntilGoneTest.kt
@@ -181,6 +181,58 @@ class WaitUntilGoneTest {
     }
 
     @Test
+    fun `waitUntilGoneInternal clamps the poll sleep to the remaining timeout`() = runTest {
+        // Codex on #482: with pollInterval > remaining time, an unclamped sleep would carry the
+        // wait a full interval past the deadline before it could fail.
+        val clock = FakeClock()
+        val sleeps = mutableListOf<Duration>()
+        var polls = 0
+
+        assertFailsWith<IllegalStateException> {
+            waitUntilGoneInternal(
+                timeout = 50.milliseconds,
+                pollInterval = 1.seconds,
+                selector = "tag=\"popup.body\"",
+                countPresent = {
+                    polls++
+                    1
+                },
+                clock = clock,
+                sleep = {
+                    sleeps += it
+                    clock.advance(it)
+                },
+            )
+        }
+
+        assertEquals(
+            listOf(50.milliseconds),
+            sleeps,
+            "the only sleep must be clamped to the deadline",
+        )
+        assertEquals(50L, clock.now(), "the wait must fail at the deadline, not an interval later")
+        assertEquals(2, polls)
+    }
+
+    @Test
+    fun `waitUntilGoneInternal observes a late disappearance at the deadline, not an interval later`() =
+        runTest {
+            val clock = FakeClock()
+            val presentPerPoll = ArrayDeque(listOf(1, 0))
+
+            waitUntilGoneInternal(
+                timeout = 50.milliseconds,
+                pollInterval = 1.seconds,
+                selector = "tag=\"popup.body\"",
+                countPresent = { presentPerPoll.removeFirst() },
+                clock = clock,
+                sleep = clock::advance,
+            )
+
+            assertEquals(50L, clock.now(), "the second poll must land on the deadline")
+        }
+
+    @Test
     fun `describeNodeSelector names every non-null criterion`() {
         assertEquals("tag=\"a\"", describeNodeSelector(tag = "a", text = null))
         assertEquals("text=\"b\"", describeNodeSelector(tag = null, text = "b"))

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -95,8 +95,8 @@ corresponding doc page is touched:
 
 - **No auto-wait.** Queries (`findByTestTag`, `findByText`, `hasTag`, `hasText`, etc.)
   do a single read. They never retry. Document them as such.
-- **EDT rule applies to all three waits.** `waitForNode`, `waitForIdle`, and
-  `waitForVisualIdle` all reject EDT callers via `rejectEdtCaller` (see
+- **EDT rule applies to all four waits.** `waitForNode`, `waitUntilGone`, `waitForIdle`,
+  and `waitForVisualIdle` all reject EDT callers via `rejectEdtCaller` (see
   `WaitForNodeTest.waitForNode rejects EDT callers with valid arguments`). Earlier
   drafts of the docs carved out `waitForNode` as exempt — that exemption is gone in
   current code. Do say "all wait helpers reject the EDT".
@@ -106,7 +106,8 @@ corresponding doc page is touched:
 - **`findOneBy*` exists only for `testTag` and `text`.** Not for content
   description, not for role.
 - **`waitForNode(tag, text)` is AND, not OR.** Both criteria must match the same
-  node.
+  node. `waitUntilGone(tag, text)` mirrors it: it returns once no single node carries
+  both, and it refreshes windows before every poll (unlike the finders).
 - **`AutomatorIdlingResource.isIdleNow` and `diagnosticMessage()`.** Not `isIdle()`,
   not `name`. Identity-based register/unregister.
 - **`AutoRecorder` has explicit capture modes.** `startWindow(...)` uses true

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -96,6 +96,10 @@ What this means in practice:
 - After an interaction that triggers state change or animation, call
   **`waitForVisualIdle()`** (pixels stable for N frames) or **`waitForIdle()`**
   (semantics fingerprint stable plus any registered idling resources).
+- After dismissing a popup, menu, or dialog, **wait for it to leave** with
+  `waitUntilGone(tag = "…")` before touching what was behind it. A popup that rendered in
+  its own `Window` takes its whole semantics tree with it, so absence is the only thing
+  left to observe.
 - A failing assertion isn't necessarily a bug in your UI — it's often "the UI hadn't
   finished updating before I read it back".
 
@@ -103,8 +107,8 @@ See [Synchronization](synchronization.md) for the full toolkit.
 
 ## The EDT rule
 
-All three wait helpers — `waitForNode`, `waitForIdle`, and `waitForVisualIdle` — refuse
-to run on the AWT event dispatch thread (EDT):
+All four wait helpers — `waitForNode`, `waitUntilGone`, `waitForIdle`, and
+`waitForVisualIdle` — refuse to run on the AWT event dispatch thread (EDT):
 
 ```
 waitForNode must not be called from the AWT event dispatch thread;

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -133,8 +133,8 @@ description, or role — see [Finding nodes](selectors.md).
   when the call originates on the AWT event dispatch thread.
 
 All interaction methods (`click`, `doubleClick`, `swipe`, `typeText`, `pasteText`, …) and all wait
-helpers (`waitForNode`, `waitForIdle`, `waitForVisualIdle`) are `suspend`, so the test
-body runs inside `runSpectreTest { … }` from the testing module. JUnit test methods don't
+helpers (`waitForNode`, `waitUntilGone`, `waitForIdle`, `waitForVisualIdle`) are `suspend`, so
+the test body runs inside `runSpectreTest { … }` from the testing module. JUnit test methods don't
 run on the AWT event dispatch thread, so no extra `withContext` is needed here. If you
 ever call wait helpers from a coroutine on `Dispatchers.Main` (Swing EDT), wrap them in
 `withContext(Dispatchers.Default)` — they reject EDT callers at runtime. See

--- a/docs/guide/selectors.md
+++ b/docs/guide/selectors.md
@@ -90,7 +90,8 @@ val caseInsensitive: Boolean = automator.hasText(TextQuery.exact("submit", ignor
 
 These are the same single snapshot read as the finders: they do **not** call
 `refreshWindows()`. If a popup window may have just appeared or vanished, call
-`refreshWindows()` (or `tree()`) first.
+`refreshWindows()` (or `tree()`) first — or, when you are waiting for the popup to close,
+use [`waitUntilGone`](synchronization.md#waituntilgone), which refreshes before every poll.
 
 ## Working with the result
 

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -2,7 +2,7 @@
 
 Spectre deliberately doesn't wrap reads and actions in an implicit idle barrier. The
 flip side is that you have a small but explicit set of wait helpers, and you decide
-where to put them. This page covers all three.
+where to put them. This page covers all four.
 
 ## Interactive-only: Compose Hot Reload settle
 
@@ -14,8 +14,8 @@ documented under [Compose Hot Reload awareness](hot-reload.md). Prefer
 
 ## The EDT rule
 
-All three wait helpers — `waitForNode`, `waitForIdle`, and `waitForVisualIdle` — refuse
-to run on the AWT event dispatch thread:
+All four wait helpers — `waitForNode`, `waitUntilGone`, `waitForIdle`, and
+`waitForVisualIdle` — refuse to run on the AWT event dispatch thread:
 
 ```
 waitForNode must not be called from the AWT event dispatch thread;
@@ -24,7 +24,7 @@ wrap the call with withContext(Dispatchers.Default) or similar.
 
 This is enforced because their loops snapshot semantics via `invokeAndWait`/`readOnEdt`
 — running on the EDT would either deadlock or skip the bounded worker that enforces the
-timeout. None of the three are exempt.
+timeout. None of the four are exempt.
 
 The standard pattern in tests — JUnit runs tests off the EDT, so no `withContext` is
 needed:
@@ -72,6 +72,41 @@ between two.
 Use it once after launching the UI to know your test can start touching things, and
 optionally after each interaction that introduces new content (a dialog opening, a list
 item appearing).
+
+## `waitUntilGone`
+
+The "it has left the screen" barrier — `waitForNode`'s counterpart for absence:
+
+```kotlin
+automator.click(dismissButton)
+automator.waitUntilGone(
+    tag = "popup.body",
+    timeout = 5.seconds,
+    pollInterval = 100.milliseconds,
+)
+```
+
+Polls until **no** node in any tracked window matches every non-null criterion you pass,
+then returns. As with `waitForNode`, you must pass at least one of `tag` or `text`, and
+passing both means "no single node carrying this tag **and** this text".
+
+Every poll calls `refreshWindows()` first, and that is the point of the helper. Compose
+Desktop popups — menus, combo boxes, speed search — can render in their own `Window`, so
+dismissing one takes the whole window, and every node in it, out of the tracked-window
+set. There is no node left to query; only its absence across all tracked windows is
+observable, and a window vanishing between two polls is seen rather than answered from a
+stale snapshot.
+
+On timeout it throws an `IllegalStateException` that names the selector, the timeout, and
+what was still on screen:
+
+```
+waitUntilGone timed out after 5000ms: 1 node(s) matching tag="popup.body" still present in tracked windows
+```
+
+Use it after dismissing a popup, menu, or dialog — before asserting on whatever the
+dismissal revealed, or before the next click that would otherwise land on the closing
+surface.
 
 ## `waitForIdle`
 
@@ -211,5 +246,7 @@ don't have to fall back to `Thread.sleep`.
 | `waitForVisualIdle.pollInterval` | 16 ms (~60 FPS)|
 | `waitForNode.timeout`     | 5 s                   |
 | `waitForNode.pollInterval`| 100 ms                |
+| `waitUntilGone.timeout`   | 5 s                   |
+| `waitUntilGone.pollInterval` | 100 ms             |
 
 These are tuned for desktop; bump them up freely if your scenarios are heavier.

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -73,8 +73,8 @@ java.lang.IllegalStateException: waitForIdle must not be called from the AWT eve
 dispatch thread; wrap the call with withContext(Dispatchers.Default) or similar.
 ```
 
-All three wait helpers — `waitForNode`, `waitForIdle`, and `waitForVisualIdle` — refuse
-to run on the AWT event dispatch thread. They snapshot semantics via
+All four wait helpers — `waitForNode`, `waitUntilGone`, `waitForIdle`, and
+`waitForVisualIdle` — refuse to run on the AWT event dispatch thread. They snapshot semantics via
 `invokeAndWait`/`readOnEdt`. Running them on the EDT would either deadlock or skip the
 bounded worker that enforces the timeout, so the helpers raise
 `IllegalStateException` instead. The exact wait name in the message tells you which

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/AutomatorAssertions.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/AutomatorAssertions.kt
@@ -47,13 +47,6 @@ suspend fun ComposeAutomator.waitForTestTag(
         findOneByTestTag(tag)
     }
 
-/** Wait until no node with the given testTag is present. */
-suspend fun ComposeAutomator.waitUntilGone(tag: String, timeout: Duration = 5.seconds) {
-    eventually(description = "no node with testTag '$tag'", timeout = timeout) {
-        if (findOneByTestTag(tag) == null) Unit else null
-    }
-}
-
 /**
  * Click the picker entry for a scenario by its `scenario.<name>` testTag, then wait until the
  * right-pane `scenario.title` node either gains a value (first navigation) or its text changes

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitUntilGoneValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitUntilGoneValidationTest.kt
@@ -1,0 +1,121 @@
+package dev.sebastiano.spectre.sample.validation
+
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Live-Compose coverage for
+ * [`ComposeAutomator.waitUntilGone`][dev.sebastiano.spectre.core.ComposeAutomator.waitUntilGone]
+ * (#438): the wait-for-absence counterpart to `waitForNode`.
+ *
+ * The argument-validation, EDT-rejection, and timeout-diagnostic contracts are exercised at the
+ * unit level in `WaitUntilGoneTest`. What needs a real Compose surface is the thing the verb exists
+ * for: a dismissed popup or a closed secondary `Window` takes its whole semantics tree out of the
+ * tracked-window set, and only its absence across every tracked window is observable.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class WaitUntilGoneValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre #438 waitUntilGone validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `waitUntilGone returns once a dismissed popup's nodes leave every tracked window`(): Unit =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.popup")
+                click(waitForTestTag("popup.toggleButton"))
+                waitForTestTag("popup.body")
+
+                click(waitForTestTag("popup.dismissButton"))
+                waitUntilGone(tag = "popup.body")
+
+                // The wait refreshes windows before each poll, so the snapshot it returns on is
+                // current: nothing under the popup's tag may remain anywhere.
+                assertFalse(hasTag("popup.body"), "popup body still present after waitUntilGone")
+                assertFalse(hasTag("popup.text"), "popup text still present after waitUntilGone")
+            }
+        }
+
+    @Test
+    fun `waitUntilGone returns once a closed secondary Window leaves the tracked set`(): Unit =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.multiwindow")
+                click(waitForTestTag("multiwindow.toggleButton"))
+                val secondaryText = waitForTestTag("multiwindow.secondary.text")
+                val secondarySurfaceId = secondaryText.surfaceId
+
+                click(waitForTestTag("multiwindow.secondary.dismissButton"))
+                waitUntilGone(tag = "multiwindow.secondary.text")
+
+                assertFalse(
+                    hasTag("multiwindow.secondary.text"),
+                    "secondary window text still present after waitUntilGone",
+                )
+                eventually(description = "surface $secondarySurfaceId to stop being tracked") {
+                    if (secondarySurfaceId !in surfaceIds()) Unit else null
+                }
+            }
+        }
+
+    @Test
+    fun `waitUntilGone matches by text`(): Unit = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.popup")
+            click(waitForTestTag("popup.toggleButton"))
+            val popupText = waitForTestTag("popup.text").text
+            assertNotNull(popupText, "popup.text must expose its text")
+
+            click(waitForTestTag("popup.dismissButton"))
+            waitUntilGone(text = popupText)
+
+            assertFalse(hasText(popupText), "popup text still present after waitUntilGone")
+        }
+    }
+
+    @Test
+    fun `waitUntilGone names the selector and timeout when the node stays on screen`(): Unit =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.counter")
+                waitForTestTag("incrementButton")
+
+                val error =
+                    assertFailsWith<IllegalStateException> {
+                        waitUntilGone(
+                            tag = "incrementButton",
+                            timeout = 250.milliseconds,
+                            pollInterval = 50.milliseconds,
+                        )
+                    }
+
+                val message = error.message.orEmpty()
+                assertTrue(
+                    message.contains("waitUntilGone timed out after 250ms"),
+                    "expected the timeout in the message, got: $message",
+                )
+                assertTrue(
+                    message.contains("tag=\"incrementButton\""),
+                    "expected the selector in the message, got: $message",
+                )
+            }
+        }
+}

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -28,8 +28,8 @@ If you're testing an individual composable in isolation → use `ComposeTestRule
 ## Gotchas
 
 - **Use `runSpectreTest`, not `runTest`.** `runTest` collapses `delay()` to zero, which silently breaks `longClick` hold durations, `swipe` step pacing, and clipboard-settle polling. Prefer `runSpectreTest` from the testing module (real wall time + leak detection); plain `runBlocking` is a fallback.
-- **Selectors are non-waiting.** Every `findBy...` / `findOneBy...` call reads the semantics tree once. Call `waitForNode` before querying any node that might not exist yet.
-- **EDT rule.** All three wait helpers (`waitForNode`, `waitForIdle`, and `waitForVisualIdle`) throw `IllegalStateException` when called from the AWT event dispatch thread. Standard JUnit test methods run off the EDT so this isn't normally an issue; if you call them from the EDT, wrap with `withContext(Dispatchers.Default)`.
+- **Selectors are non-waiting.** Every `findBy...` / `findOneBy...` call reads the semantics tree once. Call `waitForNode` before querying any node that might not exist yet, and `waitUntilGone` after dismissing a popup, menu, or dialog before touching what was behind it.
+- **EDT rule.** All four wait helpers (`waitForNode`, `waitUntilGone`, `waitForIdle`, and `waitForVisualIdle`) throw `IllegalStateException` when called from the AWT event dispatch thread. Standard JUnit test methods run off the EDT so this isn't normally an issue; if you call them from the EDT, wrap with `withContext(Dispatchers.Default)`.
 - **Expression-body tests.** Write `@Test fun mySpec(): Unit = runSpectreTest { ... }`. JUnit 5.14+ rejects non-void test methods, and Kotlin infers the return type from the last expression in the `runSpectreTest` body.
 
 ## Setup
@@ -149,6 +149,9 @@ val img = automator.screenshot(node)                    // native window capture
 // After launching — poll until a node appears
 automator.waitForNode(tag = "root-content")
 
+// After dismissing a popup / menu / dialog — poll until nothing matches in any tracked window
+automator.waitUntilGone(tag = "popup.body")
+
 // After an interaction — wait for semantics tree + idling resources to settle
 automator.waitForIdle()
 
@@ -165,7 +168,7 @@ automator.waitForVisualIdle()  // pixels settled
 val result = automator.findOneByTestTag("Result")
 ```
 
-All three wait helpers are `suspend` and **must not** be called from the AWT EDT. Default timeout is 5 s; all parameters are tunable.
+All four wait helpers are `suspend` and **must not** be called from the AWT EDT. Default timeout is 5 s; all parameters are tunable.
 
 ## Input drivers
 

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -209,6 +209,11 @@ Always wait before querying state that depends on a prior action.
 - **`waitForNode(tag = "...", timeout = 5.seconds)`** — wait until a node with
   the given tag (or text) exists. Throws on timeout. Use this when a *new*
   node must appear.
+- **`waitUntilGone(tag = "...", timeout = 5.seconds)`** — wait until *no* node
+  with the given tag (or text) exists in any tracked window. Refreshes windows
+  before every poll, so a popup that closes its own `Window` counts as gone.
+  Throws `IllegalStateException` naming the selector on timeout. Use this
+  after dismissing a popup, menu, or dialog.
 - **`waitForIdle()`** — wait until the semantics fingerprint stabilizes and
   all registered `AutomatorIdlingResource`s are idle. Use this when you've
   triggered work that updates semantics but no specific node appears.
@@ -225,8 +230,8 @@ is more precise.
 
 ### Rule 3: never call any wait on the EDT
 
-All three of `waitForNode`, `waitForIdle`, and `waitForVisualIdle` actively
-reject being called from the AWT event dispatch thread — they need to
+All four of `waitForNode`, `waitUntilGone`, `waitForIdle`, and `waitForVisualIdle`
+actively reject being called from the AWT event dispatch thread — they need to
 `invokeAndWait` onto the EDT to read state, so running them *on* the EDT would
 deadlock. If your dispatcher is Swing-backed (the IntelliJ EDT dispatcher, a
 custom `Swing` dispatcher, etc.), wrap the wait in
@@ -329,7 +334,7 @@ touches that area*; they are not needed for the common case.
 | Symptom | Cause | Fix |
 |---|---|---|
 | `findOneBy…` returns `null` right after an interaction | Selectors don't wait | Add `waitForNode(...)` or `waitForVisualIdle()` first |
-| Test deadlocks or throws inside any `waitFor…` | Called from the AWT EDT | Wrap in `withContext(Dispatchers.Default) { … }` — applies to all three waits, including `waitForNode` |
+| Test deadlocks or throws inside any `waitFor…` / `waitUntilGone` | Called from the AWT EDT | Wrap in `withContext(Dispatchers.Default) { … }` — applies to all four waits, including `waitForNode` and `waitUntilGone` |
 | `longClick`/`swipe`/`typeText` complete instantly and miss | Test body uses `runTest` | Switch to `runSpectreTest` |
 | Two parallel test JVMs steal focus from each other | Both use real `RobotDriver()` | Use `RobotDriver.synthetic(rootWindow)` |
 | Parallel JVMs must preserve real OS input behavior | Real focus/pointer/clipboard state is shared across processes | Opt in to experimental coordination, add `spectre-input-coordinator-server` at runtime, use `Required` and JUnit `InputIsolationConfig.perTest()` |

--- a/skills/spectre/references/intellij.md
+++ b/skills/spectre/references/intellij.md
@@ -41,7 +41,7 @@ class RunSpectreAction : AnAction() {
 
 `executeOnPooledThread` (or any non-EDT dispatcher) is required. The
 automator's outer loop — polling, retries, waits — runs on the calling
-thread. All three wait helpers (`waitForNode`, `waitForIdle`,
+thread. All four wait helpers (`waitForNode`, `waitUntilGone`, `waitForIdle`,
 `waitForVisualIdle`) reject EDT callers with `IllegalStateException`, so
 calling them from the EDT fails fast rather than silently deadlocking on
 the `invokeAndWait` round-trip. Per-tick semantics reads internally marshal
@@ -55,13 +55,17 @@ If the task also involves Jewel popup rendering, `ComposePanel` embedding,
 (`OnSameCanvas` vs separate window), `JewelFlags.useCustomPopupRenderer`,
 and theme rules that affect what the automator sees.
 
-Two facts worth knowing up front:
+Three facts worth knowing up front:
 
 - Compose Desktop defaults `compose.layers.type` to `OnSameCanvas`, so most
   popups render inside their host AWT window rather than creating a new
   one. The automator already handles this — but if you've explicitly opted
   into separate windows, popups will show up as additional discovered
   surfaces in `tree()`.
+- Dismissing a popup that renders in its own window removes that window —
+  and every node in it — from the tracked set. Wait for that with
+  `waitUntilGone(tag = …)`, which refreshes windows before each poll; a
+  one-shot `findBy…` read against the last snapshot cannot observe it.
 - An embedded `ComposePanel` has no top-level title. Window-targeted
   recording can't follow it; use region capture or pass the host IDE frame.
 


### PR DESCRIPTION
## Summary

Closes #438. Adds `ComposeAutomator.waitUntilGone(tag, text, timeout, pollInterval)`, the wait-for-absence counterpart to `waitForNode`, for 0.6.0.

- **Gone** means no node matching the selector in *any* tracked window, main windows and popups alike, with `refreshWindows()` before every poll (the same cadence as `waitForNode`), so a popup window vanishing between polls is observed rather than answered from a stale snapshot.
- Returns as soon as the selector matches nothing; `tag` + `text` is AND on a single node, mirroring `waitForNode`.
- `rejectEdtCaller("waitUntilGone")` for parity with the other waits; argument validation runs first, as in `waitForNode`.
- **No bare `withTimeout` cancellation escapes.** The loop is deadline-based (`waitUntilGoneInternal`, with the same injectable clock/sleep seam as `waitForIdleInternal`) and fails with an `IllegalStateException` naming the selector, the timeout, and how many matching nodes were still present at the last observation:
  `waitUntilGone timed out after 5000ms: 1 node(s) matching tag="popup.body" still present in tracked windows`

### Also in this PR

- The tag/text matcher and the refresh-then-read poll step are shared between `waitForNode` and `waitUntilGone` as file-private helpers (no behaviour change to `waitForNode`). This also keeps `ComposeAutomator` inside detekt's `LargeClass` budget (default 600 logical lines): the class was already within a dozen lines of it, and the new verb pushed it over. It is now within a handful of lines, so the next public verb will need either a real split or a narrow `@Suppress("LargeClass")` like `ReflectiveAutomatorHandler` carries. Nothing is suppressed here.
- `sample-desktop`'s validation suite drops its private `waitUntilGone` extension; its existing callers (popup dismissal, JDialog, multi-window, popup-layer variants incl. `WINDOW`) now resolve to the core verb.
- `core/api/core.api` regenerated; the diff is purely additive (the function and its `$default` synthetic).
- Docs: new `waitUntilGone` section in `docs/guide/synchronization.md` next to `waitForNode`, defaults-table rows, and the "three wait helpers" phrasing updated to four across the guide, `DOCS-STYLE.md`, and both skills. `mkdocs build --strict` passes.
- `WaitUntilGoneValidationTest` added to the fail-closed required-class lists in `validation-linux.yml` / `validation-windows.yml`.

### Follow-ups (not done here, maintainer's call)

- A generic `waitUntil { predicate }` falls out of the same machinery (`waitUntilGoneInternal` is a "wait until this count is zero" loop with diagnostics), but deliberately not added: speculative API in a published module is expensive to withdraw.
- No CLI/MCP/agent counterpart (`wait-for-node` has one; `wait-until-gone` does not) — core only for now.
- Once this ships, the private `waitUntilGone` in Jewel's `int-ui-standalone-tests` (`CustomPopupRendererSpectreTest.kt`, JEWEL-1396) can be deleted. Different repository, not attempted here.

## Test plan

- [x] `./gradlew check` passes locally
- [x] `./gradlew ktfmtFormat` produced no changes
- [x] `core`: `WaitUntilGoneTest` — argument validation, EDT rejection (both orderings), immediate return on an empty tracked set, and virtual-time loop tests pinning the timeout message and the "one final observation at the deadline" contract. Written red-first.
- [x] `sample-desktop` validation: `WaitUntilGoneValidationTest` — dismissed popup, closed secondary `Window` leaving the tracked set, text selector, and the timeout message against a live surface. Green under Xvfb locally, together with `MultiWindowAndPopupValidationTest`, `WaitForNodeMatchingValidationTest`, `Issue7CompletionValidationTest`, and `validationTestLayerWindow`.
- [x] `mkdocs build --strict` passes

## Confirmations

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR is **not** LLM-generated. (See the "no clanker PRs or issues" rule.) — intentionally unchecked: this PR was produced in the maintainer's own Claude Code session, at the maintainer's request.
- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).