### PR TITLE
fix(cli): parse the Java version past the JAVA_TOOL_OPTIONS banner

### DIFF
--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -84,7 +84,7 @@ abstract class PatchStartScripts : DefaultTask() {
                     fi
                     for spectre_java_home in "${'$'}{HOME:-}/.sdkman/candidates/java/current" /usr/lib/jvm/* /Library/Java/JavaVirtualMachines/*/Contents/Home; do
                         if [ -x "${'$'}spectre_java_home/bin/java" ]; then
-                            spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | sed -n '/version "/{s/.*version "\([^" ]*\)".*/\1/p;q;}')
+                            spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | sed -n '/^[^ ]* version "/{s/.*version "\([^" ]*\)".*/\1/p;q;}')
                             spectre_java_feature=${'$'}{spectre_java_version%%.*}
                             case "${'$'}spectre_java_feature" in
                                 '' | *[!0-9]*) continue ;;
@@ -110,9 +110,13 @@ abstract class PatchStartScripts : DefaultTask() {
         private val UNIX_JDK_PREFLIGHT =
             """
             # Spectre requires Java 21 or later. Attach operations validate jdk.attach themselves.
-            # Match the first line carrying the version: a JVM started with JAVA_TOOL_OPTIONS set
-            # prints "Picked up JAVA_TOOL_OPTIONS: ..." to stderr ahead of it.
-            spectre_java_version=${'$'}("${'$'}JAVACMD" -version 2>&1 | sed -n '/version "/{s/.*version "\([^" ]*\)".*/\1/p;q;}')
+            # Match the JVM's own version record (`openjdk version "..."` / `java version "..."`),
+            # not merely the first line containing `version "`. A JVM started with JAVA_TOOL_OPTIONS
+            # set prints "Picked up JAVA_TOOL_OPTIONS: ..." to stderr ahead of the record, and that
+            # banner echoes the variable's contents, which can themselves contain `version "..."`.
+            # Anchoring on <word><space>version " skips every such preamble, including the
+            # "NOTE: Picked up JDK_JAVA_OPTIONS: ..." form.
+            spectre_java_version=${'$'}("${'$'}JAVACMD" -version 2>&1 | sed -n '/^[^ ]* version "/{s/.*version "\([^" ]*\)".*/\1/p;q;}')
             spectre_java_feature=${'$'}{spectre_java_version%%.*}
             case "${'$'}spectre_java_feature" in
                 '' | *[!0-9]*) die "ERROR: Could not determine the Java version from ${'$'}JAVACMD." ;;

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -19,12 +19,7 @@ abstract class PatchStartScripts : DefaultTask() {
     }
 
     private fun patchUnix(script: File) {
-        script.writeText(
-            script
-                .readText()
-                .replace("# Determine the Java command to use to start the JVM.", UNIX_JAVA_SEARCH)
-                .replace(UNIX_DEFAULT_JVM_OPTIONS_COMMENT, UNIX_JDK_PREFLIGHT),
-        )
+        script.writeText(patchUnixScript(script.readText()))
     }
 
     private fun patchWindows(script: File) {
@@ -51,7 +46,16 @@ abstract class PatchStartScripts : DefaultTask() {
         script.writeText(patchedScript.replace("\n", "\r\n"))
     }
 
-    private companion object {
+    internal companion object {
+        /**
+         * Injects the local JDK search and the Java 21 preflight into a Gradle-generated Unix
+         * launcher.
+         */
+        internal fun patchUnixScript(original: String): String =
+            original
+                .replace("# Determine the Java command to use to start the JVM.", UNIX_JAVA_SEARCH)
+                .replace(UNIX_DEFAULT_JVM_OPTIONS_COMMENT, UNIX_JDK_PREFLIGHT)
+
         private val UNIX_JAVA_SEARCH =
             """
             # Prefer a bundled runtime only when it matches this host.
@@ -80,7 +84,7 @@ abstract class PatchStartScripts : DefaultTask() {
                     fi
                     for spectre_java_home in "${'$'}{HOME:-}/.sdkman/candidates/java/current" /usr/lib/jvm/* /Library/Java/JavaVirtualMachines/*/Contents/Home; do
                         if [ -x "${'$'}spectre_java_home/bin/java" ]; then
-                            spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
+                            spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | sed -n '/version "/{s/.*version "\([^" ]*\)".*/\1/p;q;}')
                             spectre_java_feature=${'$'}{spectre_java_version%%.*}
                             case "${'$'}spectre_java_feature" in
                                 '' | *[!0-9]*) continue ;;
