### PR TITLE
test(release-smoke): cover experimental input coordination gate (#459)

### DIFF
--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -237,6 +237,7 @@ class SmokeLibSchemaTest(unittest.TestCase):
             "input-coord-revoke",
             "input-coord-forced-recovery",
             "input-coord-junit-pertest",
+            "input-coord-headed-robot",
         }
         self.assertEqual(expected, set(smoke_lib.REQUIRED_SCENARIO_IDS))
 
@@ -611,6 +612,11 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn(
             "the per-test lease is still held while failure evidence is captured", text
         )
+        # The headed cell is operator-recorded and must never be satisfiable by the automated
+        # coordinator cells, which pass headless. It stays hard n/a until evidence is supplied.
+        self.assertIn("input-coord-headed-robot", text)
+        self.assertIn("--headed-robot-evidence", text)
+        self.assertIn("HEADED_ROBOT_NA_REASON", text)
         # Non-login SSH / xvfb-run must still see rustup cargo for helper rebuilds.
         self.assertIn("apply_linux_toolchain_path", text)
         # Nested buildSrc test must not start a daemon that --stops parent ./gradlew check.

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -345,16 +345,36 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn("operator evidence: ran on Mattone", recorded.detail)
         self.assertEqual([], smoke_lib.hard_failures([recorded]))
 
-    def test_input_coordination_smoke_skip_reason_present_on_this_checkout(self):
-        # The experimental coordinator + isolation test surface exists on this tree, so the cells
-        # are hard-runnable (no display needed) and must not be N/A.
-        self.assertIsNone(smoke_lib.input_coordination_smoke_skip_reason(ROOT))
+    def test_input_coordination_surface_present_on_this_checkout(self):
+        # The experimental coordinator + isolation proofs exist on this tree, so the cells are
+        # hard-runnable (no display needed) and must actually execute.
+        self.assertIsNone(smoke_lib.input_coordination_missing_surface(ROOT))
 
-    def test_input_coordination_smoke_skip_reason_when_surface_absent(self):
+    def test_missing_coordination_surface_fails_rather_than_skips(self):
+        """A deleted or renamed proof must not turn six hard cells green by omission."""
         with tempfile.TemporaryDirectory() as tmp:
-            reason = smoke_lib.input_coordination_smoke_skip_reason(Path(tmp))
-            self.assertIsNotNone(reason)
-            self.assertIn("re-scope the release gate", reason)
+            detail = smoke_lib.input_coordination_missing_surface(Path(tmp))
+            self.assertIsNotNone(detail)
+            self.assertIn("failure, not a skip", detail)
+            self.assertIn("re-scope the release", detail)
+            # The gate that matters: a reasoned n/a is ignored by hard_failures(), so the runner
+            # must record a missing proof as a fail row instead.
+            failed = smoke_lib.scenario_result(
+                "input-coord-contention",
+                name="x",
+                result=smoke_lib.RESULT_FAIL,
+                detail=detail,
+            )
+            self.assertEqual(["input-coord-contention"], smoke_lib.hard_failures([failed]))
+            ignored = smoke_lib.scenario_result(
+                "input-coord-contention", name="x", result="n/a", reason=detail
+            )
+            self.assertEqual(
+                [],
+                smoke_lib.hard_failures([ignored]),
+                "a reasoned n/a is ignored by hard_failures — exactly why a missing proof "
+                "must not be recorded as one",
+            )
 
     def test_assert_junit_testcases_passed_rejects_skipped(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -607,7 +627,7 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn("*PointerMoveLive*", text)
         # #459: experimental input-coordination delta hard cells must drive the coordinator's own
         # deterministic + forked-process + JUnit-isolation tests, fail-closed on the JUnit XML.
-        self.assertIn("input_coordination_smoke_skip_reason", text)
+        self.assertIn("input_coordination_missing_surface", text)
         self.assertIn("assert_junit_testcases_passed", text)
         self.assertIn(":input-coordinator-server:test", text)
         self.assertIn(":testing:test", text)

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -606,6 +606,11 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn(
             "concurrent per-test invocations never hold the desktop lease at the same time", text
         )
+        # Each half of the per-test bullet is gated by name. Gating only the class would let the
+        # evidence-capture method be removed or renamed while the cell still reported pass.
+        self.assertIn(
+            "the per-test lease is still held while failure evidence is captured", text
+        )
         # Non-login SSH / xvfb-run must still see rustup cargo for helper rebuilds.
         self.assertIn("apply_linux_toolchain_path", text)
         # Nested buildSrc test must not start a daemon that --stops parent ./gradlew check.

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -231,6 +231,12 @@ class SmokeLibSchemaTest(unittest.TestCase):
             "maven-local-consumer",
             "portal-token-warmup",
             "pointer-move",
+            "input-coord-contention",
+            "input-coord-cancellation",
+            "input-coord-quarantine",
+            "input-coord-revoke",
+            "input-coord-forced-recovery",
+            "input-coord-junit-pertest",
         }
         self.assertEqual(expected, set(smoke_lib.REQUIRED_SCENARIO_IDS))
 
@@ -297,6 +303,79 @@ class SmokeLibSchemaTest(unittest.TestCase):
             with self.assertRaises(RuntimeError) as raised:
                 smoke_lib.assert_pointer_move_live_executed(root)
             self.assertIn("skipped", str(raised.exception))
