### PR TITLE
Default every automator factory to synthetic RobotDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 </h1>
 
 A Kotlin library for driving Compose Desktop UIs from automated tests. Reads the semantics
-tree, drives mouse and keyboard input — either real OS-level events via `java.awt.Robot` or
-synthetic AWT events dispatched straight into the window hierarchy (`RobotDriver.synthetic(...)`,
-useful when tests run in parallel and can't fight over OS focus) — and records the screen,
+tree, drives mouse and keyboard input — synthetic AWT events dispatched straight into the
+window hierarchy by default (`RobotDriver.synthetic()`), or real OS-level events via
+`java.awt.Robot` when you pass `RobotDriver()` — and records the screen,
 against IDE-hosted Compose surfaces (IntelliJ, Jewel) and standalone desktop apps alike.
 
 > [!IMPORTANT]
@@ -50,7 +50,7 @@ npx skills add rock3r/spectre --skill spectre
 
 ## Modules
 
-- `core` — semantics tree, selectors, coordinate mapping, Robot-backed input.
+- `core` — semantics tree, selectors, coordinate mapping, synthetic-or-Robot input.
 - `server` — embedded HTTP transport (Ktor) for cross-JVM access. **Experimental**; see
   [`docs/SECURITY.md`](docs/SECURITY.md) for the trust model.
 - `recording` — region capture, window-targeted video capture, and native still

--- a/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
+++ b/agent/src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt
@@ -265,12 +265,33 @@ public object SpectreAgent {
                         "See https://github.com/rock3r/spectre/issues/472"
                 )
             }
-            robotDriverClass.getDeclaredConstructor(policyClass).newInstance(policy)
+            invokeSyntheticFactory(robotDriverClass, policy)
+                ?: robotDriverClass.getDeclaredConstructor(policyClass).newInstance(policy)
         } catch (_: ClassNotFoundException) {
-            robotDriverClass.getDeclaredConstructor().newInstance()
+            invokeSyntheticFactory(robotDriverClass, policy = null)
+                ?: robotDriverClass.getDeclaredConstructor().newInstance()
         } catch (_: NoSuchMethodException) {
-            robotDriverClass.getDeclaredConstructor().newInstance()
+            invokeSyntheticFactory(robotDriverClass, policy = null)
+                ?: robotDriverClass.getDeclaredConstructor().newInstance()
         }
