### PR TITLE
fix(input): reject symlinked ancestors of a coordinator endpoint (#465)

### DIFF
--- a/.github/workflows/macos-check.yml
+++ b/.github/workflows/macos-check.yml
@@ -27,6 +27,11 @@ on:
       - "agent-runtime/**"
       - "agent-test-fixture/**"
       - "cli/**"
+      # The input coordinator's endpoint layout is OS-specific (`/tmp` resolves to
+      # `/private/tmp` on macOS, `%LOCALAPPDATA%\Temp` on Windows) and its symlink guards can
+      # only be exercised against the real layout, so changes there need the full OS matrix.
+      - "input-coordinator/**"
+      - "input-coordinator-server/**"
       - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"
@@ -48,6 +53,8 @@ on:
       - "agent-runtime/**"
       - "agent-test-fixture/**"
       - "cli/**"
+      - "input-coordinator/**"
+      - "input-coordinator-server/**"
       - "buildSrc/**"
       - "recording/**"
       - "recording-linux/**"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -35,6 +35,11 @@ on:
       # (#455). Without this path, a Windows-only fix in `:cli` cannot be verified before
       # merge and `:cli` regressions reach main before CI sees them.
       - "cli/**"
+      # The input coordinator's endpoint layout is OS-specific (`/tmp` resolves to
+      # `/private/tmp` on macOS, `%LOCALAPPDATA%\Temp` on Windows) and its symlink guards can
+      # only be exercised against the real layout, so changes there need the full OS matrix.
+      - "input-coordinator/**"
+      - "input-coordinator-server/**"
       # `buildSrc/` carries Windows-conditional *build* logic, not just Windows-conditional
       # tests: `VerifyCliDistributionZip.verifyLauncher` shells out through cmd.exe to run the
       # packaged `spectre.bat` under a scrubbed PATH, and only that branch can break. #475 was
@@ -65,6 +70,8 @@ on:
       # (#455). Without this path, a Windows-only fix in `:cli` cannot be verified before
       # merge and `:cli` regressions reach main before CI sees them.
       - "cli/**"
+      - "input-coordinator/**"
+      - "input-coordinator-server/**"
       # `buildSrc/` carries Windows-conditional *build* logic, not just Windows-conditional
       # tests: `VerifyCliDistributionZip.verifyLauncher` shells out through cmd.exe to run the
       # packaged `spectre.bat` under a scrubbed PATH, and only that branch can break. #475 was

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -48,14 +48,18 @@ out of scope.
    a testing affordance for the same machine and the same user, not a remote-control
    protocol. See [Agent attach](guide/agent.md).
 
-5. **The input coordinator is a same-user cooperative boundary.** Its canonical endpoint lives in
-   a short owner-checked directory and rejects symlink/path substitution. On POSIX filesystems it
-   enforces directory mode 0700 and socket mode 0600. On Windows it uses the current user's
-   `LOCALAPPDATA` and inherits the existing directory ACL; unlike the agent transport, the
-   coordinator layer does not replace that ACL with an owner-only one. Java Unix-domain sockets do
-   not expose portable peer credentials, so requester labels are self-reported attribution, not
-   authentication. The coordinator never records typed text, clipboard contents, selectors,
-   credentials, or prompts.
+5. **The input coordinator is a same-user cooperative boundary.** Its canonical endpoint lives in a
+   short owner-checked directory and rejects symlink/path substitution: neither the endpoint
+   directory nor any ancestor of it may be a symbolic link, with macOS's root-level `/tmp`, `/var`,
+   and `/etc` aliases into `/private` as the only exemption. The default endpoint is canonical
+   before it is prepared. A caller-supplied endpoint must be an absolute path beneath a directory
+   the caller already trusts: Spectre detects substitution there but does not verify who owns the
+   ancestors. On POSIX filesystems it enforces directory mode 0700 and socket mode 0600. On Windows
+   it uses the current user's `LOCALAPPDATA` and inherits the existing directory ACL; unlike the
+   agent transport, the coordinator layer does not replace that ACL with an owner-only one. Java
+   Unix-domain sockets do not expose portable peer credentials, so requester labels are
+   self-reported attribution, not authentication. The coordinator never records typed text,
+   clipboard contents, selectors, credentials, or prompts.
 
    Revocation requires the exact observed lease ID. Normal revoke fences the owner and waits for
    cleanup acknowledgement. Session EOF also fences a live holder rather than advancing FIFO,

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -253,6 +253,12 @@ closed until an operator makes an exact-ID forced recovery decision.
   rejects path substitution but does not rewrite the Windows ACL. Labels are diagnostic
   attribution, not authentication; typed text, clipboard contents, selectors, credentials, and
   prompts are never recorded.
+- The default endpoint is canonical, and Spectre keeps its trust boundary. A caller-supplied
+  endpoint must be an absolute path beneath a directory you already trust: Spectre refuses an
+  endpoint directory, or any ancestor of it, that is a symbolic link, with macOS's root-level
+  `/tmp`, `/var`, and `/etc` aliases into `/private` as the one exemption. It does not check who
+  owns the directories above the endpoint. If your path goes through a link, pass the canonical
+  form (`toRealPath()`) instead.
 
 Coordination remains **Experimental** until headed two-process smoke records FIFO contention,
 holder crash, exact revoke, forced recovery, and JUnit parallelism on macOS, Windows, and Linux

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -21,9 +21,20 @@ import java.util.HexFormat
  * caller-supplied endpoint must be an absolute path beneath a directory the caller already trusts:
  * [OwnerOnlyEndpointProtection.prepareDirectory] refuses a symbolic link at the endpoint directory
  * or at any ancestor of it, but it does not verify who owns those ancestors.
+ *
+ * [directory] must be the parent of [socketPath]. The guard above protects the socket's parent,
+ * while the coordinator keeps its election lock and recovery ledger in [directory]; letting the two
+ * differ would route that state through a directory nothing checked.
  */
 @ExperimentalSpectreInputCoordinationApi
-public data class CoordinatorEndpoint(public val directory: Path, public val socketPath: Path)
+public data class CoordinatorEndpoint(public val directory: Path, public val socketPath: Path) {
+    init {
+        require(socketPath.parent == directory) {
+            "Coordinator endpoint directory $directory must be the socket's parent, " +
+                "was ${socketPath.parent}"
+        }
+    }
+}
 
 /** Resolves a short endpoint that is independent of the launching process's environment. */
 @ExperimentalSpectreInputCoordinationApi

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -106,7 +106,9 @@ public sealed interface OwnerOnlyEndpointProtection {
 private object PosixOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
     override fun prepareDirectory(socketPath: Path) {
         val directory = socketPath.toAbsolutePath().parent
-        rejectSymbolicAncestors(directory)
+        val ownerOnly = PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMISSIONS)
+        // Parents may legitimately be missing (#462); nothing is created when they all exist.
+        prepareAncestors(directory) { ancestor -> Files.createDirectory(ancestor, ownerOnly) }
         if (Files.exists(directory, NOFOLLOW_LINKS)) {
             rejectSubstituted(directory, role = "directory")
             val permissions = Files.getPosixFilePermissions(directory, NOFOLLOW_LINKS)
@@ -114,13 +116,8 @@ private object PosixOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
                 throw IOException("Existing coordinator directory $directory must be owner-only")
             }
         } else {
-            val ownerOnly = PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMISSIONS)
-            // Parents may legitimately be missing (#462). Each of them, and the endpoint directory
-            // itself, goes through the atomic createDirectory: on a world-writable /tmp another
-            // user could plant a symlink between the ancestor walk above and this call, and
-            // createDirectories would happily adopt a symlink whose target is a directory,
-            // putting the lock, ledger, and socket under their control.
-            createMissingParents(directory) { parent -> Files.createDirectory(parent, ownerOnly) }
+            // The atomic createDirectory refuses to adopt anything already at this path, symlinks
+            // included, so a link planted here loses the race rather than capturing the endpoint.
             Files.createDirectory(directory, ownerOnly)
         }
     }
