### PR TITLE
fix(input): require a coordinator endpoint's directory to be the socket's parent

### DIFF
--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -11,9 +11,25 @@ import java.nio.file.attribute.PosixFilePermission
 import java.security.MessageDigest
 import java.util.HexFormat
 
-/** Canonical per-user directory and Unix-domain socket used by the local coordinator. */
+/**
+ * Canonical per-user directory and Unix-domain socket used by the local coordinator.
+ *
+ * [directory] must be the parent of [socketPath]. The socket's parent is the directory
+ * [OwnerOnlyEndpointProtection.prepareDirectory] guards and creates, while the election lock and
+ * the recovery ledger are placed in [directory]; if the two could diverge, those two files would
+ * land in a directory nothing ever checked.
+ */
 @ExperimentalSpectreInputCoordinationApi
-public data class CoordinatorEndpoint(public val directory: Path, public val socketPath: Path)
+public data class CoordinatorEndpoint(public val directory: Path, public val socketPath: Path) {
+    init {
+        // Lexical on purpose, so `..` is not folded away: the OS resolves it against whatever
+        // precedes it at the time, so a spelling that only normalises to the socket's parent can
+        // still name a different directory once a symbolic link sits in between.
+        require(socketPath.toAbsolutePath().parent == directory.toAbsolutePath()) {
+            "Coordinator directory $directory must be the parent of socket $socketPath"
+        }
+    }
+}
 
 /** Resolves a short endpoint that is independent of the launching process's environment. */
 @ExperimentalSpectreInputCoordinationApi

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -22,10 +22,13 @@ import java.util.HexFormat
 @ExperimentalSpectreInputCoordinationApi
 public data class CoordinatorEndpoint(public val directory: Path, public val socketPath: Path) {
     init {
-        // Lexical on purpose, so `..` is not folded away: the OS resolves it against whatever
-        // precedes it at the time, so a spelling that only normalises to the socket's parent can
-        // still name a different directory once a symbolic link sits in between.
-        require(socketPath.toAbsolutePath().parent == directory.toAbsolutePath()) {
+        // `..` is never folded away: the OS resolves it against whatever precedes it at the time,
+        // so a spelling that only normalises to the socket's parent can still name a different
+        // directory once a symbolic link sits in between. A `.` segment cannot do that -- it
+        // always names the directory it sits in -- and toAbsolutePath() preserves it, so folding
+        // only `.` accepts spellings that were already equivalent without weakening the check.
+        val socketParent = socketPath.toAbsolutePath().withoutDotSegments().parent
+        require(socketParent == directory.toAbsolutePath().withoutDotSegments()) {
             "Coordinator directory $directory must be the parent of socket $socketPath"
         }
     }
@@ -163,6 +166,21 @@ private fun rejectSubstitutedDirectory(directory: Path) {
         throw IOException("Coordinator directory $directory is not a directory")
     }
 }
+
+/**
+ * Drops `.` name elements, leaving every other segment -- `..` included -- exactly where it was.
+ *
+ * [Path.normalize] cannot be used here because it also collapses `..`, which the OS resolves
+ * against whatever precedes it rather than lexically.
+ */
+private fun Path.withoutDotSegments(): Path {
+    if (none { it.toString() == CURRENT_DIRECTORY_SEGMENT }) return this
+    return fold(root ?: Path.of("")) { path, segment ->
+        if (segment.toString() == CURRENT_DIRECTORY_SEGMENT) path else path.resolve(segment)
+    }
+}
+
+private const val CURRENT_DIRECTORY_SEGMENT: String = "."
 
 private fun rejectSymbolicParent(parent: Path?) {
     if (parent != null && Files.isSymbolicLink(parent)) {

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
@@ -77,6 +77,56 @@ class CoordinatorEndpointTest {
     }
 
     @Test
+    fun `a directory that is not the socket's parent is rejected`() {
+        // The socket's parent is what OwnerOnlyEndpointProtection guards and creates, while the
+        // election lock and recovery ledger are placed in `directory`. Letting the two diverge
+        // would leave the lock and ledger in a directory nothing ever checked.
+        val directory = temporaryDirectory.resolve("lock-and-ledger")
+        val socketPath = temporaryDirectory.resolve("socket").resolve("input.sock")
+
+        val failure =
+            assertFailsWith<IllegalArgumentException> {
+                CoordinatorEndpoint(directory = directory, socketPath = socketPath)
+            }
+
+        val message = failure.message.orEmpty()
+        assertTrue(message.contains("must be the parent of"), message)
+        assertTrue(message.contains(directory.toString()), message)
+        assertTrue(message.contains(socketPath.toString()), message)
+    }
+
+    @Test
+    fun `a directory that only matches the socket's parent after normalisation is rejected`() {
+        // `..` is resolved by the OS through whatever the preceding segment is at the time, so a
+        // spelling that normalises to the socket's parent can still name a different directory
+        // once a symlink sits in between. The comparison is lexical on purpose.
+        val directory =
+            temporaryDirectory.resolve("coordinator").resolve("..").resolve("coordinator")
+        val socketPath = temporaryDirectory.resolve("coordinator").resolve("input.sock")
+
+        assertFailsWith<IllegalArgumentException> {
+            CoordinatorEndpoint(directory = directory, socketPath = socketPath)
+        }
+    }
+
+    @Test
+    fun `a fallback socket candidate keeps the endpoint constructible`() {
+        // InputCoordinatorClient.connect rebuilds the endpoint as `copy(socketPath = located.path)`
+        // once a coordinator answers on a fallback path (#462), which re-runs the check above.
+        // Candidates are generation-suffixed siblings, so they keep the socket's parent; if that
+        // ever stops holding, connecting through a fallback would throw instead of working.
+        val endpoint =
+            CoordinatorEndpoint(
+                directory = temporaryDirectory,
+                socketPath = temporaryDirectory.resolve("input.sock"),
+            )
+
+        CoordinatorSocketCandidates.candidates(endpoint.socketPath).forEach { candidate ->
+            assertEquals(temporaryDirectory, endpoint.copy(socketPath = candidate).directory)
+        }
+    }
+
+    @Test
     fun `owner-only directory is created with private POSIX permissions`() {
         val endpoint =
             CoordinatorEndpoint(

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
@@ -110,6 +110,19 @@ class CoordinatorEndpointTest {
     }
 
     @Test
+    fun `a directory spelled with a dot segment is accepted`() {
+        // `.` always names the directory it sits in, whatever symbolic links are in the path, so
+        // folding it away can only accept spellings that were already equivalent -- unlike `..`,
+        // which the OS resolves against whatever precedes it. Raised by Codex review on PR #486.
+        val directory = temporaryDirectory.resolve(".")
+        val socketPath = temporaryDirectory.resolve("input.sock")
+
+        val endpoint = CoordinatorEndpoint(directory = directory, socketPath = socketPath)
+
+        assertEquals(directory, endpoint.directory, "the caller's spelling is kept as given")
+    }
+
+    @Test
     fun `a fallback socket candidate keeps the endpoint constructible`() {
         // InputCoordinatorClient.connect rebuilds the endpoint as `copy(socketPath = located.path)`
         // once a coordinator answers on a fallback path (#462), which re-runs the check above.


### PR DESCRIPTION
## Summary

`CoordinatorEndpoint` was a plain pair of paths that different code trusted differently:

- `OwnerOnlyEndpointProtection.prepareDirectory(socketPath)` guards and creates the **socket's parent** (symlink checks, POSIX 0700).
- `LocalCoordinatorServer` places the election lock (`coordinator.lock`) and the recovery ledger (`recovery.properties`) in **`endpoint.directory`**.

Nothing tied the two together, so `CoordinatorEndpoint(directory = A, socketPath = B/input.sock)` with `A != B` put the socket inside the protected directory `B` while the lock and ledger landed in `A`, which nothing ever checked. An `init` block now requires `socketPath.toAbsolutePath().parent == directory.toAbsolutePath()`.

Every in-tree constructor (`CoordinatorEndpointResolver.resolve`, `CoordinatorProcessMain`, and all tests) already keeps the two consistent, so this closes an embedder-facing edge of the experimental API rather than a live bug.

Two things worth a reviewer's eye:

- **The comparison is deliberately lexical, not normalised.** The OS resolves a `..` segment against whatever precedes it at the time, so a spelling that only *normalises* to the socket's parent can still name a different directory once a symbolic link sits in between. Same reasoning as the ancestor walk in #483.
- **The `#462` fallback path still works.** `InputCoordinatorClient.connect` rebuilds the endpoint as `copy(socketPath = located.path)` once a coordinator answers on a generation-suffixed candidate, and `copy` re-runs `init`. Those candidates come from `resolveSibling`, so they keep the socket's parent and the check passes — but that is exactly the kind of thing that would silently turn into a connect-time throw if candidate generation ever moved, so there is a test pinning it.

`init` adds no members, so the ABI dump is unchanged and `:input-coordinator:checkKotlinAbi` passes against the committed dump.

The alternative discussed for this hole — deriving the lock and ledger from `socketPath.parent` in `LocalCoordinatorServer` and leaving `directory` unvalidated — is still open if you would rather not throw from a data class constructor. This PR takes the validation route because `require` in a coordinator constructor already matches `CoordinatorEndpointResolver.resolve` and `CoordinatorSocketCandidates.candidates`.

Refs #465 (found while looking at that issue; it does not close it — #483 does).

## Test plan

Three new cases in `CoordinatorEndpointTest`, written red-first and confirmed failing with `AssertionFailedError` (no exception thrown) before the `init` block existed:

- a mismatched `directory` / `socketPath` pair is rejected, with both paths in the message
- a `..` spelling that only normalises to the socket's parent is rejected
- every `CoordinatorSocketCandidates` fallback keeps the endpoint constructible

- [x] `./gradlew check` passes locally
- [x] `./gradlew ktfmtFormat` produced no changes

Three failures unrelated to this diff had to be worked around in the sandbox I ran in; all three are environmental and should not affect CI, but flagging them in case they are useful:

1. `:recording:buildWaylandHelper` — `libdbus-1-dev` was not installed (CI installs it explicitly).
2. `:agent:test` → `UdsPathLimitsTest` — container locale was `POSIX`, so `sun.jnu.encoding=ANSI_X3.4-1968` and `Path.of("é")` threw `InvalidPathException`. Passes under `LANG=C.utf8`.
3. `:cli:verifyCliDistributionZip` — the sandbox's proxy sets `JAVA_TOOL_OPTIONS`, and the JVM's `Picked up JAVA_TOOL_OPTIONS:` banner takes line 1 of `java -version`, which the packaged launcher's `sed -n '1s/...'` preflight parses. Passes with the variable unset. Worth knowing that a user with `JAVA_TOOL_OPTIONS` set in their environment would hit this against the real launcher.

## Confirmations

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR is **not** LLM-generated. (See the "no clanker PRs or issues" rule.)
- [ ] I'm licensing this contribution under [Apache-2.0](../LICENSE).

---
_Generated by [Claude Code](https://claude.ai/code/session_016nvzBXQgPGU4BzJhEevwf7)_