@@ -106,7 +110,9 @@ abstract class PatchStartScripts : DefaultTask() {
         private val UNIX_JDK_PREFLIGHT =
             """
             # Spectre requires Java 21 or later. Attach operations validate jdk.attach themselves.
-            spectre_java_version=${'$'}("${'$'}JAVACMD" -version 2>&1 | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
+            # Match the first line carrying the version: a JVM started with JAVA_TOOL_OPTIONS set
+            # prints "Picked up JAVA_TOOL_OPTIONS: ..." to stderr ahead of it.
+            spectre_java_version=${'$'}("${'$'}JAVACMD" -version 2>&1 | sed -n '/version "/{s/.*version "\([^" ]*\)".*/\1/p;q;}')
             spectre_java_feature=${'$'}{spectre_java_version%%.*}
             case "${'$'}spectre_java_feature" in
                 '' | *[!0-9]*) die "ERROR: Could not determine the Java version from ${'$'}JAVACMD." ;;

--- a/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
+++ b/buildSrc/src/main/kotlin/dev/sebastiano/spectre/build/PatchStartScripts.kt
@@ -84,7 +84,7 @@ abstract class PatchStartScripts : DefaultTask() {
                     fi
                     for spectre_java_home in "${'$'}{HOME:-}/.sdkman/candidates/java/current" /usr/lib/jvm/* /Library/Java/JavaVirtualMachines/*/Contents/Home; do
                         if [ -x "${'$'}spectre_java_home/bin/java" ]; then
-                            spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | sed -n '/^[^ ]* version "/{s/.*version "\([^" ]*\)".*/\1/p;q;}')
+                            spectre_java_version=${'$'}("${'$'}spectre_java_home/bin/java" -version 2>&1 | grep -E '^(java|openjdk) version "' | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
                             spectre_java_feature=${'$'}{spectre_java_version%%.*}
                             case "${'$'}spectre_java_feature" in
                                 '' | *[!0-9]*) continue ;;
@@ -110,13 +110,14 @@ abstract class PatchStartScripts : DefaultTask() {
         private val UNIX_JDK_PREFLIGHT =
             """
             # Spectre requires Java 21 or later. Attach operations validate jdk.attach themselves.
-            # Match the JVM's own version record (`openjdk version "..."` / `java version "..."`),
-            # not merely the first line containing `version "`. A JVM started with JAVA_TOOL_OPTIONS
-            # set prints "Picked up JAVA_TOOL_OPTIONS: ..." to stderr ahead of the record, and that
-            # banner echoes the variable's contents, which can themselves contain `version "..."`.
-            # Anchoring on <word><space>version " skips every such preamble, including the
-            # "NOTE: Picked up JDK_JAVA_OPTIONS: ..." form.
-            spectre_java_version=${'$'}("${'$'}JAVACMD" -version 2>&1 | sed -n '/^[^ ]* version "/{s/.*version "\([^" ]*\)".*/\1/p;q;}')
+            # Read the version only from the JVM's own record, whose first token is `java` or
+            # `openjdk`. Anything JAVA_TOOL_OPTIONS causes to be printed lands on stderr ahead of
+            # that record and must not be parsed: the "Picked up JAVA_TOOL_OPTIONS: ..." banner
+            # echoes the variable's contents, a -javaagent premain can print its own banner, and
+            # either can itself contain `version "..."`. Matching the record names is what keeps
+            # a decoy from being read as the runtime's version. `grep -E` alternation is POSIX,
+            # unlike BRE `\|`, so BSD sed/grep on macOS accepts this too.
+            spectre_java_version=${'$'}("${'$'}JAVACMD" -version 2>&1 | grep -E '^(java|openjdk) version "' | sed -n '1s/.*version "\([^" ]*\)".*/\1/p')
             spectre_java_feature=${'$'}{spectre_java_version%%.*}
             case "${'$'}spectre_java_feature" in
                 '' | *[!0-9]*) die "ERROR: Could not determine the Java version from ${'$'}JAVACMD." ;;

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
@@ -56,6 +56,33 @@ class PatchStartScriptsTest {
     }
 
     @Test
