### PR TITLE
feat(core): add waitUntil, a predicate wait scoped to the semantics tree

### DIFF
--- a/.github/workflows/validation-linux.yml
+++ b/.github/workflows/validation-linux.yml
@@ -257,7 +257,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest WaitUntilGoneValidationTest NewInteractionsValidationTest SampleAppFixtureStartupDiagnosticsTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest WaitUntilGoneValidationTest WaitUntilValidationTest NewInteractionsValidationTest SampleAppFixtureStartupDiagnosticsTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/.github/workflows/validation-windows.yml
+++ b/.github/workflows/validation-windows.yml
@@ -164,7 +164,7 @@ jobs:
           shopt -s globstar nullglob
 
           declare -A required_classes_by_task=(
-            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest WaitUntilGoneValidationTest SampleAppFixtureStartupDiagnosticsTest"
+            ["validationTest"]="Issue7CompletionValidationTest Issue8CompletionValidationTest Issue8FidelityValidationTest Issue14PerfValidationTest MultiWindowAndPopupValidationTest PopupLayerVariantsValidationTest RecompositionMonitorValidationTest AtomicCaptureValidationTest FailureArtifactsValidationTest FailureVideoValidationTest RunSpectreTestValidationTest WaitForVisualIdleValidationTest WaitUntilGoneValidationTest WaitUntilValidationTest SampleAppFixtureStartupDiagnosticsTest"
             ["validationTestLayerComponent"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerSameCanvas"]="PopupLayerVariantsValidationTest"
             ["validationTestLayerWindow"]="PopupLayerVariantsValidationTest"

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -141,6 +141,8 @@ public final class dev/sebastiano/spectre/core/ComposeAutomator {
 	public static synthetic fun waitForNode-ck1zr5g$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun waitForVisualIdle-t_idYME (JIJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun waitForVisualIdle-t_idYME$default (Ldev/sebastiano/spectre/core/ComposeAutomator;JIJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public final fun waitUntil-jKevqZI (Ljava/lang/String;JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun waitUntil-jKevqZI$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;JJLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun waitUntilGone-ck1zr5g (Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun waitUntilGone-ck1zr5g$default (Ldev/sebastiano/spectre/core/ComposeAutomator;Ljava/lang/String;Ljava/lang/String;JJLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun windowIdentities ()Ljava/util/List;

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -889,6 +889,10 @@ private constructor(
      * decide, nothing more. That is the same discipline the [AutomatorTree]-only receiver is
      * pointing at, from the other direction (Codex on #489).
      *
+     * Unlike [waitForNode] and [waitUntilGone], this verb is in-process only: [condition] is a
+     * lambda, which does not cross a process boundary, so there is no CLI, MCP, or agent-attach
+     * equivalent. Remote callers phrase the barrier as a selector wait instead.
+     *
      * **Scope: Spectre-observable state only.** [condition] is a lambda on [AutomatorTree], and
      * that receiver is the whole point: what this verb waits on is the semantics tree. Kotlin
      * closures can of course capture whatever is in scope, so this is a boundary the API declines

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -883,6 +883,12 @@ private constructor(
      * [description] is all the failure can say about the condition, so phrase it as the state you
      * were waiting for ("the settings dialog is showing"), not as an action.
      *
+     * [timeout] bounds the polling loop, not a single poll: each poll runs to completion before the
+     * deadline is re-checked, so a [condition] that blocks overruns it (as a hung EDT would, for
+     * this wait and every other). Keep the condition cheap and side-effect free — read the tree and
+     * decide, nothing more. That is the same discipline the [AutomatorTree]-only receiver is
+     * pointing at, from the other direction (Codex on #489).
+     *
      * **Scope: Spectre-observable state only.** [condition] is a lambda on [AutomatorTree], and
      * that receiver is the whole point: what this verb waits on is the semantics tree. Kotlin
      * closures can of course capture whatever is in scope, so this is a boundary the API declines

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -675,48 +675,7 @@ private constructor(
 
     private fun computeUiFingerprintUnbounded(): String = readOnEdt {
         refreshWindows()
-        buildString {
-            for (window in windows) {
-                append(window.surfaceId)
-                append('|')
-                val nodes = semanticsReader.readAllNodes(listOf(window))
-                append(nodes.size)
-                append('|')
-                for (node in nodes) {
-                    append(node.key.toString())
-                    val bounds = node.boundsInWindow
-                    append('@')
-                    append(bounds.left.toBits())
-                    append(',')
-                    append(bounds.top.toBits())
-                    append(',')
-                    append(bounds.right.toBits())
-                    append(',')
-                    append(bounds.bottom.toBits())
-                    node.role?.let {
-                        append(':')
-                        append(it.toString())
-                    }
-                    if (node.isFocused) append(":F")
-                    if (node.isDisabled) append(":D")
-                    if (node.isSelected) append(":S")
-                    if (node.texts.isNotEmpty()) {
-                        append(":T")
-                        append(node.texts.joinToString(separator = "").hashCode())
-                    }
-                    if (node.contentDescriptions.isNotEmpty()) {
-                        append(":C")
-                        append(node.contentDescriptions.joinToString(separator = "").hashCode())
-                    }
-                    node.editableText?.let {
-                        append(":E")
-                        append(it.hashCode())
-                    }
-                    append(';')
-                }
-                append("||")
-            }
-        }
+        uiFingerprint(windows, semanticsReader)
     }
 
     private suspend fun sampleFrameHash(budgetMs: Long): Int? {
@@ -874,7 +833,7 @@ private constructor(
         // the more actionable signal in that case.
         require(tag != null || text != null) { "Either tag or text must be specified" }
         rejectEdtCaller("waitForNode")
-        return waitUntil(timeout = timeout, pollInterval = pollInterval) {
+        return pollUntilNotNull(timeout = timeout, pollInterval = pollInterval) {
             refreshedNodes().firstOrNull { it.matchesSelector(tag, text) }
         }
     }
@@ -908,6 +867,49 @@ private constructor(
             pollInterval = pollInterval,
             selector = describeNodeSelector(tag, text),
             countPresent = { refreshedNodes().count { it.matchesSelector(tag, text) } },
+        )
+    }
+
+    /**
+     * Waits until [condition] holds for the Spectre-visible semantics tree: the open-ended
+     * counterpart to [waitForNode] and [waitUntilGone], for barriers a tag/text selector cannot
+     * express — "three rows are showing", "the label no longer reads Loading…", "the dialog and the
+     * toast are both gone".
+     *
+     * Each poll calls [tree], so the condition always sees a freshly refreshed snapshot rather than
+     * a stale one; the tree is read on the EDT and [condition] then runs on the calling coroutine,
+     * so a slow predicate cannot stall the UI it is observing. Returns as soon as the condition
+     * holds. On timeout throws [IllegalStateException] naming [description] and the timeout —
+     * [description] is all the failure can say about the condition, so phrase it as the state you
+     * were waiting for ("the settings dialog is showing"), not as an action.
+     *
+     * **Scope: Spectre-observable state only.** [condition] is a lambda on [AutomatorTree], and
+     * that receiver is the whole point: what this verb waits on is the semantics tree. Kotlin
+     * closures can of course capture whatever is in scope, so this is a boundary the API declines
+     * to invite rather than one it can enforce — but waiting on state Spectre cannot see (a service
+     * flag, a file on disk, an HTTP response) is your own job, and doing it here buys you nothing
+     * but a misleading timeout message. Await that state with the tool that owns it — `withTimeout`
+     * around your own suspending call, an `awaitility`-style helper, a [registerIdlingResource]
+     * implementation if it should also gate [waitForIdle] — and use this verb for the UI barrier
+     * that follows.
+     *
+     * @throws IllegalArgumentException if [description] is blank.
+     */
+    public suspend fun waitUntil(
+        description: String,
+        timeout: Duration = 5.seconds,
+        pollInterval: Duration = 100.milliseconds,
+        condition: AutomatorTree.() -> Boolean,
+    ) {
+        // Same ordering as waitForNode / waitUntilGone: bad arguments are the more actionable
+        // error for an EDT caller doing two things wrong.
+        require(description.isNotBlank()) { "description must not be blank" }
+        rejectEdtCaller("waitUntil")
+        waitUntilInternal(
+            timeout = timeout,
+            pollInterval = pollInterval,
+            description = description,
+            condition = { readOnEdt { tree() }.condition() },
         )
     }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/UiFingerprint.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/UiFingerprint.kt
@@ -51,11 +51,11 @@ private fun StringBuilder.appendNodeFingerprint(node: AutomatorNode) {
     if (node.isSelected) append(":S")
     if (node.texts.isNotEmpty()) {
         append(":T")
-        append(node.texts.joinToString(separator = "").hashCode())
+        append(fingerprintHashOf(node.texts))
     }
     if (node.contentDescriptions.isNotEmpty()) {
         append(":C")
-        append(node.contentDescriptions.joinToString(separator = "").hashCode())
+        append(fingerprintHashOf(node.contentDescriptions))
     }
     node.editableText?.let {
         append(":E")
@@ -63,3 +63,16 @@ private fun StringBuilder.appendNodeFingerprint(node: AutomatorNode) {
     }
     append(';')
 }
+
+/**
+ * Collapses a node's text or content-description list into the hash [uiFingerprint] embeds.
+ *
+ * The separator is load-bearing. Joining with nothing makes `["ab", "c"]` and `["a", "bc"]` hash
+ * identically, so re-segmented text would read as an unchanged fingerprint and let
+ * [ComposeAutomator.waitForIdle] return on a UI that actually did change. U+0001 is a control
+ * character that cannot occur in rendered UI text, so it can never collide with content. It is
+ * written as an escape rather than a raw control byte so it stays visible to anyone reading,
+ * copying, or reviewing this line — as a raw byte it once went missing in a refactor unnoticed.
+ */
+internal fun fingerprintHashOf(values: List<String>): Int =
+    values.joinToString(separator = "\u0001").hashCode()

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/UiFingerprint.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/UiFingerprint.kt
@@ -1,0 +1,65 @@
+@file:OptIn(InternalSpectreApi::class)
+
+package dev.sebastiano.spectre.core
+
+/**
+ * Structural fingerprint of every tracked Compose surface: the value [ComposeAutomator.waitForIdle]
+ * samples and watches for stability over its quiet period.
+ *
+ * The fingerprint covers what a semantics-level idle barrier cares about — surface identity, node
+ * identity and count, layout bounds, role, focus/disabled/selected flags, and hashes of text,
+ * content descriptions, and editable text. Anything not in here is invisible to `waitForIdle`;
+ * pixels that change without changing semantics are [ComposeAutomator.waitForVisualIdle]'s job.
+ *
+ * The exact encoding is an implementation detail — only equality between two consecutive samples is
+ * meaningful, never the string itself. Callers must read on the EDT (semantics access requires it)
+ * and refresh the tracked-window set first, so a surface that appeared or vanished is part of the
+ * sample rather than answered from a stale snapshot.
+ */
+internal fun uiFingerprint(windows: List<TrackedWindow>, semanticsReader: SemanticsReader): String =
+    buildString {
+        for (window in windows) {
+            append(window.surfaceId)
+            append('|')
+            val nodes = semanticsReader.readAllNodes(listOf(window))
+            append(nodes.size)
+            append('|')
+            for (node in nodes) {
+                appendNodeFingerprint(node)
+            }
+            append("||")
+        }
+    }
+
+private fun StringBuilder.appendNodeFingerprint(node: AutomatorNode) {
+    append(node.key.toString())
+    val bounds = node.boundsInWindow
+    append('@')
+    append(bounds.left.toBits())
+    append(',')
+    append(bounds.top.toBits())
+    append(',')
+    append(bounds.right.toBits())
+    append(',')
+    append(bounds.bottom.toBits())
+    node.role?.let {
+        append(':')
+        append(it.toString())
+    }
+    if (node.isFocused) append(":F")
+    if (node.isDisabled) append(":D")
+    if (node.isSelected) append(":S")
+    if (node.texts.isNotEmpty()) {
+        append(":T")
+        append(node.texts.joinToString(separator = "").hashCode())
+    }
+    if (node.contentDescriptions.isNotEmpty()) {
+        append(":C")
+        append(node.contentDescriptions.joinToString(separator = "").hashCode())
+    }
+    node.editableText?.let {
+        append(":E")
+        append(it.hashCode())
+    }
+    append(';')
+}

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
@@ -6,7 +6,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 
-internal suspend fun <T : Any> waitUntil(
+internal suspend fun <T : Any> pollUntilNotNull(
     timeout: Duration = 5.seconds,
     pollInterval: Duration = 100.milliseconds,
     predicate: () -> T?,
@@ -23,22 +23,47 @@ internal suspend fun <T : Any> waitUntil(
     }
 
 /**
- * Absence-wait loop behind [ComposeAutomator.waitUntilGone]: samples [countPresent] until it
- * reports zero matching nodes, then returns.
+ * Deadline-based poll loop shared by [waitUntilGoneInternal] and [waitUntilInternal]: samples
+ * [satisfied] until it reports `true`, then returns; on running out of time raises a plain
+ * [IllegalStateException] carrying [timeoutMessage].
  *
- * Unlike [waitUntil], the timeout is a deadline the loop checks itself rather than a `withTimeout`
- * cancellation, so running out of time raises a plain [IllegalStateException] naming [selector],
- * the timeout, and how many nodes were still present at the last observation — the diagnostics an
- * absence wait exists to report. A bare `TimeoutCancellationException` says nothing about what
- * stayed on screen.
+ * Unlike [pollUntilNotNull], the timeout is a deadline the loop checks itself rather than a
+ * `withTimeout` cancellation, so the failure is an ordinary exception naming what was awaited
+ * rather than a bare `TimeoutCancellationException` that says nothing about it. [timeoutMessage] is
+ * evaluated only on timeout, so a caller can fold in whatever the last observation saw.
  *
  * The loop always samples at least once and takes one final sample at the deadline, so a zero
- * timeout still gets a real observation and the count in the error is the last thing seen. Each
- * sleep is clamped to the time left, so a [pollInterval] longer than the remaining timeout never
- * carries the wait a full interval past the deadline (Codex on #482).
+ * timeout still gets a real observation and the message describes the last thing seen. Each sleep
+ * is clamped to the time left, so a [pollInterval] longer than the remaining timeout never carries
+ * the wait a full interval past the deadline (Codex on #482).
  *
  * The injectable [clock]/[sleep] seam mirrors [waitForIdleInternal] so the loop can run on virtual
  * time in tests without a live Compose tree.
+ */
+private suspend fun pollUntilDeadline(
+    timeout: Duration,
+    pollInterval: Duration,
+    satisfied: () -> Boolean,
+    timeoutMessage: () -> String,
+    clock: MonotonicClock,
+    sleep: suspend (Duration) -> Unit,
+) {
+    val deadline = clock.now() + timeout.inWholeMilliseconds
+    while (true) {
+        if (satisfied()) return
+        val remainingMs = deadline - clock.now()
+        if (remainingMs <= 0) error(timeoutMessage())
+        sleep(minOf(pollInterval, remainingMs.milliseconds))
+    }
+}
+
+/**
+ * Absence-wait loop behind [ComposeAutomator.waitUntilGone]: samples [countPresent] until it
+ * reports zero matching nodes, then returns.
+ *
+ * Running out of time raises an [IllegalStateException] naming [selector], the timeout, and how
+ * many nodes were still present at the last observation — the diagnostics an absence wait exists to
+ * report. See [pollUntilDeadline] for the loop's timing contract.
  */
 internal suspend fun waitUntilGoneInternal(
     timeout: Duration,
@@ -48,19 +73,52 @@ internal suspend fun waitUntilGoneInternal(
     clock: MonotonicClock = SystemClock(),
     sleep: suspend (Duration) -> Unit = { delay(it) },
 ) {
-    val deadline = clock.now() + timeout.inWholeMilliseconds
-    while (true) {
-        val present = countPresent()
-        if (present == 0) return
-        val remainingMs = deadline - clock.now()
-        if (remainingMs <= 0) {
-            error(
-                "waitUntilGone timed out after ${timeout.inWholeMilliseconds}ms: " +
-                    "$present node(s) matching $selector still present in tracked windows"
-            )
-        }
-        sleep(minOf(pollInterval, remainingMs.milliseconds))
-    }
+    var lastPresent = 0
+    pollUntilDeadline(
+        timeout = timeout,
+        pollInterval = pollInterval,
+        satisfied = {
+            lastPresent = countPresent()
+            lastPresent == 0
+        },
+        timeoutMessage = {
+            "waitUntilGone timed out after ${timeout.inWholeMilliseconds}ms: " +
+                "$lastPresent node(s) matching $selector still present in tracked windows"
+        },
+        clock = clock,
+        sleep = sleep,
+    )
+}
+
+/**
+ * Predicate-wait loop behind [ComposeAutomator.waitUntil]: samples [condition] until it reports
+ * `true`, then returns.
+ *
+ * Running out of time raises an [IllegalStateException] naming the caller's own [description] and
+ * the timeout. The description is all the loop knows about the condition — a predicate, unlike a
+ * node selector, cannot be rendered back into a diagnostic — which is why
+ * [ComposeAutomator.waitUntil] requires a non-blank one. See [pollUntilDeadline] for the loop's
+ * timing contract.
+ */
+internal suspend fun waitUntilInternal(
+    timeout: Duration,
+    pollInterval: Duration,
+    description: String,
+    condition: () -> Boolean,
+    clock: MonotonicClock = SystemClock(),
+    sleep: suspend (Duration) -> Unit = { delay(it) },
+) {
+    pollUntilDeadline(
+        timeout = timeout,
+        pollInterval = pollInterval,
+        satisfied = condition,
+        timeoutMessage = {
+            "waitUntil timed out after ${timeout.inWholeMilliseconds}ms: " +
+                "condition \"$description\" never held in tracked windows"
+        },
+        clock = clock,
+        sleep = sleep,
+    )
 }
 
 /** Renders a tag/text node selector as `tag="…"`, `text="…"` for wait diagnostics. */

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/WaitUtilities.kt
@@ -37,6 +37,12 @@ internal suspend fun <T : Any> pollUntilNotNull(
  * is clamped to the time left, so a [pollInterval] longer than the remaining timeout never carries
  * the wait a full interval past the deadline (Codex on #482).
  *
+ * An observation is accepted whenever it finds [satisfied] true, including one that lands past the
+ * deadline because a real `delay` overshot it under load. The timeout is therefore not a hard bound
+ * on returning success. That is deliberate: throwing after observing the condition hold would emit
+ * a diagnostic that is simply false, and failing a wait whose condition did settle manufactures
+ * flakiness on loaded machines. `WaitUntilTest` pins it (Codex on #489).
+ *
  * The injectable [clock]/[sleep] seam mirrors [waitForIdleInternal] so the loop can run on virtual
  * time in tests without a live Compose tree.
  */

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/ComposeAutomatorPublicSurfaceTest.kt
@@ -387,6 +387,7 @@ class ComposeAutomatorPublicSurfaceTest {
                 "waitForIdle",
                 "waitForVisualIdle",
                 "waitForNode",
+                "waitUntil",
                 "waitUntilGone",
                 "printTree",
                 "monitorRecompositions",

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/UiFingerprintTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/UiFingerprintTest.kt
@@ -1,0 +1,45 @@
+package dev.sebastiano.spectre.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+
+/**
+ * Pins the one part of [uiFingerprint] that can be tested without a live Compose tree: how a node's
+ * text / content-description list collapses to a hash.
+ *
+ * `WaitForIdleTest` stubs the fingerprint function wholesale, so nothing there can see a change in
+ * how the fingerprint is *built*. That gap let a separator go missing during a refactor: without
+ * one, `["ab", "c"]` and `["a", "bc"]` hash the same, and `waitForIdle` reads a real semantics
+ * change as a stable UI and returns early. Caught by Codex review on #489.
+ */
+class UiFingerprintTest {
+
+    @Test
+    fun `lists with the same characters but different segmentation hash differently`() {
+        assertNotEquals(
+            fingerprintHashOf(listOf("ab", "c")),
+            fingerprintHashOf(listOf("a", "bc")),
+            "a separator-less join makes these collide, which hides a real semantics change",
+        )
+    }
+
+    @Test
+    fun `an element boundary is distinguishable from no boundary at all`() {
+        assertNotEquals(fingerprintHashOf(listOf("a", "b")), fingerprintHashOf(listOf("ab")))
+    }
+
+    @Test
+    fun `equal lists hash equally`() {
+        assertEquals(fingerprintHashOf(listOf("Loading…")), fingerprintHashOf(listOf("Loading…")))
+        assertEquals(fingerprintHashOf(emptyList()), fingerprintHashOf(emptyList()))
+    }
+
+    @Test
+    fun `a changed element changes the hash`() {
+        assertNotEquals(
+            fingerprintHashOf(listOf("Count: 1")),
+            fingerprintHashOf(listOf("Count: 2")),
+        )
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUntilTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUntilTest.kt
@@ -1,0 +1,288 @@
+package dev.sebastiano.spectre.core
+
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.SwingUtilities
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeSource
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+
+/**
+ * Unit-level tests for [ComposeAutomator.waitUntil], the predicate-shaped wait scoped to the
+ * Spectre-observable semantics tree.
+ *
+ * Mirrors `WaitUntilGoneTest`: the public-boundary contracts (argument validation, EDT rejection,
+ * the receiver the predicate is handed, immediate return) run against a headless automator, and the
+ * polling loop itself is exercised through [waitUntilInternal] on virtual time — the same seam
+ * `waitForIdleInternal` and `waitUntilGoneInternal` use — so the timeout diagnostics are pinned
+ * without a live Compose tree. The end-to-end paths that need real Compose live in the
+ * sample-desktop validation suite (`WaitUntilValidationTest`).
+ */
+class WaitUntilTest {
+
+    @Test
+    fun `waitUntil requires a non-blank description`() = runBlocking {
+        val automator = headlessAutomator()
+        val error =
+            assertFailsWith<IllegalArgumentException> {
+                automator.waitUntil(description = "   ") { true }
+            }
+        assertEquals("description must not be blank", error.message)
+    }
+
+    @Test
+    fun `waitUntil returns at once when the condition already holds`() = runBlocking {
+        // With window discovery off the tracked set is empty, so a condition phrased against it
+        // holds on the first poll: the wait must return instead of sitting out the timeout.
+        val automator =
+            ComposeAutomator.inProcess(
+                robotDriver = RobotDriver.headless(),
+                discoverWindows = false,
+            )
+        val started = TimeSource.Monotonic.markNow()
+        automator.waitUntil(description = "no window is tracked", timeout = 10.seconds) {
+            windows().isEmpty()
+        }
+        assertTrue(
+            started.elapsedNow() < 5.seconds,
+            "waitUntil should return as soon as the condition holds, took ${started.elapsedNow()}",
+        )
+    }
+
+    @Test
+    fun `waitUntil hands each poll a freshly read tree`() = runBlocking {
+        // The condition is scoped to the semantics tree, and the tree it sees must be current:
+        // every poll goes through tree(), which refreshes windows before reading nodes.
+        val automator =
+            ComposeAutomator.inProcess(
+                robotDriver = RobotDriver.headless(),
+                discoverWindows = false,
+            )
+        val seen = mutableListOf<AutomatorTree>()
+
+        automator.waitUntil(
+            description = "the third poll",
+            timeout = 10.seconds,
+            pollInterval = 1.milliseconds,
+        ) {
+            seen += this
+            seen.size == 3
+        }
+
+        assertEquals(3, seen.size)
+        assertTrue(
+            seen.distinct().size == 3,
+            "each poll must observe its own tree snapshot, got ${seen.size} polls over " +
+                "${seen.distinct().size} distinct trees",
+        )
+    }
+
+    @Test
+    fun `waitUntil names the description and the timeout when the condition never holds`() =
+        runBlocking {
+            val automator = headlessAutomator()
+            val error =
+                assertFailsWith<IllegalStateException> {
+                    automator.waitUntil(
+                        description = "the settings dialog is showing",
+                        timeout = 100.milliseconds,
+                        pollInterval = 10.milliseconds,
+                    ) {
+                        false
+                    }
+                }
+
+            val message = error.message.orEmpty()
+            assertTrue(
+                message.contains("waitUntil timed out after 100ms"),
+                "expected the timeout in the message, got: $message",
+            )
+            assertTrue(
+                message.contains("the settings dialog is showing"),
+                "expected the description in the message, got: $message",
+            )
+        }
+
+    @Test
+    fun `waitUntil reports the bad-argument error when called from the EDT with a blank description`() {
+        // Argument validation must run BEFORE the EDT check, mirroring waitForNode and
+        // waitUntilGone: the bad input is the more actionable diagnostic for a caller doing
+        // two things wrong.
+        assumeLiveAwtAvailable()
+        val automator = headlessAutomator()
+        val errorRef = AtomicReference<Throwable?>()
+        SwingUtilities.invokeAndWait {
+            runBlocking {
+                errorRef.set(
+                    runCatching { automator.waitUntil(description = "") { true } }.exceptionOrNull()
+                )
+            }
+        }
+        val error = errorRef.get()
+        assertTrue(
+            error is IllegalArgumentException,
+            "expected IllegalArgumentException, got $error",
+        )
+        assertEquals("description must not be blank", error.message)
+    }
+
+    @Test
+    fun `waitUntil rejects EDT callers with valid arguments`() {
+        assumeLiveAwtAvailable()
+        val automator = headlessAutomator()
+        val errorRef = AtomicReference<Throwable?>()
+        SwingUtilities.invokeAndWait {
+            runBlocking {
+                errorRef.set(
+                    runCatching { automator.waitUntil(description = "anything") { true } }
+                        .exceptionOrNull()
+                )
+            }
+        }
+        val error = errorRef.get()
+        assertTrue(error is IllegalStateException, "expected IllegalStateException, got $error")
+        assertTrue(
+            error.message?.contains(
+                "waitUntil must not be called from the AWT event dispatch thread"
+            ) == true,
+            "expected curated EDT message, got: ${error.message}",
+        )
+    }
+
+    @Test
+    fun `waitUntilInternal returns as soon as the condition holds`() = runTest {
+        val clock = FakeClock()
+        val holdsPerPoll = ArrayDeque(listOf(false, false, true))
+        var polls = 0
+
+        waitUntilInternal(
+            timeout = 1.seconds,
+            pollInterval = 100.milliseconds,
+            description = "the popup is showing",
+            condition = {
+                polls++
+                holdsPerPoll.removeFirst()
+            },
+            clock = clock,
+            sleep = clock::advance,
+        )
+
+        assertEquals(3, polls, "should stop polling on the first satisfied observation")
+    }
+
+    @Test
+    fun `waitUntilInternal fails naming the description and the timeout`() = runTest {
+        val clock = FakeClock()
+        var polls = 0
+
+        // A bare withTimeout cancellation would surface as TimeoutCancellationException (a
+        // CancellationException) and say nothing about what was awaited; the contract is a plain
+        // IllegalStateException carrying the caller's own description.
+        val error =
+            assertFailsWith<IllegalStateException> {
+                waitUntilInternal(
+                    timeout = 500.milliseconds,
+                    pollInterval = 100.milliseconds,
+                    description = "the popup is showing",
+                    condition = {
+                        polls++
+                        false
+                    },
+                    clock = clock,
+                    sleep = clock::advance,
+                )
+            }
+
+        val message = error.message.orEmpty()
+        assertTrue(
+            message.contains("waitUntil timed out after 500ms"),
+            "expected the timeout in the message, got: $message",
+        )
+        assertTrue(
+            message.contains("the popup is showing"),
+            "expected the description in the message, got: $message",
+        )
+        // Polls at t=0,100,...,500: the loop keeps observing until the deadline and takes one
+        // final observation at it, mirroring waitUntilGoneInternal.
+        assertEquals(6, polls)
+    }
+
+    @Test
+    fun `waitUntilInternal observes the condition once even with a zero timeout`() = runTest {
+        val clock = FakeClock()
+        var polls = 0
+
+        waitUntilInternal(
+            timeout = Duration.ZERO,
+            pollInterval = 100.milliseconds,
+            description = "the popup is showing",
+            condition = {
+                polls++
+                true
+            },
+            clock = clock,
+            sleep = clock::advance,
+        )
+
+        assertEquals(1, polls, "a zero timeout must still take one observation")
+    }
+
+    @Test
+    fun `waitUntilInternal clamps the poll sleep to the remaining timeout`() = runTest {
+        val clock = FakeClock()
+        val sleeps = mutableListOf<Duration>()
+        var polls = 0
+
+        assertFailsWith<IllegalStateException> {
+            waitUntilInternal(
+                timeout = 50.milliseconds,
+                pollInterval = 1.seconds,
+                description = "the popup is showing",
+                condition = {
+                    polls++
+                    false
+                },
+                clock = clock,
+                sleep = {
+                    sleeps += it
+                    clock.advance(it)
+                },
+            )
+        }
+
+        assertEquals(
+            listOf(50.milliseconds),
+            sleeps,
+            "the only sleep must be clamped to the deadline",
+        )
+        assertEquals(50L, clock.now(), "the wait must fail at the deadline, not an interval later")
+        assertEquals(2, polls)
+    }
+
+    @Test
+    fun `waitUntilInternal observes a late condition at the deadline, not an interval later`() =
+        runTest {
+            val clock = FakeClock()
+            val holdsPerPoll = ArrayDeque(listOf(false, true))
+
+            waitUntilInternal(
+                timeout = 50.milliseconds,
+                pollInterval = 1.seconds,
+                description = "the popup is showing",
+                condition = { holdsPerPoll.removeFirst() },
+                clock = clock,
+                sleep = clock::advance,
+            )
+
+            assertEquals(50L, clock.now(), "the second poll must land on the deadline")
+        }
+
+    private fun headlessAutomator(): ComposeAutomator =
+        ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUntilTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUntilTest.kt
@@ -283,6 +283,36 @@ class WaitUntilTest {
             assertEquals(50L, clock.now(), "the second poll must land on the deadline")
         }
 
+    @Test
+    fun `waitUntilInternal accepts a condition observed true after the sleep overshoots`() =
+        runTest {
+            // Characterisation test, not a new contract: this pins behaviour the shared loop has
+            // had since waitUntilGone shipped, so it stays a deliberate choice rather than an
+            // accident (Codex on #489). A real delay() can resume past the deadline under
+            // scheduler load. When the condition is true at that observation the wait returns
+            // instead of throwing, for two reasons: reporting "never held" about a condition just
+            // observed to hold would be a false diagnostic, and failing a wait whose condition did
+            // settle manufactures flakiness on loaded machines. The strict alternative — reject
+            // any observation past the deadline — is a semantics change to waitUntilGone as well,
+            // so it is not this PR's to make.
+            val clock = FakeClock()
+            val holdsPerPoll = ArrayDeque(listOf(false, true))
+
+            waitUntilInternal(
+                timeout = 50.milliseconds,
+                pollInterval = 1.seconds,
+                description = "the popup is showing",
+                condition = { holdsPerPoll.removeFirst() },
+                clock = clock,
+                sleep = { clock.advance(it + 20.milliseconds) },
+            )
+
+            assertTrue(
+                clock.now() > 50,
+                "the accepted observation must land past the deadline, got ${clock.now()}",
+            )
+        }
+
     private fun headlessAutomator(): ComposeAutomator =
         ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
 }

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUtilitiesTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/WaitUtilitiesTest.kt
@@ -12,7 +12,8 @@ class WaitUtilitiesTest {
 
     @Test
     fun `returns immediately when predicate succeeds on first call`() = runTest {
-        val result = waitUntil(timeout = 5.seconds, pollInterval = 100.milliseconds) { "found" }
+        val result =
+            pollUntilNotNull(timeout = 5.seconds, pollInterval = 100.milliseconds) { "found" }
         assertEquals("found", result)
     }
 
@@ -20,7 +21,7 @@ class WaitUtilitiesTest {
     fun `retries until predicate succeeds`() = runTest {
         var calls = 0
         val result =
-            waitUntil(timeout = 5.seconds, pollInterval = 10.milliseconds) {
+            pollUntilNotNull(timeout = 5.seconds, pollInterval = 10.milliseconds) {
                 calls++
                 if (calls >= 3) "found" else null
             }
@@ -31,7 +32,7 @@ class WaitUtilitiesTest {
     @Test
     fun `throws TimeoutCancellationException when timeout expires`() = runTest {
         assertFailsWith<TimeoutCancellationException> {
-            waitUntil(timeout = 100.milliseconds, pollInterval = 10.milliseconds) { null }
+            pollUntilNotNull(timeout = 100.milliseconds, pollInterval = 10.milliseconds) { null }
         }
     }
 
@@ -39,7 +40,7 @@ class WaitUtilitiesTest {
     fun `predicate is called multiple times before timeout`() = runTest {
         var calls = 0
         try {
-            waitUntil(timeout = 200.milliseconds, pollInterval = 10.milliseconds) {
+            pollUntilNotNull(timeout = 200.milliseconds, pollInterval = 10.milliseconds) {
                 calls++
                 null
             }

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -95,9 +95,9 @@ corresponding doc page is touched:
 
 - **No auto-wait.** Queries (`findByTestTag`, `findByText`, `hasTag`, `hasText`, etc.)
   do a single read. They never retry. Document them as such.
-- **EDT rule applies to all four waits.** `waitForNode`, `waitUntilGone`, `waitForIdle`,
-  and `waitForVisualIdle` all reject EDT callers via `rejectEdtCaller` (see
-  `WaitForNodeTest.waitForNode rejects EDT callers with valid arguments`). Earlier
+- **EDT rule applies to all five waits.** `waitForNode`, `waitUntilGone`, `waitUntil`,
+  `waitForIdle`, and `waitForVisualIdle` all reject EDT callers via `rejectEdtCaller`
+  (see `WaitForNodeTest.waitForNode rejects EDT callers with valid arguments`). Earlier
   drafts of the docs carved out `waitForNode` as exempt — that exemption is gone in
   current code. Do say "all wait helpers reject the EDT".
 - **`refreshWindows` is only auto-called by `tree()`.** `findBy*`, `hasTag`/`hasText`,
@@ -108,6 +108,12 @@ corresponding doc page is touched:
 - **`waitForNode(tag, text)` is AND, not OR.** Both criteria must match the same
   node. `waitUntilGone(tag, text)` mirrors it: it returns once no single node carries
   both, and it refreshes windows before every poll (unlike the finders).
+- **`waitUntil` takes a required non-blank `description` and an `AutomatorTree`
+  receiver.** The predicate is `AutomatorTree.() -> Boolean`, not `() -> Boolean`: the
+  tree snapshot is the only thing it is handed. Don't document it as a general-purpose
+  "wait for anything" helper — waiting on non-Spectre state is the user's own job. Do
+  say the receiver is a boundary the API declines to invite, not one it enforces
+  (closures can still capture).
 - **`AutomatorIdlingResource.isIdleNow` and `diagnosticMessage()`.** Not `isIdle()`,
   not `name`. Identity-based register/unregister.
 - **`AutoRecorder` has explicit capture modes.** `startWindow(...)` uses true

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -100,6 +100,9 @@ What this means in practice:
   `waitUntilGone(tag = "…")` before touching what was behind it. A popup that rendered in
   its own `Window` takes its whole semantics tree with it, so absence is the only thing
   left to observe.
+- When the barrier is about the shape of the UI rather than one node — a row count, a
+  combination of conditions, the tracked-window set — **`waitUntil(description) { … }`**
+  takes a predicate on the tree snapshot.
 - A failing assertion isn't necessarily a bug in your UI — it's often "the UI hadn't
   finished updating before I read it back".
 
@@ -107,8 +110,8 @@ See [Synchronization](synchronization.md) for the full toolkit.
 
 ## The EDT rule
 
-All four wait helpers — `waitForNode`, `waitUntilGone`, `waitForIdle`, and
-`waitForVisualIdle` — refuse to run on the AWT event dispatch thread (EDT):
+All five wait helpers — `waitForNode`, `waitUntilGone`, `waitUntil`, `waitForIdle`,
+and `waitForVisualIdle` — refuse to run on the AWT event dispatch thread (EDT):
 
 ```
 waitForNode must not be called from the AWT event dispatch thread;

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -133,7 +133,8 @@ description, or role — see [Finding nodes](selectors.md).
   when the call originates on the AWT event dispatch thread.
 
 All interaction methods (`click`, `doubleClick`, `swipe`, `typeText`, `pasteText`, …) and all wait
-helpers (`waitForNode`, `waitUntilGone`, `waitForIdle`, `waitForVisualIdle`) are `suspend`, so
+helpers (`waitForNode`, `waitUntilGone`, `waitUntil`, `waitForIdle`, `waitForVisualIdle`) are
+`suspend`, so
 the test body runs inside `runSpectreTest { … }` from the testing module. JUnit test methods don't
 run on the AWT event dispatch thread, so no extra `withContext` is needed here. If you
 ever call wait helpers from a coroutine on `Dispatchers.Main` (Swing EDT), wrap them in

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -135,6 +135,10 @@ condition holds.
 say about your condition, so phrase it as the state you were waiting for, not as an
 action.
 
+Keep the condition cheap and side-effect free — read the tree and decide, nothing more.
+`timeout` bounds the polling loop rather than a single poll: each poll runs to completion
+before the deadline is re-checked, so a condition that blocks will overrun it.
+
 ```
 waitUntil timed out after 5000ms: condition "the lazy list has realised at least five rows" never held in tracked windows
 ```

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -2,7 +2,7 @@
 
 Spectre deliberately doesn't wrap reads and actions in an implicit idle barrier. The
 flip side is that you have a small but explicit set of wait helpers, and you decide
-where to put them. This page covers all four.
+where to put them. This page covers all five.
 
 ## Interactive-only: Compose Hot Reload settle
 
@@ -14,8 +14,8 @@ documented under [Compose Hot Reload awareness](hot-reload.md). Prefer
 
 ## The EDT rule
 
-All four wait helpers — `waitForNode`, `waitUntilGone`, `waitForIdle`, and
-`waitForVisualIdle` — refuse to run on the AWT event dispatch thread:
+All five wait helpers — `waitForNode`, `waitUntilGone`, `waitUntil`, `waitForIdle`,
+and `waitForVisualIdle` — refuse to run on the AWT event dispatch thread:
 
 ```
 waitForNode must not be called from the AWT event dispatch thread;
@@ -24,7 +24,7 @@ wrap the call with withContext(Dispatchers.Default) or similar.
 
 This is enforced because their loops snapshot semantics via `invokeAndWait`/`readOnEdt`
 — running on the EDT would either deadlock or skip the bounded worker that enforces the
-timeout. None of the four are exempt.
+timeout. None of the five are exempt.
 
 The standard pattern in tests — JUnit runs tests off the EDT, so no `withContext` is
 needed:
@@ -107,6 +107,69 @@ waitUntilGone timed out after 5000ms: 1 node(s) matching tag="popup.body" still 
 Use it after dismissing a popup, menu, or dialog — before asserting on whatever the
 dismissal revealed, or before the next click that would otherwise land on the closing
 surface.
+
+## `waitUntil`
+
+The open-ended barrier, for conditions a tag/text selector cannot express — a node
+*count*, a *comparison*, a *combination*:
+
+```kotlin
+automator.waitUntil(
+    description = "the lazy list has realised at least five rows",
+    timeout = 5.seconds,
+    pollInterval = 100.milliseconds,
+) {
+    allNodes().count { it.testTag?.startsWith("row.") == true } >= 5
+}
+```
+
+The lambda is a predicate on
+[`AutomatorTree`](automator.md#surfaces-and-the-semantics-tree) — the same snapshot
+`tree()` returns, so `windows()`, `allNodes()`, and `roots()` are what you phrase the
+condition against. Every poll re-reads that tree (and refreshes windows
+first, exactly like `waitUntilGone`), so a window or popup that appeared between two
+polls is seen rather than answered from a stale snapshot. Returns as soon as the
+condition holds.
+
+`description` is required and must not be blank: it is the only thing the failure can
+say about your condition, so phrase it as the state you were waiting for, not as an
+action.
+
+```
+waitUntil timed out after 5000ms: condition "the lazy list has realised at least five rows" never held in tracked windows
+```
+
+Reach for it when the barrier is about the shape of the UI rather than one node:
+
+```kotlin
+// A combination — "the popup is gone AND its trigger is back" is one barrier, not two.
+automator.click(dismissButton)
+automator.waitUntil(description = "the popup is dismissed and its trigger is usable") {
+    val tags = allNodes().mapNotNull { it.testTag }.toSet()
+    "popup.body" !in tags && "popup.toggleButton" in tags
+}
+
+// The tracked-window set itself.
+automator.waitUntil(description = "the secondary window is being tracked") {
+    windows().size > 1
+}
+```
+
+For a single node appearing or disappearing, `waitForNode` and `waitUntilGone` say what
+you mean with less ceremony — use those.
+
+### It waits on the UI, not on your program
+
+`waitUntil` is scoped to what Spectre can see: the semantics tree it hands your
+predicate. Kotlin closures can capture anything in scope, so nothing stops you polling a
+service flag, a file, or an HTTP response from inside the lambda — but that is a
+boundary this helper declines to invite rather than one it can enforce, and crossing it
+buys you nothing except a timeout message that describes the wrong thing.
+
+Wait for non-UI state with the tool that owns it: `withTimeout` around your own
+suspending call, your test framework's polling helper, or an
+[`AutomatorIdlingResource`](#idling-resources) if that state should also gate
+`waitForIdle`. Then use `waitUntil` for the UI barrier that follows.
 
 ## `waitForIdle`
 
@@ -248,5 +311,7 @@ don't have to fall back to `Thread.sleep`.
 | `waitForNode.pollInterval`| 100 ms                |
 | `waitUntilGone.timeout`   | 5 s                   |
 | `waitUntilGone.pollInterval` | 100 ms             |
+| `waitUntil.timeout`       | 5 s                   |
+| `waitUntil.pollInterval`  | 100 ms                |
 
 These are tuned for desktop; bump them up freely if your scenarios are heavier.

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -170,6 +170,11 @@ automator.waitUntil(description = "the secondary window is being tracked") {
 For a single node appearing or disappearing, `waitForNode` and `waitUntilGone` say what
 you mean with less ceremony — use those.
 
+Unlike those two, `waitUntil` is **in-process only**. Its condition is a Kotlin lambda, and
+a lambda does not cross a process boundary, so there is no CLI, MCP, or agent-attach
+equivalent — see the [capability matrix](capability-matrix.md) for what each transport
+reaches. Over a transport, phrase the barrier as a selector wait instead.
+
 ### It waits on the UI, not on your program
 
 `waitUntil` is scoped to what Spectre can see: the semantics tree it hands your

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -73,7 +73,7 @@ java.lang.IllegalStateException: waitForIdle must not be called from the AWT eve
 dispatch thread; wrap the call with withContext(Dispatchers.Default) or similar.
 ```
 
-All four wait helpers — `waitForNode`, `waitUntilGone`, `waitForIdle`, and
+All five wait helpers — `waitForNode`, `waitUntilGone`, `waitUntil`, `waitForIdle`, and
 `waitForVisualIdle` — refuse to run on the AWT event dispatch thread. They snapshot semantics via
 `invokeAndWait`/`readOnEdt`. Running them on the EDT would either deadlock or skip the
 bounded worker that enforces the timeout, so the helpers raise

--- a/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitUntilValidationTest.kt
+++ b/sample-desktop/src/validation/kotlin/dev/sebastiano/spectre/sample/validation/WaitUntilValidationTest.kt
@@ -1,0 +1,128 @@
+package dev.sebastiano.spectre.sample.validation
+
+import java.awt.GraphicsEnvironment
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assumptions.assumeFalse
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.TestInstance
+
+/**
+ * Live-Compose coverage for
+ * [`ComposeAutomator.waitUntil`][dev.sebastiano.spectre.core.ComposeAutomator.waitUntil]: the
+ * predicate-shaped wait scoped to the Spectre-visible semantics tree.
+ *
+ * The argument-validation, EDT-rejection, and timeout-diagnostic contracts are exercised at the
+ * unit level in `WaitUntilTest`. What needs a real Compose surface is what the verb exists for:
+ * barriers a tag/text selector cannot express — a node *count*, a *combination* of conditions, the
+ * shape of the tracked-window set — evaluated against a tree that every poll re-reads, so a window
+ * or popup that appeared between two polls is seen rather than answered from a stale snapshot.
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class WaitUntilValidationTest {
+
+    private val fixture = SampleAppFixture(title = "Spectre waitUntil validation")
+
+    @BeforeAll
+    fun start() {
+        assumeFalse(GraphicsEnvironment.isHeadless(), "Needs a real AWT display")
+        fixture.start()
+    }
+
+    @AfterAll fun stop() = fixture.stop()
+
+    @Test
+    fun `waitUntil waits on a node count, which no tag or text selector can express`(): Unit =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.scroll")
+                waitForTestTag("scroll.list")
+
+                waitUntil(description = "the lazy list has realised at least five items") {
+                    allNodes().count { it.testTag?.startsWith("scroll.item.") == true } >= 5
+                }
+
+                assertTrue(
+                    tree().allNodes().count { it.testTag?.startsWith("scroll.item.") == true } >= 5,
+                    "waitUntil returned before the item count condition actually held",
+                )
+            }
+        }
+
+    @Test
+    fun `waitUntil observes a secondary window entering and leaving the tracked set`(): Unit =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.multiwindow")
+                val trackedBefore = tree().windows().size
+
+                // The new surface only becomes visible to the condition because every poll goes
+                // through tree(), which refreshes the tracked-window set first.
+                click(waitForTestTag("multiwindow.toggleButton"))
+                waitUntil(description = "the secondary window joins the tracked set") {
+                    windows().size > trackedBefore
+                }
+
+                val secondary = waitForTestTag("multiwindow.secondary.text")
+                val secondarySurfaceId = secondary.surfaceId
+
+                click(waitForTestTag("multiwindow.secondary.dismissButton"))
+                waitUntil(description = "the secondary window leaves the tracked set") {
+                    windows().none { window -> window.surfaceId == secondarySurfaceId }
+                }
+            }
+        }
+
+    @Test
+    fun `waitUntil waits on a combination of conditions`(): Unit = runBlocking {
+        with(fixture.automator) {
+            navigateToScenario("scenario.popup")
+            click(waitForTestTag("popup.toggleButton"))
+            waitForTestTag("popup.body")
+
+            // "Everything the popup contributed is gone AND the trigger is back" is one barrier,
+            // not two: waitUntilGone can only express half of it per call.
+            click(waitForTestTag("popup.dismissButton"))
+            waitUntil(
+                description = "the popup is dismissed and its trigger is interactable again"
+            ) {
+                val tags = allNodes().mapNotNull { it.testTag }.toSet()
+                "popup.body" !in tags && "popup.text" !in tags && "popup.toggleButton" in tags
+            }
+        }
+    }
+
+    @Test
+    fun `waitUntil names the description and the timeout when the condition never holds`(): Unit =
+        runBlocking {
+            with(fixture.automator) {
+                navigateToScenario("scenario.counter")
+                waitForTestTag("incrementButton")
+
+                val error =
+                    assertFailsWith<IllegalStateException> {
+                        waitUntil(
+                            description = "a second increment button appears",
+                            timeout = 250.milliseconds,
+                            pollInterval = 50.milliseconds,
+                        ) {
+                            allNodes().count { it.testTag == "incrementButton" } > 1
+                        }
+                    }
+
+                val message = error.message.orEmpty()
+                assertTrue(
+                    message.contains("waitUntil timed out after 250ms"),
+                    "expected the timeout in the message, got: $message",
+                )
+                assertTrue(
+                    message.contains("a second increment button appears"),
+                    "expected the description in the message, got: $message",
+                )
+            }
+        }
+}

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -28,8 +28,8 @@ If you're testing an individual composable in isolation → use `ComposeTestRule
 ## Gotchas
 
 - **Use `runSpectreTest`, not `runTest`.** `runTest` collapses `delay()` to zero, which silently breaks `longClick` hold durations, `swipe` step pacing, and clipboard-settle polling. Prefer `runSpectreTest` from the testing module (real wall time + leak detection); plain `runBlocking` is a fallback.
-- **Selectors are non-waiting.** Every `findBy...` / `findOneBy...` call reads the semantics tree once. Call `waitForNode` before querying any node that might not exist yet, and `waitUntilGone` after dismissing a popup, menu, or dialog before touching what was behind it.
-- **EDT rule.** All four wait helpers (`waitForNode`, `waitUntilGone`, `waitForIdle`, and `waitForVisualIdle`) throw `IllegalStateException` when called from the AWT event dispatch thread. Standard JUnit test methods run off the EDT so this isn't normally an issue; if you call them from the EDT, wrap with `withContext(Dispatchers.Default)`.
+- **Selectors are non-waiting.** Every `findBy...` / `findOneBy...` call reads the semantics tree once. Call `waitForNode` before querying any node that might not exist yet, and `waitUntilGone` after dismissing a popup, menu, or dialog before touching what was behind it. For barriers no selector expresses — a node count, a combination — use `waitUntil(description) { ... }`.
+- **EDT rule.** All five wait helpers (`waitForNode`, `waitUntilGone`, `waitUntil`, `waitForIdle`, and `waitForVisualIdle`) throw `IllegalStateException` when called from the AWT event dispatch thread. Standard JUnit test methods run off the EDT so this isn't normally an issue; if you call them from the EDT, wrap with `withContext(Dispatchers.Default)`.
 - **Expression-body tests.** Write `@Test fun mySpec(): Unit = runSpectreTest { ... }`. JUnit 5.14+ rejects non-void test methods, and Kotlin infers the return type from the last expression in the `runSpectreTest` body.
 
 ## Setup
@@ -152,6 +152,11 @@ automator.waitForNode(tag = "root-content")
 // After dismissing a popup / menu / dialog — poll until nothing matches in any tracked window
 automator.waitUntilGone(tag = "popup.body")
 
+// For a barrier no tag/text selector expresses — the predicate receives the AutomatorTree
+automator.waitUntil(description = "at least five rows are showing") {
+    allNodes().count { it.testTag?.startsWith("row.") == true } >= 5
+}
+
 // After an interaction — wait for semantics tree + idling resources to settle
 automator.waitForIdle()
 
@@ -168,7 +173,7 @@ automator.waitForVisualIdle()  // pixels settled
 val result = automator.findOneByTestTag("Result")
 ```
 
-All four wait helpers are `suspend` and **must not** be called from the AWT EDT. Default timeout is 5 s; all parameters are tunable.
+All five wait helpers are `suspend` and **must not** be called from the AWT EDT. Default timeout is 5 s; all parameters are tunable. `waitUntil` is scoped to the semantics tree it hands the predicate — wait for non-Spectre state (a service flag, a file, an HTTP response) with the tool that owns it, not inside the lambda.
 
 ## Input drivers
 

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -214,6 +214,14 @@ Always wait before querying state that depends on a prior action.
   before every poll, so a popup that closes its own `Window` counts as gone.
   Throws `IllegalStateException` naming the selector on timeout. Use this
   after dismissing a popup, menu, or dialog.
+- **`waitUntil(description = "...") { ... }`** — wait until a predicate on the
+  `AutomatorTree` snapshot holds. The lambda's receiver is the tree, so phrase
+  the condition with `windows()` / `allNodes()` / `roots()`; every poll re-reads
+  it (refreshing windows first). Throws `IllegalStateException` naming your
+  `description` on timeout, so write it as the state you were waiting for. Use
+  this for barriers no tag/text selector expresses — a node count, a comparison,
+  a combination. It is scoped to Spectre-observable state: wait for a service
+  flag, a file, or an HTTP response with the tool that owns it, not in here.
 - **`waitForIdle()`** — wait until the semantics fingerprint stabilizes and
   all registered `AutomatorIdlingResource`s are idle. Use this when you've
   triggered work that updates semantics but no specific node appears.
@@ -230,10 +238,10 @@ is more precise.
 
 ### Rule 3: never call any wait on the EDT
 
-All four of `waitForNode`, `waitUntilGone`, `waitForIdle`, and `waitForVisualIdle`
-actively reject being called from the AWT event dispatch thread — they need to
-`invokeAndWait` onto the EDT to read state, so running them *on* the EDT would
-deadlock. If your dispatcher is Swing-backed (the IntelliJ EDT dispatcher, a
+All five of `waitForNode`, `waitUntilGone`, `waitUntil`, `waitForIdle`, and
+`waitForVisualIdle` actively reject being called from the AWT event dispatch
+thread — they need to `invokeAndWait` onto the EDT to read state, so running
+them *on* the EDT would deadlock. If your dispatcher is Swing-backed (the IntelliJ EDT dispatcher, a
 custom `Swing` dispatcher, etc.), wrap the wait in
 `withContext(Dispatchers.Default) { … }` (or any non-EDT dispatcher) so the
 wait suspends off-thread. The user docs you may have read elsewhere have an
@@ -334,7 +342,7 @@ touches that area*; they are not needed for the common case.
 | Symptom | Cause | Fix |
 |---|---|---|
 | `findOneBy…` returns `null` right after an interaction | Selectors don't wait | Add `waitForNode(...)` or `waitForVisualIdle()` first |
-| Test deadlocks or throws inside any `waitFor…` / `waitUntilGone` | Called from the AWT EDT | Wrap in `withContext(Dispatchers.Default) { … }` — applies to all four waits, including `waitForNode` and `waitUntilGone` |
+| Test deadlocks or throws inside any `waitFor…` / `waitUntil…` | Called from the AWT EDT | Wrap in `withContext(Dispatchers.Default) { … }` — applies to all five waits, including `waitForNode`, `waitUntilGone`, and `waitUntil` |
 | `longClick`/`swipe`/`typeText` complete instantly and miss | Test body uses `runTest` | Switch to `runSpectreTest` |
 | Two parallel test JVMs steal focus from each other | Both use real `RobotDriver()` | Use `RobotDriver.synthetic(rootWindow)` |
 | Parallel JVMs must preserve real OS input behavior | Real focus/pointer/clipboard state is shared across processes | Opt in to experimental coordination, add `spectre-input-coordinator-server` at runtime, use `Required` and JUnit `InputIsolationConfig.perTest()` |

--- a/skills/spectre/references/intellij.md
+++ b/skills/spectre/references/intellij.md
@@ -41,8 +41,9 @@ class RunSpectreAction : AnAction() {
 
 `executeOnPooledThread` (or any non-EDT dispatcher) is required. The
 automator's outer loop — polling, retries, waits — runs on the calling
-thread. All four wait helpers (`waitForNode`, `waitUntilGone`, `waitForIdle`,
-`waitForVisualIdle`) reject EDT callers with `IllegalStateException`, so
+thread. All five wait helpers (`waitForNode`, `waitUntilGone`, `waitUntil`,
+`waitForIdle`, `waitForVisualIdle`) reject EDT callers with
+`IllegalStateException`, so
 calling them from the EDT fails fast rather than silently deadlocking on
 the `invokeAndWait` round-trip. Per-tick semantics reads internally marshal
 back to the EDT.


### PR DESCRIPTION
## Summary

Adds `ComposeAutomator.waitUntil(description, timeout, pollInterval) { … }`, the open-ended
counterpart to `waitForNode` / `waitUntilGone`, for barriers a tag/text selector cannot express: a
node count, a comparison, a combination of conditions, the shape of the tracked-window set. Refs #438.

```kotlin
automator.waitUntil(description = "the lazy list has realised at least five rows") {
    allNodes().count { it.testTag?.startsWith("row.") == true } >= 5
}
```

The predicate is an `AutomatorTree.() -> Boolean`, and that receiver **is** the scoping mechanism:
the semantics tree is the only thing handed to the condition, so the verb doesn't read as a
general-purpose "wait for anything" utility. Kotlin closures can still capture outside state, so
this is a boundary the API declines to invite rather than one it can enforce — the KDoc and the user
guide say exactly that, and say what to reach for instead (`withTimeout` around your own suspending
call, or an `AutomatorIdlingResource` if the state should also gate `waitForIdle`).

Each poll reads the tree on the EDT (`tree()` refreshes windows first, so a surface that appeared or
vanished between polls is observed rather than answered from a stale snapshot) and evaluates the
predicate on the calling coroutine, so a slow condition can't stall the UI it's watching. On timeout
it throws `IllegalStateException` naming the caller's `description` and the timeout, matching
`waitUntilGone`'s diagnostics style. `description` must be non-blank — it's the only thing the
failure can say about the condition — and that validation runs ahead of the EDT check, as in
`waitForNode` / `waitUntilGone`.

`AutomatorTree` deliberately gains **no** new members: `windows()`, `allNodes()`, and `roots()`
already express the conditions readably, so there was nothing to widen.

Three implementation notes worth a reviewer's attention:

- The deadline loop behind `waitUntilGoneInternal` is now a shared `pollUntilDeadline` with a
  caller-supplied timeout message — same timing contract (one observation minimum, one final
  observation at the deadline, sleeps clamped to the time left, injectable `clock`/`sleep` seam).
  `waitUntilGone`'s behaviour is unchanged and its existing tests still pin it, unmodified.
- The pre-existing internal top-level `waitUntil` (the `() -> T?` poller) is renamed
  `pollUntilNotNull` so one name in this package doesn't mean two different things. Resolution would
  have worked either way; the rename removes the trap.
- Adding a public verb pushed `ComposeAutomator` past detekt's `LargeClass` budget. Rather than
  suppress it, the UI-fingerprint formatting moved to a file-scope collaborator
  (`core/.../UiFingerprint.kt`) — a cohesive concern needing nothing from the automator but the
  tracked windows and the semantics reader. No `@Suppress`, no config change.

  ⚠️ **This was originally described as a pure move with no behaviour change, and that was wrong.**
  Both list hashes joined on a literal U+0001 separator; retyping the block dropped it, because a
  raw control byte renders as nothing in a terminal read *and* in the diff. Without it
  `["ab", "c"]` and `["a", "bc"]` hash identically, so re-segmented text would read as an unchanged
  fingerprint and let `waitForIdle` return on a UI that did change. Caught by Codex review, fixed in
  92bc3e4, and the separator is now a Kotlin escape rather than a raw byte so it can't go invisible
  again. The rest of the block was byte-compared against the original; those two separators were the
  only losses.

`core/api/core.api` is regenerated; the diff is two added lines and nothing removed.

Docs: new `waitUntil` section in `docs/guide/synchronization.md` (with a subsection on why it doesn't
wait on your program), its defaults in the table, and the "four wait helpers" phrasing updated to
five across the guide, `DOCS-STYLE.md`, and the skill files.

### Known limitation, deliberately not fixed here

`timeout` bounds the polling loop, not a single poll: each poll runs to completion before the
deadline is re-checked, so a blocking condition overruns it. This is family-wide rather than new —
`readOnEdt { tree() }` is an unbounded `invokeAndWait`, so a hung EDT overruns `waitUntilGone` and
`waitForNode` the same way. Making the timeout a true bound means running each poll on a worker with
the remaining budget and doing it across all the waits for consistency; that's a threading-contract
change for @rock3r to make deliberately, not something to slip into this PR. The KDoc and guide now
state the real contract instead of implying a stronger one.
[Discussion](https://github.com/rock3r/spectre/pull/489#discussion_r3916892930).

## Test plan

TDD per `docs/TESTING.md`: the tests went in first and were proven red (unresolved references) before
any production change, and the public-surface allowlist test failed exactly as expected before it was
updated in this same commit.

- [x] `./gradlew check` passes locally
- [x] `./gradlew ktfmtFormat` produced no changes

New coverage:

- `core/…/WaitUntilTest.kt` (11 tests) — public-boundary contracts against a headless automator
  (blank-description validation ahead of the EDT check, EDT rejection, a freshly-read tree per poll,
  the timeout message) plus the loop on virtual time through the internal seam, mirroring
  `WaitUntilGoneTest`.
- `core/…/UiFingerprintTest.kt` (4 tests) — pins the fingerprint's list-hash separator. This gap is
  why the regression above reached green CI: `WaitForIdleTest` stubs the fingerprint function
  wholesale, so nothing in the suite could observe how the fingerprint is *built*. Both failing
  cases were confirmed red against the separator-less version before the fix landed.
- `sample-desktop/…/WaitUntilValidationTest.kt` (4 tests) — live Compose: a node count, a secondary
  window entering and leaving the tracked set, a combined condition, and the timeout diagnostics.
  Registered in the required-class lists in both `validation-linux.yml` and `validation-windows.yml`.

Both suites were also run under `xvfb-run` locally, so the EDT-rejection tests actually executed
rather than being skipped as they are in a headless JVM, and all four live-Compose validation tests
passed against a real Compose surface. `mkdocs build --strict` is clean.

Two local failures were environmental and confirmed as such rather than assumed: `UdsPathLimitsTest`
fails identically on an unmodified `main` (this container's POSIX locale can't encode `é` in a path),
and `:cli:verifyCliDistributionZip` breaks because `JAVA_TOOL_OPTIONS` prints a banner as the first
line of `java -version`, which the launcher's `sed -n '1s/…/'` then parses. Both pass with
`LANG=C.UTF-8` and `JAVA_TOOL_OPTIONS` unset; neither is related to this change.

## Confirmations

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR is **not** LLM-generated. (See the "no clanker PRs or issues" rule.)

  **Left unchecked deliberately — this PR is Claude-authored, at @rock3r's request in a Claude Code
  session.** Ticking it would be false. Flagging it here so the "no clanker PRs" rule is applied by
  you rather than bypassed by me.

- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nhbq5cfftvk3ZjDv9GVWqz