### PR TITLE
docs: boundsInWindow is Compose pixels, not dp (#495)

### DIFF
--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -101,6 +101,14 @@ internal constructor(
     // Geometry is always read live: layout can change between node lookup and action,
     // so a snapshot would let click/screenshot drift to stale coordinates after scrolling
     // or recomposition-driven repositioning.
+    /**
+     * Layout bounds within the window's Compose surface, in physical (Compose) pixels.
+     *
+     * Values are already density-scaled: a 24.dp inset measures 48 here on a 2× display. Compare
+     * against `Dp.roundToPx()` / `LocalDensity`-scaled values. For AWT/Robot input and recording
+     * regions, use [boundsOnScreen] or [centerOnScreen], which divide by the display scale; do not
+     * multiply this rect by density.
+     */
     public val boundsInWindow: Rect
         get() = readOnEdt { semanticsNode.boundsInWindow }
 

--- a/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
+++ b/core/src/main/kotlin/dev/sebastiano/spectre/core/AutomatorNode.kt
@@ -106,8 +106,8 @@ internal constructor(
      *
      * Values are already density-scaled: a 24.dp inset measures 48 here on a 2× display. Compare
      * against `Dp.roundToPx()` / `LocalDensity`-scaled values. For AWT/Robot input and recording
-     * regions, use [boundsOnScreen] or [centerOnScreen], which divide by the display scale; do not
-     * multiply this rect by density.
+     * regions, use [boundsOnScreen] or [centerOnScreen], which divide by the display scale and add
+     * the surface/panel screen origin; do not multiply this rect by density.
      */
     public val boundsInWindow: Rect
         get() = readOnEdt { semanticsNode.boundsInWindow }

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -287,8 +287,9 @@ compositor and not raw framebuffer reads.
   window come out at the same resolution. See
   [Atomic capture — Pixel scale](guide/capture.md#pixel-scale).
 - `Rectangle` coordinates passed to `start(...)` are in screen pixels. If you derive the region
-  from `AutomatorNode.boundsOnScreen` you get the right thing for free; if you derive it from
-  `boundsInWindow` you have to apply the density yourself.
+  from `AutomatorNode.boundsOnScreen` you get the right thing for free. `boundsInWindow` is already
+  in Compose / device pixels (density-scaled); converting those to AWT/region coordinates means
+  **dividing** by the display scale. Do not multiply by density.
 
 ## Permissions and process lifecycle
 

--- a/docs/RECORDING-LIMITATIONS.md
+++ b/docs/RECORDING-LIMITATIONS.md
@@ -286,10 +286,12 @@ compositor and not raw framebuffer reads.
 - Still capture follows the same rule, so a `spectre capture` PNG and a recording of the same
   window come out at the same resolution. See
   [Atomic capture — Pixel scale](guide/capture.md#pixel-scale).
-- `Rectangle` coordinates passed to `start(...)` are in screen pixels. If you derive the region
-  from `AutomatorNode.boundsOnScreen` you get the right thing for free. `boundsInWindow` is already
-  in Compose / device pixels (density-scaled); converting those to AWT/region coordinates means
-  **dividing** by the display scale. Do not multiply by density.
+- `Rectangle` coordinates passed to `start(...)` are in screen pixels. Prefer
+  `AutomatorNode.boundsOnScreen` — it already divides by the display scale and adds the Compose
+  surface's screen origin. `boundsInWindow` is already in Compose / device pixels (density-scaled)
+  and window-relative; if you convert it yourself, divide by the display scale **and** add the
+  surface/panel screen origin. Dividing alone lands near `(0, 0)` when the window is not at the
+  screen origin. Do not multiply by density.
 
 ## Permissions and process lifecycle
 

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -164,8 +164,11 @@ Use, in order of preference:
 
 `AutomatorNode` exposes `testTag`, `text`/`texts`, `contentDescription(s)`,
 `role`, `isFocused`, `isDisabled`, `isSelected`, `editableText`, plus
-coordinates: `boundsInWindow` (dp), `boundsOnScreen` (screen pixels,
-post-HiDPI), `centerOnScreen`. Tree navigation via `children`/`parent`.
+coordinates: `boundsInWindow` (Compose pixels, already density-scaled),
+`boundsOnScreen` (screen pixels, post-HiDPI), `centerOnScreen`. Tree
+navigation via `children`/`parent`. Compare `boundsInWindow` against
+`Dp.roundToPx()` / `LocalDensity`-scaled values; compare `boundsOnScreen`
+against dp figures directly.
 
 ## Driving input
 
@@ -356,7 +359,7 @@ touches that area*; they are not needed for the common case.
 | `pasteText` times out on macOS in CI | Clipboard manager rewriting `NSPasteboard` | Disable clipboard utilities in CI |
 | Recording misses popups that escape the host window | Popups live in their own AWT window outside both the region rectangle *and* a window-targeted capture | Choose an explicit region (or full-desktop crop) wide enough to include where the popup opens, or document the limitation — neither region nor window targeting follows cross-window popups |
 | Window-targeted Wayland recording throws `IllegalStateException` | `xprop` missing or non-GNOME compositor | Use `AutoRecorder.startRegion(...)` with an explicit rectangle |
-| Coordinates derived from `boundsInWindow` land off-target on HiDPI | `boundsInWindow` is dp; screen is pixels | Use `boundsOnScreen`/`centerOnScreen`, or apply density |
+| Coordinates derived from `boundsInWindow` land off-target on HiDPI | `boundsInWindow` is Compose pixels (already density-scaled); AWT/Robot and recording regions use screen pixels | Use `boundsOnScreen`/`centerOnScreen` for input and region targeting. If converting yourself, divide Compose pixels by the display scale — do not multiply |
 
 ## What Spectre is NOT (don't pretend it is)
 

--- a/skills/spectre/SKILL.md
+++ b/skills/spectre/SKILL.md
@@ -359,7 +359,7 @@ touches that area*; they are not needed for the common case.
 | `pasteText` times out on macOS in CI | Clipboard manager rewriting `NSPasteboard` | Disable clipboard utilities in CI |
 | Recording misses popups that escape the host window | Popups live in their own AWT window outside both the region rectangle *and* a window-targeted capture | Choose an explicit region (or full-desktop crop) wide enough to include where the popup opens, or document the limitation — neither region nor window targeting follows cross-window popups |
 | Window-targeted Wayland recording throws `IllegalStateException` | `xprop` missing or non-GNOME compositor | Use `AutoRecorder.startRegion(...)` with an explicit rectangle |
-| Coordinates derived from `boundsInWindow` land off-target on HiDPI | `boundsInWindow` is Compose pixels (already density-scaled); AWT/Robot and recording regions use screen pixels | Use `boundsOnScreen`/`centerOnScreen` for input and region targeting. If converting yourself, divide Compose pixels by the display scale — do not multiply |
+| Coordinates derived from `boundsInWindow` land off-target on HiDPI | `boundsInWindow` is Compose pixels (already density-scaled) and window-relative; AWT/Robot and recording regions use screen pixels | Use `boundsOnScreen`/`centerOnScreen` for input and region targeting. If converting yourself, divide by the display scale **and** add the surface/panel screen origin — do not multiply |
 
 ## What Spectre is NOT (don't pretend it is)
 

--- a/skills/spectre/references/recording.md
+++ b/skills/spectre/references/recording.md
@@ -96,11 +96,13 @@ If a test must run on those compositors, use `startRegion(...)` with a fixed
 ## HiDPI and coordinates
 
 `Rectangle` arguments are in **screen pixels** (post-HiDPI scaling), as is
-`AutomatorNode.boundsOnScreen`. `AutomatorNode.boundsInWindow` is already in
-**Compose / device pixels** (density-scaled). Reaching AWT or recording-region
-coordinates means **dividing** by the display scale — or just use
-`boundsOnScreen`, which does that conversion. Multiplying by density
-double-scales the region on a Retina display.
+`AutomatorNode.boundsOnScreen`. Prefer `boundsOnScreen`: it already divides by
+the display scale and adds the surface/panel screen origin.
+`AutomatorNode.boundsInWindow` is already in **Compose / device pixels**
+(density-scaled) and window-relative. If you convert it yourself, do both
+steps — dividing alone lands near `(0, 0)` when the window is not at the
+screen origin. Multiplying by density double-scales the region on a Retina
+display.
 
 ## Frame drops
 

--- a/skills/spectre/references/recording.md
+++ b/skills/spectre/references/recording.md
@@ -96,9 +96,11 @@ If a test must run on those compositors, use `startRegion(...)` with a fixed
 ## HiDPI and coordinates
 
 `Rectangle` arguments are in **screen pixels** (post-HiDPI scaling), as is
-`AutomatorNode.boundsOnScreen`. `AutomatorNode.boundsInWindow` is in **dp**.
-If you compute a recording region from `boundsInWindow`, apply the display
-density yourself — otherwise the region will be off on a Retina display.
+`AutomatorNode.boundsOnScreen`. `AutomatorNode.boundsInWindow` is already in
+**Compose / device pixels** (density-scaled). Reaching AWT or recording-region
+coordinates means **dividing** by the display scale — or just use
+`boundsOnScreen`, which does that conversion. Multiplying by density
+double-scales the region on a Retina display.
 
 ## Frame drops
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #495.

Four docs said or implied `AutomatorNode.boundsInWindow` is in **dp**, or told callers to “apply the display density” when deriving AWT/recording regions. The source of truth (`HiDpiMapper` KDoc and `composeToAwtX`) is that Compose semantics geometry is already in physical (Compose) pixels; conversion to AWT/Robot **divides** by scale **and adds the surface/panel screen origin**.

That “apply density” wording reads as multiply and would double-scale a region on a 2× display — the exact Retina failure the sentences claimed to prevent. Downstream Compose Pi review-bot P2s (ADUX-sandbox/Compose-Pi#2245, waiting resync in #2252) followed that reading.

Docs + KDoc only. No mapper or runtime geometry changes.

## What changed

- `skills/spectre/SKILL.md` — `boundsInWindow` is Compose pixels (density-scaled); compare it against `Dp.roundToPx()` / `LocalDensity`-scaled values and `boundsOnScreen` against dp figures.
- `skills/spectre/SKILL.md` pitfalls row — keep `boundsOnScreen`/`centerOnScreen` for input and region targeting; conversion is divide-by-scale **plus** surface/panel origin (do not multiply).
- `skills/spectre/references/recording.md` — same unit + conversion-direction correction, including origin translation.
- `docs/RECORDING-LIMITATIONS.md` — same; addresses Codex P2 that divide-alone lands near `(0, 0)` when the window is not at screen origin.
- `AutomatorNode.boundsInWindow` KDoc — pin the unit and the full `boundsOnScreen` conversion (scale + origin).

Left alone (already correct): `docs/guide/selectors.md`, `skill/SKILL.md`, `docs/spikes/209-injection/api-audit.md`.

`HiDpiMapper.kt` is untouched.

## Test plan

- [x] Grep for leftover `boundsInWindow` / “in dp” / “apply density” / divide-alone claims
- [x] `./gradlew check` — BUILD SUCCESSFUL after the origin-translation follow-up
- [x] `mkdocs build --strict` — built successfully

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-050a80c9-d752-409c-ab65-e10917a35d53?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-050a80c9-d752-409c-ab65-e10917a35d53&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