+    fun `the preflight reads the JVM record, not a version-shaped banner payload`(
+        @TempDir root: Path
+    ) {
+        // JAVA_TOOL_OPTIONS can itself carry `version "..."` — a property default, a note, a
+        // path. The banner then looks like a version record, and matching any line containing
+        // `version "` reads the property instead of the JVM, rejecting a supported runtime.
+        // The same shape reaches the launcher as `NOTE: Picked up JDK_JAVA_OPTIONS: ...`.
+        // Raised by Codex review on PR #485.
+        val jdk =
+            fakeJdk(
+                root,
+                "decoy",
+                version = "21.0.10",
+                banner = true,
+                bannerOptions = "-Dnote=version \"17.0.2\"",
+            )
+
+        val result = runLauncher(root, javaHome = jdk)
+
+        assertEquals(0, result.exitCode, "launcher failed:\n${result.output}")
+        assertFalse(
+            result.output.contains("17.0.2"),
+            "the banner payload was parsed as the Java version:\n${result.output}",
+        )
+    }
+
+    @Test
     fun `the preflight accepts a Java 21 runtime without the banner`(@TempDir root: Path) {
         // Regression guard: the banner fix must not change how a plain `java -version` is read.
         val jdk = fakeJdk(root, "plain", version = "21.0.10", banner = false)
@@ -127,18 +154,29 @@ class PatchStartScriptsTest {
         return LauncherResult(process.exitValue(), output)
     }
 
-    private fun fakeJdk(root: Path, name: String, version: String, banner: Boolean): Path {
+    private fun fakeJdk(
+        root: Path,
+        name: String,
+        version: String,
+        banner: Boolean,
+        bannerOptions: String = DEFAULT_BANNER_OPTIONS,
+    ): Path {
         val jdkHome = root.resolve("jdk-$name")
-        writeFakeJava(jdkHome, version, banner)
+        writeFakeJava(jdkHome, version, banner, bannerOptions)
         return jdkHome
     }
 
     /** Writes a `bin/java` script that answers `-version` and `--list-modules` like a real JDK. */
-    private fun writeFakeJava(jdkHome: Path, version: String, banner: Boolean) {
+    private fun writeFakeJava(
+        jdkHome: Path,
+        version: String,
+        banner: Boolean,
+        bannerOptions: String = DEFAULT_BANNER_OPTIONS,
+    ) {
         val java = jdkHome.resolve("bin/java")
         Files.createDirectories(java.parent)
         val bannerLine =
-            if (banner) "echo 'Picked up JAVA_TOOL_OPTIONS: -Dspectre.test=true' >&2" else ":"
+            if (banner) "echo 'Picked up JAVA_TOOL_OPTIONS: $bannerOptions' >&2" else ":"
         Files.writeString(
             java,
             """
@@ -172,6 +210,8 @@ class PatchStartScriptsTest {
 
     private companion object {
         private const val COMMAND_TIMEOUT_SECONDS: Long = 30
+
+        private const val DEFAULT_BANNER_OPTIONS = "-Dspectre.test=true"
 
         /**
          * Minimal stand-in for the Gradle-generated launcher: the two anchors [PatchStartScripts]

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
@@ -6,6 +6,7 @@ import java.nio.file.Path
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledOnOs
@@ -83,6 +84,59 @@ class PatchStartScriptsTest {
     }
 
     @Test
+    fun `the preflight ignores a version-shaped agent banner`(@TempDir root: Path) {
+        // A -javaagent installed through JAVA_TOOL_OPTIONS can print its own premain banner
+        // ahead of the JVM record, and a single-token one such as `Agent version "17.0.2"` has
+        // the very shape of a record. Only `java`/`openjdk` name a real record.
+        // Raised by Codex review on PR #485.
+        val jdk = fakeJdk(root, "agent", version = "21.0.2", banner = false)
+        Files.writeString(
+            jdk.resolve("bin/java"),
+            """
+            #!/bin/sh
+            case "${'$'}1" in
+                -version)
+                    echo 'Agent version "17.0.2"' >&2
+                    echo 'openjdk version "21.0.2" 2024-01-16' >&2
+                    ;;
+                --list-modules)
+                    echo 'jdk.attach@21.0.2'
+                    ;;
+            esac
+            """
+                .trimIndent() + "\n",
+        )
+        check(jdk.resolve("bin/java").toFile().setExecutable(true))
+
+        val result = runLauncher(root, javaHome = jdk)
+
+        assertEquals(0, result.exitCode, "launcher failed:\n${result.output}")
+        assertFalse(
+            result.output.contains("17.0.2"),
+            "the agent banner was parsed as the Java version:\n${result.output}",
+        )
+    }
+
+    @Test
+    fun `a launcher that never exits fails on the timeout instead of hanging`(
+        @TempDir root: Path
+    ) {
+        // The harness must bound its own runs: draining the pipe to EOF before waiting would
+        // block forever here and hang CI rather than failing. Raised by Codex review on PR #485.
+        val jdk = fakeJdk(root, "wedged", version = "21.0.10", banner = false, hangs = true)
+
+        val failure =
+            assertThrows(IllegalStateException::class.java) {
+                runLauncher(root, javaHome = jdk, timeoutSeconds = 2)
+            }
+
+        assertTrue(
+            failure.message.orEmpty().contains("did not finish within 2 seconds"),
+            "unexpected failure: ${failure.message}",
+        )
+    }
+
+    @Test
     fun `the preflight accepts a Java 21 runtime without the banner`(@TempDir root: Path) {
         // Regression guard: the banner fix must not change how a plain `java -version` is read.
         val jdk = fakeJdk(root, "plain", version = "21.0.10", banner = false)
@@ -132,25 +186,31 @@ class PatchStartScriptsTest {
     private fun runLauncher(
         root: Path,
         javaHome: Path?,
+        timeoutSeconds: Long = COMMAND_TIMEOUT_SECONDS,
         configureEnvironment: (MutableMap<String, String>) -> Unit = {},
     ): LauncherResult {
         val launcher = root.resolve("app/bin/spectre")
         Files.createDirectories(launcher.parent)
         Files.writeString(launcher, PatchStartScripts.patchUnixScript(UNPATCHED_LAUNCHER))
 
+        // Redirect to a file rather than draining the pipe inline: reading to EOF first would
+        // block forever on a launcher that never exits, so the timeout below would never be
+        // reached and a regression would hang the whole CI job instead of failing this test.
+        val outputFile = launcher.resolveSibling("launcher-output.txt")
         val processBuilder =
-            ProcessBuilder("/bin/sh", launcher.toString()).redirectErrorStream(true)
+            ProcessBuilder("/bin/sh", launcher.toString())
+                .redirectErrorStream(true)
+                .redirectOutput(outputFile.toFile())
         val environment = processBuilder.environment()
         environment.remove("JAVA_HOME")
         if (javaHome != null) environment["JAVA_HOME"] = javaHome.toString()
         configureEnvironment(environment)
 
         val process = processBuilder.start()
-        val output = process.inputStream.bufferedReader().use { it.readText() }
-        check(process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-            process.destroyForcibly()
-            "launcher did not finish within $COMMAND_TIMEOUT_SECONDS seconds:\n$output"
-        }
+        val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
+        if (!finished) process.destroyForcibly().waitFor()
+        val output = Files.readString(outputFile)
+        check(finished) { "launcher did not finish within $timeoutSeconds seconds:\n$output" }
         return LauncherResult(process.exitValue(), output)
     }
 
@@ -160,9 +220,10 @@ class PatchStartScriptsTest {
         version: String,
         banner: Boolean,
         bannerOptions: String = DEFAULT_BANNER_OPTIONS,
+        hangs: Boolean = false,
     ): Path {
         val jdkHome = root.resolve("jdk-$name")
-        writeFakeJava(jdkHome, version, banner, bannerOptions)
+        writeFakeJava(jdkHome, version, banner, bannerOptions, hangs)
         return jdkHome
     }
 
@@ -172,17 +233,21 @@ class PatchStartScriptsTest {
         version: String,
         banner: Boolean,
         bannerOptions: String = DEFAULT_BANNER_OPTIONS,
+        hangs: Boolean = false,
     ) {
         val java = jdkHome.resolve("bin/java")
         Files.createDirectories(java.parent)
         val bannerLine =
             if (banner) "echo 'Picked up JAVA_TOOL_OPTIONS: $bannerOptions' >&2" else ":"
+        // A JVM that never returns wedges the launcher, which is what bounds the harness.
+        val hangLine = if (hangs) "sleep 600" else ":"
         Files.writeString(
             java,
             """
             #!/bin/sh
             case "${'$'}1" in
                 -version)
+                    $hangLine
                     $bannerLine
                     echo 'openjdk version "$version" 2026-01-20' >&2
                     echo 'OpenJDK Runtime Environment (build $version+7)' >&2

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
@@ -35,8 +35,8 @@ class PatchStartScriptsTest {
 
         val result = runLauncher(root, javaHome = jdk)
 
-        assertEquals(0, result.exitCode, "launcher failed:\n${'$'}{result.output}")
-        assertFalse(result.output.contains("ERROR"), "launcher failed:\n${'$'}{result.output}")
+        assertEquals(0, result.exitCode, "launcher failed:\n${result.output}")
+        assertFalse(result.output.contains("ERROR"), "launcher failed:\n${result.output}")
     }
 
     @Test
@@ -48,10 +48,10 @@ class PatchStartScriptsTest {
 
         val result = runLauncher(root, javaHome = jdk)
 
-        assertEquals(1, result.exitCode, "launcher should have died:\n${'$'}{result.output}")
+        assertEquals(1, result.exitCode, "launcher should have died:\n${result.output}")
         assertTrue(
             result.output.contains("Spectre requires JDK 21 or later; found Java 17.0.2"),
-            "unexpected launcher output:\n${'$'}{result.output}",
+            "unexpected launcher output:\n${result.output}",
         )
     }
 
@@ -62,8 +62,8 @@ class PatchStartScriptsTest {
 
         val result = runLauncher(root, javaHome = jdk)
 
-        assertEquals(0, result.exitCode, "launcher failed:\n${'$'}{result.output}")
-        assertFalse(result.output.contains("ERROR"), "launcher failed:\n${'$'}{result.output}")
+        assertEquals(0, result.exitCode, "launcher failed:\n${result.output}")
+        assertFalse(result.output.contains("ERROR"), "launcher failed:\n${result.output}")
     }
 
     @Test
@@ -89,10 +89,10 @@ class PatchStartScriptsTest {
                 environment["PATH"] = pathWithoutJava.toString()
             }
 
-        assertEquals(0, result.exitCode, "launcher failed:\n${'$'}{result.output}")
+        assertEquals(0, result.exitCode, "launcher failed:\n${result.output}")
         assertTrue(
-            result.output.contains("JAVACMD=${'$'}{sdkmanJdk.resolve("bin/java")}"),
-            "the sdkman candidate was not selected:\n${'$'}{result.output}",
+            result.output.contains("JAVACMD=${sdkmanJdk.resolve("bin/java")}"),
+            "the sdkman candidate was not selected:\n${result.output}",
         )
     }
 
@@ -122,13 +122,13 @@ class PatchStartScriptsTest {
         val output = process.inputStream.bufferedReader().use { it.readText() }
         check(process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
             process.destroyForcibly()
-            "launcher did not finish within ${'$'}COMMAND_TIMEOUT_SECONDS seconds:\n${'$'}output"
+            "launcher did not finish within $COMMAND_TIMEOUT_SECONDS seconds:\n$output"
         }
         return LauncherResult(process.exitValue(), output)
     }
 
     private fun fakeJdk(root: Path, name: String, version: String, banner: Boolean): Path {
-        val jdkHome = root.resolve("jdk-${'$'}name")
+        val jdkHome = root.resolve("jdk-$name")
         writeFakeJava(jdkHome, version, banner)
         return jdkHome
     }
@@ -145,20 +145,20 @@ class PatchStartScriptsTest {
             #!/bin/sh
             case "${'$'}1" in
                 -version)
-                    ${'$'}bannerLine
-                    echo 'openjdk version "${'$'}version" 2026-01-20' >&2
-                    echo 'OpenJDK Runtime Environment (build ${'$'}version+7)' >&2
-                    echo 'OpenJDK 64-Bit Server VM (build ${'$'}version+7, mixed mode, sharing)' >&2
+                    $bannerLine
+                    echo 'openjdk version "$version" 2026-01-20' >&2
+                    echo 'OpenJDK Runtime Environment (build $version+7)' >&2
+                    echo 'OpenJDK 64-Bit Server VM (build $version+7, mixed mode, sharing)' >&2
                     ;;
                 --list-modules)
