### PR TITLE
fix(input): accept an endpoint directory spelled with a dot segment

### DIFF
--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -29,7 +29,15 @@ import java.util.HexFormat
 @ExperimentalSpectreInputCoordinationApi
 public data class CoordinatorEndpoint(public val directory: Path, public val socketPath: Path) {
     init {
-        require(socketPath.parent == directory) {
+        // Compared as absolute paths with `.` folded out. Absolute because prepareDirectory guards
+        // socketPath.toAbsolutePath().parent, so that is the directory this has to agree with; and
+        // `.` folded because it always names the directory it sits in, whatever symbolic links are
+        // in the path, so two spellings that differ only by one already name the same place. `..`
+        // is deliberately left where it is: the OS resolves it against whatever precedes it, so
+        // collapsing it lexically is what would let a substituted link through -- which is also
+        // why Path.normalize, which collapses both, cannot be used here.
+        val socketParent = socketPath.toAbsolutePath().withoutDotSegments().parent
+        require(socketParent == directory.toAbsolutePath().withoutDotSegments()) {
             "Coordinator endpoint directory $directory must be the socket's parent, " +
                 "was ${socketPath.parent}"
         }
@@ -221,9 +229,24 @@ private fun rejectSubstituted(path: Path, role: String) {
     }
 }
 
+/**
+ * Drops `.` name elements, leaving every other segment -- `..` included -- exactly where it was.
+ *
+ * [Path.normalize] is not usable here: it also collapses `..`, which the OS resolves against
+ * whatever precedes it rather than lexically.
+ */
+private fun Path.withoutDotSegments(): Path {
+    if (none { it.toString() == CURRENT_DIRECTORY_SEGMENT }) return this
+    return fold(root ?: Path.of("")) { path, segment ->
+        if (segment.toString() == CURRENT_DIRECTORY_SEGMENT) path else path.resolve(segment)
+    }
+}
+
 private fun isMacOs(): Boolean =
     System.getProperty("os.name").orEmpty().startsWith("Mac", ignoreCase = true)
 
 private val MACOS_ROOT_ALIASES: Set<String> = setOf("tmp", "var", "etc")
 
 private const val PRIVATE_ALIAS_DIRECTORY: String = "private"
+
+private const val CURRENT_DIRECTORY_SEGMENT: String = "."

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpointTest.kt
@@ -187,4 +187,35 @@ class CoordinatorEndpointTest {
 
         assertEquals(directory, endpoint.socketPath.parent)
     }
+
+    @Test
+    fun `a directory spelled with a dot segment names the socket's parent`() {
+        // Raised by Codex on #486. `.` always names the directory it sits in, whatever symbolic
+        // links are in the path, so these two spell one directory -- but `socketPath.parent` has
+        // no `.` element and `directory` keeps it, so the endpoint was refused.
+        val directory = temporaryDirectory.resolve(".")
+        val socketPath = temporaryDirectory.resolve("input.sock")
+
+        val endpoint = CoordinatorEndpoint(directory = directory, socketPath = socketPath)
+
+        assertEquals(directory, endpoint.directory, "the caller's spelling is kept as given")
+    }
+
+    @Test
+    fun `a fallback socket candidate keeps the endpoint constructible`() {
+        // InputCoordinatorClient.connect rebuilds the endpoint as `copy(socketPath = located.path)`
+        // once a coordinator answers on a fallback path (#462), and copy re-runs the check above.
+        // Candidates are generation-suffixed siblings, so they keep the socket's parent and this
+        // passes today; pinning it means a change to candidate generation fails here rather than
+        // silently turning every fallback connect into a throw.
+        val endpoint =
+            CoordinatorEndpoint(
+                directory = temporaryDirectory,
+                socketPath = temporaryDirectory.resolve("input.sock"),
+            )
+
+        CoordinatorSocketCandidates.candidates(endpoint.socketPath).forEach { candidate ->
+            assertEquals(temporaryDirectory, endpoint.copy(socketPath = candidate).directory)
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Follow-up to #483, from the Codex review on #486 (now closed as superseded). Two small things, both on top of the merged ancestor-validation work.

**1. A `.` segment in `directory` no longer rejects a valid endpoint.**

`CoordinatorEndpoint(base.resolve("."), base.resolve("input.sock"))` names one directory twice, but `socketPath.parent` carries no `.` element while `directory` keeps it, so `require(socketPath.parent == directory)` refused it. Reproduced before changing anything:

```
dir.toAbsolutePath()         = /tmp/base/.
sock.toAbsolutePath().parent = /tmp/base
equal? false
```

The comparison is now made on absolute paths with `.` folded out:

- **Absolute**, because `prepareDirectory` guards `socketPath.toAbsolutePath().parent` — that is the directory this invariant exists to agree with, so comparing the absolute forms matches what is actually protected rather than how the caller happened to spell it.
- **`.` folded**, because a `.` always names the directory it sits in whatever symbolic links are in the path, so two spellings differing only by one already name the same place.
- **`..` left exactly where it is.** The OS resolves it against whatever precedes it, so collapsing it lexically is precisely what would let a substituted link through. `Path.normalize` collapses both and so is unusable here; there is a small `withoutDotSegments()` helper instead, with that constraint recorded in its KDoc.

**2. A regression guard on the `#462` fallback path.**

`InputCoordinatorClient.connect` rebuilds the endpoint as `copy(socketPath = located.path)` once a coordinator answers on a generation-suffixed candidate, and `copy` re-runs `init`. It passes today because candidates are `resolveSibling` paths that keep the socket's parent — which is exactly why it is worth pinning: a change to candidate generation would otherwise turn every fallback connect into a constructor throw, far from where the change was made.

No ABI change; `:input-coordinator:checkKotlinAbi` passes against the committed dump.

Refs #465.

## Test plan

- `a directory spelled with a dot segment names the socket's parent` — **red** against the merged check (`AssertionFailedError`, the endpoint was rejected), green after the fold.
- `a fallback socket candidate keeps the endpoint constructible` — passes before and after; it is a guard, not a fix, and is labelled as such in the test comment.
- `an endpoint whose directory is not the socket's parent is rejected` (from #483) still passes, so the `..` spelling is still refused. That pair is the point: only `.` is folded.

- [x] `./gradlew check` passes locally
- [x] `./gradlew ktfmtFormat` produced no changes

## Confirmations

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR is **not** LLM-generated. (See the "no clanker PRs or issues" rule.)
- [ ] I'm licensing this contribution under [Apache-2.0](../LICENSE).

---
_Generated by [Claude Code](https://claude.ai/code/session_016nvzBXQgPGU4BzJhEevwf7)_