### PR TITLE
test(release-smoke): automate the headed two-JVM Robot contention cell (#491)

### DIFF
--- a/.github/scripts/test-release-smoke-scripts.py
+++ b/.github/scripts/test-release-smoke-scripts.py
@@ -327,7 +327,7 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn("LocalCoordinatorServer", parallel_text)
         self.assertIn("Executors", parallel_text)
 
-    def test_headed_robot_cell_blocks_without_operator_evidence(self):
+    def test_headed_robot_cell_blocks_without_evidence_or_automated_run(self):
         """A reasoned n/a would let the runner print ALL HARD SCENARIOS PASSED; it must fail."""
         missing = smoke_lib.headed_robot_cell(None)
         self.assertEqual("fail", missing.result)
@@ -339,11 +339,83 @@ class SmokeLibSchemaTest(unittest.TestCase):
         for blank in ("", "   "):
             self.assertEqual("fail", smoke_lib.headed_robot_cell(blank).result)
 
-    def test_headed_robot_cell_passes_only_with_recorded_evidence(self):
+    def test_headed_robot_cell_passes_on_recorded_evidence(self):
         recorded = smoke_lib.headed_robot_cell("ran on Mattone; run URL ...")
         self.assertEqual("pass", recorded.result)
         self.assertIn("operator evidence: ran on Mattone", recorded.detail)
         self.assertEqual([], smoke_lib.hard_failures([recorded]))
+
+    def test_headed_robot_cell_passes_on_the_automated_proof_alone(self):
+        """#491: a host that can run the e2e needs no human signature."""
+        automated = smoke_lib.scenario_result(
+            smoke_lib.HEADED_ROBOT_SCENARIO_ID,
+            name=smoke_lib.HEADED_ROBOT_NAME,
+            result="pass",
+            seconds=41,
+        )
+        cell = smoke_lib.headed_robot_cell(None, automated=automated)
+        self.assertEqual("pass", cell.result)
+        self.assertEqual(41, cell.seconds)
+        self.assertIn(smoke_lib.HEADED_ROBOT_GRADLE_TASK, cell.detail)
+        self.assertEqual([], smoke_lib.hard_failures([cell]))
+
+    def test_operator_evidence_cannot_paper_over_a_red_automated_run(self):
+        """The one precedence that matters: an observed failure outranks a signature."""
+        automated = smoke_lib.scenario_result(
+            smoke_lib.HEADED_ROBOT_SCENARIO_ID,
+            name=smoke_lib.HEADED_ROBOT_NAME,
+            result="fail",
+            detail="two headed Robot JVMs interleaved their keystrokes",
+        )
+        cell = smoke_lib.headed_robot_cell("ran on Mattone; looked fine", automated=automated)
+        self.assertEqual("fail", cell.result)
+        self.assertIn("interleaved", cell.detail)
+        self.assertEqual(
+            ["input-coord-headed-robot"], smoke_lib.hard_failures([cell])
+        )
+
+    def test_a_host_that_cannot_run_the_e2e_still_fails_without_evidence(self):
+        """The escape hatch is for the operator, not for the absence of one."""
+        reason = "no xvfb-run on this host"
+        blocked = smoke_lib.headed_robot_cell(None, unavailable_reason=reason)
+        self.assertEqual("fail", blocked.result)
+        self.assertIn(reason, blocked.detail)
+        self.assertEqual(
+            ["input-coord-headed-robot"], smoke_lib.hard_failures([blocked])
+        )
+        # ...and with evidence it passes, still saying why the automation did not run.
+        signed = smoke_lib.headed_robot_cell("ran on Mattone", unavailable_reason=reason)
+        self.assertEqual("pass", signed.result)
+        self.assertIn(reason, signed.detail)
+        self.assertIn("operator evidence: ran on Mattone", signed.detail)
+
+    def test_headed_robot_proof_sources_exist_on_this_checkout(self):
+        self.assertIsNone(smoke_lib.headed_robot_missing_surface(ROOT))
+
+    def test_a_deleted_headed_proof_fails_rather_than_falling_back_to_a_signature(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            detail = smoke_lib.headed_robot_missing_surface(Path(tmp))
+            self.assertIsNotNone(detail)
+            self.assertIn("failure, not a skip", detail)
+            cell = smoke_lib.headed_robot_cell("ran on Mattone", missing_surface=detail)
+            self.assertEqual("fail", cell.result)
+            self.assertEqual(
+                ["input-coord-headed-robot"], smoke_lib.hard_failures([cell])
+            )
+
+    def test_headed_robot_gradle_task_and_testcase_match_the_kotlin_proof(self):
+        """The XML needle is how the cell proves the e2e ran; a rename must break here."""
+        test_source = ROOT / smoke_lib.HEADED_ROBOT_TEST_SOURCE
+        text = test_source.read_text(encoding="utf-8")
+        self.assertIn(smoke_lib.HEADED_ROBOT_TESTCASE, text)
+        # Two forked probe JVMs, released together, each with a Required-policy real Robot.
+        probe = (ROOT / smoke_lib.HEADED_ROBOT_PROBE_SOURCE).read_text(encoding="utf-8")
+        self.assertIn("RobotDriver(InputLeasePolicy.Required)", probe)
+        self.assertIn("ProcessBuilder", text)
+        build_script = (ROOT / "sample-desktop" / "build.gradle.kts").read_text(encoding="utf-8")
+        self.assertIn(
+            smoke_lib.HEADED_ROBOT_GRADLE_TASK.rsplit(":", maxsplit=1)[-1], build_script
+        )
 
     def test_input_coordination_surface_present_on_this_checkout(self):
         # The experimental coordinator + isolation proofs exist on this tree, so the cells are
@@ -650,11 +722,22 @@ class SmokeLibSchemaTest(unittest.TestCase):
         self.assertIn(
             "the per-test lease is still held while failure evidence is captured", text
         )
-        # The headed cell is operator-recorded and must never be satisfiable by the automated
-        # coordinator cells, which pass headless. It stays hard n/a until evidence is supplied.
+        # The headed cell is never satisfiable by the automated coordinator cells above, which
+        # pass headless. It is driven by its own Robot e2e where the host can run one, and the
+        # operator flag stays as the escape hatch for hosts that cannot (#491).
         self.assertIn("input-coord-headed-robot", text)
         self.assertIn("--headed-robot-evidence", text)
         self.assertIn("headed_robot_cell", text)
+        self.assertIn("HEADED_ROBOT_GRADLE_TASK", text)
+        self.assertIn("headed_robot_missing_surface", text)
+        # Robot cells must leave the compositor seat, so the headed cell uses the same xvfb
+        # wrapper and forced-X11 env as junit-live -- not the plain coordination scenario_env.
+        headed = text[text.index("--- headed two-JVM Robot contention") :]
+        headed = headed[: headed.index("# --- agent attach")]
+        self.assertIn("robot_prefix", headed)
+        self.assertIn("_robot_env(", headed)
+        self.assertIn("robot_xvfb_unavailable_reason", headed)
+        self.assertIn("assert_junit_testcases_passed", headed)
         # Non-login SSH / xvfb-run must still see rustup cargo for helper rebuilds.
         self.assertIn("apply_linux_toolchain_path", text)
         # Nested buildSrc test must not start a daemon that --stops parent ./gradlew check.
@@ -1056,6 +1139,18 @@ class DocsAndSchemaPolicyTest(unittest.TestCase):
             "input-coord-junit-pertest",
         ):
             self.assertIn(coordination_id, docs)
+
+    def test_release_smoke_docs_say_where_the_headed_cell_is_automated(self):
+        """#491: an operator must be able to tell, from this page, whether they still sign."""
+        docs = (ROOT / "docs" / "RELEASE-SMOKE.md").read_text(encoding="utf-8")
+        self.assertIn("input-coord-headed-robot", docs)
+        self.assertIn(smoke_lib.HEADED_ROBOT_GRADLE_TASK, docs)
+        # The escape hatch has to stay documented, and so does the one host that still needs it.
+        self.assertIn("--headed-robot-evidence", docs)
+        self.assertIn("-HeadedRobotEvidence", docs)
+        self.assertIn("Windows SSH", docs)
+        # ...as does the precedence, which is the part a reader would otherwise guess wrong.
+        self.assertIn("outranks an unverifiable note", docs)
 
     def test_validate_report_rejects_missing_required_ids(self):
         preflight = smoke_lib.collect_preflight(ROOT, version="0.5.0")

--- a/.github/scripts/test-windows-release-smoke-script.sh
+++ b/.github/scripts/test-windows-release-smoke-script.sh
@@ -115,13 +115,24 @@ grep -F -q 'two independent client JVMs never hold the desktop lease at the same
 grep -F -q 'ParallelPerTestInputIsolationTest' "$script" || fail "Windows runner missing parallel per-test isolation proof"
 grep -F -q 'concurrent per-test invocations never hold the desktop lease at the same time' "$script" || fail "Windows runner missing parallel per-test needle"
 grep -F -q 'the per-test lease is still held while failure evidence is captured' "$script" || fail "Windows runner missing evidence-capture needle"
-# Headed contention is operator-recorded: it must stay hard n/a unless evidence is passed, so the
-# automated (headless-capable) coordinator cells can never satisfy the headed claim on their own.
+# --- #491 headed two-JVM Robot contention ---
+# The automated (headless-capable) coordinator cells can never satisfy the headed claim on their
+# own, so this cell has its own real-Robot e2e, and the operator flag survives as the escape hatch
+# for hosts that cannot run one (Windows SSH has no interactive desktop for Robot to type into).
+grep -F -q 'Invoke-HeadedRobotCell' "$script" || fail "Windows runner missing headed-robot cell runner"
+grep -F -q ':sample-desktop:headedRobotContentionTest' "$script" || fail "Windows runner missing headed-robot Gradle task"
+grep -F -q 'two Robot JVMs typing into one field never interleave their keystrokes' "$script" || fail "Windows runner missing headed-robot testcase needle"
+grep -F -q 'sample-desktop\build\test-results\headedRobotContentionTest' "$script" || fail "Windows runner missing headed-robot JUnit results path"
+grep -F -q 'Get-HeadedRobotMissingSurface' "$script" || fail "Windows runner missing headed-robot surface probe"
+grep -F -q 'HeadedRobotContentionTest.kt' "$script" || fail "Windows runner missing headed-robot proof source"
 grep -F -q 'HeadedRobotEvidence' "$script" || fail "Windows runner missing headed-robot operator evidence parameter"
-grep -F -q 'operator-run on a real desktop and was NOT recorded' "$script" || fail "Windows runner missing headed-robot blocking message"
-# Absent evidence must be a hard FAIL, not a reasoned n/a: the summary's failure count ignores a
+grep -F -q 'was NOT recorded' "$script" || fail "Windows runner missing headed-robot blocking message"
+# An operator note must never outrank an observed red run -- that is where the escape hatch would
+# do real damage, because the note is unverifiable and the failure is measured.
+grep -F -q 'does not override an observed failure' "$script" || fail "Windows headed-robot cell must not let evidence mask a red automated run"
+# Absent both, it must be a hard FAIL, not a reasoned n/a: the summary's failure count ignores a
 # reasoned n/a, so an n/a here would report overall success without the headed proof.
-grep -F -q 'Result "fail" -Detail "headed two-JVM Robot contention' "$script" || fail "Windows headed-robot cell must FAIL (not n/a) when evidence is absent"
+grep -F -q 'Result "fail" -Detail $headedDetail' "$script" || fail "Windows headed-robot cell must FAIL (not n/a) when neither proof nor evidence is present"
 grep -F -q 'windows-ssh' "$script" || fail "SSH displayMode honesty for WGC missing"
 grep -F -q 'WGC requires native interactive console' "$script" || fail "WGC interactive-console N/A reason missing"
 grep -F -q 'AgentAttachIntegration e2e includes WGC node screenshots' "$script" || fail "SSH agent-attach-core hard n/a reason missing"

--- a/docs/RELEASE-SMOKE.md
+++ b/docs/RELEASE-SMOKE.md
@@ -69,7 +69,7 @@ These are structural, not one-release accidents:
 | --- | --- | --- |
 | CLI package-channel (Homebrew/Scoop) contracts | Structural on every Unix `check` (`python3`); install-semantics when Ruby present or under `CI` (issue #400) | Optional: install Ruby on a clean Linux box and run `./gradlew verifyHomebrewFormulaInstallSemantics` if claiming formula behaviour beyond CI |
 | Agent attach + contract corpus (live UI) | Linux Xvfb + macOS desktop; Windows **transport/ACL** unit tests | **Windows headed desktop** (not SSH-only for capture) |
-| Input coordinator contention/recovery | Deterministic + forked process on every OS | Automated pre-tag as the `input-coord-*` cells (both entrypoints, fail-closed JUnit XML). Those all pass headless, so headed real-input contention is a **separate hard cell**, `input-coord-headed-robot`, recorded by an operator |
+| Input coordinator contention/recovery | Deterministic + forked process on every OS | Automated pre-tag as the `input-coord-*` cells (both entrypoints, fail-closed JUnit XML). Those all pass headless, so headed real-input contention is a **separate hard cell**, `input-coord-headed-robot` — automated too (Linux Xvfb, macOS and Windows desktops), with an operator signature only where no host can run it |
 | Agent Windows UI e2e | Opt-in only: `-Pspectre.agent.attachE2e.allowWindows=true` | Run that property on Mattone-class boxes |
 | Agent real-keyboard `typeText` and `pressKey` | Runs on CI (`CI=true`); **skipped** on developer machines | Add `-Pspectre.agent.realKeyboard=true` on an idle desktop |
 | Agent **inject** attach | Linux + macOS e2e | **Windows** inject fixture (no preinstalled core) |
@@ -136,14 +136,34 @@ Non-overlap in both is an invariant, not a timing race: the lease is mutually ex
 waiter cannot be granted until the holder releases. A failure means genuine interleaving, never a
 slow machine.
 
-What remains outside automation is the **headed** half of the first bullet, and it is a hard cell,
-not a residual. Every automated cell above passes headless and under SSH, because none of them
+The **headed** half of the first bullet is a seventh hard cell, `input-coord-headed-robot`, and
+not a residual. Every cell in the table above passes headless and under SSH, because none of them
 constructs a `RobotDriver`: together they prove the *lease* is mutually exclusive, never that two
-processes' real OS input does not interleave. That is `input-coord-headed-robot`, which the harness
-cannot run for you — it is a hard **fail** until an operator drives two
-`RobotDriver(InputLeasePolicy.Required)` JVMs on a real desktop and records it
-(`--headed-robot-evidence "<note>"` on Unix, `-HeadedRobotEvidence "<note>"` on Windows). Do not
-treat green `input-coord-*` cells as satisfying it. To add or change one of these cells, follow
+processes' real OS input does not interleave. Do not treat green `input-coord-*` cells as
+satisfying it.
+
+Since [#491](https://github.com/rock3r/spectre/issues/491) that cell is automated too. Both
+entrypoints run `:sample-desktop:headedRobotContentionTest`, which forks two JVMs, each with its
+own `RobotDriver(InputLeasePolicy.Required)`, releases them from one barrier, and has both type a
+distinguishable block into the same focused text field of one fixture window. An `ababab` field is
+the failure being ruled out. The e2e is genuinely contended by construction, and says so: each
+probe pays for coordinator launch and window focus *before* the barrier, and the test then measures
+that the second probe asked for the keyboard while the first was still typing — otherwise it fails
+as a broken barrier rather than reporting a vacuous pass.
+
+| Platform | How the cell is satisfied |
+| --- | --- |
+| Linux Xorg/Xvfb | Automated. `release-smoke.py` runs the task under the same `xvfb-run` wrapper and forced-X11 env as `junit-live` — Robot cells must leave the compositor seat (#432). Hard **fail** if `xvfb-run` is absent, unless an operator signs. |
+| macOS desktop | Automated, if `java.awt.Robot` has Accessibility (TCC) permission. Without it the probes' input is dropped and the cell **fails**; grant it, or sign for a run on a Mac that has it. |
+| Windows interactive / RDP | Automated. |
+| Windows SSH | **Not** automated — an SSH session has no interactive desktop for Robot to type into, so the cell needs an operator signature there. |
+
+The operator flag survives as that escape hatch: `--headed-robot-evidence "<note>"` on Unix,
+`-HeadedRobotEvidence "<note>"` on Windows. It cannot rescue a red automated run — an observed
+interleave outranks an unverifiable note — and it does not substitute for a deleted proof source.
+Absent both a run and a signature, the cell is a hard **fail**.
+
+To add or change one of these cells, follow
 [Adding a scenario ID](#adding-a-scenario-id-per-release-delta-or-permanent-baseline); do not leave
 one-off `./gradlew` commands only in chat.
 
@@ -336,7 +356,7 @@ Shared across macOS / Linux / Windows entrypoints (`scripts/smoke_lib.py` → `R
 | `input-coord-revoke` | Exact-ID normal revoke fences only its own lease and cannot affect a newer one. |
 | `input-coord-forced-recovery` | Explicit forced recovery reports `unsafeTakeover=true` and advances the FIFO queue. |
 | `input-coord-junit-pertest` | `InputIsolationConfig.perTest()` serialises factory, body, evidence, and teardown (`:testing:test` `InputIsolationLifecycleTest`). |
-| `input-coord-headed-robot` | **Operator-run.** Two `RobotDriver(InputLeasePolicy.Required)` JVMs dispatching real OS input on a headed desktop must not interleave. The harness cannot automate this, so it is a hard **fail** — the smoke exits non-zero — unless the operator passes `--headed-robot-evidence` / `-HeadedRobotEvidence`. A reasoned `n/a` would be ignored by the fail-closed check and report success, so absence is deliberately a failure. Required on every OS whose release notes claim headed coordination. |
+| `input-coord-headed-robot` | Two `RobotDriver(InputLeasePolicy.Required)` JVMs dispatching real OS input on a headed desktop must not interleave. Driven by `:sample-desktop:headedRobotContentionTest` (fail-closed on its JUnit XML) wherever the host can run it: Linux under `xvfb-run`, a macOS desktop with Accessibility granted, Windows interactive/RDP. Where it cannot — Windows SSH, a Linux box without `xvfb-run` — the operator passes `--headed-robot-evidence` / `-HeadedRobotEvidence`. With neither it is a hard **fail** and the smoke exits non-zero; a reasoned `n/a` would be ignored by the fail-closed check and report success, so absence is deliberately a failure. Required on every OS whose release notes claim headed coordination. |
 
 The `input-coord-*` cells ([#459](https://github.com/rock3r/spectre/pull/459)) are the automated form of the
 [Experimental input coordination release gate](#experimental-input-coordination-release-gate). Each drives the
@@ -346,8 +366,8 @@ empty-filter run cannot fake `pass`. They need no display, so they stay **hard**
 **fail**, not a skip: deleting or renaming one of these tests must not turn six hard cells green by
 omission. Dropping the feature legitimately means re-scoping affirmatively — remove the
 `input-coord-*` IDs from `REQUIRED_SCENARIO_IDS` and update this page. Fully-headed
-two-`RobotDriver` physical-mouse contention is a separate hard cell, `input-coord-headed-robot`,
-which only an operator can record (below).
+two-`RobotDriver` real-input contention is a separate hard cell, `input-coord-headed-robot`, which
+runs its own Robot e2e where the host allows and is operator-recorded where it does not (below).
 
 The Unix runner registers **every** required ID end-to-end (fail-closed). Environment-impossible
 cells must be explicit hard `n/a` with reason — never a silent omit or fake `pass`.
@@ -378,7 +398,8 @@ coverage to the runner rather than leaving a one-release command only in chat.
 | Preflight / check / agent attach·inject·launch / CLI package / MCP SDK / Maven Local | `release-smoke.py` (macOS/Linux); Windows PS shares IDs | — |
 | Live JUnit failure artifacts/video + atomic capture | `release-smoke.py` → `junit-live` | Windows: run on macOS/Linux baseline (hard `n/a` on Windows entrypoint with reason) |
 | Pointer-move hover (#433 / #435) | Unix + Windows `pointer-move` → `*PointerMoveLive*` | Fail-closed on all three OSes; hard `n/a` only if the verbs disappear |
-| Input coordination gate (#459: contention / cancellation / quarantine / revoke / forced recovery / JUnit PerTest) | Unix + Windows `input-coord-*` (coordinator protocol + forked process + JUnit isolation, fail-closed XML) | **Hard** `input-coord-headed-robot`: two-`RobotDriver` real-mouse contention on a headed desktop, recorded via `--headed-robot-evidence` / `-HeadedRobotEvidence` |
+| Input coordination gate (#459: contention / cancellation / quarantine / revoke / forced recovery / JUnit PerTest) | Unix + Windows `input-coord-*` (coordinator protocol + forked process + JUnit isolation, fail-closed XML) | — |
+| Headed two-`RobotDriver` real-input contention (#491) | Unix + Windows `input-coord-headed-robot` → `:sample-desktop:headedRobotContentionTest` (Linux Xvfb, macOS desktop with TCC, Windows interactive/RDP) | **Hard** on hosts that cannot run it (Windows SSH; no `xvfb-run`): record via `--headed-robot-evidence` / `-HeadedRobotEvidence` |
 | Host native recording | macOS SCK + Linux X11 in `release-smoke.py`; WGC in Windows PS when **interactive** | SSH WGC is N/A (not PASS) |
 | TCC / notarization / app seal | — | macOS recipes below |
 | Real Wayland portal | — | Real Wayland session (Xvfb ≠ Wayland) |
@@ -508,10 +529,19 @@ release SHA.
   need no display, so they are hard on macOS, Windows (including SSH), and Linux Xorg/Xvfb. A
   missing proof source is a hard **fail** rather than a reasoned `n/a` (which `hard_failures()`
   ignores), so a rename cannot pass six cells by omission; re-scope the release affirmatively if
-  the feature is genuinely dropped. The one thing these cells do **not** cover is a fully-headed two-`RobotDriver` physical
-  **real-mouse** run: they all pass headless, so `input-coord-headed-robot` carries that claim as a
-  hard operator-recorded cell. Absent evidence it reports **fail** (not a reasoned `n/a`, which
-  `hard_failures()` ignores), so the smoke cannot report success without it. Automating it (a Robot-backed two-JVM contention e2e) is a follow-up.
+  the feature is genuinely dropped. The one thing these cells do **not** cover is a fully-headed
+  two-`RobotDriver` **real-input** run: they all pass headless, so `input-coord-headed-robot`
+  carries that claim as a seventh hard cell.
+- **#491 headed two-JVM Robot contention:** `input-coord-headed-robot` is now driven by
+  `:sample-desktop:headedRobotContentionTest` on both entrypoints — two forked JVMs, each with
+  `RobotDriver(InputLeasePolicy.Required)`, released from one barrier onto a single focused text
+  field, asserting the two typed blocks never interleave and that the second probe genuinely
+  contended for the keyboard. It runs on Linux under `xvfb-run`, on a macOS desktop that has
+  granted Robot Accessibility (TCC), and on Windows interactive/RDP; a **Windows SSH** session has
+  no interactive desktop and still needs `-HeadedRobotEvidence`. Absent both a run and a signature
+  the cell reports **fail** (not a reasoned `n/a`, which `hard_failures()` ignores), so the smoke
+  cannot report success without it — and a signature never rescues a red automated run, because an
+  observed interleave is a measurement and a note is not.
 - **Linux helper `cargo` on Robot cells:** Unix harness prepends `$CARGO_HOME/bin` or
   `~/.cargo/bin` to PATH. Non-login SSH + `xvfb-run` otherwise cannot start
   `:recording:buildWaylandHelper` when `--rerun-tasks` rebuilds the helper. Do **not**

--- a/sample-desktop/build.gradle.kts
+++ b/sample-desktop/build.gradle.kts
@@ -49,6 +49,13 @@ dependencies {
     detektPlugins(libs.compose.rules.detekt)
 
     testImplementation(libs.kotlin.testJunit5)
+    // @Tag on the headed Robot contention e2e (#491), which `test` filters out and the dedicated
+    // `headedRobotContentionTest` task selects.
+    testImplementation(libs.junit5.api)
+    // The forked contention probes construct RobotDriver(InputLeasePolicy.Required), which reaches
+    // the coordinator through a ServiceLoader provider. Without the server artifact on the probe's
+    // runtime classpath every acquisition fails COORDINATOR_PROVIDER_MISSING.
+    testRuntimeOnly(projects.inputCoordinatorServer)
 
     "validationImplementation"(libs.kotlin.testJunit5)
     "validationImplementation"(libs.junit5.api)
@@ -58,6 +65,13 @@ dependencies {
 }
 
 tasks.withType<Test>().configureEach { useJUnitPlatform() }
+
+// The headed two-JVM Robot contention e2e (#491) lives in `test` next to the Robot smoke rig it
+// reuses, but it drives the real OS keyboard and forks two coordinator clients, so it must never
+// run as part of `check` on a headless CI worker. Tag literal mirrors `HEADED_ROBOT_TAG`.
+val headedRobotTag = "headedRobot"
+
+tasks.test { useJUnitPlatform { excludeTags(headedRobotTag) } }
 
 // Configuration Cache "Runs tasks in parallel within the same project"
 // (https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:intro), so the
@@ -99,6 +113,45 @@ tasks
     .withType<Test>()
     .matching { it.name.startsWith("validationTest") }
     .configureEach { usesService(validationTestSerialiser) }
+
+// Backs the `input-coord-headed-robot` release-smoke cell. Run headed: a real macOS/Windows
+// desktop, or Linux under `xvfb-run`. Unlike the `input-coord-*` protocol cells this one cannot
+// pass headless, which is the entire point of it existing.
+@Suppress("UNUSED_VARIABLE")
+val headedRobotContentionTest by
+    tasks.registering(Test::class) {
+        description =
+            "Proves two RobotDriver(InputLeasePolicy.Required) JVMs cannot interleave real input."
+        group = "verification"
+        testClassesDirs = sourceSets["test"].output.classesDirs
+        classpath = sourceSets["test"].runtimeClasspath
+        useJUnitPlatform { includeTags(headedRobotTag) }
+        // One fixture window per JVM; Compose Desktop leaves global EDT state behind.
+        forkEvery = 1
+        // Same Skiko constraint as the validation lane: Xvfb and cold Windows GPU init cannot be
+        // relied on for a hardware context. A caller override still wins for local GPU work.
+        if (OperatingSystem.current().isLinux || OperatingSystem.current().isWindows) {
+            val renderApi = providers.systemProperty("skiko.renderApi").orElse("SOFTWARE_COMPAT")
+            systemProperty("skiko.renderApi", renderApi.get())
+        }
+        // The opposite of the validation lane's default. A macOS UI-element process is
+        // background-only and never takes keyboard focus, so the probes' keystrokes would land
+        // nowhere and the field would come back empty.
+        systemProperty("apple.awt.UIElement", "false")
+        // Red-proof lever, off unless asked for: forwards
+        // -Dspectre.headedContention.distinctDesktopKeys=true to the worker so each probe gets its
+        // own desktop resource key and mutual exclusion is disabled. See HeadedRobotContentionTest.
+        systemProperty(
+            "spectre.headedContention.distinctDesktopKeys",
+            providers
+                .systemProperty("spectre.headedContention.distinctDesktopKeys")
+                .orElse("false")
+                .get(),
+        )
+        // Real OS input plus a forked coordinator: the validation Test tasks are serialised for
+        // the same reason, and a concurrent worker JVM here would contend for the actual keyboard.
+        usesService(validationTestSerialiser)
+    }
 
 // Mark every validation-driven worker JVM as a macOS UI element. AppKit treats UI-element
 // processes as background-only — no Dock icon, no menu bar, and (the part the user cares about)

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/HeadedRobotContention.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/HeadedRobotContention.kt
@@ -1,0 +1,109 @@
+package dev.sebastiano.spectre.sample
+
+/**
+ * Shared vocabulary for the headed two-JVM Robot contention proof (#491).
+ *
+ * The parent test ([HeadedRobotContentionTest]), the forked probe ([HeadedRobotContentionProbe]),
+ * and the deterministic verdict cases ([HeadedRobotContentionAnalysisTest]) all read their
+ * constants from here so a change to the block size or the alphabet cannot drift between the three.
+ */
+
+/** JUnit tag carried by the headed e2e. Mirrored literally in `sample-desktop/build.gradle.kts`. */
+internal const val HEADED_ROBOT_TAG: String = "headedRobot"
+
+/** Character typed by the first probe JVM. */
+internal const val FIRST_BLOCK_CHARACTER: Char = 'a'
+
+/** Character typed by the second probe JVM. */
+internal const val SECOND_BLOCK_CHARACTER: Char = 'b'
+
+/**
+ * Characters each probe types in one `typeText` call.
+ *
+ * `RobotDriver` sets `Robot.autoDelay` to 10ms and `typeText` issues a press and a release per
+ * character, so a block occupies the real keyboard for roughly 0.8s. That matters: the whole proof
+ * rests on the two JVMs *wanting* the keyboard at the same time, and a burst short enough to finish
+ * inside the other process's scheduling jitter would serialise itself. Lower-case letters are
+ * deliberate — an upper-case block would add a Shift press/release around every character, which
+ * makes a failure harder to read without making contention any more real.
+ */
+internal const val BLOCK_LENGTH: Int = 40
+
+/**
+ * Opening words of the verdict when the two blocks were shredded into each other.
+ *
+ * Pinned as a constant because it is the string a red proof has to show. "The test failed" is not
+ * evidence that this test can detect interleaving; failing *with this sentence* is.
+ */
+internal const val INTERLEAVED_FAILURE: String =
+    "two headed Robot JVMs interleaved their keystrokes"
+
+/** One uninterrupted run of a single character, as observed in the shared text field. */
+internal data class TypedRun(val character: Char, val length: Int) {
+    override fun toString(): String = "'$character'x$length"
+}
+
+/** Collapses adjacent equal characters of [text] into runs, left to right. */
+internal fun typedRuns(text: String): List<TypedRun> {
+    val runs = mutableListOf<TypedRun>()
+    for (character in text) {
+        val last = runs.lastOrNull()
+        if (last != null && last.character == character) {
+            runs[runs.lastIndex] = last.copy(length = last.length + 1)
+        } else {
+            runs += TypedRun(character, length = 1)
+        }
+    }
+    return runs
+}
+
+/**
+ * Returns `null` when [text] holds the two blocks back to back in either order, and otherwise says
+ * what went wrong — starting with [INTERLEAVED_FAILURE] if, and only if, the two blocks were
+ * shredded into each other.
+ *
+ * Interleaving is separated from short or contaminated content on purpose. Both are failures and
+ * both block the tag, but only one of them means the desktop lease stopped being mutually
+ * exclusive; reporting a dropped keystroke under the interleaving sentence would send the next
+ * reader hunting a coordinator bug that is not there.
+ */
+internal fun describeContentionFailure(
+    text: String,
+    firstCharacter: Char,
+    secondCharacter: Char,
+    blockLength: Int,
+): String? {
+    val expected =
+        "expected '$firstCharacter'x$blockLength and '$secondCharacter'x$blockLength back to " +
+            "back in either order"
+    val observed = "observed ${typedRuns(text)} in ${quoted(text)}"
+    val foreign = text.filterNot { it == firstCharacter || it == secondCharacter }.toSortedSet()
+    if (foreign.isNotEmpty()) {
+        return "the shared field holds characters neither probe typed " +
+            "(${foreign.joinToString()}); $expected, $observed"
+    }
+    val runs = typedRuns(text)
+    if (runs.size > EXPECTED_RUN_COUNT) {
+        return "$INTERLEAVED_FAILURE: $expected, $observed"
+    }
+    if (runs.size < EXPECTED_RUN_COUNT) {
+        return "only ${runs.size} of the two blocks reached the shared field; $expected, $observed"
+    }
+    if (runs.any { it.length != blockLength }) {
+        return "both blocks arrived unmixed but incomplete, so keystrokes were dropped between " +
+            "the probes and the field; $expected, $observed"
+    }
+    return null
+}
+
+private fun quoted(text: String): String =
+    if (text.length <= QUOTED_TEXT_LIMIT) {
+        "\"$text\""
+    } else {
+        "\"${text.take(QUOTED_TEXT_LIMIT)}\"... (${text.length} characters)"
+    }
+
+/** One run per probe: any more is interleaving, any fewer means a block never landed. */
+private const val EXPECTED_RUN_COUNT: Int = 2
+
+private const val QUOTED_TEXT_LIMIT: Int = 200

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/HeadedRobotContentionAnalysisTest.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/HeadedRobotContentionAnalysisTest.kt
@@ -1,0 +1,87 @@
+package dev.sebastiano.spectre.sample
+
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Deterministic proof that the headed-contention verdict has teeth.
+ *
+ * [HeadedRobotContentionTest] can only observe whatever the desktop actually produced, so the
+ * assertion it leans on is pinned here instead: an `ababab` field is the failure mode the headed
+ * cell exists to rule out, and it must be reported as *interleaving* specifically — a verdict that
+ * merely returns "not the expected string" would look like a valid red proof while actually failing
+ * for the wrong reason.
+ *
+ * These cases run headless as part of `./gradlew check`; the headed e2e is tagged out of `test`.
+ */
+class HeadedRobotContentionAnalysisTest {
+
+    @Test
+    fun `two contiguous blocks pass in either order`() {
+        assertNull(describeContentionFailure("aaaabbbb", 'a', 'b', blockLength = 4))
+        assertNull(describeContentionFailure("bbbbaaaa", 'a', 'b', blockLength = 4))
+    }
+
+    @Test
+    fun `perfectly alternating keystrokes are reported as interleaving`() {
+        val failure = describeContentionFailure("abababab", 'a', 'b', blockLength = 4)
+        assertNotNull(failure)
+        assertTrue(
+            failure.startsWith(INTERLEAVED_FAILURE),
+            "interleaving must be named as such, got: $failure",
+        )
+        // The observed content belongs in the message: without it a reader cannot tell a clean
+        // hand-off from a shredded one, and the release report only carries this string.
+        assertTrue(failure.contains("abababab"), "failure must quote the field content: $failure")
+    }
+
+    @Test
+    fun `a single spliced block is interleaving too`() {
+        // The realistic shape when one JVM wins most of the race but not all of it.
+        val failure = describeContentionFailure("aaabbbbaa", 'a', 'b', blockLength = 5)
+        assertNotNull(failure)
+        assertTrue(failure.startsWith(INTERLEAVED_FAILURE), "got: $failure")
+    }
+
+    @Test
+    fun `dropped keystrokes are not reported as interleaving`() {
+        // Two clean runs, but short. Real, and worth failing on — just not the same defect, and
+        // calling it interleaving would send the next reader hunting a coordinator bug.
+        val failure = describeContentionFailure("aaabbbb", 'a', 'b', blockLength = 4)
+        assertNotNull(failure)
+        assertTrue(
+            !failure.startsWith(INTERLEAVED_FAILURE),
+            "short blocks are a delivery failure, not interleaving: $failure",
+        )
+        assertTrue(failure.contains("3"), "failure must report the observed run lengths: $failure")
+    }
+
+    @Test
+    fun `a field holding only one block fails`() {
+        val failure = describeContentionFailure("aaaa", 'a', 'b', blockLength = 4)
+        assertNotNull(failure)
+        assertTrue(!failure.startsWith(INTERLEAVED_FAILURE), "got: $failure")
+    }
+
+    @Test
+    fun `an empty field fails`() {
+        assertNotNull(describeContentionFailure("", 'a', 'b', blockLength = 4))
+    }
+
+    @Test
+    fun `foreign characters fail even when the two blocks are contiguous`() {
+        // A stray modifier or a stuck key changes what reached the field; the run shape alone
+        // would still look like two clean blocks.
+        val failure = describeContentionFailure("aaaaXbbbb", 'a', 'b', blockLength = 4)
+        assertNotNull(failure)
+        assertTrue(failure.contains("X"), "failure must name the foreign character: $failure")
+    }
+
+    @Test
+    fun `run length encoding collapses adjacent equal characters`() {
+        assertTrue(typedRuns("aabbb") == listOf(TypedRun('a', 2), TypedRun('b', 3)))
+        assertTrue(typedRuns("") == emptyList<TypedRun>())
+    }
+}

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/HeadedRobotContentionProbe.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/HeadedRobotContentionProbe.kt
@@ -1,0 +1,107 @@
+@file:JvmName("HeadedRobotContentionProbe")
+@file:OptIn(dev.sebastiano.spectre.input.ExperimentalSpectreInputCoordinationApi::class)
+
+package dev.sebastiano.spectre.sample
+
+import dev.sebastiano.spectre.core.InputLeasePolicy
+import dev.sebastiano.spectre.core.RobotDriver
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Duration
+import kotlin.system.exitProcess
+import kotlinx.coroutines.runBlocking
+
+/**
+ * Child-JVM half of [HeadedRobotContentionTest] (#491).
+ *
+ * Runs in its own process with its own `RobotDriver(InputLeasePolicy.Required)` so the proof
+ * involves two genuinely independent sources of **real OS input**, not two drivers sharing one JVM
+ * (which a plain in-process mutex would already serialise) and not two coordinator client sessions
+ * that never touch the keyboard (which is what the `input-coord-*` protocol cells already cover,
+ * and why they all pass headless).
+ *
+ * Order of operations, all of it load-bearing:
+ * 1. **Warm up.** One coordinated click on the shared text field. This launches or connects the
+ *    coordinator, establishes the driver's client session, and focuses the field — every slow,
+ *    variable step is spent here, *before* the barrier, so what the barrier releases is two
+ *    processes that are one lease acquisition away from typing.
+ * 2. **Signal readiness**, then park on the parent's gate file.
+ * 3. **Type one block in a single `typeText` call.** One call is deliberate: `RobotDriver` holds
+ *    one lease for a whole `typeText`, so a block is the unit the coordinator is allowed to
+ *    serialise. Splitting it across calls would take a fresh lease per call and interleaving
+ *    between them would be entirely legitimate — the test would then be asserting something the
+ *    coordinator never promised.
+ * 4. **Record wall-clock timestamps** so the parent can prove demand actually overlapped rather
+ *    than assuming it. `currentTimeMillis`, not `nanoTime`: the two are only comparable across
+ *    processes as wall clock.
+ *
+ * Usage: `<screenX> <screenY> <character> <blockLength> <readyFile> <goFile> <outputFile>`
+ */
+public fun main(arguments: Array<String>) {
+    require(arguments.size == EXPECTED_ARGUMENT_COUNT) {
+        "Usage: <screenX> <screenY> <character> <blockLength> <readyFile> <goFile> <outputFile>"
+    }
+    val screenX = arguments[0].toInt()
+    val screenY = arguments[1].toInt()
+    val character = arguments[2].single()
+    val blockLength = arguments[3].toInt()
+    val readyFile = Path.of(arguments[4])
+    val goFile = Path.of(arguments[5])
+    val outputFile = Path.of(arguments[6])
+
+    try {
+        runBlocking {
+            typeOneBlock(screenX, screenY, character, blockLength, readyFile, goFile, outputFile)
+        }
+    } catch (failure: Throwable) {
+        System.err.println(
+            "headed contention probe '$character' failed: ${failure.message}\n" +
+                failure.stackTraceToString()
+        )
+        exitProcess(1)
+    }
+    exitProcess(0)
+}
+
+@Suppress("LongParameterList")
+private suspend fun typeOneBlock(
+    screenX: Int,
+    screenY: Int,
+    character: Char,
+    blockLength: Int,
+    readyFile: Path,
+    goFile: Path,
+    outputFile: Path,
+) {
+    RobotDriver(InputLeasePolicy.Required).use { driver ->
+        // Warm-up: pays for coordinator launch, client session setup, and focusing the field while
+        // nothing is racing. The field is still empty here, so the caret lands at offset 0 for
+        // both probes and neither block can be typed into the middle of the other's text.
+        driver.click(screenX, screenY)
+
+        Files.writeString(readyFile, "ready\n")
+        awaitGate(goFile)
+
+        val requestedAt = System.currentTimeMillis()
+        driver.typeText(character.toString().repeat(blockLength))
+        val typedTo = System.currentTimeMillis()
+        // `typedFrom` is not measurable from here: the lease is acquired inside `typeText`, so the
+        // wait for the other probe is folded into the call. `requestedAt` (when this process began
+        // wanting the keyboard) and `typedTo` (when it stopped using it) are what the parent needs
+        // to prove the two demands overlapped.
+        Files.writeString(outputFile, "REQUESTED $requestedAt\nTYPED_TO $typedTo\n")
+    }
+}
+
+private fun awaitGate(goFile: Path) {
+    val deadline = System.nanoTime() + Duration.ofSeconds(GATE_TIMEOUT_SECONDS).toNanos()
+    while (System.nanoTime() < deadline) {
+        if (Files.exists(goFile)) return
+        Thread.sleep(GATE_POLL_MILLIS)
+    }
+    error("parent never opened the contention gate at $goFile")
+}
+
+private const val EXPECTED_ARGUMENT_COUNT: Int = 7
+private const val GATE_TIMEOUT_SECONDS: Long = 120
+private const val GATE_POLL_MILLIS: Long = 5

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/HeadedRobotContentionTest.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/HeadedRobotContentionTest.kt
@@ -1,0 +1,287 @@
+package dev.sebastiano.spectre.sample
+
+import androidx.compose.ui.awt.ComposePanel
+import java.awt.Dimension
+import java.awt.Point
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+import javax.swing.JFrame
+import javax.swing.SwingUtilities
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Tag
+
+/**
+ * Release-gate proof that two processes driving **real OS input** cannot shred each other's
+ * keystrokes — the `input-coord-headed-robot` smoke cell (#491, follow-up to #484).
+ *
+ * The `input-coord-*` protocol cells already prove the desktop lease is mutually exclusive across
+ * process boundaries, `TwoClientJvmContentionTest` included. What none of them can observe is the
+ * thing the lease exists for: every one of them passes headless and under SSH because not one
+ * constructs a `RobotDriver`. This test does. Two forked JVMs each take
+ * `RobotDriver(InputLeasePolicy.Required)` and type one block into the same focused text field of
+ * the same fixture window; an `ababab` field is the failure being ruled out, and it is invisible to
+ * every lease-level proof.
+ *
+ * **Why it is genuinely contended.** Starting two JVMs back to back proves nothing: JVM startup
+ * plus coordinator launch easily outlasts a block of typing, the two would trivially serialise
+ * themselves, and the assertion would pass against a coordinator enforcing nothing. So each probe
+ * pays all of that up front, signals readiness, and parks on a parent-controlled gate — and the
+ * test then *measures* the overlap rather than trusting it: the probe that asked for the keyboard
+ * second must have asked while the first was still typing, or this fails as a broken barrier rather
+ * than reporting a vacuous pass.
+ *
+ * **Red proof.** Mutual exclusion can be switched off without touching production code, because a
+ * Linux desktop key is derived from `WAYLAND_DISPLAY` while `java.awt.Robot` follows `DISPLAY`:
+ * ```
+ * ./gradlew :sample-desktop:headedRobotContentionTest \
+ *     -Dspectre.headedContention.distinctDesktopKeys=true
+ * ```
+ *
+ * gives each probe its own fake `WAYLAND_DISPLAY`, so one coordinator hands both a lease at once
+ * while both keep typing at the same X display. That run must fail, and it must fail with
+ * [INTERLEAVED_FAILURE] — a failure for any other reason is not a red proof.
+ *
+ * Not part of `check`: it is tagged [HEADED_ROBOT_TAG], which `test` excludes and the dedicated
+ * `headedRobotContentionTest` task selects. It needs a real desktop (macOS, Windows) or Xvfb.
+ */
+@Tag(HEADED_ROBOT_TAG)
+class HeadedRobotContentionTest {
+
+    private val workDirectory: Path = Files.createTempDirectory("spectre-headed-contention-")
+    private val goFile: Path = workDirectory.resolve("go")
+    private val children = mutableListOf<Process>()
+    private var frame: JFrame? = null
+
+    @AfterTest
+    fun cleanUp() {
+        children.forEach { child ->
+            child.destroy()
+            child.waitFor(CHILD_DESTROY_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        }
+        SwingUtilities.invokeLater {
+            frame?.isVisible = false
+            frame?.dispose()
+        }
+        Files.walk(workDirectory).use { paths ->
+            paths.sorted(Comparator.reverseOrder()).forEach { path ->
+                runCatching { Files.deleteIfExists(path) }
+            }
+        }
+    }
+
+    @Test
+    fun `two Robot JVMs typing into one field never interleave their keystrokes`() {
+        runBlocking { proveKeystrokesNeverInterleave() }
+    }
+
+    private suspend fun proveKeystrokesNeverInterleave() {
+        checkWaylandGate("HeadedRobotContentionTest")?.let { abort ->
+            // A fail, never a skip: the release cell that runs this task treats an assumption-skip
+            // as a failure precisely so an unrunnable host cannot report the headed claim green.
+            error(abort)
+        }
+        val state = openFixtureWindow()
+        val target =
+            requireNotNull(awtCenter(state, state.textFieldBounds)) {
+                "the shared text field never reported screen bounds, so no probe could aim at it"
+            }
+        printEnvironment("HeadedRobotContentionTest", state)
+        println("headed contention: aiming both probes at $target, ${blockPlanSummary()}")
+
+        val first = ProbeHandle("first", FIRST_BLOCK_CHARACTER)
+        val second = ProbeHandle("second", SECOND_BLOCK_CHARACTER)
+        start(first, target)
+        start(second, target)
+
+        awaitReady(first, second)
+        Files.writeString(goFile, "go\n")
+
+        assertEquals(0, waitForExit(first), "the '${first.character}' probe JVM exited non-zero")
+        assertEquals(0, waitForExit(second), "the '${second.character}' probe JVM exited non-zero")
+
+        assertDemandOverlapped(first.readRecord(), second.readRecord())
+
+        val observed = awaitFieldContent(state)
+        println("headed contention: field content was \"$observed\"")
+        assertNull(
+            describeContentionFailure(
+                observed,
+                FIRST_BLOCK_CHARACTER,
+                SECOND_BLOCK_CHARACTER,
+                BLOCK_LENGTH,
+            ),
+            "two RobotDriver(InputLeasePolicy.Required) JVMs did not keep their real input apart",
+        )
+    }
+
+    /**
+     * Fails unless the second probe wanted the keyboard while the first still had it.
+     *
+     * Without this the suite could pass on a host where startup skew serialised the probes on its
+     * own, which is a green light that proves nothing about the coordinator.
+     */
+    private fun assertDemandOverlapped(first: ProbeRecord, second: ProbeRecord) {
+        val (early, late) = listOf(first, second).sortedBy(ProbeRecord::requestedAt)
+        assertTrue(
+            late.requestedAt < early.typedTo,
+            "the probes never contended: '${late.character}' first asked for the keyboard at " +
+                "${late.requestedAt}, after '${early.character}' had already finished typing at " +
+                "${early.typedTo}. The barrier failed to release them together, so a pass here " +
+                "would say nothing about mutual exclusion.",
+        )
+    }
+
+    private suspend fun openFixtureWindow(): SmokeState {
+        val state = SmokeState()
+        val frameReference = AtomicReference<JFrame>()
+        SwingUtilities.invokeLater {
+            val panel =
+                ComposePanel().apply {
+                    preferredSize = Dimension(SMOKE_PANEL_WIDTH, SMOKE_PANEL_HEIGHT)
+                    setContent { SmokeContent(state) }
+                }
+            val opened =
+                JFrame("Spectre headed Robot contention").apply {
+                    defaultCloseOperation = JFrame.DISPOSE_ON_CLOSE
+                    contentPane = panel
+                    pack()
+                    setLocationRelativeTo(null)
+                    isAlwaysOnTop = true
+                    isVisible = true
+                    toFront()
+                    requestFocus()
+                }
+            state.frame = opened
+            state.composePanel = panel
+            frame = opened
+            frameReference.set(opened)
+        }
+        waitForFrame(frameReference)
+        waitForLayout(state)
+        delay(POST_LAYOUT_WARMUP_MS.milliseconds)
+        return state
+    }
+
+    private fun start(probe: ProbeHandle, target: Point) {
+        val java = Path.of(System.getProperty("java.home"), "bin", javaExecutableName()).toString()
+        val builder =
+            ProcessBuilder(
+                    java,
+                    "-cp",
+                    System.getProperty("java.class.path"),
+                    PROBE_MAIN_CLASS,
+                    target.x.toString(),
+                    target.y.toString(),
+                    probe.character.toString(),
+                    BLOCK_LENGTH.toString(),
+                    probe.readyFile.toString(),
+                    goFile.toString(),
+                    probe.outputFile.toString(),
+                )
+                .redirectOutput(ProcessBuilder.Redirect.DISCARD)
+                .redirectError(ProcessBuilder.Redirect.INHERIT)
+        if (distinctDesktopKeys()) {
+            // Red-proof lever (see the class KDoc). A Linux desktop resource key is derived from
+            // WAYLAND_DISPLAY when it is set, while java.awt.Robot dispatches through DISPLAY, so
+            // a fake value per probe removes mutual exclusion and leaves both typing at the same
+            // X display. Production code is untouched by this and never reads the property.
+            builder.environment()["WAYLAND_DISPLAY"] = "/spectre-red-proof-${probe.label}"
+        }
+        children += builder.start().also { probe.process = it }
+    }
+
+    private fun waitForExit(probe: ProbeHandle): Int {
+        val process = requireNotNull(probe.process) { "probe '${probe.label}' was never started" }
+        assertTrue(
+            process.waitFor(PROBE_TIMEOUT_SECONDS, TimeUnit.SECONDS),
+            "the '${probe.character}' probe JVM never finished within " +
+                "${PROBE_TIMEOUT_SECONDS}s of the barrier opening",
+        )
+        return process.exitValue()
+    }
+
+    /** Blocks until both probes are connected, focused on the field, and parked on the gate. */
+    private suspend fun awaitReady(vararg probes: ProbeHandle) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(READY_TIMEOUT_SECONDS)
+        while (System.nanoTime() < deadline) {
+            if (probes.all { Files.isRegularFile(it.readyFile) }) return
+            delay(READY_POLL_MILLIS.milliseconds)
+        }
+        val missing = probes.filterNot { Files.isRegularFile(it.readyFile) }.map(ProbeHandle::label)
+        error("probe JVMs never signalled readiness: ${missing.joinToString()}")
+    }
+
+    /**
+     * Reads the field once both blocks have landed, then waits a beat longer.
+     *
+     * The extra settle is not padding: returning the instant the expected length is reached would
+     * hide a stray extra keystroke, and an over-long field is exactly the kind of evidence the
+     * verdict should be allowed to see.
+     */
+    private suspend fun awaitFieldContent(state: SmokeState): String {
+        val expectedLength = BLOCK_LENGTH * 2
+        val deadline = System.nanoTime() + FIELD_SETTLE_TIMEOUT_MS * NANOS_PER_MILLI
+        while (System.nanoTime() < deadline) {
+            if (state.textValue.text.length >= expectedLength) break
+            delay(FIELD_POLL_MILLIS.milliseconds)
+        }
+        delay(POST_CLICK_SETTLE_MS.milliseconds)
+        return state.textValue.text
+    }
+
+    private fun distinctDesktopKeys(): Boolean =
+        System.getProperty("spectre.headedContention.distinctDesktopKeys").toBoolean()
+
+    private fun blockPlanSummary(): String =
+        "each probe types ${BLOCK_LENGTH}x its own character " +
+            "('$FIRST_BLOCK_CHARACTER' and '$SECOND_BLOCK_CHARACTER') in one typeText call" +
+            if (distinctDesktopKeys()) " with mutual exclusion DISABLED (red proof)" else ""
+
+    private fun javaExecutableName(): String =
+        if (System.getProperty("os.name").startsWith("Windows", ignoreCase = true)) {
+            "java.exe"
+        } else {
+            "java"
+        }
+
+    private inner class ProbeHandle(val label: String, val character: Char) {
+        val readyFile: Path = workDirectory.resolve("$label.ready")
+        val outputFile: Path = workDirectory.resolve("$label.txt")
+        var process: Process? = null
+
+        fun readRecord(): ProbeRecord {
+            assertTrue(
+                Files.isRegularFile(outputFile),
+                "the '$character' probe JVM wrote no timing record at $outputFile",
+            )
+            val lines = Files.readAllLines(outputFile)
+            fun value(prefix: String): Long =
+                lines.single { it.startsWith("$prefix ") }.removePrefix("$prefix ").trim().toLong()
+            return ProbeRecord(character, value("REQUESTED"), value("TYPED_TO"))
+        }
+    }
+
+    private data class ProbeRecord(val character: Char, val requestedAt: Long, val typedTo: Long)
+
+    private companion object {
+        const val PROBE_MAIN_CLASS: String =
+            "dev.sebastiano.spectre.sample.HeadedRobotContentionProbe"
+
+        const val READY_TIMEOUT_SECONDS: Long = 120
+        const val READY_POLL_MILLIS: Long = 25
+        const val PROBE_TIMEOUT_SECONDS: Long = 120
+        const val CHILD_DESTROY_TIMEOUT_SECONDS: Long = 5
+        const val FIELD_SETTLE_TIMEOUT_MS: Long = 15_000
+        const val FIELD_POLL_MILLIS: Long = 50
+        const val NANOS_PER_MILLI: Long = 1_000_000
+    }
+}

--- a/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
+++ b/sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample/LinuxRobotSmoke.kt
@@ -78,7 +78,7 @@ fun main() {
 // detect a pure-Wayland session with no XWayland fallback (DISPLAY unset), abort early with a
 // clear remediation rather than running the scenarios and reporting 0/6 PASS for opaque
 // reasons. Same gate Spectre's LinuxX11Grab uses from #77.
-internal fun checkWaylandGate(): String? {
+internal fun checkWaylandGate(label: String = "LinuxRobotSmoke"): String? {
     val xdgSessionType = System.getenv("XDG_SESSION_TYPE")?.lowercase()
     val waylandDisplay = System.getenv("WAYLAND_DISPLAY")
     val xdgRuntimeDir = System.getenv("XDG_RUNTIME_DIR")
@@ -90,9 +90,7 @@ internal fun checkWaylandGate(): String? {
         xdgSessionType == "wayland" || !waylandDisplay.isNullOrEmpty() || waylandSocketPresent
     if (waylandIndicator && display.isNullOrEmpty()) {
         return buildString {
-            appendLine(
-                "LinuxRobotSmoke aborting: pure-Wayland session detected and no XWayland fallback."
-            )
+            appendLine("$label aborting: pure-Wayland session detected and no XWayland fallback.")
             appendLine(
                 "  XDG_SESSION_TYPE=$xdgSessionType WAYLAND_DISPLAY=$waylandDisplay " +
                     "wayland-socket-present=$waylandSocketPresent DISPLAY=$display"

--- a/scripts/release-smoke.py
+++ b/scripts/release-smoke.py
@@ -26,6 +26,11 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from smoke_lib import (  # noqa: E402
+    HEADED_ROBOT_GRADLE_TASK,
+    HEADED_ROBOT_NAME,
+    HEADED_ROBOT_RESULTS_SUBPATH,
+    HEADED_ROBOT_SCENARIO_ID,
+    HEADED_ROBOT_TESTCASE,
     REQUIRED_SCENARIO_IDS,
     RESULT_FAIL,
     RESULT_PASS,
@@ -37,6 +42,7 @@ from smoke_lib import (  # noqa: E402
     assert_pointer_move_live_executed,
     input_coordination_missing_surface,
     headed_robot_cell,
+    headed_robot_missing_surface,
     WAYLAND_PORTAL_WARMUP_TOKEN_KEYS,
     linux_portal_token_path,
     build_report,
@@ -305,8 +311,10 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help=(
             "Operator attestation that headed two-JVM Robot contention was run on this desktop "
-            "(e.g. a note or run URL). Without it the hard input-coord-headed-robot cell stays "
-            "n/a with a blocking reason; the automated coordinator cells never satisfy it."
+            "(e.g. a note or run URL). Only needed where the automated proof cannot run (no "
+            f"xvfb-run on Linux, no interactive desktop); elsewhere {HEADED_ROBOT_GRADLE_TASK} "
+            "drives the cell. Without either the hard input-coord-headed-robot cell FAILS; the "
+            "automated coordinator cells never satisfy it."
         ),
     )
     parser.add_argument(
@@ -722,13 +730,54 @@ def main(argv: list[str] | None = None) -> int:
                 )
         add(cell)
 
-    # --- headed two-JVM Robot contention (operator-run hard cell) ---
+    # --- headed two-JVM Robot contention (hard cell) ---
     # SKILL.md requires *headed* two-JVM contention as a delta hard cell. Every cell above proves
     # the coordinator lease is mutually exclusive across processes, but none constructs a
-    # RobotDriver, so they all pass headless and under SSH. Absent operator evidence this is a
-    # hard FAIL, not a reasoned n/a: hard_failures() ignores a reasoned n/a, so an n/a here would
-    # print "ALL HARD SCENARIOS PASSED" without the headed proof.
-    add(headed_robot_cell(args.headed_robot_evidence))
+    # RobotDriver, so they all pass headless and under SSH. This one does, so unlike them it runs
+    # under the xvfb/robot wrapper and the forced-X11 env (same lane as junit-live), never the
+    # plain scenario env. Absent both the automated proof and operator evidence this is a hard
+    # FAIL, not a reasoned n/a: hard_failures() ignores a reasoned n/a, so an n/a here would print
+    # "ALL HARD SCENARIOS PASSED" without the headed proof.
+    headed_missing = headed_robot_missing_surface(ROOT)
+    headed_blocked = robot_xvfb_unavailable_reason(system)
+    headed_automated: ScenarioResult | None = None
+    if headed_missing is None and headed_blocked is None:
+        headed_automated = run_scenario(
+            HEADED_ROBOT_SCENARIO_ID,
+            name=HEADED_ROBOT_NAME,
+            command=[*robot_prefix, gradle, HEADED_ROBOT_GRADLE_TASK, *force],
+            cwd=ROOT,
+            timeout=900,
+            out_dir=out_dir,
+            env=_robot_env(scenario_env),
+            overall_deadline=overall_deadline,
+        )
+        if headed_automated.result == RESULT_PASS:
+            try:
+                # Gradle exits 0 on a tag filter that matches nothing, so the pass has to prove
+                # the e2e itself ran -- present in the XML and not <skipped/>.
+                assert_junit_testcases_passed(
+                    ROOT / HEADED_ROBOT_RESULTS_SUBPATH,
+                    needles=(HEADED_ROBOT_TESTCASE,),
+                    cell=HEADED_ROBOT_SCENARIO_ID,
+                )
+            except RuntimeError as exc:
+                headed_automated = scenario_result(
+                    HEADED_ROBOT_SCENARIO_ID,
+                    name=HEADED_ROBOT_NAME,
+                    result=RESULT_FAIL,
+                    seconds=headed_automated.seconds,
+                    detail=str(exc),
+                    log=headed_automated.log,
+                )
+    add(
+        headed_robot_cell(
+            args.headed_robot_evidence,
+            automated=headed_automated,
+            unavailable_reason=headed_blocked,
+            missing_surface=headed_missing,
+        )
+    )
 
     # --- agent attach / corpus / inject / launch-and-attach ---
     for scenario_id, name, test_filter in (

--- a/scripts/smoke_lib.py
+++ b/scripts/smoke_lib.py
@@ -54,20 +54,44 @@ REQUIRED_SCENARIO_IDS: tuple[str, ...] = (
     "input-coord-revoke",
     "input-coord-forced-recovery",
     "input-coord-junit-pertest",
-    # Operator-run: the harness cannot drive two real Robot JVMs, and the coordinator-protocol
-    # cells above pass headless. Stays a hard cell so the headed claim needs a human signature.
+    # The headed half of the gate: two real RobotDriver JVMs, which every cell above avoids
+    # constructing (that is why they all pass headless and under SSH). Driven by its own e2e on
+    # hosts that can run one, and by an operator signature on hosts that cannot -- never by the
+    # coordinator-protocol cells.
     "input-coord-headed-robot",
 )
 
 HEADED_ROBOT_SCENARIO_ID: str = "input-coord-headed-robot"
-HEADED_ROBOT_NAME: str = "Headed two-JVM Robot contention (operator-recorded)"
+HEADED_ROBOT_NAME: str = "Headed two-JVM Robot contention"
+
+# The automated proof (#491). Two forked JVMs, each with RobotDriver(InputLeasePolicy.Required),
+# type one distinguishable block into the same focused text field of one fixture window; a field
+# holding `ababab` is the failure being ruled out, and it is exactly what a lease-level proof
+# cannot observe. Both entrypoints run this task and both verify the testcase in the JUnit XML.
+HEADED_ROBOT_GRADLE_TASK: str = ":sample-desktop:headedRobotContentionTest"
+HEADED_ROBOT_RESULTS_SUBPATH: str = "sample-desktop/build/test-results/headedRobotContentionTest"
+HEADED_ROBOT_TESTCASE: str = (
+    "two Robot JVMs typing into one field never interleave their keystrokes"
+)
+_HEADED_ROBOT_SAMPLE_TEST_DIR: str = (
+    "sample-desktop/src/test/kotlin/dev/sebastiano/spectre/sample"
+)
+HEADED_ROBOT_TEST_SOURCE: str = f"{_HEADED_ROBOT_SAMPLE_TEST_DIR}/HeadedRobotContentionTest.kt"
+HEADED_ROBOT_PROBE_SOURCE: str = f"{_HEADED_ROBOT_SAMPLE_TEST_DIR}/HeadedRobotContentionProbe.kt"
+
+HEADED_ROBOT_AUTOMATED_DETAIL: str = (
+    f"automated headed two-JVM Robot contention passed ({HEADED_ROBOT_GRADLE_TASK}): two forked "
+    "RobotDriver(InputLeasePolicy.Required) JVMs released from one barrier typed into a single "
+    "focused field without interleaving"
+)
 
 # Deliberately blunt: a reader skimming a report must not mistake this row for "covered by the
 # automated cells". Both entrypoints emit this exact sentence; the contract tests pin it on each.
 HEADED_ROBOT_MISSING_EVIDENCE: str = (
-    "headed two-JVM Robot contention is operator-run on a real desktop and was NOT recorded; "
-    "the coordinator-protocol cells do not prove real-input non-interleaving, so this blocks "
-    "the tag on any OS whose release notes claim headed coordination"
+    "headed two-JVM Robot contention was NOT recorded: this host did not run the automated "
+    "proof and no operator evidence was supplied; the coordinator-protocol cells do not prove "
+    "real-input non-interleaving, so this blocks the tag on any OS whose release notes claim "
+    "headed coordination"
 )
 
 RESULT_PASS = "pass"
@@ -1112,29 +1136,111 @@ def assert_junit_testcases_passed(
             )
 
 
-def headed_robot_cell(evidence: str | None) -> ScenarioResult:
-    """Hard cell for the operator-recorded headed two-JVM Robot contention proof.
+def headed_robot_missing_surface(root: Path) -> str | None:
+    """Detail when the headed Robot contention e2e's sources are gone, else None.
 
-    Absent evidence is a **fail**, not a reasoned `n/a`. [hard_failures] deliberately ignores an
-    `n/a` that carries a reason, so recording this as `n/a` would let the runner exit 0 and print
-    "ALL HARD SCENARIOS PASSED" without the headed proof the release gate requires — the exact
-    hole a reasoned skip is supposed to prevent. The automated `input-coord-*` cells never satisfy
-    this: they construct no RobotDriver and pass headless and under SSH.
+    Same fail-closed rule as [input_coordination_missing_surface], and kept separate from it so a
+    change to one proof cannot quietly re-colour the other's cells. Deleting the e2e does not fall
+    back to the operator signature: the signature covers a *host* that cannot run the proof, not
+    the proof ceasing to exist. Dropping the claim means re-scoping the release on purpose.
     """
+    for source in (HEADED_ROBOT_TEST_SOURCE, HEADED_ROBOT_PROBE_SOURCE):
+        if not (Path(root) / source).is_file():
+            name = source.rsplit("/", maxsplit=1)[-1]
+            return (
+                f"headed two-JVM Robot contention proof missing ({name}); this is a failure, "
+                "not a skip, and an operator signature does not substitute for a deleted test: "
+                "if the surface was genuinely removed or graduated, re-scope the release by "
+                "dropping input-coord-headed-robot from REQUIRED_SCENARIO_IDS and updating "
+                "docs/RELEASE-SMOKE.md"
+            )
+    return None
+
+
+def headed_robot_cell(
+    evidence: str | None,
+    automated: ScenarioResult | None = None,
+    unavailable_reason: str | None = None,
+    missing_surface: str | None = None,
+) -> ScenarioResult:
+    """Hard cell for the headed two-JVM Robot contention proof (#459, #484, #491).
+
+    Four inputs, one precedence, and the order is the whole design:
+
+    1. `missing_surface` — the e2e's sources are gone. Fail; nothing else is consulted.
+    2. `automated` — the e2e actually ran on this host. Its verdict wins, and a **red** run wins
+       over operator evidence too: a signature is a claim about a run nobody can re-read, and an
+       observed interleave is a measurement. Letting the note outrank the measurement would put
+       the escape hatch exactly where it must never be.
+    3. `evidence` — nothing ran here, but an operator attests they ran it on a real desktop. The
+       host's `unavailable_reason` is recorded alongside so the report says *why* automation was
+       skipped rather than leaving a reader to assume it passed.
+    4. Neither — **fail**, never a reasoned `n/a`. [hard_failures] deliberately ignores an `n/a`
+       that carries a reason, so recording this as `n/a` would let the runner exit 0 and print
+       "ALL HARD SCENARIOS PASSED" without the headed proof the release gate requires. The
+       `input-coord-*` cells never fill this gap: they construct no RobotDriver and pass headless.
+    """
+    if missing_surface:
+        return scenario_result(
+            HEADED_ROBOT_SCENARIO_ID,
+            name=HEADED_ROBOT_NAME,
+            result=RESULT_FAIL,
+            detail=missing_surface,
+            hard=True,
+        )
     recorded = (evidence or "").strip()
+    if automated is not None:
+        if automated.result == RESULT_PASS:
+            detail = HEADED_ROBOT_AUTOMATED_DETAIL
+            if recorded:
+                detail = f"{detail}; operator evidence also recorded: {recorded}"
+            return scenario_result(
+                HEADED_ROBOT_SCENARIO_ID,
+                name=HEADED_ROBOT_NAME,
+                result=RESULT_PASS,
+                seconds=automated.seconds,
+                detail=detail,
+                log=automated.log,
+                hard=True,
+            )
+        detail = (
+            "the automated headed two-JVM Robot contention proof "
+            f"({HEADED_ROBOT_GRADLE_TASK}) went red on this host: {automated.detail}"
+        )
+        if recorded:
+            detail = (
+                f"{detail}. Operator evidence was also supplied ({recorded}) and does not "
+                "override an observed failure."
+            )
+        return scenario_result(
+            HEADED_ROBOT_SCENARIO_ID,
+            name=HEADED_ROBOT_NAME,
+            result=RESULT_FAIL,
+            seconds=automated.seconds,
+            detail=detail,
+            log=automated.log,
+            hard=True,
+        )
+    blocked = (unavailable_reason or "").strip()
     if recorded:
+        detail = f"operator evidence: {recorded}"
+        if blocked:
+            detail = f"{detail} (the automated proof did not run here: {blocked})"
         return scenario_result(
             HEADED_ROBOT_SCENARIO_ID,
             name=HEADED_ROBOT_NAME,
             result=RESULT_PASS,
-            detail=f"operator evidence: {recorded}",
+            detail=detail,
             hard=True,
         )
+    detail = HEADED_ROBOT_MISSING_EVIDENCE
+    if blocked:
+        detail = f"{detail}. The automated proof did not run here: {blocked}"
     return scenario_result(
         HEADED_ROBOT_SCENARIO_ID,
         name=HEADED_ROBOT_NAME,
         result=RESULT_FAIL,
-        detail=HEADED_ROBOT_MISSING_EVIDENCE,
+        detail=detail,
         hard=True,
     )
 

--- a/scripts/windows-release-smoke.ps1
+++ b/scripts/windows-release-smoke.ps1
@@ -40,7 +40,9 @@ param(
     [switch] $SkipCheck,
     [switch] $SkipMavenLocal,
     # Operator attestation that headed two-JVM Robot contention was run on this desktop.
-    # Without it the hard input-coord-headed-robot cell stays n/a with a blocking reason; the
+    # Only needed where the automated proof cannot run (a Windows SSH session has no interactive
+    # desktop for java.awt.Robot to type into); elsewhere :sample-desktop:headedRobotContentionTest
+    # drives the cell. Without either the hard input-coord-headed-robot cell FAILS; the
     # automated coordinator cells never satisfy it (they pass headless and under SSH).
     [string] $HeadedRobotEvidence = "",
     # Schema/preflight self-check only: remaining required IDs are hard n/a with reason.
@@ -262,6 +264,92 @@ function Invoke-Step {
         Write-Host ("FAIL  {0}  ({1}s): {2}" -f $Id, $secs, $msg) -ForegroundColor Red
         return (New-StepResult -Id $Id -Name $Name -Result "fail" -Seconds $secs -Detail $msg)
     }
+}
+
+function Get-HeadedRobotMissingSurface {
+    param([Parameter(Mandatory = $true)][string] $RepoRoot)
+    # Same fail-closed rule as Get-InputCoordinationMissingSurface, kept separate so a change to
+    # one proof cannot quietly re-colour the other's cells. Deleting the e2e does NOT fall back to
+    # the operator signature: that hatch covers a host which cannot run the proof, not the proof
+    # ceasing to exist. Mirrors smoke_lib.headed_robot_missing_surface.
+    $sources = @(
+        "sample-desktop\src\test\kotlin\dev\sebastiano\spectre\sample\HeadedRobotContentionTest.kt",
+        "sample-desktop\src\test\kotlin\dev\sebastiano\spectre\sample\HeadedRobotContentionProbe.kt"
+    )
+    foreach ($rel in $sources) {
+        if (-not (Test-Path -LiteralPath (Join-Path $RepoRoot $rel))) {
+            $name = Split-Path -Leaf $rel
+            return ("headed two-JVM Robot contention proof missing ({0}); this is a failure, not a skip, and an operator signature does not substitute for a deleted test: if the surface was genuinely removed or graduated, re-scope the release by dropping input-coord-headed-robot from RequiredScenarioIds and updating docs/RELEASE-SMOKE.md" -f $name)
+        }
+    }
+    return $null
+}
+
+function Invoke-HeadedRobotCell {
+    # Explicit-parameter cell runner (no closure over caller variables -- avoids the WinPS
+    # dot-sourced-scriptblock scope gotcha). Mirrors smoke_lib.headed_robot_cell, including its
+    # precedence: a missing proof source outranks everything, an automated run outranks an
+    # operator note in BOTH directions, and neither present is a fail rather than a reasoned n/a.
+    param(
+        [Parameter(Mandatory = $true)][string] $RepoRoot,
+        [Parameter(Mandatory = $true)][string] $Name,
+        [string] $Evidence = "",
+        [string] $MissingSurface = "",
+        [string] $UnavailableReason = "",
+        [ValidateRange(1, 86400)][int] $TimeoutSeconds = 900
+    )
+    $id = "input-coord-headed-robot"
+    $task = ":sample-desktop:headedRobotContentionTest"
+    if (-not [string]::IsNullOrWhiteSpace($MissingSurface)) {
+        return (New-StepResult -Id $id -Name $Name -Result "fail" -Detail $MissingSurface)
+    }
+    $recorded = ""
+    if (-not [string]::IsNullOrWhiteSpace($Evidence)) { $recorded = $Evidence.Trim() }
+
+    if ([string]::IsNullOrWhiteSpace($UnavailableReason)) {
+        Write-Host ""
+        Write-Host ("==== {0} ({1}) ====" -f $id, $Name) -ForegroundColor Cyan
+        $sw = [System.Diagnostics.Stopwatch]::StartNew()
+        try {
+            Invoke-Gradle -RepoRoot $RepoRoot -TimeoutSeconds $TimeoutSeconds -LogName $id -GradleArgs @(
+                $task,
+                "--rerun-tasks",
+                "--no-build-cache"
+            )
+            # Gradle exits 0 on a tag filter that matches nothing, so the pass has to prove the
+            # e2e itself ran -- present in the XML and not skipped.
+            Assert-JUnitTestcasesPassed -RepoRoot $RepoRoot `
+                -ResultsSubPath "sample-desktop\build\test-results\headedRobotContentionTest" `
+                -Needles @("two Robot JVMs typing into one field never interleave their keystrokes") `
+                -Cell $id
+            $sw.Stop()
+            $secs = [int]$sw.Elapsed.TotalSeconds
+            $detail = "automated headed two-JVM Robot contention passed ({0}): two forked RobotDriver(InputLeasePolicy.Required) JVMs released from one barrier typed into a single focused field without interleaving" -f $task
+            if ($recorded) {
+                $detail = ("{0}; operator evidence also recorded: {1}" -f $detail, $recorded)
+            }
+            Write-Host ("PASS  {0}  ({1}s)" -f $id, $secs) -ForegroundColor Green
+            return (New-StepResult -Id $id -Name $Name -Result "pass" -Seconds $secs -Detail $detail)
+        }
+        catch {
+            $sw.Stop()
+            $secs = [int]$sw.Elapsed.TotalSeconds
+            $msg = [string]$_.Exception.Message
+            $detail = ("the automated headed two-JVM Robot contention proof ({0}) went red on this host: {1}" -f $task, $msg)
+            if ($recorded) {
+                $detail = ("{0}. Operator evidence was also supplied ({1}) and does not override an observed failure." -f $detail, $recorded)
+            }
+            Write-Host ("FAIL  {0}  ({1}s): {2}" -f $id, $secs, $msg) -ForegroundColor Red
+            return (New-StepResult -Id $id -Name $Name -Result "fail" -Seconds $secs -Detail $detail)
+        }
+    }
+
+    if ($recorded) {
+        $signedDetail = ("operator evidence: {0} (the automated proof did not run here: {1})" -f $recorded, $UnavailableReason)
+        return (New-StepResult -Id $id -Name $Name -Result "pass" -Detail $signedDetail)
+    }
+    $headedDetail = ("headed two-JVM Robot contention was NOT recorded: this host did not run the automated proof and no operator evidence was supplied; the coordinator-protocol cells do not prove real-input non-interleaving, so this blocks the tag on any OS whose release notes claim headed coordination. The automated proof did not run here: {0}" -f $UnavailableReason)
+    return (New-StepResult -Id $id -Name $Name -Result "fail" -Detail $headedDetail)
 }
 
 function Get-PackagedSpectre {
@@ -757,17 +845,21 @@ try {
                 -ResultsSubPath $testingResults `
                 -Needles @("InputIsolationLifecycleTest", "concurrent per-test invocations never hold the desktop lease at the same time", "the per-test lease is still held while failure evidence is captured")))
 
-    # Headed two-JVM Robot contention: operator-run hard cell. SKILL.md requires *headed*
-    # contention, and every automated cell above passes headless/SSH because none builds a
-    # RobotDriver. Absent evidence this is a hard FAIL, not a reasoned n/a: the summary's failure
-    # count ignores a reasoned n/a, so an n/a here would report success without the headed proof.
-    $headedName = "Headed two-JVM Robot contention (operator-recorded)"
-    if (-not [string]::IsNullOrWhiteSpace($HeadedRobotEvidence)) {
-        [void]$results.Add((New-StepResult -Id "input-coord-headed-robot" -Name $headedName -Result "pass" -Detail ("operator evidence: {0}" -f $HeadedRobotEvidence)))
+    # Headed two-JVM Robot contention: hard cell. SKILL.md requires *headed* contention, and every
+    # automated cell above passes headless/SSH because none builds a RobotDriver. This one does, so
+    # it needs an interactive desktop: over SSH there is no window for Robot to type into and the
+    # operator signature is the only route. Absent both, a hard FAIL, not a reasoned n/a -- the
+    # summary's failure count ignores a reasoned n/a, so an n/a would report success without the
+    # headed proof.
+    $headedName = "Headed two-JVM Robot contention"
+    $headedUnavailable = ""
+    if ((Get-DisplayModeWindows) -eq "windows-ssh") {
+        $headedUnavailable = "a Windows SSH session has no interactive desktop, so java.awt.Robot input cannot reach a window"
     }
-    else {
-        [void]$results.Add((New-StepResult -Id "input-coord-headed-robot" -Name $headedName -Result "fail" -Detail "headed two-JVM Robot contention is operator-run on a real desktop and was NOT recorded; the coordinator-protocol cells do not prove real-input non-interleaving, so this blocks the tag on any OS whose release notes claim headed coordination"))
-    }
+    [void]$results.Add((Invoke-HeadedRobotCell -RepoRoot $repoRoot -Name $headedName -TimeoutSeconds $AgentE2eTimeoutSeconds `
+                -Evidence $HeadedRobotEvidence `
+                -MissingSurface (Get-HeadedRobotMissingSurface -RepoRoot $repoRoot) `
+                -UnavailableReason $headedUnavailable))
 
     if (-not $SkipAgentE2e) {
         # AgentAttachIntegration e2e includes WGC node screenshots (#362). Under SSH that is the


### PR DESCRIPTION
## Summary

`input-coord-headed-robot` was a hard **operator-recorded** cell: `fail` unless a human passed `--headed-robot-evidence` / `-HeadedRobotEvidence`, costing a manual headed run per claimed OS on every release. This adds the Robot-backed e2e that gap was waiting on, and drives the cell from it on hosts that can run one — keeping the operator flag only as the escape hatch for hosts that genuinely cannot.

`:sample-desktop:headedRobotContentionTest` forks two JVMs, each with its own `RobotDriver(InputLeasePolicy.Required)` against one coordinator, and has both type a distinguishable block into the same focused text field of one fixture window. An `ababab` field is the failure being ruled out, and it is exactly what the lease-level proofs cannot observe: every `input-coord-*` cell passes headless because not one of them constructs a `RobotDriver`.

Closes #491. Refs #459, #484.

### Not a vacuous pass

Starting two JVMs back to back proves nothing — startup skew alone can serialise them. Each probe pays for coordinator launch, client session, and field focus **before** the barrier, and the parent then *measures* the overlap rather than trusting it: the probe that asked for the keyboard second must have asked while the first was still typing, or the test fails as a broken barrier. One block is one `typeText` call, because that is the unit `RobotDriver` holds one lease for; splitting it would take a fresh lease per call and assert something the coordinator never promised.

### Fail-closed, still

- Neither an automated run nor a signature → `fail`, never a reasoned `n/a` (which `hard_failures()` ignores).
- Operator evidence **cannot** rescue a red automated run: an observed interleave is a measurement, a note is not.
- A deleted proof source is a `fail`, not a fallback to the signature.
- The pass is gated on the JUnit XML, since Gradle exits 0 on a tag filter that matches nothing.

### Which platforms are automated

| Platform | How the cell is satisfied |
| --- | --- |
| Linux Xorg/Xvfb | Automated, under the same xvfb/robot wrapper and forced-X11 env as `junit-live` (#432). Hard `fail` if `xvfb-run` is absent, unless signed. |
| macOS desktop | Automated, given Robot Accessibility (TCC). Without it the input is dropped and the cell fails. |
| Windows interactive / RDP | Automated. |
| Windows SSH | **Not** automated — no interactive desktop for Robot to type into; still needs `-HeadedRobotEvidence`. |

## Test plan

- [x] `./gradlew check` passes locally (Linux). Note: `:agent:test`'s `UdsPathLimitsTest` accented-path case needs a UTF-8 locale — unrelated to this change, and green under `LANG=C.UTF-8`.
- [x] `./gradlew ktfmtFormat` produced no changes beyond the one reflowed line it fixed.
- [x] **Green:** `xvfb-run -a ./gradlew :sample-desktop:headedRobotContentionTest --rerun-tasks --no-build-cache` → field content `aaaa…(40)bbbb…(40)`, one clean hand-off.
- [x] **Red proof:** same command with `-Dspectre.headedContention.distinctDesktopKeys=true` (each probe gets a fake `WAYLAND_DISPLAY`, so the Linux desktop key differs per process while `java.awt.Robot` keeps following `DISPLAY` — no production code changed) → fails on `bababababa…` with the message `two headed Robot JVMs interleaved their keystrokes`. Checked the *message*, not just the exit code.
- [x] The XML fail-closed gate accepts the green run and rejects the red one.
- [x] `python3 .github/scripts/test-release-smoke-scripts.py` — 66 tests OK.
- [x] `bash .github/scripts/test-windows-release-smoke-script.sh` — ASCII check, pwsh `Parser::ParseInput`, and contract greps all pass (I installed pwsh 7.4.6 locally so the parse check ran rather than skipped).
- [x] Exercised the four `Invoke-HeadedRobotCell` branches that need no Gradle under pwsh (missing surface, blocked+signed, blocked+unsigned, surface present); details match the Python side verbatim.
- [x] `HeadedRobotContentionAnalysisTest` (8 cases) runs under `check` and pins the verdict — including that dropped keystrokes are reported as a delivery failure, *not* as interleaving.
- [x] Confirmed the e2e is excluded from `:sample-desktop:test`, so `check` stays headless-safe.

**Not executed here:** macOS and Windows. Those columns are implemented but unverified — this was a Linux session, and CI's `check-macos` / `check-windows` build the tree without running the smoke harness. Someone on a Mac and a Windows box should run the task once before leaning on those rows.

## Confirmations

- [x] I'm licensing this contribution under [Apache-2.0](../LICENSE).
- Authorship: this PR was written by Claude Code at the repository owner's request, so the "not LLM-generated" box is deliberately left unticked rather than ticked falsely.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JuNWkFoJvRKSQAcziKUpMq)_