+
+    /**
+     * Prefers `RobotDriver.Companion.synthetic(policy)` / `synthetic()` so attach defaults to
+     * synthetic AWT input. Falls back to `null` when the target core predates those factories.
+     */
+    private fun invokeSyntheticFactory(robotDriverClass: Class<*>, policy: Any?): Any? {
+        val companionField =
+            runCatching { robotDriverClass.getField("Companion") }.getOrNull() ?: return null
+        val companion = companionField.get(null) ?: return null
+        val methods = companion.javaClass.methods.filter { method -> method.name == "synthetic" }
+        if (policy != null) {
+            val withPolicy = methods.firstOrNull { method ->
+                method.parameterCount == 1 && method.parameterTypes[0].isInstance(policy)
+            }
+            if (withPolicy != null) return withPolicy.invoke(companion, policy)
+        }
+        return methods.firstOrNull { method -> method.parameterCount == 0 }?.invoke(companion)
+    }
 
     private fun invokeWindowsCountReflectively(automator: Any): Int {
         // `ComposeAutomator.windows` is a stale `@Volatile` cache populated by

--- a/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgentInputCoordinationCompatibilityTest.kt
+++ b/agent/src/test/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgentInputCoordinationCompatibilityTest.kt
@@ -7,11 +7,35 @@ package dev.sebastiano.spectre.agent.runtime
 
 import dev.sebastiano.spectre.agent.AttachInputCoordination
 import dev.sebastiano.spectre.core.InputLeasePolicy
+import java.nio.file.Path
+import kotlin.io.path.readText
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
+import kotlin.test.assertTrue
 
 class SpectreAgentInputCoordinationCompatibilityTest {
+
+    @Test
+    fun `attach constructs a synthetic driver when the target companion offers one`() {
+        val source =
+            Path.of("src/main/kotlin/dev/sebastiano/spectre/agent/runtime/SpectreAgent.kt")
+                .readText()
+        assertTrue(
+            source.contains("invokeSyntheticFactory") || source.contains("synthetic"),
+            "SpectreAgent must construct RobotDriver.synthetic rather than the real-OS constructor",
+        )
+
+        val driver =
+            SpectreAgent.createCoordinatedRobotDriverOrLegacyFallback(
+                javaClass.classLoader,
+                SyntheticRecordingRobotDriver::class.java,
+            )
+
+        val constructed = assertIs<SyntheticRecordingRobotDriver>(driver)
+        assertEquals(InputLeasePolicy.Required, constructed.policy)
+        assertTrue(constructed.viaSynthetic, "attach must call Companion.synthetic(policy)")
+    }
 
     @Test
     fun `legacy target without InputLeasePolicy falls back to no-argument driver`() {
@@ -112,4 +136,20 @@ class SpectreAgentInputCoordinationCompatibilityTest {
 
     /** Stands in for `RobotDriver`'s `(InputLeasePolicy)` constructor and records what it got. */
     private class PolicyRecordingRobotDriver(val policy: InputLeasePolicy)
+
+    /**
+     * Stands in for current-core `RobotDriver.Companion.synthetic(policy)` so the attach path
+     * cannot silently keep constructing the real-OS `(InputLeasePolicy)` constructor.
+     */
+    private class SyntheticRecordingRobotDriver(
+        val policy: InputLeasePolicy,
+        val viaSynthetic: Boolean,
+    ) {
+        constructor(policy: InputLeasePolicy) : this(policy, viaSynthetic = false)
+
+        companion object {
+            fun synthetic(policy: InputLeasePolicy): SyntheticRecordingRobotDriver =
+                SyntheticRecordingRobotDriver(policy, viaSynthetic = true)
+        }
+    }
 }

--- a/core/api/core.api
+++ b/core/api/core.api
@@ -309,6 +309,8 @@ public final class dev/sebastiano/spectre/core/RobotDriver : java/lang/AutoClose
 
 public final class dev/sebastiano/spectre/core/RobotDriver$Companion {
 	public final fun headless ()Ldev/sebastiano/spectre/core/RobotDriver;
+	public final fun synthetic ()Ldev/sebastiano/spectre/core/RobotDriver;
+	public final fun synthetic (Ldev/sebastiano/spectre/core/InputLeasePolicy;)Ldev/sebastiano/spectre/core/RobotDriver;
 	public final fun synthetic (Ljava/awt/Window;)Ldev/sebastiano/spectre/core/RobotDriver;
 	public final fun synthetic (Ljava/awt/Window;Ldev/sebastiano/spectre/core/InputLeasePolicy;)Ldev/sebastiano/spectre/core/RobotDriver;
 }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt
@@ -940,8 +940,13 @@ private constructor(
 
     public companion object {
 
+        /**
+         * In-process automator. The default [robotDriver] is [RobotDriver.synthetic] — synthetic
+         * AWT events into the live window hierarchy. Pass [RobotDriver] (no-arg or wrapping an
+         * existing `java.awt.Robot`) to opt into real OS-level input.
+         */
         public fun inProcess(
-            robotDriver: RobotDriver = RobotDriver(),
+            robotDriver: RobotDriver = RobotDriver.synthetic(),
             discoverWindows: Boolean = true,
         ): ComposeAutomator =
             ComposeAutomator(

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/InputCoordination.kt
@@ -278,7 +278,9 @@ internal class InputLeaseGuard(
         return when (resource) {
             CoordinatedResource.DESKTOP_ANY -> true
             CoordinatedResource.REAL_INPUT -> capabilities.realOsInput
-            CoordinatedResource.FOCUS -> true
+            // Synthetic input already skips REAL_INPUT. FOCUS has to follow that, otherwise
+            // attach's first focusWindow is the only verb that needs a live coordinator.
+            CoordinatedResource.FOCUS -> capabilities.realOsInput
             CoordinatedResource.SYSTEM_CLIPBOARD -> capabilities.sharedSystemClipboard
         }
     }

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/RobotDriver.kt
@@ -55,9 +55,10 @@ internal constructor(
     internal val allowsPlatformCapture: Boolean
         get() = screenCapture !== HeadlessThrowingScreenCaptureAdapter
 
-    // Public surface: callers may instantiate without arguments (defaults to a fresh
-    // AWT Robot + system clipboard) or hand in an existing Robot. The internal
-    // adapter-injecting constructor is reserved for tests within this module.
+    // Public surface: the no-argument constructor is the explicit real-OS opt-in
+    // (fresh AWT Robot + system clipboard). `ComposeAutomator.inProcess()` defaults to
+    // [synthetic] instead. The internal adapter-injecting constructor is reserved for
+    // tests within this module.
     public constructor() : this(AwtRobotAdapter(), SystemClipboardAdapter())
 
     /** Creates a real Robot driver with explicit cooperative input coordination [policy]. */
@@ -525,25 +526,36 @@ internal constructor(
     public companion object {
 
         /**
+         * Returns a [RobotDriver] that delivers synthetic AWT events into the live AWT hierarchy
+         * instead of routing through `java.awt.Robot`'s OS-level input. This is the default
+         * [ComposeAutomator.inProcess] driver. Windows created after construction are still
+         * hit-tested. Screenshots still use `java.awt.Robot.createScreenCapture` so Compose/Skiko
+         * pixels come from the OS framebuffer rather than Swing repainting the host component.
+         */
+        public fun synthetic(): RobotDriver = syntheticDriver(rootWindow = null)
+
+        /**
          * Returns a [RobotDriver] that delivers synthetic AWT events directly to [rootWindow]'s AWT
          * hierarchy instead of routing through `java.awt.Robot`'s OS-level input. Screenshots still
          * use `java.awt.Robot.createScreenCapture` so Compose/Skiko pixels come from the OS
          * framebuffer rather than Swing repainting the host component.
          */
-        public fun synthetic(rootWindow: Window): RobotDriver =
-            SyntheticRobotAdapter(rootWindow).let { syntheticInput ->
-                val realCapture = AwtRobotAdapter()
-                RobotDriver(
-                    robot = syntheticInput,
-                    clipboard = SystemClipboardAdapter(),
-                    tccGuard = defaultTccGuardFor(syntheticInput, realCapture),
-                    screenCapture = realCapture,
-                )
-            }
+        public fun synthetic(rootWindow: Window): RobotDriver = syntheticDriver(rootWindow)
 
         /** Returns a synthetic-input driver with explicit shared-resource coordination [policy]. */
         @ExperimentalSpectreInputCoordinationApi
+        public fun synthetic(policy: InputLeasePolicy): RobotDriver =
+            syntheticDriver(rootWindow = null, inputLeasePolicy = policy)
+
+        /** Returns a synthetic-input driver pinned to [rootWindow] with coordination [policy]. */
+        @ExperimentalSpectreInputCoordinationApi
         public fun synthetic(rootWindow: Window, policy: InputLeasePolicy): RobotDriver =
+            syntheticDriver(rootWindow, policy)
+
+        private fun syntheticDriver(
+            rootWindow: Window?,
+            inputLeasePolicy: InputLeasePolicy = InputLeasePolicy.Off,
+        ): RobotDriver =
             SyntheticRobotAdapter(rootWindow).let { syntheticInput ->
                 val realCapture = AwtRobotAdapter()
                 RobotDriver(
@@ -551,7 +563,7 @@ internal constructor(
                     clipboard = SystemClipboardAdapter(),
                     tccGuard = defaultTccGuardFor(syntheticInput, realCapture),
                     screenCapture = realCapture,
-                    inputLeasePolicy = policy,
+                    inputLeasePolicy = inputLeasePolicy,
                 )
             }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/SyntheticRobotAdapter.kt
@@ -26,14 +26,16 @@ import javax.swing.SwingUtilities
  * - OS-level shortcuts (Cmd+Tab, system menu access, etc.) are NOT exercised — those scenarios
  *   still need [RobotDriver]
  *
- * The driver discovers click targets by walking the root window plus all owned windows
- * ([Window.getOwnedWindows]) on every dispatch, so popups and secondary windows added after
- * construction work without re-creating the driver.
+ * The driver discovers click targets by walking [rootWindow] (when pinned) plus every other
+ * top-level window and its owned tree ([Window.getWindows] / [Window.getOwnedWindows]) on every
+ * dispatch, so popups and secondary windows added after construction work without re-creating the
+ * driver. A null [rootWindow] is the no-window factory used by `RobotDriver.synthetic()`: hit
+ * testing still walks the live AWT hierarchy, and key events fall back to the first showing window.
  *
  * Clipboard access is left as the system clipboard — paste-based [RobotDriver.pasteText] still
  * works with synthetic Cmd/Ctrl+V keystrokes.
  */
-internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdapter {
+internal class SyntheticRobotAdapter(private val rootWindow: Window? = null) : RobotAdapter {
 
     // Synthetic events have no OS-level inter-event delay; we always dispatch immediately.
     // The wait loop in ComposeAutomator handles synchronisation via waitForIdle / fingerprints.
@@ -272,7 +274,7 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
                 ?: pointerTarget
                 ?: composeFallbackTarget?.findKeyListenerSelfOrDescendant()
                 ?: composeFallbackTarget
-                ?: rootWindow
+                ?: keyFallbackWindow(windows)
         val event =
             KeyEvent(
                 target,
@@ -331,7 +333,10 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
 
     private fun allWindows(): List<Window> {
         val collected = LinkedHashSet<Window>()
-        collectWindowTree(rootWindow, collected)
+        val pinned = rootWindow
+        if (pinned != null) {
+            collectWindowTree(pinned, collected)
+        }
         // Walk every other top-level window (and its owned tree). The visibility check is
         // applied per-window inside `collectWindowTree` rather than at the top level: Swing's
         // `SharedOwnerFrame` (parent of `JDialog(null, …)`) is itself a top-level window that
@@ -339,12 +344,21 @@ internal class SyntheticRobotAdapter(private val rootWindow: Window) : RobotAdap
         // here would drop those dialogs and synthetic input would silently miss them, even
         // though `WindowTracker` correctly surfaces them.
         for (other in Window.getWindows()) {
-            if (other.owner == null && other !== rootWindow) {
+            if (other.owner == null && other !== pinned) {
                 collectWindowTree(other, collected)
             }
         }
         return collected.toList()
     }
+
+    private fun keyFallbackWindow(windows: List<Window>): Window =
+        rootWindow
+            ?: windows.firstOrNull { it.isShowing }
+            ?: windows.firstOrNull()
+            ?: error(
+                "RobotDriver.synthetic() has no AWT window to deliver key events to. " +
+                    "Create the Compose/Swing window first, or pass RobotDriver.synthetic(rootWindow)."
+            )
 }
 
 /**

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/DocsGuidanceContractTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/DocsGuidanceContractTest.kt
@@ -31,6 +31,7 @@ class DocsGuidanceContractTest {
         assertContains(docs, "printTree()` returns an empty string")
         assertContains(docs, "No Component provided")
         assertContains(docs, "RobotDriver.synthetic(rootWindow =")
+        assertContains(docs, "defaults to synthetic")
         assertContains(docs, "ExperimentalSpectreInputCoordinationApi")
         assertContains(docs, "spectre-input-coordinator-server")
         assertContains(docs, "InputIsolationConfig.perTest()")

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InProcessDefaultDriverTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InProcessDefaultDriverTest.kt
@@ -1,0 +1,166 @@
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.core
+
+import dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi
+import java.awt.BorderLayout
+import java.awt.Dimension
+import java.awt.event.MouseAdapter
+import java.awt.event.MouseEvent
+import java.nio.file.Path
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+import javax.swing.JFrame
+import javax.swing.JPanel
+import javax.swing.SwingUtilities
+import kotlin.io.path.readText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Timeout
+
+/**
+ * Locks the public default: every no-driver `ComposeAutomator.inProcess()` call constructs
+ * [RobotDriver.synthetic], not a real OS [RobotDriver].
+ */
+class InProcessDefaultDriverTest {
+
+    @Test
+    fun `inProcess default argument is RobotDriver synthetic`() {
+        val source =
+            Path.of("src/main/kotlin/dev/sebastiano/spectre/core/ComposeAutomator.kt").readText()
+        assertTrue(
+            source.contains("robotDriver: RobotDriver = RobotDriver.synthetic()"),
+            "ComposeAutomator.inProcess() must default to RobotDriver.synthetic()",
+        )
+        assertFalse(
+            source.contains("robotDriver: RobotDriver = RobotDriver()"),
+            "ComposeAutomator.inProcess() must not default to the real-OS RobotDriver()",
+        )
+    }
+
+    @Test
+    fun `synthetic companion exposes a no-window factory`() {
+        val noArg =
+            RobotDriver.Companion::class.java.methods.filter { method ->
+                method.name == "synthetic" && method.parameterCount == 0
+            }
+        assertTrue(
+            noArg.isNotEmpty(),
+            "RobotDriver.synthetic() must exist so inProcess() can default to it without a window",
+        )
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `inProcess without a driver reports synthetic capabilities`() {
+        assumeLiveAwtAvailable()
+        val automator = ComposeAutomator.inProcess()
+        assertFalse(
+            automator.inputCapabilities.realOsInput,
+            "Default inProcess() must not use real OS input",
+        )
+        assertTrue(
+            automator.inputCapabilities.sharedSystemClipboard,
+            "Default synthetic driver still uses the system clipboard for pasteText",
+        )
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `explicit RobotDriver remains real OS input`() {
+        assumeLiveAwtAvailable()
+        val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver())
+        assertTrue(
+            automator.inputCapabilities.realOsInput,
+            "RobotDriver() is the explicit real-OS opt-in",
+        )
+    }
+
+    @Test
+    @Timeout(value = TIMEOUT_SECONDS, unit = TimeUnit.SECONDS)
+    fun `no-window synthetic factory hits a window created after construction`() {
+        assumeLiveAwtAvailable()
+        val companion = RobotDriver.Companion
+        val noArg =
+            companion.javaClass.methods.singleOrNull { method ->
+                method.name == "synthetic" && method.parameterCount == 0
+            }
+        assertNotNull(noArg, "RobotDriver.synthetic() factory is required")
+        val driver = noArg.invoke(companion) as RobotDriver
+        assertFalse(driver.inputCapabilities.realOsInput)
+
+        val clicks = AtomicInteger(0)
+        val shown = CountDownLatch(1)
+        val target =
+            JPanel().apply {
+                isOpaque = true
+                addMouseListener(
+                    object : MouseAdapter() {
+                        override fun mouseClicked(event: MouseEvent) {
+                            clicks.incrementAndGet()
+                        }
+                    }
+                )
+            }
+        val frame = showFrameOnEdt(target, shown)
+        try {
+            assertTrue(shown.await(SHOW_TIMEOUT_SECONDS, TimeUnit.SECONDS), "frame did not show")
+            val (x, y) = targetCenterOnScreen(target)
+            runBlocking { driver.click(x, y) }
+            drainEdt()
+            assertEquals(1, clicks.get(), "expected one synthetic click on a later-created window")
+        } finally {
+            disposeFrame(frame)
+        }
+    }
+
+    private fun showFrameOnEdt(target: JPanel, shown: CountDownLatch): JFrame {
+        lateinit var frame: JFrame
+        SwingUtilities.invokeAndWait {
+            frame =
+                JFrame("InProcessDefaultDriverTest").apply {
+                    defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                    isUndecorated = true
+                    contentPane.layout = BorderLayout()
+                    contentPane.add(target, BorderLayout.CENTER)
+                    size = Dimension(FRAME_SIZE_PX, FRAME_SIZE_PX)
+                    setLocation(FRAME_OFFSET_PX, FRAME_OFFSET_PX)
+                    isVisible = true
+                }
+            shown.countDown()
+        }
+        return frame
+    }
+
+    private fun targetCenterOnScreen(target: JPanel): Pair<Int, Int> {
+        var center = 0 to 0
+        SwingUtilities.invokeAndWait {
+            val origin = target.locationOnScreen
+            center = (origin.x + target.width / 2) to (origin.y + target.height / 2)
+        }
+        return center
+    }
+
+    private fun drainEdt() {
+        repeat(2) { SwingUtilities.invokeAndWait {} }
+    }
+
+    private fun disposeFrame(frame: JFrame) {
+        SwingUtilities.invokeLater {
+            frame.isVisible = false
+            frame.dispose()
+        }
+    }
+
+    private companion object {
+        const val TIMEOUT_SECONDS: Long = 15
+        const val SHOW_TIMEOUT_SECONDS: Long = 5
+        const val FRAME_SIZE_PX: Int = 160
+        const val FRAME_OFFSET_PX: Int = 80
+    }
+}

--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -564,8 +564,21 @@ class InputLeaseGuardTest {
     }
 
     @Test
-    fun `synthetic focus participates when coordination is required`() {
+    fun `real OS focus participates when coordination is required`() {
         val coordinator = RecordingInputLeaseCoordinator()
+        val driver = realDriver(coordinator)
+
+        driver.withBlockingInput("focusWindow") {}
+
+        assertEquals(listOf("focusWindow"), coordinator.operations)
+    }
+
+    @Test
+    fun `synthetic focus bypasses coordinator like synthetic pointer`() {
+        val coordinator =
+            RecordingInputLeaseCoordinator(
+                acquireFailure = InputCoordinatorException("COORDINATOR_IO", "did not become ready")
+            )
         val driver =
             RobotDriver(
                 robot = LeaseTestRobotAdapter(),
@@ -576,9 +589,14 @@ class InputLeaseGuardTest {
                     InputCapabilities(realOsInput = false, sharedSystemClipboard = false),
             )
 
+        // Attach's default is now synthetic+Required. focusWindow is the first coordinated
+        // verb on that path; requiring a live coordinator here is what broke macOS hosted
+        // attach (semantics reads succeeded, focusWindow threw). Synthetic clicks already
+        // skip REAL_INPUT; FOCUS has to match or the first raise dies on an unreachable
+        // coordinator while the rest of the driver never needed one.
         driver.withBlockingInput("focusWindow") {}
 
-        assertEquals(listOf("focusWindow"), coordinator.operations)
+        assertEquals(emptyList(), coordinator.operations)
     }
 
     @Test

--- a/docs/DOCS-STYLE.md
+++ b/docs/DOCS-STYLE.md
@@ -126,9 +126,11 @@ corresponding doc page is touched:
   doesn't bundle Netty/CIO/Jetty — consumers add the engine themselves.
 - **`HttpComposeAutomator.DEFAULT_PORT` is `9274`.** That's the *client* default;
   the server-side port is whatever the consumer's Ktor engine listens on.
-- **`RobotDriver` public constructors.** `RobotDriver()` (default AWT), `RobotDriver(robot)`,
-  `RobotDriver.headless()`, `RobotDriver.synthetic(rootWindow)`. The
-  adapter-injecting constructor is `internal` and not for consumers.
+- **`RobotDriver` public constructors.** `RobotDriver.synthetic()` /
+  `RobotDriver.synthetic(rootWindow)` (the `ComposeAutomator.inProcess()` default),
+  `RobotDriver()` (explicit real-OS AWT Robot), `RobotDriver(robot)`,
+  `RobotDriver.headless()`. The adapter-injecting constructor is `internal` and not
+  for consumers.
 - **`RobotDriver.headless()` throws on input/screenshot/clipboard.** Every input,
   clipboard, and screenshot call raises `UnsupportedOperationException` so accidental
   real-I/O calls fail at the call site. `WindowTracker`/`SemanticsReader` are

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,8 +1,8 @@
 # Security notes
 
 Spectre is a JVM-first library for **automating live Compose Desktop UIs in trusted local /
-test environments**. It drives real OS input, captures screenshots, and records screen content
-by design. This page documents the trust boundaries Spectre relies on, the security-sensitive
+test environments**. It can drive synthetic or real OS input, captures screenshots, and
+records screen content by design. This page documents the trust boundaries Spectre relies on, the security-sensitive
 capabilities it exposes, and the risks that are explicitly accepted for the pre-1.0 release.
 
 Spectre is **pre-1.0**. The HTTP transport and cooperative desktop input coordinator are

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -97,9 +97,11 @@ version. Unit tests for internal math are necessary, but boundary tests catch dr
 
 `./gradlew check` is the pre-push gate, so it must stay runnable on a machine you are also using.
 
-Two test paths need the whole desktop to themselves. Both send real `java.awt.Robot` key events at
-a spawned Compose window, which only works while that window owns OS keyboard focus. A terminal, an
-editor, or a notification taking focus mid-run used to fail them.
+Two test paths need the whole desktop to themselves when they opt into real
+`java.awt.Robot` key events at a spawned Compose window, which only works while that window
+owns OS keyboard focus. A terminal, an editor, or a notification taking focus mid-run used
+to fail them. The default automator path is synthetic AWT input and does not need OS focus;
+these gated paths exist for the remaining real-keyboard contract cells.
 
 | Path | Where |
 |---|---|

--- a/docs/guide/agent.md
+++ b/docs/guide/agent.md
@@ -160,9 +160,11 @@ automator, then return DTOs or bytes to the attacher.
 
 The attacher also makes a best-effort attempt to start the experimental desktop input coordinator.
 Failure to start it does not block read-only attach operations. A target using the current core
-selects `InputLeasePolicy.Required`, so real input then fails closed if coordination remains
-unavailable. When a target has an older preinstalled core without `InputLeasePolicy`, bootstrap
-falls back to its legacy no-argument `RobotDriver`; that compatibility path is uncoordinated.
+selects `InputLeasePolicy.Required` on `RobotDriver.synthetic()`, so coordinated verbs
+(clipboard paste, or real OS input if the target opted in) then fail closed if
+coordination remains unavailable. When a target has an older preinstalled core without
+`InputLeasePolicy` or `synthetic()`, bootstrap falls back to its legacy no-argument
+`RobotDriver`; that compatibility path is uncoordinated.
 
 ### Injection without preinstalled core
 

--- a/docs/guide/automator.md
+++ b/docs/guide/automator.md
@@ -17,8 +17,9 @@ Build one with the default in-process configuration:
 val automator = ComposeAutomator.inProcess()
 ```
 
-For headless CI where constructing a real `java.awt.Robot` (or touching the system
-clipboard or screen) is unavailable, swap in `RobotDriver.headless()`:
+`inProcess()` defaults to synthetic AWT input. For headless CI where constructing a
+`java.awt.Robot` screenshot adapter (or touching the system clipboard or screen) is
+unavailable, swap in `RobotDriver.headless()`:
 
 ```kotlin
 val automator = ComposeAutomator.inProcess(robotDriver = RobotDriver.headless())
@@ -131,16 +132,16 @@ other Swing-backed dispatcher.
 
 ## Real input vs. synthetic input
 
-By default `ComposeAutomator.inProcess()` uses `RobotDriver()` — `java.awt.Robot`-backed
-real OS-level input. That's what end users actually do, so it's the most realistic.
+By default `ComposeAutomator.inProcess()` uses `RobotDriver.synthetic()` — synthetic AWT
+events posted into the live window hierarchy. That stays correct when tests run in
+parallel, when the host also does other UI work, and when the automator shares a JVM
+with IntelliJ/Jewel.
 
-The trade-off is that real OS input fights for global focus. Two parallel test JVMs
-clicking at the same time will collide. For that case `RobotDriver.synthetic(rootWindow)`
-dispatches AWT events directly into the target window's event queue:
+Pass `RobotDriver()` when you specifically need real OS-level `java.awt.Robot` input:
 
-- No real cursor moves, no keyboard focus stolen.
-- Tests in parallel processes can run without coordinating focus.
-- Some interactions (e.g., system-level shortcuts) won't behave the same way as real input.
+- The real cursor moves and the app takes system-wide keyboard focus.
+- End-to-end smokes can exercise system shortcuts and focus handoffs.
+- Two parallel test JVMs clicking at the same time will collide unless they coordinate.
 
 See [Driving input](interactions.md) for the per-call differences.
 

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -513,7 +513,9 @@ Same capture-mode distinctions as the CLI table above apply to MCP tool names
   and future incompatibility. The attaching process must be the **same OS user** as the target.
 - The transport is local-only and trusts the operating-system user account. Use it only for
   trusted development and test environments.
-- Input commands send real OS events. They can move focus and change application state.
+- Input commands use the attached target's driver (synthetic AWT events by default;
+  real OS events only if that target opted into `RobotDriver()`). They can still
+  change application state.
 - Node keys are short-lived. After an interaction changes the UI, run `tree` / `find` /
   `find-text` / `wait-for-node` again. On **reload-aware** sessions, keys are also invalidated
   after `wait --reload-settled` completes.

--- a/docs/guide/cross-jvm.md
+++ b/docs/guide/cross-jvm.md
@@ -31,8 +31,10 @@ top of an in-process `ComposeAutomator`; the test JVM talks to it through
     - Every route is **unauthenticated**. Anything that can reach the bound port
       can click, type, and capture screenshots.
     - Communication is **plaintext HTTP**. There is no TLS support.
-    - `click` and `typeText` drive **real OS input**; `screenshot` captures
-      whatever pixels the host JVM can see, including content from other windows.
+    - `click` and `typeText` drive the host automator's input driver (synthetic AWT
+      events by default; real OS input if that host opted into `RobotDriver()`);
+      `screenshot` captures whatever pixels the host JVM can see, including content
+      from other windows.
     - **Bind to `127.0.0.1`.** Do not expose this server on a network-reachable
       interface. The examples below pin the loopback bind explicitly.
     - Authentication, authorization, and TLS are tracked for a separately

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -120,8 +120,9 @@ description, or role — see [Finding nodes](selectors.md).
 ## What just happened
 
 - `ComposeAutomatorExtension` and `ComposeAutomatorRule` each build a fresh
-  `ComposeAutomator` for each test. The default factory is `ComposeAutomator.inProcess()`, which uses
-  `RobotDriver` for real OS-level input.
+  `ComposeAutomator` for each test. The default factory is `ComposeAutomator.inProcess()`, which
+  defaults to synthetic AWT input (`RobotDriver.synthetic()`). Pass `RobotDriver()` if you
+  need real OS-level input.
 - `waitForNode(tag = "CounterValue")` polls the semantics tree until the node exists.
   It's how you bridge the gap between "the test started" and "the UI is on screen".
 - `waitForVisualIdle()` waits until the on-screen pixels stop changing for a few frames in
@@ -129,8 +130,9 @@ description, or role — see [Finding nodes](selectors.md).
 - `findOneByTestTag(...)` does a single semantics-tree read — no waiting. If the result
   isn't what you expect, your UI probably wasn't idle yet.
 - `automator.click(node)` is `suspend` — it resolves the node's centre on screen,
-  dispatches a real mouse click via `java.awt.Robot`, and only hops to `Dispatchers.IO`
-  when the call originates on the AWT event dispatch thread.
+  dispatches a synthetic AWT click (or a real `java.awt.Robot` click if you opted in),
+  and only hops to `Dispatchers.IO` when the call originates on the AWT event dispatch
+  thread and the driver needs it.
 
 All interaction methods (`click`, `doubleClick`, `swipe`, `typeText`, `pasteText`, …) and all wait
 helpers (`waitForNode`, `waitUntilGone`, `waitUntil`, `waitForIdle`, `waitForVisualIdle`) are

--- a/docs/guide/input-coordination.md
+++ b/docs/guide/input-coordination.md
@@ -112,9 +112,11 @@ capture inside `withExclusiveInput` when it must not race another client's input
 ## When the coordinator cannot be reached {#coordinator-unreachable}
 
 `Required` never degrades — that is what it is for. Every capability that touches shared OS state
-(`focusWindow`, `click`, `typeText`, `pasteText`, …) fails when no coordinator answers, and
-[agent attach](agent.md) always uses `Required`, so on that path a broken coordinator takes down
-the whole input surface at once.
+**for that driver** fails when no coordinator answers. Real-OS `Required` drivers lease pointer,
+keyboard, focus, and clipboard. Synthetic `Required` drivers (attach and the in-process default)
+only lease the system clipboard — `focusWindow`, `click`, and `typeText` do not need a live
+coordinator. [Agent attach](agent.md) still uses `Required`, so a broken coordinator still fails
+clipboard-backed paste and explicit exclusive scopes.
 
 The failure names what it measured and what you can do about it:
 

--- a/docs/guide/intellij.md
+++ b/docs/guide/intellij.md
@@ -110,19 +110,20 @@ See [Driving input → Real vs. synthetic input](interactions.md#real-vs-synthet
 for the full trade-off rundown across `RobotDriver()`, `RobotDriver.synthetic(...)`,
 and `RobotDriver.headless()`. Two IDE-specific notes on top of that page:
 
-- **`synthetic` is the usual default.** When the JVM running the automator is also
-  the JVM hosting the UI, real OS input would dispatch events back to the IDE
-  you're inside, fight with whatever else has focus on the host machine, and move
-  the user's cursor visibly. Synthetic AWT events skip all of that. On macOS this
+- **`synthetic` is the default.** `ComposeAutomator.inProcess()` already uses
+  `RobotDriver.synthetic()`. When the JVM running the automator is also the JVM
+  hosting the UI, real OS input would dispatch events back to the IDE you're
+  inside, fight with whatever else has focus on the host machine, and move the
+  user's cursor visibly. Synthetic AWT events skip all of that. On macOS this
   also works for helper/test JVMs launched with `apple.awt.UIElement=true`: AWT may
   never report a `Window.focusOwner`, but Spectre routes key events to the
   key-listening Compose Desktop host so focused text fields still receive
-  `typeText`. The IntelliJ-specific recipe for the `rootWindow` argument is
-  `WindowManager.getInstance().getFrame(project)` — that's the `Window` shown in
-  the action sample above.
-- **`RobotDriver()` is still valid** when you specifically need to exercise
-  OS-level shortcut chains, focus transitions, or cross-window interactions —
-  those are the only things synthetic input doesn't cover.
+  `typeText`. Pinning `rootWindow` to
+  `WindowManager.getInstance().getFrame(project)` is still the IntelliJ-specific
+  recipe — that's the `Window` shown in the action sample above.
+- **`RobotDriver()` is the explicit real-OS opt-in** when you specifically need to
+  exercise OS-level shortcut chains, focus transitions, or cross-window
+  interactions — those are the only things synthetic input doesn't cover.
 
 ### Optional: drive interactions via semantics actions
 

--- a/docs/guide/interactions.md
+++ b/docs/guide/interactions.md
@@ -69,8 +69,9 @@ test thread or use JUnit per-test isolation instead of blocking the AUT's event 
 session it proceeds uncoordinated. Choose `Required` when that fallback is unacceptable.
 
 The **attach path uses `Required`** whenever the target can coordinate at all — an injected agent
-drives real input into a process you do not own, so a coordinator it cannot reach fails the input
-verb rather than quietly stopping policing the desktop. When the coordinator itself is broken and
+drives the target's default synthetic driver (or real OS input if that target opted in) into a
+process you do not own, so a coordinator it cannot reach fails coordinated verbs rather than
+quietly stopping policing the desktop. When the coordinator itself is broken and
 that leaves you with no way forward, there is one deliberate opt-out; see
 [When the coordinator cannot be reached](input-coordination.md#coordinator-unreachable).
 
@@ -276,20 +277,12 @@ For test output that records continuous video rather than per-step images, see
 The `RobotDriver` your automator wraps governs how input is actually dispatched. The
 public surface:
 
-- **`RobotDriver()`** — the default. Uses a fresh `java.awt.Robot` plus the system
-  clipboard. Moves the real cursor, takes system-wide keyboard focus, and is visible to
-  other applications. This is what end users experience and what
-  `ComposeAutomator.inProcess()` wires up by default. On macOS, the first input or
-  screenshot call lazily probes TCC permissions (Accessibility for input, Screen
-  Recording for capture) and throws `IllegalStateException` with remediation guidance
-  when either is denied — see [Troubleshooting](troubleshooting.md#macos-robotdriver-throws-illegalstateexception-about-tcc).
-- **`RobotDriver(robot)`** — same as the no-arg form but reuses an existing
-  `java.awt.Robot` you've already constructed (e.g., one targeted at a non-default
-  `GraphicsDevice`).
-- **`RobotDriver.synthetic(rootWindow)`** — synthetic AWT events posted straight into the
-  target window's AWT hierarchy. No real cursor motion, no global focus, doesn't fight
-  with other processes. Mouse and wheel events hit-test against `rootWindow`, its owned
-  windows, and other visible top-level windows. Key events go to the current AWT focus
+- **`RobotDriver.synthetic()` / `RobotDriver.synthetic(rootWindow)`** — the default.
+  `ComposeAutomator.inProcess()` defaults to synthetic AWT events posted straight into
+  the live window hierarchy. No real cursor motion, no global focus, doesn't fight
+  with other processes. The no-window factory hit-tests every visible top-level window;
+  passing `rootWindow` pins the starting tree. Mouse and wheel events hit-test against
+  that tree plus other visible top-level windows. Key events go to the current AWT focus
   owner when one exists; when AWT has no focus owner (for example, a macOS helper JVM
   launched with `apple.awt.UIElement=true`), Spectre falls back to the key-listening AWT
   descendant under the last pointer target or Compose host. That lets Compose Desktop's
@@ -300,6 +293,17 @@ public surface:
   currently exposes rather than a Swing repaint of the Compose host. On macOS this
   still requires Screen Recording permission and an unlocked screen, but synthetic input
   itself does not need Accessibility permission.
+- **`RobotDriver()`** — the explicit real-OS opt-in. Uses a fresh `java.awt.Robot` plus
+  the system clipboard. Moves the real cursor, takes system-wide keyboard focus, and is
+  visible to other applications. This is what end users experience; pass it to
+  `ComposeAutomator.inProcess(robotDriver = RobotDriver())` when you need that fidelity.
+  On macOS, the first input or screenshot call lazily probes TCC permissions
+  (Accessibility for input, Screen Recording for capture) and throws
+  `IllegalStateException` with remediation guidance when either is denied — see
+  [Troubleshooting](troubleshooting.md#macos-robotdriver-throws-illegalstateexception-about-tcc).
+- **`RobotDriver(robot)`** — same as the no-arg real-OS form but reuses an existing
+  `java.awt.Robot` you've already constructed (e.g., one targeted at a non-default
+  `GraphicsDevice`).
 - **`RobotDriver.headless()`** — for read-only flows in headless CI where real OS I/O is
   unavailable. Every input, clipboard, and screenshot call throws
   `UnsupportedOperationException` so an accidental `automator.click(...)` /
@@ -309,21 +313,23 @@ public surface:
   going through the OS. See
   [The automator](automator.md#what-an-automator-owns) for the full picture.
 
-Pass a non-default driver via the `inProcess` factory:
+`ComposeAutomator.inProcess()` already uses `RobotDriver.synthetic()`. Pin a window or
+opt into real OS input via the factory:
 
 ```kotlin
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.RobotDriver
-val automator = ComposeAutomator.inProcess(
+val pinned = ComposeAutomator.inProcess(
     robotDriver = RobotDriver.synthetic(rootWindow = composeWindow),
 )
+val realOs = ComposeAutomator.inProcess(robotDriver = RobotDriver())
 ```
 
-Synthetic input is the right choice when you're running tests in parallel JVMs, when the
-test machine also runs unrelated UI work, or when a macOS test helper runs with
+Synthetic input is the right default for parallel test JVMs, a machine that also runs
+unrelated UI work, IntelliJ/Jewel-hosted Compose, and macOS test helpers launched with
 `apple.awt.UIElement=true` to avoid a Dock icon. That macOS mode is safe for
 per-character `typeText` with `RobotDriver.synthetic(rootWindow = ...)`, but
 clipboard-backed `pasteText` still requires a foreground-capable app
-(`apple.awt.UIElement=false`). Stick to real input for end-to-end smokes where the realism
-of the input matters (e.g., validating that a system shortcut reaches the app). See
-[Running on CI](ci.md#macos-helper-jvms) for the macOS CI trade-off.
+(`apple.awt.UIElement=false`). Opt into real OS input for end-to-end smokes where the
+realism of the input matters (e.g., validating that a system shortcut reaches the app).
+See [Running on CI](ci.md#macos-helper-jvms) for the macOS CI trade-off.

--- a/docs/guide/junit.md
+++ b/docs/guide/junit.md
@@ -484,8 +484,9 @@ need a different driver for headless CI or unit-style isolation. `RobotDriver.he
 throws on input, clipboard, and screenshot calls (see
 [Driving input](interactions.md#real-vs-synthetic-input)), so the example below is
 appropriate for tests that only exercise semantics-tree queries or rule/extension
-lifecycle — anything that needs real input should use `RobotDriver.synthetic(rootWindow)`
-or the default `RobotDriver()` instead:
+lifecycle — anything that needs input should use the default synthetic driver
+(`ComposeAutomator.inProcess()` / `RobotDriver.synthetic(rootWindow)`) or pass
+`RobotDriver()` to opt into real OS input:
 
 ```kotlin
 import dev.sebastiano.spectre.core.ComposeAutomator

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -246,8 +246,9 @@ previous clipboard contents. A few failure modes follow from those contracts:
 - **`RobotDriver.headless()` throws on `typeText` and `pasteText`.** It throws on every
   input, clipboard, and screenshot call by design (see [Driving input](interactions.md#real-vs-synthetic-input)),
   so text entry against a headless driver surfaces an `UnsupportedOperationException`
-  at the call site rather than silently dropping. Use `RobotDriver.synthetic(rootWindow)`
-  or the default `RobotDriver()` for any real-input scenario.
+  at the call site rather than silently dropping. Use the default
+  `RobotDriver.synthetic(rootWindow)` for input, or `RobotDriver()` for any real-OS
+  scenario.
 - **Compose's paste action runs on its own dispatcher.** After the keystroke,
   Spectre pumps the EDT and sleeps briefly so the paste handler can read the
   clipboard before the previous contents are restored. If you stack many
@@ -460,7 +461,7 @@ Look for patterns such as `Sandbox: java(...) deny(1) mach-lookup`,
 
 ## "macOS RobotDriver throws `IllegalStateException` about TCC"
 
-The default `RobotDriver()` lazily probes the two macOS TCC entries `java.awt.Robot`
+The real-OS `RobotDriver()` lazily probes the two macOS TCC entries `java.awt.Robot`
 needs and throws on first use if either is denied:
 
 - **Accessibility** — required for mouse and keyboard delivery. Without it,

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -158,9 +158,12 @@ shortcuts, real OS drag-and-drop) won't behave the same way. See
 ## "Every input verb fails and the coordinator will not start" {#coordinator-unreachable}
 
 Symptom: semantics reads, `windows()`, `findByTestTag` and screenshots all keep working, while
-`focusWindow`, `click`, `typeText` and `pasteText` all fail at once with a message about the input
-coordinator. That split is the signature — everything that touches the shared desktop is gated on a
-lease, and nothing else is.
+verbs that touch **shared OS state for the current driver** fail with a message about the input
+coordinator. On a real-OS `Required` driver that is `focusWindow`, `click`, `typeText`, and
+`pasteText` together. On the default synthetic `Required` driver (attach / in-process) only
+clipboard-backed `pasteText` and explicit exclusive scopes need a live coordinator — synthetic
+`focusWindow` / `click` / `typeText` do not. That split is the signature: leased shared-desktop
+work fails, everything else does not.
 
 The failure now names its own way out:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,10 +33,10 @@ familiar — Spectre brings the same "find a node, do a thing, assert" loop to C
   than a parallel test harness.
 - **In-process or cross-JVM.** Use `ComposeAutomator.inProcess()` for the simple case, or
   use the `server` module to drive a UI hosted in a different JVM (e.g., an IDE under test).
-- **Real or synthetic input.** [`ComposeAutomator.inProcess()`](guide/interactions.md)
-  defaults to OS-level `java.awt.Robot` events. Swap in `RobotDriver.synthetic(...)` and
-  AWT events go directly into the window hierarchy — useful when tests run in parallel
-  and can't fight over OS focus.
+- **Synthetic input by default.** [`ComposeAutomator.inProcess()`](guide/interactions.md)
+  defaults to synthetic AWT events dispatched straight into the window hierarchy
+  (`RobotDriver.synthetic()`). Pass `RobotDriver()` to opt into OS-level `java.awt.Robot`
+  events when you need real cursor motion, global focus, or system shortcuts.
 - **Experimental cooperative input leases.** Participating real-input test JVMs can serialise
   focus, pointer, keyboard, and clipboard work without disabling parallel query/synthetic tests.
   See [desktop input coordination](guide/input-coordination.md).

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -177,9 +177,12 @@ All five wait helpers are `suspend` and **must not** be called from the AWT EDT.
 
 ## Input drivers
 
-Use `ComposeAutomator.inProcess()` (the default) for most tests — it uses a real `java.awt.Robot` and moves the actual cursor. Switch drivers only when needed:
+Use `ComposeAutomator.inProcess()` (the default) for most tests — it defaults to
+synthetic AWT events (`RobotDriver.synthetic()`) posted into the window hierarchy.
+Switch drivers only when needed:
 
-- `RobotDriver.synthetic(rootWindow = window)` — synthetic AWT events posted directly into the window's event queue; no real cursor motion, safe for parallel test runs.
+- `RobotDriver()` — real `java.awt.Robot` input; moves the actual cursor and takes OS focus.
+- `RobotDriver.synthetic(rootWindow = window)` — same synthetic path as the default, pinned to a window.
 - `RobotDriver.headless()` — read-only; every input or screenshot call throws `UnsupportedOperationException`. Semantics-tree reads still work.
 - `ComposeAutomator.http("localhost", 7654)` — cross-JVM via HTTP; requires the `:server` module running in the target process.
 - `AgentAttach.attach(pid)` — attach to a **running** Compose JVM. The target does **not** need `spectre-core` preinstalled: when core is absent, the agent runtime injects nested `META-INF/spectre/inject-runtime.jar`. Prefer a `spectre-core` dependency when you control the target build. The attacher needs `spectre-agent` plus `spectre-agent-runtime`.

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -8,8 +8,9 @@ description: Use when writing, debugging, or reviewing tests that drive a real o
 Spectre drives **live** Compose Desktop UIs from JUnit tests. It is *not* the
 Compose Multiplatform test framework (`runComposeUiTest` / `onNodeWithTag`) —
 that one runs an off-screen Compose tree on a virtual clock. Spectre opens a real
-window, reads its semantics tree, and feeds it real OS input via
-`java.awt.Robot` (or synthetic AWT events).
+window, reads its semantics tree, and feeds it synthetic AWT events by default
+(`RobotDriver.synthetic()`), or real OS input via `java.awt.Robot` when the test
+opts in.
 
 Pick Spectre when the test needs to exercise the actual window, popups,
 IntelliJ/Jewel-hosted Compose, or to record a real video of the UI.
@@ -93,24 +94,25 @@ and `@get:Rule` for `@RegisterExtension`.
 
 ## Choosing a `RobotDriver`
 
-`ComposeAutomator.inProcess()` accepts a `RobotDriver`. Default is real input
-on the host OS. Three variants:
+`ComposeAutomator.inProcess()` accepts a `RobotDriver`. The default is
+synthetic AWT input. Three variants:
 
-- **`RobotDriver()`** — real `java.awt.Robot` input on the host. Highest
-  fidelity, but contends for global focus. Use for the default
-  single-process test run. The no-argument form remains uncoordinated while the feature is
-  experimental; when several processes genuinely require real input, use
-  `RobotDriver(InputLeasePolicy.Required)` and read `references/input-coordination.md`.
-- **`RobotDriver.synthetic(rootWindow = someTopLevelWindow)`** — dispatches
-  AWT events directly into the given `java.awt.Window` hierarchy. No global
-  focus contention, so safe for **parallel test JVMs** and for IDE-hosted
-  Compose where stealing the IDE focus would be hostile. For key events,
-  Spectre uses the current AWT focus owner when available and otherwise falls
-  back to the key-listening AWT descendant under the last pointer target or
+- **`RobotDriver.synthetic()` / `RobotDriver.synthetic(rootWindow = someTopLevelWindow)`**
+  — the default. Dispatches AWT events directly into the live `java.awt.Window`
+  hierarchy. No global focus contention, so safe for **parallel test JVMs** and
+  for IDE-hosted Compose where stealing the IDE focus would be hostile. For key
+  events, Spectre uses the current AWT focus owner when available and otherwise
+  falls back to the key-listening AWT descendant under the last pointer target or
   Compose host; this is what makes Compose Desktop `TextField` typing work in
   macOS helper JVMs launched with `apple.awt.UIElement=true`, where AWT never
   grants a `Window.focusOwner`. Does **not** see OS shortcuts (Cmd+Tab, system
   menus).
+- **`RobotDriver()`** — explicit real `java.awt.Robot` input on the host. Highest
+  fidelity, but contends for global focus. Use when a smoke must exercise OS
+  shortcuts or focus handoffs. The no-argument form remains uncoordinated while
+  the feature is experimental; when several processes genuinely require real
+  input, use `RobotDriver(InputLeasePolicy.Required)` and read
+  `references/input-coordination.md`.
 - **`RobotDriver.headless()`** — refuses to send any input. For tests that
   only read the semantics tree (e.g. asserting a screen layout) without
   driving it.
@@ -344,7 +346,7 @@ touches that area*; they are not needed for the common case.
 | `findOneBy…` returns `null` right after an interaction | Selectors don't wait | Add `waitForNode(...)` or `waitForVisualIdle()` first |
 | Test deadlocks or throws inside any `waitFor…` / `waitUntil…` | Called from the AWT EDT | Wrap in `withContext(Dispatchers.Default) { … }` — applies to all five waits, including `waitForNode`, `waitUntilGone`, and `waitUntil` |
 | `longClick`/`swipe`/`typeText` complete instantly and miss | Test body uses `runTest` | Switch to `runSpectreTest` |
-| Two parallel test JVMs steal focus from each other | Both use real `RobotDriver()` | Use `RobotDriver.synthetic(rootWindow)` |
+| Two parallel test JVMs steal focus from each other | Both opted into real `RobotDriver()` | Stay on the default `RobotDriver.synthetic()` (or pin `rootWindow`) |
 | Parallel JVMs must preserve real OS input behavior | Real focus/pointer/clipboard state is shared across processes | Opt in to experimental coordination, add `spectre-input-coordinator-server` at runtime, use `Required` and JUnit `InputIsolationConfig.perTest()` |
 | Cmd+Tab or OS shortcuts don't work under synthetic driver | Synthetic events bypass HID | Use real `RobotDriver()` for those tests |
 | Screenshot is blurry / mid-animation | Captured before frame stabilised | `waitForVisualIdle()` first |

--- a/skills/spectre/references/intellij.md
+++ b/skills/spectre/references/intellij.md
@@ -7,13 +7,15 @@ ways.
 
 ## Use the synthetic driver
 
+`ComposeAutomator.inProcess()` already defaults to synthetic AWT events.
 The real `RobotDriver()` would steal focus from the IDE and could
-mis-target windows when the developer alt-tabs away. Use
-`RobotDriver.synthetic(rootWindow = ideFrame)` so AWT events are dispatched
-directly into the IDE's window hierarchy. On macOS this also works when the
-helper/test JVM is launched with `apple.awt.UIElement=true`: AWT may never
-report a `Window.focusOwner`, but Spectre targets the key-listening Compose
-host under `ideFrame` so focused `TextField`s still receive `typeText`.
+mis-target windows when the developer alt-tabs away — keep that as an
+explicit opt-in. Pinning `RobotDriver.synthetic(rootWindow = ideFrame)` is
+still the IntelliJ recipe so AWT events start from the IDE frame. On macOS
+this also works when the helper/test JVM is launched with
+`apple.awt.UIElement=true`: AWT may never report a `Window.focusOwner`, but
+Spectre targets the key-listening Compose host under `ideFrame` so focused
+`TextField`s still receive `typeText`.
 
 ```kotlin
 import com.intellij.openapi.application.ApplicationManager

--- a/skills/spectre/references/junit.md
+++ b/skills/spectre/references/junit.md
@@ -86,7 +86,8 @@ val automatorExt = ComposeAutomatorExtension {
 }
 ```
 
-Same shape for parallel-safe synthetic input:
+Same shape when you want to pin the synthetic driver to a known window
+(the no-arg `inProcess()` default is already synthetic):
 
 ```kotlin
 @JvmField

--- a/testing/README.md
+++ b/testing/README.md
@@ -14,9 +14,10 @@ Test ergonomics for Spectre.
 - `AutomatorFactory` — typealias for the `() -> ComposeAutomator` lambda the rule and extension
   use to build their per-test instances.
 
-Both wrappers default to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
-or focused unit testing can pass a custom factory built around `RobotDriver.headless()` (see the
-`newHeadlessAutomator()` fixture in this module's tests for the recipe).
+Both wrappers default to `ComposeAutomator.inProcess()`, which defaults to synthetic AWT
+input. Tests that need a stub for headless CI or focused unit testing can pass a custom
+factory built around `RobotDriver.headless()` (see the `newHeadlessAutomator()` fixture in
+this module's tests for the recipe). Pass `RobotDriver()` to opt into real OS input.
 
 Typical test shape:
 

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutomatorFactory.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/AutomatorFactory.kt
@@ -5,8 +5,10 @@ import dev.sebastiano.spectre.core.ComposeAutomator
 /**
  * Factory for building a [ComposeAutomator] inside a test fixture.
  *
- * The default `{ ComposeAutomator.inProcess() }` is suitable for live UI tests against a real AWT
- * display. Headless or unit-style tests that only need the test ergonomics (rule/extension
- * plumbing) without a real Robot/EDT can supply a custom factory that returns a stub or a fake.
+ * The default `{ ComposeAutomator.inProcess() }` uses synthetic AWT input against a live window
+ * hierarchy. Headless or unit-style tests that only need the test ergonomics (rule/extension
+ * plumbing) without a display can supply a custom factory that returns a stub or
+ * `RobotDriver.headless()`. Pass `RobotDriver()` through a custom factory to opt into real OS
+ * input.
  */
 public typealias AutomatorFactory = () -> ComposeAutomator

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorExtension.kt
@@ -50,8 +50,8 @@ import org.junit.jupiter.api.extension.ParameterResolver
  * before the keep/delete decision (`onFailureKeep` deletes on pass; `always` keeps pass and fail).
  * Non-failure aborts use the same rules as stills and do not leave a kept video.
  *
- * The [factory] defaults to `ComposeAutomator.inProcess()`. Tests that need a stub for headless CI
- * or focused unit testing can supply their own factory.
+ * The [factory] defaults to `ComposeAutomator.inProcess()` (synthetic AWT input). Tests that need a
+ * stub for headless CI or focused unit testing can supply their own factory.
  *
  * Concurrency: the per-test instance is keyed in [ExtensionContext.Store], so parameter resolution
  * remains correct even when JUnit 5 reuses one extension instance across parallel methods. The

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorRule.kt
@@ -26,8 +26,9 @@ import org.junit.runners.model.Statement
  * The [factory] is invoked before each `@Test` method; the resulting automator is available via
  * [automator] for the duration of the test and goes out of scope after the test (including after
  * failure-artifact capture). Accessing [automator] outside a running test throws
- * [IllegalStateException]. The default factory is `ComposeAutomator.inProcess()`; tests that need a
- * stub for headless CI or focused unit testing can supply their own factory.
+ * [IllegalStateException]. The default factory is `ComposeAutomator.inProcess()` (synthetic AWT
+ * input); tests that need a stub for headless CI or focused unit testing can supply their own
+ * factory.
  *
  * ## Failure artifacts (#205)
  *

--- a/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
+++ b/testing/src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt
@@ -73,7 +73,7 @@ internal fun interface ManagedAutomatorFactory {
 internal fun defaultManagedAutomatorFactory(
     inputIsolation: InputIsolationConfig,
     coordinatedFactory: ManagedAutomatorFactory = ManagedAutomatorFactory {
-        val driver = RobotDriver(InputLeasePolicy.Required)
+        val driver = RobotDriver.synthetic(InputLeasePolicy.Required)
         runCatching { ManagedAutomator(ComposeAutomator.inProcess(driver), driver) }
             .onFailure { driver.close() }
             .getOrThrow()

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorFailureVideoTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/ComposeAutomatorFailureVideoTest.kt
@@ -161,8 +161,9 @@ class ComposeAutomatorFailureVideoTest {
     @Test
     fun `failureVideo-only constructor is source-compatible for documented form`() {
         // Construction-only guard for ComposeAutomatorExtension(failureVideo = …) and the matching
-        // Rule overload. Do not run beforeEach/apply here: the default factory uses RobotDriver(),
-        // which fails on headless CI. Lifecycle coverage uses headless factories elsewhere.
+        // Rule overload. Do not run beforeEach/apply here: the default factory uses
+        // RobotDriver.synthetic(), which still constructs a screenshot Robot and fails on
+        // headless CI. Lifecycle coverage uses headless factories elsewhere.
         val extension =
             ComposeAutomatorExtension(
                 failureVideo = FailureVideoConfig(policy = FailureVideoPolicy.OnFailureKeep)

--- a/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
+++ b/testing/src/test/kotlin/dev/sebastiano/spectre/testing/InputIsolationLifecycleTest.kt
@@ -9,11 +9,15 @@ import dev.sebastiano.spectre.core.AutomatorInputLease
 import dev.sebastiano.spectre.core.ComposeAutomator
 import dev.sebastiano.spectre.core.InputLeaseOptions
 import java.lang.reflect.Method
+import java.nio.file.Path
+import kotlin.io.path.readText
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
@@ -132,6 +136,21 @@ class InputIsolationLifecycleTest {
         rule.apply(body, Description.createTestDescription(javaClass, "compatibility")).evaluate()
 
         assertEquals(emptyList(), events)
+    }
+
+    @Test
+    fun `per-interaction default factory constructs a synthetic driver`() {
+        val source =
+            Path.of("src/main/kotlin/dev/sebastiano/spectre/testing/InputIsolationConfig.kt")
+                .readText()
+        assertTrue(
+            source.contains("RobotDriver.synthetic(InputLeasePolicy.Required)"),
+            "defaultManagedAutomatorFactory must default to RobotDriver.synthetic, not real OS Robot",
+        )
+        assertFalse(
+            source.contains("val driver = RobotDriver(InputLeasePolicy.Required)"),
+            "defaultManagedAutomatorFactory must not construct the real-OS RobotDriver(policy)",
+        )
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Default every automator factory to synthetic AWT `RobotDriver` (`RobotDriver.synthetic(...)` / existing `SyntheticRobotAdapter`). Real OS `java.awt.Robot` stays an explicit opt-in via `RobotDriver()`.

## Why

Owner intent is that Spectre should not grab the OS mouse/keyboard unless the caller asks. `ComposeAutomator.inProcess()`, agent attach, JUnit managed factories, HTTP/CLI (via `inProcess` / attach), and IntelliJ/Jewel-hosted paths all inherit this default.

## What changed

- `ComposeAutomator.inProcess()` defaults to `RobotDriver.synthetic()` (no window required; live AWT hit-test after the window exists).
- `RobotDriver.synthetic()` / `synthetic(policy)` factories for the no-window case; pinned `synthetic(rootWindow)` unchanged.
- Agent attach prefers `Companion.synthetic(policy)` and falls back to the real-OS constructor for legacy cores.
- JUnit `defaultManagedAutomatorFactory` uses `RobotDriver.synthetic(InputLeasePolicy.Required)`.
- Tests lock the default in source, reflection, live AWT, attach compatibility, and JUnit factory source.
- User-facing docs and agent skills updated; `RobotDriver()` documented as the real-OS opt-in.
- ABI dump updated for the new companion factories.

## macOS check follow-up

`focusWindow` was the first coordinated verb on attach's new synthetic+`Required` driver (`FOCUS` was always leased even when `realOsInput=false`). Semantics reads succeeded; the raise threw `SpectreAgentException` on hosted macOS. Synthetic `FOCUS` now follows `realOsInput`, matching synthetic clicks. Real-OS `Required` drivers still lease focus. Clipboard and exclusive scopes are unchanged.

## Testing

- Targeted red/green: `InputLeaseGuardTest` (`synthetic focus bypasses coordinator like synthetic pointer`).
- `xvfb-run` `:agent:test` for `AgentAttachIntegrationTest` + `AgentContractCorpusTest` (executed, not skipped).
- `./gradlew check` green locally.

Do not merge until Codex is clean and CI is green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d90a0738-9f94-4d8c-a905-ac7490b13941?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d90a0738-9f94-4d8c-a905-ac7490b13941&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