+
+    def test_input_coordination_smoke_skip_reason_present_on_this_checkout(self):
+        # The experimental coordinator + isolation test surface exists on this tree, so the cells
+        # are hard-runnable (no display needed) and must not be N/A.
+        self.assertIsNone(smoke_lib.input_coordination_smoke_skip_reason(ROOT))
+
+    def test_input_coordination_smoke_skip_reason_when_surface_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            reason = smoke_lib.input_coordination_smoke_skip_reason(Path(tmp))
+            self.assertIsNotNone(reason)
+            self.assertIn("re-scope the release gate", reason)
+
+    def test_assert_junit_testcases_passed_rejects_skipped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            results = Path(tmp)
+            (results / "TEST-coord.xml").write_text(
+                '<?xml version="1.0"?>\n'
+                '<testsuite name="LocalCoordinatorServerTest" tests="1" failures="0" '
+                'errors="0" skipped="1">\n'
+                '  <testcase name="explicit force advances FIFO and reports unsafe takeover" '
+                'classname="x"><skipped/></testcase>\n'
+                "</testsuite>\n",
+                encoding="utf-8",
+            )
+            with self.assertRaises(RuntimeError) as ctx:
+                smoke_lib.assert_junit_testcases_passed(
+                    results,
+                    needles=["explicit force advances FIFO and reports unsafe takeover"],
+                    cell="input-coord-forced-recovery",
+                )
+            self.assertIn("skipped", str(ctx.exception).lower())
+
+    def test_assert_junit_testcases_passed_requires_every_needle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            results = Path(tmp)
+            (results / "TEST-coord.xml").write_text(
+                '<?xml version="1.0"?>\n'
+                '<testsuite name="LocalCoordinatorServerTest" tests="1" failures="0" '
+                'errors="0" skipped="0">\n'
+                '  <testcase name="two independent clients receive one desktop lease in FIFO '
+                'order" classname="x" time="1.0"/>\n'
+                "</testsuite>\n",
+                encoding="utf-8",
+            )
+            # The FIFO needle is present, but the forked-coordinator needle is not: fail closed.
+            with self.assertRaises(RuntimeError) as ctx:
+                smoke_lib.assert_junit_testcases_passed(
+                    results,
+                    needles=[
+                        "two independent clients receive one desktop lease in FIFO order",
+                        "forked coordinator accepts a real client lease",
+                    ],
+                    cell="input-coord-contention",
+                )
+            self.assertIn("not found", str(ctx.exception).lower())
+
+    def test_assert_junit_testcases_passed_accepts_executed_pass(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            results = Path(tmp)
+            (results / "TEST-coord.xml").write_text(
+                '<?xml version="1.0"?>\n'
+                '<testsuite name="LocalCoordinatorServerTest" tests="1" failures="0" '
+                'errors="0" skipped="0">\n'
+                '  <testcase name="exact-id revoke rejects stale observation and fences the '
+                'actual holder" classname="x" time="1.0"/>\n'
+                "</testsuite>\n",
+                encoding="utf-8",
+            )
+            smoke_lib.assert_junit_testcases_passed(
+                results,
+                needles=["exact-id revoke rejects stale observation and fences the actual holder"],
+                cell="input-coord-revoke",
+            )
 
     def test_hard_na_without_reason_becomes_fail(self):
         result = smoke_lib.scenario_result(
@@ -485,6 +564,16 @@ class SmokeLibSchemaTest(unittest.TestCase):
         # #433: live pointer-move cell must stay fail-closed once moveTo/moveBy ship.
         self.assertIn("pointer_move_api_skip_reason", text)
         self.assertIn("*PointerMoveLive*", text)
+        # #459: experimental input-coordination delta hard cells must drive the coordinator's own
+        # deterministic + forked-process + JUnit-isolation tests, fail-closed on the JUnit XML.
+        self.assertIn("input_coordination_smoke_skip_reason", text)
+        self.assertIn("assert_junit_testcases_passed", text)
+        self.assertIn(":input-coordinator-server:test", text)
+        self.assertIn(":testing:test", text)
+        self.assertIn("LocalCoordinatorServerTest", text)
+        self.assertIn("CoordinatorProcessLauncherTest", text)
+        self.assertIn("InputIsolationLifecycleTest", text)
+        self.assertIn("explicit force advances FIFO and reports unsafe takeover", text)
         # Non-login SSH / xvfb-run must still see rustup cargo for helper rebuilds.
         self.assertIn("apply_linux_toolchain_path", text)
         # Nested buildSrc test must not start a daemon that --stops parent ./gradlew check.
@@ -875,6 +964,17 @@ class DocsAndSchemaPolicyTest(unittest.TestCase):
         self.assertIn("bump", docs.lower())
         self.assertIn("--preflight-only", docs)
         self.assertIn("preflight-only", docs)
+        # #459: the experimental input-coordination delta cells are reusable scenario IDs, so the
+        # stable-ID table / gate must document them (not leave the commands only in chat).
+        for coordination_id in (
+            "input-coord-contention",
+            "input-coord-cancellation",
+            "input-coord-quarantine",
+            "input-coord-revoke",
+            "input-coord-forced-recovery",
+            "input-coord-junit-pertest",
+        ):
+            self.assertIn(coordination_id, docs)
 
     def test_validate_report_rejects_missing_required_ids(self):
         preflight = smoke_lib.collect_preflight(ROOT, version="0.5.0")

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -304,6 +304,28 @@ class SmokeLibSchemaTest(unittest.TestCase):
                 smoke_lib.assert_pointer_move_live_executed(root)
             self.assertIn("skipped", str(raised.exception))
 
+    def test_coordination_cross_process_and_parallel_proofs_exist(self):
+        """The cells must be backed by real multi-JVM / concurrent tests, not just docs claims."""
+        contention = (
+            ROOT
+            / "input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server"
+            / "TwoClientJvmContentionTest.kt"
+        )
+        probe = contention.with_name("TwoClientJvmContentionProbe.kt")
+        parallel = (
+            ROOT
+            / "testing/src/test/kotlin/dev/sebastiano/spectre/testing"
+            / "ParallelPerTestInputIsolationTest.kt"
+        )
+        for path in (contention, probe, parallel):
+            self.assertTrue(path.is_file(), f"missing coordination gate proof: {path}")
+        # The contention proof must genuinely fork a second client process.
+        self.assertIn("ProcessBuilder", contention.read_text(encoding="utf-8"))
+        # The parallel proof must drive concurrent invocations against a real coordinator.
+        parallel_text = parallel.read_text(encoding="utf-8")
+        self.assertIn("LocalCoordinatorServer", parallel_text)
+        self.assertIn("Executors", parallel_text)
+
     def test_input_coordination_smoke_skip_reason_present_on_this_checkout(self):
         # The experimental coordinator + isolation test surface exists on this tree, so the cells
         # are hard-runnable (no display needed) and must not be N/A.
@@ -574,6 +596,16 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn("CoordinatorProcessLauncherTest", text)
         self.assertIn("InputIsolationLifecycleTest", text)
         self.assertIn("explicit force advances FIFO and reports unsafe takeover", text)
+        # The two cells whose gate bullets need cross-process / concurrent proof must drive the
+        # tests that actually supply it, not only the single-JVM sequential ones.
+        self.assertIn("TwoClientJvmContentionTest", text)
+        self.assertIn(
+            "two independent client JVMs never hold the desktop lease at the same time", text
+        )
+        self.assertIn("ParallelPerTestInputIsolationTest", text)
+        self.assertIn(
+            "concurrent per-test invocations never hold the desktop lease at the same time", text
+        )
         # Non-login SSH / xvfb-run must still see rustup cargo for helper rebuilds.
         self.assertIn("apply_linux_toolchain_path", text)
         # Nested buildSrc test must not start a daemon that --stops parent ./gradlew check.

--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -327,6 +327,24 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn("LocalCoordinatorServer", parallel_text)
         self.assertIn("Executors", parallel_text)
 
+    def test_headed_robot_cell_blocks_without_operator_evidence(self):
+        """A reasoned n/a would let the runner print ALL HARD SCENARIOS PASSED; it must fail."""
+        missing = smoke_lib.headed_robot_cell(None)
+        self.assertEqual("fail", missing.result)
+        self.assertIn("was NOT recorded", missing.detail)
+        # The actual gate: hard_failures() ignores a reasoned n/a, so this must be a fail row.
+        self.assertEqual(
+            ["input-coord-headed-robot"], smoke_lib.hard_failures([missing])
+        )
+        for blank in ("", "   "):
+            self.assertEqual("fail", smoke_lib.headed_robot_cell(blank).result)
+
+    def test_headed_robot_cell_passes_only_with_recorded_evidence(self):
+        recorded = smoke_lib.headed_robot_cell("ran on Mattone; run URL ...")
+        self.assertEqual("pass", recorded.result)
+        self.assertIn("operator evidence: ran on Mattone", recorded.detail)
+        self.assertEqual([], smoke_lib.hard_failures([recorded]))
+
     def test_input_coordination_smoke_skip_reason_present_on_this_checkout(self):
         # The experimental coordinator + isolation test surface exists on this tree, so the cells
         # are hard-runnable (no display needed) and must not be N/A.
@@ -616,7 +634,7 @@ class SmokeLibSchemaTest(unittest.TestCase):
         # coordinator cells, which pass headless. It stays hard n/a until evidence is supplied.
         self.assertIn("input-coord-headed-robot", text)
         self.assertIn("--headed-robot-evidence", text)
-        self.assertIn("HEADED_ROBOT_NA_REASON", text)
+        self.assertIn("headed_robot_cell", text)
         # Non-login SSH / xvfb-run must still see rustup cargo for helper rebuilds.
         self.assertIn("apply_linux_toolchain_path", text)
         # Nested buildSrc test must not start a daemon that --stops parent ./gradlew check.

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -96,7 +96,10 @@ done
 # --- #459 experimental input-coordination delta hard cells ---
 # The coordination cells must drive the coordinator's own deterministic + forked-process + JUnit
 # isolation tests and fail closed on the JUnit XML (never a fake PASS). Hard on Windows including SSH.
-grep -F -q 'Get-InputCoordinationSkipReason' "$script" || fail "Windows runner missing input-coordination skip-reason probe"
+grep -F -q 'Get-InputCoordinationMissingSurface' "$script" || fail "Windows runner missing input-coordination surface probe"
+# A missing proof source must FAIL, not become a reasoned n/a the failure count ignores.
+grep -F -q 'failure, not a skip' "$script" || fail "Windows missing-surface message must say it is a failure"
+grep -F -q 'Result "fail" -Detail $MissingSurface' "$script" || fail "Windows coordination cell must FAIL when its proof source is missing"
 grep -F -q 'Assert-JUnitTestcasesPassed' "$script" || fail "Windows runner missing coordination JUnit XML fail-closed gate"
 grep -F -q 'Invoke-CoordinationCell' "$script" || fail "Windows runner missing coordination cell runner"
 grep -F -q ':input-coordinator-server:test' "$script" || fail "Windows runner missing coordinator server test task"

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -88,7 +88,7 @@ for scenario_id in \
   agent-launch-and-attach cli-packaged cli-native-helper-layout cli-user-flow \
   mcp-sdk-flow host-native-recording maven-local-consumer portal-token-warmup pointer-move \
   input-coord-contention input-coord-cancellation input-coord-quarantine input-coord-revoke \
-  input-coord-forced-recovery input-coord-junit-pertest
+  input-coord-forced-recovery input-coord-junit-pertest input-coord-headed-robot
 do
   grep -F -q "$scenario_id" "$script" || fail "Windows runner missing stable scenario id: $scenario_id"
 done
@@ -112,6 +112,10 @@ grep -F -q 'two independent client JVMs never hold the desktop lease at the same
 grep -F -q 'ParallelPerTestInputIsolationTest' "$script" || fail "Windows runner missing parallel per-test isolation proof"
 grep -F -q 'concurrent per-test invocations never hold the desktop lease at the same time' "$script" || fail "Windows runner missing parallel per-test needle"
 grep -F -q 'the per-test lease is still held while failure evidence is captured' "$script" || fail "Windows runner missing evidence-capture needle"
+# Headed contention is operator-recorded: it must stay hard n/a unless evidence is passed, so the
+# automated (headless-capable) coordinator cells can never satisfy the headed claim on their own.
+grep -F -q 'HeadedRobotEvidence' "$script" || fail "Windows runner missing headed-robot operator evidence parameter"
+grep -F -q 'operator-run on a real desktop and was NOT recorded' "$script" || fail "Windows runner missing headed-robot blocking n/a reason"
 grep -F -q 'windows-ssh' "$script" || fail "SSH displayMode honesty for WGC missing"
 grep -F -q 'WGC requires native interactive console' "$script" || fail "WGC interactive-console N/A reason missing"
 grep -F -q 'AgentAttachIntegration e2e includes WGC node screenshots' "$script" || fail "SSH agent-attach-core hard n/a reason missing"

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -105,6 +105,12 @@ grep -F -q 'LocalCoordinatorServerTest' "$script" || fail "Windows runner missin
 grep -F -q 'CoordinatorProcessLauncherTest' "$script" || fail "Windows runner missing forked-coordinator filter"
 grep -F -q 'InputIsolationLifecycleTest' "$script" || fail "Windows runner missing JUnit PerTest isolation filter"
 grep -F -q 'explicit force advances FIFO and reports unsafe takeover' "$script" || fail "Windows runner missing forced-recovery testcase needle"
+# The contention and per-test cells must drive the cross-process / concurrent proofs, not just the
+# single-JVM sequential tests, or a green cell would overstate the release gate.
+grep -F -q 'TwoClientJvmContentionTest' "$script" || fail "Windows runner missing two-client-JVM contention proof"
+grep -F -q 'two independent client JVMs never hold the desktop lease at the same time' "$script" || fail "Windows runner missing two-client-JVM contention needle"
+grep -F -q 'ParallelPerTestInputIsolationTest' "$script" || fail "Windows runner missing parallel per-test isolation proof"
+grep -F -q 'concurrent per-test invocations never hold the desktop lease at the same time' "$script" || fail "Windows runner missing parallel per-test needle"
 grep -F -q 'windows-ssh' "$script" || fail "SSH displayMode honesty for WGC missing"
 grep -F -q 'WGC requires native interactive console' "$script" || fail "WGC interactive-console N/A reason missing"
 grep -F -q 'AgentAttachIntegration e2e includes WGC node screenshots' "$script" || fail "SSH agent-attach-core hard n/a reason missing"

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -86,10 +86,25 @@ grep -F -q 'hard skip without N/A reason' "$script" || fail "fail-closed hard N/
 for scenario_id in \
   preflight check junit-live agent-attach-core agent-contract-corpus agent-inject \
   agent-launch-and-attach cli-packaged cli-native-helper-layout cli-user-flow \
-  mcp-sdk-flow host-native-recording maven-local-consumer portal-token-warmup pointer-move
+  mcp-sdk-flow host-native-recording maven-local-consumer portal-token-warmup pointer-move \
+  input-coord-contention input-coord-cancellation input-coord-quarantine input-coord-revoke \
+  input-coord-forced-recovery input-coord-junit-pertest
 do
   grep -F -q "$scenario_id" "$script" || fail "Windows runner missing stable scenario id: $scenario_id"
 done
+
+# --- #459 experimental input-coordination delta hard cells ---
+# The coordination cells must drive the coordinator's own deterministic + forked-process + JUnit
+# isolation tests and fail closed on the JUnit XML (never a fake PASS). Hard on Windows including SSH.
+grep -F -q 'Get-InputCoordinationSkipReason' "$script" || fail "Windows runner missing input-coordination skip-reason probe"
+grep -F -q 'Assert-JUnitTestcasesPassed' "$script" || fail "Windows runner missing coordination JUnit XML fail-closed gate"
+grep -F -q 'Invoke-CoordinationCell' "$script" || fail "Windows runner missing coordination cell runner"
+grep -F -q ':input-coordinator-server:test' "$script" || fail "Windows runner missing coordinator server test task"
+grep -F -q ':testing:test' "$script" || fail "Windows runner missing JUnit isolation test task"
+grep -F -q 'LocalCoordinatorServerTest' "$script" || fail "Windows runner missing LocalCoordinatorServerTest filter"
+grep -F -q 'CoordinatorProcessLauncherTest' "$script" || fail "Windows runner missing forked-coordinator filter"
+grep -F -q 'InputIsolationLifecycleTest' "$script" || fail "Windows runner missing JUnit PerTest isolation filter"
+grep -F -q 'explicit force advances FIFO and reports unsafe takeover' "$script" || fail "Windows runner missing forced-recovery testcase needle"
 grep -F -q 'windows-ssh' "$script" || fail "SSH displayMode honesty for WGC missing"
 grep -F -q 'WGC requires native interactive console' "$script" || fail "WGC interactive-console N/A reason missing"
 grep -F -q 'AgentAttachIntegration e2e includes WGC node screenshots' "$script" || fail "SSH agent-attach-core hard n/a reason missing"

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -115,7 +115,10 @@ grep -F -q 'the per-test lease is still held while failure evidence is captured'
 # Headed contention is operator-recorded: it must stay hard n/a unless evidence is passed, so the
 # automated (headless-capable) coordinator cells can never satisfy the headed claim on their own.
 grep -F -q 'HeadedRobotEvidence' "$script" || fail "Windows runner missing headed-robot operator evidence parameter"
-grep -F -q 'operator-run on a real desktop and was NOT recorded' "$script" || fail "Windows runner missing headed-robot blocking n/a reason"
+grep -F -q 'operator-run on a real desktop and was NOT recorded' "$script" || fail "Windows runner missing headed-robot blocking message"
+# Absent evidence must be a hard FAIL, not a reasoned n/a: the summary's failure count ignores a
+# reasoned n/a, so an n/a here would report overall success without the headed proof.
+grep -F -q 'Result "fail" -Detail "headed two-JVM Robot contention' "$script" || fail "Windows headed-robot cell must FAIL (not n/a) when evidence is absent"
 grep -F -q 'windows-ssh' "$script" || fail "SSH displayMode honesty for WGC missing"
 grep -F -q 'WGC requires native interactive console' "$script" || fail "WGC interactive-console N/A reason missing"
 grep -F -q 'AgentAttachIntegration e2e includes WGC node screenshots' "$script" || fail "SSH agent-attach-core hard n/a reason missing"

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -111,6 +111,7 @@ grep -F -q 'TwoClientJvmContentionTest' "$script" || fail "Windows runner missin
 grep -F -q 'two independent client JVMs never hold the desktop lease at the same time' "$script" || fail "Windows runner missing two-client-JVM contention needle"
 grep -F -q 'ParallelPerTestInputIsolationTest' "$script" || fail "Windows runner missing parallel per-test isolation proof"
 grep -F -q 'concurrent per-test invocations never hold the desktop lease at the same time' "$script" || fail "Windows runner missing parallel per-test needle"
+grep -F -q 'the per-test lease is still held while failure evidence is captured' "$script" || fail "Windows runner missing evidence-capture needle"
 grep -F -q 'windows-ssh' "$script" || fail "SSH displayMode honesty for WGC missing"
 grep -F -q 'WGC requires native interactive console' "$script" || fail "WGC interactive-console N/A reason missing"
 grep -F -q 'AgentAttachIntegration e2e includes WGC node screenshots' "$script" || fail "SSH agent-attach-core hard n/a reason missing"

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -140,7 +140,7 @@ What remains outside automation is the **headed** half of the first bullet, and 
 not a residual. Every automated cell above passes headless and under SSH, because none of them
 constructs a `RobotDriver`: together they prove the *lease* is mutually exclusive, never that two
 processes' real OS input does not interleave. That is `input-coord-headed-robot`, which the harness
-cannot run for you — it stays hard `n/a` with a blocking reason until an operator drives two
+cannot run for you — it is a hard **fail** until an operator drives two
 `RobotDriver(InputLeasePolicy.Required)` JVMs on a real desktop and records it
 (`--headed-robot-evidence "<note>"` on Unix, `-HeadedRobotEvidence "<note>"` on Windows). Do not
 treat green `input-coord-*` cells as satisfying it. To add or change one of these cells, follow
@@ -336,7 +336,7 @@ Shared across macOS / Linux / Windows entrypoints (`scripts/smoke_lib.py` → `R
 | `input-coord-revoke` | Exact-ID normal revoke fences only its own lease and cannot affect a newer one. |
 | `input-coord-forced-recovery` | Explicit forced recovery reports `unsafeTakeover=true` and advances the FIFO queue. |
 | `input-coord-junit-pertest` | `InputIsolationConfig.perTest()` serialises factory, body, evidence, and teardown (`:testing:test` `InputIsolationLifecycleTest`). |
-| `input-coord-headed-robot` | **Operator-run.** Two `RobotDriver(InputLeasePolicy.Required)` JVMs dispatching real OS input on a headed desktop must not interleave. The harness cannot automate this: hard `n/a` with a blocking reason unless the operator passes `--headed-robot-evidence` / `-HeadedRobotEvidence`. Required on every OS whose release notes claim headed coordination. |
+| `input-coord-headed-robot` | **Operator-run.** Two `RobotDriver(InputLeasePolicy.Required)` JVMs dispatching real OS input on a headed desktop must not interleave. The harness cannot automate this, so it is a hard **fail** — the smoke exits non-zero — unless the operator passes `--headed-robot-evidence` / `-HeadedRobotEvidence`. A reasoned `n/a` would be ignored by the fail-closed check and report success, so absence is deliberately a failure. Required on every OS whose release notes claim headed coordination. |
 
 The `input-coord-*` cells ([#459](https://github.com/rock3r/spectre/pull/459)) are the automated form of the
 [Experimental input coordination release gate](#experimental-input-coordination-release-gate). Each drives the
@@ -506,8 +506,8 @@ release SHA.
   `n/a` means the experimental coordinator test surface was removed or graduated — re-scope the
   gate. The one thing these cells do **not** cover is a fully-headed two-`RobotDriver` physical
   **real-mouse** run: they all pass headless, so `input-coord-headed-robot` carries that claim as a
-  hard operator-recorded cell and blocks the tag on any OS claiming headed coordination until
-  evidence is supplied. Automating it (a Robot-backed two-JVM contention e2e) is a follow-up.
+  hard operator-recorded cell. Absent evidence it reports **fail** (not a reasoned `n/a`, which
+  `hard_failures()` ignores), so the smoke cannot report success without it. Automating it (a Robot-backed two-JVM contention e2e) is a follow-up.
 - **Linux helper `cargo` on Robot cells:** Unix harness prepends `$CARGO_HOME/bin` or
   `~/.cargo/bin` to PATH. Non-login SSH + `xvfb-run` otherwise cannot start
   `:recording:buildWaylandHelper` when `--rerun-tasks` rebuilds the helper. Do **not**

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -69,7 +69,7 @@ These are structural, not one-release accidents:
 | --- | --- | --- |
 | CLI package-channel (Homebrew/Scoop) contracts | Structural on every Unix `check` (`python3`); install-semantics when Ruby present or under `CI` (issue #400) | Optional: install Ruby on a clean Linux box and run `./gradlew verifyHomebrewFormulaInstallSemantics` if claiming formula behaviour beyond CI |
 | Agent attach + contract corpus (live UI) | Linux Xvfb + macOS desktop; Windows **transport/ACL** unit tests | **Windows headed desktop** (not SSH-only for capture) |
-| Input coordinator contention/recovery | Deterministic + forked process on every OS | Automated pre-tag as the `input-coord-*` cells (both entrypoints, fail-closed JUnit XML); optional physical two-`RobotDriver` real-mouse contention on a headed desktop |
+| Input coordinator contention/recovery | Deterministic + forked process on every OS | Automated pre-tag as the `input-coord-*` cells (both entrypoints, fail-closed JUnit XML). Those all pass headless, so headed real-input contention is a **separate hard cell**, `input-coord-headed-robot`, recorded by an operator |
 | Agent Windows UI e2e | Opt-in only: `-Pspectre.agent.attachE2e.allowWindows=true` | Run that property on Mattone-class boxes |
 | Agent real-keyboard `typeText` and `pressKey` | Runs on CI (`CI=true`); **skipped** on developer machines | Add `-Pspectre.agent.realKeyboard=true` on an idle desktop |
 | Agent **inject** attach | Linux + macOS e2e | **Windows** inject fixture (no preinstalled core) |
@@ -136,10 +136,14 @@ Non-overlap in both is an invariant, not a timing race: the lease is mutually ex
 waiter cannot be granted until the holder releases. A failure means genuine interleaving, never a
 slow machine.
 
-What remains outside automation is narrower than the bullets: a physical two-process **real-mouse**
-run (two `RobotDriver(InputLeasePolicy.Required)` JVMs dispatching actual OS input on a headed
-desktop) proves the Robot layer on top of the lease, and stays an **optional manual residual** — it
-does not gate the tag once the `input-coord-*` cells are green. To add or change one of these cells, follow
+What remains outside automation is the **headed** half of the first bullet, and it is a hard cell,
+not a residual. Every automated cell above passes headless and under SSH, because none of them
+constructs a `RobotDriver`: together they prove the *lease* is mutually exclusive, never that two
+processes' real OS input does not interleave. That is `input-coord-headed-robot`, which the harness
+cannot run for you — it stays hard `n/a` with a blocking reason until an operator drives two
+`RobotDriver(InputLeasePolicy.Required)` JVMs on a real desktop and records it
+(`--headed-robot-evidence "<note>"` on Unix, `-HeadedRobotEvidence "<note>"` on Windows). Do not
+treat green `input-coord-*` cells as satisfying it. To add or change one of these cells, follow
 [Adding a scenario ID](#adding-a-scenario-id-per-release-delta-or-permanent-baseline); do not leave
 one-off `./gradlew` commands only in chat.
 
@@ -332,6 +336,7 @@ Shared across macOS / Linux / Windows entrypoints (`scripts/smoke_lib.py` → `R
 | `input-coord-revoke` | Exact-ID normal revoke fences only its own lease and cannot affect a newer one. |
 | `input-coord-forced-recovery` | Explicit forced recovery reports `unsafeTakeover=true` and advances the FIFO queue. |
 | `input-coord-junit-pertest` | `InputIsolationConfig.perTest()` serialises factory, body, evidence, and teardown (`:testing:test` `InputIsolationLifecycleTest`). |
+| `input-coord-headed-robot` | **Operator-run.** Two `RobotDriver(InputLeasePolicy.Required)` JVMs dispatching real OS input on a headed desktop must not interleave. The harness cannot automate this: hard `n/a` with a blocking reason unless the operator passes `--headed-robot-evidence` / `-HeadedRobotEvidence`. Required on every OS whose release notes claim headed coordination. |
 
 The `input-coord-*` cells ([#459](https://github.com/rock3r/spectre/pull/459)) are the automated form of the
 [Experimental input coordination release gate](#experimental-input-coordination-release-gate). Each drives the
@@ -339,7 +344,7 @@ coordinator's own deterministic + forked-process + JUnit-isolation tests with `-
 fails closed on the JUnit XML (the exact testcase must have executed, not assumption-skipped) so a cache-only or
 empty-filter run cannot fake `pass`. They need no display, so they stay **hard** on all three OSes; a hard `n/a`
 means the experimental coordinator test surface was removed or graduated — re-scope the gate, do not treat it as a
-routine skip. Fully-headed two-`RobotDriver` physical-mouse contention stays an optional manual residual (below).
+routine skip. Fully-headed two-`RobotDriver` physical-mouse contention is a separate hard cell, `input-coord-headed-robot`, which only an operator can record (below).
 
 The Unix runner registers **every** required ID end-to-end (fail-closed). Environment-impossible
 cells must be explicit hard `n/a` with reason — never a silent omit or fake `pass`.
@@ -370,7 +375,7 @@ coverage to the runner rather than leaving a one-release command only in chat.
 | Preflight / check / agent attach·inject·launch / CLI package / MCP SDK / Maven Local | `release-smoke.py` (macOS/Linux); Windows PS shares IDs | — |
 | Live JUnit failure artifacts/video + atomic capture | `release-smoke.py` → `junit-live` | Windows: run on macOS/Linux baseline (hard `n/a` on Windows entrypoint with reason) |
 | Pointer-move hover (#433 / #435) | Unix + Windows `pointer-move` → `*PointerMoveLive*` | Fail-closed on all three OSes; hard `n/a` only if the verbs disappear |
-| Input coordination gate (#459: contention / cancellation / quarantine / revoke / forced recovery / JUnit PerTest) | Unix + Windows `input-coord-*` (coordinator protocol + forked process + JUnit isolation, fail-closed XML) | Optional physical two-`RobotDriver` real-mouse contention on a headed desktop |
+| Input coordination gate (#459: contention / cancellation / quarantine / revoke / forced recovery / JUnit PerTest) | Unix + Windows `input-coord-*` (coordinator protocol + forked process + JUnit isolation, fail-closed XML) | **Hard** `input-coord-headed-robot`: two-`RobotDriver` real-mouse contention on a headed desktop, recorded via `--headed-robot-evidence` / `-HeadedRobotEvidence` |
 | Host native recording | macOS SCK + Linux X11 in `release-smoke.py`; WGC in Windows PS when **interactive** | SSH WGC is N/A (not PASS) |
 | TCC / notarization / app seal | — | macOS recipes below |
 | Real Wayland portal | — | Real Wayland session (Xvfb ≠ Wayland) |
@@ -499,9 +504,10 @@ release SHA.
   `ParallelPerTestInputIsolationTest` for JUnit PerTest) and fails closed on the JUnit XML. They
   need no display, so they are hard on macOS, Windows (including SSH), and Linux Xorg/Xvfb. A hard
   `n/a` means the experimental coordinator test surface was removed or graduated — re-scope the
-  gate. A fully-headed two-`RobotDriver(InputLeasePolicy.Required)` physical **real-mouse** run is
-  the only piece these cells do not cover and stays an **optional** operator step, not a tag
-  blocker.
+  gate. The one thing these cells do **not** cover is a fully-headed two-`RobotDriver` physical
+  **real-mouse** run: they all pass headless, so `input-coord-headed-robot` carries that claim as a
+  hard operator-recorded cell and blocks the tag on any OS claiming headed coordination until
+  evidence is supplied. Automating it (a Robot-backed two-JVM contention e2e) is a follow-up.
 - **Linux helper `cargo` on Robot cells:** Unix harness prepends `$CARGO_HOME/bin` or
   `~/.cargo/bin` to PATH. Non-login SSH + `xvfb-run` otherwise cannot start
   `:recording:buildWaylandHelper` when `--rerun-tasks` rebuilds the helper. Do **not**

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -69,7 +69,7 @@ These are structural, not one-release accidents:
 | --- | --- | --- |
 | CLI package-channel (Homebrew/Scoop) contracts | Structural on every Unix `check` (`python3`); install-semantics when Ruby present or under `CI` (issue #400) | Optional: install Ruby on a clean Linux box and run `./gradlew verifyHomebrewFormulaInstallSemantics` if claiming formula behaviour beyond CI |
 | Agent attach + contract corpus (live UI) | Linux Xvfb + macOS desktop; Windows **transport/ACL** unit tests | **Windows headed desktop** (not SSH-only for capture) |
-| Input coordinator contention/recovery | Deterministic + forked process on every OS | Two real-input JVMs, holder crash, exact revoke, and explicit forced recovery on a headed desktop |
+| Input coordinator contention/recovery | Deterministic + forked process on every OS | Automated pre-tag as the `input-coord-*` cells (both entrypoints, fail-closed JUnit XML); optional physical two-`RobotDriver` real-mouse contention on a headed desktop |
 | Agent Windows UI e2e | Opt-in only: `-Pspectre.agent.attachE2e.allowWindows=true` | Run that property on Mattone-class boxes |
 | Agent real-keyboard `typeText` and `pressKey` | Runs on CI (`CI=true`); **skipped** on developer machines | Add `-Pspectre.agent.realKeyboard=true` on an idle desktop |
 | Agent **inject** attach | Linux + macOS e2e | **Windows** inject fixture (no preinstalled core) |
@@ -104,6 +104,28 @@ The Experimental label does not turn these into soft cells. If an OS cannot be e
 the release notes/platform claim rather than calling the coordinator cross-platform. Making
 `Auto` the no-argument driver default is a separate stability decision and requires the full matrix
 again.
+
+These six bullets are automated as the `input-coord-*` scenario IDs on **both** entrypoints
+(`scripts/release-smoke.py` and `scripts/windows-release-smoke.ps1`), each fail-closed on the
+coordinator's own JUnit XML:
+
+| Gate bullet | Scenario ID | Proof driven |
+| --- | --- | --- |
+| Two independent JVMs, FIFO, no interleave | `input-coord-contention` | `LocalCoordinatorServerTest` FIFO across two client sessions **+** `CoordinatorProcessLauncherTest` real forked-coordinator JVM |
+| Cancelled waiter, next not stranded | `input-coord-cancellation` | `LocalCoordinatorServerTest` cancelled-acquire-preserves-FIFO |
+| Holder loss fenced until ack / exact force | `input-coord-quarantine` | `LocalCoordinatorServerTest` crashed-holder quarantine → exact-ID unsafe recovery |
+| Exact-ID revoke cannot hit a newer lease | `input-coord-revoke` | `LocalCoordinatorServerTest` stale-observation revoke fences the actual holder |
+| Forced recovery reports `unsafeTakeover=true` | `input-coord-forced-recovery` | `LocalCoordinatorServerTest` explicit force advances FIFO + unsafe takeover |
+| Parallel JUnit `perTest()` serialises lifecycle | `input-coord-junit-pertest` | `InputIsolationLifecycleTest` (JUnit 4 + 5 whole-test lease across factory/body/evidence/teardown) |
+
+These proofs are deterministic and display-independent, so the cells are **hard on all three OSes**
+(macOS, Windows including SSH, and Linux Xorg/Xvfb) and are not Robot cells — they run with the plain
+scenario env, never the Xvfb/Robot wrapper. A physical two-process real-mouse contention run (two
+`RobotDriver(InputLeasePolicy.Required)` JVMs interleaving actual OS input on a headed desktop) is
+beyond any automated test and stays an **optional manual residual** — it does not gate the tag once
+the `input-coord-*` cells are green. To add or change one of these cells, follow
+[Adding a scenario ID](#adding-a-scenario-id-per-release-delta-or-permanent-baseline); do not leave
+one-off `./gradlew` commands only in chat.
 
 ## Environments
 
@@ -288,6 +310,20 @@ Shared across macOS / Linux / Windows entrypoints (`scripts/smoke_lib.py` → `R
 | `maven-local-consumer` | Maven Local publication + fresh consumer |
 | `portal-token-warmup` | Linux Wayland: one interactive ScreenCast grant at run start, then reuse the stored restore token. Hard `n/a` on macOS/Windows/Xvfb. |
 | `pointer-move` | In-process `moveTo` / `moveBy` hover without click (`:sample-desktop:validationTest --tests '*PointerMoveLive*'`). Hard `n/a` only if the verbs disappear from `ComposeAutomator`. |
+| `input-coord-contention` | Two independent JVMs take one desktop lease in FIFO order (`:input-coordinator-server:test` FIFO client contention + forked-coordinator process). Hard on macOS/Windows/Linux Xorg/Xvfb — no display needed, so hard on Windows SSH too. |
+| `input-coord-cancellation` | A cancelled queued waiter is removed without stranding the next waiter. |
+| `input-coord-quarantine` | A crashed holder stays fenced/quarantined until exact-ID forced recovery, without granting stale ownership. |
+| `input-coord-revoke` | Exact-ID normal revoke fences only its own lease and cannot affect a newer one. |
+| `input-coord-forced-recovery` | Explicit forced recovery reports `unsafeTakeover=true` and advances the FIFO queue. |
+| `input-coord-junit-pertest` | `InputIsolationConfig.perTest()` serialises factory, body, evidence, and teardown (`:testing:test` `InputIsolationLifecycleTest`). |
+
+The `input-coord-*` cells ([#459](https://github.com/rock3r/spectre/pull/459)) are the automated form of the
+[Experimental input coordination release gate](#experimental-input-coordination-release-gate). Each drives the
+coordinator's own deterministic + forked-process + JUnit-isolation tests with `--rerun-tasks --no-build-cache`, and
+fails closed on the JUnit XML (the exact testcase must have executed, not assumption-skipped) so a cache-only or
+empty-filter run cannot fake `pass`. They need no display, so they stay **hard** on all three OSes; a hard `n/a`
+means the experimental coordinator test surface was removed or graduated — re-scope the gate, do not treat it as a
+routine skip. Fully-headed two-`RobotDriver` physical-mouse contention stays an optional manual residual (below).
 
 The Unix runner registers **every** required ID end-to-end (fail-closed). Environment-impossible
 cells must be explicit hard `n/a` with reason — never a silent omit or fake `pass`.
@@ -318,6 +354,7 @@ coverage to the runner rather than leaving a one-release command only in chat.
 | Preflight / check / agent attach·inject·launch / CLI package / MCP SDK / Maven Local | `release-smoke.py` (macOS/Linux); Windows PS shares IDs | — |
 | Live JUnit failure artifacts/video + atomic capture | `release-smoke.py` → `junit-live` | Windows: run on macOS/Linux baseline (hard `n/a` on Windows entrypoint with reason) |
 | Pointer-move hover (#433 / #435) | Unix + Windows `pointer-move` → `*PointerMoveLive*` | Fail-closed on all three OSes; hard `n/a` only if the verbs disappear |
+| Input coordination gate (#459: contention / cancellation / quarantine / revoke / forced recovery / JUnit PerTest) | Unix + Windows `input-coord-*` (coordinator protocol + forked process + JUnit isolation, fail-closed XML) | Optional physical two-`RobotDriver` real-mouse contention on a headed desktop |
 | Host native recording | macOS SCK + Linux X11 in `release-smoke.py`; WGC in Windows PS when **interactive** | SSH WGC is N/A (not PASS) |
 | TCC / notarization / app seal | — | macOS recipes below |
 | Real Wayland portal | — | Real Wayland session (Xvfb ≠ Wayland) |
@@ -438,6 +475,15 @@ release SHA.
   --no-build-cache` and reject assumption-skips via JUnit XML. A hard `n/a` now means the
   source probe could not see `moveTo`/`moveBy` — treat that as a regression, not a skip.
   CLI / MCP / agent verbs are still a follow-up.
+- **#459 experimental input coordination:** the six delta hard cells are automated as the
+  `input-coord-*` scenario IDs on both entrypoints. Each forces `--rerun-tasks --no-build-cache`
+  over the coordinator's own tests (`LocalCoordinatorServerTest` FIFO/cancellation/quarantine/
+  revoke/forced-recovery, `CoordinatorProcessLauncherTest` forked coordinator JVM, and
+  `InputIsolationLifecycleTest` JUnit PerTest) and fails closed on the JUnit XML. They need no
+  display, so they are hard on macOS, Windows (including SSH), and Linux Xorg/Xvfb. A hard `n/a`
+  means the experimental coordinator test surface was removed or graduated — re-scope the gate.
+  A fully-headed two-`RobotDriver(InputLeasePolicy.Required)` physical-mouse contention run is the
+  only piece these cells do not cover and stays an **optional** operator step, not a tag blocker.
 - **Linux helper `cargo` on Robot cells:** Unix harness prepends `$CARGO_HOME/bin` or
   `~/.cargo/bin` to PATH. Non-login SSH + `xvfb-run` otherwise cannot start
   `:recording:buildWaylandHelper` when `--rerun-tasks` rebuilds the helper. Do **not**

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -111,19 +111,35 @@ coordinator's own JUnit XML:
 
 | Gate bullet | Scenario ID | Proof driven |
 | --- | --- | --- |
-| Two independent JVMs, FIFO, no interleave | `input-coord-contention` | `LocalCoordinatorServerTest` FIFO across two client sessions **+** `CoordinatorProcessLauncherTest` real forked-coordinator JVM |
+| Two independent JVMs, FIFO, no interleave | `input-coord-contention` | `TwoClientJvmContentionTest` — two forked **client** JVMs whose held intervals must be disjoint — **+** `LocalCoordinatorServerTest` FIFO across two client sessions **+** `CoordinatorProcessLauncherTest` real forked-coordinator JVM |
 | Cancelled waiter, next not stranded | `input-coord-cancellation` | `LocalCoordinatorServerTest` cancelled-acquire-preserves-FIFO |
 | Holder loss fenced until ack / exact force | `input-coord-quarantine` | `LocalCoordinatorServerTest` crashed-holder quarantine → exact-ID unsafe recovery |
 | Exact-ID revoke cannot hit a newer lease | `input-coord-revoke` | `LocalCoordinatorServerTest` stale-observation revoke fences the actual holder |
 | Forced recovery reports `unsafeTakeover=true` | `input-coord-forced-recovery` | `LocalCoordinatorServerTest` explicit force advances FIFO + unsafe takeover |
-| Parallel JUnit `perTest()` serialises lifecycle | `input-coord-junit-pertest` | `InputIsolationLifecycleTest` (JUnit 4 + 5 whole-test lease across factory/body/evidence/teardown) |
+| Parallel JUnit `perTest()` serialises lifecycle | `input-coord-junit-pertest` | `InputIsolationLifecycleTest` (JUnit 4 + 5 whole-test lease across factory/body/evidence/teardown) **+** `ParallelPerTestInputIsolationTest` (concurrent invocations against a real coordinator must not overlap) |
 
 These proofs are deterministic and display-independent, so the cells are **hard on all three OSes**
 (macOS, Windows including SSH, and Linux Xorg/Xvfb) and are not Robot cells — they run with the plain
-scenario env, never the Xvfb/Robot wrapper. A physical two-process real-mouse contention run (two
-`RobotDriver(InputLeasePolicy.Required)` JVMs interleaving actual OS input on a headed desktop) is
-beyond any automated test and stays an **optional manual residual** — it does not gate the tag once
-the `input-coord-*` cells are green. To add or change one of these cells, follow
+scenario env, never the Xvfb/Robot wrapper.
+
+Two of the bullets need proof that a single sequential JVM cannot give, so they are backed by
+dedicated tests rather than by the coordinator's in-process suite alone:
+
+- `TwoClientJvmContentionTest` forks **two independent client JVMs** against one coordinator and
+  asserts their held wall-clock intervals are disjoint. Give the two processes separate desktop
+  keys and it fails, so the assertion is load-bearing rather than vacuous.
+- `ParallelPerTestInputIsolationTest` runs concurrent `perTest()` extension lifecycles against a
+  real coordinator on a hermetic endpoint and asserts no two leases overlap. Remove the mutual
+  exclusion and all invocations overlap and it fails.
+
+Non-overlap in both is an invariant, not a timing race: the lease is mutually exclusive, so a
+waiter cannot be granted until the holder releases. A failure means genuine interleaving, never a
+slow machine.
+
+What remains outside automation is narrower than the bullets: a physical two-process **real-mouse**
+run (two `RobotDriver(InputLeasePolicy.Required)` JVMs dispatching actual OS input on a headed
+desktop) proves the Robot layer on top of the lease, and stays an **optional manual residual** — it
+does not gate the tag once the `input-coord-*` cells are green. To add or change one of these cells, follow
 [Adding a scenario ID](#adding-a-scenario-id-per-release-delta-or-permanent-baseline); do not leave
 one-off `./gradlew` commands only in chat.
 
@@ -478,12 +494,14 @@ release SHA.
 - **#459 experimental input coordination:** the six delta hard cells are automated as the
   `input-coord-*` scenario IDs on both entrypoints. Each forces `--rerun-tasks --no-build-cache`
   over the coordinator's own tests (`LocalCoordinatorServerTest` FIFO/cancellation/quarantine/
-  revoke/forced-recovery, `CoordinatorProcessLauncherTest` forked coordinator JVM, and
-  `InputIsolationLifecycleTest` JUnit PerTest) and fails closed on the JUnit XML. They need no
-  display, so they are hard on macOS, Windows (including SSH), and Linux Xorg/Xvfb. A hard `n/a`
-  means the experimental coordinator test surface was removed or graduated — re-scope the gate.
-  A fully-headed two-`RobotDriver(InputLeasePolicy.Required)` physical-mouse contention run is the
-  only piece these cells do not cover and stays an **optional** operator step, not a tag blocker.
+  revoke/forced-recovery, `CoordinatorProcessLauncherTest` forked coordinator JVM,
+  `TwoClientJvmContentionTest` two forked client JVMs, and `InputIsolationLifecycleTest` +
+  `ParallelPerTestInputIsolationTest` for JUnit PerTest) and fails closed on the JUnit XML. They
+  need no display, so they are hard on macOS, Windows (including SSH), and Linux Xorg/Xvfb. A hard
+  `n/a` means the experimental coordinator test surface was removed or graduated — re-scope the
+  gate. A fully-headed two-`RobotDriver(InputLeasePolicy.Required)` physical **real-mouse** run is
+  the only piece these cells do not cover and stays an **optional** operator step, not a tag
+  blocker.
 - **Linux helper `cargo` on Robot cells:** Unix harness prepends `$CARGO_HOME/bin` or
   `~/.cargo/bin` to PATH. Non-login SSH + `xvfb-run` otherwise cannot start
   `:recording:buildWaylandHelper` when `--rerun-tasks` rebuilds the helper. Do **not**

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -342,9 +342,12 @@ The `input-coord-*` cells ([#459](https://github.com/rock3r/spectre/pull/459)) a
 [Experimental input coordination release gate](#experimental-input-coordination-release-gate). Each drives the
 coordinator's own deterministic + forked-process + JUnit-isolation tests with `--rerun-tasks --no-build-cache`, and
 fails closed on the JUnit XML (the exact testcase must have executed, not assumption-skipped) so a cache-only or
-empty-filter run cannot fake `pass`. They need no display, so they stay **hard** on all three OSes; a hard `n/a`
-means the experimental coordinator test surface was removed or graduated — re-scope the gate, do not treat it as a
-routine skip. Fully-headed two-`RobotDriver` physical-mouse contention is a separate hard cell, `input-coord-headed-robot`, which only an operator can record (below).
+empty-filter run cannot fake `pass`. They need no display, so they stay **hard** on all three OSes. A missing proof source is a hard
+**fail**, not a skip: deleting or renaming one of these tests must not turn six hard cells green by
+omission. Dropping the feature legitimately means re-scoping affirmatively — remove the
+`input-coord-*` IDs from `REQUIRED_SCENARIO_IDS` and update this page. Fully-headed
+two-`RobotDriver` physical-mouse contention is a separate hard cell, `input-coord-headed-robot`,
+which only an operator can record (below).
 
 The Unix runner registers **every** required ID end-to-end (fail-closed). Environment-impossible
 cells must be explicit hard `n/a` with reason — never a silent omit or fake `pass`.
@@ -502,9 +505,10 @@ release SHA.
   revoke/forced-recovery, `CoordinatorProcessLauncherTest` forked coordinator JVM,
   `TwoClientJvmContentionTest` two forked client JVMs, and `InputIsolationLifecycleTest` +
   `ParallelPerTestInputIsolationTest` for JUnit PerTest) and fails closed on the JUnit XML. They
-  need no display, so they are hard on macOS, Windows (including SSH), and Linux Xorg/Xvfb. A hard
-  `n/a` means the experimental coordinator test surface was removed or graduated — re-scope the
-  gate. The one thing these cells do **not** cover is a fully-headed two-`RobotDriver` physical
+  need no display, so they are hard on macOS, Windows (including SSH), and Linux Xorg/Xvfb. A
+  missing proof source is a hard **fail** rather than a reasoned `n/a` (which `hard_failures()`
+  ignores), so a rename cannot pass six cells by omission; re-scope the release affirmatively if
+  the feature is genuinely dropped. The one thing these cells do **not** cover is a fully-headed two-`RobotDriver` physical
   **real-mouse** run: they all pass headless, so `input-coord-headed-robot` carries that claim as a
   hard operator-recorded cell. Absent evidence it reports **fail** (not a reasoned `n/a`, which
   `hard_failures()` ignores), so the smoke cannot report success without it. Automating it (a Robot-backed two-JVM contention e2e) is a follow-up.

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/TwoClientJvmContentionProbe.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/TwoClientJvmContentionProbe.kt
@@ -13,26 +13,38 @@ import java.time.Duration
  * Child-JVM half of [TwoClientJvmContentionTest].
  *
  * Runs in its own process so the contention proof involves two genuinely independent client JVMs,
- * not two client sessions sharing one. Acquires the desktop lease, records the wall-clock interval
- * it held it, and releases.
+ * not two client sessions sharing one. Connects, announces readiness, waits on a parent-controlled
+ * barrier, then acquires the desktop lease and records the wall-clock interval it held it.
+ *
+ * The barrier matters: JVM startup easily outlasts the hold, so simply launching the two probes
+ * back to back could let the first release before the second even asks. Their intervals would then
+ * be disjoint whether or not the coordinator enforces anything, and the test would pass vacuously.
+ * Both probes connect first and block until the parent opens the gate, so demand genuinely
+ * overlaps.
  *
  * Wall-clock (`currentTimeMillis`) is deliberate: `nanoTime` is only comparable within one JVM, and
  * the whole point here is comparing intervals recorded by two different processes.
  *
- * Usage: `<socketPath> <resourceKey> <ownerLabel> <holdMillis> <outputFile>`
+ * Usage: `<socketPath> <resourceKey> <ownerLabel> <holdMillis> <outputFile> <readyFile> <goFile>`
  */
 public fun main(arguments: Array<String>) {
     require(arguments.size == EXPECTED_ARGUMENT_COUNT) {
-        "Usage: <socketPath> <resourceKey> <ownerLabel> <holdMillis> <outputFile>"
+        "Usage: <socketPath> <resourceKey> <ownerLabel> <holdMillis> <outputFile> " +
+            "<readyFile> <goFile>"
     }
     val socketPath = Path.of(arguments[0])
     val resourceKey = DesktopResourceKey(arguments[1])
     val ownerLabel = arguments[2]
     val holdMillis = arguments[3].toLong()
     val outputFile = Path.of(arguments[4])
+    val readyFile = Path.of(arguments[5])
+    val goFile = Path.of(arguments[6])
 
     val endpoint = CoordinatorEndpoint(socketPath.parent, socketPath)
     LocalInputCoordinatorClient.connect(endpoint, resourceKey, ownerLabel).use { client ->
+        // Connected and about to contend: tell the parent, then wait for both probes to be here.
+        Files.writeString(readyFile, "ready\n")
+        awaitGate(goFile)
         client.acquire(Duration.ofSeconds(ACQUIRE_TIMEOUT_SECONDS), "click").use {
             val acquiredAt = System.currentTimeMillis()
             Thread.sleep(holdMillis)
@@ -44,5 +56,16 @@ public fun main(arguments: Array<String>) {
     }
 }
 
-private const val EXPECTED_ARGUMENT_COUNT: Int = 5
+private fun awaitGate(goFile: Path) {
+    val deadline = System.nanoTime() + Duration.ofSeconds(GATE_TIMEOUT_SECONDS).toNanos()
+    while (System.nanoTime() < deadline) {
+        if (Files.exists(goFile)) return
+        Thread.sleep(GATE_POLL_MILLIS)
+    }
+    error("parent never opened the contention gate at $goFile")
+}
+
+private const val EXPECTED_ARGUMENT_COUNT: Int = 7
 private const val ACQUIRE_TIMEOUT_SECONDS: Long = 30
+private const val GATE_TIMEOUT_SECONDS: Long = 60
+private const val GATE_POLL_MILLIS: Long = 5

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/TwoClientJvmContentionProbe.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/TwoClientJvmContentionProbe.kt
@@ -1,0 +1,48 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LocalInputCoordinatorClient
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+
+/**
+ * Child-JVM half of [TwoClientJvmContentionTest].
+ *
+ * Runs in its own process so the contention proof involves two genuinely independent client JVMs,
+ * not two client sessions sharing one. Acquires the desktop lease, records the wall-clock interval
+ * it held it, and releases.
+ *
+ * Wall-clock (`currentTimeMillis`) is deliberate: `nanoTime` is only comparable within one JVM, and
+ * the whole point here is comparing intervals recorded by two different processes.
+ *
+ * Usage: `<socketPath> <resourceKey> <ownerLabel> <holdMillis> <outputFile>`
+ */
+public fun main(arguments: Array<String>) {
+    require(arguments.size == EXPECTED_ARGUMENT_COUNT) {
+        "Usage: <socketPath> <resourceKey> <ownerLabel> <holdMillis> <outputFile>"
+    }
+    val socketPath = Path.of(arguments[0])
+    val resourceKey = DesktopResourceKey(arguments[1])
+    val ownerLabel = arguments[2]
+    val holdMillis = arguments[3].toLong()
+    val outputFile = Path.of(arguments[4])
+
+    val endpoint = CoordinatorEndpoint(socketPath.parent, socketPath)
+    LocalInputCoordinatorClient.connect(endpoint, resourceKey, ownerLabel).use { client ->
+        client.acquire(Duration.ofSeconds(ACQUIRE_TIMEOUT_SECONDS), "click").use {
+            val acquiredAt = System.currentTimeMillis()
+            Thread.sleep(holdMillis)
+            // Written before the lease closes: a reader can then prove the two processes' held
+            // intervals never overlapped.
+            val releasedAt = System.currentTimeMillis()
+            Files.writeString(outputFile, "ACQUIRED $acquiredAt\nRELEASED $releasedAt\n")
+        }
+    }
+}
+
+private const val EXPECTED_ARGUMENT_COUNT: Int = 5
+private const val ACQUIRE_TIMEOUT_SECONDS: Long = 30

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/TwoClientJvmContentionTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/TwoClientJvmContentionTest.kt
@@ -1,0 +1,128 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input.server
+
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Release-gate proof that two **independent client JVMs** are serialised by the coordinator.
+ *
+ * `LocalCoordinatorServerTest` proves FIFO between two client sessions inside one JVM, and
+ * `CoordinatorProcessLauncherTest` forks the coordinator but connects a single client. Neither
+ * exercises the release gate's actual claim — two separate client processes contending for one
+ * desktop — so a regression that only appears across process boundaries would pass both. This test
+ * closes that gap and backs the `input-coord-contention` smoke cell (see docs/RELEASE-SMOKE.md).
+ *
+ * Non-overlap here is an invariant, not a timing race: the lease is mutually exclusive, so the
+ * second process physically cannot hold it until the first releases. A failure means real
+ * interleaving, never a slow machine.
+ */
+class TwoClientJvmContentionTest {
+
+    private val temporaryDirectory: Path = Files.createTempDirectory("spc-2jvm-")
+    private val endpoint =
+        CoordinatorEndpoint(temporaryDirectory, temporaryDirectory.resolve("coordinator.sock"))
+    private val resource = DesktopResourceKey("user:501/two-jvm-contention")
+    private var server: LocalCoordinatorServer? = null
+    private val children = mutableListOf<Process>()
+
+    @AfterTest
+    fun cleanUp() {
+        children.forEach { child ->
+            child.destroy()
+            child.waitFor(CHILD_DESTROY_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }
+        runCatching { server?.close() }
+        // Unlike the sibling coordinator tests, this one also leaves the probes' lease records
+        // behind, so clear the whole tree rather than a fixed list of known files.
+        Files.walk(temporaryDirectory).use { paths ->
+            paths.sorted(Comparator.reverseOrder()).forEach { path ->
+                runCatching { Files.deleteIfExists(path) }
+            }
+        }
+    }
+
+    @Test
+    fun `two independent client JVMs never hold the desktop lease at the same time`() {
+        server =
+            LocalCoordinatorServer(endpoint, idleTimeout = Duration.ofMinutes(1)).also {
+                it.start()
+            }
+        val firstOutput = temporaryDirectory.resolve("first.txt")
+        val secondOutput = temporaryDirectory.resolve("second.txt")
+
+        // Started back to back so they genuinely contend; whichever wins the race holds first.
+        val first = startProbe("first-jvm", firstOutput)
+        val second = startProbe("second-jvm", secondOutput)
+
+        assertEquals(0, first.waitFor(), "first client JVM exited non-zero")
+        assertEquals(0, second.waitFor(), "second client JVM exited non-zero")
+
+        val firstHeld = readHeldInterval(firstOutput)
+        val secondHeld = readHeldInterval(secondOutput)
+
+        val disjoint = firstHeld.second <= secondHeld.first || secondHeld.second <= firstHeld.first
+        assertTrue(
+            disjoint,
+            "two client JVMs overlapped on one desktop lease: " +
+                "first=[${firstHeld.first}, ${firstHeld.second}] " +
+                "second=[${secondHeld.first}, ${secondHeld.second}]",
+        )
+    }
+
+    private fun startProbe(ownerLabel: String, output: Path): Process {
+        val java = Path.of(System.getProperty("java.home"), "bin", javaExecutableName()).toString()
+        val process =
+            ProcessBuilder(
+                    java,
+                    "-cp",
+                    System.getProperty("java.class.path"),
+                    PROBE_MAIN_CLASS,
+                    endpoint.socketPath.toString(),
+                    resource.value,
+                    ownerLabel,
+                    HOLD_MILLIS.toString(),
+                    output.toString(),
+                )
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+                .start()
+        children += process
+        return process
+    }
+
+    /** Returns the child's `(acquiredAt, releasedAt)` wall-clock pair. */
+    private fun readHeldInterval(output: Path): Pair<Long, Long> {
+        assertTrue(Files.isRegularFile(output), "child JVM wrote no lease record at $output")
+        val lines = Files.readAllLines(output)
+        val acquired = lines.single { it.startsWith("ACQUIRED ") }.removePrefix("ACQUIRED ").trim()
+        val released = lines.single { it.startsWith("RELEASED ") }.removePrefix("RELEASED ").trim()
+        return acquired.toLong() to released.toLong()
+    }
+
+    private fun javaExecutableName(): String =
+        if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+            "java.exe"
+        } else {
+            "java"
+        }
+
+    private companion object {
+        const val PROBE_MAIN_CLASS: String =
+            "dev.sebastiano.spectre.input.server.TwoClientJvmContentionProbeKt"
+
+        /** Long enough that a genuine overlap is unmistakable at millisecond clock granularity. */
+        const val HOLD_MILLIS: Long = 400
+
+        const val CHILD_DESTROY_TIMEOUT_SECONDS: Long = 5
+    }
+}

--- a/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/TwoClientJvmContentionTest.kt
+++ b/input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/TwoClientJvmContentionTest.kt
@@ -59,10 +59,18 @@ class TwoClientJvmContentionTest {
             }
         val firstOutput = temporaryDirectory.resolve("first.txt")
         val secondOutput = temporaryDirectory.resolve("second.txt")
+        val firstReady = temporaryDirectory.resolve("first.ready")
+        val secondReady = temporaryDirectory.resolve("second.ready")
+        val goFile = temporaryDirectory.resolve("go")
 
-        // Started back to back so they genuinely contend; whichever wins the race holds first.
-        val first = startProbe("first-jvm", firstOutput)
-        val second = startProbe("second-jvm", secondOutput)
+        val first = startProbe("first-jvm", firstOutput, firstReady, goFile)
+        val second = startProbe("second-jvm", secondOutput, secondReady, goFile)
+
+        // Both probes are connected and parked on the gate before either may acquire. Without this
+        // barrier, JVM startup skew could exceed the hold, the two intervals would be trivially
+        // disjoint, and the test would pass even with mutual exclusion removed.
+        awaitReady(firstReady, secondReady)
+        Files.writeString(goFile, "go\n")
 
         assertEquals(0, first.waitFor(), "first client JVM exited non-zero")
         assertEquals(0, second.waitFor(), "second client JVM exited non-zero")
@@ -79,7 +87,12 @@ class TwoClientJvmContentionTest {
         )
     }
 
-    private fun startProbe(ownerLabel: String, output: Path): Process {
+    private fun startProbe(
+        ownerLabel: String,
+        output: Path,
+        readyFile: Path,
+        goFile: Path,
+    ): Process {
         val java = Path.of(System.getProperty("java.home"), "bin", javaExecutableName()).toString()
         val process =
             ProcessBuilder(
@@ -92,12 +105,25 @@ class TwoClientJvmContentionTest {
                     ownerLabel,
                     HOLD_MILLIS.toString(),
                     output.toString(),
+                    readyFile.toString(),
+                    goFile.toString(),
                 )
                 .redirectOutput(ProcessBuilder.Redirect.DISCARD)
                 .redirectError(ProcessBuilder.Redirect.INHERIT)
                 .start()
         children += process
         return process
+    }
+
+    /** Blocks until every probe has connected and parked on the gate. */
+    private fun awaitReady(vararg readyFiles: Path) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(READY_TIMEOUT_SECONDS)
+        while (System.nanoTime() < deadline) {
+            if (readyFiles.all(Files::isRegularFile)) return
+            Thread.sleep(READY_POLL_MILLIS)
+        }
+        val missing = readyFiles.filterNot(Files::isRegularFile)
+        error("client JVMs never signalled readiness: ${missing.joinToString()}")
     }
 
     /** Returns the child's `(acquiredAt, releasedAt)` wall-clock pair. */
@@ -122,6 +148,9 @@ class TwoClientJvmContentionTest {
 
         /** Long enough that a genuine overlap is unmistakable at millisecond clock granularity. */
         const val HOLD_MILLIS: Long = 400
+
+        const val READY_TIMEOUT_SECONDS: Long = 60
+        const val READY_POLL_MILLIS: Long = 5
 
         const val CHILD_DESTROY_TIMEOUT_SECONDS: Long = 5
     }

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -36,6 +36,7 @@ from smoke_lib import (  # noqa: E402
     assert_mcp_fixture_e2e_executed,
     assert_pointer_move_live_executed,
     input_coordination_smoke_skip_reason,
+    HEADED_ROBOT_NA_REASON,
     WAYLAND_PORTAL_WARMUP_TOKEN_KEYS,
     linux_portal_token_path,
     build_report,
@@ -298,6 +299,15 @@ def main(argv: list[str] | None = None) -> int:
         "--skip-recording",
         action="store_true",
         help="Skip host native recording smoke (records hard n/a with reason)",
+    )
+    parser.add_argument(
+        "--headed-robot-evidence",
+        default=None,
+        help=(
+            "Operator attestation that headed two-JVM Robot contention was run on this desktop "
+            "(e.g. a note or run URL). Without it the hard input-coord-headed-robot cell stays "
+            "n/a with a blocking reason; the automated coordinator cells never satisfy it."
+        ),
     )
     parser.add_argument(
         "--preflight-only",
@@ -709,6 +719,34 @@ def main(argv: list[str] | None = None) -> int:
                     log=cell.log,
                 )
         add(cell)
+
+    # --- headed two-JVM Robot contention (operator-run hard cell) ---
+    # SKILL.md requires *headed* two-JVM contention as a delta hard cell. The cells above prove the
+    # coordinator lease is mutually exclusive across processes, but none of them constructs a
+    # RobotDriver, so they pass headless and under SSH. Only a human on a real desktop can close
+    # that gap today, so this records their attestation rather than inventing a pass.
+    headed_name = "Headed two-JVM Robot contention (operator-recorded)"
+    headed_evidence = (args.headed_robot_evidence or "").strip()
+    if headed_evidence:
+        add(
+            scenario_result(
+                "input-coord-headed-robot",
+                name=headed_name,
+                result=RESULT_PASS,
+                detail=f"operator evidence: {headed_evidence}",
+                hard=True,
+            )
+        )
+    else:
+        add(
+            scenario_result(
+                "input-coord-headed-robot",
+                name=headed_name,
+                result="n/a",
+                reason=HEADED_ROBOT_NA_REASON,
+                hard=True,
+            )
+        )
 
     # --- agent attach / corpus / inject / launch-and-attach ---
     for scenario_id, name, test_filter in (

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -36,7 +36,7 @@ from smoke_lib import (  # noqa: E402
     assert_mcp_fixture_e2e_executed,
     assert_pointer_move_live_executed,
     input_coordination_smoke_skip_reason,
-    HEADED_ROBOT_NA_REASON,
+    headed_robot_cell,
     WAYLAND_PORTAL_WARMUP_TOKEN_KEYS,
     linux_portal_token_path,
     build_report,
@@ -721,32 +721,12 @@ def main(argv: list[str] | None = None) -> int:
         add(cell)
 
     # --- headed two-JVM Robot contention (operator-run hard cell) ---
-    # SKILL.md requires *headed* two-JVM contention as a delta hard cell. The cells above prove the
-    # coordinator lease is mutually exclusive across processes, but none of them constructs a
-    # RobotDriver, so they pass headless and under SSH. Only a human on a real desktop can close
-    # that gap today, so this records their attestation rather than inventing a pass.
-    headed_name = "Headed two-JVM Robot contention (operator-recorded)"
-    headed_evidence = (args.headed_robot_evidence or "").strip()
-    if headed_evidence:
-        add(
-            scenario_result(
-                "input-coord-headed-robot",
-                name=headed_name,
-                result=RESULT_PASS,
-                detail=f"operator evidence: {headed_evidence}",
-                hard=True,
-            )
-        )
-    else:
-        add(
-            scenario_result(
-                "input-coord-headed-robot",
-                name=headed_name,
-                result="n/a",
-                reason=HEADED_ROBOT_NA_REASON,
-                hard=True,
-            )
-        )
+    # SKILL.md requires *headed* two-JVM contention as a delta hard cell. Every cell above proves
+    # the coordinator lease is mutually exclusive across processes, but none constructs a
+    # RobotDriver, so they all pass headless and under SSH. Absent operator evidence this is a
+    # hard FAIL, not a reasoned n/a: hard_failures() ignores a reasoned n/a, so an n/a here would
+    # print "ALL HARD SCENARIOS PASSED" without the headed proof.
+    add(headed_robot_cell(args.headed_robot_evidence))
 
     # --- agent attach / corpus / inject / launch-and-attach ---
     for scenario_id, name, test_filter in (

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -31,9 +31,11 @@ from smoke_lib import (  # noqa: E402
     RESULT_PASS,
     ScenarioResult,
     apply_linux_toolchain_path,
+    assert_junit_testcases_passed,
     assert_linux_portal_tokens_captured,
     assert_mcp_fixture_e2e_executed,
     assert_pointer_move_live_executed,
+    input_coordination_smoke_skip_reason,
     WAYLAND_PORTAL_WARMUP_TOKEN_KEYS,
     linux_portal_token_path,
     build_report,
@@ -579,6 +581,120 @@ def main(argv: list[str] | None = None) -> int:
                     log=pointer.log,
                 )
         add(pointer)
+
+    # --- experimental desktop input coordination (#459 delta hard cells) ---
+    # Deterministic coordinator protocol + forked-process + JUnit-isolation proofs for the
+    # spectre-release input-coordination gate. These do not need a display, so they stay hard on
+    # macOS, Windows, and Linux Xorg/Xvfb (Experimental status does not make them soft — see
+    # docs/RELEASE-SMOKE.md "Experimental input coordination release gate"). They are not Robot
+    # cells, so they run with the plain scenario env, never the xvfb/robot wrapper.
+    coordination_skip = input_coordination_smoke_skip_reason(ROOT)
+    server_results = ROOT / "input-coordinator-server" / "build" / "test-results" / "test"
+    testing_results = ROOT / "testing" / "build" / "test-results" / "test"
+    coordination_cells = (
+        (
+            "input-coord-contention",
+            "Two independent JVMs take one desktop lease in FIFO order",
+            ":input-coordinator-server:test",
+            (
+                "*LocalCoordinatorServerTest.two independent clients receive one desktop "
+                "lease in FIFO order",
+                "*CoordinatorProcessLauncherTest.forked coordinator accepts a real client lease",
+            ),
+            server_results,
+            (
+                "two independent clients receive one desktop lease in FIFO order",
+                "forked coordinator accepts a real client lease",
+            ),
+        ),
+        (
+            "input-coord-cancellation",
+            "Cancelled queued waiter does not strand the next waiter",
+            ":input-coordinator-server:test",
+            (
+                "*LocalCoordinatorServerTest.interrupting a queued acquisition removes it "
+                "without disturbing FIFO",
+            ),
+            server_results,
+            ("interrupting a queued acquisition removes it without disturbing FIFO",),
+        ),
+        (
+            "input-coord-quarantine",
+            "Crashed holder stays fenced/quarantined without stale ownership",
+            ":input-coordinator-server:test",
+            (
+                "*LocalCoordinatorServerTest.successor quarantines a crashed holder until "
+                "exact-id unsafe recovery",
+            ),
+            server_results,
+            ("successor quarantines a crashed holder until exact-id unsafe recovery",),
+        ),
+        (
+            "input-coord-revoke",
+            "Exact-ID normal revoke cannot affect a newer lease",
+            ":input-coordinator-server:test",
+            (
+                "*LocalCoordinatorServerTest.exact-id revoke rejects stale observation and "
+                "fences the actual holder",
+            ),
+            server_results,
+            ("exact-id revoke rejects stale observation and fences the actual holder",),
+        ),
+        (
+            "input-coord-forced-recovery",
+            "Explicit forced recovery reports unsafeTakeover and advances the queue",
+            ":input-coordinator-server:test",
+            ("*LocalCoordinatorServerTest.explicit force advances FIFO and reports unsafe takeover",),
+            server_results,
+            ("explicit force advances FIFO and reports unsafe takeover",),
+        ),
+        (
+            "input-coord-junit-pertest",
+            "Parallel JUnit PerTest serialises factory/body/evidence/teardown",
+            ":testing:test",
+            ("*InputIsolationLifecycleTest",),
+            testing_results,
+            ("InputIsolationLifecycleTest",),
+        ),
+    )
+    for scenario_id, name, task, filters, results_dir, needles in coordination_cells:
+        if coordination_skip is not None:
+            add(
+                scenario_result(
+                    scenario_id,
+                    name=name,
+                    result="n/a",
+                    reason=coordination_skip,
+                    hard=True,
+                )
+            )
+            continue
+        tests_args: list[str] = []
+        for test_filter in filters:
+            tests_args += ["--tests", test_filter]
+        cell = run_scenario(
+            scenario_id,
+            name=name,
+            command=[gradle, task, *tests_args, *force],
+            cwd=ROOT,
+            timeout=600,
+            out_dir=out_dir,
+            env=scenario_env,
+            overall_deadline=overall_deadline,
+        )
+        if cell.result == RESULT_PASS:
+            try:
+                assert_junit_testcases_passed(results_dir, needles=needles, cell=scenario_id)
+            except RuntimeError as exc:
+                cell = scenario_result(
+                    scenario_id,
+                    name=name,
+                    result=RESULT_FAIL,
+                    seconds=cell.seconds,
+                    detail=str(exc),
+                    log=cell.log,
+                )
+        add(cell)
 
     # --- agent attach / corpus / inject / launch-and-attach ---
     for scenario_id, name, test_filter in (

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -594,15 +594,18 @@ def main(argv: list[str] | None = None) -> int:
     coordination_cells = (
         (
             "input-coord-contention",
-            "Two independent JVMs take one desktop lease in FIFO order",
+            "Two independent client JVMs take one desktop lease without interleaving",
             ":input-coordinator-server:test",
             (
+                # The real gate claim: two separate client processes, not two sessions in one JVM.
+                "*TwoClientJvmContentionTest",
                 "*LocalCoordinatorServerTest.two independent clients receive one desktop "
                 "lease in FIFO order",
                 "*CoordinatorProcessLauncherTest.forked coordinator accepts a real client lease",
             ),
             server_results,
             (
+                "two independent client JVMs never hold the desktop lease at the same time",
                 "two independent clients receive one desktop lease in FIFO order",
                 "forked coordinator accepts a real client lease",
             ),
@@ -652,9 +655,17 @@ def main(argv: list[str] | None = None) -> int:
             "input-coord-junit-pertest",
             "Parallel JUnit PerTest serialises factory/body/evidence/teardown",
             ":testing:test",
-            ("*InputIsolationLifecycleTest",),
+            (
+                # Lifecycle test proves the lease spans factory/body/evidence/teardown; the
+                # parallel test proves concurrent invocations cannot overlap. Both are required.
+                "*InputIsolationLifecycleTest",
+                "*ParallelPerTestInputIsolationTest",
+            ),
             testing_results,
-            ("InputIsolationLifecycleTest",),
+            (
+                "InputIsolationLifecycleTest",
+                "concurrent per-test invocations never hold the desktop lease at the same time",
+            ),
         ),
     )
     for scenario_id, name, task, filters, results_dir, needles in coordination_cells:

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -35,7 +35,7 @@ from smoke_lib import (  # noqa: E402
     assert_linux_portal_tokens_captured,
     assert_mcp_fixture_e2e_executed,
     assert_pointer_move_live_executed,
-    input_coordination_smoke_skip_reason,
+    input_coordination_missing_surface,
     headed_robot_cell,
     WAYLAND_PORTAL_WARMUP_TOKEN_KEYS,
     linux_portal_token_path,
@@ -598,7 +598,7 @@ def main(argv: list[str] | None = None) -> int:
     # macOS, Windows, and Linux Xorg/Xvfb (Experimental status does not make them soft — see
     # docs/RELEASE-SMOKE.md "Experimental input coordination release gate"). They are not Robot
     # cells, so they run with the plain scenario env, never the xvfb/robot wrapper.
-    coordination_skip = input_coordination_smoke_skip_reason(ROOT)
+    coordination_missing = input_coordination_missing_surface(ROOT)
     server_results = ROOT / "input-coordinator-server" / "build" / "test-results" / "test"
     testing_results = ROOT / "testing" / "build" / "test-results" / "test"
     coordination_cells = (
@@ -682,13 +682,15 @@ def main(argv: list[str] | None = None) -> int:
         ),
     )
     for scenario_id, name, task, filters, results_dir, needles in coordination_cells:
-        if coordination_skip is not None:
+        if coordination_missing is not None:
+            # Fail, not a reasoned n/a: hard_failures() ignores the latter, so a deleted or
+            # renamed test file would turn every coordination cell green by omission.
             add(
                 scenario_result(
                     scenario_id,
                     name=name,
-                    result="n/a",
-                    reason=coordination_skip,
+                    result=RESULT_FAIL,
+                    detail=coordination_missing,
                     hard=True,
                 )
             )

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -665,6 +665,9 @@ def main(argv: list[str] | None = None) -> int:
             (
                 "InputIsolationLifecycleTest",
                 "concurrent per-test invocations never hold the desktop lease at the same time",
+                # Named explicitly: the class-level filter would still run without it, so gating
+                # only the class name would let the evidence half of the bullet silently vanish.
+                "the per-test lease is still held while failure evidence is captured",
             ),
         ),
     )

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -44,6 +44,16 @@ REQUIRED_SCENARIO_IDS: tuple[str, ...] = (
     "maven-local-consumer",
     "portal-token-warmup",
     "pointer-move",
+    # Experimental desktop input coordination (#459). Delta hard cells on macOS, Windows, and
+    # Linux Xorg/Xvfb per the spectre-release skill. The coordinator protocol/lifecycle tests are
+    # deterministic and display-independent, so these stay hard on every OS entrypoint (including
+    # Windows SSH) rather than n/a like the WGC/attach-screenshot cells.
+    "input-coord-contention",
+    "input-coord-cancellation",
+    "input-coord-quarantine",
+    "input-coord-revoke",
+    "input-coord-forced-recovery",
+    "input-coord-junit-pertest",
 )
 
 RESULT_PASS = "pass"
@@ -1001,6 +1011,87 @@ def assert_pointer_move_live_executed(root: Path) -> None:
         raise RuntimeError(
             f"PointerMoveLive testcase not found in JUnit XML under {results_dir}"
         )
+
+
+# --- Experimental desktop input coordination (#459 release gate) ---------------------------------
+
+# The coordinator's own deterministic + forked-process tests are the automated proof for each
+# gate bullet in docs/RELEASE-SMOKE.md. They do not need a display, so the cells stay hard on
+# every OS. A missing test source means the experimental surface was removed or moved, which is a
+# regression the smoke must surface (mirrors pointer_move_api_skip_reason).
+_INPUT_COORDINATOR_SERVER_TEST_SOURCE = Path(
+    "input-coordinator-server/src/test/kotlin/dev/sebastiano/spectre/input/server/"
+    "LocalCoordinatorServerTest.kt"
+)
+_INPUT_ISOLATION_TEST_SOURCE = Path(
+    "testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt"
+)
+
+
+def input_coordination_smoke_skip_reason(root: Path) -> str | None:
+    """Hard N/A reason only when the experimental coordination test surface is gone.
+
+    These are hard cells on macOS, Windows, and Linux Xorg/Xvfb per the spectre-release skill;
+    Experimental status does not make them soft. The only legitimate N/A is the surface having
+    been removed or graduated, in which case the release plan must be re-scoped — treat it as a
+    regression signal, not a routine skip.
+    """
+    for source in (_INPUT_COORDINATOR_SERVER_TEST_SOURCE, _INPUT_ISOLATION_TEST_SOURCE):
+        if not (Path(root) / source).is_file():
+            return (
+                f"experimental input coordination test surface missing ({source.name}); "
+                "re-scope the release gate before smoking coordination"
+            )
+    return None
+
+
+def assert_junit_testcases_passed(
+    results_dir: Path,
+    *,
+    needles: Sequence[str],
+    cell: str,
+) -> None:
+    """Fail closed unless every named JUnit testcase actually executed and passed.
+
+    Gradle `--tests` exits 0 when a filter matches nothing or when every method assumption-skips,
+    so a hard coordination pass must prove the specific testcase ran (present, not `<skipped/>`,
+    and its testsuite reported no failures/errors). Mirrors assert_pointer_move_live_executed and
+    assert_mcp_fixture_e2e_executed.
+    """
+    results_dir = Path(results_dir)
+    if not results_dir.is_dir():
+        raise RuntimeError(
+            f"{cell} test results missing under {results_dir} (Gradle did not write JUnit XML)"
+        )
+    xml_files = sorted(results_dir.glob("TEST-*.xml"))
+    if not xml_files:
+        raise RuntimeError(f"{cell} produced no TEST-*.xml under {results_dir}")
+    for needle in needles:
+        found = False
+        for path in xml_files:
+            try:
+                raw = path.read_text(encoding="utf-8", errors="replace")
+            except OSError as exc:
+                raise RuntimeError(f"unable to read {path}: {exc}") from exc
+            if needle not in raw:
+                continue
+            found = True
+            if "<skipped" in raw:
+                raise RuntimeError(
+                    f"{cell} testcase '{needle}' was skipped (assumption); hard pass "
+                    "requires the coordination test to execute"
+                )
+            for attr in ("failures", "errors"):
+                match = re.search(rf'{attr}="(\d+)"', raw)
+                if match and int(match.group(1)) > 0:
+                    raise RuntimeError(
+                        f"{cell} reported {attr}={match.group(1)} for '{needle}' in {path.name}"
+                    )
+            break
+        if not found:
+            raise RuntimeError(
+                f"{cell} testcase '{needle}' not found in JUnit XML under {results_dir}"
+            )
 
 
 def packaged_cli_executable(root: Path, system: str | None = None, machine: str | None = None) -> Path:

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -59,10 +59,12 @@ REQUIRED_SCENARIO_IDS: tuple[str, ...] = (
     "input-coord-headed-robot",
 )
 
-# Why the headed cell is n/a until an operator records it. The wording is deliberately blunt:
-# a reader skimming a report must not mistake this row for "covered by the automated cells".
-# Both entrypoints emit this exact sentence; the contract tests pin it on each.
-HEADED_ROBOT_NA_REASON: str = (
+HEADED_ROBOT_SCENARIO_ID: str = "input-coord-headed-robot"
+HEADED_ROBOT_NAME: str = "Headed two-JVM Robot contention (operator-recorded)"
+
+# Deliberately blunt: a reader skimming a report must not mistake this row for "covered by the
+# automated cells". Both entrypoints emit this exact sentence; the contract tests pin it on each.
+HEADED_ROBOT_MISSING_EVIDENCE: str = (
     "headed two-JVM Robot contention is operator-run on a real desktop and was NOT recorded; "
     "the coordinator-protocol cells do not prove real-input non-interleaving, so this blocks "
     "the tag on any OS whose release notes claim headed coordination"
@@ -1104,6 +1106,33 @@ def assert_junit_testcases_passed(
             raise RuntimeError(
                 f"{cell} testcase '{needle}' not found in JUnit XML under {results_dir}"
             )
+
+
+def headed_robot_cell(evidence: str | None) -> ScenarioResult:
+    """Hard cell for the operator-recorded headed two-JVM Robot contention proof.
+
+    Absent evidence is a **fail**, not a reasoned `n/a`. [hard_failures] deliberately ignores an
+    `n/a` that carries a reason, so recording this as `n/a` would let the runner exit 0 and print
+    "ALL HARD SCENARIOS PASSED" without the headed proof the release gate requires — the exact
+    hole a reasoned skip is supposed to prevent. The automated `input-coord-*` cells never satisfy
+    this: they construct no RobotDriver and pass headless and under SSH.
+    """
+    recorded = (evidence or "").strip()
+    if recorded:
+        return scenario_result(
+            HEADED_ROBOT_SCENARIO_ID,
+            name=HEADED_ROBOT_NAME,
+            result=RESULT_PASS,
+            detail=f"operator evidence: {recorded}",
+            hard=True,
+        )
+    return scenario_result(
+        HEADED_ROBOT_SCENARIO_ID,
+        name=HEADED_ROBOT_NAME,
+        result=RESULT_FAIL,
+        detail=HEADED_ROBOT_MISSING_EVIDENCE,
+        hard=True,
+    )
 
 
 def packaged_cli_executable(root: Path, system: str | None = None, machine: str | None = None) -> Path:

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -1042,19 +1042,23 @@ _INPUT_ISOLATION_TEST_SOURCE = Path(
 )
 
 
-def input_coordination_smoke_skip_reason(root: Path) -> str | None:
-    """Hard N/A reason only when the experimental coordination test surface is gone.
+def input_coordination_missing_surface(root: Path) -> str | None:
+    """Detail for a coordination cell whose proof source is gone, else None.
 
-    These are hard cells on macOS, Windows, and Linux Xorg/Xvfb per the spectre-release skill;
-    Experimental status does not make them soft. The only legitimate N/A is the surface having
-    been removed or graduated, in which case the release plan must be re-scoped — treat it as a
-    regression signal, not a routine skip.
+    Absence is a **fail**, never a reasoned `n/a`. [hard_failures] ignores a reasoned `n/a`, so
+    returning one here would let deleting or renaming a single test file turn all six coordination
+    cells green-by-omission and still print "ALL HARD SCENARIOS PASSED" — the whole gate defeated
+    by a rename. Legitimately dropping the feature means affirmatively re-scoping the release:
+    remove the IDs from [REQUIRED_SCENARIO_IDS] and update docs/RELEASE-SMOKE.md, which is a
+    reviewable change rather than a silent one.
     """
     for source in (_INPUT_COORDINATOR_SERVER_TEST_SOURCE, _INPUT_ISOLATION_TEST_SOURCE):
         if not (Path(root) / source).is_file():
             return (
-                f"experimental input coordination test surface missing ({source.name}); "
-                "re-scope the release gate before smoking coordination"
+                f"experimental input coordination proof missing ({source.name}); this is a "
+                "failure, not a skip: if the surface was genuinely removed or graduated, "
+                "re-scope the release by dropping the input-coord-* IDs from "
+                "REQUIRED_SCENARIO_IDS and updating docs/RELEASE-SMOKE.md"
             )
     return None
 

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -54,6 +54,18 @@ REQUIRED_SCENARIO_IDS: tuple[str, ...] = (
     "input-coord-revoke",
     "input-coord-forced-recovery",
     "input-coord-junit-pertest",
+    # Operator-run: the harness cannot drive two real Robot JVMs, and the coordinator-protocol
+    # cells above pass headless. Stays a hard cell so the headed claim needs a human signature.
+    "input-coord-headed-robot",
+)
+
+# Why the headed cell is n/a until an operator records it. The wording is deliberately blunt:
+# a reader skimming a report must not mistake this row for "covered by the automated cells".
+# Both entrypoints emit this exact sentence; the contract tests pin it on each.
+HEADED_ROBOT_NA_REASON: str = (
+    "headed two-JVM Robot contention is operator-run on a real desktop and was NOT recorded; "
+    "the coordinator-protocol cells do not prove real-input non-interleaving, so this blocks "
+    "the tag on any OS whose release notes claim headed coordination"
 )
 
 RESULT_PASS = "pass"

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -66,7 +66,15 @@ $script:RequiredScenarioIds = @(
     "host-native-recording",
     "maven-local-consumer",
     "portal-token-warmup",
-    "pointer-move"
+    "pointer-move",
+    # Experimental desktop input coordination (#459) delta hard cells -- hard on Windows too
+    # (coordinator protocol tests need no display; run under SSH as well as an interactive console).
+    "input-coord-contention",
+    "input-coord-cancellation",
+    "input-coord-quarantine",
+    "input-coord-revoke",
+    "input-coord-forced-recovery",
+    "input-coord-junit-pertest"
 )
 $ErrorActionPreference = "Stop"
 # Avoid StrictMode edge cases with dynamic PSCustomObject / native interop on WinPS 5.1.
@@ -366,6 +374,108 @@ function Assert-PointerMoveLiveExecuted {
     }
 }
 
+function Get-InputCoordinationSkipReason {
+    param([Parameter(Mandatory = $true)][string] $RepoRoot)
+    # Hard N/A only when the experimental coordination test surface is gone (regression signal).
+    # These are hard cells on every OS per the spectre-release skill; Experimental does not make
+    # them soft. Mirrors smoke_lib.input_coordination_smoke_skip_reason.
+    $sources = @(
+        "input-coordinator-server\src\test\kotlin\dev\sebastiano\spectre\input\server\LocalCoordinatorServerTest.kt",
+        "testing\src\test\kotlin\dev\sebastiano\spectre\testing\InputIsolationLifecycleTest.kt"
+    )
+    foreach ($rel in $sources) {
+        if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot $rel))) {
+            $name = Split-Path -Leaf $rel
+            return ("experimental input coordination test surface missing ({0}); re-scope the release gate before smoking coordination" -f $name)
+        }
+    }
+    return $null
+}
+
+function Assert-JUnitTestcasesPassed {
+    param(
+        [Parameter(Mandatory = $true)][string] $RepoRoot,
+        [Parameter(Mandatory = $true)][string] $ResultsSubPath,
+        [Parameter(Mandatory = $true)][string[]] $Needles,
+        [Parameter(Mandatory = $true)][string] $Cell
+    )
+    # Fail closed: Gradle --tests exits 0 when a filter matches nothing or every method
+    # assumption-skips, so a hard coordination pass must prove each named testcase actually ran
+    # (present, not <skipped/>, no suite failures/errors). Mirrors Assert-PointerMoveLiveExecuted.
+    $resultsDir = Join-Path $RepoRoot $ResultsSubPath
+    if (-not (Test-Path -LiteralPath $resultsDir)) {
+        throw "$Cell test results missing under $resultsDir (Gradle did not write JUnit XML)"
+    }
+    $xmlFiles = @(Get-ChildItem -LiteralPath $resultsDir -Filter "TEST-*.xml" -ErrorAction SilentlyContinue)
+    if ($xmlFiles.Count -eq 0) {
+        throw "$Cell produced no TEST-*.xml under $resultsDir"
+    }
+    foreach ($needle in $Needles) {
+        $found = $false
+        foreach ($f in $xmlFiles) {
+            $raw = [string](Get-Content -LiteralPath $f.FullName -Raw -ErrorAction SilentlyContinue)
+            if ([string]::IsNullOrWhiteSpace($raw)) { continue }
+            if ($raw -notmatch [regex]::Escape($needle)) { continue }
+            $found = $true
+            if ($raw -match "<skipped") {
+                throw "$Cell testcase '$needle' was skipped (assumption); hard pass requires the coordination test to execute"
+            }
+            if ($raw -match 'failures="[1-9]' -or $raw -match 'errors="[1-9]') {
+                throw "$Cell reported failures/errors for '$needle' in $($f.Name)"
+            }
+            break
+        }
+        if (-not $found) {
+            throw "$Cell testcase '$needle' not found in JUnit XML under $resultsDir"
+        }
+    }
+}
+
+function Invoke-CoordinationCell {
+    # Explicit-parameter cell runner (no closure over loop variables -- avoids the WinPS
+    # dot-sourced-scriptblock scope gotcha). Returns a New-StepResult row.
+    param(
+        [Parameter(Mandatory = $true)][string] $RepoRoot,
+        [Parameter(Mandatory = $true)][string] $Id,
+        [Parameter(Mandatory = $true)][string] $Name,
+        [Parameter(Mandatory = $true)][string] $Task,
+        [Parameter(Mandatory = $true)][string[]] $Filters,
+        [Parameter(Mandatory = $true)][string] $ResultsSubPath,
+        [Parameter(Mandatory = $true)][string[]] $Needles,
+        [string] $SkipReason = "",
+        [ValidateRange(1, 86400)][int] $TimeoutSeconds = 600
+    )
+    if (-not [string]::IsNullOrWhiteSpace($SkipReason)) {
+        return (New-StepResult -Id $Id -Name $Name -Result "n/a" -Reason $SkipReason)
+    }
+    Write-Host ""
+    Write-Host ("==== {0} ({1}) ====" -f $Id, $Name) -ForegroundColor Cyan
+    $sw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        $gradleArgs = New-Object System.Collections.Generic.List[string]
+        [void]$gradleArgs.Add($Task)
+        foreach ($f in $Filters) {
+            [void]$gradleArgs.Add("--tests")
+            [void]$gradleArgs.Add($f)
+        }
+        [void]$gradleArgs.Add("--rerun-tasks")
+        [void]$gradleArgs.Add("--no-build-cache")
+        Invoke-Gradle -RepoRoot $RepoRoot -TimeoutSeconds $TimeoutSeconds -LogName $Id -GradleArgs ([string[]]$gradleArgs)
+        Assert-JUnitTestcasesPassed -RepoRoot $RepoRoot -ResultsSubPath $ResultsSubPath -Needles $Needles -Cell $Id
+        $sw.Stop()
+        $secs = [int]$sw.Elapsed.TotalSeconds
+        Write-Host ("PASS  {0}  ({1}s)" -f $Id, $secs) -ForegroundColor Green
+        return (New-StepResult -Id $Id -Name $Name -Result "pass" -Seconds $secs)
+    }
+    catch {
+        $sw.Stop()
+        $secs = [int]$sw.Elapsed.TotalSeconds
+        $msg = [string]$_.Exception.Message
+        Write-Host ("FAIL  {0}  ({1}s): {2}" -f $Id, $secs, $msg) -ForegroundColor Red
+        return (New-StepResult -Id $Id -Name $Name -Result "fail" -Seconds $secs -Detail $msg)
+    }
+}
+
 function Get-GitText {
     param([string] $RepoRoot, [string[]] $GitArgs)
     try {
@@ -595,6 +705,50 @@ try {
         }
         [void]$results.Add($step)
     }
+
+    # Experimental desktop input coordination (#459 delta hard cells). Deterministic coordinator
+    # protocol + forked-process + JUnit-isolation proofs; no display is needed, so these stay hard
+    # on Windows including SSH (unlike the WGC / attach-screenshot cells). See docs/RELEASE-SMOKE.md
+    # "Experimental input coordination release gate".
+    $coordinationSkip = Get-InputCoordinationSkipReason -RepoRoot $repoRoot
+    $serverResults = "input-coordinator-server\build\test-results\test"
+    $testingResults = "testing\build\test-results\test"
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+                -Id "input-coord-contention" -Name "Two independent JVMs take one desktop lease in FIFO order" `
+                -Task ":input-coordinator-server:test" `
+                -Filters @("*LocalCoordinatorServerTest.two independent clients receive one desktop lease in FIFO order", "*CoordinatorProcessLauncherTest.forked coordinator accepts a real client lease") `
+                -ResultsSubPath $serverResults `
+                -Needles @("two independent clients receive one desktop lease in FIFO order", "forked coordinator accepts a real client lease")))
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+                -Id "input-coord-cancellation" -Name "Cancelled queued waiter does not strand the next waiter" `
+                -Task ":input-coordinator-server:test" `
+                -Filters @("*LocalCoordinatorServerTest.interrupting a queued acquisition removes it without disturbing FIFO") `
+                -ResultsSubPath $serverResults `
+                -Needles @("interrupting a queued acquisition removes it without disturbing FIFO")))
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+                -Id "input-coord-quarantine" -Name "Crashed holder stays fenced/quarantined without stale ownership" `
+                -Task ":input-coordinator-server:test" `
+                -Filters @("*LocalCoordinatorServerTest.successor quarantines a crashed holder until exact-id unsafe recovery") `
+                -ResultsSubPath $serverResults `
+                -Needles @("successor quarantines a crashed holder until exact-id unsafe recovery")))
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+                -Id "input-coord-revoke" -Name "Exact-ID normal revoke cannot affect a newer lease" `
+                -Task ":input-coordinator-server:test" `
+                -Filters @("*LocalCoordinatorServerTest.exact-id revoke rejects stale observation and fences the actual holder") `
+                -ResultsSubPath $serverResults `
+                -Needles @("exact-id revoke rejects stale observation and fences the actual holder")))
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+                -Id "input-coord-forced-recovery" -Name "Explicit forced recovery reports unsafeTakeover and advances the queue" `
+                -Task ":input-coordinator-server:test" `
+                -Filters @("*LocalCoordinatorServerTest.explicit force advances FIFO and reports unsafe takeover") `
+                -ResultsSubPath $serverResults `
+                -Needles @("explicit force advances FIFO and reports unsafe takeover")))
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+                -Id "input-coord-junit-pertest" -Name "Parallel JUnit PerTest serialises factory/body/evidence/teardown" `
+                -Task ":testing:test" `
+                -Filters @("*InputIsolationLifecycleTest") `
+                -ResultsSubPath $testingResults `
+                -Needles @("InputIsolationLifecycleTest")))
 
     if (-not $SkipAgentE2e) {
         # AgentAttachIntegration e2e includes WGC node screenshots (#362). Under SSH that is the

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -757,13 +757,14 @@ try {
 
     # Headed two-JVM Robot contention: operator-run hard cell. SKILL.md requires *headed*
     # contention, and every automated cell above passes headless/SSH because none builds a
-    # RobotDriver. Record the operator's attestation rather than inventing a pass.
+    # RobotDriver. Absent evidence this is a hard FAIL, not a reasoned n/a: the summary's failure
+    # count ignores a reasoned n/a, so an n/a here would report success without the headed proof.
     $headedName = "Headed two-JVM Robot contention (operator-recorded)"
     if (-not [string]::IsNullOrWhiteSpace($HeadedRobotEvidence)) {
         [void]$results.Add((New-StepResult -Id "input-coord-headed-robot" -Name $headedName -Result "pass" -Detail ("operator evidence: {0}" -f $HeadedRobotEvidence)))
     }
     else {
-        [void]$results.Add((New-StepResult -Id "input-coord-headed-robot" -Name $headedName -Result "n/a" -Reason "headed two-JVM Robot contention is operator-run on a real desktop and was NOT recorded; the coordinator-protocol cells do not prove real-input non-interleaving, so this blocks the tag on any OS whose release notes claim headed coordination"))
+        [void]$results.Add((New-StepResult -Id "input-coord-headed-robot" -Name $headedName -Result "fail" -Detail "headed two-JVM Robot contention is operator-run on a real desktop and was NOT recorded; the coordinator-protocol cells do not prove real-input non-interleaving, so this blocks the tag on any OS whose release notes claim headed coordination"))
     }
 
     if (-not $SkipAgentE2e) {

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -748,7 +748,7 @@ try {
                 -Task ":testing:test" `
                 -Filters @("*InputIsolationLifecycleTest", "*ParallelPerTestInputIsolationTest") `
                 -ResultsSubPath $testingResults `
-                -Needles @("InputIsolationLifecycleTest", "concurrent per-test invocations never hold the desktop lease at the same time")))
+                -Needles @("InputIsolationLifecycleTest", "concurrent per-test invocations never hold the desktop lease at the same time", "the per-test lease is still held while failure evidence is captured")))
 
     if (-not $SkipAgentE2e) {
         # AgentAttachIntegration e2e includes WGC node screenshots (#362). Under SSH that is the

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -714,11 +714,11 @@ try {
     $serverResults = "input-coordinator-server\build\test-results\test"
     $testingResults = "testing\build\test-results\test"
     [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
-                -Id "input-coord-contention" -Name "Two independent JVMs take one desktop lease in FIFO order" `
+                -Id "input-coord-contention" -Name "Two independent client JVMs take one desktop lease without interleaving" `
                 -Task ":input-coordinator-server:test" `
-                -Filters @("*LocalCoordinatorServerTest.two independent clients receive one desktop lease in FIFO order", "*CoordinatorProcessLauncherTest.forked coordinator accepts a real client lease") `
+                -Filters @("*TwoClientJvmContentionTest", "*LocalCoordinatorServerTest.two independent clients receive one desktop lease in FIFO order", "*CoordinatorProcessLauncherTest.forked coordinator accepts a real client lease") `
                 -ResultsSubPath $serverResults `
-                -Needles @("two independent clients receive one desktop lease in FIFO order", "forked coordinator accepts a real client lease")))
+                -Needles @("two independent client JVMs never hold the desktop lease at the same time", "two independent clients receive one desktop lease in FIFO order", "forked coordinator accepts a real client lease")))
     [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
                 -Id "input-coord-cancellation" -Name "Cancelled queued waiter does not strand the next waiter" `
                 -Task ":input-coordinator-server:test" `
@@ -746,9 +746,9 @@ try {
     [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
                 -Id "input-coord-junit-pertest" -Name "Parallel JUnit PerTest serialises factory/body/evidence/teardown" `
                 -Task ":testing:test" `
-                -Filters @("*InputIsolationLifecycleTest") `
+                -Filters @("*InputIsolationLifecycleTest", "*ParallelPerTestInputIsolationTest") `
                 -ResultsSubPath $testingResults `
-                -Needles @("InputIsolationLifecycleTest")))
+                -Needles @("InputIsolationLifecycleTest", "concurrent per-test invocations never hold the desktop lease at the same time")))
 
     if (-not $SkipAgentE2e) {
         # AgentAttachIntegration e2e includes WGC node screenshots (#362). Under SSH that is the

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -379,7 +379,7 @@ function Assert-PointerMoveLiveExecuted {
     }
 }
 
-function Get-InputCoordinationSkipReason {
+function Get-InputCoordinationMissingSurface {
     param([Parameter(Mandatory = $true)][string] $RepoRoot)
     # Hard N/A only when the experimental coordination test surface is gone (regression signal).
     # These are hard cells on every OS per the spectre-release skill; Experimental does not make
@@ -391,7 +391,7 @@ function Get-InputCoordinationSkipReason {
     foreach ($rel in $sources) {
         if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot $rel))) {
             $name = Split-Path -Leaf $rel
-            return ("experimental input coordination test surface missing ({0}); re-scope the release gate before smoking coordination" -f $name)
+            return ("experimental input coordination proof missing ({0}); this is a failure, not a skip: if the surface was genuinely removed or graduated, re-scope the release by dropping the input-coord-* IDs from RequiredScenarioIds and updating docs/RELEASE-SMOKE.md" -f $name)
         }
     }
     return $null
@@ -447,11 +447,13 @@ function Invoke-CoordinationCell {
         [Parameter(Mandatory = $true)][string[]] $Filters,
         [Parameter(Mandatory = $true)][string] $ResultsSubPath,
         [Parameter(Mandatory = $true)][string[]] $Needles,
-        [string] $SkipReason = "",
+        [string] $MissingSurface = "",
         [ValidateRange(1, 86400)][int] $TimeoutSeconds = 600
     )
-    if (-not [string]::IsNullOrWhiteSpace($SkipReason)) {
-        return (New-StepResult -Id $Id -Name $Name -Result "n/a" -Reason $SkipReason)
+    if (-not [string]::IsNullOrWhiteSpace($MissingSurface)) {
+        # Fail, not a reasoned n/a: the summary's failure count ignores the latter, so a deleted
+        # or renamed test file would turn every coordination cell green by omission.
+        return (New-StepResult -Id $Id -Name $Name -Result "fail" -Detail $MissingSurface)
     }
     Write-Host ""
     Write-Host ("==== {0} ({1}) ====" -f $Id, $Name) -ForegroundColor Cyan
@@ -715,40 +717,40 @@ try {
     # protocol + forked-process + JUnit-isolation proofs; no display is needed, so these stay hard
     # on Windows including SSH (unlike the WGC / attach-screenshot cells). See docs/RELEASE-SMOKE.md
     # "Experimental input coordination release gate".
-    $coordinationSkip = Get-InputCoordinationSkipReason -RepoRoot $repoRoot
+    $coordinationMissing = Get-InputCoordinationMissingSurface -RepoRoot $repoRoot
     $serverResults = "input-coordinator-server\build\test-results\test"
     $testingResults = "testing\build\test-results\test"
-    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -MissingSurface $coordinationMissing -TimeoutSeconds $AgentE2eTimeoutSeconds `
                 -Id "input-coord-contention" -Name "Two independent client JVMs take one desktop lease without interleaving" `
                 -Task ":input-coordinator-server:test" `
                 -Filters @("*TwoClientJvmContentionTest", "*LocalCoordinatorServerTest.two independent clients receive one desktop lease in FIFO order", "*CoordinatorProcessLauncherTest.forked coordinator accepts a real client lease") `
                 -ResultsSubPath $serverResults `
                 -Needles @("two independent client JVMs never hold the desktop lease at the same time", "two independent clients receive one desktop lease in FIFO order", "forked coordinator accepts a real client lease")))
-    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -MissingSurface $coordinationMissing -TimeoutSeconds $AgentE2eTimeoutSeconds `
                 -Id "input-coord-cancellation" -Name "Cancelled queued waiter does not strand the next waiter" `
                 -Task ":input-coordinator-server:test" `
                 -Filters @("*LocalCoordinatorServerTest.interrupting a queued acquisition removes it without disturbing FIFO") `
                 -ResultsSubPath $serverResults `
                 -Needles @("interrupting a queued acquisition removes it without disturbing FIFO")))
-    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -MissingSurface $coordinationMissing -TimeoutSeconds $AgentE2eTimeoutSeconds `
                 -Id "input-coord-quarantine" -Name "Crashed holder stays fenced/quarantined without stale ownership" `
                 -Task ":input-coordinator-server:test" `
                 -Filters @("*LocalCoordinatorServerTest.successor quarantines a crashed holder until exact-id unsafe recovery") `
                 -ResultsSubPath $serverResults `
                 -Needles @("successor quarantines a crashed holder until exact-id unsafe recovery")))
-    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -MissingSurface $coordinationMissing -TimeoutSeconds $AgentE2eTimeoutSeconds `
                 -Id "input-coord-revoke" -Name "Exact-ID normal revoke cannot affect a newer lease" `
                 -Task ":input-coordinator-server:test" `
                 -Filters @("*LocalCoordinatorServerTest.exact-id revoke rejects stale observation and fences the actual holder") `
                 -ResultsSubPath $serverResults `
                 -Needles @("exact-id revoke rejects stale observation and fences the actual holder")))
-    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -MissingSurface $coordinationMissing -TimeoutSeconds $AgentE2eTimeoutSeconds `
                 -Id "input-coord-forced-recovery" -Name "Explicit forced recovery reports unsafeTakeover and advances the queue" `
                 -Task ":input-coordinator-server:test" `
                 -Filters @("*LocalCoordinatorServerTest.explicit force advances FIFO and reports unsafe takeover") `
                 -ResultsSubPath $serverResults `
                 -Needles @("explicit force advances FIFO and reports unsafe takeover")))
-    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -SkipReason $coordinationSkip -TimeoutSeconds $AgentE2eTimeoutSeconds `
+    [void]$results.Add((Invoke-CoordinationCell -RepoRoot $repoRoot -MissingSurface $coordinationMissing -TimeoutSeconds $AgentE2eTimeoutSeconds `
                 -Id "input-coord-junit-pertest" -Name "Parallel JUnit PerTest serialises factory/body/evidence/teardown" `
                 -Task ":testing:test" `
                 -Filters @("*InputIsolationLifecycleTest", "*ParallelPerTestInputIsolationTest") `

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -39,6 +39,10 @@ param(
     [switch] $SkipPackageCli,
     [switch] $SkipCheck,
     [switch] $SkipMavenLocal,
+    # Operator attestation that headed two-JVM Robot contention was run on this desktop.
+    # Without it the hard input-coord-headed-robot cell stays n/a with a blocking reason; the
+    # automated coordinator cells never satisfy it (they pass headless and under SSH).
+    [string] $HeadedRobotEvidence = "",
     # Schema/preflight self-check only: remaining required IDs are hard n/a with reason.
     # Not a release GO.
     [switch] $PreflightOnly,
@@ -74,7 +78,8 @@ $script:RequiredScenarioIds = @(
     "input-coord-quarantine",
     "input-coord-revoke",
     "input-coord-forced-recovery",
-    "input-coord-junit-pertest"
+    "input-coord-junit-pertest",
+    "input-coord-headed-robot"
 )
 $ErrorActionPreference = "Stop"
 # Avoid StrictMode edge cases with dynamic PSCustomObject / native interop on WinPS 5.1.
@@ -749,6 +754,17 @@ try {
                 -Filters @("*InputIsolationLifecycleTest", "*ParallelPerTestInputIsolationTest") `
                 -ResultsSubPath $testingResults `
                 -Needles @("InputIsolationLifecycleTest", "concurrent per-test invocations never hold the desktop lease at the same time", "the per-test lease is still held while failure evidence is captured")))
+
+    # Headed two-JVM Robot contention: operator-run hard cell. SKILL.md requires *headed*
+    # contention, and every automated cell above passes headless/SSH because none builds a
+    # RobotDriver. Record the operator's attestation rather than inventing a pass.
+    $headedName = "Headed two-JVM Robot contention (operator-recorded)"
+    if (-not [string]::IsNullOrWhiteSpace($HeadedRobotEvidence)) {
+        [void]$results.Add((New-StepResult -Id "input-coord-headed-robot" -Name $headedName -Result "pass" -Detail ("operator evidence: {0}" -f $HeadedRobotEvidence)))
+    }
+    else {
+        [void]$results.Add((New-StepResult -Id "input-coord-headed-robot" -Name $headedName -Result "n/a" -Reason "headed two-JVM Robot contention is operator-run on a real desktop and was NOT recorded; the coordinator-protocol cells do not prove real-input non-interleaving, so this blocks the tag on any OS whose release notes claim headed coordination"))
+    }
 
     if (-not $SkipAgentE2e) {
         # AgentAttachIntegration e2e includes WGC node screenshots (#362). Under SSH that is the

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ParallelPerTestInputIsolationTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ParallelPerTestInputIsolationTest.kt
@@ -22,6 +22,7 @@ import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
 
 /**
  * Release-gate proof that **concurrent** `InputIsolationConfig.perTest()` invocations serialise.
@@ -64,7 +65,11 @@ class ParallelPerTestInputIsolationTest {
         val heldIntervals = CopyOnWriteArrayList<Pair<Long, Long>>()
         val leaseFactory = coordinatorBackedLeaseFactory(heldIntervals)
         val executor = Executors.newFixedThreadPool(INVOCATIONS)
-        // Release every invocation at once so they genuinely contend for the same desktop.
+        // Release every invocation at once so they genuinely contend for the same desktop. The
+        // readiness latch is what makes that true: opening the start line before every worker has
+        // reached it would let stragglers run their bodies serially, and the non-overlap assertion
+        // would then pass even with no mutual exclusion at all.
+        val ready = CountDownLatch(INVOCATIONS)
         val startLine = CountDownLatch(1)
 
         try {
@@ -78,6 +83,7 @@ class ParallelPerTestInputIsolationTest {
                                 factory = { newHeadlessAutomator() },
                             )
                         val context = contextFor("invocation-$invocation")
+                        ready.countDown()
                         startLine.await()
                         extension.beforeEach(context)
                         // Stands in for the test body: long enough that a lost lease shows up as
@@ -86,6 +92,10 @@ class ParallelPerTestInputIsolationTest {
                         extension.afterEach(context)
                     }
                 }
+            assertTrue(
+                ready.await(READY_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+                "every worker must be parked on the start line before the run begins",
+            )
             startLine.countDown()
             futures.forEach { it.get(INVOCATION_TIMEOUT_SECONDS, TimeUnit.SECONDS) }
         } finally {
@@ -105,6 +115,57 @@ class ParallelPerTestInputIsolationTest {
                     "[${earlier.first}, ${earlier.second}] and [${later.first}, ${later.second}]",
             )
         }
+    }
+
+    @Test
+    fun `the per-test lease is still held while failure evidence is captured`(
+        @TempDir reportsRoot: Path
+    ) {
+        // The gate requires the lease to span factory, body, *evidence*, and teardown. Lifecycle
+        // ordering implies it, but only driving the real capture callback proves it: a release
+        // moved ahead of evidence capture must fail this test rather than be argued away.
+        var releasedBeforeEvidence: Boolean? = null
+        val released = java.util.concurrent.atomic.AtomicBoolean(false)
+        val leaseFactory = InputTestLeaseFactory { _, _ ->
+            object : AutomatorInputLease {
+                override fun bind(automator: ComposeAutomator): AutoCloseable = AutoCloseable {}
+
+                override fun close() {
+                    released.set(true)
+                }
+            }
+        }
+        val extension =
+            ComposeAutomatorExtension(
+                failureArtifacts = FailureArtifactsConfig(reportsRoot = reportsRoot),
+                inputIsolation = InputIsolationConfig.perTest(),
+                leaseFactory = leaseFactory,
+                factory = { newHeadlessAutomator() },
+            )
+        val context =
+            RecordingExtensionContext(
+                failure = AssertionError("boom"),
+                testClass = javaClass,
+                methodName = fixtureMethod().name,
+                uniqueId = "[test:evidence]",
+            )
+
+        extension.beforeEach(context)
+        extension.afterTestExecution(context)
+        releasedBeforeEvidence = released.get()
+        extension.afterEach(context)
+
+        assertEquals(
+            true,
+            context.storeValue("failureArtifactsCaptured"),
+            "failure evidence capture must actually have run for this to prove anything",
+        )
+        assertEquals(
+            false,
+            releasedBeforeEvidence,
+            "the per-test lease was released before failure evidence was captured",
+        )
+        assertTrue(released.get(), "the per-test lease must be released after teardown")
     }
 
     /**
@@ -160,5 +221,6 @@ class ParallelPerTestInputIsolationTest {
         const val BODY_MILLIS: Long = 150
         const val ACQUIRE_TIMEOUT_SECONDS: Long = 30
         const val INVOCATION_TIMEOUT_SECONDS: Long = 60
+        const val READY_TIMEOUT_SECONDS: Long = 60
     }
 }

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ParallelPerTestInputIsolationTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ParallelPerTestInputIsolationTest.kt
@@ -1,0 +1,164 @@
+@file:OptIn(
+    dev.sebastiano.spectre.core.InternalSpectreApi::class,
+    dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class,
+)
+
+package dev.sebastiano.spectre.testing
+
+import dev.sebastiano.spectre.core.AutomatorInputLease
+import dev.sebastiano.spectre.core.ComposeAutomator
+import dev.sebastiano.spectre.input.CoordinatorEndpoint
+import dev.sebastiano.spectre.input.DesktopResourceKey
+import dev.sebastiano.spectre.input.LocalInputCoordinatorClient
+import dev.sebastiano.spectre.input.server.LocalCoordinatorServer
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Release-gate proof that **concurrent** `InputIsolationConfig.perTest()` invocations serialise.
+ *
+ * [InputIsolationLifecycleTest] proves the whole-test lease spans factory, body, evidence, and
+ * teardown, but it drives one extension at a time against a recording (fake) lease, so it would
+ * stay green even if two parallel invocations could hold the desktop at once. This test runs
+ * several invocations concurrently against a **real** coordinator on a hermetic endpoint and
+ * asserts their held intervals never overlap. It backs the `input-coord-junit-pertest` smoke cell
+ * (see docs/RELEASE-SMOKE.md).
+ *
+ * Non-overlap is an invariant rather than a timing race: the lease is mutually exclusive, so a
+ * later invocation cannot be granted until the previous one releases. A failure means genuine
+ * interleaving, not a slow machine.
+ */
+class ParallelPerTestInputIsolationTest {
+
+    private val temporaryDirectory: Path = Files.createTempDirectory("spc-par-")
+    private val endpoint =
+        CoordinatorEndpoint(temporaryDirectory, temporaryDirectory.resolve("coordinator.sock"))
+    private val resource = DesktopResourceKey("user:501/parallel-per-test")
+    private var server: LocalCoordinatorServer? = null
+
+    @AfterTest
+    fun cleanUp() {
+        runCatching { server?.close() }
+        Files.walk(temporaryDirectory).use { paths ->
+            paths.sorted(Comparator.reverseOrder()).forEach { path ->
+                runCatching { Files.deleteIfExists(path) }
+            }
+        }
+    }
+
+    @Test
+    fun `concurrent per-test invocations never hold the desktop lease at the same time`() {
+        server =
+            LocalCoordinatorServer(endpoint, idleTimeout = Duration.ofMinutes(1)).also {
+                it.start()
+            }
+        val heldIntervals = CopyOnWriteArrayList<Pair<Long, Long>>()
+        val leaseFactory = coordinatorBackedLeaseFactory(heldIntervals)
+        val executor = Executors.newFixedThreadPool(INVOCATIONS)
+        // Release every invocation at once so they genuinely contend for the same desktop.
+        val startLine = CountDownLatch(1)
+
+        try {
+            val futures =
+                (1..INVOCATIONS).map { invocation ->
+                    executor.submit {
+                        val extension =
+                            ComposeAutomatorExtension(
+                                inputIsolation = InputIsolationConfig.perTest(),
+                                leaseFactory = leaseFactory,
+                                factory = { newHeadlessAutomator() },
+                            )
+                        val context = contextFor("invocation-$invocation")
+                        startLine.await()
+                        extension.beforeEach(context)
+                        // Stands in for the test body: long enough that a lost lease shows up as
+                        // a real overlap at millisecond clock granularity.
+                        Thread.sleep(BODY_MILLIS)
+                        extension.afterEach(context)
+                    }
+                }
+            startLine.countDown()
+            futures.forEach { it.get(INVOCATION_TIMEOUT_SECONDS, TimeUnit.SECONDS) }
+        } finally {
+            executor.shutdownNow()
+        }
+
+        assertEquals(
+            INVOCATIONS,
+            heldIntervals.size,
+            "every concurrent per-test invocation must acquire and release exactly one lease",
+        )
+        val ordered = heldIntervals.sortedBy { it.first }
+        ordered.zipWithNext().forEach { (earlier, later) ->
+            assertTrue(
+                earlier.second <= later.first,
+                "concurrent per-test invocations overlapped on one desktop lease: " +
+                    "[${earlier.first}, ${earlier.second}] and [${later.first}, ${later.second}]",
+            )
+        }
+    }
+
+    /**
+     * A whole-test lease backed by the real coordinator, recording the window it was held.
+     *
+     * The release timestamp is taken *before* closing the lease on purpose: the coordinator can
+     * grant the next waiter the moment the close is processed, so timestamping afterwards could
+     * order this release after the next acquire and fail a correctly serialised run. Recording it
+     * first keeps every interval a subset of the true hold, which still exposes real overlap.
+     */
+    private fun coordinatorBackedLeaseFactory(
+        heldIntervals: MutableList<Pair<Long, Long>>
+    ): InputTestLeaseFactory = InputTestLeaseFactory { _, ownerLabel ->
+        val client = LocalInputCoordinatorClient.connect(endpoint, resource, ownerLabel)
+        val lease =
+            try {
+                client.acquire(Duration.ofSeconds(ACQUIRE_TIMEOUT_SECONDS), "junitPerTest")
+            } catch (failure: Throwable) {
+                client.close()
+                throw failure
+            }
+        val acquiredAt = System.currentTimeMillis()
+        object : AutomatorInputLease {
+            override fun bind(automator: ComposeAutomator): AutoCloseable = AutoCloseable {}
+
+            override fun close() {
+                val releasedAt = System.currentTimeMillis()
+                try {
+                    lease.close()
+                } finally {
+                    client.close()
+                    heldIntervals += acquiredAt to releasedAt
+                }
+            }
+        }
+    }
+
+    private fun contextFor(displayName: String): RecordingExtensionContext =
+        RecordingExtensionContext(
+            failure = null,
+            testClass = javaClass,
+            methodName = fixtureMethod().name,
+            uniqueId = "[test:$displayName]",
+        )
+
+    private fun fixtureMethod(): java.lang.reflect.Method =
+        javaClass.getDeclaredMethod("parallelTestFixture")
+
+    @Suppress("unused") private fun parallelTestFixture(): Unit = Unit
+
+    private companion object {
+        const val INVOCATIONS: Int = 4
+        const val BODY_MILLIS: Long = 150
+        const val ACQUIRE_TIMEOUT_SECONDS: Long = 30
+        const val INVOCATION_TIMEOUT_SECONDS: Long = 60
+    }
+}


### PR DESCRIPTION
## Summary

The release smoke harness predated #459 (experimental desktop input coordination): `REQUIRED_SCENARIO_IDS` held 15 IDs, none touching the coordinator, so the `spectre-release` skill's input-coordination hard cells existed only as ad-hoc commands. This adds the six delta hard cells — plus a seventh for the headed residual, see below — as reusable scenario IDs, wired per **Adding a scenario ID** in `docs/RELEASE-SMOKE.md` (`REQUIRED_SCENARIO_IDS` + both entrypoints + contract tests + docs). Unblocks tagging 0.6.0.

| Gate bullet | Scenario ID | Proof driven |
| --- | --- | --- |
| Two independent JVMs, FIFO, no interleave | `input-coord-contention` | `LocalCoordinatorServerTest` FIFO across two client sessions **+** `CoordinatorProcessLauncherTest` real forked-coordinator JVM **+** `TwoClientJvmContentionTest` (two real child JVMs, disjoint hold intervals) |
| Cancelled waiter, next not stranded | `input-coord-cancellation` | `LocalCoordinatorServerTest` |
| Holder loss fenced until ack / exact force | `input-coord-quarantine` | `LocalCoordinatorServerTest` |
| Exact-ID revoke cannot hit a newer lease | `input-coord-revoke` | `LocalCoordinatorServerTest` |
| Forced recovery reports `unsafeTakeover=true` | `input-coord-forced-recovery` | `LocalCoordinatorServerTest` |
| Parallel JUnit `perTest()` serialises lifecycle | `input-coord-junit-pertest` | `InputIsolationLifecycleTest` **+** `ParallelPerTestInputIsolationTest` (4 concurrent lifecycles, disjoint intervals; lease still held while failure evidence is captured) |
| Headed two-JVM Robot contention | `input-coord-headed-robot` | operator-recorded evidence — see below |

Each automated cell forces `--rerun-tasks --no-build-cache` and fails closed on the JUnit XML via a new `assert_junit_testcases_passed` gate: the named testcase must actually have executed — present in the XML, not a skipped entry, and its suite reporting no failures or errors — so an empty `--tests` filter or an assumption-skip cannot fake a `pass`.

**Why these are hard on all three OSes.** The coordinator protocol/isolation tests are deterministic and need no display, so unlike the WGC / attach-screenshot cells they stay hard on macOS, Windows *including SSH*, and Linux Xorg/Xvfb. They are not Robot cells, so they run with the plain scenario env, never the Xvfb/Robot wrapper.

**A missing proof source is a failure, not a skip.** If either coordination test source is gone, the cells emit `fail` with a detail naming the file. They deliberately do *not* emit a reasoned `n/a`: `hard_failures()` ignores an `n/a` that carries a reason, so deleting or renaming one test file would otherwise turn every coordination cell green-by-omission. Genuine removal or graduation of the surface means re-scoping the release — dropping the `input-coord-*` IDs and updating `docs/RELEASE-SMOKE.md` — not letting the harness shrug.

**The headed residual is a hard operator cell.** A fully-headed two-`RobotDriver(InputLeasePolicy.Required)` physical-mouse contention run is the one thing the automated cells cannot cover: the coordinator-protocol proofs show the *protocol* never double-grants, not that real OS input never interleaves. Rather than mark it soft or claim it silently, `input-coord-headed-robot` **fails** unless an operator passes `--headed-robot-evidence` (`-HeadedRobotEvidence` on Windows), so somebody must consciously sign it off per claimed OS before the tag. Automating it is filed as follow-up work; it gates the 0.6.0 tag, not this merge.

Also verified (unchanged, per the skill's three extra gate conditions): the marker is still `RequiresOptIn.Level.WARNING` (test-pinned by `ExperimentalInputCoordinationApiTest`); no-argument `RobotDriver()` is still uncoordinated (`InputLeasePolicy.Off` default); the consumer skill and published guide still describe the same opt-in, runtime dependency, cooperative boundary, and unsafe-force semantics (untouched here, string-pinned by `DocsGuidanceContractTest`).

Refs #459.

## Test plan

- [x] `./gradlew check` passes locally — full run, `:check` + all test tasks + both smoke-script gates
- [x] `./gradlew ktfmtFormat` / `detekt` clean on the new Kotlin

Beyond the gate, each cell was executed for real on Linux:

- Method-level `--tests` filters select exactly the intended methods (contention = 2 `LocalCoordinatorServerTest` + forked-launcher + `TwoClientJvmContentionTest`; the four single-purpose cells = 4/0/0/0; `InputIsolationLifecycleTest` = 7/0/0/0; `ParallelPerTestInputIsolationTest` = 2/0/0/0), all green.
- `assert_junit_testcases_passed` accepts that real output (testcase names carry a trailing `()`, matched as a substring) and **fails closed** on a needle whose method did not run — red-proofed against a fixture with only the evidence-capture method removed.
- The parallel per-test proof was red-proofed by keying the desktop resource per acquire: without a shared key the four invocations genuinely overlap and the interval assertion fails, so it is load-bearing rather than vacuous.
- `release-smoke.py --preflight-only` enumerates all 22 required IDs and validates the report schema.
- `verifyReleaseSmokeScripts` (59 Python contract tests) and `verifyWindowsReleaseSmokeScript` both pass.

Reviewer note on what is *not* proven here: the macOS and Windows columns were implemented but not executed — no such hosts in this session (CI's own `check-macos` / `check-windows` cover the build, not the smoke run). The Windows PowerShell could not be `pwsh`-parsed locally (not installed; same SKIP path the contract test takes on a Linux agent), so it rests on the ASCII-only check plus the contract needles. Two sandbox-only fixes were needed to get the gate green and are environmental, not code: `libdbus-1-dev` for `:recording:buildWaylandHelper`, and a UTF-8 locale — without one, `UdsPathLimitsTest` fails in `Path.of` on an accented Windows path because the JVM boots `sun.jnu.encoding=ANSI_X3.4-1968`. That last one is a latent trap for any contributor on a C-locale box; happy to file it separately.

## Confirmations

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR is **not** LLM-generated. (See the "no clanker PRs or issues" rule.)
- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).

Leaving the first box unticked deliberately rather than misrepresenting it: this was written by Claude Code in your own session, at your direction, so the "no clanker PRs" rule (aimed at drive-by LLM submissions) doesn't apply — but the box says what it says, and ticking it would be false.