@@ -145,15 +142,12 @@ private object PosixOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
 private object BasicOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
     override fun prepareDirectory(socketPath: Path) {
         val directory = socketPath.toAbsolutePath().parent
-        rejectSymbolicAncestors(directory)
+        // Parents may be missing: on Windows the base is %LOCALAPPDATA%\Temp, which is absent on
+        // profiles whose temp directory has been redirected (#462).
+        prepareAncestors(directory) { ancestor -> Files.createDirectory(ancestor) }
         if (Files.exists(directory, NOFOLLOW_LINKS)) {
             rejectSubstituted(directory, role = "directory")
         } else {
-            // Parents may be missing: on Windows the base is %LOCALAPPDATA%\Temp, which is absent
-            // on profiles whose temp directory has been redirected (#462). Every component keeps
-            // the atomic createDirectory, which refuses to adopt anything already sitting at that
-            // path, symlinks included.
-            createMissingParents(directory) { parent -> Files.createDirectory(parent) }
             Files.createDirectory(directory)
         }
     }
@@ -166,50 +160,56 @@ private object BasicOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
 }
 
 /**
- * Refuses a symbolic link anywhere above [directory], except a root-level alias into `/private`.
+ * Validates every ancestor of [directory] top-down and creates the missing ones, one atomic
+ * [createDirectory] each.
+ *
+ * Each component is checked immediately before it is descended into, rather than validating the
+ * whole chain up front and then creating blindly. A link planted between those two passes used to
+ * be invisible: the creation scan stopped at the newly existing component without looking at it,
+ * and the endpoint directory's own `createDirectory` then resolved straight through it into the
+ * attacker's target. The atomic creation only ever protected the final component, never the
+ * traversal that reaches it.
  *
  * The walk is lexical and deliberately not normalised: the OS resolves a `..` that follows a
- * planted link against the link's target, so the link itself has to stay visible to this check.
+ * planted link against the link's target, so the link itself has to stay visible to this check. It
+ * cannot make traversal race-free — only an `openat`-style descent could — but every component is
+ * now rejected on sight instead of being skipped.
  */
