### PR TITLE
fix(input): descend a coordinator endpoint's path with openat (#487)

### DIFF
--- a/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
+++ b/core/src/test/kotlin/dev/sebastiano/spectre/core/InputLeaseGuardTest.kt
@@ -479,7 +479,7 @@ class InputLeaseGuardTest {
         }
 
     @Test
-    fun `cancellation after production acquisition closes the discarded lease`() = runTest {
+    fun `cancellation after production acquisition closes the discarded lease`() = runBlocking {
         val directory = Files.createTempDirectory("spc-h-")
         val endpoint = CoordinatorEndpoint(directory, directory.resolve("coordinator.sock"))
         val resource = DesktopResourceKey("test/cancelled-handoff")
@@ -496,6 +496,12 @@ class InputLeaseGuardTest {
                 },
             )
         try {
+            // Same real-coordinator shape as the queued-cancel test above: runBlocking, not
+            // runTest. The test dispatcher plus a blocking status poll left a window where
+            // cancel() ran after acquire() had already published the lease, so the successor
+            // hit a still-held desktop. That showed up on macOS hosted check as
+            // InputCoordinatorException with no message (check-macos on da0165b); Linux and
+            // the other production-coordinator tests in this class stayed green.
             val discarded =
                 async(start = CoroutineStart.UNDISPATCHED) {
                     coordinator.acquire(InputLeaseOptions(), "discarded", immediate = false)
@@ -504,6 +510,10 @@ class InputLeaseGuardTest {
 
             discarded.cancel()
             discarded.join()
+
+            awaitCoordinatorStatus(endpoint, resource, "the discarded lease to be released") {
+                it.holder == null
+            }
 
             LocalInputCoordinatorClient.connect(endpoint, resource, "successor").use { successor ->
                 successor.acquire(JavaDuration.ofSeconds(2), "successor").close()

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -57,13 +57,16 @@ out of scope.
    ancestors. On POSIX filesystems it enforces directory mode 0700 and socket mode 0600. On Windows
    it uses the current user's `LOCALAPPDATA` and inherits the existing directory ACL; unlike the
    agent transport, the coordinator layer does not replace that ACL with an owner-only one.
-   Traversal to the endpoint is `openat`-style on POSIX — each component is resolved exactly once,
+   Traversal to the endpoint is `openat`-style on Linux — each component is resolved exactly once,
    relative to a descriptor already open on the component above it — so an ancestor cannot be
-   substituted midway through the walk. The JDK exposes no equivalent on Windows, where the walk
-   stays lexical and re-resolves the whole path on every check, leaving a component accepted a
-   moment earlier open to being swapped before the next call reaches through it (#487). Creating a
-   missing component resolves an absolute path on both platforms; on POSIX a walk that finds its
-   parent substituted at that point fails rather than adopting what it created. Java
+   substituted midway through the walk. This is not a POSIX-wide property: the JDK only offers an
+   `openat`-backed `SecureDirectoryStream` where all six `*at` calls resolve, which excludes macOS,
+   and Windows has no equivalent at all. On those hosts the walk stays lexical and re-resolves the
+   whole path on every check, leaving a component accepted a moment earlier open to being swapped
+   before the next call reaches through it (#487); the endpoint is still owner-only and every
+   component is still rejected on sight. Creating a missing component resolves an absolute path
+   everywhere; on Linux a walk that finds its parent substituted at that point fails rather than
+   adopting what it created. Java
    Unix-domain sockets do not expose portable peer credentials, so requester labels are
    self-reported attribution, not authentication. The coordinator never records typed text,
    clipboard contents, selectors, credentials, or prompts.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -56,7 +56,14 @@ out of scope.
    the caller already trusts: Spectre detects substitution there but does not verify who owns the
    ancestors. On POSIX filesystems it enforces directory mode 0700 and socket mode 0600. On Windows
    it uses the current user's `LOCALAPPDATA` and inherits the existing directory ACL; unlike the
-   agent transport, the coordinator layer does not replace that ACL with an owner-only one. Java
+   agent transport, the coordinator layer does not replace that ACL with an owner-only one.
+   Traversal to the endpoint is `openat`-style on POSIX — each component is resolved exactly once,
+   relative to a descriptor already open on the component above it — so an ancestor cannot be
+   substituted midway through the walk. The JDK exposes no equivalent on Windows, where the walk
+   stays lexical and re-resolves the whole path on every check, leaving a component accepted a
+   moment earlier open to being swapped before the next call reaches through it (#487). Creating a
+   missing component resolves an absolute path on both platforms; on POSIX a walk that finds its
+   parent substituted at that point fails rather than adopting what it created. Java
    Unix-domain sockets do not expose portable peer credentials, so requester labels are
    self-reported attribution, not authentication. The coordinator never records typed text,
    clipboard contents, selectors, credentials, or prompts.

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -98,11 +98,12 @@ public sealed interface OwnerOnlyEndpointProtection {
      * this runs is rejected rather than adopted. Ownership of the existing ancestors is not
      * checked: a caller-supplied endpoint must sit beneath a directory the caller already trusts.
      *
-     * How much a concurrent substitution can do depends on the filesystem. On POSIX the components
-     * are walked with an `openat`-style descent that resolves each of them exactly once
-     * ([prepareEndpointDirectory]); on Windows, where the JDK exposes no such descent, the walk is
-     * lexical and re-resolves the path on every call, so a component accepted a moment ago can
-     * still be swapped before the next call reaches through it (#487).
+     * How much a concurrent substitution can do depends on the host. Where the JDK exposes an
+     * `openat`-backed [SecureDirectoryStream] — Linux in practice — the components are walked with
+     * a descent that resolves each of them exactly once ([prepareEndpointDirectory]). Where it does
+     * not — Windows, and macOS, which never reports the capability — the walk is lexical and
+     * re-resolves the path on every call, so a component accepted a moment ago can still be swapped
+     * before the next call reaches through it (#487).
      */
     @Throws(IOException::class) public fun prepareDirectory(socketPath: Path)
 
@@ -162,6 +163,10 @@ private object BasicOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
 /**
  * Prepares the endpoint [directory] and every ancestor of it with an `openat`-style descent.
  *
+ * Only where the platform has one. [SecureDirectoryStream] is not a POSIX guarantee: macOS never
+ * reports the JDK's `SUPPORTS_OPENAT` capability, so it takes [prepareEndpointDirectoryLexically]
+ * instead and keeps exactly the guarantees it had before #487. The hardening below is Linux's.
+ *
  * Every component is opened relative to a descriptor for the component above it, never by
  * re-resolving the whole path from the root, and always with [NOFOLLOW_LINKS]. That is what a
  * lexical walk cannot do (#487): `java.nio.file` re-resolves the entire path string on every call,
@@ -201,7 +206,13 @@ internal fun prepareEndpointDirectory(directory: Path, afterDescendingInto: (Pat
         throw IOException("Coordinator directory $directory must not be the filesystem root")
     }
     val lastIndex = absolute.nameCount - 1
-    var current = openRootDirectory(root)
+    var current =
+        openRootDirectory(root)
+            ?: run {
+                // No openat on this host (macOS); keep the pre-#487 guarantees rather than refuse.
+                prepareEndpointDirectoryLexically(directory)
+                return
+            }
     var currentPath = root
     try {
         absolute.forEachIndexed { index, component ->
@@ -340,17 +351,47 @@ private fun SecureDirectoryStream<Path>.readAttributesOrNull(
  * callers believing in a guarantee they no longer have. Every POSIX filesystem the coordinator
  * selects this protection for returns one.
  */
-private fun openRootDirectory(root: Path): SecureDirectoryStream<Path> {
+/**
+ * Opens the filesystem root as a [SecureDirectoryStream], or null where the platform has none.
+ *
+ * Not every POSIX host has one. The JDK sets its `SUPPORTS_OPENAT` capability only when all six of
+ * `openat`, `fstatat`, `unlinkat`, `renameat`, `futimesat` and `fdopendir` resolve, and it does not
+ * even look `futimesat` up under `_ALLBSD_SOURCE`, so macOS always returns a plain
+ * `UnixDirectoryStream` and the descent is in practice a Linux one. Null means the caller falls
+ * back to [prepareEndpointDirectoryLexically] rather than failing: refusing to prepare an endpoint
+ * at all would take the coordinator off Darwin entirely, which is a far worse outcome than keeping
+ * the guarantees that platform already had.
+ */
+private fun openRootDirectory(root: Path): SecureDirectoryStream<Path>? {
     val stream = Files.newDirectoryStream(root)
     @Suppress("UNCHECKED_CAST") val secure = stream as? SecureDirectoryStream<Path>
-    if (secure == null) {
-        stream.close()
-        throw IOException(
-            "Coordinator endpoint traversal needs a SecureDirectoryStream to resolve each " +
-                "component once; $root gave ${stream.javaClass.name}"
-        )
-    }
+    if (secure == null) stream.close()
     return secure
+}
+
+/**
+ * Prepares [directory] the way the POSIX path did before #487, for hosts with no `openat` descent.
+ *
+ * Every component is still validated immediately before it is descended into, and the endpoint is
+ * still owner-only, but the walk re-resolves the whole path on every call, so a component accepted
+ * a moment earlier can be replaced before the next call reaches through it. That is the residual
+ * window #487 closes on Linux and cannot close here.
+ */
+internal fun prepareEndpointDirectoryLexically(directory: Path) {
+    val ownerOnly = PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMISSIONS)
+    // Parents may legitimately be missing (#462); nothing is created when they all exist.
+    prepareAncestors(directory) { ancestor -> Files.createDirectory(ancestor, ownerOnly) }
+    if (Files.exists(directory, NOFOLLOW_LINKS)) {
+        rejectSubstituted(directory, role = "directory")
+        val permissions = Files.getPosixFilePermissions(directory, NOFOLLOW_LINKS)
+        if (permissions != OWNER_ONLY_DIRECTORY_PERMISSIONS) {
+            throw IOException("Existing coordinator directory $directory must be owner-only")
+        }
+    } else {
+        // The atomic createDirectory refuses to adopt anything already at this path, symlinks
+        // included, so a link planted here loses the race rather than capturing the endpoint.
+        Files.createDirectory(directory, ownerOnly)
+    }
 }
 
 private val OWNER_ONLY_DIRECTORY_PERMISSIONS: Set<PosixFilePermission> =
@@ -364,10 +405,10 @@ private val OWNER_ONLY_DIRECTORY_PERMISSIONS: Set<PosixFilePermission> =
  * Validates every ancestor of [directory] top-down and creates the missing ones, one atomic
  * [createDirectory] each.
  *
- * This is the fallback for filesystems with no `openat` to descend with, which in practice means
- * Windows: [Files.newDirectoryStream] returns a plain `DirectoryStream` there, so
- * [prepareEndpointDirectory]'s fd-relative walk has nothing to hold a component open with. POSIX
- * callers do not reach this.
+ * This is the walk for hosts with no `openat` to descend with: Windows, whose
+ * [Files.newDirectoryStream] returns a plain `DirectoryStream`, and — through
+ * [prepareEndpointDirectoryLexically] — macOS, which never reports the JDK capability that backs
+ * [SecureDirectoryStream]. Only Linux reaches [prepareEndpointDirectory]'s fd-relative descent.
  *
  * Each component is checked immediately before it is descended into, rather than validating the
  * whole chain up front and then creating blindly. A link planted between those two passes used to

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -179,6 +179,15 @@ private object BasicOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
  *
  * Missing parents are legitimate (#462): nothing is created when they all exist.
  *
+ * A filesystem-root directory (`/` on POSIX) has no components to descend into, so it is rejected
+ * rather than adopted: the walk would otherwise open the root, skip the owner-only check, and
+ * return. The previous lexical walk rejected that shape because `/` is not mode 0700.
+ *
+ * After this function returns the descriptors are closed. Later path-based operations — election
+ * lock, recovery ledger, socket bind — re-resolve from the root and are outside this walk's
+ * guarantee. Pinning an endpoint descriptor through server startup is a follow-up, not the mkdirat
+ * leftover #487 accepted.
+ *
  * [afterDescendingInto] is a test seam, in the same spirit as [isTrustedPrivateAlias]'s `root` and
  * `macOs` parameters; production passes nothing. It fires with each component the descent has just
  * opened, which is the instant a test needs in order to stage the substitution this walk exists to
@@ -188,6 +197,9 @@ internal fun prepareEndpointDirectory(directory: Path, afterDescendingInto: (Pat
     val absolute = directory.toAbsolutePath()
     val root =
         absolute.root ?: throw IOException("Coordinator directory $directory must be absolute")
+    if (absolute.nameCount == 0) {
+        throw IOException("Coordinator directory $directory must not be the filesystem root")
+    }
     val lastIndex = absolute.nameCount - 1
     var current = openRootDirectory(root)
     var currentPath = root

--- a/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
+++ b/input-coordinator/src/main/kotlin/dev/sebastiano/spectre/input/CoordinatorEndpoint.kt
@@ -7,7 +7,13 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.FileAlreadyExistsException
 import java.nio.file.Files
 import java.nio.file.LinkOption.NOFOLLOW_LINKS
+import java.nio.file.NoSuchFileException
 import java.nio.file.Path
+import java.nio.file.SecureDirectoryStream
+import java.nio.file.attribute.BasicFileAttributeView
+import java.nio.file.attribute.BasicFileAttributes
+import java.nio.file.attribute.PosixFileAttributeView
+import java.nio.file.attribute.PosixFileAttributes
 import java.nio.file.attribute.PosixFilePermission
 import java.nio.file.attribute.PosixFilePermissions
 import java.security.MessageDigest
@@ -91,6 +97,12 @@ public sealed interface OwnerOnlyEndpointProtection {
      * only root can create. Missing components are created one at a time so a link planted while
      * this runs is rejected rather than adopted. Ownership of the existing ancestors is not
      * checked: a caller-supplied endpoint must sit beneath a directory the caller already trusts.
+     *
+     * How much a concurrent substitution can do depends on the filesystem. On POSIX the components
+     * are walked with an `openat`-style descent that resolves each of them exactly once
+     * ([prepareEndpointDirectory]); on Windows, where the JDK exposes no such descent, the walk is
+     * lexical and re-resolves the path on every call, so a component accepted a moment ago can
+     * still be swapped before the next call reaches through it (#487).
      */
     @Throws(IOException::class) public fun prepareDirectory(socketPath: Path)
 
@@ -113,21 +125,7 @@ public sealed interface OwnerOnlyEndpointProtection {
 
 private object PosixOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
     override fun prepareDirectory(socketPath: Path) {
-        val directory = socketPath.toAbsolutePath().parent
-        val ownerOnly = PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMISSIONS)
-        // Parents may legitimately be missing (#462); nothing is created when they all exist.
-        prepareAncestors(directory) { ancestor -> Files.createDirectory(ancestor, ownerOnly) }
-        if (Files.exists(directory, NOFOLLOW_LINKS)) {
-            rejectSubstituted(directory, role = "directory")
-            val permissions = Files.getPosixFilePermissions(directory, NOFOLLOW_LINKS)
-            if (permissions != OWNER_ONLY_DIRECTORY_PERMISSIONS) {
-                throw IOException("Existing coordinator directory $directory must be owner-only")
-            }
-        } else {
-            // The atomic createDirectory refuses to adopt anything already at this path, symlinks
-            // included, so a link planted here loses the race rather than capturing the endpoint.
-            Files.createDirectory(directory, ownerOnly)
-        }
+        prepareEndpointDirectory(socketPath.toAbsolutePath().parent)
     }
 
     override fun protectSocket(socketPath: Path) {
@@ -137,12 +135,6 @@ private object PosixOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
         Files.setPosixFilePermissions(socketPath, OWNER_ONLY_SOCKET_PERMISSIONS)
     }
 
-    private val OWNER_ONLY_DIRECTORY_PERMISSIONS: Set<PosixFilePermission> =
-        setOf(
-            PosixFilePermission.OWNER_READ,
-            PosixFilePermission.OWNER_WRITE,
-            PosixFilePermission.OWNER_EXECUTE,
-        )
     private val OWNER_ONLY_SOCKET_PERMISSIONS: Set<PosixFilePermission> =
         setOf(PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_WRITE)
 }
@@ -168,8 +160,202 @@ private object BasicOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
 }
 
 /**
+ * Prepares the endpoint [directory] and every ancestor of it with an `openat`-style descent.
+ *
+ * Every component is opened relative to a descriptor for the component above it, never by
+ * re-resolving the whole path from the root, and always with [NOFOLLOW_LINKS]. That is what a
+ * lexical walk cannot do (#487): `java.nio.file` re-resolves the entire path string on every call,
+ * so an ancestor accepted a moment ago could be replaced with a symbolic link before the next call
+ * resolved through it, and the endpoint landed in the attacker's tree. A descriptor already open on
+ * a directory keeps naming that directory no matter what happens to the name it was reached by, so
+ * the substitution has nothing left to redirect.
+ *
+ * One step still resolves an absolute path: [SecureDirectoryStream] has no `mkdirat`, so a missing
+ * component is created by [Files.createDirectory]. Its result is never trusted — the fd-relative
+ * open that follows is what decides whether anything is adopted — and the file-key guard in
+ * [createChildDirectory] fails the walk closed when the parent has been substituted since it was
+ * accepted. What is left of the window is a directory created in a tree the caller did not intend;
+ * it cannot become the endpoint.
+ *
+ * Missing parents are legitimate (#462): nothing is created when they all exist.
+ *
+ * [afterDescendingInto] is a test seam, in the same spirit as [isTrustedPrivateAlias]'s `root` and
+ * `macOs` parameters; production passes nothing. It fires with each component the descent has just
+ * opened, which is the instant a test needs in order to stage the substitution this walk exists to
+ * survive.
+ */
+internal fun prepareEndpointDirectory(directory: Path, afterDescendingInto: (Path) -> Unit = {}) {
+    val absolute = directory.toAbsolutePath()
+    val root =
+        absolute.root ?: throw IOException("Coordinator directory $directory must be absolute")
+    val lastIndex = absolute.nameCount - 1
+    var current = openRootDirectory(root)
+    var currentPath = root
+    try {
+        absolute.forEachIndexed { index, component ->
+            val descended =
+                current.descendInto(currentPath, component, isEndpoint = index == lastIndex)
+            current.close()
+            current = descended.stream
+            currentPath = descended.path
+            afterDescendingInto(currentPath)
+        }
+    } finally {
+        current.close()
+    }
+}
+
+/** A component the descent has opened, and the path that names it once aliases are followed. */
+private class Descended(val stream: SecureDirectoryStream<Path>, val path: Path)
+
+/**
+ * Opens [component] relative to the directory this stream holds, creating it when it is missing.
+ *
+ * The fd-relative `readAttributes` only classifies the component so the failure can name what is
+ * wrong with it; the `NOFOLLOW_LINKS` open below is what enforces the rule, and it would refuse a
+ * link planted between the two.
+ */
+private fun SecureDirectoryStream<Path>.descendInto(
+    parentPath: Path,
+    component: Path,
+    isEndpoint: Boolean,
+): Descended {
+    val role = if (isEndpoint) "directory" else "ancestor"
+    val childPath = parentPath.resolve(component)
+    val attributes = readAttributesOrNull(component)
+    var created = false
+    when {
+        attributes == null -> created = createChildDirectory(parentPath, childPath, role)
+        attributes.isSymbolicLink -> {
+            if (isEndpoint || !isTrustedPrivateAlias(childPath, childPath.root)) {
+                throw IOException("Coordinator $role $childPath must not be a symbolic link")
+            }
+            // A Darwin root alias. Following it through the descriptor is the exemption; only root
+            // can rewrite an entry directly under /, so there is no unprivileged swap to lose here.
+            val target = childPath.root.resolve(PRIVATE_ALIAS_DIRECTORY).resolve(component)
+            return Descended(newDirectoryStream(component), target)
+        }
+        !attributes.isDirectory ->
+            throw IOException("Coordinator $role $childPath is not a directory")
+    }
+    val stream = newDirectoryStream(component, NOFOLLOW_LINKS)
+    var handedOver = false
+    try {
+        // A directory this walk created is owner-only by construction. One it merely adopted is
+        // not, and "already existed" includes losing the create race to someone else.
+        if (isEndpoint && !created) requireOwnerOnly(stream, childPath)
+        handedOver = true
+    } finally {
+        if (!handedOver) stream.close()
+    }
+    return Descended(stream, childPath)
+}
+
+/**
+ * Rejects an adopted endpoint directory that is not owner-only.
+ *
+ * The mode is read back from the open descriptor rather than from the path: this is the directory
+ * the coordinator will actually use, whatever the path resolves to by now.
+ */
+private fun requireOwnerOnly(stream: SecureDirectoryStream<Path>, path: Path) {
+    val permissions =
+        stream
+            .getFileAttributeView(PosixFileAttributeView::class.java)
+            .readAttributes()
+            .permissions()
+    if (permissions != OWNER_ONLY_DIRECTORY_PERMISSIONS) {
+        throw IOException("Existing coordinator directory $path must be owner-only")
+    }
+}
+
+/**
+ * Creates [childPath], which the descent found missing, leaving adoption to the caller's open.
+ *
+ * This is the one step that cannot be done relative to the descriptor, so it compares the open
+ * directory's file key against the one [parentPath] resolves to now and refuses to create anything
+ * when they differ — that is a parent substituted since the descent accepted it.
+ *
+ * Returns whether this walk is the one that created the directory; losing the race to a concurrent
+ * creator is not an error, but the loser has adopted a directory it cannot vouch for.
+ */
+private fun SecureDirectoryStream<Path>.createChildDirectory(
+    parentPath: Path,
+    childPath: Path,
+    role: String,
+): Boolean {
+    val openKey =
+        getFileAttributeView(BasicFileAttributeView::class.java).readAttributes().fileKey()
+    val resolvedKey =
+        runCatching {
+                Files.readAttributes(parentPath, BasicFileAttributes::class.java, NOFOLLOW_LINKS)
+                    .fileKey()
+            }
+            .getOrNull()
+    if (openKey == null || openKey != resolvedKey) {
+        throw IOException(
+            "Coordinator $role $childPath cannot be created: $parentPath was replaced while the " +
+                "endpoint directory was being prepared"
+        )
+    }
+    return try {
+        Files.createDirectory(
+            childPath,
+            PosixFilePermissions.asFileAttribute(OWNER_ONLY_DIRECTORY_PERMISSIONS),
+        )
+        true
+    } catch (_: FileAlreadyExistsException) {
+        // Another process created it first, legitimately or not. The fd-relative open decides
+        // whether it is usable, and the caller still has to check what it adopted.
+        false
+    }
+}
+
+private fun SecureDirectoryStream<Path>.readAttributesOrNull(
+    component: Path
+): PosixFileAttributes? =
+    try {
+        getFileAttributeView(component, PosixFileAttributeView::class.java, NOFOLLOW_LINKS)
+            .readAttributes()
+    } catch (_: NoSuchFileException) {
+        null
+    }
+
+/**
+ * Opens the filesystem root, which is the only component the descent takes on trust.
+ *
+ * Fails closed when the provider does not hand back a [SecureDirectoryStream]: without one there is
+ * no fd-relative open to descend with, and silently falling back to the lexical walk would leave
+ * callers believing in a guarantee they no longer have. Every POSIX filesystem the coordinator
+ * selects this protection for returns one.
+ */
+private fun openRootDirectory(root: Path): SecureDirectoryStream<Path> {
+    val stream = Files.newDirectoryStream(root)
+    @Suppress("UNCHECKED_CAST") val secure = stream as? SecureDirectoryStream<Path>
+    if (secure == null) {
+        stream.close()
+        throw IOException(
+            "Coordinator endpoint traversal needs a SecureDirectoryStream to resolve each " +
+                "component once; $root gave ${stream.javaClass.name}"
+        )
+    }
+    return secure
+}
+
+private val OWNER_ONLY_DIRECTORY_PERMISSIONS: Set<PosixFilePermission> =
+    setOf(
+        PosixFilePermission.OWNER_READ,
+        PosixFilePermission.OWNER_WRITE,
+        PosixFilePermission.OWNER_EXECUTE,
+    )
+
+/**
  * Validates every ancestor of [directory] top-down and creates the missing ones, one atomic
  * [createDirectory] each.
+ *
+ * This is the fallback for filesystems with no `openat` to descend with, which in practice means
+ * Windows: [Files.newDirectoryStream] returns a plain `DirectoryStream` there, so
+ * [prepareEndpointDirectory]'s fd-relative walk has nothing to hold a component open with. POSIX
+ * callers do not reach this.
  *
  * Each component is checked immediately before it is descended into, rather than validating the
  * whole chain up front and then creating blindly. A link planted between those two passes used to
@@ -180,8 +366,9 @@ private object BasicOwnerOnlyEndpointProtection : OwnerOnlyEndpointProtection {
  *
  * The walk is lexical and deliberately not normalised: the OS resolves a `..` that follows a
  * planted link against the link's target, so the link itself has to stay visible to this check. It
- * cannot make traversal race-free — only an `openat`-style descent could — but every component is
- * now rejected on sight instead of being skipped.
+ * cannot make traversal race-free (#487) — every `java.nio.file` call re-resolves the whole path
+ * from the root, so a component accepted a moment ago can be replaced before the next call reaches
+ * through it — but every component is rejected on sight instead of being skipped.
  */
 private fun prepareAncestors(directory: Path, createDirectory: (Path) -> Unit) {
     val ancestors = generateSequence(directory.parent) { it.parent }.toList().asReversed()

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionDescentTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionDescentTest.kt
@@ -9,6 +9,8 @@ import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.Path
 import kotlin.io.path.createSymbolicLinkPointingTo
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -108,6 +110,23 @@ class OwnerOnlyEndpointProtectionDescentTest {
         val failure =
             assertIs<IOException>(outcome.exceptionOrNull(), "the descent must fail closed")
         assertTrue(failure.message.orEmpty().contains("replaced"), failure.message)
+    }
+
+    @Test
+    fun `a filesystem-root endpoint directory is rejected`() {
+        assumePosixFilesystem()
+        // `/input.sock` makes the socket's parent the filesystem root. The descent opens `/` and
+        // then has zero components left, so without an explicit check it would return without
+        // ever applying the owner-only invariant the previous lexical walk enforced on `/`.
+        val socket = Path.of("/input.sock")
+        assertEquals(0, socket.toAbsolutePath().parent.nameCount)
+
+        val failure =
+            assertFailsWith<IOException> {
+                OwnerOnlyEndpointProtection.forPath(socket).prepareDirectory(socket)
+            }
+
+        assertTrue(failure.message.orEmpty().contains("filesystem root"), failure.message)
     }
 
     /**

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionDescentTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionDescentTest.kt
@@ -7,6 +7,8 @@ import java.nio.file.FileSystemException
 import java.nio.file.Files
 import java.nio.file.LinkOption.NOFOLLOW_LINKS
 import java.nio.file.Path
+import java.nio.file.SecureDirectoryStream
+import java.nio.file.attribute.PosixFilePermissions
 import kotlin.io.path.createSymbolicLinkPointingTo
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -39,7 +41,7 @@ class OwnerOnlyEndpointProtectionDescentTest {
 
     @Test
     fun `an ancestor swapped after it was accepted cannot redirect the descent`() {
-        assumePosixFilesystem()
+        assumeSecureDirectoryStreams()
         assumeCanCreateSymbolicLinks()
         val intermediate = Files.createDirectory(temporaryDirectory.resolve("mid"))
         Files.createDirectory(intermediate.resolve("base"))
@@ -81,7 +83,7 @@ class OwnerOnlyEndpointProtectionDescentTest {
 
     @Test
     fun `the endpoint directory is not created through a parent swapped after it was accepted`() {
-        assumePosixFilesystem()
+        assumeSecureDirectoryStreams()
         assumeCanCreateSymbolicLinks()
         val base = Files.createDirectory(temporaryDirectory.resolve("base"))
         val attackerTree = Files.createDirectory(temporaryDirectory.resolve("attacker"))
@@ -129,10 +131,64 @@ class OwnerOnlyEndpointProtectionDescentTest {
         assertTrue(failure.message.orEmpty().contains("filesystem root"), failure.message)
     }
 
+    @Test
+    fun `the lexical fallback still enforces the endpoint contract`() {
+        // macOS never gets a SecureDirectoryStream: the JDK sets SUPPORTS_OPENAT only when all six
+        // *at functions resolve, and futimesat is not looked up under _ALLBSD_SOURCE, so
+        // Files.newDirectoryStream returns a plain UnixDirectoryStream there. The descent falls
+        // back to the lexical walk rather than failing, and that fallback has to keep the
+        // guarantees the walk had before #487. Driven directly because a Linux host cannot produce
+        // a non-secure stream to reach it through the front door.
+        assumePosixFilesystem()
+        val socket =
+            temporaryDirectory
+                .resolve("missing")
+                .resolve("base")
+                .resolve(ENDPOINT_DIRECTORY_NAME)
+                .resolve("input.sock")
+
+        prepareEndpointDirectoryLexically(socket.parent)
+
+        assertTrue(Files.isDirectory(socket.parent), "the endpoint directory should exist")
+        assertEquals(
+            PosixFilePermissions.fromString("rwx------"),
+            Files.getPosixFilePermissions(socket.parent),
+            "the endpoint directory must be owner-only",
+        )
+    }
+
+    @Test
+    fun `the lexical fallback rejects a symbolic link above the endpoint`() {
+        assumePosixFilesystem()
+        assumeCanCreateSymbolicLinks()
+        val target = Files.createDirectory(temporaryDirectory.resolve("target"))
+        val link = temporaryDirectory.resolve("link").createSymbolicLinkPointingTo(target)
+        val directory = link.resolve("base").resolve(ENDPOINT_DIRECTORY_NAME)
+
+        val failure = assertFailsWith<IOException> { prepareEndpointDirectoryLexically(directory) }
+
+        assertTrue(failure.message.orEmpty().contains("symbolic link"), failure.message)
+        assertFalse(
+            Files.exists(target.resolve("base")),
+            "nothing may be created through the link before it is rejected",
+        )
+    }
+
     /**
      * [prepareEndpointDirectory] is the POSIX preparation; Windows keeps the lexical walk in
      * `BasicOwnerOnlyEndpointProtection` and has no `openat` to descend with.
      */
+    private fun assumeSecureDirectoryStreams() {
+        assumePosixFilesystem()
+        val secure =
+            Files.newDirectoryStream(temporaryDirectory).use { it is SecureDirectoryStream<*> }
+        assumeTrue(
+            secure,
+            "the openat descent needs SecureDirectoryStream; macOS never reports SUPPORTS_OPENAT " +
+                "(futimesat is not resolved under _ALLBSD_SOURCE) and falls back to the lexical walk",
+        )
+    }
+
     private fun assumePosixFilesystem() {
         assumeTrue(
             Files.getFileStore(temporaryDirectory).supportsFileAttributeView("posix"),

--- a/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionDescentTest.kt
+++ b/input-coordinator/src/test/kotlin/dev/sebastiano/spectre/input/OwnerOnlyEndpointProtectionDescentTest.kt
@@ -1,0 +1,147 @@
+@file:OptIn(ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.input
+
+import java.io.IOException
+import java.nio.file.FileSystemException
+import java.nio.file.Files
+import java.nio.file.LinkOption.NOFOLLOW_LINKS
+import java.nio.file.Path
+import kotlin.io.path.createSymbolicLinkPointingTo
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.io.TempDir
+
+/**
+ * #487: validating each ancestor immediately before descending into it (#483) is not the same as
+ * descending atomically. A lexical walk re-resolves the whole path string from the root on every
+ * `java.nio.file` call, so an ancestor accepted a moment ago can be replaced with a symbolic link
+ * before the next call resolves through it.
+ *
+ * These tests stage exactly that substitution, at the one instant that matters, through the
+ * [prepareEndpointDirectory] seam. They are the evidence for #487: a walk that resolves each
+ * component once, relative to a directory it already holds open, cannot be redirected by a swap
+ * that lands after the component was accepted. They fail against the lexical walk, which follows
+ * the planted link and creates the endpoint inside the attacker's tree without complaint.
+ *
+ * What they do not show is that no window remains at all. `SecureDirectoryStream` has no `mkdirat`,
+ * so a missing component is still created through its absolute path; see [prepareEndpointDirectory]
+ * for what that costs and what still holds when it is lost.
+ */
+class OwnerOnlyEndpointProtectionDescentTest {
+
+    @TempDir lateinit var temporaryDirectory: Path
+
+    @Test
+    fun `an ancestor swapped after it was accepted cannot redirect the descent`() {
+        assumePosixFilesystem()
+        assumeCanCreateSymbolicLinks()
+        val intermediate = Files.createDirectory(temporaryDirectory.resolve("mid"))
+        Files.createDirectory(intermediate.resolve("base"))
+        val attackerTree = Files.createDirectory(temporaryDirectory.resolve("attacker"))
+        val decoy = Files.createDirectory(attackerTree.resolve("base"))
+        val relocated = temporaryDirectory.resolve("relocated-mid")
+        val directory = intermediate.resolve("base").resolve(ENDPOINT_DIRECTORY_NAME)
+
+        // Captured rather than asserted inline, so the assertion that matters -- that nothing
+        // landed in the attacker's tree -- is evaluated even when the walk completes happily.
+        val outcome = runCatching {
+            prepareEndpointDirectory(directory) { accepted ->
+                // The instant "mid" has been accepted and before its child is resolved: move
+                // the real directory aside and leave a link to the attacker's tree in its
+                // place. A lexical walk re-resolves "mid/base" from the root and lands in the
+                // decoy; a descent holding "mid" open cannot be moved off it.
+                if (accepted.fileName?.toString() == "mid" && !Files.isSymbolicLink(intermediate)) {
+                    Files.move(intermediate, relocated)
+                    intermediate.createSymbolicLinkPointingTo(attackerTree)
+                }
+            }
+        }
+
+        assertFalse(
+            Files.exists(decoy.resolve(ENDPOINT_DIRECTORY_NAME), NOFOLLOW_LINKS),
+            "the endpoint must not be created through the substituted ancestor",
+        )
+        assertFalse(
+            Files.exists(
+                relocated.resolve("base").resolve(ENDPOINT_DIRECTORY_NAME),
+                NOFOLLOW_LINKS,
+            ),
+            "a substitution mid-descent must fail closed rather than create anything",
+        )
+        val failure =
+            assertIs<IOException>(outcome.exceptionOrNull(), "the descent must fail closed")
+        assertTrue(failure.message.orEmpty().contains("replaced"), failure.message)
+    }
+
+    @Test
+    fun `the endpoint directory is not created through a parent swapped after it was accepted`() {
+        assumePosixFilesystem()
+        assumeCanCreateSymbolicLinks()
+        val base = Files.createDirectory(temporaryDirectory.resolve("base"))
+        val attackerTree = Files.createDirectory(temporaryDirectory.resolve("attacker"))
+        val relocated = temporaryDirectory.resolve("relocated-base")
+        val directory = base.resolve(ENDPOINT_DIRECTORY_NAME)
+
+        val outcome = runCatching {
+            prepareEndpointDirectory(directory) { accepted ->
+                // Same substitution one level lower, where the endpoint directory itself is
+                // what gets created through the link rather than a further ancestor.
+                if (accepted.fileName?.toString() == "base" && !Files.isSymbolicLink(base)) {
+                    Files.move(base, relocated)
+                    base.createSymbolicLinkPointingTo(attackerTree)
+                }
+            }
+        }
+
+        assertFalse(
+            Files.exists(attackerTree.resolve(ENDPOINT_DIRECTORY_NAME), NOFOLLOW_LINKS),
+            "the endpoint must not be created inside the attacker's tree",
+        )
+        assertFalse(
+            Files.exists(relocated.resolve(ENDPOINT_DIRECTORY_NAME), NOFOLLOW_LINKS),
+            "a substitution mid-descent must fail closed rather than create anything",
+        )
+        val failure =
+            assertIs<IOException>(outcome.exceptionOrNull(), "the descent must fail closed")
+        assertTrue(failure.message.orEmpty().contains("replaced"), failure.message)
+    }
+
+    /**
+     * [prepareEndpointDirectory] is the POSIX preparation; Windows keeps the lexical walk in
+     * `BasicOwnerOnlyEndpointProtection` and has no `openat` to descend with.
+     */
+    private fun assumePosixFilesystem() {
+        assumeTrue(
+            Files.getFileStore(temporaryDirectory).supportsFileAttributeView("posix"),
+            "the openat-style descent is the POSIX path",
+        )
+    }
+
+    /** See the identical helper in [OwnerOnlyEndpointProtectionAncestorTest] (#467). */
+    private fun assumeCanCreateSymbolicLinks() {
+        val probe = temporaryDirectory.resolve("symlink-probe")
+        val canCreate =
+            try {
+                probe.createSymbolicLinkPointingTo(temporaryDirectory.resolve("probe-target"))
+                Files.deleteIfExists(probe)
+                true
+            } catch (_: UnsupportedOperationException) {
+                false
+            } catch (_: FileSystemException) {
+                false
+            }
+        assumeTrue(
+            canCreate,
+            "Host cannot create symbolic links (Windows: enable Developer Mode or grant " +
+                "SeCreateSymbolicLinkPrivilege); the descent stays covered on hosts that can.",
+        )
+    }
+
+    private companion object {
+        const val ENDPOINT_DIRECTORY_NAME: String = "spectre-input-abcd1234"
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-lands the existing #487 openat-style coordinator endpoint descent after it was accidentally merged to `main` as [`0de7da0`](https://github.com/rock3r/spectre/commit/0de7da0) (`dry-run`) and correctly reverted by [#493](https://github.com/rock3r/spectre/pull/493) ([`a2ba0ec`](https://github.com/rock3r/spectre/commit/a2ba0ec) / merge [`21dd7e8`](https://github.com/rock3r/spectre/commit/21dd7e8)).

This is a cherry-pick of the original Claude commit [`f493cb1`](https://github.com/rock3r/spectre/commit/f493cb1) (`fix(input): descend a coordinator endpoint's path with openat (#487)`) onto current `main`. Rebased onto [`fd2d040`](https://github.com/rock3r/spectre/commit/fd2d040) (#492).

Follow-ups on this branch:

- [`87cf8b3`](https://github.com/rock3r/spectre/commit/87cf8b3): reject a filesystem-root endpoint (`nameCount == 0`).
- [`da0165b`](https://github.com/rock3r/spectre/commit/da0165b): fall back to the lexical walk on hosts without `SecureDirectoryStream` (macOS).
- [`7d56ee1`](https://github.com/rock3r/spectre/commit/7d56ee1): `InputLeaseGuardTest` discarded-lease handoff uses `runBlocking` and waits for the holder to clear (macOS `check-macos` / `:core:test`).

Closes #487.

## Test plan

- [x] `./gradlew :input-coordinator:check` after the openat / root-rejection / lexical-fallback work
- [x] `./gradlew :core:test --tests '*InputLeaseGuardTest*'` after the discarded-lease handoff fix (also looped the targeted test 5×)
- [ ] macOS `check-macos` on `7d56ee1`

## Confirmations

- Re-lands existing Claude work from `f493cb1`, plus the Codex / CI follow-ups above.
- Licensed under Apache-2.0 with the rest of the repository.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-60bbc9cb-cfad-4ae0-b3b0-4d2b0a02495a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-60bbc9cb-cfad-4ae0-b3b0-4d2b0a02495a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

