### PR TITLE
Close the transport parity gap for waitUntilGone (#438)

### DIFF
--- a/agent/api/agent.api
+++ b/agent/api/agent.api
@@ -148,6 +148,8 @@ public final class dev/sebastiano/spectre/agent/AttachedAutomator : java/lang/Au
 	public static synthetic fun waitForNode$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/String;Ljava/lang/String;JJILjava/lang/Object;)Ldev/sebastiano/spectre/agent/transport/NodeSnapshotDto;
 	public final fun waitForVisualIdle (JIJ)V
 	public static synthetic fun waitForVisualIdle$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;JIJILjava/lang/Object;)V
+	public final fun waitUntilGone (Ljava/lang/String;Ljava/lang/String;JJ)V
+	public static synthetic fun waitUntilGone$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/String;Ljava/lang/String;JJILjava/lang/Object;)V
 	public final fun windowIdentities (Ljava/lang/Integer;)Ljava/util/List;
 	public static synthetic fun windowIdentities$default (Ldev/sebastiano/spectre/agent/AttachedAutomator;Ljava/lang/Integer;ILjava/lang/Object;)Ljava/util/List;
 	public final fun windows ()Ljava/util/List;

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -344,6 +344,45 @@ internal constructor(
     }
 
     /**
+     * Wait until **no** semantics node matches [tag] and/or [text] (AND when both are set), same as
+     * in-process `ComposeAutomator.waitUntilGone` (#438) — the absence counterpart to
+     * [waitForNode], for dismissed popups, menus, and dialogs.
+     *
+     * On timeout throws [SpectreAgentException] with category `timeout`, whose message keeps the
+     * automator's own diagnostics — the selector, the timeout, and how many matching nodes were
+     * still present in tracked windows.
+     *
+     * The wire deadline is [timeoutMs] **plus** [DIAGNOSTIC_DEADLINE_SLACK_MS], unlike
+     * [waitForNode]'s exact-[timeoutMs] deadline, and the slack is what makes those diagnostics
+     * reachable. The agent claims an op whose deadline has passed by the time the handler returns
+     * and answers "Deadline elapsed during op" instead — which, on an exact deadline, is a race the
+     * automator's own timeout always loses, since it fires at the same instant. Trailing the
+     * automator's budget lets the real message come back and still leaves the wire deadline ahead
+     * of the agent's suspend-bridge backstop (`timeoutMs + 2s`), so a wedged automator fails closed
+     * on the wire exactly as before.
+     */
+    @Throws(IOException::class)
+    public fun waitUntilGone(
+        tag: String? = null,
+        text: String? = null,
+        timeoutMs: Long = 5_000,
+        pollIntervalMs: Long = 100,
+    ) {
+        val deadline = System.currentTimeMillis() + timeoutMs + DIAGNOSTIC_DEADLINE_SLACK_MS
+        val resp =
+            exchange(
+                AgentRequest.WaitUntilGone(
+                    tag = tag,
+                    text = text,
+                    timeoutMs = timeoutMs,
+                    pollIntervalMs = pollIntervalMs,
+                ),
+                deadlineEpochMs = deadline,
+            )
+        if (resp !is AgentResponse.Ok) throw wireMismatch("Ok", resp)
+    }
+
+    /**
      * Wait until consecutive visual frames are stable (#201). Same semantics as in-process
      * `ComposeAutomator.waitForVisualIdle`.
      */
@@ -438,3 +477,14 @@ internal constructor(
     private fun wireMismatch(expected: String, actual: AgentResponse): IOException =
         IOException("Wire protocol mismatch: expected $expected, got ${actual::class.simpleName}")
 }