-private fun rejectSymbolicAncestors(directory: Path) {
-    val substituted =
-        generateSequence(directory.parent) { it.parent }
-            .firstOrNull { Files.isSymbolicLink(it) && !isTrustedPrivateAlias(it, it.root) }
-    if (substituted != null) {
-        throw IOException("Coordinator ancestor $substituted must not be a symbolic link")
-    }
-}
-
-/**
- * Whether [link] is a symbolic link directly under [root] that points at `private/<same name>`: the
- * layout macOS uses for `/tmp`, `/var`, and `/etc`. Only root can create an entry directly under
- * the filesystem root, so another user cannot have planted such an alias. [root] is a parameter
- * only so tests can stage a fake root; production passes the real one.
- */
-internal fun isTrustedPrivateAlias(link: Path, root: Path): Boolean {
-    if (link.parent != root || !Files.isSymbolicLink(link)) return false
-    val target = runCatching { Files.readSymbolicLink(link) }.getOrNull() ?: return false
-    return target == Path.of(PRIVATE_ALIAS_DIRECTORY).resolve(link.fileName)
-}
-
-/**
- * Creates every missing ancestor of [directory] with one atomic [createDirectory] each, outermost
- * first. A component that appears between the walk and its creation is accepted only if it is a
- * real directory: `createDirectories` would also adopt a symbolic link whose target is a directory,
- * which is exactly the substitution this file exists to refuse.
- */
-private fun createMissingParents(directory: Path, createDirectory: (Path) -> Unit) {
-    val missing =
-        generateSequence(directory.parent) { it.parent }
-            .takeWhile { !Files.exists(it, NOFOLLOW_LINKS) }
-            .toList()
-    missing.asReversed().forEach { parent ->
-        try {
-            createDirectory(parent)
-        } catch (_: FileAlreadyExistsException) {
-            rejectSubstituted(parent, role = "parent")
+private fun prepareAncestors(directory: Path, createDirectory: (Path) -> Unit) {
+    val ancestors = generateSequence(directory.parent) { it.parent }.toList().asReversed()
+    ancestors.forEach { ancestor ->
+        if (Files.exists(ancestor, NOFOLLOW_LINKS)) {
+            if (!isTrustedPrivateAlias(ancestor, ancestor.root)) {
+                rejectSubstituted(ancestor, role = "ancestor")
+            }
+        } else {
+            try {
+                createDirectory(ancestor)
+            } catch (_: FileAlreadyExistsException) {
+                rejectSubstituted(ancestor, role = "ancestor")
+            }
         }
     }
+}
+
+/**
+ * Whether [link] is one of the root-level aliases macOS ships — `/tmp`, `/var`, and `/etc`, each
+ * pointing at `private/<same name>` — and so may be descended into rather than refused.
+ *
+ * The exemption is deliberately narrow. It is a fixed list of names rather than a path shape, and
+ * it applies on Darwin only: an ordinary Windows user with Developer Mode can create an entry at a
+ * drive root, so a planted `C:\tmp -> private\tmp` would otherwise read as trusted. On macOS the
+ * filesystem root is writable by root alone, which is what makes these aliases safe to follow.
+ *
+ * [root] and [macOs] are parameters only so tests can stage a fake root and both platforms;
+ * production passes the real ones.
+ */
+internal fun isTrustedPrivateAlias(link: Path, root: Path, macOs: Boolean = isMacOs()): Boolean {
+    if (!macOs || link.parent != root || !Files.isSymbolicLink(link)) return false
+    val name = link.fileName.toString()
+    if (name !in MACOS_ROOT_ALIASES) return false
+    val target = runCatching { Files.readSymbolicLink(link) }.getOrNull() ?: return false
+    return target == Path.of(PRIVATE_ALIAS_DIRECTORY).resolve(name)
 }
 
 private fun rejectSubstituted(path: Path, role: String) {
@@ -220,5 +220,10 @@ private fun rejectSubstituted(path: Path, role: String) {
         throw IOException("Coordinator $role $path is not a directory")
     }
 }
+
+private fun isMacOs(): Boolean =
+    System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true)
+
+private val MACOS_ROOT_ALIASES: Set<String> = setOf("tmp", "var", "etc")
 
 private const val PRIVATE_ALIAS_DIRECTORY: String = "private"

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -4,14 +4,24 @@ package dev.sebastiano.spectre.input
 
 import java.io.IOException
 import java.nio.charset.StandardCharsets
+import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.Path
 import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.attribute.PosixFilePermissions
 import java.security.MessageDigest
 import java.util.HexFormat
 
-/** Canonical per-user directory and Unix-domain socket used by the local coordinator. */
+/**
+ * Canonical per-user directory and Unix-domain socket used by the local coordinator.
+ *
+ * [CoordinatorEndpointResolver.resolve] canonicalises an existing base, so the default endpoint
+ * from [LocalCoordinatorEnvironment.defaultEndpoint] carries no symbolic link above it. A
+ * caller-supplied endpoint must be an absolute path beneath a directory the caller already trusts:
+ * [OwnerOnlyEndpointProtection.prepareDirectory] refuses a symbolic link at the endpoint directory
+ * or at any ancestor of it, but it does not verify who owns those ancestors.
+ */
 @ExperimentalSpectreInputCoordinationApi
 public data class CoordinatorEndpoint(public val directory: Path, public val socketPath: Path)
 
@@ -54,7 +64,15 @@ public object CoordinatorEndpointResolver {
 /** Enforces the same-user trust boundary for a coordinator endpoint and its socket file. */
 @ExperimentalSpectreInputCoordinationApi
 public sealed interface OwnerOnlyEndpointProtection {
-    /** Creates or validates the socket's parent directory without following a substituted link. */
+    /**
+     * Creates or validates the socket's parent directory without following a substituted link.
+     *
+     * Neither the endpoint directory nor any ancestor of it may be a symbolic link. The one
+     * exemption is a root-level alias into `/private` — `/tmp`, `/var`, and `/etc` on macOS — which
+     * only root can create. Missing components are created one at a time so a link planted while
+     * this runs is rejected rather than adopted. Ownership of the existing ancestors is not
+     * checked: a caller-supplied endpoint must sit beneath a directory the caller already trusts.
+     */
     @Throws(IOException::class) public fun prepareDirectory(socketPath: Path)
 
     /** Applies owner-only access to a socket after it has been bound. */
@@ -77,24 +95,21 @@ public sealed interface OwnerOnlyEndpointProtection {
 private object PosixOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
     override fun prepareDirectory(socketPath: Path) {
         val directory = socketPath.toAbsolutePath().parent
+        rejectSymbolicAncestors(directory)
         if (Files.exists(directory, NOFOLLOW_LINKS)) {
-            rejectSubstitutedDirectory(directory)
+            rejectSubstituted(directory, role = "directory")
             val permissions = Files.getPosixFilePermissions(directory, NOFOLLOW_LINKS)
             if (permissions != OWNER_ONLY_DIRECTORY_PERMISSIONS) {
                 throw IOException("Existing coordinator directory $directory must be owner-only")
             }
         } else {
-            rejectSymbolicParent(directory.parent)
-            val ownerOnly =
-                java.nio.file.attribute.PosixFilePermissions.asFileAttribute(
-                    OWNER_ONLY_DIRECTORY_PERMISSIONS
-                )
-            // Parents may legitimately be missing (#462), but only they are created loosely. The
-            // endpoint directory itself still goes through the atomic createDirectory: on a
-            // world-writable /tmp another user could plant a symlink between the exists() check
-            // above and this call, and createDirectories would happily adopt a symlink whose
-            // target is a directory, putting the lock, ledger, and socket under their control.
-            directory.parent?.let { Files.createDirectories(it, ownerOnly) }
+            val ownerOnly = PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMISSIONS)
+            // Parents may legitimately be missing (#462). Each of them, and the endpoint directory
+            // itself, goes through the atomic createDirectory: on a world-writable /tmp another
+            // user could plant a symlink between the ancestor walk above and this call, and
+            // createDirectories would happily adopt a symlink whose target is a directory,
+            // putting the lock, ledger, and socket under their control.
+            createMissingParents(directory) { parent -> Files.createDirectory(parent, ownerOnly) }
             Files.createDirectory(directory, ownerOnly)
         }
     }
@@ -119,15 +134,15 @@ private object PosixOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
 private object BasicOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
     override fun prepareDirectory(socketPath: Path) {
         val directory = socketPath.toAbsolutePath().parent
+        rejectSymbolicAncestors(directory)
         if (Files.exists(directory, NOFOLLOW_LINKS)) {
-            rejectSubstitutedDirectory(directory)
+            rejectSubstituted(directory, role = "directory")
         } else {
-            rejectSymbolicParent(directory.parent)
-            // Only the parents are created loosely: on Windows the base is %LOCALAPPDATA%\Temp,
-            // which is absent on profiles whose temp directory has been redirected (#462). The
-            // endpoint directory itself keeps the atomic createDirectory, which refuses to adopt
-            // anything already sitting at that path, symlinks included.
-            directory.parent?.let { Files.createDirectories(it) }
+            // Parents may be missing: on Windows the base is %LOCALAPPDATA%\Temp, which is absent
+            // on profiles whose temp directory has been redirected (#462). Every component keeps
+            // the atomic createDirectory, which refuses to adopt anything already sitting at that
+            // path, symlinks included.
+            createMissingParents(directory) { parent -> Files.createDirectory(parent) }
             Files.createDirectory(directory)
         }
     }
@@ -139,17 +154,60 @@ private object BasicOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
     }
 }
 
-private fun rejectSubstitutedDirectory(directory: Path) {
-    if (Files.isSymbolicLink(directory)) {
-        throw IOException("Coordinator directory $directory must not be a symbolic link")
-    }
-    if (!Files.isDirectory(directory, NOFOLLOW_LINKS)) {
-        throw IOException("Coordinator directory $directory is not a directory")
+/**
+ * Refuses a symbolic link anywhere above [directory], except a root-level alias into `/private`.
+ *
+ * The walk is lexical and deliberately not normalised: the OS resolves a `..` that follows a
+ * planted link against the link's target, so the link itself has to stay visible to this check.
+ */
+private fun rejectSymbolicAncestors(directory: Path) {
+    val substituted =
+        generateSequence(directory.parent) { it.parent }
+            .firstOrNull { Files.isSymbolicLink(it) && !isTrustedPrivateAlias(it, it.root) }
+    if (substituted != null) {
+        throw IOException("Coordinator ancestor $substituted must not be a symbolic link")
     }
 }
 
-private fun rejectSymbolicParent(parent: Path?) {
-    if (parent != null && Files.isSymbolicLink(parent)) {
-        throw IOException("Coordinator parent $parent must not be a symbolic link")
+/**
+ * Whether [link] is a symbolic link directly under [root] that points at `private/<same name>`: the
+ * layout macOS uses for `/tmp`, `/var`, and `/etc`. Only root can create an entry directly under
+ * the filesystem root, so another user cannot have planted such an alias. [root] is a parameter
+ * only so tests can stage a fake root; production passes the real one.
+ */
+internal fun isTrustedPrivateAlias(link: Path, root: Path): Boolean {
+    if (link.parent != root || !Files.isSymbolicLink(link)) return false
+    val target = runCatching { Files.readSymbolicLink(link) }.getOrNull() ?: return false
+    return target == Path.of(PRIVATE_ALIAS_DIRECTORY).resolve(link.fileName)
+}
+
+/**
+ * Creates every missing ancestor of [directory] with one atomic [createDirectory] each, outermost
+ * first. A component that appears between the walk and its creation is accepted only if it is a
+ * real directory: `createDirectories` would also adopt a symbolic link whose target is a directory,
+ * which is exactly the substitution this file exists to refuse.
+ */
+private fun createMissingParents(directory: Path, createDirectory: (Path) -> Unit) {
+    val missing =
+        generateSequence(directory.parent) { it.parent }
+            .takeWhile { !Files.exists(it, NOFOLLOW_LINKS) }
+            .toList()
+    missing.asReversed().forEach { parent ->
+        try {
+            createDirectory(parent)
+        } catch (_: FileAlreadyExistsException) {
+            rejectSubstituted(parent, role = "parent")
+        }
     }
 }
+
+private fun rejectSubstituted(path: Path, role: String) {
+    if (Files.isSymbolicLink(path)) {
+        throw IOException("Coordinator $role $path must not be a symbolic link")
+    }
+    if (!Files.isDirectory(path, NOFOLLOW_LINKS)) {
+        throw IOException("Coordinator $role $path is not a directory")
+    }
+}
+
+private const val PRIVATE_ALIAS_DIRECTORY: String = "private"

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
@@ -162,4 +162,29 @@ class CoordinatorEndpointTest {
 
         assertTrue(failure.message.orEmpty().contains("owner-only"))
     }
+
+    @Test
+    fun `an endpoint whose directory is not the socket's parent is rejected`() {
+        // The owner-only guard protects the socket's parent, but the election lock and recovery
+        // ledger live in `directory`. If the two could differ, a caller-supplied endpoint could
+        // route coordinator state through a directory nothing checked.
+        val failure =
+            assertFailsWith<IllegalArgumentException> {
+                CoordinatorEndpoint(
+                    directory = temporaryDirectory.resolve("elsewhere"),
+                    socketPath = temporaryDirectory.resolve("coordinator").resolve("input.sock"),
+                )
+            }
+
+        assertTrue(failure.message.orEmpty().contains("parent"), failure.message)
+    }
+
+    @Test
+    fun `an endpoint whose directory is the socket's parent is accepted`() {
+        val directory = temporaryDirectory.resolve("coordinator")
+
+        val endpoint = CoordinatorEndpoint(directory, directory.resolve("input.sock"))
+
+        assertEquals(directory, endpoint.socketPath.parent)
+    }
 }

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionAncestorTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionAncestorTest.kt
@@ -128,9 +128,17 @@ class OwnerOnlyEndpointProtectionAncestorTest {
     @Test
     fun `the macOS tmp alias keeps a caller-supplied tmp endpoint working`() {
         val tmp = Path.of("/tmp")
+        // Gate on the OS, not just the link: the exemption is Darwin-only, so on a non-macOS host
+        // whose /tmp happens to be a symbolic link -- some container images do that -- production
+        // rejects it and this expectation does not hold. Skipping there keeps `./gradlew check`
+        // green for those contributors, which is the failure shape #467 was about.
+        assumeTrue(
+            System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true),
+            "the /private aliases are a Darwin layout",
+        )
         assumeTrue(
             Files.isSymbolicLink(tmp),
-            "only meaningful where /tmp is an alias into /private, which is the macOS layout",
+            "only meaningful where /tmp is an alias into /private",
         )
         // A base under /tmp that does not exist yet: resolve() would only normalise it, so the
         // /tmp link stays in the path handed to prepareDirectory. This must keep working.

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionAncestorTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionAncestorTest.kt
@@ -1,0 +1,214 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.io.IOException
+import java.nio.file.FileSystemException
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.attribute.PosixFilePermissions
+import java.util.UUID
+import kotlin.io.path.createSymbolicLinkPointingTo
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * #465: `prepareDirectory` guarded the endpoint directory and its immediate parent, but nothing
+ * above them. A caller-supplied endpoint whose base directory does not exist yet is only
+ * normalised, never canonicalised, so a symbolic link planted higher up — in a shared `/tmp`, say —
+ * was followed silently and the election lock, recovery ledger, and socket all landed inside the
+ * link's target while still appearing to satisfy the owner-only contract.
+ *
+ * The obvious remedy, rejecting every symlinked ancestor, cannot be applied literally: on macOS
+ * `/tmp`, `/var`, and `/etc` are themselves symbolic links into `/private`, and JUnit's `@TempDir`
+ * lives under `/var/folders`. Those root-level aliases are the one exemption, and the only one.
+ */
+class OwnerOnlyEndpointProtectionAncestorTest {
+
+    @TempDir lateinit var temporaryDirectory: Path
+
+    @Test
+    fun `a symbolic link above a missing base is rejected instead of followed`() {
+        assumeCanCreateSymbolicLinks()
+        val target = Files.createDirectory(temporaryDirectory.resolve("target"))
+        val link = temporaryDirectory.resolve("link").createSymbolicLinkPointingTo(target)
+        // "base" does not exist, which is exactly the shape CoordinatorEndpointResolver only
+        // normalises. The link sits two levels above the endpoint directory, one above the
+        // immediate parent that was already checked.
+        val socket = link.resolve("base").resolve(ENDPOINT_DIRECTORY_NAME).resolve("input.sock")
+
+        val failure =
+            assertFailsWith<IOException> {
+                OwnerOnlyEndpointProtection.forPath(socket).prepareDirectory(socket)
+            }
+
+        assertTrue(failure.message.orEmpty().contains("symbolic link"), failure.message)
+        assertFalse(
+            Files.exists(target.resolve("base")),
+            "nothing may be created through the link before it is rejected",
+        )
+    }
+
+    @Test
+    fun `a symbolic link above an existing endpoint directory is rejected`() {
+        assumeCanCreateSymbolicLinks()
+        val target = temporaryDirectory.resolve("target")
+        val existing =
+            Files.createDirectories(target.resolve("base").resolve(ENDPOINT_DIRECTORY_NAME))
+        if (Files.getFileStore(existing).supportsFileAttributeView("posix")) {
+            // Owner-only, so the only thing left to object to is the ancestor.
+            Files.setPosixFilePermissions(existing, PosixFilePermissions.fromString("rwx------"))
+        }
+        val link = temporaryDirectory.resolve("link").createSymbolicLinkPointingTo(target)
+        val socket = link.resolve("base").resolve(ENDPOINT_DIRECTORY_NAME).resolve("input.sock")
+
+        val failure =
+            assertFailsWith<IOException> {
+                OwnerOnlyEndpointProtection.forPath(socket).prepareDirectory(socket)
+            }
+
+        assertTrue(failure.message.orEmpty().contains("symbolic link"), failure.message)
+    }
+
+    @Test
+    fun `a symbolic link as the immediate parent is still rejected`() {
+        assumeCanCreateSymbolicLinks()
+        val target = Files.createDirectory(temporaryDirectory.resolve("target"))
+        val link = temporaryDirectory.resolve("link").createSymbolicLinkPointingTo(target)
+        val socket = link.resolve(ENDPOINT_DIRECTORY_NAME).resolve("input.sock")
+
+        val failure =
+            assertFailsWith<IOException> {
+                OwnerOnlyEndpointProtection.forPath(socket).prepareDirectory(socket)
+            }
+
+        assertTrue(failure.message.orEmpty().contains("symbolic link"), failure.message)
+        assertFalse(Files.exists(target.resolve(ENDPOINT_DIRECTORY_NAME)))
+    }
+
+    @Test
+    fun `a missing base several levels deep is created beneath real ancestors`() {
+        val socket =
+            temporaryDirectory
+                .resolve("missing")
+                .resolve("base")
+                .resolve(ENDPOINT_DIRECTORY_NAME)
+                .resolve("input.sock")
+
+        OwnerOnlyEndpointProtection.forPath(socket).prepareDirectory(socket)
+
+        assertTrue(Files.isDirectory(socket.parent), "the endpoint directory should exist")
+        if (Files.getFileStore(socket.parent).supportsFileAttributeView("posix")) {
+            assertTrue(
+                Files.getPosixFilePermissions(socket.parent) ==
+                    PosixFilePermissions.fromString("rwx------"),
+                "the endpoint directory must stay owner-only",
+            )
+        }
+    }
+
+    @Test
+    fun `an intermediate component occupied by a regular file is rejected`() {
+        Files.createFile(temporaryDirectory.resolve("base"))
+        val socket =
+            temporaryDirectory
+                .resolve("base")
+                .resolve(ENDPOINT_DIRECTORY_NAME)
+                .resolve("input.sock")
+
+        assertFailsWith<IOException> {
+            OwnerOnlyEndpointProtection.forPath(socket).prepareDirectory(socket)
+        }
+    }
+
+    @Test
+    fun `the macOS tmp alias keeps a caller-supplied tmp endpoint working`() {
+        val tmp = Path.of("/tmp")
+        assumeTrue(
+            Files.isSymbolicLink(tmp),
+            "only meaningful where /tmp is an alias into /private, which is the macOS layout",
+        )
+        // A base under /tmp that does not exist yet: resolve() would only normalise it, so the
+        // /tmp link stays in the path handed to prepareDirectory. This must keep working.
+        val base = tmp.resolve("spectre-465-${UUID.randomUUID().toString().take(8)}")
+        val socket = base.resolve(ENDPOINT_DIRECTORY_NAME).resolve("input.sock")
+        try {
+            OwnerOnlyEndpointProtection.forPath(socket).prepareDirectory(socket)
+
+            assertTrue(Files.isDirectory(socket.parent), "the endpoint directory should exist")
+        } finally {
+            Files.deleteIfExists(socket.parent)
+            Files.deleteIfExists(base)
+        }
+    }
+
+    @Test
+    fun `a root-level link into private is a trusted alias`() {
+        assumeCanCreateSymbolicLinks()
+        Files.createDirectories(temporaryDirectory.resolve("private").resolve("tmp"))
+        val alias =
+            temporaryDirectory
+                .resolve("tmp")
+                .createSymbolicLinkPointingTo(Path.of("private", "tmp"))
+
+        assertTrue(isTrustedPrivateAlias(alias, root = temporaryDirectory))
+    }
+
+    @Test
+    fun `links that are not the root-level private alias are not trusted`() {
+        assumeCanCreateSymbolicLinks()
+        Files.createDirectories(temporaryDirectory.resolve("private").resolve("tmp"))
+        Files.createDirectories(temporaryDirectory.resolve("elsewhere"))
+        Files.createDirectories(temporaryDirectory.resolve("sub").resolve("private").resolve("tmp"))
+        val pointingElsewhere =
+            temporaryDirectory.resolve("tmp").createSymbolicLinkPointingTo(Path.of("elsewhere"))
+        val differentName =
+            temporaryDirectory
+                .resolve("var")
+                .createSymbolicLinkPointingTo(Path.of("private", "tmp"))
+        val belowTheRoot =
+            temporaryDirectory
+                .resolve("sub")
+                .resolve("tmp")
+                .createSymbolicLinkPointingTo(Path.of("private", "tmp"))
+        val plainDirectory = temporaryDirectory.resolve("private")
+
+        assertFalse(isTrustedPrivateAlias(pointingElsewhere, root = temporaryDirectory))
+        assertFalse(isTrustedPrivateAlias(differentName, root = temporaryDirectory))
+        assertFalse(isTrustedPrivateAlias(belowTheRoot, root = temporaryDirectory))
+        assertFalse(isTrustedPrivateAlias(plainDirectory, root = temporaryDirectory))
+    }
+
+    /**
+     * Windows needs Developer Mode or `SeCreateSymbolicLinkPrivilege` to create a symbolic link and
+     * otherwise throws [FileSystemException], not [UnsupportedOperationException] (#467). Skip
+     * cleanly there rather than fail `./gradlew check`; hosts that can create links still cover the
+     * guard.
+     */
+    private fun assumeCanCreateSymbolicLinks() {
+        val probe = temporaryDirectory.resolve("symlink-probe")
+        val canCreate =
+            try {
+                probe.createSymbolicLinkPointingTo(temporaryDirectory.resolve("probe-target"))
+                Files.deleteIfExists(probe)
+                true
+            } catch (_: UnsupportedOperationException) {
+                false
+            } catch (_: FileSystemException) {
+                false
+            }
+        assumeTrue(
+            canCreate,
+            "Host cannot create symbolic links (Windows: enable Developer Mode or grant " +
+                "SeCreateSymbolicLinkPrivilege); the ancestor guards stay covered on hosts that can.",
+        )
+    }
+
+    private companion object {
+        const val ENDPOINT_DIRECTORY_NAME: String = "spectre-input-abcd1234"
+    }
+}

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionAncestorTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionAncestorTest.kt
@@ -155,7 +155,7 @@ class OwnerOnlyEndpointProtectionAncestorTest {
                 .resolve("tmp")
                 .createSymbolicLinkPointingTo(Path.of("private", "tmp"))
 
-        assertTrue(isTrustedPrivateAlias(alias, root = temporaryDirectory))
+        assertTrue(isTrustedPrivateAlias(alias, root = temporaryDirectory, macOs = true))
     }
 
     @Test
@@ -166,7 +166,7 @@ class OwnerOnlyEndpointProtectionAncestorTest {
         Files.createDirectories(temporaryDirectory.resolve("sub").resolve("private").resolve("tmp"))
         val pointingElsewhere =
             temporaryDirectory.resolve("tmp").createSymbolicLinkPointingTo(Path.of("elsewhere"))
-        val differentName =
+        val mismatchedTarget =
             temporaryDirectory
                 .resolve("var")
                 .createSymbolicLinkPointingTo(Path.of("private", "tmp"))
@@ -177,10 +177,79 @@ class OwnerOnlyEndpointProtectionAncestorTest {
                 .createSymbolicLinkPointingTo(Path.of("private", "tmp"))
         val plainDirectory = temporaryDirectory.resolve("private")
 
-        assertFalse(isTrustedPrivateAlias(pointingElsewhere, root = temporaryDirectory))
-        assertFalse(isTrustedPrivateAlias(differentName, root = temporaryDirectory))
-        assertFalse(isTrustedPrivateAlias(belowTheRoot, root = temporaryDirectory))
-        assertFalse(isTrustedPrivateAlias(plainDirectory, root = temporaryDirectory))
+        assertFalse(isTrustedPrivateAlias(pointingElsewhere, temporaryDirectory, macOs = true))
+        assertFalse(isTrustedPrivateAlias(mismatchedTarget, temporaryDirectory, macOs = true))
+        assertFalse(isTrustedPrivateAlias(belowTheRoot, temporaryDirectory, macOs = true))
+        assertFalse(isTrustedPrivateAlias(plainDirectory, temporaryDirectory, macOs = true))
+    }
+
+    @Test
+    fun `the private alias exemption does not apply off macOS`() {
+        // #483 review: on Windows with Developer Mode, an ordinary user can create an entry at a
+        // drive root, so a planted `C:\tmp -> private\tmp` would otherwise read as trusted. Only
+        // Darwin ships these aliases, so only Darwin honours them.
+        assumeCanCreateSymbolicLinks()
+        Files.createDirectories(temporaryDirectory.resolve("private").resolve("tmp"))
+        val alias =
+            temporaryDirectory
+                .resolve("tmp")
+                .createSymbolicLinkPointingTo(Path.of("private", "tmp"))
+
+        assertFalse(isTrustedPrivateAlias(alias, root = temporaryDirectory, macOs = false))
+    }
+
+    @Test
+    fun `only the aliases macOS actually ships are trusted`() {
+        // The exemption is a fixed list, not a path shape: /tmp, /var and /etc are what Darwin
+        // links into /private, and nothing else gets the same pass.
+        assumeCanCreateSymbolicLinks()
+        Files.createDirectories(temporaryDirectory.resolve("private").resolve("opt"))
+        val undocumented =
+            temporaryDirectory
+                .resolve("opt")
+                .createSymbolicLinkPointingTo(Path.of("private", "opt"))
+
+        assertFalse(isTrustedPrivateAlias(undocumented, root = temporaryDirectory, macOs = true))
+    }
+
+    @Test
+    fun `every macOS root alias is trusted`() {
+        assumeCanCreateSymbolicLinks()
+        listOf("tmp", "var", "etc").forEach { name ->
+            Files.createDirectories(temporaryDirectory.resolve("private").resolve(name))
+            val alias =
+                temporaryDirectory
+                    .resolve(name)
+                    .createSymbolicLinkPointingTo(Path.of("private", name))
+
+            assertTrue(
+                isTrustedPrivateAlias(alias, root = temporaryDirectory, macOs = true),
+                "/$name is a real Darwin alias and must stay usable",
+            )
+        }
+    }
+
+    @Test
+    fun `a symbolic link at the first existing ancestor is rejected before anything is created`() {
+        // #483 review: the parent walk used to stop at the first existing component without
+        // validating it, so a link that appeared there after the ancestor check was followed by
+        // the endpoint directory's own createDirectory. Every component is now checked immediately
+        // before it is descended into.
+        assumeCanCreateSymbolicLinks()
+        val target = Files.createDirectory(temporaryDirectory.resolve("target"))
+        val boundary = temporaryDirectory.resolve("boundary").createSymbolicLinkPointingTo(target)
+        val socket = boundary.resolve(ENDPOINT_DIRECTORY_NAME).resolve("input.sock")
+
+        val failure =
+            assertFailsWith<IOException> {
+                OwnerOnlyEndpointProtection.forPath(socket).prepareDirectory(socket)
+            }
+
+        assertTrue(failure.message.orEmpty().contains("symbolic link"), failure.message)
+        assertFalse(
+            Files.exists(target.resolve(ENDPOINT_DIRECTORY_NAME)),
+            "the endpoint directory must not be created through the link",
+        )
     }
 
     /**


### PR DESCRIPTION
## Summary

Closes #465.

`OwnerOnlyEndpointProtection.prepareDirectory` now refuses a symbolic link at **any** ancestor of the endpoint directory, not just the immediate parent, with exactly one exemption: the root-level aliases Darwin ships (`/tmp`, `/var`, `/etc` → `private/…`), where only root can create an entry at the filesystem root. Ancestors are validated and created in a single top-down walk that checks each component immediately before descending into it. Ownership of the ancestors is deliberately **not** verified; the docs state the embedder contract instead.

This is the issue's third direction (state the contract, assert what can be asserted) plus the one cheap, portable assertion that actually catches the planted-link case.

### Contract change for embedders

A caller-supplied `CoordinatorEndpoint` that passes through a symbolic link anywhere above the endpoint directory is now rejected with `Coordinator ancestor <path> must not be a symbolic link`, unless the link is one of the Darwin aliases. Previously it was followed silently. Embedders whose path goes through some other link (`/var/run` on Linux, a symlinked home, a Nix store path) must pass the canonical form (`toRealPath()`). The default endpoint is unchanged on every platform: `resolve()` already canonicalises an existing base, so macOS's `/tmp` is `/private/tmp` before the guard runs, and `%LOCALAPPDATA%\Temp` has no symlink ancestors.

`CoordinatorEndpoint` additionally requires `directory == socketPath.parent`. The guard protects the socket's parent, while `LocalCoordinatorServer` keeps its election lock and recovery ledger in `directory`; letting the two differ routed that state through a directory nothing checked. Every in-tree constructor already satisfied the invariant.

One relaxation falls out of applying the alias uniformly: a directly-constructed endpoint whose *immediate* parent is macOS's `/tmp` used to be rejected as a symlinked parent and now works. A planted symlink as the immediate parent stays rejected.

### Rejected

- **Canonicalise a caller-supplied base the way `resolve` does.** It does not close the gap: `toRealPath()` follows a pre-planted link and hands back the attacker's directory as an honest-looking canonical path. It only narrows a TOCTOU window for the one process that canonicalised, while other processes keep connecting through the original spelling, and it silently rewrites the path the embedder supplied.
- **Validate the canonical form against an expected per-user root.** A whitelist of roots is wrong for containers, CI scratch directories, and `XDG_RUNTIME_DIR`, and membership in `/tmp` is not a trust property in the first place: `/tmp` is sticky and world-writable, which is precisely where a link gets planted.
- **Verify ownership and writability of every ancestor** (what `DaemonServer` does for the CLI daemon). It is the stronger guard, but it goes beyond symlinked ancestors, has known false positives (a service account owning a parent), and its Windows semantics were not validated here. Documented as the boundary instead; easy to add later if wanted.

### Known limit

Path traversal is not race-free and this PR does not claim otherwise. Every component is checked immediately before it is descended into, so nothing is skipped, but closing the window entirely needs an `openat`-style descent (`SecureDirectoryStream`, which POSIX supports and Windows does not). The KDoc says so at the walk. Happy to do that as a follow-up if you want the POSIX path fully closed.

### CI scope

The macOS and Windows workflows now include `input-coordinator/**` and `input-coordinator-server/**` in their path filters: the endpoint layout is OS-specific and the `/tmp` alias test only runs on a real Mac. Drop that hunk if you would rather keep those filters as they were.

## Test plan

New `OwnerOnlyEndpointProtectionAncestorTest`, written first and proven red: the two higher-ancestor cases completed without throwing against the old guard, and the two alias-scope cases against the first version of the predicate.

| Case | Result |
|---|---|
| symlinked higher ancestor, base missing (the issue's scenario) | rejected, nothing created through the link |
| symlinked higher ancestor, endpoint directory already exists | rejected |
| symlinked immediate parent | still rejected |
| symlink at the first existing ancestor | rejected before anything is created |
| missing base several levels deep | created, endpoint directory stays 0700 |
| intermediate component that is a regular file | rejected |
| caller-supplied path under a symlinked `/tmp` | works; runs only where `/tmp` is a link (macOS), skipped elsewhere |
| all three Darwin aliases (`tmp`, `var`, `etc`) | trusted |
| alias-shaped link off Darwin | not trusted |
| undocumented alias-shaped name on Darwin | not trusted |
| endpoint whose `directory` is not the socket's parent | rejected at construction |

Every symlink-creating test probes link creation first and assumption-skips where the host refuses it, the pattern #476 established for Windows without Developer Mode.

One coverage caveat, stated rather than papered over: the first-existing-ancestor test passes against the old code too, because only a genuine race reached that gap. It guards the new structure; the race itself has no deterministic test without a seam in the walk.

- [x] `./gradlew check` passes locally (Linux, `LC_ALL=C.UTF-8`, `JAVA_TOOL_OPTIONS` unset; the sandbox's POSIX locale and injected JVM options otherwise break three unrelated unicode-path tests and the CLI zip's launcher preflight)
- [x] `./gradlew ktfmtFormat` produced no changes
- [x] `mkdocs build --strict` passes
- [x] ABI dump unchanged: only private and `internal` declarations were added
- [x] macOS and Windows legs green on CI (`check-macos` and `check-windows` both passed on `f6acbb4`; the earlier `check-macos` red on `be453f9` was an unrelated flake in `DaemonFixtureIntegrationTest`, whose attach retry budget expired on a busy runner, and it passed on the next commit without a change to that path)

## Confirmations

- This PR **is** LLM-generated, produced by Claude Code at the repository owner's request, so the "not LLM-generated" confirmation is deliberately left unchecked.
- [ ] Licensing under [Apache-2.0](../LICENSE) is the owner's call to confirm.