-                    echo 'java.base@${'$'}version'
-                    echo 'jdk.attach@${'$'}version'
+                    echo 'java.base@$version'
+                    echo 'jdk.attach@$version'
                     ;;
             esac
             """
                 .trimIndent() + "\n",
         )
-        check(java.toFile().setExecutable(true)) { "Could not make ${'$'}java executable" }
+        check(java.toFile().setExecutable(true)) { "Could not make $java executable" }
     }
 
     private fun hostTool(name: String): Path =
@@ -168,7 +168,7 @@ class PatchStartScriptsTest {
             .map { File(it, name) }
             .firstOrNull { it.canExecute() }
             ?.toPath()
-            ?: error("Could not find ${'$'}name on PATH")
+            ?: error("Could not find $name on PATH")
 
     private companion object {
         private const val COMMAND_TIMEOUT_SECONDS: Long = 30

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
@@ -1,0 +1,214 @@
+package dev.sebastiano.spectre.build
+
+import java.io.File
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledOnOs
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * Unit coverage for the Java 21 preflight [PatchStartScripts] injects into the generated Unix
+ * `bin/spectre` launcher.
+ *
+ * Runs the real patched launcher under `/bin/sh` against a fake `java`, so the version parsing is
+ * exercised exactly as shipped rather than re-implemented. The fake mimics a JVM started with
+ * `JAVA_TOOL_OPTIONS` exported (common on CI runners, behind corporate proxies, and in container
+ * images): every such JVM prints `Picked up JAVA_TOOL_OPTIONS: ...` to stderr *before* the
+ * `version "..."` line. A preflight that only reads the first line of `java -version` then finds
+ * no version and kills the launcher even though the runtime is fine.
+ */
+@DisabledOnOs(OS.WINDOWS) // Exercises the POSIX launcher under /bin/sh.
+class PatchStartScriptsTest {
+
+    @Test
+    fun `the preflight accepts a Java 21 runtime that echoes JAVA_TOOL_OPTIONS first`(
+        @TempDir root: Path
+    ) {
+        val jdk = fakeJdk(root, "banner", version = "21.0.10", banner = true)
+
+        val result = runLauncher(root, javaHome = jdk)
+
+        assertEquals(0, result.exitCode, "launcher failed:\n${'$'}{result.output}")
+        assertFalse(result.output.contains("ERROR"), "launcher failed:\n${'$'}{result.output}")
+    }
+
+    @Test
+    fun `the preflight still rejects an old runtime that echoes JAVA_TOOL_OPTIONS first`(
+        @TempDir root: Path
+    ) {
+        // Proves the version really is parsed from the line after the banner, not just skipped.
+        val jdk = fakeJdk(root, "old", version = "17.0.2", banner = true)
+
+        val result = runLauncher(root, javaHome = jdk)
+
+        assertEquals(1, result.exitCode, "launcher should have died:\n${'$'}{result.output}")
+        assertTrue(
+            result.output.contains("Spectre requires JDK 21 or later; found Java 17.0.2"),
+            "unexpected launcher output:\n${'$'}{result.output}",
+        )
+    }
+
+    @Test
+    fun `the preflight accepts a Java 21 runtime without the banner`(@TempDir root: Path) {
+        // Regression guard: the banner fix must not change how a plain `java -version` is read.
+        val jdk = fakeJdk(root, "plain", version = "21.0.10", banner = false)
+
+        val result = runLauncher(root, javaHome = jdk)
+
+        assertEquals(0, result.exitCode, "launcher failed:\n${'$'}{result.output}")
+        assertFalse(result.output.contains("ERROR"), "launcher failed:\n${'$'}{result.output}")
+    }
+
+    @Test
+    // macOS asks /usr/libexec/java_home first, which a test cannot stub, so the sdkman
+    // candidate below would never be probed on a mac with a host JDK 21 installed.
+    @EnabledOnOs(OS.LINUX)
+    fun `the local JDK search accepts a candidate that echoes JAVA_TOOL_OPTIONS first`(
+        @TempDir root: Path
+    ) {
+        val home = root.resolve("home")
+        val sdkmanJdk = home.resolve(".sdkman/candidates/java/current")
+        writeFakeJava(sdkmanJdk, version = "21.0.10", banner = true)
+        // A PATH that carries the tools the search needs but no `java`, so the search runs.
+        val pathWithoutJava = root.resolve("path-without-java")
+        Files.createDirectories(pathWithoutJava)
+        for (tool in listOf("sed", "grep")) {
+            Files.createSymbolicLink(pathWithoutJava.resolve(tool), hostTool(tool))
+        }
+
+        val result =
+            runLauncher(root, javaHome = null) { environment ->
+                environment["HOME"] = home.toString()
+                environment["PATH"] = pathWithoutJava.toString()
+            }
+
+        assertEquals(0, result.exitCode, "launcher failed:\n${'$'}{result.output}")
+        assertTrue(
+            result.output.contains("JAVACMD=${'$'}{sdkmanJdk.resolve("bin/java")}"),
+            "the sdkman candidate was not selected:\n${'$'}{result.output}",
+        )
+    }
+
+    private class LauncherResult(val exitCode: Int, val output: String)
+
+    /**
+     * Patches [UNPATCHED_LAUNCHER] with the real [PatchStartScripts] logic, then runs it under
+     * `/bin/sh` with `JAVA_HOME` pointing at [javaHome] (or unset when null).
+     */
+    private fun runLauncher(
+        root: Path,
+        javaHome: Path?,
+        configureEnvironment: (MutableMap<String, String>) -> Unit = {},
+    ): LauncherResult {
+        val launcher = root.resolve("app/bin/spectre")
+        Files.createDirectories(launcher.parent)
+        Files.writeString(launcher, PatchStartScripts.patchUnixScript(UNPATCHED_LAUNCHER))
+
+        val processBuilder =
+            ProcessBuilder("/bin/sh", launcher.toString()).redirectErrorStream(true)
+        val environment = processBuilder.environment()
+        environment.remove("JAVA_HOME")
+        if (javaHome != null) environment["JAVA_HOME"] = javaHome.toString()
+        configureEnvironment(environment)
+
+        val process = processBuilder.start()
+        val output = process.inputStream.bufferedReader().use { it.readText() }
+        check(process.waitFor(COMMAND_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+            process.destroyForcibly()
+            "launcher did not finish within ${'$'}COMMAND_TIMEOUT_SECONDS seconds:\n${'$'}output"
+        }
+        return LauncherResult(process.exitValue(), output)
+    }
+
+    private fun fakeJdk(root: Path, name: String, version: String, banner: Boolean): Path {
+        val jdkHome = root.resolve("jdk-${'$'}name")
+        writeFakeJava(jdkHome, version, banner)
+        return jdkHome
+    }
+
+    /** Writes a `bin/java` script that answers `-version` and `--list-modules` like a real JDK. */
+    private fun writeFakeJava(jdkHome: Path, version: String, banner: Boolean) {
+        val java = jdkHome.resolve("bin/java")
+        Files.createDirectories(java.parent)
+        val bannerLine =
+            if (banner) "echo 'Picked up JAVA_TOOL_OPTIONS: -Dspectre.test=true' >&2" else ":"
+        Files.writeString(
+            java,
+            """
+            #!/bin/sh
+            case "${'$'}1" in
+                -version)
+                    ${'$'}bannerLine
+                    echo 'openjdk version "${'$'}version" 2026-01-20' >&2
+                    echo 'OpenJDK Runtime Environment (build ${'$'}version+7)' >&2
+                    echo 'OpenJDK 64-Bit Server VM (build ${'$'}version+7, mixed mode, sharing)' >&2
+                    ;;
+                --list-modules)
+                    echo 'java.base@${'$'}version'
+                    echo 'jdk.attach@${'$'}version'
+                    ;;
+            esac
+            """
+                .trimIndent() + "\n",
+        )
+        check(java.toFile().setExecutable(true)) { "Could not make ${'$'}java executable" }
+    }
+
+    private fun hostTool(name: String): Path =
+        System.getenv("PATH")
+            .orEmpty()
+            .split(File.pathSeparator)
+            .map { File(it, name) }
+            .firstOrNull { it.canExecute() }
+            ?.toPath()
+            ?: error("Could not find ${'$'}name on PATH")
+
+    private companion object {
+        private const val COMMAND_TIMEOUT_SECONDS: Long = 30
+
+        /**
+         * Minimal stand-in for the Gradle-generated launcher: the two anchors [PatchStartScripts]
+         * rewrites, the `die` helper, and the `JAVACMD` resolution the preflight relies on. It
+         * echoes the resolved `JAVACMD` instead of starting the JVM.
+         */
+        private val UNPATCHED_LAUNCHER =
+            """
+            #!/bin/sh
+            APP_HOME=${'$'}{0%/bin/*}
+
+            die () {
+                echo
+                echo "${'$'}*"
+                echo
+                exit 1
+            } >&2
+
+            # Determine the Java command to use to start the JVM.
+            if [ -n "${'$'}JAVA_HOME" ] ; then
+                JAVACMD=${'$'}JAVA_HOME/bin/java
+                if [ ! -x "${'$'}JAVACMD" ] ; then
+                    die "ERROR: JAVA_HOME is set to an invalid directory: ${'$'}JAVA_HOME"
+                fi
+            else
+                JAVACMD=java
+                if ! command -v java >/dev/null 2>&1
+                then
+                    die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH."
+                fi
+            fi
+
+            # Add default JVM options here. You can also use JAVA_OPTS and SPECTRE_OPTS to pass JVM options to this script.
+            DEFAULT_JVM_OPTS=""
+
+            echo "JAVACMD=${'$'}JAVACMD"
+            """
+                .trimIndent() + "\n"
+    }
+}

--- a/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
+++ b/buildSrc/src/test/kotlin/dev/sebastiano/spectre/build/PatchStartScriptsTest.kt
@@ -134,6 +134,13 @@ class PatchStartScriptsTest {
             failure.message.orEmpty().contains("did not finish within 2 seconds"),
             "unexpected failure: ${failure.message}",
         )
+        // Killing only the launcher would leave the wedged `java` behind on every run, on dev
+        // machines and persistent CI workers alike. Raised by Codex review on PR #485.
+        val wedgedPid = Files.readString(jdk.resolve(HANG_PID_FILE)).trim().toLong()
+        assertFalse(
+            ProcessHandle.of(wedgedPid).map { it.isAlive }.orElse(false),
+            "the launcher's descendant ($wedgedPid) outlived the timeout",
+        )
     }
 
     @Test
@@ -208,7 +215,17 @@ class PatchStartScriptsTest {
 
         val process = processBuilder.start()
         val finished = process.waitFor(timeoutSeconds, TimeUnit.SECONDS)
-        if (!finished) process.destroyForcibly().waitFor()
+        if (!finished) {
+            // Snapshot the tree before killing the root: destroyForcibly only signals the direct
+            // child, and once it dies its children are reparented and no longer reachable from
+            // here. A wedged `java` would otherwise outlive every run of this suite.
+            val descendants = process.descendants().toList()
+            process.destroyForcibly().waitFor()
+            descendants.forEach { descendant ->
+                descendant.destroyForcibly()
+                runCatching { descendant.onExit().get(DESCENDANT_EXIT_SECONDS, TimeUnit.SECONDS) }
+            }
+        }
         val output = Files.readString(outputFile)
         check(finished) { "launcher did not finish within $timeoutSeconds seconds:\n$output" }
         return LauncherResult(process.exitValue(), output)
@@ -239,8 +256,15 @@ class PatchStartScriptsTest {
         Files.createDirectories(java.parent)
         val bannerLine =
             if (banner) "echo 'Picked up JAVA_TOOL_OPTIONS: $bannerOptions' >&2" else ":"
-        // A JVM that never returns wedges the launcher, which is what bounds the harness.
-        val hangLine = if (hangs) "sleep 600" else ":"
+        // A JVM that never returns wedges the launcher, which is what bounds the harness. It
+        // records the sleeper's pid so a test can assert the timeout reaped the whole tree, and
+        // the duration stays modest so a regression leaks for minutes rather than hours.
+        val hangLine =
+            if (hangs) {
+                "sleep 120 & echo ${'$'}! > \"${jdkHome.resolve(HANG_PID_FILE)}\"; wait"
+            } else {
+                ":"
+            }
         Files.writeString(
             java,
             """
@@ -277,6 +301,10 @@ class PatchStartScriptsTest {
         private const val COMMAND_TIMEOUT_SECONDS: Long = 30
 
         private const val DEFAULT_BANNER_OPTIONS = "-Dspectre.test=true"
+
+        private const val DESCENDANT_EXIT_SECONDS: Long = 5
+
+        private const val HANG_PID_FILE = "hang.pid"
 
         /**
          * Minimal stand-in for the Gradle-generated launcher: the two anchors [PatchStartScripts]


### PR DESCRIPTION
## Summary

The Java 21 preflight `PatchStartScripts` injects into the Unix `bin/spectre` launcher read the version with `sed -n '1s/.../p'`, so it only ever inspected line 1 of `java -version`. A JVM started with `JAVA_TOOL_OPTIONS` set prints `Picked up JAVA_TOOL_OPTIONS: ...` to stderr *ahead* of the version line, so the extracted version came back empty and the launcher died with `ERROR: Could not determine the Java version from ...` even though the bundled runtime was fine.

That variable is common on CI runners, behind corporate proxies and in container images — and Spectre's own tooling sets it. [`scripts/mcp-stdio-smoke.py`](https://github.com/rock3r/spectre/blob/main/scripts/mcp-stdio-smoke.py) `--daemon-user`, whose help calls it *"recommended with `--attach-pid`"*, puts the daemon isolation flags into `JAVA_TOOL_OPTIONS` on the env it hands the packaged launcher, and [the troubleshooting guide](https://github.com/rock3r/spectre/blob/main/docs/guide/troubleshooting.md) tells readers to pass properties the same way when they start a daemon themselves. So the release-smoke path and a documented workflow both walk into this.

Both Unix call sites — the preflight and the local JDK search — now read the version only from the JVM's own record:

```sh
"$JAVACMD" -version 2>&1 | grep -E '^(java|openjdk) version "' | sed -n '1s/.*version "\([^" ]*\)".*/\1/p'
```

The key point is that **everything `JAVA_TOOL_OPTIONS` causes to be printed lands on the same stream, ahead of the record**, so the match has to identify the record rather than merely skip a known preamble. Two rounds of Codex review found decoys that a looser match accepts:

- the banner echoes the variable's *contents*, so a payload like `-Dnote=version "17.0.2"` is itself version-shaped;
- a `-javaagent` premain can print its own banner, and a single-token one such as `Agent version "17.0.2"` has the exact shape of a record.

Only `java` and `openjdk` begin a real version record, and every mainstream JDK prints one of the two, so matching the record names is what makes the decoys inert. `grep -E` alternation is POSIX — BRE `\|` is a GNU extension and would not survive BSD sed on the macOS runner, which `macos-check.yml` exercises. `grep` is already a hard dependency of the launcher (the `jdk.attach` probe uses it).

The Windows branch is untouched and still uses `findstr`.

Behaviour verified case by case:

| `java -version` output | before | after |
|---|---|---|
| banner, then `version "21.0.10"` | *(empty → died)* | `21.0.10` |
| banner whose payload contains `version "17.0.2"` | *(empty → died)* | `21.0.10` |
| agent banner `Agent version "17.0.2"` first | *(empty → died)* | `21.0.2` |
| `NOTE: Picked up JDK_JAVA_OPTIONS: version "9"` first | *(empty → died)* | `21.0.1` |
| plain `openjdk version "21.0.10"` | `21.0.10` | `21.0.10` |
| Oracle-style `java version "21.0.2"` | `21.0.2` | `21.0.2` |
| JDK 8-style `version "1.8.0_392"` | `1.8.0_392` | `1.8.0_392` |
| no version record at all | *(empty)* | *(empty — existing `die` path)* |

## Test plan

Followed the red-green cycle in [docs/TESTING.md](https://github.com/rock3r/spectre/blob/main/docs/TESTING.md); every test below was confirmed red against the code it replaces.

- [x] New `PatchStartScriptsTest` (`:buildSrcUnitTests`) patches the launcher with the real `PatchStartScripts` logic and runs it under `/bin/sh` against a fake `java`, so the shipped parsing is exercised rather than re-implemented. Cases: Java 21 accepted behind a banner; Java 17 still rejected *with its parsed version* (proving the version is read, not merely skipped); a version-shaped banner payload ignored; a version-shaped agent banner ignored; no-banner output unchanged; the local JDK search picking a bannered sdkman candidate.
- [x] The original bug was red first: 3 of 4 cases failed with `Could not determine the Java version from .../jdk-banner/bin/java`.
- [x] Both Codex findings were reproduced before fixing — decoy payload: old → `17.0.2`, fixed → `21.0.10`; agent banner: old → `17.0.2`, fixed → `21.0.2`.
- [x] The test harness could not enforce its own timeout: draining the merged stream to EOF blocks forever on a launcher that never exits, so a regression would hang the CI job instead of failing. Demonstrated — the old ordering had to be killed at 90s; it now fails in ~2s. Covered by a test using a wedged fake JDK.
- [x] `:cli:verifyCliDistributionZip` with `JAVA_TOOL_OPTIONS` exported went from **red** (`ERROR: Could not determine the Java version from .../runtime/bin/java`, against the real jlink runtime) to **green**.
- [x] `./gradlew check` passes locally with `JAVA_TOOL_OPTIONS` exported.

`buildSrc` sits outside the ktfmt/detekt source sets, so `ktfmtFormat` does not cover these files; they follow the surrounding buildSrc style.

### Known gap, not addressed here

The Windows branch has the same weakness: `findstr /i /c:"version"` matches any line containing "version" and `tokens=3` takes the quoted field, so the decoy-payload and agent-banner cases misparse there too. That is pre-existing rather than introduced by this PR, and it can't be exercised from a Linux host, so it is left for a follow-up rather than folded in untested.

## Confirmations

- [ ] I read [CONTRIBUTING.md](https://github.com/rock3r/spectre/blob/main/CONTRIBUTING.md) and this PR is **not** LLM-generated. (See the "no clanker PRs or issues" rule.)
- [x] I'm licensing this contribution under [Apache-2.0](https://github.com/rock3r/spectre/blob/main/LICENSE).