+
+/**
+ * How far [AttachedAutomator.waitUntilGone]'s wire deadline trails its wait budget so the
+ * automator's own timeout — the one carrying the absence diagnostics — wins the race against the
+ * agent's deadline claim. Well under the agent's `timeoutMs + 2s` suspend-bridge backstop, so the
+ * wire deadline is still the earlier of the two safety nets.
+ *
+ * Top-level rather than a companion constant: a `const val` in a companion of a public class is a
+ * public static field on the JVM, and this is an implementation detail, not published API.
+ */
+private const val DIAGNOSTIC_DEADLINE_SLACK_MS: Long = 1_000

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/AttachedAutomator.kt
@@ -327,7 +327,7 @@ internal constructor(
         timeoutMs: Long = 5_000,
         pollIntervalMs: Long = 100,
     ): NodeSnapshotDto {
-        val deadline = System.currentTimeMillis() + timeoutMs
+        val deadline = waitDeadlineFor(timeoutMs)
         val resp =
             exchange(
                 AgentRequest.WaitForNode(
@@ -352,14 +352,7 @@ internal constructor(
      * automator's own diagnostics — the selector, the timeout, and how many matching nodes were
      * still present in tracked windows.
      *
-     * The wire deadline is [timeoutMs] **plus** [DIAGNOSTIC_DEADLINE_SLACK_MS], unlike
-     * [waitForNode]'s exact-[timeoutMs] deadline, and the slack is what makes those diagnostics
-     * reachable. The agent claims an op whose deadline has passed by the time the handler returns
-     * and answers "Deadline elapsed during op" instead — which, on an exact deadline, is a race the
-     * automator's own timeout always loses, since it fires at the same instant. Trailing the
-     * automator's budget lets the real message come back and still leaves the wire deadline ahead
-     * of the agent's suspend-bridge backstop (`timeoutMs + 2s`), so a wedged automator fails closed
-     * on the wire exactly as before.
+     * Wire deadline comes from [waitDeadlineFor], like every other wait.
      */
     @Throws(IOException::class)
     public fun waitUntilGone(
@@ -368,7 +361,7 @@ internal constructor(
         timeoutMs: Long = 5_000,
         pollIntervalMs: Long = 100,
     ) {
-        val deadline = System.currentTimeMillis() + timeoutMs + DIAGNOSTIC_DEADLINE_SLACK_MS
+        val deadline = waitDeadlineFor(timeoutMs)
         val resp =
             exchange(
                 AgentRequest.WaitUntilGone(
@@ -392,7 +385,7 @@ internal constructor(
         stableFrames: Int = 3,
         pollIntervalMs: Long = 16,
     ) {
-        val deadline = System.currentTimeMillis() + timeoutMs
+        val deadline = waitDeadlineFor(timeoutMs)
         val resp =
             exchange(
                 AgentRequest.WaitForVisualIdle(
@@ -422,7 +415,7 @@ internal constructor(
         quietPeriodMs: Long = 64,
         pollIntervalMs: Long = 16,
     ) {
-        val deadline = System.currentTimeMillis() + timeoutMs
+        val deadline = waitDeadlineFor(timeoutMs)
         val resp =
             exchange(
                 AgentRequest.WaitForIdle(
@@ -474,17 +467,35 @@ internal constructor(
         return resp
     }
 
+    /**
+     * Absolute wire deadline for a wait whose own budget is [timeoutMs].
+     *
+     * Deliberately **not** `now + timeoutMs`. The agent enforces this deadline twice — a scheduler
+     * claims the op when it passes, and `executeOp` discards the handler's answer for "Deadline
+     * elapsed during op" if it passed while the handler ran — and on an exact deadline both fire at
+     * the same instant the automator's own timeout does. The automator always loses that race, so
+     * callers got the transport's phrase instead of the message the wait exists to produce:
+     * `waitForIdle` names the busy idling resources, `waitForVisualIdle` the frame samples,
+     * `waitUntilGone` the selector and how many nodes are still present.
+     *
+     * [WAIT_DEADLINE_SLACK_MS] of trailing room lets the real message come back while keeping the
+     * wire deadline ahead of the agent's own suspend-bridge backstop (`timeoutMs + 2s`), so a
+     * wedged automator is still claimed on the wire rather than waiting unbounded.
+     */
+    private fun waitDeadlineFor(timeoutMs: Long): Long =
+        System.currentTimeMillis() + timeoutMs + WAIT_DEADLINE_SLACK_MS
+
     private fun wireMismatch(expected: String, actual: AgentResponse): IOException =
         IOException("Wire protocol mismatch: expected $expected, got ${actual::class.simpleName}")
 }
 
 /**
- * How far [AttachedAutomator.waitUntilGone]'s wire deadline trails its wait budget so the
- * automator's own timeout — the one carrying the absence diagnostics — wins the race against the
- * agent's deadline claim. Well under the agent's `timeoutMs + 2s` suspend-bridge backstop, so the
- * wire deadline is still the earlier of the two safety nets.
+ * How far every wait's wire deadline trails its wait budget, so the automator's own timeout — the
+ * one carrying the diagnostics — wins the race against the agent's deadline claim. Well under the
+ * agent's `timeoutMs + 2s` suspend-bridge backstop, so the wire deadline is still the earlier of
+ * the two safety nets.
  *
  * Top-level rather than a companion constant: a `const val` in a companion of a public class is a
  * public static field on the JVM, and this is an implementation detail, not published API.
  */
-private const val DIAGNOSTIC_DEADLINE_SLACK_MS: Long = 1_000
+private const val WAIT_DEADLINE_SLACK_MS: Long = 1_000

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/ReflectiveAutomatorHandler.kt
@@ -191,6 +191,7 @@ internal class ReflectiveAutomatorHandler(
                 )
             is AgentRequest.Cancel -> AgentResponse.Ok
             is AgentRequest.WaitForNode -> waitOps.handleWaitForNode(request)
+            is AgentRequest.WaitUntilGone -> waitOps.handleWaitUntilGone(request)
             is AgentRequest.WaitForVisualIdle -> waitOps.handleWaitForVisualIdle(request)
             is AgentRequest.WaitForIdle -> waitOps.handleWaitForIdle(request)
             AgentRequest.PrintTree -> handlePrintTree()

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveMapper.kt
@@ -9,8 +9,9 @@ import dev.sebastiano.spectre.agent.transport.NodeSnapshotDto
 import java.lang.reflect.Method
 
 /**
- * Reflective bridge for wait ops (#201 waitForNode/waitForVisualIdle, #362 waitForIdle). Lives
- * outside [ReflectiveAutomatorHandler] to keep that class under detekt complexity limits.
+ * Reflective bridge for wait ops (#201 waitForNode/waitForVisualIdle, #362 waitForIdle, #438
+ * waitUntilGone). Lives outside [ReflectiveAutomatorHandler] to keep that class under detekt
+ * complexity limits.
  *
  * Kotlin mangles `Duration` parameters into primitive `long` carrying [kotlin.time.Duration]'s
  * packed `rawValue` (not plain nanoseconds) and renames methods (e.g. `waitForNode-ck1zr5g`).
@@ -35,6 +36,22 @@ internal class WaitOpsReflectiveMapper(
     private val waitForNodeSuspendMethod: Method? =
         automatorClass.methods.firstOrNull {
             it.name.startsWith("waitForNode") &&
+                it.parameterTypes.size == 5 &&
+                it.parameterTypes[0] == String::class.java &&
+                it.parameterTypes[1] == String::class.java &&
+                it.parameterTypes[2] == longPrimitive &&
+                it.parameterTypes[3] == longPrimitive &&
+                it.parameterTypes[4].name == CONTINUATION_FQN
+        }
+
+    /**
+     * `waitUntilGone(tag, text, timeout, pollInterval)` (#438) — two Strings + two packed
+     * Durations + Continuation. Same JVM shape as `waitForNode`; only the return type differs
+     * (`Unit` rather than a node).
+     */
+    private val waitUntilGoneSuspendMethod: Method? =
+        automatorClass.methods.firstOrNull {
+            it.name.startsWith("waitUntilGone") &&
                 it.parameterTypes.size == 5 &&
                 it.parameterTypes[0] == String::class.java &&
                 it.parameterTypes[1] == String::class.java &&
@@ -100,6 +117,42 @@ internal class WaitOpsReflectiveMapper(
             } else {
                 AgentResponse.Nodes(listOf(mapNode(node)))
             }
+        }
+    }
+
+    /**
+     * Absence wait (#438). The automator raises a plain [IllegalStateException] whose message names
+     * the selector, the timeout, and how many matching nodes were still present; [runWait] keeps
+     * that message verbatim under taxonomy `timeout` so the diagnostics reach the attach client
+     * rather than degrading to a bare "timed out".
+     */
+    fun handleWaitUntilGone(request: AgentRequest.WaitUntilGone): AgentResponse {
+        if (request.tag == null && request.text == null) {
+            return AgentResponse.Error(
+                message = "Either tag or text must be specified",
+                category = AgentErrorCategory.InvalidSelector.wireName,
+            )
+        }
+        val method =
+            waitUntilGoneSuspendMethod
+                ?: return AgentResponse.Error(
+                    message = "ComposeAutomator does not expose waitUntilGone",
+                    category = AgentErrorCategory.UnsupportedOperation.wireName,
+                )
+        val timeoutMs = request.timeoutMs ?: DEFAULT_WAIT_TIMEOUT_MS
+        val pollMs = request.pollIntervalMs ?: DEFAULT_WAIT_POLL_MS
+        return runWait {
+            suspendInvoker.invoke(
+                method,
+                automator,
+                request.tag,
+                request.text,
+                // Duration is a value class: JVM surface is packed rawValue, not plain nanos.
+                durationStorageFromMs(timeoutMs),
+                durationStorageFromMs(pollMs),
+                timeoutMsOverride = timeoutMs + SUSPEND_BRIDGE_SLACK_MS,
+            )
+            AgentResponse.Ok
         }
     }
 

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/transport/Wire.kt
@@ -224,6 +224,26 @@ internal sealed interface AgentRequest {
     ) : AgentRequest
 
     /**
+     * Wait until **no** node matches [tag] and/or [text] (AND when both set), same semantics as
+     * in-process `ComposeAutomator.waitUntilGone` (#438) — the absence counterpart to
+     * [WaitForNode], for dismissed popups, menus, and dialogs.
+     *
+     * Timeouts are milliseconds; null uses the automator defaults (5s timeout, 100ms poll). Replies
+     * with [AgentResponse.Ok] once nothing matches, or [AgentResponse.Error] (`timeout` /
+     * `invalidSelector`). The `timeout` message carries the automator's own absence diagnostics —
+     * selector, timeout, and how many matching nodes were still present — so the wait's whole point
+     * survives the transport boundary.
+     */
+    @Serializable
+    @SerialName("waitUntilGone")
+    data class WaitUntilGone(
+        val tag: String? = null,
+        val text: String? = null,
+        val timeoutMs: Long? = null,
+        val pollIntervalMs: Long? = null,
+    ) : AgentRequest
+
+    /**
      * Wait until consecutive visual frames are stable (#201). Same semantics as in-process
      * `ComposeAutomator.waitForVisualIdle`. Null durations use automator defaults. Replies with
      * [AgentResponse.Ok] or [AgentResponse.Error] category `timeout`.
@@ -283,6 +303,7 @@ internal val AgentRequest.logLabel: String
             is AgentRequest.Hello -> "hello"
             is AgentRequest.Cancel -> "cancel"
             is AgentRequest.WaitForNode -> "waitForNode"
+            is AgentRequest.WaitUntilGone -> "waitUntilGone"
             is AgentRequest.WaitForVisualIdle -> "waitForVisualIdle"
             is AgentRequest.WaitForIdle -> "waitForIdle"
             AgentRequest.PrintTree -> "printTree"
@@ -314,6 +335,7 @@ internal val AgentRequest.requiresInputLane: Boolean
             is AgentRequest.Hello,
             is AgentRequest.Cancel,
             is AgentRequest.WaitForNode,
+            is AgentRequest.WaitUntilGone,
             is AgentRequest.WaitForVisualIdle,
             is AgentRequest.WaitForIdle,
             AgentRequest.PrintTree -> false

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
@@ -8,6 +8,7 @@ import dev.sebastiano.spectre.testing.contract.AutomatorContractCorpus
 import dev.sebastiano.spectre.testing.contract.AutomatorContractDriver
 import dev.sebastiano.spectre.testing.contract.AutomatorTransport
 import dev.sebastiano.spectre.testing.contract.ContractNode
+import dev.sebastiano.spectre.testing.contract.ContractWaitFailure
 import dev.sebastiano.spectre.testing.contract.ContractWindow
 import dev.sebastiano.spectre.testing.contract.ScreenshotProbe
 import java.awt.GraphicsEnvironment
@@ -321,6 +322,28 @@ class AgentContractCorpusTest {
                 error("waitForNode was expected to time out")
             } catch (ex: SpectreAgentException) {
                 return ex.category.wireName
+            }
+        }
+
+        override fun waitUntilGone(tag: String?, text: String?, timeoutMs: Long) {
+            automator.waitUntilGone(tag = tag, text = text, timeoutMs = timeoutMs)
+        }
+
+        override fun waitUntilGoneFailure(
+            tag: String?,
+            text: String?,
+            timeoutMs: Long,
+        ): ContractWaitFailure {
+            try {
+                automator.waitUntilGone(tag = tag, text = text, timeoutMs = timeoutMs)
+                error("waitUntilGone was expected to time out")
+            } catch (ex: SpectreAgentException) {
+                // Verbatim: the corpus asserts the absence diagnostics survived attach, so
+                // reshaping the message here would test the driver instead of the transport.
+                return ContractWaitFailure(
+                    category = ex.category.wireName,
+                    message = ex.message.orEmpty(),
+                )
             }
         }
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/AgentContractCorpusTest.kt
@@ -309,6 +309,8 @@ class AgentContractCorpusTest {
 
         override val supportsWaitTaxonomy: Boolean = true
 
+        override val supportsAbsenceWait: Boolean = true
+
         override fun waitForNode(tag: String?, text: String?, timeoutMs: Long): String =
             automator.waitForNode(tag = tag, text = text, timeoutMs = timeoutMs).key
 

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/WaitDeadlineDiagnosticsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/WaitDeadlineDiagnosticsTest.kt
@@ -10,6 +10,7 @@ import dev.sebastiano.spectre.agent.transport.IpcServer
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 import kotlin.io.path.deleteIfExists
 import kotlin.test.AfterTest
 import kotlin.test.Test
@@ -123,6 +124,13 @@ class WaitDeadlineDiagnosticsTest {
     /**
      * A wedged automator — one that never returns — must still fail closed on the wire rather than
      * hanging, so the slack that lets a real timeout through cannot become an unbounded wait.
+     *
+     * Asserts *promptness*, not a taxonomy. Which category a wedged op comes back as is a genuine
+     * race in the session: [MultiplexedIpcSession]'s deadline task claims the response as `timeout`
+     * after aborting the worker, while the aborted worker itself prefers `cancelled` if it wins the
+     * same claim. Both are legitimate answers for "aborted at the deadline" — Linux happened to
+     * land on `timeout` every time and Windows CI on `cancelled` — so pinning one would be pinning
+     * a coin flip. Returning far sooner than the wedge is the property that actually matters here.
      */
     @Test
     fun `a wait that never returns still fails closed on the wire deadline`() {
@@ -135,11 +143,24 @@ class WaitDeadlineDiagnosticsTest {
             )
 
         withAttached(automator) { attached ->
+            val startedAt = System.nanoTime()
             val failure =
                 assertFailsWithAgentTimeout("waitUntilGone") {
                     attached.waitUntilGone(tag = "popup.body", timeoutMs = WAIT_MS)
                 }
-            assertEquals(AgentErrorCategory.Timeout, failure.category)
+            val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+
+            assertTrue(
+                failure.category in setOf(AgentErrorCategory.Timeout, AgentErrorCategory.Cancelled),
+                "a wedged wait must be claimed as an abort, got ${failure.category}: " +
+                    failure.message,
+            )
+            assertTrue(
+                elapsedMs < WEDGED_CLAIM_BUDGET_MS,
+                "wedged wait took ${elapsedMs}ms to fail closed; the wire deadline should have " +
+                    "claimed it around ${WAIT_MS}ms + slack, well before the ${WEDGED_SLEEP_MS}ms " +
+                    "wedge — the slack must not become an unbounded wait",
+            )
         }
     }
 
@@ -204,6 +225,13 @@ class WaitDeadlineDiagnosticsTest {
 
         /** Longer than the wire deadline's slack, so the wedged case is claimed on the wire. */
         const val WEDGED_SLEEP_MS: Long = 30_000
+
+        /**
+         * Ceiling for the wedged case to fail closed. Generous against a loaded CI runner while
+         * still far below [WEDGED_SLEEP_MS], so passing means the deadline fired rather than the
+         * wedge simply finishing.
+         */
+        const val WEDGED_CLAIM_BUDGET_MS: Long = 15_000
 
         /**
          * Inverse of the reflective bridge's `durationStorageFromMs` for the nanos-storage form.

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/WaitDeadlineDiagnosticsTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/WaitDeadlineDiagnosticsTest.kt
@@ -1,0 +1,213 @@
+@file:OptIn(ExperimentalSpectreAgentApi::class)
+
+package dev.sebastiano.spectre.agent
+
+import dev.sebastiano.spectre.agent.runtime.ReflectiveAutomatorHandler
+import dev.sebastiano.spectre.agent.runtime.WaitFakeAutomator
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+import dev.sebastiano.spectre.agent.transport.IpcClient
+import dev.sebastiano.spectre.agent.transport.IpcServer
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.io.path.deleteIfExists
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.condition.EnabledOnOs
+import org.junit.jupiter.api.condition.OS
+
+/**
+ * Every wait's timeout diagnostics must survive attach.
+ *
+ * The wire deadline the client attaches to a wait op is enforced by the agent twice: a scheduler
+ * claims the op at the deadline, and `executeOp` discards the handler's answer for "Deadline
+ * elapsed during op" if the deadline passed while the handler ran. On an exact `now + timeoutMs`
+ * deadline, both fire at the same instant the automator's own timeout does — a race the automator
+ * always loses, so callers got the transport's phrase instead of the wait's real message.
+ *
+ * That message is what each wait exists to produce: `waitForIdle` names the busy idling resources,
+ * `waitForVisualIdle` names the sample counts, `waitUntilGone` names the selector and how many
+ * nodes are still present. This drives the **real** boundary — a public [AttachedAutomator] over a
+ * real [IpcClient]/[IpcServer] pair on a Unix domain socket, through the reflective bridge — with
+ * fakes that genuinely consume their wait budget before failing, so the race is live rather than
+ * hypothetical.
+ */
+@EnabledOnOs(OS.LINUX, OS.MAC, OS.WINDOWS)
+class WaitDeadlineDiagnosticsTest {
+    private val udsPath: Path =
+        udsBase().resolve("sp-wd-${UUID.randomUUID().toString().take(8)}.sock")
+
+    @AfterTest
+    fun cleanUp() {
+        runCatching { udsPath.deleteIfExists() }
+    }
+
+    @Test
+    fun `waitForNode timeout keeps the automator's message, not the wire deadline's`() {
+        val diagnostic = "Timed out waiting for ${WAIT_MS} ms"
+        val automator =
+            WaitFakeAutomator(
+                waitForNodeImpl = { _, _, timeoutRaw, _ -> failAfterBudget(timeoutRaw, diagnostic) }
+            )
+
+        withAttached(automator) { attached ->
+            val failure =
+                assertFailsWithAgentTimeout("waitForNode") {
+                    attached.waitForNode(tag = "never-appears", timeoutMs = WAIT_MS)
+                }
+            assertDiagnosticSurvived(failure, diagnostic)
+        }
+    }
+
+    @Test
+    fun `waitForIdle timeout keeps the busy-resource diagnostic`() {
+        val diagnostic = "waitForIdle timed out after ${WAIT_MS}ms: network queue has 3 in flight"
+        val automator =
+            WaitFakeAutomator(
+                waitForIdleImpl = { timeoutRaw, _, _ -> failAfterBudget(timeoutRaw, diagnostic) }
+            )
+
+        withAttached(automator) { attached ->
+            val failure =
+                assertFailsWithAgentTimeout("waitForIdle") {
+                    attached.waitForIdle(timeoutMs = WAIT_MS)
+                }
+            assertDiagnosticSurvived(failure, diagnostic)
+        }
+    }
+
+    @Test
+    fun `waitForVisualIdle timeout keeps the frame-sample diagnostic`() {
+        val diagnostic =
+            "waitForVisualIdle timed out after ${WAIT_MS}ms: 12 samples, pixels never settled"
+        val automator =
+            WaitFakeAutomator(
+                waitForVisualIdleImpl = { timeoutRaw, _, _ ->
+                    failAfterBudget(timeoutRaw, diagnostic)
+                }
+            )
+
+        withAttached(automator) { attached ->
+            val failure =
+                assertFailsWithAgentTimeout("waitForVisualIdle") {
+                    attached.waitForVisualIdle(timeoutMs = WAIT_MS)
+                }
+            assertDiagnosticSurvived(failure, diagnostic)
+        }
+    }
+
+    @Test
+    fun `waitUntilGone timeout keeps the still-present diagnostic`() {
+        val diagnostic =
+            """waitUntilGone timed out after ${WAIT_MS}ms: 2 node(s) matching tag="popup.body" """ +
+                "still present in tracked windows"
+        val automator =
+            WaitFakeAutomator(
+                waitUntilGoneImpl = { _, _, timeoutRaw, _ ->
+                    failAfterBudget(timeoutRaw, diagnostic)
+                }
+            )
+
+        withAttached(automator) { attached ->
+            val failure =
+                assertFailsWithAgentTimeout("waitUntilGone") {
+                    attached.waitUntilGone(tag = "popup.body", timeoutMs = WAIT_MS)
+                }
+            assertDiagnosticSurvived(failure, diagnostic)
+        }
+    }
+
+    /**
+     * A wedged automator — one that never returns — must still fail closed on the wire rather than
+     * hanging, so the slack that lets a real timeout through cannot become an unbounded wait.
+     */
+    @Test
+    fun `a wait that never returns still fails closed on the wire deadline`() {
+        val automator =
+            WaitFakeAutomator(
+                waitUntilGoneImpl = { _, _, _, _ ->
+                    Thread.sleep(WEDGED_SLEEP_MS)
+                    error("wedged automator should have been claimed by the wire deadline")
+                }
+            )
+
+        withAttached(automator) { attached ->
+            val failure =
+                assertFailsWithAgentTimeout("waitUntilGone") {
+                    attached.waitUntilGone(tag = "popup.body", timeoutMs = WAIT_MS)
+                }
+            assertEquals(AgentErrorCategory.Timeout, failure.category)
+        }
+    }
+
+    /** Sleeps the wait's own budget, then fails the way the real automator does. */
+    private fun failAfterBudget(timeoutRaw: Long, message: String): Nothing {
+        Thread.sleep(millisFromDurationStorage(timeoutRaw))
+        error(message)
+    }
+
+    private fun assertDiagnosticSurvived(failure: SpectreAgentException, diagnostic: String) {
+        assertEquals(AgentErrorCategory.Timeout, failure.category)
+        assertTrue(
+            failure.message.orEmpty().contains(diagnostic),
+            "wait diagnostics were replaced by the wire deadline's own phrase: ${failure.message}",
+        )
+    }
+
+    private inline fun assertFailsWithAgentTimeout(
+        op: String,
+        block: () -> Unit,
+    ): SpectreAgentException {
+        val thrown =
+            try {
+                block()
+                null
+            } catch (ex: Exception) {
+                ex
+            }
+        return assertIs<SpectreAgentException>(thrown, "$op should have failed, got $thrown")
+    }
+
+    private fun withAttached(automator: Any, block: (AttachedAutomator) -> Unit) {
+        IpcServer(udsPath, ReflectiveAutomatorHandler(automator)).use {
+            awaitSocket(udsPath)
+            AttachedAutomator(pid = ProcessHandle.current().pid(), client = IpcClient(udsPath)) {}
+                .use(block)
+        }
+    }
+
+    private fun awaitSocket(path: Path, timeoutMs: Long = 5_000) {
+        val deadline = System.nanoTime() + timeoutMs * 1_000_000L
+        while (System.nanoTime() < deadline) {
+            if (Files.exists(path)) return
+            Thread.sleep(10)
+        }
+        error("UDS path $path did not appear within ${timeoutMs}ms")
+    }
+
+    private fun udsBase(): Path =
+        if (System.getProperty("os.name").orEmpty().startsWith("Windows", ignoreCase = true)) {
+            Path.of(System.getProperty("java.io.tmpdir"))
+        } else {
+            Path.of("/tmp")
+        }
+
+    private companion object {
+        /**
+         * Short enough to keep the suite quick, long enough that the sleeping fake and the wire
+         * deadline genuinely race rather than being ordered by scheduling luck.
+         */
+        const val WAIT_MS: Long = 300
+
+        /** Longer than the wire deadline's slack, so the wedged case is claimed on the wire. */
+        const val WEDGED_SLEEP_MS: Long = 30_000
+
+        /**
+         * Inverse of the reflective bridge's `durationStorageFromMs` for the nanos-storage form.
+         */
+        fun millisFromDurationStorage(raw: Long): Long = (raw shr 1) / 1_000_000L
+    }
+}

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveHandlerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveHandlerTest.kt
@@ -8,6 +8,7 @@ import dev.sebastiano.spectre.agent.transport.AgentResponse
 import java.awt.Rectangle
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * #201 wait ops through the real [ReflectiveAutomatorHandler] reflective bridge: success path,
@@ -66,6 +67,60 @@ class WaitOpsReflectiveHandlerTest {
     }
 
     @Test
+    fun `WaitUntilGone success returns Ok with packed Duration rawValues`() {
+        val fake = WaitFakeAutomator()
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response =
+            handler.handle(
+                AgentRequest.WaitUntilGone(
+                    tag = "popup.body",
+                    timeoutMs = 1_000,
+                    pollIntervalMs = 50,
+                )
+            )
+        check(response is AgentResponse.Ok) { "expected Ok, got $response" }
+        assertEquals(listOf<String?>("popup.body"), fake.waitUntilGoneTags.toList())
+        // Packed Duration rawValue for 1000ms / 50ms: nanos << 1, not plain inWholeNanoseconds.
+        assertEquals(listOf(1_000L * 1_000_000L shl 1), fake.waitUntilGoneTimeoutRaw.toList())
+        assertEquals(listOf(50L * 1_000_000L shl 1), fake.waitUntilGonePollRaw.toList())
+    }
+
+    @Test
+    fun `WaitUntilGone timeout keeps selector, timeout, and still-present count in the message`() {
+        val stillPresent =
+            """waitUntilGone timed out after 400ms: 2 node(s) matching tag="popup.body" """ +
+                "still present in tracked windows"
+        val fake =
+            WaitFakeAutomator(
+                waitUntilGoneImpl = { _: String?, _: String?, _: Long, _: Long ->
+                    // Core raises a plain IllegalStateException carrying the absence diagnostics.
+                    error(stillPresent)
+                }
+            )
+        val handler = ReflectiveAutomatorHandler(fake)
+
+        val response =
+            handler.handle(
+                AgentRequest.WaitUntilGone(tag = "popup.body", timeoutMs = 400, pollIntervalMs = 50)
+            )
+        check(response is AgentResponse.Error) { "expected Error, got $response" }
+        assertEquals(AgentErrorCategory.Timeout.wireName, response.category)
+        assertTrue(
+            response.message.contains(stillPresent),
+            "absence diagnostics degraded to \"${response.message}\"",
+        )
+    }
+
+    @Test
+    fun `WaitUntilGone refuses when neither tag nor text is set`() {
+        val handler = ReflectiveAutomatorHandler(WaitFakeAutomator())
+        val response = handler.handle(AgentRequest.WaitUntilGone(tag = null, text = null))
+        check(response is AgentResponse.Error)
+        assertEquals(AgentErrorCategory.InvalidSelector.wireName, response.category)
+    }
+
+    @Test
     fun `WaitForIdle success invokes target-side wait with packed Duration rawValues`() {
         val fake = WaitFakeAutomator()
         val handler = ReflectiveAutomatorHandler(fake)
@@ -110,12 +165,16 @@ internal class WaitFakeAutomator(
     private val allNodesValue: List<Any> = emptyList(),
     private val waitForNodeImpl: ((String?, String?, Long, Long) -> Any?)? = null,
     private val waitForIdleImpl: ((Long, Long, Long) -> Any?)? = null,
+    private val waitUntilGoneImpl: ((String?, String?, Long, Long) -> Any?)? = null,
 ) {
     val waitForNodeTags = mutableListOf<String?>()
     val waitForNodeTimeoutRaw = mutableListOf<Long>()
     val waitForIdleTimeoutRaw = mutableListOf<Long>()
     val waitForIdleQuietRaw = mutableListOf<Long>()
     val waitForIdlePollRaw = mutableListOf<Long>()
+    val waitUntilGoneTags = mutableListOf<String?>()
+    val waitUntilGoneTimeoutRaw = mutableListOf<Long>()
+    val waitUntilGonePollRaw = mutableListOf<Long>()
 
     @Suppress("unused") fun refreshWindows() = Unit
 
@@ -167,6 +226,23 @@ internal class WaitFakeAutomator(
         waitForIdlePollRaw += pollRaw
         waitForIdleImpl?.let {
             return it(timeoutRaw, quietRaw, pollRaw)
+        }
+        return Unit
+    }
+
+    @Suppress("unused", "UNUSED_PARAMETER")
+    fun waitUntilGone(
+        tag: String?,
+        text: String?,
+        timeoutRaw: Long,
+        pollRaw: Long,
+        continuation: kotlin.coroutines.Continuation<Any?>,
+    ): Any? {
+        waitUntilGoneTags += tag
+        waitUntilGoneTimeoutRaw += timeoutRaw
+        waitUntilGonePollRaw += pollRaw
+        waitUntilGoneImpl?.let {
+            return it(tag, text, timeoutRaw, pollRaw)
         }
         return Unit
     }

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveHandlerTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/WaitOpsReflectiveHandlerTest.kt
@@ -166,6 +166,7 @@ internal class WaitFakeAutomator(
     private val waitForNodeImpl: ((String?, String?, Long, Long) -> Any?)? = null,
     private val waitForIdleImpl: ((Long, Long, Long) -> Any?)? = null,
     private val waitUntilGoneImpl: ((String?, String?, Long, Long) -> Any?)? = null,
+    private val waitForVisualIdleImpl: ((Long, Int, Long) -> Any?)? = null,
 ) {
     val waitForNodeTags = mutableListOf<String?>()
     val waitForNodeTimeoutRaw = mutableListOf<Long>()
@@ -212,7 +213,12 @@ internal class WaitFakeAutomator(
         stableFrames: Int,
         pollRaw: Long,
         continuation: kotlin.coroutines.Continuation<Any?>,
-    ): Any? = Unit
+    ): Any? {
+        waitForVisualIdleImpl?.let {
+            return it(timeoutRaw, stableFrames, pollRaw)
+        }
+        return Unit
+    }
 
     @Suppress("unused", "UNUSED_PARAMETER")
     fun waitForIdle(

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/IpcRoundTripTest.kt
@@ -585,7 +585,8 @@ class IpcRoundTripTest {
             is AgentRequest.TypeText,
             is AgentRequest.Cancel,
             is AgentRequest.WaitForVisualIdle,
-            is AgentRequest.WaitForIdle -> AgentResponse.Ok
+            is AgentRequest.WaitForIdle,
+            is AgentRequest.WaitUntilGone -> AgentResponse.Ok
             AgentRequest.PrintTree -> AgentResponse.TreeDump("")
             is AgentRequest.Screenshot -> AgentResponse.Screenshot(ByteArray(0))
             is AgentRequest.Capture ->

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WaitOpsInfrastructureTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/transport/WaitOpsInfrastructureTest.kt
@@ -3,6 +3,7 @@
 package dev.sebastiano.spectre.agent.transport
 
 import dev.sebastiano.spectre.agent.runtime.ReflectiveAutomatorHandler
+import dev.sebastiano.spectre.agent.runtime.WaitFakeAutomator
 import java.nio.file.Path
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
@@ -141,6 +142,51 @@ class WaitOpsInfrastructureTest {
                     assertEquals(AgentErrorCategory.Timeout.wireName, err.category)
                 }
             }
+    }
+
+    /**
+     * Absence wait over the **real** boundary: the server dispatches through
+     * [ReflectiveAutomatorHandler] and the reflective wait bridge, and the reply crosses real CBOR
+     * framing on a real UDS. The timeout diagnostics (selector, timeout, still-present count) are
+     * the point of `waitUntilGone`, so this asserts they arrive intact rather than degrading to a
+     * bare "timed out".
+     */
+    @Test
+    fun `waitUntilGone Ok and timeout diagnostics survive the reflective IPC boundary`() {
+        val diagnostics =
+            """waitUntilGone timed out after 400ms: 3 node(s) matching tag="popup.body" """ +
+                "still present in tracked windows"
+        val calls = AtomicInteger(0)
+        val automator =
+            WaitFakeAutomator(
+                waitUntilGoneImpl = { _, _, _, _ ->
+                    if (calls.getAndIncrement() == 0) Unit else error(diagnostics)
+                }
+            )
+        IpcServer(udsPath, ReflectiveAutomatorHandler(automator)).use {
+            awaitSocket(udsPath)
+            IpcClient(udsPath).use { client ->
+                assertEquals(
+                    AgentResponse.Ok,
+                    client.send(
+                        AgentRequest.WaitUntilGone(
+                            tag = "popup.body",
+                            timeoutMs = 500,
+                            pollIntervalMs = 50,
+                        )
+                    ),
+                )
+                val err =
+                    assertIs<AgentResponse.Error>(
+                        client.send(AgentRequest.WaitUntilGone(tag = "popup.body", timeoutMs = 400))
+                    )
+                assertEquals(AgentErrorCategory.Timeout.wireName, err.category)
+                assertTrue(
+                    err.message.contains(diagnostics),
+                    "absence diagnostics degraded over the wire to \"${err.message}\"",
+                )
+            }
+        }
     }
 
     @Test

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/SpectreCli.kt
@@ -150,6 +150,7 @@ private class RootCommand(
             FindCommand(request, output),
             FindByTextCommand(request, output),
             WaitForNodeCommand(request, output),
+            WaitUntilGoneCommand(request, output),
             WaitForVisualIdleCommand(request, output),
             WaitCommand(request, output),
             ClickCommand(request, output),
@@ -753,6 +754,47 @@ private class WaitForNodeCommand(
                     "${node.key} ${node.testTag ?: node.role ?: "Node"}"
                 }
             )
+        output.appendLine()
+    }
+}
+
+/**
+ * `spectre wait-until-gone <session> --tag/--text` — wait for absence (#438).
+ *
+ * The absence counterpart to `wait-for-node`: it returns once nothing matches, and on timeout the
+ * daemon error already names the selector, the timeout, and how many matching nodes were still
+ * present, so the command lets that message through rather than restating it.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+private class WaitUntilGoneCommand(
+    private val request: (DaemonRequest) -> DaemonResponse,
+    private val output: Appendable,
+) : CliktCommand(name = "wait-until-gone") {
+    private val sessionId: String by argument()
+    private val tag: String? by option("--tag")
+    private val text: String? by option("--text")
+    private val timeoutMs: Long by option("--timeout-ms").long().default(5_000)
+    private val json: Boolean by option("--json").flag(default = false)
+
+    override fun run() {
+        val completedSessionId =
+            when (
+                val response =
+                    request(
+                        DaemonRequest.WaitUntilGone(
+                            sessionId = sessionId,
+                            tag = tag,
+                            text = text,
+                            timeoutMs = timeoutMs,
+                        )
+                    )
+            ) {
+                is DaemonResponse.Completed -> response.sessionId
+                is DaemonResponse.Error -> throw DaemonCommandException(response)
+                else -> error("Daemon returned an unexpected response to wait-until-gone")
+            }
+        if (json) output.append(CLI_JSON.encodeToString(CompletionJson(id = completedSessionId)))
+        else output.append("Selector gone for session $completedSessionId.")
         output.appendLine()
     }
 }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonProtocol.kt
@@ -12,7 +12,7 @@ import kotlinx.serialization.cbor.Cbor
 /** Shared client/daemon wire protocol metadata for Spectre's agent-facing entrypoints. */
 @OptIn(ExperimentalSerializationApi::class)
 public object DaemonProtocol {
-    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 12)
+    public val CurrentVersion: DaemonProtocolVersion = DaemonProtocolVersion(major = 1, minor = 13)
 
     public val cbor: Cbor = Cbor {
         ignoreUnknownKeys = true
@@ -66,6 +66,7 @@ public object DaemonProtocol {
             is DaemonRequest.PressKey -> versionFor(INPUT_VERBS_INTRODUCED_MINOR)
             is DaemonRequest.WaitForNode,
             is DaemonRequest.WaitForVisualIdle -> versionFor(WAIT_OPS_INTRODUCED_MINOR)
+            is DaemonRequest.WaitUntilGone -> versionFor(WAIT_UNTIL_GONE_INTRODUCED_MINOR)
             is DaemonRequest.WaitForReloadSettled -> versionFor(RELOAD_SETTLE_INTRODUCED_MINOR)
             is DaemonRequest.FindByText,
             is DaemonRequest.FindByContentDescription,
@@ -124,6 +125,15 @@ public object DaemonProtocol {
      * into the existing "daemon protocol is too old, run `spectre daemon kill`" error instead.
      */
     internal const val SCREEN_PIXEL_STILLS_INTRODUCED_MINOR: Int = 12
+
+    /**
+     * `waitUntilGone`, the wait-for-absence counterpart to `waitForNode` (#438).
+     *
+     * A capability floor: the op is a new wire discriminator, so a daemon built before it rejects
+     * the frame rather than answering it. Requiring 1.13 turns that into the existing "daemon
+     * protocol is too old, run `spectre daemon kill`" error.
+     */
+    private const val WAIT_UNTIL_GONE_INTRODUCED_MINOR: Int = 13
 }
 
 @Serializable public data class DaemonProtocolVersion(public val major: Int, public val minor: Int)
@@ -243,6 +253,25 @@ public sealed interface DaemonRequest {
     @Serializable
     @SerialName("waitForNode")
     public data class WaitForNode(
+        public val sessionId: String,
+        public val tag: String? = null,
+        public val text: String? = null,
+        public val timeoutMs: Long = 5_000,
+        public val pollIntervalMs: Long = 100,
+    ) : DaemonRequest
+
+    /**
+     * Wait until **no** node matches [tag] and/or [text] (AND when both set) — the absence
+     * counterpart to [WaitForNode] (#438), for dismissed popups, menus, and dialogs.
+     *
+     * Replies with [DaemonResponse.Completed] once nothing matches. A timeout is a
+     * [DaemonResponse.Error] with code [DaemonErrorCode.Timeout] and category `timeout` whose
+     * message keeps the automator's own diagnostics — selector, timeout, and how many matching
+     * nodes were still present — because those diagnostics are the point of the verb.
+     */
+    @Serializable
+    @SerialName("waitUntilGone")
+    public data class WaitUntilGone(
         public val sessionId: String,
         public val tag: String? = null,
         public val text: String? = null,

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionAutomator.kt
@@ -34,6 +34,19 @@ internal interface DaemonSessionAutomator : AutoCloseable {
         pollIntervalMs: Long = 100,
     ): NodeSnapshotDto
 
+    /**
+     * Wait until no node matches [tag] and/or [text] (#438). Throws on timeout; the thrown
+     * exception carries the automator's absence diagnostics (selector, timeout, still-present
+     * count), which the registry maps onto the daemon wire rather than replacing.
+     */
+    @Throws(IOException::class)
+    fun waitUntilGone(
+        tag: String? = null,
+        text: String? = null,
+        timeoutMs: Long = 5_000,
+        pollIntervalMs: Long = 100,
+    )
+
     @Throws(IOException::class)
     fun waitForVisualIdle(timeoutMs: Long = 5_000, stableFrames: Int = 3, pollIntervalMs: Long = 16)
 
@@ -134,6 +147,13 @@ internal class AttachedDaemonSession(
         timeoutMs: Long,
         pollIntervalMs: Long,
     ): NodeSnapshotDto = delegate.waitForNode(tag, text, timeoutMs, pollIntervalMs)
+
+    override fun waitUntilGone(
+        tag: String?,
+        text: String?,
+        timeoutMs: Long,
+        pollIntervalMs: Long,
+    ): Unit = delegate.waitUntilGone(tag, text, timeoutMs, pollIntervalMs)
 
     override fun waitForVisualIdle(timeoutMs: Long, stableFrames: Int, pollIntervalMs: Long): Unit =
         delegate.waitForVisualIdle(timeoutMs, stableFrames, pollIntervalMs)

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonSessionRegistry.kt
@@ -54,6 +54,7 @@ internal constructor(
     public fun handle(request: DaemonRequest): DaemonResponse =
         when (request) {
             is DaemonRequest.WaitForNode,
+            is DaemonRequest.WaitUntilGone,
             is DaemonRequest.WaitForVisualIdle,
             is DaemonRequest.WaitForReloadSettled -> handleWaitOutsideLock(request)
             is DaemonRequest.Attach -> attach(request.targetPid)
@@ -105,6 +106,7 @@ internal constructor(
             is DaemonRequest.RecordingStatus -> handleSessionCommand(request)
             // Wait ops / detach / shutdown / attach are dispatched by [handle] outside the monitor.
             is DaemonRequest.WaitForNode,
+            is DaemonRequest.WaitUntilGone,
             is DaemonRequest.WaitForVisualIdle,
             is DaemonRequest.WaitForReloadSettled ->
                 error("wait ops must use handleWaitOutsideLock")
@@ -115,6 +117,7 @@ internal constructor(
         val sessionId =
             when (request) {
                 is DaemonRequest.WaitForNode -> request.sessionId
+                is DaemonRequest.WaitUntilGone -> request.sessionId
                 is DaemonRequest.WaitForVisualIdle -> request.sessionId
                 is DaemonRequest.WaitForReloadSettled -> request.sessionId
                 else -> error("not a wait request")
@@ -122,6 +125,7 @@ internal constructor(
         val waitTimeoutMs =
             when (request) {
                 is DaemonRequest.WaitForNode -> request.timeoutMs
+                is DaemonRequest.WaitUntilGone -> request.timeoutMs
                 is DaemonRequest.WaitForVisualIdle -> request.timeoutMs
                 is DaemonRequest.WaitForReloadSettled -> request.timeoutMs
                 else -> error("not a wait request")
@@ -176,6 +180,7 @@ internal constructor(
                         )
                 DaemonResponse.Nodes(request.sessionId, listOf(stamped))
             }
+            is DaemonRequest.WaitUntilGone -> waitUntilGoneResponse(session.automator, request)
             is DaemonRequest.WaitForVisualIdle -> {
                 session.automator.waitForVisualIdle(
                     timeoutMs = request.timeoutMs,

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/WaitUntilGoneDaemonMapping.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/daemon/WaitUntilGoneDaemonMapping.kt
@@ -1,0 +1,56 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.SpectreAgentException
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+
+/**
+ * Runs `waitUntilGone` for one session and maps its outcome onto the daemon wire (#438).
+ *
+ * Kept out of [DaemonSessionRegistry]'s generic `IOException` arm on purpose. That arm answers
+ * every session op with `operationFailed` and no category, which is the right default but the wrong
+ * answer here: an absence wait's whole value is its failure message, which names the selector, the
+ * timeout, and how many matching nodes were still present in tracked windows. Flattening that — and
+ * the #199 `timeout` taxonomy that lets a caller tell "still on screen" from "the session died" —
+ * would leave remote callers with strictly less than the in-process API gives them.
+ *
+ * Lives beside
+ * [mapReloadSettleOutcome][dev.sebastiano.spectre.cli.hotreload.mapReloadSettleOutcome] in shape:
+ * one op's outcome, one response mapping, its own file.
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+internal fun waitUntilGoneResponse(
+    automator: DaemonSessionAutomator,
+    request: DaemonRequest.WaitUntilGone,
+): DaemonResponse =
+    try {
+        automator.waitUntilGone(
+            tag = request.tag,
+            text = request.text,
+            timeoutMs = request.timeoutMs,
+            pollIntervalMs = request.pollIntervalMs,
+        )
+        DaemonResponse.Completed(request.sessionId)
+    } catch (exception: SpectreAgentException) {
+        DaemonResponse.Error(
+            code = daemonErrorCodeFor(exception.category),
+            // Verbatim: the agent already composed the diagnostics, and rewording them here would
+            // be the exact degradation this mapping exists to prevent.
+            message = exception.message ?: "waitUntilGone failed",
+            category = exception.category.wireName,
+        )
+    }
+
+/**
+ * Maps a #199 agent taxonomy category onto the daemon's own error code.
+ *
+ * Only the categories a wait can produce get a dedicated code; everything else stays
+ * [DaemonErrorCode.OperationFailed] while the precise taxonomy still travels in
+ * [DaemonResponse.Error.category].
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+private fun daemonErrorCodeFor(category: AgentErrorCategory): DaemonErrorCode =
+    when (category) {
+        AgentErrorCategory.Timeout -> DaemonErrorCode.Timeout
+        else -> DaemonErrorCode.OperationFailed
+    }

--- a/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
+++ b/cli/src/main/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServer.kt
@@ -190,6 +190,34 @@ public object SpectreMcpServer {
                 .asResult { it is DaemonResponse.Nodes }
         }
         server.addTool(
+            name = "wait_until_gone",
+            description =
+                "Wait until NO semantics node matches tag and/or text (#438) — the absence " +
+                    "counterpart to wait_for_node, for dismissed popups, menus, and dialogs. " +
+                    "Refreshes tracked windows before each poll, so a popup that closed its whole " +
+                    "window is observed rather than answered from a stale tree. On timeout the " +
+                    "error names the selector, the timeout, and how many matching nodes were " +
+                    "still present.",
+            inputSchema =
+                schema(
+                    "session_id" to "string",
+                    "tag" to "string",
+                    "text" to "string",
+                    "timeout_ms" to "integer",
+                    required = listOf("session_id"),
+                ),
+        ) { call ->
+            request(
+                    DaemonRequest.WaitUntilGone(
+                        sessionId = call.requiredSessionId(),
+                        tag = call.optionalString("tag"),
+                        text = call.optionalString("text"),
+                        timeoutMs = call.optionalLong("timeout_ms") ?: 5_000L,
+                    )
+                )
+                .asResult { it is DaemonResponse.Completed }
+        }
+        server.addTool(
             name = "wait_for_visual_idle",
             description = "Wait until consecutive visual frames are stable (#201).",
             inputSchema =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/SpectreCliTest.kt
@@ -61,6 +61,75 @@ class SpectreCliTest {
     }
 
     @Test
+    fun `wait-until-gone sends the absence wait and prints stable JSON completion output`() {
+        val output = StringBuilder()
+        val cli =
+            SpectreCli(
+                request = { request ->
+                    assertEquals(
+                        DaemonRequest.WaitUntilGone(
+                            sessionId = "pid-42",
+                            tag = "popup.body",
+                            text = null,
+                            timeoutMs = 2_000,
+                        ),
+                        request,
+                    )
+                    DaemonResponse.Completed("pid-42")
+                },
+                output = output,
+            )
+
+        assertEquals(
+            0,
+            cli.run(
+                listOf(
+                    "wait-until-gone",
+                    "pid-42",
+                    "--tag",
+                    "popup.body",
+                    "--timeout-ms",
+                    "2000",
+                    "--json",
+                )
+            ),
+        )
+        assertEquals("{\"version\":1,\"id\":\"pid-42\"}\n", output.toString())
+    }
+
+    @Test
+    fun `wait-until-gone reports the still-present diagnostics on timeout`() {
+        val output = StringBuilder()
+        val errorOutput = StringBuilder()
+        val diagnostics =
+            """waitUntilGone timed out after 400ms: 2 node(s) matching tag="popup.body" """ +
+                "still present in tracked windows"
+        val cli =
+            SpectreCli(
+                request = {
+                    DaemonResponse.Error(
+                        code = DaemonErrorCode.Timeout,
+                        message = diagnostics,
+                        category = "timeout",
+                    )
+                },
+                output = output,
+                errorOutput = errorOutput,
+            )
+
+        // Timeout shares the daemon-failure exit code with the other wait verbs (5), so scripts
+        // keep one "the daemon said no" branch; the diagnostics live in the message.
+        assertEquals(
+            5,
+            cli.run(
+                listOf("wait-until-gone", "pid-42", "--tag", "popup.body", "--timeout-ms", "400")
+            ),
+        )
+        assertEquals("", output.toString())
+        assertEquals("Spectre daemon error: $diagnostics\n", errorOutput.toString())
+    }
+
+    @Test
     fun `screenshot writes PNG output and reports its stable JSON path`() {
         val output = StringBuilder()
         val imagePath = Files.createTempFile("spectre-cli-test", ".png")

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonEndpointTest.kt
@@ -34,6 +34,7 @@ class DaemonEndpointTest {
     fun `discovers prior minor-version sockets during the stable endpoint migration`() {
         assertEquals(
             listOf(
+                Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-12.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-11.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-10.sock"),
                 Path.of("/tmp", "sp-d-2bd806c9", "daemon-v1-9.sock"),

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonHandshakeTest.kt
@@ -115,6 +115,14 @@ class DaemonHandshakeTest {
                 DaemonRequest.WaitForReloadSettled(sessionId = "session-1234")
             ),
         )
+        // waitUntilGone (#438) is a new discriminator: an older daemon would reject the frame
+        // rather than answer it, so it floors at its own minor.
+        assertEquals(
+            DaemonProtocolVersion(major = 1, minor = 13),
+            DaemonProtocol.minimumDaemonVersion(
+                DaemonRequest.WaitUntilGone(sessionId = "session-1234", tag = "popup.body")
+            ),
+        )
     }
 
     @Test

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonWaitUntilGoneTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/DaemonWaitUntilGoneTest.kt
@@ -1,0 +1,184 @@
+package dev.sebastiano.spectre.cli.daemon
+
+import dev.sebastiano.spectre.agent.ExperimentalSpectreAgentApi
+import dev.sebastiano.spectre.agent.SpectreAgentException
+import dev.sebastiano.spectre.agent.transport.AgentErrorCategory
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * `waitUntilGone` over the **real** daemon boundary (#438 transport parity): a live [DaemonServer]
+ * on a Unix domain socket, requests and responses encoded by the production [DaemonWireCodec], and
+ * a [DaemonClient] on the other side — not a hand-built response object.
+ *
+ * The verb exists for its timeout diagnostics, so the timeout case asserts that the selector, the
+ * timeout, and the still-present count all survive the CBOR round trip alongside the stable
+ * `timeout` taxonomy, rather than degrading to a bare "timed out".
+ */
+@OptIn(ExperimentalSpectreAgentApi::class)
+class DaemonWaitUntilGoneTest {
+
+    @Test
+    fun `waitUntilGone completes over the daemon wire once nothing matches`() {
+        val socketPath = temporarySocketPath()
+        val calls = mutableListOf<List<Any?>>()
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(
+                waitUntilGoneAction = { tag, text, timeoutMs, pollIntervalMs ->
+                    calls += listOf(tag, text, timeoutMs, pollIntervalMs)
+                }
+            )
+        }
+        val server = DaemonServer(socketPath, registry = registry)
+
+        try {
+            assertIs<DaemonResponse.Attached>(
+                DaemonClient(socketPath).request(DaemonRequest.Attach(4242))
+            )
+
+            val response =
+                DaemonClient(socketPath)
+                    .request(
+                        DaemonRequest.WaitUntilGone(
+                            sessionId = "pid-4242",
+                            tag = "popup.body",
+                            timeoutMs = 1_500,
+                            pollIntervalMs = 25,
+                        )
+                    )
+
+            val completed = assertIs<DaemonResponse.Completed>(response)
+            assertEquals("pid-4242", completed.sessionId)
+            assertEquals(listOf(listOf<Any?>("popup.body", null, 1_500L, 25L)), calls)
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
+    fun `waitUntilGone timeout keeps selector, timeout, and still-present count over the wire`() {
+        val socketPath = temporarySocketPath()
+        val diagnostics =
+            """waitUntilGone timed out after 400ms: 2 node(s) matching tag="popup.body" """ +
+                "still present in tracked windows"
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(
+                waitUntilGoneAction = { _, _, _, _ ->
+                    throw SpectreAgentException(
+                        category = AgentErrorCategory.Timeout,
+                        message =
+                            "Agent reported timeout for waitUntilGone: " +
+                                "IllegalStateException: $diagnostics",
+                    )
+                }
+            )
+        }
+        val server = DaemonServer(socketPath, registry = registry)
+
+        try {
+            assertIs<DaemonResponse.Attached>(
+                DaemonClient(socketPath).request(DaemonRequest.Attach(4343))
+            )
+
+            val response =
+                DaemonClient(socketPath)
+                    .request(
+                        DaemonRequest.WaitUntilGone(
+                            sessionId = "pid-4343",
+                            tag = "popup.body",
+                            timeoutMs = 400,
+                        )
+                    )
+
+            val error = assertIs<DaemonResponse.Error>(response)
+            assertEquals(DaemonErrorCode.Timeout, error.code)
+            assertEquals(AgentErrorCategory.Timeout.wireName, error.category)
+            assertTrue(
+                error.message.contains(diagnostics),
+                "absence diagnostics degraded over the daemon wire to \"${error.message}\"",
+            )
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
+    fun `waitUntilGone relays a non-timeout taxonomy without claiming a timeout`() {
+        val socketPath = temporarySocketPath()
+        val registry = DaemonSessionRegistry {
+            TestDaemonSessionAutomator(
+                waitUntilGoneAction = { _, _, _, _ ->
+                    throw SpectreAgentException(
+                        category = AgentErrorCategory.InvalidSelector,
+                        message =
+                            "Agent reported invalidSelector for waitUntilGone: " +
+                                "Either tag or text must be specified",
+                    )
+                }
+            )
+        }
+        val server = DaemonServer(socketPath, registry = registry)
+
+        try {
+            assertIs<DaemonResponse.Attached>(
+                DaemonClient(socketPath).request(DaemonRequest.Attach(4444))
+            )
+
+            val error =
+                assertIs<DaemonResponse.Error>(
+                    DaemonClient(socketPath)
+                        .request(DaemonRequest.WaitUntilGone(sessionId = "pid-4444"))
+                )
+            // Not every agent failure is a timeout: only `timeout` earns the timeout code, while
+            // the precise taxonomy still rides along in `category`.
+            assertEquals(DaemonErrorCode.OperationFailed, error.code)
+            assertEquals(AgentErrorCategory.InvalidSelector.wireName, error.category)
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    @Test
+    fun `waitUntilGone on an unknown session fails closed`() {
+        val socketPath = temporarySocketPath()
+        val server = DaemonServer(socketPath, registry = DaemonSessionRegistry { error("unused") })
+
+        try {
+            val error =
+                assertIs<DaemonResponse.Error>(
+                    DaemonClient(socketPath)
+                        .request(DaemonRequest.WaitUntilGone(sessionId = "pid-1", tag = "gone"))
+                )
+            assertEquals(DaemonErrorCode.SessionNotFound, error.code)
+        } finally {
+            server.close()
+            assertTrue(server.awaitTermination())
+            deleteTemporarySocketPath(socketPath)
+        }
+    }
+
+    private fun temporarySocketPath(): Path =
+        if ("posix" in FileSystems.getDefault().supportedFileAttributeViews()) {
+            Path.of("/tmp", "sp-g-${UUID.randomUUID().toString().take(8)}", "daemon", "daemon.sock")
+        } else {
+            Files.createTempDirectory("spectre-gone-test").resolve("daemon").resolve("daemon.sock")
+        }
+
+    private fun deleteTemporarySocketPath(socketPath: Path) {
+        Files.deleteIfExists(socketPath)
+        Files.deleteIfExists(socketPath.parent)
+        Files.deleteIfExists(socketPath.parent.parent)
+    }
+}

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/daemon/TestDaemonSessionAutomator.kt
@@ -45,6 +45,11 @@ internal class TestDaemonSessionAutomator(
         { _, _, _, _ ->
             error("waitForNode not stubbed")
         },
+    private val waitUntilGoneAction:
+        (tag: String?, text: String?, timeoutMs: Long, pollIntervalMs: Long) -> Unit =
+        { _, _, _, _ ->
+            error("waitUntilGone not stubbed")
+        },
     private val finalizeRecordingAction: (Set<String>) -> Unit = {},
     private val closeAction: () -> Unit = {},
 ) : DaemonSessionAutomator {
@@ -82,6 +87,11 @@ internal class TestDaemonSessionAutomator(
     ): NodeSnapshotDto {
         ensureOpen("waitForNode")
         return waitForNodeResult(tag, text, timeoutMs, pollIntervalMs)
+    }
+
+    override fun waitUntilGone(tag: String?, text: String?, timeoutMs: Long, pollIntervalMs: Long) {
+        ensureOpen("waitUntilGone")
+        waitUntilGoneAction(tag, text, timeoutMs, pollIntervalMs)
     }
 
     override fun waitForVisualIdle(timeoutMs: Long, stableFrames: Int, pollIntervalMs: Long): Unit =

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpServerTest.kt
@@ -83,6 +83,7 @@ class SpectreMcpServerTest {
                 "find",
                 "find_text",
                 "wait_for_node",
+                "wait_until_gone",
                 "wait_for_visual_idle",
                 "wait_for_reload_settled",
                 "click",
@@ -382,6 +383,70 @@ class SpectreMcpServerTest {
             "session session-42 was not found",
             (result.content.single() as TextContent).text,
         )
+    }
+
+    @Test
+    fun `wait_until_gone forwards the selector and timeout to the daemon`() = runBlocking {
+        var seen: DaemonRequest? = null
+        val server =
+            SpectreMcpServer.create(
+                request = { request ->
+                    seen = request
+                    DaemonResponse.Completed("pid-42")
+                }
+            )
+
+        val result =
+            invokeTool(
+                server,
+                "wait_until_gone",
+                buildJsonObject {
+                    put("session_id", "pid-42")
+                    put("tag", "popup.body")
+                    put("timeout_ms", 750)
+                },
+            )
+
+        assertEquals(
+            DaemonRequest.WaitUntilGone(
+                sessionId = "pid-42",
+                tag = "popup.body",
+                text = null,
+                timeoutMs = 750,
+            ),
+            seen,
+        )
+        assertTrue(result.isError != true, "wait_until_gone should succeed on Completed")
+    }
+
+    @Test
+    fun `wait_until_gone surfaces the still-present diagnostics as an MCP error`() = runBlocking {
+        val diagnostics =
+            """waitUntilGone timed out after 400ms: 2 node(s) matching tag="popup.body" """ +
+                "still present in tracked windows"
+        val server =
+            SpectreMcpServer.create(
+                request = {
+                    DaemonResponse.Error(
+                        code = DaemonErrorCode.Timeout,
+                        message = diagnostics,
+                        category = "timeout",
+                    )
+                }
+            )
+
+        val result =
+            invokeTool(
+                server,
+                "wait_until_gone",
+                buildJsonObject {
+                    put("session_id", "pid-42")
+                    put("tag", "popup.body")
+                },
+            )
+
+        assertTrue(result.isError == true)
+        assertEquals(diagnostics, (result.content.single() as TextContent).text)
     }
 
     private suspend fun invokeTool(

--- a/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
+++ b/cli/src/test/kotlin/dev/sebastiano/spectre/cli/mcp/SpectreMcpStdioIntegrationTest.kt
@@ -127,6 +127,7 @@ class SpectreMcpStdioIntegrationTest {
                         "tree",
                         "type_text",
                         "wait_for_node",
+                        "wait_until_gone",
                         "wait_for_visual_idle",
                         "wait_for_reload_settled",
                         "windows",

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -345,11 +345,19 @@ agent's in-target automator (timeout / quiet / poll; absolute deadline on the wi
 `waitForNode`). It does **not** observe idling resources registered on a different automator
 instance in the app. **Idling-resource registration** and `withTracing` remain in-process-only.
 
-`waitUntilGone` is the absence counterpart to `waitForNode` and carries the same absolute
-deadline. Its timeout is category `timeout` like the other waits, but the message is the
-deliverable: the in-target automator's own diagnostics — the selector, the timeout, and how many
-matching nodes were still present in tracked windows — travel back verbatim, so an attach client
-learns *what* is still on screen rather than only that the wait expired.
+Every wait's **timeout message travels back verbatim**. All four report category `timeout`, but
+the message is what makes a timeout actionable, and each wait produces its own: `waitForIdle`
+names the busy idling resources, `waitForVisualIdle` the frame-sample counts, `waitUntilGone` the
+selector and how many matching nodes were still present in tracked windows. An attach client
+learns *why* the wait expired, not merely that it did.
+
+That costs a little trailing room on the wire. The absolute deadline the client attaches to a wait
+is its budget **plus one second**, not the budget exactly: the agent enforces that deadline both
+with a scheduler and with a post-handler check, and on an exact deadline both fire at the same
+instant the in-target automator's own timeout does — a race the automator always loses, leaving
+callers with `Deadline elapsed during op` instead of the real message. The slack stays well inside
+the agent's own `timeout + 2s` suspend-bridge backstop, so a wedged automator is still claimed on
+the wire rather than waiting unbounded.
 
 Richer input verbs (`doubleClick` / `longClick` / `swipe` / `scrollWheel` / `pressKey`)
 are available over agent, HTTP, and daemon/CLI/MCP (#203). `focusWindow(nodeKey)` raises

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -321,6 +321,7 @@ can add a reliable preflight via `HotSpotDiagnosticMXBean`.
 | `capture(windowIndex)`| `AgentRequest.Capture`           | `AtomicCaptureResult` |
 | `windowIdentities(windowIndex?)` | `AgentRequest.WindowIdentity` | `List<WindowIdentityDto>` |
 | `waitForNode(...)`    | `AgentRequest.WaitForNode`       | `NodeSnapshotDto` |
+| `waitUntilGone(...)`  | `AgentRequest.WaitUntilGone`     | `Unit` (absence wait — #438; timeout error keeps the selector, timeout, and still-present count) |
 | `waitForVisualIdle(...)` | `AgentRequest.WaitForVisualIdle` | `Unit`         |
 | `waitForIdle(...)`    | `AgentRequest.WaitForIdle`       | `Unit` (fingerprint wait; no idling-resource registration over attach — #362) |
 | `printTree()`         | `AgentRequest.PrintTree`         | `String` (human-readable dump — #362) |
@@ -338,11 +339,17 @@ translateY)`; scale widths/heights by `scaleX`/`scaleY` only (no translation). D
 recording (#183) uses this so capture stays on the daemon host rather than over the
 transport.
 
-`waitForNode`, `waitForVisualIdle` (#201), and `waitForIdle` (#362) are available over the
-agent transport. `waitForIdle` runs a **fingerprint-only** wait on the agent's in-target
-automator (timeout / quiet / poll; absolute deadline on the wire like `waitForNode`). It does
-**not** observe idling resources registered on a different automator instance in the app.
-**Idling-resource registration** and `withTracing` remain in-process-only.
+`waitForNode`, `waitForVisualIdle` (#201), `waitForIdle` (#362), and `waitUntilGone` (#438)
+are available over the agent transport. `waitForIdle` runs a **fingerprint-only** wait on the
+agent's in-target automator (timeout / quiet / poll; absolute deadline on the wire like
+`waitForNode`). It does **not** observe idling resources registered on a different automator
+instance in the app. **Idling-resource registration** and `withTracing` remain in-process-only.
+
+`waitUntilGone` is the absence counterpart to `waitForNode` and carries the same absolute
+deadline. Its timeout is category `timeout` like the other waits, but the message is the
+deliverable: the in-target automator's own diagnostics — the selector, the timeout, and how many
+matching nodes were still present in tracked windows — travel back verbatim, so an attach client
+learns *what* is still on screen rather than only that the wait expired.
 
 Richer input verbs (`doubleClick` / `longClick` / `swipe` / `scrollWheel` / `pressKey`)
 are available over agent, HTTP, and daemon/CLI/MCP (#203). `focusWindow(nodeKey)` raises
@@ -585,9 +592,9 @@ Not additive-safe without a version bump:
   # PowerShell: quote -P… so the shell does not split on the property name
   ./gradlew :agent:test "-Pspectre.agent.attachE2e.allowWindows=true" --tests '*AgentAttachIntegration*'
   ```
-- **Wait ops.** `waitForNode`, `waitForVisualIdle`, and fingerprint `waitForIdle` are
-  supported over agent IPC with shared deadline budgets and cancel. Idling-resource
-  registration stays in-process only.
+- **Wait ops.** `waitForNode`, `waitUntilGone`, `waitForVisualIdle`, and fingerprint
+  `waitForIdle` are supported over agent IPC with shared deadline budgets and cancel.
+  Idling-resource registration stays in-process only.
 - **IntelliJ-hosted Compose**: the classloader-disambiguation rule (D-14 in the plan) was
   designed to handle `PluginClassLoader` chains but isn't automatically tested yet. If
   you hit issues attaching to an IntelliJ-hosted target, file a Spectre issue with the
@@ -657,7 +664,8 @@ Restart Claude Code after changing the configuration. It can then use these tool
 1. `list_processes` to find the target PID.
 2. `attach` with that PID and retain the returned `sessionId`.
 3. `tree`, `find`, or `find_text` / `wait_for_node` for keys, then input tools
-   (`click`, `double_click`, `long_click`, `swipe`, `scroll_wheel`, `press_key`, `type_text`).
+   (`click`, `double_click`, `long_click`, `swipe`, `scroll_wheel`, `press_key`, `type_text`),
+   and `wait_until_gone` after a dismissal before touching what it revealed.
 4. `screenshot` with `fullscreen=true` for an inline full-desktop PNG (window/surface targets
    fail closed on attach), or `capture` / `record_*` for daemon-filesystem artifacts (paths only).
 5. When the target runs under Compose Hot Reload: call `wait_for_reload_settled` **before**

--- a/docs/guide/capability-matrix.md
+++ b/docs/guide/capability-matrix.md
@@ -80,7 +80,8 @@ boundary without a different design:
 | `waitForIdle` (idling-resource registration) | Live callbacks — use fingerprint wait over attach instead (#362) |
 
 Remote **waits** (`waitForNode` over agent — #201, also CLI `wait-for-node` / MCP
-`wait_for_node`; **`waitForIdle` fingerprint wait** over agent — #362), **selectors**
+`wait_for_node`; **`waitUntilGone`** over agent — #438, also CLI `wait-until-gone` / MCP
+`wait_until_gone`; **`waitForIdle` fingerprint wait** over agent — #362), **selectors**
 (`findByText` / role / content-description — #202), and **input verbs** (`doubleClick` /
 `swipe` / `scrollWheel` — #203) are **Supported** on agent under Linux Xvfb and macOS desktop
 via `AgentContractCorpusTest` / reflective wait suites against `agent-test-fixture`. Agent
@@ -89,9 +90,21 @@ via `AgentContractCorpusTest` / reflective wait suites against `agent-test-fixtu
 retries — same class as `typeText`). Agent **`focusWindow`** (#364) is **Supported** on Linux
 Xvfb and macOS desktop (raises the window hosting a node before real keyboard input); HTTP
 `focusWindow` is **Unsupported by design** for this issue. HTTP selector entry points are covered
-by headless `HttpContractCorpusTest`. Some HTTP input/wait cells and agent `longClick` /
+by headless `HttpContractCorpusTest`. Some HTTP input cells and agent `longClick` /
 `waitForVisualIdle` remain **Not yet CI-executed**. Idling-resource **registration** over attach
 stays **Unsupported by design**.
+
+The **HTTP** transport exposes no wait route at all — `SpectreServer` has none — so every HTTP wait
+cell (`waitForNode`, `waitUntilGone`, `waitForVisualIdle`) is **Not yet CI-executed** because it is
+unrouted, not because a routed op is waiting on a display-backed fixture. `waitUntilGone` was added
+only where `waitForNode` already reaches: in-process, agent attach, CLI, and MCP.
+
+For `waitUntilGone`, the agent cells are claimed on the strength of two corpus scenarios that run
+inside `AgentContractCorpusTest`: a selector that matches nothing returns instead of burning its
+budget, and a selector that is still on screen times out with taxonomy `timeout` **and** a message
+still naming the selector, the timeout, and the still-present node count. The second scenario is the
+one that matters for a transport claim — a boundary that flattened those diagnostics into a bare
+"timed out" would fail the cell rather than quietly pass it.
 
 ## How to read a cell
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -155,6 +155,7 @@ spectre tree <session-id> --json
 spectre find <session-id> save-button --json
 spectre find-text <session-id> "Save" --json
 spectre wait-for-node <session-id> --tag save-button
+spectre wait-until-gone <session-id> --tag popup-body
 spectre wait-for-visual-idle <session-id>
 spectre click <session-id> <node-key>
 spectre double-click <session-id> <node-key>
@@ -201,11 +202,22 @@ Every session command takes the session id as the first argument unless noted. M
 | `find <session-id> <test-tag>` | Exact Compose test-tag match | Single snapshot; does not wait |
 | `find-text <session-id> <text>` | Find by visible/editable text | Exact match by default; `--substring` for contains |
 | `wait-for-node <session-id>` | Poll until tag and/or text match | `--tag`, `--text` (at least one), `--timeout-ms` default **5000** |
+| `wait-until-gone <session-id>` | Poll until **nothing** matches tag and/or text | `--tag`, `--text` (at least one), `--timeout-ms` default **5000** |
 | `wait-for-visual-idle <session-id>` | Wait until consecutive frames are stable | `--timeout-ms` default **5000** |
 | `wait --reload-settled <session-id>` | Compose Hot Reload settle only | Requires `--reload-settled`; `--timeout-ms` default **60000**; fails closed when HR is not active |
 
 Queries (`find`, `find-text`, `tree`) do a **single read** — they never retry. Use
 `wait-for-node` when the UI is still settling.
+
+`wait-until-gone` is the absence counterpart: it returns once nothing matches, so use it after
+dismissing a popup, menu, or dialog rather than polling `find` yourself. It refreshes the tracked
+windows before every poll, which is what lets it see a Compose popup that took its whole window
+with it. On timeout it exits **5** and prints the selector, the timeout, and how many matching
+nodes were still on screen:
+
+```text
+Spectre daemon error: Agent reported timeout for waitUntilGone: IllegalStateException: waitUntilGone timed out after 5000ms: 1 node(s) matching tag="popup.body" still present in tracked windows
+```
 
 ### Input
 
@@ -397,6 +409,7 @@ Inputs use snake_case JSON fields. Successful non-screenshot tools return **JSON
 | `find` | `session_id`, `test_tag` | — | nodes list (exact test tag) |
 | `find_text` | `session_id`, `text` | `exact` (default **true**) | nodes list |
 | `wait_for_node` | `session_id` | `tag`, `text`, `timeout_ms` (**5000**) | nodes when matched |
+| `wait_until_gone` | `session_id` | `tag`, `text`, `timeout_ms` (**5000**) | `{ "sessionId" }` completed once nothing matches; `isError` on timeout, with the selector, timeout, and still-present count in the message |
 | `wait_for_visual_idle` | `session_id` | `timeout_ms` (**5000**) | `{ "sessionId" }` completed |
 | `wait_for_reload_settled` | `session_id` | `timeout_ms` (**60000**) | completed; fails if HR inactive |
 | `click` | `session_id`, `node_key` | — | completed |

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -108,6 +108,12 @@ Use it after dismissing a popup, menu, or dialog — before asserting on whateve
 dismissal revealed, or before the next click that would otherwise land on the closing
 surface.
 
+It is reachable over every transport `waitForNode` reaches: CLI
+[`wait-until-gone`](cli.md#inspection-and-waits), MCP `wait_until_gone`, and agent attach
+(`AttachedAutomator.waitUntilGone`). The timeout diagnostics above cross those boundaries
+intact, so a remote caller still learns which selector stayed on screen and how many nodes
+matched — see the [capability matrix](capability-matrix.md) for the per-transport cell states.
+
 ## `waitForIdle`
 
 The "everything has settled" barrier:

--- a/docs/guide/synchronization.md
+++ b/docs/guide/synchronization.md
@@ -111,8 +111,10 @@ surface.
 It is reachable over every transport `waitForNode` reaches: CLI
 [`wait-until-gone`](cli.md#inspection-and-waits), MCP `wait_until_gone`, and agent attach
 (`AttachedAutomator.waitUntilGone`). The timeout diagnostics above cross those boundaries
-intact, so a remote caller still learns which selector stayed on screen and how many nodes
-matched — see the [capability matrix](capability-matrix.md) for the per-transport cell states.
+intact — as do the other waits' — so a remote caller still learns which selector stayed on
+screen and how many nodes matched. See the [capability matrix](capability-matrix.md) for the
+per-transport cell states and [agent attach](agent.md) for how the wire deadline is sized to
+let those messages through.
 
 ## `waitForIdle`
 

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -209,6 +209,7 @@ public abstract interface class dev/sebastiano/spectre/testing/contract/Automato
 	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
 	public fun focusWindow (Ljava/lang/String;)V
 	public fun getExpectsFixtureSemantics ()Z
+	public fun getSupportsAbsenceWait ()Z
 	public fun getSupportsExtendedParity ()Z
 	public fun getSupportsFixtureParity ()Z
 	public fun getSupportsWaitTaxonomy ()Z
@@ -235,6 +236,7 @@ public final class dev/sebastiano/spectre/testing/contract/AutomatorContractDriv
 	public static synthetic fun findByText$default (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;ZILjava/lang/Object;)Ljava/util/List;
 	public static fun focusWindow (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;)V
 	public static fun getExpectsFixtureSemantics (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
+	public static fun getSupportsAbsenceWait (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
 	public static fun getSupportsExtendedParity (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
 	public static fun getSupportsFixtureParity (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z
 	public static fun getSupportsWaitTaxonomy (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;)Z

--- a/testing/api/testing.api
+++ b/testing/api/testing.api
@@ -221,6 +221,8 @@ public abstract interface class dev/sebastiano/spectre/testing/contract/Automato
 	public abstract fun typeText (Ljava/lang/String;)V
 	public fun waitForNode (Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/String;
 	public fun waitForNodeFailureCategory (Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/String;
+	public fun waitUntilGone (Ljava/lang/String;Ljava/lang/String;J)V
+	public fun waitUntilGoneFailure (Ljava/lang/String;Ljava/lang/String;J)Ldev/sebastiano/spectre/testing/contract/ContractWaitFailure;
 	public abstract fun windows ()Ljava/util/List;
 }
 
@@ -243,6 +245,8 @@ public final class dev/sebastiano/spectre/testing/contract/AutomatorContractDriv
 	public static fun swipe (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Ljava/lang/String;)V
 	public static fun waitForNode (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/String;
 	public static fun waitForNodeFailureCategory (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Ljava/lang/String;J)Ljava/lang/String;
+	public static fun waitUntilGone (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Ljava/lang/String;J)V
+	public static fun waitUntilGoneFailure (Ldev/sebastiano/spectre/testing/contract/AutomatorContractDriver;Ljava/lang/String;Ljava/lang/String;J)Ldev/sebastiano/spectre/testing/contract/ContractWaitFailure;
 }
 
 public final class dev/sebastiano/spectre/testing/contract/AutomatorOperation : java/lang/Enum {
@@ -265,6 +269,7 @@ public final class dev/sebastiano/spectre/testing/contract/AutomatorOperation : 
 	public static final field WaitForIdle Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field WaitForNode Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field WaitForVisualIdle Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
+	public static final field WaitUntilGone Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field WindowIdentities Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field Windows Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
 	public static final field WithTracing Ldev/sebastiano/spectre/testing/contract/AutomatorOperation;
@@ -361,6 +366,19 @@ public final class dev/sebastiano/spectre/testing/contract/ContractNode {
 	public final fun getKey ()Ljava/lang/String;
 	public final fun getTestTag ()Ljava/lang/String;
 	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class dev/sebastiano/spectre/testing/contract/ContractWaitFailure {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Ldev/sebastiano/spectre/testing/contract/ContractWaitFailure;
+	public static synthetic fun copy$default (Ldev/sebastiano/spectre/testing/contract/ContractWaitFailure;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Ldev/sebastiano/spectre/testing/contract/ContractWaitFailure;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCategory ()Ljava/lang/String;
+	public final fun getMessage ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
@@ -1,5 +1,7 @@
 package dev.sebastiano.spectre.testing.contract
 
+import java.util.concurrent.TimeUnit
+
 /**
  * Transport-agnostic view of a tracked window for the shared contract corpus.
  *
@@ -100,6 +102,29 @@ public interface AutomatorContractDriver : AutoCloseable {
         error("waitForNodeFailureCategory not implemented for $transport")
 
     /**
+     * Optional absence wait (#438). Must return once nothing matches [tag] / [text], and throw when
+     * the selector is still present at [timeoutMs].
+     */
+    public fun waitUntilGone(tag: String?, text: String?, timeoutMs: Long) {
+        error("waitUntilGone not implemented for $transport")
+    }
+
+    /**
+     * Stable taxonomy name **and** message for a failed [waitUntilGone], the counterpart to
+     * [waitForNodeFailureCategory].
+     *
+     * The message is part of the contract, not decoration: an absence wait that times out is only
+     * actionable if it says which selector is still on screen, how long it waited, and how many
+     * nodes matched. Implementations return what the transport actually delivered — never a
+     * synthesised message — so a transport that flattens the diagnostics fails the corpus.
+     */
+    public fun waitUntilGoneFailure(
+        tag: String?,
+        text: String?,
+        timeoutMs: Long,
+    ): ContractWaitFailure = error("waitUntilGoneFailure not implemented for $transport")
+
+    /**
      * Optional screenshot probe. Return `null` if the transport/driver does not exercise screenshot
      * in this corpus level; non-null means bytes or a decoded image were obtained.
      */
@@ -124,14 +149,20 @@ public interface AutomatorContractDriver : AutoCloseable {
         get() = supportsFixtureParity
 
     /**
-     * When true, [waitForNodeFailureCategory] is implemented (agent + in-process). HTTP has no wait
-     * routes (#201 is agent-scoped).
+     * When true, [waitForNodeFailureCategory] and [waitUntilGone] are implemented (agent +
+     * in-process). HTTP has no wait routes at all (#201 is agent-scoped), so it stays false there.
      */
     public val supportsWaitTaxonomy: Boolean
         get() = false
 
     override fun close() {}
 }
+
+/**
+ * What a transport actually reported for a failed wait: the #199-style taxonomy [category] and the
+ * verbatim [message] the caller would see.
+ */
+public data class ContractWaitFailure(public val category: String, public val message: String)
 
 /** Lightweight screenshot proof without forcing BufferedImage on every driver. */
 public data class ScreenshotProbe(public val byteCount: Int, public val formatHint: String = "png")
@@ -339,6 +370,25 @@ public object AutomatorContractCorpus {
                     }
                     "category=$category"
                 }
+            // #438 absence wait, mirror image of the above: a selector that matches nothing is
+            // already gone, so the wait must return rather than burn its budget. Runs headless
+            // too — an empty tree is the strongest possible "nothing matches".
+            out +=
+                scenario("wait-until-gone-absent-selector", driver.transport) {
+                    val budgetMs = ABSENT_SELECTOR_BUDGET_MS
+                    val startedAt = System.nanoTime()
+                    driver.waitUntilGone(
+                        tag = "agent-fixture-never-appears",
+                        text = null,
+                        timeoutMs = budgetMs,
+                    )
+                    val elapsedMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startedAt)
+                    check(elapsedMs < budgetMs) {
+                        "waitUntilGone waited ${elapsedMs}ms for a selector that never matched; " +
+                            "it should return on the first poll"
+                    }
+                    "elapsedMs=$elapsedMs"
+                }
         }
         return out
     }
@@ -373,17 +423,7 @@ public object AutomatorContractCorpus {
                 check(nodes.isNotEmpty()) { "findByContentDescription empty" }
                 "matched=${nodes.size}"
             }
-        out +=
-            scenario("wait-for-node-present-tag", driver.transport) {
-                val key =
-                    driver.waitForNode(
-                        tag = ContractFixtureTags.BUTTON,
-                        text = null,
-                        timeoutMs = 3_000,
-                    )
-                check(key.isNotBlank()) { "waitForNode returned blank key" }
-                "key=$key"
-            }
+        out += fixtureWaitScenarios(driver)
         // #364: raise the window hosting a known node before further Robot input.
         out +=
             scenario("focus-window-fixture-button", driver.transport) {
@@ -452,6 +492,62 @@ public object AutomatorContractCorpus {
             }
         return out
     }
+
+    /**
+     * Fixture-backed wait scenarios: `waitForNode` finds a node that is there (#201), and
+     * `waitUntilGone` refuses to call one that is still there gone (#438).
+     *
+     * Split out of [fixtureParityScenarios] so each stays readable — the wait pair asserts on
+     * timing and failure diagnostics, the rest asserts on selectors and input verbs.
+     */
+    private fun fixtureWaitScenarios(driver: AutomatorContractDriver): List<ScenarioResult> {
+        val out = mutableListOf<ScenarioResult>()
+        out +=
+            scenario("wait-for-node-present-tag", driver.transport) {
+                val key =
+                    driver.waitForNode(
+                        tag = ContractFixtureTags.BUTTON,
+                        text = null,
+                        timeoutMs = 3_000,
+                    )
+                check(key.isNotBlank()) { "waitForNode returned blank key" }
+                "key=$key"
+            }
+        // #438: the fixture button is permanently on screen, so an absence wait for it must time
+        // out — and the diagnostics are the deliverable. Asserting the message (not just the
+        // taxonomy) is what stops a transport from flattening "2 nodes matching tag=… are still
+        // there" into a bare "timed out" on its way across the boundary.
+        out +=
+            scenario("wait-until-gone-timeout-diagnostics", driver.transport) {
+                val timeoutMs = 400L
+                val failure =
+                    driver.waitUntilGoneFailure(
+                        tag = ContractFixtureTags.BUTTON,
+                        text = null,
+                        timeoutMs = timeoutMs,
+                    )
+                check(failure.category == "timeout") {
+                    "expected timeout taxonomy, got category=${failure.category}"
+                }
+                val missing = buildList {
+                    if (!failure.message.contains(ContractFixtureTags.BUTTON)) add("selector")
+                    if (!failure.message.contains("${timeoutMs}ms")) add("timeout")
+                    if (!STILL_PRESENT_COUNT.containsMatchIn(failure.message)) add("count")
+                }
+                check(missing.isEmpty()) {
+                    "absence diagnostics lost ${missing.joinToString()} crossing the transport: " +
+                        failure.message
+                }
+                "category=${failure.category}"
+            }
+        return out
+    }
+
+    /** Budget for the absent-selector scenario: the wait must return long before this. */
+    private const val ABSENT_SELECTOR_BUDGET_MS: Long = 5_000
+
+    /** Matches the "N node(s)" clause every `waitUntilGone` timeout must carry. */
+    private val STILL_PRESENT_COUNT = Regex("""\d+ node\(s\)""")
 
     private inline fun scenario(
         id: String,

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/AutomatorContractCorpus.kt
@@ -149,10 +149,23 @@ public interface AutomatorContractDriver : AutoCloseable {
         get() = supportsFixtureParity
 
     /**
-     * When true, [waitForNodeFailureCategory] and [waitUntilGone] are implemented (agent +
-     * in-process). HTTP has no wait routes at all (#201 is agent-scoped), so it stays false there.
+     * When true, [waitForNodeFailureCategory] is implemented (agent + in-process). HTTP has no wait
+     * routes (#201 is agent-scoped).
      */
     public val supportsWaitTaxonomy: Boolean
+        get() = false
+
+    /**
+     * When true, [waitUntilGone] and [waitUntilGoneFailure] are implemented (#438).
+     *
+     * Deliberately its own gate rather than folded into [supportsWaitTaxonomy]. That flag's
+     * published contract promised only [waitForNodeFailureCategory], so a driver that already sets
+     * it true — including one outside this repo — would suddenly be asked for an absence wait it
+     * never claimed and fail the corpus on the default `error(...)` below. Defaulting to false
+     * keeps upgrading `:testing` a no-op for those drivers, the same compatibility care the
+     * deprecated [supportsExtendedParity] alias exists for.
+     */
+    public val supportsAbsenceWait: Boolean
         get() = false
 
     override fun close() {}
@@ -370,9 +383,12 @@ public object AutomatorContractCorpus {
                     }
                     "category=$category"
                 }
-            // #438 absence wait, mirror image of the above: a selector that matches nothing is
-            // already gone, so the wait must return rather than burn its budget. Runs headless
-            // too — an empty tree is the strongest possible "nothing matches".
+        }
+        if (driver.supportsAbsenceWait) {
+            // #438 absence wait, mirror image of the taxonomy scenario above: a selector that
+            // matches nothing is already gone, so the wait must return rather than burn its
+            // budget. Runs headless too — an empty tree is the strongest possible "nothing
+            // matches".
             out +=
                 scenario("wait-until-gone-absent-selector", driver.transport) {
                     val budgetMs = ABSENT_SELECTOR_BUDGET_MS
@@ -517,6 +533,7 @@ public object AutomatorContractCorpus {
         // out — and the diagnostics are the deliverable. Asserting the message (not just the
         // taxonomy) is what stops a transport from flattening "2 nodes matching tag=… are still
         // there" into a bare "timed out" on its way across the boundary.
+        if (!driver.supportsAbsenceWait) return out
         out +=
             scenario("wait-until-gone-timeout-diagnostics", driver.transport) {
                 val timeoutMs = 400L

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrix.kt
@@ -441,6 +441,22 @@ public object CapabilityMatrix {
         )
         add(
             CapabilityCell(
+                operation = AutomatorOperation.WaitUntilGone,
+                transport = AutomatorTransport.InProcess,
+                platform = PlatformPrerequisite.AnyJvm,
+                state = CellState.Supported,
+                evidence =
+                    listOf(
+                        coreEvidence(
+                            "core-wait-until-gone",
+                            "WaitUntilGoneTest.kt",
+                            "Core waitUntilGone unit tests, including the timeout diagnostics",
+                        )
+                    ),
+            )
+        )
+        add(
+            CapabilityCell(
                 operation = AutomatorOperation.RegisterIdlingResource,
                 transport = AutomatorTransport.InProcess,
                 platform = PlatformPrerequisite.AnyJvm,
@@ -478,6 +494,7 @@ public object CapabilityMatrix {
         for (op in
             listOf(
                 AutomatorOperation.WaitForNode,
+                AutomatorOperation.WaitUntilGone,
                 AutomatorOperation.FindByText,
                 AutomatorOperation.FindByRole,
                 AutomatorOperation.FindByContentDescription,
@@ -554,7 +571,26 @@ public object CapabilityMatrix {
                 AutomatorOperation.Swipe,
                 AutomatorOperation.ScrollWheel,
                 AutomatorOperation.PressKey,
+            )) {
+            add(
+                CapabilityCell(
+                    operation = op,
+                    transport = AutomatorTransport.Http,
+                    platform = PlatformPrerequisite.AnyJvm,
+                    state = CellState.NotYetCiExecuted,
+                    rationale =
+                        "HTTP routes exist (#203); display-backed HTTP fixture corpus still open.",
+                )
+            )
+        }
+        // Waits are a different gap from the input verbs above: `SpectreServer` exposes no wait
+        // route at all, so these are unrouted rather than routed-but-unexercised. `waitUntilGone`
+        // (#438) inherits `waitForNode`'s position exactly — it is not added to a transport that
+        // carries no waits.
+        for (op in
+            listOf(
                 AutomatorOperation.WaitForNode,
+                AutomatorOperation.WaitUntilGone,
                 AutomatorOperation.WaitForVisualIdle,
             )) {
             add(
@@ -564,7 +600,8 @@ public object CapabilityMatrix {
                     platform = PlatformPrerequisite.AnyJvm,
                     state = CellState.NotYetCiExecuted,
                     rationale =
-                        "HTTP routes exist (#201–#203); display-backed HTTP fixture corpus still open.",
+                        "The HTTP transport has no wait routes (#201 was agent-scoped); use " +
+                            "in-process or agent attach until HTTP waits are designed.",
                 )
             )
         }

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrixModels.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/contract/CapabilityMatrixModels.kt
@@ -54,6 +54,8 @@ public enum class AutomatorOperation {
     Capture,
     WindowIdentities,
     WaitForNode,
+    /** Wait until nothing matches a tag/text selector — absence counterpart to [WaitForNode]. */
+    WaitUntilGone,
     WaitForVisualIdle,
     WaitForIdle,
     RegisterIdlingResource,

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/AbsenceWaitCapabilityGateTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/AbsenceWaitCapabilityGateTest.kt
@@ -1,0 +1,97 @@
+package dev.sebastiano.spectre.testing.contract
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The #438 absence-wait scenarios are gated on their own capability, not on
+ * [AutomatorContractDriver.supportsWaitTaxonomy].
+ *
+ * That flag's published contract promised only `waitForNodeFailureCategory`. Folding the absence
+ * wait into it would ask every driver that already sets it true — including drivers outside this
+ * repo — for a `waitUntilGone` they never claimed, and fail the corpus on the interface's default
+ * `error(...)`. Upgrading `:testing` must stay a no-op for them, so this pins the gate rather than
+ * trusting the two flags to stay independent by accident.
+ */
+class AbsenceWaitCapabilityGateTest {
+
+    @Test
+    fun `a driver claiming only wait taxonomy is never asked for an absence wait`() {
+        val driver = WaitTaxonomyOnlyDriver()
+
+        val result = AutomatorContractCorpus.run(driver = driver, realKeyboardEnabled = false)
+
+        assertEquals(
+            0,
+            driver.absenceWaitCalls,
+            "a driver that never claimed supportsAbsenceWait must not have waitUntilGone called",
+        )
+        assertTrue(
+            result.results.none { it.id.startsWith("wait-until-gone") },
+            "absence scenarios must not be recorded for a driver that did not opt in: " +
+                result.results.filter { it.id.startsWith("wait-until-gone") },
+        )
+        // The old contract still holds: its own wait scenario runs, and the whole corpus passes.
+        assertTrue(
+            result.results.any { it.id == "wait-for-node-timeout-taxonomy" },
+            "supportsWaitTaxonomy must still drive its own scenario",
+        )
+        result.requireAllPassed()
+    }
+
+    @Test
+    fun `opting in adds the absence scenario and actually calls the driver`() {
+        // Mirror image, so the gate cannot pass by disabling the scenario for everyone.
+        val driver = WaitTaxonomyOnlyDriver(absenceWait = true)
+
+        val result = AutomatorContractCorpus.run(driver = driver, realKeyboardEnabled = false)
+
+        assertEquals(1, driver.absenceWaitCalls)
+        assertTrue(
+            result.results.any { it.id == "wait-until-gone-absent-selector" },
+            "opted-in driver must run the absence scenario",
+        )
+        result.requireAllPassed()
+    }
+
+    /** Headless driver claiming the pre-#438 wait contract only, unless [absenceWait] is set. */
+    private class WaitTaxonomyOnlyDriver(private val absenceWait: Boolean = false) :
+        AutomatorContractDriver {
+        var absenceWaitCalls: Int = 0
+
+        override val transport: AutomatorTransport = AutomatorTransport.InProcess
+        override val expectsFixtureSemantics: Boolean = false
+        override val supportsWaitTaxonomy: Boolean = true
+        override val supportsAbsenceWait: Boolean
+            get() = absenceWait
+
+        override fun windows(): List<ContractWindow> = emptyList()
+
+        override fun allNodes(): List<ContractNode> = emptyList()
+
+        override fun findByTestTag(tag: String): List<ContractNode> = emptyList()
+
+        override fun findByText(text: String, exact: Boolean): List<ContractNode> = emptyList()
+
+        override fun findByContentDescription(description: String): List<ContractNode> = emptyList()
+
+        override fun findByRole(role: String): List<ContractNode> = emptyList()
+
+        override fun click(nodeKey: String): Unit = error("no node $nodeKey")
+
+        override fun typeText(text: String) = Unit
+
+        override fun waitForNodeFailureCategory(
+            tag: String?,
+            text: String?,
+            timeoutMs: Long,
+        ): String = "timeout"
+
+        override fun waitUntilGone(tag: String?, text: String?, timeoutMs: Long) {
+            absenceWaitCalls++
+        }
+
+        override fun close() = Unit
+    }
+}

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/InProcessContractCorpusTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/InProcessContractCorpusTest.kt
@@ -134,6 +134,30 @@ private class InProcessContractDriver(private val automator: ComposeAutomator) :
         }
     }
 
+    override fun waitUntilGone(tag: String?, text: String?, timeoutMs: Long) {
+        runBlocking {
+            automator.waitUntilGone(tag = tag, text = text, timeout = timeoutMs.milliseconds)
+        }
+    }
+
+    override fun waitUntilGoneFailure(
+        tag: String?,
+        text: String?,
+        timeoutMs: Long,
+    ): ContractWaitFailure {
+        try {
+            waitUntilGone(tag = tag, text = text, timeoutMs = timeoutMs)
+            error("waitUntilGone was expected to time out")
+        } catch (ex: IllegalStateException) {
+            // In-process has no wire taxonomy; the absence timeout is an IllegalStateException
+            // whose message carries the diagnostics. Report the message verbatim so the corpus
+            // sees exactly what a caller would.
+            val message = ex.message.orEmpty()
+            if (!message.contains("timed out")) throw ex
+            return ContractWaitFailure(category = "timeout", message = message)
+        }
+    }
+
     override fun screenshotProbe(): ScreenshotProbe? {
         val image = automator.screenshot()
         return ScreenshotProbe(

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/InProcessContractCorpusTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/contract/InProcessContractCorpusTest.kt
@@ -107,6 +107,8 @@ private class InProcessContractDriver(private val automator: ComposeAutomator) :
 
     override val supportsWaitTaxonomy: Boolean = true
 
+    override val supportsAbsenceWait: Boolean = true
+
     override fun waitForNode(tag: String?, text: String?, timeoutMs: Long): String = runBlocking {
         automator
             .waitForNode(tag = tag, text = text, timeout = timeoutMs.milliseconds)


### PR DESCRIPTION
## Summary

`waitUntilGone` landed in `:core` only (#438 / #482), so anyone driving a UI over the CLI, MCP, or agent attach still had to hand-roll the polling loop the verb was added to remove. This takes it everywhere `waitForNode` already reaches — agent (`AgentRequest.WaitUntilGone`, the reflective wait bridge, `AttachedAutomator.waitUntilGone`), daemon/CLI (`spectre wait-until-gone`, protocol minor → 1.13), and MCP (`wait_until_gone`).

**Not HTTP.** `SpectreServer` exposes no wait route at all, so `waitUntilGone` keeps `waitForNode`'s position there rather than inventing a wait surface. While checking that, the matrix rationale for the HTTP wait cells turned out to say *"HTTP routes exist (#201–#203)"*, which is false for the three wait ops; the wait cells now say what's true (unrouted) and the input verbs keep theirs. No cell **states** changed.

The second commit is a follow-up you asked for after review of the first. The absence wait needed its wire deadline to trail its budget, or the agent answered `Deadline elapsed during op` instead of the automator's message — and `waitForNode`, `waitForIdle` and `waitForVisualIdle` had the identical race and were still losing theirs. The agent enforces the deadline twice (a scheduler claims the op when it passes; `executeOp` discards the handler's answer if it passed while the handler ran), and on an exact `now + timeoutMs` deadline both fire at the same instant the automator's own timeout does. The automator always loses that race, so attach callers never saw what core actually produces: `waitForIdle` names the busy idling resources (including each resource's `diagnosticMessage()`), `waitForVisualIdle` the frame-sample counts, `waitUntilGone` the selector and still-present count. All four now share one second of trailing room, well inside the agent's own `timeout + 2s` suspend-bridge backstop, so a wedged automator is still claimed on the wire.

Refs #438.

## Test plan

The new corpus scenario is what caught the deadline bug, against the live fixture rather than in review — worth knowing when judging whether the coverage is load-bearing.

- [x] `./gradlew check` passes locally — **except** `:cli:verifyCliDistributionZip`, which fails in this container with *"Could not determine the Java version from …/runtime/bin/java"*. Verified it fails identically on clean `main` here, so it's the sandbox's bundled runtime, not this change; it is **unproven** on my side and needs CI.
- [x] `./gradlew ktfmtFormat` produced no changes
- [x] `AgentContractCorpusTest` under `xvfb-run`: `tests="2" skipped="0" failures="0"` — executed, not assumption-skipped. Full `:agent:test --rerun-tasks`: 396 tests, 0 failures.
- [x] `mkdocs build --strict` clean

What a reviewer might want to run:

- `./gradlew :testing:test --tests "*ContractCorpus*" --tests "*CapabilityMatrixEvidenceTest*"`
- `xvfb-run -a ./gradlew :agent:test --tests "*AgentContractCorpusTest*" --rerun-tasks` — the fixture-backed `wait-until-gone-timeout-diagnostics` scenario is the one that fails if a boundary flattens the message
- `./gradlew :agent:test --tests "*WaitDeadlineDiagnosticsTest*"` — drives a real `AttachedAutomator` over a real UDS with fakes that consume their whole wait budget; red on three of four waits before the second commit

Coverage added: two contract-corpus scenarios (a selector matching nothing returns instead of burning its budget, on every wait-capable transport including headless; a selector still on screen times out with taxonomy `timeout` **and** a message still naming selector, timeout and still-present count, fixture-backed), a real-daemon-wire suite (`DaemonWaitUntilGoneTest`), CLI and MCP surface tests, and the reflective/IPC boundary tests.

Matrix cells are claimed only where CI proves them: in-process via `WaitUntilGoneTest`, agent Linux Xvfb / macOS via `AgentContractCorpusTest`. Nothing claimed for HTTP.

Two consequential edits worth flagging: the protocol bump gave `DaemonEndpointTest`'s legacy-socket list a `daemon-v1-12.sock` entry, and both ABI dumps were regenerated (additive only).

## Confirmations

- [ ] I read [CONTRIBUTING.md](../CONTRIBUTING.md) and this PR is **not** LLM-generated. (See the "no clanker PRs or issues" rule.)

  Deliberately left unticked, because it would be false: this branch was written by Claude in your own Claude Code session, at your direction, including the explicit instruction to open this PR. Flagging it rather than quietly ticking the box — the no-clanker rule is yours to apply or waive here.
- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fzt8Sg4oC7NvMbgsyKsqto

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fzt8Sg4oC7NvMbgsyKsqto)_